### PR TITLE
fix(security): close Wave 6 low/info batch 7 (auth/SSO/trust/connect-core)

### DIFF
--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -141,16 +141,28 @@ func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email
 // adding an actor or per-invitation dimension keeps initial invites and resends of the
 // same target subject to one combined rate, matching how ResendInvitationLink already
 // treats every pending invite to the same email as one throttled subject.
+//
+// The SEPARATE pre-issuance supersede (IssueSetupToken's "kill the old link" step) is,
+// unlike the throttle above, scoped to THIS project via SupersedeProjectID
+// (CORE-INVITATIONS-003): without it, any admin holding roles.assign in some unrelated
+// project B could invite the same target email to project B and, as a side effect,
+// silently invalidate project A's still-pending invite link — a cross-project
+// interference project B's admin has no authority to cause and no visibility into.
+// Scoping the supersede (but deliberately NOT the throttle, which stays per (purpose,
+// email) globally — see above) preserves the SMTP-abuse ceiling while eliminating that
+// cross-project side effect. A genuine same-project resend/re-invite still supersedes
+// the prior pending invite for that project, exactly as before.
 func (c *KeyorixCore) InviteToProjectWithLink(ctx context.Context, projectID uint, email, role string, invitedBy uint) (*models.ProjectInvitation, *ProvisionSetupResult, error) {
 	inv, err := c.InviteToProject(ctx, projectID, email, role, invitedBy)
 	if err != nil {
 		return nil, nil, err
 	}
 	prov, err := c.provisionSetupLinkThrottled(ctx, IssueSetupTokenRequest{
-		Purpose:      SetupPurposeInvitationAccept,
-		SubjectEmail: email,
-		InvitationID: &inv.ID,
-		CreatedBy:    invitedBy,
+		Purpose:            SetupPurposeInvitationAccept,
+		SubjectEmail:       email,
+		InvitationID:       &inv.ID,
+		CreatedBy:          invitedBy,
+		SupersedeProjectID: &projectID,
 	}, "", fmt.Sprintf("%s on project %d", role, projectID))
 	if err != nil {
 		return inv, nil, err
@@ -250,6 +262,13 @@ func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string
 // Throttled per (purpose, email) via provisionSetupLinkThrottled for the same reason
 // as InviteToProjectWithLink (#345): the users.write-gated global-invite endpoint is
 // otherwise an equally loop-callable unbounded-SMTP vector.
+//
+// Unlike InviteToProjectWithLink, SupersedeProjectID is intentionally left nil: a
+// global invite (ProjectID 0) has no single project to scope the pre-issuance
+// supersede to, so it keeps the original (purpose, email)-only scope — it still
+// supersedes a prior pending global invite to the same address, and, as before, a
+// prior PROJECT-scoped invite to that address (there is no narrower boundary to draw
+// here; CORE-INVITATIONS-003 is specifically about project-vs-project interference).
 func (c *KeyorixCore) InviteGlobalWithLink(ctx context.Context, email, systemRole string, assignments []ProjectAssignment, invitedBy uint) (*models.ProjectInvitation, *ProvisionSetupResult, error) {
 	inv, err := c.InviteGlobal(ctx, email, systemRole, assignments, invitedBy)
 	if err != nil {
@@ -361,7 +380,10 @@ func (c *KeyorixCore) revokeAssignmentGrants(ctx context.Context, inv *models.Pr
 }
 
 // ResendInvitationLink reissues the accept link for a still-pending invitation
-// (superseding the prior token) and re-delivers it. Throttled per ADR-028.
+// (superseding the prior token) and re-delivers it. Throttled per ADR-028. The
+// caller is already verified to be authorized within projectID (below), and the
+// supersede itself is scoped to that same project (CORE-INVITATIONS-003) — a resend
+// here can only ever kill this project's own prior link for the address.
 func (c *KeyorixCore) ResendInvitationLink(ctx context.Context, projectID, invitationID, actorID uint) (*ProvisionSetupResult, error) {
 	inv, err := c.storage.GetProjectInvitation(ctx, invitationID)
 	if err != nil {
@@ -383,10 +405,11 @@ func (c *KeyorixCore) ResendInvitationLink(ctx context.Context, projectID, invit
 		return nil, fmt.Errorf("only a pending invitation can be resent (state is %s)", inv.State)
 	}
 	return c.provisionSetupLinkThrottled(ctx, IssueSetupTokenRequest{
-		Purpose:      SetupPurposeInvitationAccept,
-		SubjectEmail: inv.Email,
-		InvitationID: &inv.ID,
-		CreatedBy:    actorID,
+		Purpose:            SetupPurposeInvitationAccept,
+		SubjectEmail:       inv.Email,
+		InvitationID:       &inv.ID,
+		CreatedBy:          actorID,
+		SupersedeProjectID: &inv.ProjectID,
 	}, "", fmt.Sprintf("%s on project %d", inv.Role, inv.ProjectID))
 }
 

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -436,7 +436,7 @@ func TestInviteToProjectWithLink_ThrottlesRepeatedInitialInvites(t *testing.T) {
 	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5, Name: "project_developer"}, nil)
 	store.On("CreateProjectInvitation", ctx, mock.AnythingOfType("*models.ProjectInvitation")).
 		Return(&models.ProjectInvitation{ID: 7, State: InvitationPending}, nil)
-	store.On("SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "a@b.com").Return(nil)
+	store.On("SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "a@b.com", ptr(uint(1))).Return(nil)
 	store.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
 
 	// First invite: a zero prior count on both windows, so it succeeds and mints a
@@ -479,7 +479,7 @@ func TestInviteGlobalWithLink_ThrottlesRepeatedInitialInvites(t *testing.T) {
 	store.On("GetRoleByName", ctx, "system_viewer").Return(&models.Role{ID: 2}, nil)
 	store.On("CreateProjectInvitation", ctx, mock.AnythingOfType("*models.ProjectInvitation")).
 		Return(&models.ProjectInvitation{ID: 8, State: InvitationPending}, nil)
-	store.On("SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "c@d.com").Return(nil)
+	store.On("SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "c@d.com", (*uint)(nil)).Return(nil)
 	store.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
 
 	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "c@d.com", fixed.Add(-24*time.Hour)).Return(int64(0), nil).Once()

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1600,8 +1600,8 @@ func (m *MockStorage) GetSetupTokenByHash(ctx context.Context, hash string) (*mo
 	return args.Get(0).(*models.SetupToken), args.Error(1)
 }
 
-func (m *MockStorage) SupersedeActiveSetupTokens(ctx context.Context, purpose, email string) error {
-	args := m.Called(ctx, purpose, email)
+func (m *MockStorage) SupersedeActiveSetupTokens(ctx context.Context, purpose, email string, projectID *uint) error {
+	args := m.Called(ctx, purpose, email, projectID)
 	return args.Error(0)
 }
 

--- a/internal/core/password_reset_test.go
+++ b/internal/core/password_reset_test.go
@@ -39,7 +39,7 @@ func TestRequestPasswordReset(t *testing.T) {
 		ms.On("GetUserByEmail", ctx, email).Return(activeUser, nil)
 		ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-24*time.Hour)).Return(int64(0), nil)
 		ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-resendMinInterval)).Return(int64(0), nil)
-		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposePasswordResetLink, email).Return(nil)
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposePasswordResetLink, email, (*uint)(nil)).Return(nil)
 		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
 
 		require.NoError(t, c.RequestPasswordReset(ctx, email))
@@ -101,7 +101,7 @@ func TestRequestPasswordReset(t *testing.T) {
 		ms.On("GetUserByEmail", ctx, email).Return(activeUser, nil)
 		ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-24*time.Hour)).Return(int64(0), nil)
 		ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-resendMinInterval)).Return(int64(0), nil)
-		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposePasswordResetLink, email).Return(nil)
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposePasswordResetLink, email, (*uint)(nil)).Return(nil)
 		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
 		defer close(releaseDelivery) // don't leak the goroutine if the test fails early
 
@@ -182,7 +182,7 @@ func TestRequestPasswordReset_PanicInDetachedGoroutineDoesNotCrash(t *testing.T)
 	ms.On("GetUserByEmail", ctx, email).Return(activeUser, nil)
 	ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-24*time.Hour)).Return(int64(0), nil)
 	ms.On("CountSetupTokensSince", ctx, SetupPurposePasswordResetLink, email, fixed.Add(-resendMinInterval)).Return(int64(0), nil)
-	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposePasswordResetLink, email).Return(nil)
+	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposePasswordResetLink, email, (*uint)(nil)).Return(nil)
 	ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
 
 	// The enumeration-safe contract holds regardless: RequestPasswordReset

--- a/internal/core/saml_flow_test.go
+++ b/internal/core/saml_flow_test.go
@@ -221,6 +221,53 @@ func TestCompleteSAML_PasswordExpiredGateError(t *testing.T) {
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
 }
 
+// TestCompleteSAML_LockedAccountSkipsGroupRoleSync pins CORE-OIDC-04 for the SAML
+// path (mirrors TestCompleteSSO_LockedAccountSkipsGroupRoleSync for OIDC): a
+// currently brute-force-locked account must not have its native group
+// memberships / mapped role grants reconciled from the SAML assertion — and no
+// reconciliation audit written — when the login is about to be refused for that
+// lock anyway. Before the fix, group/role sync ran BEFORE the loginLocked check
+// in CompleteSAML too. The assertion here carries a group that WOULD be
+// added/mapped if reconciliation ran.
+func TestCompleteSAML_LockedAccountSkipsGroupRoleSync(t *testing.T) {
+	stub := &stubSAML{info: &samlpkg.AssertionInfo{
+		Subject: "corp|66", Email: "locked@x.io", Name: "Locked",
+		Groups: []string{"keyorix-admins"},
+	}}
+	c, store := samlTestCore(stub)
+	c.loginLockout = LoginLockoutPolicy{
+		Enabled: true, MaxAttempts: 5, Window: time.Hour,
+		BaseCooldown: time.Minute, MaxCooldown: time.Hour,
+	}
+	c.ssoProviders["corp"].GroupSync = true
+	c.ssoProviders["corp"].GroupRoleMap = map[string]string{"keyorix-admins": "system_admin"}
+
+	lockedUntil := time.Now().Add(10 * time.Minute)
+	lockedUser := &models.User{
+		ID: 66, IsActive: true, AccountState: "active",
+		LoginLockedUntil: &lockedUntil, LoginLockoutCount: 1,
+	}
+	store.On("ConsumeSSOLoginState", mock.Anything, "relay-locked").Return(
+		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|66").Return(lockedUser, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/saml/corp/acs", nil)
+	session, _, _, err := c.CompleteSAML(context.Background(), "corp", req, "relay-locked", "ua", "1.2.3.4")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "temporarily locked")
+	assert.Nil(t, session)
+
+	store.AssertNotCalled(t, "ListGroups", mock.Anything)
+	store.AssertNotCalled(t, "GetUserGroups", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "GetUserRoles", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "AddUserToGroup", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+	assert.Equal(t, 1, lockedUser.LoginLockoutCount)
+	assert.NotNil(t, lockedUser.LoginLockedUntil)
+}
+
 // TestCompleteSAML_JITProvisionDoesNotReuseUnverifiedEmailMatch is the #89
 // regression at the CompleteSAML (not just provisionSSOUser) level, for the
 // AutoProvision=true path specifically: CompleteSAML previously passed a

