### PR TITLE
fix(handlers): require a live project for secret-dependency rotation order/plan

### DIFF
--- a/server/http/handlers/handlers_s13_pat_notif_rotpol_deps_test.go
+++ b/server/http/handlers/handlers_s13_pat_notif_rotpol_deps_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -485,15 +486,36 @@ func TestGetProjectRotationOrder_BadID_S13(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// TestGetProjectRotationOrder_HappyPath_S13 — project with no secrets → empty order.
+// TestGetProjectRotationOrder_HappyPath_S13 — a real, live project with no
+// secrets → empty order, 200. Uses a fresh isolated core (rather than the
+// shared newSecretHandlerS4 DB) so it can create its own real Project row: a
+// scoped role binding survives project soft-delete, so the handler now
+// re-checks project liveness before returning data, and a bare hardcoded
+// project ID with no backing row would 404.
 func TestGetProjectRotationOrder_HappyPath_S13(t *testing.T) {
 	t.Parallel()
-	h := newSecretHandlerS4(t)
-	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "1"))
+	cs := freshCoreS12(t)
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	proj, err := cs.Storage().CreateProject(context.Background(), &models.Project{Name: "proj-rotorder-happy-s13"})
+	require.NoError(t, err)
+
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", strconv.FormatUint(uint64(proj.ID), 10)))
 	w := httptest.NewRecorder()
 	h.GetProjectRotationOrder(w, req)
-	// no project means storage returns empty slice → 200
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestGetProjectRotationOrder_ProjectNotFound_S13 pins the project-liveness fix
+// itself: a role binding scoped to a project ID with no backing row (or a
+// soft-deleted one) must 404, not silently return an empty order.
+func TestGetProjectRotationOrder_ProjectNotFound_S13(t *testing.T) {
+	t.Parallel()
+	h := newSecretHandlerS4(t)
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "999999"))
+	w := httptest.NewRecorder()
+	h.GetProjectRotationOrder(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 // TestGetProjectRotationPlan_BadID_S13 — non-numeric id → 400.
@@ -506,14 +528,31 @@ func TestGetProjectRotationPlan_BadID_S13(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// TestGetProjectRotationPlan_HappyPath_S13 — no secrets in project → 200.
+// TestGetProjectRotationPlan_HappyPath_S13 — a real, live project with no
+// secrets → 200. See TestGetProjectRotationOrder_HappyPath_S13 for why this
+// needs a real backing Project row now.
 func TestGetProjectRotationPlan_HappyPath_S13(t *testing.T) {
 	t.Parallel()
-	h := newSecretHandlerS4(t)
-	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "1"))
+	cs := freshCoreS12(t)
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	proj, err := cs.Storage().CreateProject(context.Background(), &models.Project{Name: "proj-rotplan-happy-s13"})
+	require.NoError(t, err)
+
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", strconv.FormatUint(uint64(proj.ID), 10)))
 	w := httptest.NewRecorder()
 	h.GetProjectRotationPlan(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestGetProjectRotationPlan_ProjectNotFound_S13 — see the Order twin above.
+func TestGetProjectRotationPlan_ProjectNotFound_S13(t *testing.T) {
+	t.Parallel()
+	h := newSecretHandlerS4(t)
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "999999"))
+	w := httptest.NewRecorder()
+	h.GetProjectRotationPlan(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 // TestGetDeploymentRotationPlan_HappyPath_S13 — empty DB → 200.

--- a/server/http/handlers/secret_dependencies.go
+++ b/server/http/handlers/secret_dependencies.go
@@ -172,6 +172,15 @@ func (h *SecretHandler) GetProjectRotationOrder(w http.ResponseWriter, r *http.R
 		h.sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
 		return
 	}
+	// A scoped role binding survives project soft-delete (RequireScopedPermission
+	// authorizes on the binding, not on the project's current lifecycle state), so
+	// re-check the project is actually live before returning its rotation data —
+	// mirrors the identical fix in the gRPC twin (ProjectGRPCService.
+	// GetProjectRotationOrder).
+	if _, err := h.coreService.GetProject(r.Context(), uint(id)); err != nil {
+		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
+		return
+	}
 	order, err := h.coreService.GetProjectRotationOrder(r.Context(), uint(id))
 	if err != nil {
 		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
@@ -191,6 +200,13 @@ func (h *SecretHandler) GetProjectRotationPlan(w http.ResponseWriter, r *http.Re
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
 		h.sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	// See GetProjectRotationOrder above: a scoped role binding survives project
+	// soft-delete, so re-check liveness before returning rotation data — mirrors
+	// the gRPC twin's identical fix.
+	if _, err := h.coreService.GetProject(r.Context(), uint(id)); err != nil {
+		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
 		return
 	}
 	plan, err := h.coreService.GenerateRotationPlan(r.Context(), uint(id))


### PR DESCRIPTION
## Summary
- `GetProjectRotationOrder`/`GetProjectRotationPlan` had no liveness check on
  the project ID before delegating to the underlying core function, so a
  nonexistent project id silently returned an empty rotation order/plan (200)
  instead of a 404 — two existing tests' own fixtures documented this as
  expected behavior (`// no project means storage returns empty slice → 200`).
- Adds a `core.GetProject` existence check to both handlers before the
  underlying call.

## Test plan
- [x] Rewrote the two affected happy-path tests to seed a real project row
      instead of a bare hardcoded id.
- [x] Added dedicated `_ProjectNotFound_S13` tests pinning the 404 fix.
- [x] `go build`/`go vet`/`gofmt` clean
- [x] `gosec -severity medium` clean
