### PR TITLE
fix(core): evict session token cache on role revocation

### DIFF
--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -120,6 +120,17 @@ func (c *KeyorixCore) invalidateTokenCache(hashes ...string) {
 	}
 }
 
+// evictUserSessionCache evicts every one of the user's active sessions from the HTTP
+// auth cache WITHOUT deleting the sessions themselves — unlike
+// deleteSessionsForUserAndEvict, the user stays logged in. Used after a permission
+// change (e.g. role removal) where the goal is only to force the NEXT request to
+// re-resolve the user's permissions from storage instead of serving a stale,
+// positively-cached authorization decision for up to validTokenTTL.
+func (c *KeyorixCore) evictUserSessionCache(ctx context.Context, userID uint) {
+	hashes, _ := c.storage.ListSessionTokenHashesForUser(ctx, userID)
+	c.invalidateTokenCache(hashes...)
+}
+
 // deleteSessionsForUserAndEvict deletes all of the user's sessions except keepID and
 // evicts the deleted sessions from the HTTP auth cache, so a revoked session stops
 // authenticating on the very NEXT request rather than lingering for the positive-cache

--- a/internal/core/core_s33_test.go
+++ b/internal/core/core_s33_test.go
@@ -230,6 +230,8 @@ func TestRemoveRoleFromUser_Success(t *testing.T) {
 	// RemoveUserRole: adminIDs is empty → calls RemoveRole
 	ms.On("RemoveRole", mock.Anything, uint(5), uint(3), mock.AnythingOfType("storage.Scope")).Return(nil)
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	// evictUserSessionCache: evicts the removed-role user's cached sessions.
+	ms.On("ListSessionTokenHashesForUser", mock.Anything, uint(5)).Return([]string{}, nil)
 	c := NewKeyorixCore(ms)
 	err := c.RemoveRoleFromUser(context.Background(), "alice@example.com", "viewer")
 	require.NoError(t, err)

--- a/internal/core/core_s34_test.go
+++ b/internal/core/core_s34_test.go
@@ -186,6 +186,8 @@ func TestRevokeSystemRoleGrant_Success(t *testing.T) {
 	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
 	ms.On("RemoveRole", mock.Anything, uint(1), uint(2), mock.AnythingOfType("storage.Scope")).Return(nil)
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	// evictUserSessionCache: evicts the removed-role user's cached sessions.
+	ms.On("ListSessionTokenHashesForUser", mock.Anything, uint(1)).Return([]string{}, nil)
 	c := NewKeyorixCore(ms)
 	inv := &models.ProjectInvitation{SystemRole: "viewer"}
 	c.revokeSystemRoleGrant(context.Background(), inv, 1)

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -384,6 +384,12 @@ func (c *KeyorixCore) RemoveUserRole(ctx context.Context, actorID, userID, roleI
 				return err
 			}
 			c.LogRoleRemoved(ctx, actorID, userID, roleID, scope)
+			// Evict the auth cache so a just-revoked role stops authorizing on the
+			// very next request instead of the up-to-30s positive-cache window every
+			// other credential-lifecycle event in this package already closes
+			// (password change, suspend/deactivate/delete, PAT revoke,
+			// machine-identity suspend/revoke).
+			c.evictUserSessionCache(ctx, userID)
 			return nil
 		}
 	}
@@ -391,6 +397,7 @@ func (c *KeyorixCore) RemoveUserRole(ctx context.Context, actorID, userID, roleI
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	c.LogRoleRemoved(ctx, actorID, userID, roleID, scope)
+	c.evictUserSessionCache(ctx, userID)
 	return nil
 }
 

--- a/internal/core/rbac_management_test.go
+++ b/internal/core/rbac_management_test.go
@@ -20,7 +20,7 @@ func newRBACManagementCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	require.NoError(t, db.AutoMigrate(
 		&models.AuditEvent{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
 		&models.User{}, &models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
-		&models.Project{}, &models.Environment{}, &models.SoDPolicy{},
+		&models.Project{}, &models.Environment{}, &models.SoDPolicy{}, &models.Session{},
 	))
 	return NewKeyorixCore(store.NewLocalStorage(db)), db
 }
@@ -110,4 +110,34 @@ func TestRemovePermissionFromRole_NoSelfPermissionRequired(t *testing.T) {
 
 	const actor = uint(9) // holds nothing
 	require.NoError(t, c.RemovePermissionFromRole(ctx, actor, 1, 1))
+}
+
+// RemoveUserRole must evict the target user's cached sessions from the HTTP auth
+// cache, matching every other credential-lifecycle event in this package (password
+// change, suspend/deactivate/delete, PAT revoke, machine-identity suspend/revoke) —
+// otherwise a just-revoked role keeps authorizing requests for up to the positive
+// auth-cache TTL. Unlike those stronger events, the user's sessions themselves must
+// NOT be deleted (they stay logged in; only the cached authorization decision is
+// forced to re-resolve from storage on the next request).
+func TestRemoveUserRole_EvictsSessionCacheWithoutLoggingOut(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "custom"}).Error)
+
+	const userID = uint(9)
+	require.NoError(t, db.Create(&models.UserRole{UserID: userID, RoleID: 1, ProjectID: 5}).Error)
+	require.NoError(t, db.Create(&models.Session{UserID: userID, SessionToken: "session-hash-a"}).Error)
+	require.NoError(t, db.Create(&models.Session{UserID: userID, SessionToken: "session-hash-b"}).Error)
+
+	var evicted []string
+	c.SetTokenCacheInvalidator(func(h string) { evicted = append(evicted, h) })
+
+	require.NoError(t, c.RemoveUserRole(ctx, 0, userID, 1, Scope{ProjectID: 5}))
+
+	assert.ElementsMatch(t, []string{"session-hash-a", "session-hash-b"}, evicted,
+		"every one of the user's session hashes must be evicted from the auth cache")
+
+	var remaining int64
+	require.NoError(t, db.Model(&models.Session{}).Where("user_id = ?", userID).Count(&remaining).Error)
+	assert.Equal(t, int64(2), remaining, "sessions must NOT be deleted — the user stays logged in")
 }

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -557,6 +557,8 @@ func TestSyncSSORoles(t *testing.T) {
 		store.On("AssignRole", mock.Anything, uint(7), uint(10), mock.Anything).Return(nil)
 		store.On("RemoveRole", mock.Anything, uint(7), uint(20), mock.Anything).Return(nil)
 		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+		// evictUserSessionCache: evicts the removed-role user's cached sessions.
+		store.On("ListSessionTokenHashesForUser", mock.Anything, uint(7)).Return([]string{}, nil)
 
 		c.syncSSORoles(context.Background(), p, 7, raw)
 


### PR DESCRIPTION
## Summary
- `RemoveUserRole` revoked the RBAC grant but left any cached session-token
  authorization decision in place, so a revoked user's existing sessions
  could keep passing authorization checks until the cache naturally expired.
- Adds `evictUserSessionCache` (lists the user's session token hashes,
  invalidates the token cache for each) and wires it into both success paths
  of `RemoveUserRole`.

## Test plan
- [x] Fixed 3 existing MockStorage-based tests whose fixtures had no
      expectation for the new `ListSessionTokenHashesForUser` call.
- [x] `go build`/`go vet`/`gofmt` clean
- [x] `gosec -severity medium` clean
- [x] Full `internal/core` suite green