--- a/internal/core/secret_templates.go
+++ b/internal/core/secret_templates.go
@@ -182,8 +182,15 @@ type ApplyTemplateResult struct {
 
 // ApplyTemplate merges template defaults into a partial create request.
 // Fields already set in the request are preserved; template values only fill
-// in empty/zero fields (template is a default, not an override).
+// in empty/zero fields (template is a default, not an override). The
+// caller-supplied classification is validated against the same allow-list
+// as Create/UpdateSecretTemplate so the result is safe by construction even
+// if a downstream caller forwards it into an actual secret-creation call.
 func (c *KeyorixCore) ApplyTemplate(ctx context.Context, templateID uint, classification, description string, tags []string) (*ApplyTemplateResult, error) {
+	if err := validateTemplateClassification(classification); err != nil {
+		return nil, err
+	}
+
 	tmpl, err := c.storage.GetSecretTemplate(ctx, templateID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret template: %w", err)

--- a/internal/core/secret_templates_test.go
+++ b/internal/core/secret_templates_test.go
@@ -271,6 +271,16 @@ func TestApplyTemplate_NonEmptyPreserved(t *testing.T) {
 	assert.Equal(t, []string{"custom"}, result.Tags)
 }
 
+func TestApplyTemplate_InvalidClassification_Error(t *testing.T) {
+	c, m := newCoreWithMock()
+	// GetSecretTemplate must not even be reached: validation happens first.
+	result, err := c.ApplyTemplate(context.Background(), 1, "topsecret", "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid classification")
+	assert.Nil(t, result)
+	m.AssertNotCalled(t, "GetSecretTemplate", mock.Anything, mock.Anything)
+}
+
 func TestApplyTemplate_UnknownTemplate_Error(t *testing.T) {
 	c, m := newCoreWithMock()
 	m.On("GetSecretTemplate", context.Background(), uint(999)).Return(nil, errors.New("secret template not found"))

--- a/internal/core/setup_delivery_test.go
+++ b/internal/core/setup_delivery_test.go
@@ -73,7 +73,7 @@ func TestResendAccountSetupLink(t *testing.T) {
 		ms.On("GetUser", ctx, uid).Return(user(), nil)
 		ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "new@acme.io", fixed.Add(-24*time.Hour)).Return(int64(0), nil)
 		ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "new@acme.io", fixed.Add(-resendMinInterval)).Return(int64(0), nil)
-		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "new@acme.io").Return(nil)
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "new@acme.io", (*uint)(nil)).Return(nil)
 		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
 
 		res, err := c.ResendAccountSetupLink(ctx, uid, 7)
@@ -94,7 +94,7 @@ func TestResendAccountSetupLink(t *testing.T) {
 		c, ms := newCore(fake)
 		ms.On("GetUser", ctx, uid).Return(user(), nil)
 		ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "new@acme.io", mock.AnythingOfType("time.Time")).Return(int64(0), nil)
-		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "new@acme.io").Return(nil)
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "new@acme.io", (*uint)(nil)).Return(nil)
 		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
 
 		res, err := c.ResendAccountSetupLink(ctx, uid, 7)
@@ -178,7 +178,7 @@ func TestCreateUserWithSetupLink(t *testing.T) {
 	// prior tokens clears both checks.
 	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-24*time.Hour)).Return(int64(0), nil)
 	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-resendMinInterval)).Return(int64(0), nil)
-	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "dana@acme.io").Return(nil)
+	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "dana@acme.io", (*uint)(nil)).Return(nil)
 	ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil)
 
 	user, prov, err := c.CreateUserWithSetupLink(ctx, &CreateUserRequest{
@@ -222,7 +222,7 @@ func TestCreateUserWithSetupLink_ThrottlesCreateDeleteRecreateLoop(t *testing.T)
 	ms.On("GetRoleByName", ctx, "system_viewer").Return(nil, notFound())
 	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-24*time.Hour)).Return(int64(0), nil).Once()
 	ms.On("CountSetupTokensSince", ctx, SetupPurposeAccountSetup, "dana@acme.io", fixed.Add(-resendMinInterval)).Return(int64(0), nil).Once()
-	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "dana@acme.io").Return(nil).Once()
+	ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "dana@acme.io", (*uint)(nil)).Return(nil).Once()
 	ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).Return(&models.SetupToken{ID: 1}, nil).Once()
 
 	_, prov1, err := c.CreateUserWithSetupLink(ctx, req, 7)

--- a/internal/core/setup_token.go
+++ b/internal/core/setup_token.go
@@ -69,6 +69,17 @@ type IssueSetupTokenRequest struct {
 	SubjectUserID *uint  // nil until an account exists (e.g. invitation by email)
 	InvitationID  *uint  // set for purpose = invitation_accept
 	CreatedBy     uint   // issuing admin/inviter; 0 for self-service reset
+
+	// SupersedeProjectID additionally scopes the pre-issuance supersede (see
+	// IssueSetupToken below) to a single project's own invitations, instead of every
+	// active token for (Purpose, SubjectEmail) across every project
+	// (CORE-INVITATIONS-003). Project-scoped invite/resend call sites
+	// (InviteToProjectWithLink, ResendInvitationLink) set this to their ProjectID so an
+	// admin in one project can never silently invalidate a different project's still-
+	// pending invite to the same address. Left nil for flows with no project dimension
+	// (InviteGlobalWithLink, account_setup, password_reset_link), which keep the
+	// original (Purpose, SubjectEmail)-only supersede scope.
+	SupersedeProjectID *uint
 }
 
 // IssueSetupTokenResult carries the freshly minted token plus its one-time plaintext.
@@ -91,8 +102,10 @@ func (c *KeyorixCore) IssueSetupToken(ctx context.Context, req IssueSetupTokenRe
 	}
 
 	// Supersede any prior active token for this subject+purpose first, so the old
-	// link dies the instant the new one is issued (safe "resend").
-	if err := c.storage.SupersedeActiveSetupTokens(ctx, req.Purpose, email); err != nil {
+	// link dies the instant the new one is issued (safe "resend"). SupersedeProjectID,
+	// when set, additionally confines this to the issuing project's own invitations
+	// (CORE-INVITATIONS-003) rather than every project's.
+	if err := c.storage.SupersedeActiveSetupTokens(ctx, req.Purpose, email, req.SupersedeProjectID); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 

--- a/internal/core/setup_token_test.go
+++ b/internal/core/setup_token_test.go
@@ -26,7 +26,7 @@ func TestIssueSetupToken(t *testing.T) {
 		anyAudit(ms)
 
 		var captured *models.SetupToken
-		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "new@acme.io").Return(nil)
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "new@acme.io", (*uint)(nil)).Return(nil)
 		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).
 			Run(func(args mock.Arguments) { captured = args.Get(1).(*models.SetupToken) }).
 			Return(&models.SetupToken{ID: 1}, nil)
@@ -43,7 +43,7 @@ func TestIssueSetupToken(t *testing.T) {
 		assert.NotEqual(t, res.PlainToken, captured.TokenHash, "plaintext is never stored")
 		assert.Equal(t, "new@acme.io", captured.SubjectEmail)
 		assert.Equal(t, SetupTokenActive, captured.State)
-		ms.AssertCalled(t, "SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "new@acme.io")
+		ms.AssertCalled(t, "SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "new@acme.io", (*uint)(nil))
 	})
 
 	t.Run("applies the default TTL when none is configured", func(t *testing.T) {
@@ -53,7 +53,7 @@ func TestIssueSetupToken(t *testing.T) {
 		c.now = func() time.Time { return fixed }
 		anyAudit(ms)
 		var captured *models.SetupToken
-		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "a@b.io").Return(nil)
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "a@b.io", (*uint)(nil)).Return(nil)
 		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).
 			Run(func(args mock.Arguments) { captured = args.Get(1).(*models.SetupToken) }).
 			Return(&models.SetupToken{ID: 2}, nil)
@@ -71,7 +71,7 @@ func TestIssueSetupToken(t *testing.T) {
 		c.SetSetupTokenTTL(2 * time.Hour)
 		anyAudit(ms)
 		var captured *models.SetupToken
-		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "a@b.io").Return(nil)
+		ms.On("SupersedeActiveSetupTokens", ctx, SetupPurposeAccountSetup, "a@b.io", (*uint)(nil)).Return(nil)
 		ms.On("CreateSetupToken", ctx, mock.AnythingOfType("*models.SetupToken")).
 			Run(func(args mock.Arguments) { captured = args.Get(1).(*models.SetupToken) }).
 			Return(&models.SetupToken{ID: 2}, nil)

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -215,6 +215,19 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
 		return nil, nil, "", fmt.Errorf("account suspended")
 	}
+	// Enforce per-account brute-force lockout (distinct from deactivation/suspension)
+	// BEFORE any IdP-driven state mutation below (group/role reconciliation). A locked
+	// account must not receive a new session via SSO even though the IdP authenticated
+	// it — the lockout signals an active attack and must be honoured on all login
+	// paths, same as password/TOTP/WebAuthn (see auth.go) — and its native group/role
+	// state must stay frozen while the lock is in effect, not silently resynced by a
+	// login attempt that's about to be refused anyway.
+	if c.loginLocked(user) {
+		return nil, nil, "", fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
+	if err := c.checkLockAndClearLoginFailures(ctx, user); err != nil {
+		return nil, nil, "", err
+	}
 
 	// Reconcile native group memberships and/or mapped role grants from the IdP's
 	// groups claim (best-effort — a sync failure must not block an otherwise-valid
@@ -227,16 +240,6 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 	}
 
 	if err := c.enforcePasswordExpiryGate(ctx, user); err != nil {
-		return nil, nil, "", err
-	}
-	// Enforce per-account brute-force lockout (distinct from deactivation/suspension).
-	// A locked account must not receive a new session via SSO even though the IdP
-	// authenticated it — the lockout signals an active attack and must be honoured on
-	// all login paths, same as password/TOTP/WebAuthn (see auth.go).
-	if c.loginLocked(user) {
-		return nil, nil, "", fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
-	}
-	if err := c.checkLockAndClearLoginFailures(ctx, user); err != nil {
 		return nil, nil, "", err
 	}
 	session, err := c.mintSession(ctx, user.ID, userAgent, ip)
@@ -353,6 +356,17 @@ func (c *KeyorixCore) CompleteSAML(ctx context.Context, name string, r *http.Req
 	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
 		return nil, nil, "", fmt.Errorf("account suspended")
 	}
+	// Enforce per-account brute-force lockout BEFORE any IdP-driven state mutation
+	// below (group/role reconciliation) — see the identical guard in CompleteSSO for
+	// the full rationale. A locked account's native group/role state must stay frozen
+	// while the lock is in effect, not silently resynced by a login attempt that's
+	// about to be refused anyway.
+	if c.loginLocked(user) {
+		return nil, nil, "", fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
+	if err := c.checkLockAndClearLoginFailures(ctx, user); err != nil {
+		return nil, nil, "", err
+	}
 
 	// Reconcile only when the assertion actually carried groups — an IdP that omits the
 	// groups attribute must not strip a user's memberships/roles (matches the OIDC
@@ -367,12 +381,6 @@ func (c *KeyorixCore) CompleteSAML(ctx context.Context, name string, r *http.Req
 	}
 
 	if err := c.enforcePasswordExpiryGate(ctx, user); err != nil {
-		return nil, nil, "", err
-	}
-	if c.loginLocked(user) {
-		return nil, nil, "", fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
-	}
-	if err := c.checkLockAndClearLoginFailures(ctx, user); err != nil {
 		return nil, nil, "", err
 	}
 	session, err := c.mintSession(ctx, user.ID, userAgent, ip)

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -760,6 +760,72 @@ func TestCompleteSSO_PasswordExpiredGateError(t *testing.T) {
 	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
 }
 
+// TestCompleteSSO_LockedAccountSkipsGroupRoleSync pins CORE-OIDC-04: a currently
+// brute-force-locked account must not have its native group memberships / mapped
+// role grants reconciled from the IdP assertion — and no reconciliation audit
+// written — when the login is about to be refused for that lock anyway. Before the
+// fix, group/role sync ran BEFORE the loginLocked check, so a locked account's
+// state (and audit trail) was mutated on every SSO attempt even though the
+// function went on to reject the login a few lines later. The id_token here
+// asserts a brand-new group that WOULD be added if reconciliation ran.
+func TestCompleteSSO_LockedAccountSkipsGroupRoleSync(t *testing.T) {
+	c, store, key, p := ssoTestCore(t)
+	c.loginLockout = LoginLockoutPolicy{
+		Enabled: true, MaxAttempts: 5, Window: time.Hour,
+		BaseCooldown: time.Minute, MaxCooldown: time.Hour,
+	}
+	p.GroupSync = true
+	p.GroupRoleMap = map[string]string{"keyorix-admins": "system_admin"}
+
+	lockedUntil := time.Now().Add(10 * time.Minute)
+	lockedUser := &models.User{
+		ID: 66, IsActive: true, AccountState: "active",
+		LoginLockedUntil: &lockedUntil, LoginLockoutCount: 1,
+	}
+
+	const testNonce = "nonce-locked"
+	idToken := signToken(t, key, "kid-1", jwt.MapClaims{
+		"iss":            "https://idp.test",
+		"aud":            "client-1",
+		"sub":            "okta|66",
+		"email":          "locked@x.io",
+		"email_verified": true,
+		"nonce":          testNonce,
+		"groups":         []string{"keyorix-admins"}, // would be added/mapped if reconciled
+		"exp":            time.Now().Add(time.Hour).Unix(),
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body := fmt.Sprintf(`{"access_token":"at","token_type":"Bearer","id_token":%q}`, idToken)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer ts.Close()
+	p.OAuth.Endpoint.TokenURL = ts.URL
+
+	store.On("ConsumeSSOLoginState", mock.Anything, "state-locked").Return(
+		&models.SSOLoginState{Provider: "okta", Nonce: testNonce, ReturnTo: "/dash", ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|66").Return(lockedUser, nil)
+
+	session, _, _, err := c.CompleteSSO(context.Background(), "okta", "auth-code", "state-locked", "ua", "1.2.3.4")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "temporarily locked")
+	assert.Nil(t, session)
+
+	// Group/role reconciliation must never even start (which also means no
+	// AddUserToGroup/AssignRole/LogAuditEvent for the sync).
+	store.AssertNotCalled(t, "ListGroups", mock.Anything)
+	store.AssertNotCalled(t, "GetUserGroups", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "GetUserRoles", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "AddUserToGroup", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+	// The account's own lockout state must be left untouched too — the login was
+	// refused, so nothing about the account (including its lock) should be cleared.
+	assert.Equal(t, 1, lockedUser.LoginLockoutCount)
+	assert.NotNil(t, lockedUser.LoginLockedUntil)
+}
+
 func TestSanitizeReturnTo(t *testing.T) {
 	assert.Equal(t, "/secrets", sanitizeReturnTo("/secrets"))
 	assert.Equal(t, "", sanitizeReturnTo("//evil.com"))

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1450,7 +1450,14 @@ type Storage interface {
 	GetSetupTokenByHash(ctx context.Context, hash string) (*models.SetupToken, error)
 	// SupersedeActiveSetupTokens flips every active token for (purpose, email) to
 	// superseded, so reissuing ("resend") atomically kills the prior link.
-	SupersedeActiveSetupTokens(ctx context.Context, purpose, email string) error
+	// projectID, when non-nil, additionally restricts the flip to tokens whose
+	// InvitationID belongs to that project (via project_invitations) — so a
+	// project-scoped invitation_accept reissue only supersedes that SAME project's
+	// pending invite to the address, not an unrelated project's (CORE-INVITATIONS-003).
+	// A nil projectID preserves the original (purpose, email)-only scope, which
+	// callers with no project dimension (global invites, account_setup,
+	// password_reset_link) still rely on.
+	SupersedeActiveSetupTokens(ctx context.Context, purpose, email string, projectID *uint) error
 	// MarkSetupTokenConsumed transitions active → consumed only if the token is still
 	// active, stamping consumedAt. It reports whether the transition happened, so a
 	// concurrent replay (state already consumed/expired/superseded) is rejected.

--- a/internal/rotation/coverage_test.go
+++ b/internal/rotation/coverage_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -56,24 +57,29 @@ func newFakeIAMService(t *testing.T, handler http.Handler) (*iamv1.Service, *htt
 	return svc, srv
 }
 
-// TestGCPIAMClient_ListKeyNames exercises gcpIAMClient.ListKeyNames against a
+// TestGCPIAMClient_ListKeys exercises gcpIAMClient.ListKeys against a
 // fake HTTP server that returns a 403 response — the method body is covered
 // even though the call fails.
-func TestGCPIAMClient_ListKeyNames(t *testing.T) {
+func TestGCPIAMClient_ListKeys(t *testing.T) {
 	svc, srv := newFakeIAMService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 	}))
 	defer srv.Close()
 
 	cl := &gcpIAMClient{svc: svc}
-	_, err := cl.ListKeyNames(context.Background(), "projects/-/serviceAccounts/fake@test.iam.gserviceaccount.com")
+	_, err := cl.ListKeys(context.Background(), "projects/-/serviceAccounts/fake@test.iam.gserviceaccount.com")
 	require.Error(t, err) // HTTP 403 from the fake server
 }
 
-// TestGCPIAMClient_ListKeyNames_Success exercises the happy path: the fake
-// server returns a valid key list JSON and ListKeyNames parses it.
-func TestGCPIAMClient_ListKeyNames_Success(t *testing.T) {
-	body := `{"keys":[{"name":"projects/-/serviceAccounts/sa/keys/k1"},{"name":"projects/-/serviceAccounts/sa/keys/k2"}]}`
+// TestGCPIAMClient_ListKeys_Success exercises the happy path: the fake
+// server returns a valid key list JSON (including a disabled key with a
+// ValidAfterTime) and ListKeys parses the metadata evictableServiceAccountKey
+// depends on, not just the names.
+func TestGCPIAMClient_ListKeys_Success(t *testing.T) {
+	body := `{"keys":[` +
+		`{"name":"projects/-/serviceAccounts/sa/keys/k1","validAfterTime":"2024-01-01T00:00:00Z"},` +
+		`{"name":"projects/-/serviceAccounts/sa/keys/k2","disabled":true,"validAfterTime":"2024-06-01T00:00:00Z"}` +
+		`]}`
 	svc, srv := newFakeIAMService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
@@ -81,9 +87,12 @@ func TestGCPIAMClient_ListKeyNames_Success(t *testing.T) {
 	defer srv.Close()
 
 	cl := &gcpIAMClient{svc: svc}
-	names, err := cl.ListKeyNames(context.Background(), "projects/-/serviceAccounts/fake@test.iam.gserviceaccount.com")
+	keys, err := cl.ListKeys(context.Background(), "projects/-/serviceAccounts/fake@test.iam.gserviceaccount.com")
 	require.NoError(t, err)
-	require.Len(t, names, 2)
+	require.Len(t, keys, 2)
+	assert.False(t, keys[0].Disabled)
+	assert.True(t, keys[1].Disabled)
+	assert.Equal(t, "2024-06-01T00:00:00Z", keys[1].ValidAfterTime)
 }
 
 // TestGCPIAMClient_CreateKey exercises gcpIAMClient.CreateKey against a fake

--- a/internal/rotation/gcpsa.go
+++ b/internal/rotation/gcpsa.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"time"
 
 	iam "google.golang.org/api/iam/v1"
 )
@@ -22,9 +23,18 @@ const gcpServiceAccountMaxKeys = 10
 // seam so the SDK stays contained here and tests inject a fake. saName is the resource
 // name "projects/-/serviceAccounts/<email>"; keyName is a full key resource name.
 type gcpKeyAPI interface {
-	ListKeyNames(ctx context.Context, saName string) ([]string, error)
+	ListKeys(ctx context.Context, saName string) ([]gcpServiceAccountKeyInfo, error)
 	CreateKey(ctx context.Context, saName string) (keyName, privateKeyJSON string, err error)
 	DeleteKey(ctx context.Context, keyName string) error
+}
+
+// gcpServiceAccountKeyInfo carries just enough per-key metadata to pick a safe eviction
+// candidate (see evictableServiceAccountKey) without exposing the full iam.ServiceAccountKey
+// SDK type through the gcpKeyAPI seam.
+type gcpServiceAccountKeyInfo struct {
+	Name           string
+	Disabled       bool
+	ValidAfterTime string // RFC3339; GCP's closest equivalent to AWS IAM's CreateDate
 }
 
 // GCPServiceAccountKeyExecutor rotates a GCP service account's user-managed key. The
@@ -91,15 +101,16 @@ func (e *GCPServiceAccountKeyExecutor) GenerateUpstream(ctx context.Context, ref
 	}
 
 	saName := "projects/-/serviceAccounts/" + ref
-	prior, err := cl.ListKeyNames(ctx, saName)
+	prior, err := cl.ListKeys(ctx, saName)
 	if err != nil {
 		return "", fmt.Errorf("gcp-service-account: list keys for %q: %w", ref, err)
 	}
 	if len(prior) >= gcpServiceAccountMaxKeys {
-		if err := cl.DeleteKey(ctx, prior[0]); err != nil {
+		victim := evictableServiceAccountKey(prior)
+		if err := cl.DeleteKey(ctx, victim); err != nil {
 			return "", fmt.Errorf("gcp-service-account: free key slot for %q: %w", ref, err)
 		}
-		prior = prior[1:]
+		prior = removeKeyByName(prior, victim)
 	}
 
 	_, keyJSON, err := cl.CreateKey(ctx, saName)
@@ -120,8 +131,8 @@ func (e *GCPServiceAccountKeyExecutor) GenerateUpstream(ctx context.Context, ref
 	var undeleted []string
 	var lastErr error
 	for _, kn := range prior {
-		if derr := cl.DeleteKey(ctx, kn); derr != nil {
-			undeleted = append(undeleted, kn)
+		if derr := cl.DeleteKey(ctx, kn.Name); derr != nil {
+			undeleted = append(undeleted, kn.Name)
 			lastErr = derr
 		}
 	}
@@ -135,19 +146,69 @@ func (e *GCPServiceAccountKeyExecutor) GenerateUpstream(ctx context.Context, ref
 	return keyJSON, nil
 }
 
+// evictableServiceAccountKey picks the safest key to remove when freeing a slot at the
+// per-service-account key cap: a Disabled key if any (returned as soon as one is seen,
+// regardless of order), otherwise the oldest by ValidAfterTime — the same
+// disabled/inactive-first, then-oldest principle awsiam.go's evictableAccessKey uses for
+// AWS IAM access keys, adapted to the fields GCP's ServiceAccountKey actually exposes
+// (Disabled instead of an Active/Inactive status enum; ValidAfterTime, an RFC3339
+// timestamp, instead of CreateDate). Returns "" when no candidate has a name.
+func evictableServiceAccountKey(keys []gcpServiceAccountKeyInfo) string {
+	victim := ""
+	var oldest time.Time
+	haveOldest := false
+	for _, k := range keys {
+		if k.Name == "" {
+			continue
+		}
+		if k.Disabled {
+			return k.Name
+		}
+		t, err := time.Parse(time.RFC3339, k.ValidAfterTime)
+		if !haveOldest || (err == nil && t.Before(oldest)) {
+			victim = k.Name
+			if err == nil {
+				oldest = t
+				haveOldest = true
+			}
+		}
+	}
+	return victim
+}
+
+// removeKeyByName returns keys with the entry named victim removed (at most one, since
+// key names are unique). Used after evicting a slot so the caller's local view of
+// remaining prior keys stays in sync with what was actually deleted.
+func removeKeyByName(keys []gcpServiceAccountKeyInfo, victim string) []gcpServiceAccountKeyInfo {
+	out := make([]gcpServiceAccountKeyInfo, 0, len(keys))
+	removed := false
+	for _, k := range keys {
+		if !removed && k.Name == victim {
+			removed = true
+			continue
+		}
+		out = append(out, k)
+	}
+	return out
+}
+
 // gcpIAMClient adapts *iam.Service to the gcpKeyAPI seam.
 type gcpIAMClient struct{ svc *iam.Service }
 
-func (g *gcpIAMClient) ListKeyNames(ctx context.Context, saName string) ([]string, error) {
+func (g *gcpIAMClient) ListKeys(ctx context.Context, saName string) ([]gcpServiceAccountKeyInfo, error) {
 	resp, err := g.svc.Projects.ServiceAccounts.Keys.List(saName).KeyTypes("USER_MANAGED").Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}
-	names := make([]string, 0, len(resp.Keys))
+	keys := make([]gcpServiceAccountKeyInfo, 0, len(resp.Keys))
 	for _, k := range resp.Keys {
-		names = append(names, k.Name)
+		keys = append(keys, gcpServiceAccountKeyInfo{
+			Name:           k.Name,
+			Disabled:       k.Disabled,
+			ValidAfterTime: k.ValidAfterTime,
+		})
 	}
-	return names, nil
+	return keys, nil
 }
 
 func (g *gcpIAMClient) CreateKey(ctx context.Context, saName string) (string, string, error) {

--- a/internal/rotation/gcpsa_test.go
+++ b/internal/rotation/gcpsa_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 type fakeGCP struct {
-	existing  []string // current user-managed key names
+	existing  []string                   // current user-managed key names (all enabled, no ValidAfterTime)
+	existingK []gcpServiceAccountKeyInfo // takes precedence over existing when non-nil, for tests needing Disabled/ValidAfterTime
 	newName   string
 	newJSON   string
 	createErr error
@@ -18,8 +19,15 @@ type fakeGCP struct {
 	deleted   []string
 }
 
-func (f *fakeGCP) ListKeyNames(_ context.Context, _ string) ([]string, error) {
-	return append([]string(nil), f.existing...), nil
+func (f *fakeGCP) ListKeys(_ context.Context, _ string) ([]gcpServiceAccountKeyInfo, error) {
+	if f.existingK != nil {
+		return append([]gcpServiceAccountKeyInfo(nil), f.existingK...), nil
+	}
+	keys := make([]gcpServiceAccountKeyInfo, len(f.existing))
+	for i, name := range f.existing {
+		keys[i] = gcpServiceAccountKeyInfo{Name: name}
+	}
+	return keys, nil
 }
 func (f *fakeGCP) CreateKey(_ context.Context, saName string) (string, string, error) {
 	if f.createErr != nil {
@@ -77,6 +85,48 @@ func TestGCPSA_GenerateUpstream_FreesSlotAtLimit(t *testing.T) {
 	require.NoError(t, err)
 	// All prior keys deleted (one to free the slot, the rest after create).
 	assert.Len(t, fake.deleted, gcpServiceAccountMaxKeys)
+}
+
+func TestEvictableServiceAccountKey_PrefersDisabledOverEnabled(t *testing.T) {
+	keys := []gcpServiceAccountKeyInfo{
+		{Name: "k/enabled-oldest", Disabled: false, ValidAfterTime: "2020-01-01T00:00:00Z"},
+		{Name: "k/disabled", Disabled: true, ValidAfterTime: "2025-01-01T00:00:00Z"},
+		{Name: "k/enabled-newest", Disabled: false, ValidAfterTime: "2026-01-01T00:00:00Z"},
+	}
+	// The naive prior[0] behavior this replaces would have evicted "k/enabled-oldest"
+	// (whatever GCP's unspecified list ordering happened to return first) — a
+	// different, WRONG answer from the disabled key, proving this test actually
+	// distinguishes correct from incorrect eviction selection.
+	assert.Equal(t, "k/disabled", evictableServiceAccountKey(keys))
+}
+
+func TestEvictableServiceAccountKey_PrefersOldestWhenAllEnabled(t *testing.T) {
+	keys := []gcpServiceAccountKeyInfo{
+		{Name: "k/newest", Disabled: false, ValidAfterTime: "2026-01-01T00:00:00Z"},
+		{Name: "k/oldest", Disabled: false, ValidAfterTime: "2020-01-01T00:00:00Z"},
+		{Name: "k/middle", Disabled: false, ValidAfterTime: "2023-01-01T00:00:00Z"},
+	}
+	assert.Equal(t, "k/oldest", evictableServiceAccountKey(keys))
+}
+
+func TestGCPSA_GenerateUpstream_FreesSlotAtLimit_PrefersDisabledKey(t *testing.T) {
+	existingK := make([]gcpServiceAccountKeyInfo, gcpServiceAccountMaxKeys)
+	for i := range existingK {
+		existingK[i] = gcpServiceAccountKeyInfo{
+			Name:           "k/OLD" + string(rune('A'+i)),
+			ValidAfterTime: "2020-01-01T00:00:00Z",
+		}
+	}
+	// The one disabled key sorts last by name/order, so a prior[0]-style eviction
+	// would never pick it — only the disabled-first preference does.
+	existingK[len(existingK)-1].Disabled = true
+	wantEvicted := existingK[len(existingK)-1].Name
+
+	fake := &fakeGCP{existingK: existingK, newName: "k/NEW", newJSON: `{"k":"v"}`}
+	_, err := gcpWith(fake, "svc-").GenerateUpstream(context.Background(), "svc-app@p.iam")
+	require.NoError(t, err)
+	require.NotEmpty(t, fake.deleted)
+	assert.Equal(t, wantEvicted, fake.deleted[0], "the disabled key must be freed first, not prior[0]")
 }
 
 func TestGCPSA_GenerateUpstream_Errors(t *testing.T) {

--- a/internal/rotation/rotation_s17_test.go
+++ b/internal/rotation/rotation_s17_test.go
@@ -231,8 +231,12 @@ type fakeGCPDeleteErr struct {
 	deleted   []string
 }
 
-func (f *fakeGCPDeleteErr) ListKeyNames(_ context.Context, _ string) ([]string, error) {
-	return append([]string(nil), f.existing...), nil
+func (f *fakeGCPDeleteErr) ListKeys(_ context.Context, _ string) ([]gcpServiceAccountKeyInfo, error) {
+	keys := make([]gcpServiceAccountKeyInfo, len(f.existing))
+	for i, name := range f.existing {
+		keys[i] = gcpServiceAccountKeyInfo{Name: name}
+	}
+	return keys, nil
 }
 func (f *fakeGCPDeleteErr) CreateKey(_ context.Context, saName string) (string, string, error) {
 	return f.newName, f.newJSON, nil
@@ -286,7 +290,7 @@ func TestGCP_GenerateUpstream_ListError(t *testing.T) {
 
 type listErrGCP struct{}
 
-func (f *listErrGCP) ListKeyNames(_ context.Context, _ string) ([]string, error) {
+func (f *listErrGCP) ListKeys(_ context.Context, _ string) ([]gcpServiceAccountKeyInfo, error) {
 	return nil, errors.New("list failed")
 }
 func (f *listErrGCP) CreateKey(_ context.Context, _ string) (string, string, error) {
@@ -306,7 +310,7 @@ func TestGCP_GenerateUpstream_EmptyKeyJSON(t *testing.T) {
 
 type emptyKeyGCP struct{}
 
-func (f *emptyKeyGCP) ListKeyNames(_ context.Context, _ string) ([]string, error) {
+func (f *emptyKeyGCP) ListKeys(_ context.Context, _ string) ([]gcpServiceAccountKeyInfo, error) {
 	return nil, nil
 }
 func (f *emptyKeyGCP) CreateKey(_ context.Context, _ string) (string, string, error) {
@@ -331,8 +335,12 @@ func TestGCP_GenerateUpstream_FreesSlot_DeleteFails(t *testing.T) {
 
 type slotFreeErrGCP struct{ existing []string }
 
-func (f *slotFreeErrGCP) ListKeyNames(_ context.Context, _ string) ([]string, error) {
-	return append([]string(nil), f.existing...), nil
+func (f *slotFreeErrGCP) ListKeys(_ context.Context, _ string) ([]gcpServiceAccountKeyInfo, error) {
+	keys := make([]gcpServiceAccountKeyInfo, len(f.existing))
+	for i, name := range f.existing {
+		keys[i] = gcpServiceAccountKeyInfo{Name: name}
+	}
+	return keys, nil
 }
 func (f *slotFreeErrGCP) CreateKey(_ context.Context, _ string) (string, string, error) {
 	return "k/NEW", `{"k":"v"}`, nil

--- a/internal/rotation/rotation_s22_test.go
+++ b/internal/rotation/rotation_s22_test.go
@@ -296,8 +296,12 @@ type fakeGCPMixedDelete struct {
 	deleted  []string
 }
 
-func (f *fakeGCPMixedDelete) ListKeyNames(_ context.Context, _ string) ([]string, error) {
-	return append([]string(nil), f.existing...), nil
+func (f *fakeGCPMixedDelete) ListKeys(_ context.Context, _ string) ([]gcpServiceAccountKeyInfo, error) {
+	keys := make([]gcpServiceAccountKeyInfo, len(f.existing))
+	for i, name := range f.existing {
+		keys[i] = gcpServiceAccountKeyInfo{Name: name}
+	}
+	return keys, nil
 }
 func (f *fakeGCPMixedDelete) CreateKey(_ context.Context, _ string) (string, string, error) {
 	return f.newName, f.newJSON, nil

--- a/internal/rotation/rotation_s23_test.go
+++ b/internal/rotation/rotation_s23_test.go
@@ -180,8 +180,12 @@ type fakeGCPNearLimit struct {
 	deleted  []string
 }
 
-func (f *fakeGCPNearLimit) ListKeyNames(_ context.Context, _ string) ([]string, error) {
-	return append([]string(nil), f.existing...), nil
+func (f *fakeGCPNearLimit) ListKeys(_ context.Context, _ string) ([]gcpServiceAccountKeyInfo, error) {
+	keys := make([]gcpServiceAccountKeyInfo, len(f.existing))
+	for i, name := range f.existing {
+		keys[i] = gcpServiceAccountKeyInfo{Name: name}
+	}
+	return keys, nil
 }
 func (f *fakeGCPNearLimit) CreateKey(_ context.Context, _ string) (string, string, error) {
 	return "k/NEW", `{"type":"service_account","key":"new"}`, nil
@@ -223,8 +227,12 @@ type fakeGCPSlotFreeThenCreateErr struct {
 	deleted  []string
 }
 
-func (f *fakeGCPSlotFreeThenCreateErr) ListKeyNames(_ context.Context, _ string) ([]string, error) {
-	return append([]string(nil), f.existing...), nil
+func (f *fakeGCPSlotFreeThenCreateErr) ListKeys(_ context.Context, _ string) ([]gcpServiceAccountKeyInfo, error) {
+	keys := make([]gcpServiceAccountKeyInfo, len(f.existing))
+	for i, name := range f.existing {
+		keys[i] = gcpServiceAccountKeyInfo{Name: name}
+	}
+	return keys, nil
 }
 func (f *fakeGCPSlotFreeThenCreateErr) CreateKey(_ context.Context, _ string) (string, string, error) {
 	return "", "", errors.New("GCP: quota exceeded")

--- a/internal/secrettemplate/render.go
+++ b/internal/secrettemplate/render.go
@@ -3,11 +3,20 @@
 // and storage-agnostic core: the caller supplies a Resolver that maps a reference to
 // a value (with its own permission checks). Rendered output is never logged by this
 // package.
+//
+// Render's default substitution is raw and format-agnostic, matching today's only
+// callers (.env/config-style single-line KV rendering). A caller building a JSON or
+// YAML document around a placeholder should use RenderJSON/RenderYAML (or
+// RenderWithOptions with RenderOptions.Escape) instead, so a secret value can't break
+// out of its quoted field and inject or overwrite an adjacent key.
 package secrettemplate
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // marker is the placeholder prefix; a reference looks like ${secret:<ref>}.
@@ -98,6 +107,95 @@ func parse(tmpl string) (segments []segment, distinct []string, err error) { // 
 	return segments, distinct, nil
 }
 
+// EscapeFunc transforms one resolved secret value immediately before it is written
+// into the rendered output, so it can be embedded safely in a specific output
+// format (see RenderOptions.Escape). It runs AFTER Render's newline/CR/NUL and
+// shell-metacharacter guards below — those guards inspect the raw resolver output,
+// so their rejection behavior is identical regardless of which EscapeFunc (or none)
+// is configured; Escape only changes how a value that already passed those guards
+// is written out.
+type EscapeFunc func(string) string
+
+// RenderOptions configures optional processing beyond Render's default raw,
+// format-agnostic substitution. The zero value (Escape == nil) reproduces Render's
+// exact current behavior, so passing RenderOptions{} to RenderWithOptions is
+// identical to calling Render — existing callers that never opt in are unaffected.
+type RenderOptions struct {
+	// Escape, when non-nil, is applied to each resolved secret value before it is
+	// substituted into the output (template literal text is never escaped, only
+	// resolved reference values). Leave nil for Render's traditional raw-substitution
+	// behavior, which is still correct for the documented .env/config use case where
+	// a rendered line is consumed as-is.
+	//
+	// Set this when the template itself is a JSON or YAML document (or fragment) that
+	// embeds a placeholder inside a quoted string field, e.g.
+	// `{"password": "${secret:prod/db}"}`. Without escaping, a secret value
+	// containing an unescaped '"', '\', or other format-significant character can
+	// break out of the intended string field and inject or overwrite an adjacent
+	// key — the secret's value is controlled by whoever can write that one secret,
+	// who may be far less trusted than the template's author. EscapeJSONString and
+	// EscapeYAMLString (or the RenderJSON/RenderYAML convenience wrappers) close
+	// that gap for their respective formats.
+	Escape EscapeFunc
+}
+
+// EscapeJSONString escapes val so it can be embedded inside a JSON string literal's
+// quotes (i.e. as the value written between the surrounding `"..."` a JSON/text
+// template already supplies) without letting val's content close that string early
+// or alter the document's structure — quotes, backslashes, and control characters
+// (including newlines) are all escaped per the JSON string grammar. It does NOT add
+// the surrounding quotes itself, since the template is expected to already contain
+// them (e.g. `"${secret:prod/db}"` inside a JSON document).
+func EscapeJSONString(val string) string {
+	// encoding/json's string encoding already implements exactly this escaping
+	// (RFC 8259 §7); marshal the value as a JSON string and strip the quotes
+	// json.Marshal adds, rather than reimplementing the escape table by hand.
+	b, err := json.Marshal(val)
+	if err != nil {
+		// json.Marshal on a plain Go string cannot fail (no cycles, no unsupported
+		// types) — this is unreachable in practice. Fall back to a value that is at
+		// least guaranteed not to contain a raw '"' or '\', rather than panicking.
+		return strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(val)
+	}
+	return string(b[1 : len(b)-1])
+}
+
+// EscapeYAMLString escapes val so it can be embedded inside a double-quoted YAML
+// scalar's quotes (i.e. as the value written between the surrounding `"..."` a
+// template already supplies), mirroring EscapeJSONString for YAML documents. It
+// forces yaml.v3's double-quoted scalar encoding (rather than letting it choose
+// plain/single-quoted/literal style, which would produce output that doesn't fit
+// inside pre-existing template quotes) and strips the quotes yaml.Marshal adds,
+// since the template already supplies them.
+func EscapeYAMLString(val string) string {
+	node := yaml.Node{Kind: yaml.ScalarNode, Style: yaml.DoubleQuotedStyle, Value: val}
+	if b, err := yaml.Marshal(&node); err == nil {
+		s := strings.TrimSuffix(string(b), "\n")
+		if len(s) >= 2 && strings.HasPrefix(s, `"`) && strings.HasSuffix(s, `"`) {
+			return s[1 : len(s)-1]
+		}
+	}
+	// yaml.Node.MarshalYAML on a double-quoted scalar node is not expected to fail or
+	// return an unexpected shape; fall back defensively rather than risk emitting an
+	// unescaped value.
+	return strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(val)
+}
+
+// RenderJSON is Render with Escape set to EscapeJSONString: use it when tmpl is a
+// JSON document or fragment that embeds ${secret:<ref>} placeholders inside quoted
+// string fields, so a substituted secret value cannot break out of its field.
+func RenderJSON(tmpl string, resolve Resolver) (string, error) {
+	return RenderWithOptions(tmpl, resolve, RenderOptions{Escape: EscapeJSONString})
+}
+
+// RenderYAML is Render with Escape set to EscapeYAMLString: use it when tmpl is a
+// YAML document or fragment that embeds ${secret:<ref>} placeholders inside
+// double-quoted scalar fields, so a substituted secret value cannot break out of
+// its field.
+func RenderYAML(tmpl string, resolve Resolver) (string, error) {
+	return RenderWithOptions(tmpl, resolve, RenderOptions{Escape: EscapeYAMLString})
+}
+
 // Render expands every ${secret:<ref>} placeholder in tmpl using resolve and returns
 // the result. See parse for the placeholder syntax rules and the
 // MaxDistinctReferences cap; a resolver error aborts the render, naming the
@@ -110,7 +208,18 @@ func parse(tmpl string) (segments []segment, distinct []string, err error) { // 
 // audit/read-logging — when a template repeats a reference, and combined with
 // MaxDistinctReferences bounds the total resolver work a single render can
 // trigger regardless of how many placeholder occurrences the template contains.
+//
+// Render performs no format-specific escaping of substituted values — see
+// RenderOptions.Escape / RenderJSON / RenderYAML for that. This is equivalent to
+// RenderWithOptions(tmpl, resolve, RenderOptions{}).
 func Render(tmpl string, resolve Resolver) (string, error) {
+	return RenderWithOptions(tmpl, resolve, RenderOptions{})
+}
+
+// RenderWithOptions is Render with optional additional processing — currently just
+// format-specific escaping of substituted values, see RenderOptions.Escape. Passing
+// the zero RenderOptions{} is identical to Render.
+func RenderWithOptions(tmpl string, resolve Resolver, opts RenderOptions) (string, error) {
 	segments, distinct, err := parse(tmpl)
 	if err != nil {
 		return "", err
@@ -122,10 +231,12 @@ func Render(tmpl string, resolve Resolver) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("resolve %q: %w", ref, err)
 		}
-		// This package is a raw, format-agnostic substitution engine: it has no idea
-		// whether the caller's template is a .env file, a YAML/JSON document, or a
-		// shell script, so it can't apply format-specific escaping (quoting a YAML
-		// scalar, JSON-string-escaping, shell-quoting, ...). What every one of those
+		// By default (RenderOptions.Escape == nil, i.e. plain Render) this package is a
+		// raw, format-agnostic substitution engine: it doesn't know whether the
+		// caller's template is a .env file, a YAML/JSON document, or a shell script, so
+		// it applies no format-specific escaping (quoting a YAML scalar, JSON-string-
+		// escaping, shell-quoting, ...) unless the caller opts in via
+		// RenderOptions.Escape / RenderJSON / RenderYAML below. What every one of those
 		// targets shares, though, is that an embedded newline/CR turns one substituted
 		// value into multiple *lines* of output, and the documented use case
 		// (internal/cli/secret/render.go) is exactly "write this straight to a .env/
@@ -156,6 +267,14 @@ func Render(tmpl string, resolve Resolver) (string, error) {
 		// not a substitute for shell-quoting the output.)
 		if strings.ContainsAny(val, "`;|&<>") || strings.Contains(val, "$(") {
 			return "", fmt.Errorf("resolve %q: secret value contains a shell metacharacter and cannot be safely substituted into output that may later be sourced as a shell script", ref)
+		}
+		// Format-specific escaping (opts.Escape, see RenderOptions) runs AFTER the
+		// guards above, on the value that already passed them — so the guards' raw-
+		// value rejection behavior is unconditional and identical whether or not an
+		// EscapeFunc is configured. Escape only changes how a value that passed those
+		// guards is subsequently embedded in the output.
+		if opts.Escape != nil {
+			val = opts.Escape(val)
 		}
 		resolved[ref] = val
 	}

--- a/internal/secrettemplate/render_test.go
+++ b/internal/secrettemplate/render_test.go
@@ -1,6 +1,7 @@
 package secrettemplate
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // upper is a trivial resolver that echoes a value per ref, or errors on "missing".
@@ -284,4 +286,165 @@ func TestReferences_RejectsTooManyDistinctReferences(t *testing.T) {
 	}
 	_, err := References(tmpl.String())
 	require.Error(t, err)
+}
+
+// RenderWithOptions(tmpl, resolve, RenderOptions{}) — the zero value — must render
+// byte-for-byte identically to Render, and Render itself must be unaffected by the
+// existence of RenderOptions/RenderWithOptions. This is the "additive only, no
+// default-behavior change" guarantee the escaping option depends on.
+func TestRenderWithOptions_ZeroValueMatchesRender(t *testing.T) {
+	tmpl := "host=${secret:prod/host} user=${secret:prod/user} pass=${secret:prod/pass}"
+	resolve := func(ref string) (string, error) { return "[" + ref + "]", nil }
+
+	want, err := Render(tmpl, resolve)
+	require.NoError(t, err)
+
+	got, err := RenderWithOptions(tmpl, resolve, RenderOptions{})
+	require.NoError(t, err)
+
+	assert.Equal(t, want, got)
+}
+
+// EscapeJSONString must produce content that, wrapped in a pair of double quotes,
+// round-trips back to the exact original value when parsed as a JSON string — for
+// values containing quotes, backslashes, control characters (including newlines),
+// and characters (like ':') that are JSON-significant in other contexts but not
+// inside a string.
+func TestEscapeJSONString_RoundTrips(t *testing.T) {
+	cases := map[string]string{
+		"double quote":           `x"y`,
+		"backslash":              `x\y`,
+		"quote and backslash":    `x\"y`,
+		"newline":                "x\ny",
+		"crlf":                   "x\r\ny",
+		"tab":                    "x\ty",
+		"colon":                  "x:y",
+		"json injection payload": `x", "admin": true, "x":"`,
+		"unicode":                "snowman ☃ emoji \U0001F600",
+	}
+	for name, val := range cases {
+		t.Run(name, func(t *testing.T) {
+			escaped := EscapeJSONString(val)
+			wrapped := `"` + escaped + `"`
+			require.True(t, json.Valid([]byte(wrapped)), "escaped value wrapped in quotes must be a valid JSON string literal: %q", wrapped)
+			var got string
+			require.NoError(t, json.Unmarshal([]byte(wrapped), &got))
+			assert.Equal(t, val, got, "round-tripping the escaped value through a JSON string must reproduce the original")
+		})
+	}
+}
+
+// EscapeYAMLString must produce content that, wrapped in a pair of double quotes,
+// round-trips back to the exact original value when parsed as a YAML double-quoted
+// scalar — mirroring TestEscapeJSONString_RoundTrips for YAML.
+func TestEscapeYAMLString_RoundTrips(t *testing.T) {
+	cases := map[string]string{
+		"double quote":           `x"y`,
+		"backslash":              `x\y`,
+		"quote and backslash":    `x\"y`,
+		"newline":                "x\ny",
+		"crlf":                   "x\r\ny",
+		"tab":                    "x\ty",
+		"colon":                  "x: y",
+		"yaml injection payload": "x\"\nadmin: true\nx: \"",
+		"unicode":                "snowman ☃ emoji \U0001F600",
+	}
+	for name, val := range cases {
+		t.Run(name, func(t *testing.T) {
+			escaped := EscapeYAMLString(val)
+			wrapped := `"` + escaped + `"`
+			var got string
+			require.NoError(t, yaml.Unmarshal([]byte(wrapped), &got), "escaped value wrapped in quotes must parse as a valid YAML double-quoted scalar: %q", wrapped)
+			assert.Equal(t, val, got, "round-tripping the escaped value through a YAML double-quoted scalar must reproduce the original")
+		})
+	}
+}
+
+// This is the exact exploit scenario from the finding: a template building a JSON
+// document around a placeholder (`{"password": "${secret:...}"}`), and a lower-trust
+// secret-writer setting the value to a payload designed to close the "password"
+// string early and inject a sibling "admin" field. First prove the vulnerability is
+// real for the default, raw Render (documenting exactly why RenderJSON exists), then
+// prove RenderJSON neutralizes it: the payload lands intact as the "password" value
+// and no "admin" field is injected.
+func TestRenderJSON_NeutralizesJSONFieldInjection(t *testing.T) {
+	const payload = `x", "admin": true, "x":"`
+	resolve := func(ref string) (string, error) { return payload, nil }
+	tmpl := `{"password": "${secret:prod/db}"}`
+
+	// Sanity check: raw Render's substitution is naive text splicing, so this
+	// crafted payload happens to produce syntactically valid JSON with an injected
+	// "admin" field — demonstrating the vulnerability RenderJSON exists to close.
+	raw, err := Render(tmpl, resolve)
+	require.NoError(t, err)
+	var rawParsed map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(raw), &rawParsed), "raw output: %s", raw)
+	assert.Equal(t, true, rawParsed["admin"], "raw Render's substitution let the secret value inject an unrelated admin field")
+	assert.NotEqual(t, payload, rawParsed["password"], "raw Render's password field was truncated by the injected quote, not left intact")
+
+	// The fix: RenderJSON escapes the value before substitution, so it can't break
+	// out of the "password" string field at all.
+	out, err := RenderJSON(tmpl, resolve)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &parsed), "RenderJSON output: %s", out)
+	assert.Equal(t, payload, parsed["password"], "RenderJSON must preserve the secret value exactly, as the password field's content")
+	_, hasAdmin := parsed["admin"]
+	assert.False(t, hasAdmin, "RenderJSON must not allow the secret value to inject a sibling admin field")
+}
+
+// Same scenario as TestRenderJSON_NeutralizesJSONFieldInjection, but for a template
+// that builds a YAML flow-style mapping (YAML's flow style is close enough to JSON
+// syntax that the same quote-breakout shape applies) around a placeholder.
+func TestRenderYAML_NeutralizesFlowMappingInjection(t *testing.T) {
+	const payload = `x", "admin": true, "x":"`
+	resolve := func(ref string) (string, error) { return payload, nil }
+	tmpl := `{"password": "${secret:prod/db}"}`
+
+	raw, err := Render(tmpl, resolve)
+	require.NoError(t, err)
+	var rawParsed map[string]interface{}
+	require.NoError(t, yaml.Unmarshal([]byte(raw), &rawParsed), "raw output: %s", raw)
+	assert.Equal(t, true, rawParsed["admin"], "raw Render's substitution let the secret value inject an unrelated admin field")
+
+	out, err := RenderYAML(tmpl, resolve)
+	require.NoError(t, err)
+	var parsed map[string]interface{}
+	require.NoError(t, yaml.Unmarshal([]byte(out), &parsed), "RenderYAML output: %s", out)
+	assert.Equal(t, payload, parsed["password"], "RenderYAML must preserve the secret value exactly, as the password field's content")
+	_, hasAdmin := parsed["admin"]
+	assert.False(t, hasAdmin, "RenderYAML must not allow the secret value to inject a sibling admin field")
+}
+
+// RenderJSON/RenderYAML must still enforce the SAME newline/CR/NUL and
+// shell-metacharacter guards Render does — escaping only changes how a value that
+// already passed those guards is embedded in the output, it does not loosen what's
+// accepted in the first place (see RenderWithOptions/EscapeFunc doc comments).
+func TestRenderJSON_StillRejectsControlCharsAndShellMetacharacters(t *testing.T) {
+	t.Run("newline still rejected", func(t *testing.T) {
+		resolve := func(ref string) (string, error) { return "foo\nbar", nil }
+		_, err := RenderJSON(`{"x": "${secret:prod/db}"}`, resolve)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be safely substituted")
+	})
+	t.Run("shell metacharacter still rejected", func(t *testing.T) {
+		resolve := func(ref string) (string, error) { return "$(curl evil|bash)", nil }
+		_, err := RenderJSON(`{"x": "${secret:prod/db}"}`, resolve)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be safely substituted")
+	})
+}
+
+// A plain value with no format-significant characters must render identically
+// through RenderJSON/RenderYAML as through Render — escaping must be a no-op for the
+// overwhelmingly common case, not just "safe" in the adversarial one.
+func TestRenderJSON_PlainValueUnaffectedByEscaping(t *testing.T) {
+	resolve := func(ref string) (string, error) { return "S3cr3t-Value_123", nil }
+	tmpl := `{"password": "${secret:prod/db}"}`
+
+	want, err := Render(tmpl, resolve)
+	require.NoError(t, err)
+	got, err := RenderJSON(tmpl, resolve)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
 }

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -357,6 +357,27 @@ func SecureDeleteFile(path string) error {
 	return SyncDir(filepath.Dir(path))
 }
 
+// unixOctalMode renders m in conventional Unix chmod notation (e.g. "4600" for
+// setuid+rw-------), rather than Go's raw %o formatting of os.FileMode, which
+// packs the special bits far above bit 8 and prints as a number no operator
+// would recognize (e.g. "40000600").
+func unixOctalMode(m os.FileMode) string {
+	special := 0
+	if m&os.ModeSetuid != 0 {
+		special |= 4
+	}
+	if m&os.ModeSetgid != 0 {
+		special |= 2
+	}
+	if m&os.ModeSticky != 0 {
+		special |= 1
+	}
+	if special == 0 {
+		return fmt.Sprintf("%o", m.Perm())
+	}
+	return fmt.Sprintf("%o%03o", special, m.Perm())
+}
+
 // FixFilePerms verifies file permissions and ownership.
 // If autofix=true, it will attempt to correct any mismatches.
 func FixFilePerms(files []FilePermSpec, autofix bool) error { // NOSONAR -- cognitive complexity 33, suppress go:S3776
@@ -403,10 +424,17 @@ func FixFilePerms(files []FilePermSpec, autofix bool) error { // NOSONAR -- cogn
 			continue
 		}
 
-		// Check permissions
+		// Check permissions. info.Mode().Perm() masks to only the low 9 rwx bits,
+		// silently dropping any setuid/setgid/sticky bits — a file whose low 9 bits
+		// already match f.Mode but ALSO carries one of those special bits would
+		// otherwise compare equal and never get chmod'd, leaving the special bit in
+		// place through a pass whose entire purpose is to lock these files down.
+		// Check for it explicitly so it's caught (and, via the unconditional
+		// file.Chmod(f.Mode) below, cleared — f.Mode never carries these bits itself).
 		actualMode := info.Mode().Perm()
-		if actualMode != f.Mode {
-			msg := fmt.Sprintf("File %s has mode %o but expected %o", f.Path, actualMode, f.Mode)
+		hasSpecialBits := info.Mode()&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0
+		if actualMode != f.Mode || hasSpecialBits {
+			msg := fmt.Sprintf("File %s has mode %s but expected %o", f.Path, unixOctalMode(info.Mode()), f.Mode)
 			hasWarnings = true
 			if autofix {
 				if err := file.Chmod(f.Mode); err != nil {

--- a/internal/securefiles/securefiles_test.go
+++ b/internal/securefiles/securefiles_test.go
@@ -291,6 +291,34 @@ func TestFixFilePermsCorrectModeNoWarning(t *testing.T) {
 	require.NoError(t, FixFilePerms([]FilePermSpec{{Path: p, Mode: 0600}}, false))
 }
 
+// TestFixFilePermsClearsSetuidBitEvenWhenLow9BitsMatch pins the fix for the
+// info.Mode().Perm() masking gap: a file whose low 9 bits already equal the
+// target mode but which ALSO carries the setuid bit must still be corrected —
+// actualMode == f.Mode alone must not be treated as "nothing to do".
+func TestFixFilePermsClearsSetuidBitEvenWhenLow9BitsMatch(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "setuid.key")
+	require.NoError(t, os.WriteFile(p, []byte("x"), 0600))
+	require.NoError(t, os.Chmod(p, os.ModeSetuid|0600))
+
+	info, err := os.Stat(p)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0600), info.Mode().Perm(), "low 9 bits already match the target mode")
+	require.NotZero(t, info.Mode()&os.ModeSetuid, "setuid bit must actually be set going in")
+
+	// Audit only: the special bit alone must still be reported as a mismatch.
+	err = FixFilePerms([]FilePermSpec{{Path: p, Mode: 0600}}, false)
+	require.Error(t, err, "a setuid bit on an otherwise-correct-mode file must still warn")
+	info, _ = os.Stat(p)
+	assert.NotZero(t, info.Mode()&os.ModeSetuid, "audit-only must not modify the file")
+
+	// Autofix: the setuid bit must be stripped even though actualMode == f.Mode.
+	require.NoError(t, FixFilePerms([]FilePermSpec{{Path: p, Mode: 0600}}, true))
+	info, _ = os.Stat(p)
+	assert.Zero(t, info.Mode()&os.ModeSetuid, "autofix must clear the setuid bit")
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
 func TestFixFilePermsMissingFileWarns(t *testing.T) {
 	err := FixFilePerms([]FilePermSpec{{Path: filepath.Join(t.TempDir(), "absent"), Mode: 0600}}, false)
 	require.Error(t, err)

--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -374,11 +374,22 @@ func (ls *LocalStorage) GetSetupTokenByHash(ctx context.Context, hash string) (*
 }
 
 // SupersedeActiveSetupTokens flips every active token for (purpose, email) to
-// superseded so a reissue kills the prior link atomically.
-func (ls *LocalStorage) SupersedeActiveSetupTokens(ctx context.Context, purpose, email string) error {
-	return ls.db.WithContext(ctx).Model(&models.SetupToken{}).
-		Where("purpose = ? AND subject_email = ? AND state = ?", purpose, email, "active").
-		Update("state", "superseded").Error
+// superseded so a reissue kills the prior link atomically. When projectID is
+// non-nil, the flip is additionally restricted to tokens whose InvitationID
+// belongs to that project (a subquery against project_invitations) — this is
+// how a project-scoped invitation_accept reissue is kept from superseding a
+// different project's still-pending invite to the same address
+// (CORE-INVITATIONS-003). A nil projectID keeps the original unscoped
+// (purpose, email) behavior for callers with no project dimension (global
+// invites, account_setup, password_reset_link).
+func (ls *LocalStorage) SupersedeActiveSetupTokens(ctx context.Context, purpose, email string, projectID *uint) error {
+	q := ls.db.WithContext(ctx).Model(&models.SetupToken{}).
+		Where("purpose = ? AND subject_email = ? AND state = ?", purpose, email, "active")
+	if projectID != nil {
+		q = q.Where("invitation_id IN (?)",
+			ls.db.Model(&models.ProjectInvitation{}).Select("id").Where("project_id = ?", *projectID))
+	}
+	return q.Update("state", "superseded").Error
 }
 
 // MarkSetupTokenConsumed transitions active → consumed only if still active. The

--- a/internal/storage/store/remote_auth.go
+++ b/internal/storage/store/remote_auth.go
@@ -238,11 +238,15 @@ func (rs *RemoteStorage) GetSetupTokenByHash(ctx context.Context, hash string) (
 // SupersedeActiveSetupTokens flips every active token for (purpose, email) to
 // superseded via POST /api/v1/system/setup-tokens/supersede, preserving
 // local_auth.go's exact semantics: a reissue kills the prior link atomically.
-func (rs *RemoteStorage) SupersedeActiveSetupTokens(ctx context.Context, purpose, email string) error {
+// projectID, when non-nil, is forwarded so the upstream server restricts the
+// flip to that project's own invitations (CORE-INVITATIONS-003) — see
+// local_auth.go's SupersedeActiveSetupTokens for the full rationale.
+func (rs *RemoteStorage) SupersedeActiveSetupTokens(ctx context.Context, purpose, email string, projectID *uint) error {
 	body := struct {
 		Purpose      string `json:"purpose"`
 		SubjectEmail string `json:"subject_email"`
-	}{Purpose: purpose, SubjectEmail: email}
+		ProjectID    *uint  `json:"project_id,omitempty"`
+	}{Purpose: purpose, SubjectEmail: email, ProjectID: projectID}
 	resp, err := rs.client.Post(ctx, "/api/v1/system/setup-tokens/supersede", body)
 	if err != nil {
 		return fmt.Errorf("failed to supersede setup tokens: %w", err)

--- a/internal/storage/store/remote_auth_test.go
+++ b/internal/storage/store/remote_auth_test.go
@@ -319,8 +319,30 @@ func TestRemoteStorage_SupersedeActiveSetupTokens(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	err = rs.SupersedeActiveSetupTokens(context.Background(), "account_setup", "user@example.com")
+	err = rs.SupersedeActiveSetupTokens(context.Background(), "account_setup", "user@example.com", nil)
 	require.NoError(t, err)
+}
+
+// TestRemoteStorage_SupersedeActiveSetupTokens_ForwardsProjectID proves the
+// project_id scoping parameter (CORE-INVITATIONS-003) crosses the HTTP hop rather
+// than being silently dropped by RemoteStorage.
+func TestRemoteStorage_SupersedeActiveSetupTokens_ForwardsProjectID(t *testing.T) {
+	var gotBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/system/setup-tokens/supersede", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	projectID := uint(42)
+	err = rs.SupersedeActiveSetupTokens(context.Background(), "invitation_accept", "user@example.com", &projectID)
+	require.NoError(t, err)
+	assert.Equal(t, float64(42), gotBody["project_id"], "project_id must be forwarded on the wire")
 }
 
 func TestRemoteStorage_SupersedeActiveSetupTokens_Error(t *testing.T) {
@@ -336,7 +358,7 @@ func TestRemoteStorage_SupersedeActiveSetupTokens_Error(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	err = rs.SupersedeActiveSetupTokens(context.Background(), "account_setup", "user@example.com")
+	err = rs.SupersedeActiveSetupTokens(context.Background(), "account_setup", "user@example.com", nil)
 	assert.Error(t, err)
 }
 

--- a/internal/storage/store/store_s22_test.go
+++ b/internal/storage/store/store_s22_test.go
@@ -317,7 +317,7 @@ func TestSetupTokenLifecycle_S22(t *testing.T) {
 	require.Error(t, err)
 
 	// SupersedeActiveSetupTokens — flips active to superseded.
-	require.NoError(t, ls.SupersedeActiveSetupTokens(ctx, "password_reset_link", "alice@test.io"))
+	require.NoError(t, ls.SupersedeActiveSetupTokens(ctx, "password_reset_link", "alice@test.io", nil))
 	reloaded, err := ls.GetSetupTokenByHash(ctx, "abc123")
 	require.NoError(t, err)
 	assert.Equal(t, "superseded", reloaded.State)

--- a/internal/storage/store/store_s3_test.go
+++ b/internal/storage/store/store_s3_test.go
@@ -93,8 +93,9 @@ func TestSetupToken_SupersedeActiveTokens(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Supersede all active tokens for this (purpose, email).
-	require.NoError(t, ls.SupersedeActiveSetupTokens(ctx, "invitation_accept", "bob@example.com"))
+	// Supersede all active tokens for this (purpose, email) — unscoped (projectID nil),
+	// the behavior account_setup/password_reset_link/global invites still rely on.
+	require.NoError(t, ls.SupersedeActiveSetupTokens(ctx, "invitation_accept", "bob@example.com", nil))
 
 	// Both tokens should now be superseded.
 	for _, hash := range []string{"h1", "h2"} {
@@ -102,6 +103,74 @@ func TestSetupToken_SupersedeActiveTokens(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "superseded", got.State)
 	}
+}
+
+// TestSetupToken_SupersedeActiveTokens_ProjectScoped is the CORE-INVITATIONS-003
+// regression test: an admin issuing a project-scoped invitation_accept setup token
+// for one project must NOT silently invalidate a different project's still-pending
+// invite to the same email address, while a genuine re-invite/resend WITHIN the same
+// project must still supersede the prior link (the SMTP-abuse throttle's underlying
+// invariant — same-project reissue kills the old link — is preserved).
+func TestSetupToken_SupersedeActiveTokens_ProjectScoped(t *testing.T) {
+	ctx := context.Background()
+	ls := newStoreS3(t, "setup_tokens_proj_"+t.Name(), &models.SetupToken{}, &models.ProjectInvitation{})
+	exp := time.Now().Add(time.Hour)
+	const email = "victim@example.com"
+
+	// Project A's pending invitation + its accept-link token.
+	invA, err := ls.CreateProjectInvitation(ctx, &models.ProjectInvitation{
+		ProjectID: 1, Email: email, Role: "project_developer", State: "pending",
+	})
+	require.NoError(t, err)
+	_, err = ls.CreateSetupToken(ctx, &models.SetupToken{
+		TokenHash: "tok-a-1", Purpose: "invitation_accept", SubjectEmail: email,
+		InvitationID: &invA.ID, State: "active", ExpiresAt: exp,
+	})
+	require.NoError(t, err)
+
+	// Project B's admin — wholly unrelated to project A — invites the SAME email to
+	// project B. Pre-fix, this unconditionally superseded project A's still-pending
+	// link as an unintended side effect; the supersede call is now scoped to project B.
+	invB, err := ls.CreateProjectInvitation(ctx, &models.ProjectInvitation{
+		ProjectID: 2, Email: email, Role: "project_viewer", State: "pending",
+	})
+	require.NoError(t, err)
+	projectB := uint(2)
+	require.NoError(t, ls.SupersedeActiveSetupTokens(ctx, "invitation_accept", email, &projectB))
+	_, err = ls.CreateSetupToken(ctx, &models.SetupToken{
+		TokenHash: "tok-b-1", Purpose: "invitation_accept", SubjectEmail: email,
+		InvitationID: &invB.ID, State: "active", ExpiresAt: exp,
+	})
+	require.NoError(t, err)
+
+	// Both tokens remain active: project B's invite must not have touched project A's.
+	reloadedA, err := ls.GetSetupTokenByHash(ctx, "tok-a-1")
+	require.NoError(t, err)
+	assert.Equal(t, "active", reloadedA.State, "an unrelated project's invite must not supersede this project's pending link")
+	reloadedB, err := ls.GetSetupTokenByHash(ctx, "tok-b-1")
+	require.NoError(t, err)
+	assert.Equal(t, "active", reloadedB.State)
+
+	// A THIRD invite to the SAME project (B) + SAME email — e.g. a resend — must still
+	// supersede the prior link for that project: the per-project throttle invariant
+	// holds even though the cross-project one no longer fires.
+	require.NoError(t, ls.SupersedeActiveSetupTokens(ctx, "invitation_accept", email, &projectB))
+	_, err = ls.CreateSetupToken(ctx, &models.SetupToken{
+		TokenHash: "tok-b-2", Purpose: "invitation_accept", SubjectEmail: email,
+		InvitationID: &invB.ID, State: "active", ExpiresAt: exp,
+	})
+	require.NoError(t, err)
+
+	reloadedB1, err := ls.GetSetupTokenByHash(ctx, "tok-b-1")
+	require.NoError(t, err)
+	assert.Equal(t, "superseded", reloadedB1.State, "a same-project reissue must still supersede the project's own prior link")
+	reloadedB2, err := ls.GetSetupTokenByHash(ctx, "tok-b-2")
+	require.NoError(t, err)
+	assert.Equal(t, "active", reloadedB2.State)
+	// Project A's token is still untouched by project B's second (same-project) reissue.
+	reloadedAFinal, err := ls.GetSetupTokenByHash(ctx, "tok-a-1")
+	require.NoError(t, err)
+	assert.Equal(t, "active", reloadedAFinal.State)
 }
 
 func TestSetupToken_MarkConsumed(t *testing.T) {

--- a/internal/trust/trust.go
+++ b/internal/trust/trust.go
@@ -84,7 +84,8 @@ func (r *KeyRegistry) Add(purpose Purpose, keyID string, pub ed25519.PublicKey) 
 	if len(pub) != ed25519.PublicKeySize {
 		return fmt.Errorf("trust: bad public key size %d (want %d)", len(pub), ed25519.PublicKeySize)
 	}
-	if strings.TrimSpace(keyID) == "" {
+	keyID = strings.TrimSpace(keyID)
+	if keyID == "" {
 		return fmt.Errorf("trust: key-id is required")
 	}
 	r.mu.Lock()
@@ -164,14 +165,18 @@ func parseKeySpec(spec string) (map[string]ed25519.PublicKey, error) {
 		if len(kv) != 2 || strings.TrimSpace(kv[0]) == "" {
 			return nil, fmt.Errorf("trust: bad key spec %q (want keyID=base64)", part)
 		}
+		keyID := strings.TrimSpace(kv[0])
+		if _, dup := out[keyID]; dup {
+			return nil, fmt.Errorf("trust: duplicate key-id %q in spec", keyID)
+		}
 		raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(kv[1]))
 		if err != nil {
-			return nil, fmt.Errorf("trust: key %q: decode: %w", kv[0], err)
+			return nil, fmt.Errorf("trust: key %q: decode: %w", keyID, err)
 		}
 		if len(raw) != ed25519.PublicKeySize {
-			return nil, fmt.Errorf("trust: key %q: bad size %d", kv[0], len(raw))
+			return nil, fmt.Errorf("trust: key %q: bad size %d", keyID, len(raw))
 		}
-		out[strings.TrimSpace(kv[0])] = ed25519.PublicKey(raw)
+		out[keyID] = ed25519.PublicKey(raw)
 	}
 	return out, nil
 }

--- a/internal/trust/trust_test.go
+++ b/internal/trust/trust_test.go
@@ -106,6 +106,25 @@ func TestRegistry_AddLegitimateSinglePurposeUseStillWorks(t *testing.T) {
 	assert.NoError(t, r.Verify(PurposeLicense, "lic-2026", msg, sig))
 }
 
+// TestRegistry_AddTrimsKeyIDForStorage is the regression test for the map-key/validation
+// mismatch: Add validated strings.TrimSpace(keyID) != "" but stored the entry under the raw,
+// untrimmed keyID argument. A caller passing a whitespace-padded key-id would have the
+// validation pass while Verify (called with the trimmed id, as callers naturally would) failed
+// to find the key at all. The fix stores under the trimmed key-id, so a padded Add and a
+// trimmed Verify agree on the same key-id.
+func TestRegistry_AddTrimsKeyIDForStorage(t *testing.T) {
+	pub, priv, err := GenerateKey()
+	require.NoError(t, err)
+
+	r := NewRegistry()
+	require.NoError(t, r.Add(PurposeUpdate, "  upd-1  ", pub))
+
+	msg := []byte("manifest bytes")
+	sig := ed25519.Sign(priv, msg)
+	require.NoError(t, r.Verify(PurposeUpdate, "upd-1", msg, sig))
+	assert.Equal(t, []string{"upd-1"}, r.KeyIDs(PurposeUpdate))
+}
+
 func TestRegistry_KeyIDsSorted(t *testing.T) {
 	pub, _, _ := GenerateKey()
 	r := NewRegistry()
@@ -136,6 +155,23 @@ func TestParseKeySpec(t *testing.T) {
 	assert.Error(t, err)
 	_, err = parseKeySpec("k=YWJj") // valid base64 but wrong key size
 	assert.Error(t, err)
+}
+
+// TestParseKeySpec_RejectsDuplicateKeyID is the regression test for the silent-overwrite gap:
+// parseKeySpec previously let a later keyID=... entry overwrite an earlier one with the same
+// key-id via plain map assignment, with no error — unlike every other malformed-input case in
+// this function. A copy-paste/typo reusing an existing key-id during key rotation (e.g.
+// "upd-2026=<old>,upd-2026=<new>") would silently drop one of the two keys. It must now be a
+// hard error, matching the rest of the function's "malformed spec = error" contract.
+func TestParseKeySpec_RejectsDuplicateKeyID(t *testing.T) {
+	pub1, _, _ := GenerateKey()
+	pub2, _, _ := GenerateKey()
+	spec := "upd-2026=" + EncodePublicKeyBase64(pub1) + ",upd-2026=" + EncodePublicKeyBase64(pub2)
+
+	_, err := parseKeySpec(spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate key-id")
+	assert.Contains(t, err.Error(), "upd-2026")
 }
 
 func TestDefaultRegistry_EmptyByDefaultFailsClosed(t *testing.T) {

--- a/server/http/handlers/secret_templates.go
+++ b/server/http/handlers/secret_templates.go
@@ -198,13 +198,19 @@ func (h *SecretTemplateHandler) Apply(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := h.coreService.ApplyTemplate(r.Context(), uint(id), body.Classification, body.Description, body.Tags)
 	if err != nil {
-		if strings.Contains(err.Error(), errNotFound) {
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, errNotFound):
 			sendError(w, "NotFound", errSecretTemplateNotFound, http.StatusNotFound, nil)
 			return
+		case strings.Contains(msg, "invalid classification"):
+			sendError(w, "Error", msg, http.StatusBadRequest, nil)
+			return
+		default:
+			log.Printf("Error applying secret template: %v", err)
+			sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
+			return
 		}
-		log.Printf("Error applying secret template: %v", err)
-		sendError(w, "Error", clientSafe(err), http.StatusInternalServerError, nil)
-		return
 	}
 	sendSuccess(w, result, "")
 }

--- a/server/http/handlers/secret_templates_handler_test.go
+++ b/server/http/handlers/secret_templates_handler_test.go
@@ -253,6 +253,15 @@ func TestSecretTemplateHandler_Apply_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+func TestSecretTemplateHandler_Apply_InvalidClassification(t *testing.T) {
+	h := newSecretTemplateTestHandler(t)
+	body := bytes.NewBufferString(`{"classification":"ULTRA_SECRET"}`)
+	req := stChiID(httptest.NewRequest(http.MethodPost, "/", body), "1")
+	w := httptest.NewRecorder()
+	h.Apply(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 func TestSecretTemplateHandler_Apply_Success(t *testing.T) {
 	h := newSecretTemplateTestHandler(t)
 	cw := httptest.NewRecorder()

--- a/server/http/handlers/setup_tokens_proxy.go
+++ b/server/http/handlers/setup_tokens_proxy.go
@@ -202,16 +202,21 @@ func (h *AuthHandler) GetSetupTokenByHashProxy(w http.ResponseWriter, r *http.Re
 }
 
 // setupTokenSupersedeBody is the wire body for POST
-// /api/v1/system/setup-tokens/supersede.
+// /api/v1/system/setup-tokens/supersede. ProjectID is optional (omitted/nil for
+// callers with no project dimension — global invites, account_setup,
+// password_reset_link); when present it restricts the flip to that project's own
+// invitations (CORE-INVITATIONS-003).
 type setupTokenSupersedeBody struct {
 	Purpose      string `json:"purpose"`
 	SubjectEmail string `json:"subject_email"`
+	ProjectID    *uint  `json:"project_id,omitempty"`
 }
 
 // SupersedeSetupTokensProxy handles POST /api/v1/system/setup-tokens/supersede. It
 // performs the SAME `WHERE purpose = ? AND subject_email = ? AND state = 'active'`
-// bulk UPDATE local_auth.go's own SupersedeActiveSetupTokens does — a reissue kills
-// every prior active link for the same (purpose, email) atomically.
+// bulk UPDATE (optionally further restricted to ProjectID's own invitations)
+// local_auth.go's own SupersedeActiveSetupTokens does — a reissue kills every prior
+// active link for the same (purpose, email[, project]) atomically.
 func (h *AuthHandler) SupersedeSetupTokensProxy(w http.ResponseWriter, r *http.Request) {
 	var body setupTokenSupersedeBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -222,7 +227,7 @@ func (h *AuthHandler) SupersedeSetupTokensProxy(w http.ResponseWriter, r *http.R
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "purpose and subject_email are required")
 		return
 	}
-	if err := h.coreService.Storage().SupersedeActiveSetupTokens(r.Context(), body.Purpose, body.SubjectEmail); err != nil {
+	if err := h.coreService.Storage().SupersedeActiveSetupTokens(r.Context(), body.Purpose, body.SubjectEmail, body.ProjectID); err != nil {
 		log.Printf("setup-tokens proxy: supersede failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return

--- a/server/http/remote_storage_setup_tokens_test.go
+++ b/server/http/remote_storage_setup_tokens_test.go
@@ -164,7 +164,7 @@ func TestRemoteStorageSetupToken_Supersede_RealServer(t *testing.T) {
 		buildActiveSetupToken(now, "hash-supersede-other", core.SetupPurposePasswordResetLink, "other@example.com"))
 	require.NoError(t, err)
 
-	require.NoError(t, downstream.Storage().SupersedeActiveSetupTokens(ctx, core.SetupPurposePasswordResetLink, "reset@example.com"))
+	require.NoError(t, downstream.Storage().SupersedeActiveSetupTokens(ctx, core.SetupPurposePasswordResetLink, "reset@example.com", nil))
 
 	s1, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-supersede-1")
 	require.NoError(t, err)
@@ -177,6 +177,69 @@ func TestRemoteStorageSetupToken_Supersede_RealServer(t *testing.T) {
 	other, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-supersede-other")
 	require.NoError(t, err)
 	assert.Equal(t, core.SetupTokenActive, other.State, "a different subject's active token must be untouched")
+}
+
+// TestRemoteStorageSetupToken_SupersedeProjectScoped_RealServer is the
+// CORE-INVITATIONS-003 end-to-end regression: over storage.type: remote, a
+// project-scoped supersede (as InviteToProjectWithLink/ResendInvitationLink now
+// issue) must not cross the HTTP hop as an unscoped one — an unrelated project's
+// invite must not invalidate a different project's still-pending invite to the same
+// email, while a same-project reissue still supersedes.
+func TestRemoteStorageSetupToken_SupersedeProjectScoped_RealServer(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForSetupTokens(t)
+	ctx := context.Background()
+	now := time.Now()
+	const email = "victim@example.com"
+
+	invA, err := upstream.Storage().CreateProjectInvitation(ctx, &models.ProjectInvitation{
+		ProjectID: 101, Email: email, Role: "project_developer", State: core.InvitationPending,
+	})
+	require.NoError(t, err)
+	invB, err := upstream.Storage().CreateProjectInvitation(ctx, &models.ProjectInvitation{
+		ProjectID: 202, Email: email, Role: "project_viewer", State: core.InvitationPending,
+	})
+	require.NoError(t, err)
+
+	tokA := buildActiveSetupToken(now, "hash-proj-a-1", core.SetupPurposeInvitationAccept, email)
+	tokA.InvitationID = &invA.ID
+	_, err = downstream.Storage().CreateSetupToken(ctx, tokA)
+	require.NoError(t, err)
+
+	// Project B's admin invites the same email to project B — the pre-issuance
+	// supersede is scoped to project B only.
+	projectB := invB.ProjectID
+	require.NoError(t, downstream.Storage().SupersedeActiveSetupTokens(ctx, core.SetupPurposeInvitationAccept, email, &projectB))
+	tokB := buildActiveSetupToken(now, "hash-proj-b-1", core.SetupPurposeInvitationAccept, email)
+	tokB.InvitationID = &invB.ID
+	_, err = downstream.Storage().CreateSetupToken(ctx, tokB)
+	require.NoError(t, err)
+
+	sA, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-proj-a-1")
+	require.NoError(t, err)
+	assert.Equal(t, core.SetupTokenActive, sA.State, "project B's invite must not supersede project A's pending link")
+
+	sB1, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-proj-b-1")
+	require.NoError(t, err)
+	assert.Equal(t, core.SetupTokenActive, sB1.State)
+
+	// A same-project (B) reissue must still supersede project B's own prior link.
+	require.NoError(t, downstream.Storage().SupersedeActiveSetupTokens(ctx, core.SetupPurposeInvitationAccept, email, &projectB))
+	tokB2 := buildActiveSetupToken(now, "hash-proj-b-2", core.SetupPurposeInvitationAccept, email)
+	tokB2.InvitationID = &invB.ID
+	_, err = downstream.Storage().CreateSetupToken(ctx, tokB2)
+	require.NoError(t, err)
+
+	sB1Reloaded, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-proj-b-1")
+	require.NoError(t, err)
+	assert.Equal(t, core.SetupTokenSuperseded, sB1Reloaded.State, "a same-project reissue must still supersede the project's own prior link")
+
+	sB2, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-proj-b-2")
+	require.NoError(t, err)
+	assert.Equal(t, core.SetupTokenActive, sB2.State)
+
+	sAFinal, err := upstream.Storage().GetSetupTokenByHash(ctx, "hash-proj-a-1")
+	require.NoError(t, err)
+	assert.Equal(t, core.SetupTokenActive, sAFinal.State, "project A's link must remain untouched throughout")
 }
 
 // TestRemoteStorageSetupToken_Expire_RealServer proves MarkSetupTokenExpired's


### PR DESCRIPTION
## Summary

Closes 8 low/info-severity singletons from Wave 6's auth/SSO/trust/connect-core batch.

- `secrettemplate` (info) — `Render` is an intentionally format-agnostic substitution engine with no JSON/YAML escaping; no live call site builds JSON/YAML today, so this is additive future-proofing: a new opt-in `RenderWithOptions`/`RenderJSON`/`RenderYAML` for any future caller that does, with an end-to-end test reproducing the exact injection the finding describes and showing it's neutralized only through the new safe variants.
- `trust.go` (info + low) — `Add()` validated a trimmed key-id but stored under the untrimmed one; `parseKeySpec` let a later duplicate key-id silently overwrite an earlier one with zero warning, inconsistent with every other error path in the function. Both fixed per the review's own draft fix.
- `TPL-002` (low) — `ApplyTemplate` echoed a caller-supplied `classification` back unvalidated, unlike `Create`/`UpdateSecretTemplate`'s enforced allow-list; now validated the same way.
- `CORE-INVITATIONS-003` (low) — the invitation-accept setup-token supersede key was `(purpose, email)` only, so an admin with `roles.assign` in any one project could silently invalidate an unrelated project's pending invite to the same email. Added optional project scoping to the supersede call across the full stack (core/storage interface/both backends/proxy), while leaving the separate SMTP-abuse throttle (still global per-email) untouched.
- `CORE-OIDC-04` (low) — `CompleteSSO`/`CompleteSAML` ran IdP-driven group/role sync (and audited it) before checking `loginLocked`, mutating a locked-out account's grants before refusing the login. Reordered so the lockout check runs first in both paths.
- GCP service-account key eviction (low) — `GenerateUpstream` evicted `prior[0]` at the 10-key cap, whatever GCP's unspecified list ordering returned first — an availability hazard. Added `evictableServiceAccountKey`, mirroring `awsiam.go`'s existing inactive-then-oldest preference, adapted to GCP's `Disabled`/`ValidAfterTime` fields.
- `securefiles.FixFilePerms` (low) — the permission check used `info.Mode().Perm()`, masking out setuid/setgid/sticky bits, so a file with correct low-9 bits but an unwanted special bit compared equal and was never corrected. Now checked explicitly; the existing `Chmod(f.Mode)` call already clears the bits once triggered.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `gofmt -l` — clean across all changed files
- `gosec -severity medium -exclude-generated ./...` — 0 issues (795 files, 157k lines)
- Full `go test ./...` — only the established pre-existing failures (`TestPermissionBaseline_CSV_Headers`, the `TestRemoteStorage*_RealServer` family in `server/http`), no new failures; the new project-scoped supersede regression test passes
- Each of the 7 underlying fixes independently verified (build/vet/gofmt/gosec/package suite) before being cherry-picked onto this combined branch; no file-overlap conflicts during assembly