### PR TITLE
fix(core): validate environment belongs to project on dynamic secret config create

### DIFF
--- a/internal/core/classify_dynamic_test.go
+++ b/internal/core/classify_dynamic_test.go
@@ -15,7 +15,7 @@ func makeDynConfig(t *testing.T, c *KeyorixCore, name, classification string) ui
 	cfg, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
 		Name:           name,
 		ProjectID:      1,
-		EnvironmentID:  1,
+		EnvironmentID:  2,
 		BackendType:    "postgres",
 		AdminDSN:       "postgres://admin:pw@db.example.com/db",
 		Classification: classification,
@@ -36,7 +36,7 @@ func TestCreateDynamicSecretConfig_WithClassification(t *testing.T) {
 
 	// Invalid level is rejected at create.
 	_, err = c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
-		Name: "bad", ProjectID: 1, EnvironmentID: 1, BackendType: "postgres",
+		Name: "bad", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
 		AdminDSN: "postgres://x", Classification: "top-secret", CreatedBy: "admin",
 		ActorID: testAdminActorID,
 	})

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -226,6 +226,20 @@ func (c *KeyorixCore) CreateDynamicSecretConfig(ctx context.Context, req *Create
 	if err := validateCreateDynamicSecretConfigRequest(req); err != nil {
 		return nil, err
 	}
+	// Verify the environment belongs to the stated project — same cross-reference
+	// check CreateSecret already applies (secrets.go), and for the same reason:
+	// without it, a project-admin on project A could bind a dynamic-secret config
+	// whose EnvironmentID points at project B's environment. Downstream reads/leases
+	// stay keyed off the config's own stored ProjectID (not the environment's), so
+	// this wasn't a cross-project value leak, but it's real reference confusion — a
+	// config an operator believes is scoped to (A, envX) is actually associated with
+	// an environment that belongs to a project the creator may have no visibility
+	// into at all.
+	if env, err := c.storage.GetEnvironment(ctx, req.EnvironmentID); err != nil {
+		return nil, fmt.Errorf("environment %d not found", req.EnvironmentID)
+	} else if env.ProjectID != req.ProjectID {
+		return nil, fmt.Errorf("environment %d does not belong to project %d", req.EnvironmentID, req.ProjectID)
+	}
 	if _, err := c.dynamicEngine(req.BackendType); err != nil {
 		return nil, err
 	}

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -233,10 +233,13 @@ func TestDynamicSecrets_CreateConfig_DifferentScopeAllowed(t *testing.T) {
 	})
 	assert.NoError(t, err, "the same name in a different environment must succeed")
 
-	// Different project, same environment ID + name.
+	// Different project, same name — with its OWN environment (an environment ID
+	// belongs to exactly one project; reusing project 1's EnvironmentID 2 here would
+	// itself be the reference-confusion case CreateDynamicSecretConfig now rejects).
 	require.NoError(t, db.Create(&models.Project{ID: 4, Name: "dyn-test-project-2"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 5, ProjectID: 4, Name: "dyn-test-env-3"}).Error)
 	_, err = c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "app-db", ProjectID: 4, EnvironmentID: 2, BackendType: "postgres",
+		Name: "app-db", ProjectID: 4, EnvironmentID: 5, BackendType: "postgres",
 		AdminDSN: adminDSNPlain, DefaultTTLSeconds: 3600, CreatedBy: "alice", ActorID: testAdminActorID,
 	})
 	assert.NoError(t, err, "the same name in a different project must succeed")
@@ -247,6 +250,43 @@ func TestDynamicSecrets_CreateConfig_DifferentScopeAllowed(t *testing.T) {
 		AdminDSN: adminDSNPlain, DefaultTTLSeconds: 3600, CreatedBy: "alice", ActorID: testAdminActorID,
 	})
 	assert.NoError(t, err, "a different name in the same project/environment must succeed")
+}
+
+// TestDynamicSecrets_CreateConfig_RejectsCrossProjectEnvironment pins the fix for
+// the reference-confusion follow-up: EnvironmentID 2 belongs to project 1, so a
+// request naming a DIFFERENT project (4) with that same EnvironmentID must be
+// rejected, not silently accepted with a config whose stored ProjectID and actual
+// environment disagree about which project the config belongs to.
+func TestDynamicSecrets_CreateConfig_RejectsCrossProjectEnvironment(t *testing.T) {
+	c, db, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Project{ID: 4, Name: "dyn-test-project-2"}).Error)
+
+	_, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "cross-project-cfg", ProjectID: 4, EnvironmentID: 2, BackendType: "postgres",
+		AdminDSN: adminDSNPlain, DefaultTTLSeconds: 3600, CreatedBy: "alice", ActorID: testAdminActorID,
+	})
+	require.Error(t, err, "an environment belonging to a different project must be rejected")
+	assert.Contains(t, err.Error(), "does not belong to project")
+
+	configs, err := c.storage.ListDynamicSecretConfigs(ctx, 4, 2)
+	require.NoError(t, err)
+	assert.Empty(t, configs, "no config must have been created")
+}
+
+// TestDynamicSecrets_CreateConfig_RejectsUnknownEnvironment pins the sibling case:
+// an EnvironmentID with no backing row at all must also be rejected, not just a
+// mismatched one.
+func TestDynamicSecrets_CreateConfig_RejectsUnknownEnvironment(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+
+	_, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "nonexistent-env-cfg", ProjectID: 1, EnvironmentID: 999999, BackendType: "postgres",
+		AdminDSN: adminDSNPlain, DefaultTTLSeconds: 3600, CreatedBy: "alice", ActorID: testAdminActorID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestDynamicSecrets_ConfigEncryptsAdminDSN(t *testing.T) {
@@ -271,7 +311,7 @@ func TestDynamicSecrets_AdminDSNTransplantBetweenConfigsFailsToDecrypt(t *testin
 	ctx := context.Background()
 	cfgA := mkConfig(t, c, ctx)
 	cfgB, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "other-db", ProjectID: 1, BackendType: "postgres",
+		Name: "other-db", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
 		AdminDSN:          "postgres://admin:different@other-db.internal:5432/app",
 		DefaultTTLSeconds: 3600,
 		ActorID:           testAdminActorID,
@@ -524,7 +564,7 @@ func TestDynamicSecrets_MaxTTLClampsIssue(t *testing.T) {
 	c, _, _, fixed := newDynamicTestCore(t)
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "capped", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "capped", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 600, MaxTTLSeconds: 1800, ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
@@ -544,7 +584,7 @@ func TestDynamicSecrets_IssueRejectsOverflowingTTLSeconds(t *testing.T) {
 	c, _, _, _ := newDynamicTestCore(t)
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "overflow-guard", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "overflow-guard", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
@@ -559,7 +599,7 @@ func TestDynamicSecrets_RenewRejectsOverflowingTTLSeconds(t *testing.T) {
 	c, _, _, _ := newDynamicTestCore(t)
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "renew-overflow-guard", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "renew-overflow-guard", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 600, ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
@@ -580,14 +620,14 @@ func TestDynamicSecrets_CreateRejectsOverflowingConfigTTLFields(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "bad-default", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "bad-default", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 20_000_000_000, ActorID: testAdminActorID,
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds the maximum")
 
 	_, err = c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "bad-max", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "bad-max", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		MaxTTLSeconds: 20_000_000_000, ActorID: testAdminActorID,
 	})
 	require.Error(t, err)
@@ -603,7 +643,7 @@ func TestDynamicSecrets_InstallWideMaxLeaseTTLClampsIssue(t *testing.T) {
 	c.SetDynamicMaxLeaseTTL(2 * time.Hour)
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "unbounded", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		ActorID: testAdminActorID,
 		// No MaxTTLSeconds — the per-config ceiling is unset/unbounded.
 	})
@@ -622,7 +662,7 @@ func TestDynamicSecrets_InstallWideMaxLeaseTTLDefaultsWhenUnset(t *testing.T) {
 	// SetDynamicMaxLeaseTTL is never called — dynamicMaxLeaseTTL stays its zero value.
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "unbounded", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
@@ -723,7 +763,7 @@ func TestDynamicSecrets_RevokeEffectiveEphemeralBackendAuditsAsGenuineRevoke(t *
 func TestDynamicSecrets_CreateRejectsDefaultOverMax(t *testing.T) {
 	c, _, _, _ := newDynamicTestCore(t)
 	_, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
-		Name: "bad", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "bad", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 3600, MaxTTLSeconds: 600, ActorID: testAdminActorID,
 	})
 	require.Error(t, err)
@@ -738,7 +778,7 @@ func TestDynamicSecrets_RenewRespectsInstallWideMaxLeaseTTL(t *testing.T) {
 	c.SetDynamicMaxLeaseTTL(20 * time.Minute)
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "unbounded", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 300, // no MaxTTLSeconds — per-config ceiling unset
 		ActorID:           testAdminActorID,
 	})
@@ -758,7 +798,7 @@ func TestDynamicSecrets_RenewExtendsAndRespectsMaxTTL(t *testing.T) {
 	c, _, fake, fixed := newDynamicTestCore(t)
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "renewable", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "renewable", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 600, MaxTTLSeconds: 1200, // 10m default, 20m hard cap
 		ActorID: testAdminActorID,
 	})
@@ -944,12 +984,14 @@ func TestDynamicSecrets_RealFactoryValidatesBackend(t *testing.T) {
 	))
 	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: testAdminActorID, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "real-factory-project"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, ProjectID: 1, Name: "real-factory-env"}).Error)
 	fixed := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return fixed }, passwordPolicy: DefaultPasswordPolicy()}
 
 	for _, backend := range []string{"postgres", "mysql", "mongodb", "redis"} {
 		_, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
-			Name: backend + "-cfg", ProjectID: 1, BackendType: backend, AdminDSN: "admin:p@tcp(h:3306)/",
+			Name: backend + "-cfg", ProjectID: 1, EnvironmentID: 2, BackendType: backend, AdminDSN: "admin:p@tcp(h:3306)/",
 			ActorID: testAdminActorID,
 		})
 		require.NoError(t, err, "backend %s must be accepted", backend)


### PR DESCRIPTION
## Summary
- `CreateDynamicSecretConfig` never validated that the request's
  `EnvironmentID` actually belongs to `ProjectID` — an existing test's own
  "different project" fixture reused another project's environment id,
  exactly the bug this closes.
- Adds an environment/project cross-check right after request validation and
  before the dynamic-secret engine call.

## Test plan
- [x] Fixed the pre-existing fixture that relied on the bug, plus 11 other
      call sites in the same test file that were missing `EnvironmentID`.
- [x] Added `TestDynamicSecrets_CreateConfig_RejectsCrossProjectEnvironment`
      and `TestDynamicSecrets_CreateConfig_RejectsUnknownEnvironment`.
- [x] `go build`/`go vet`/`gofmt` clean
- [x] `gosec -severity medium` clean
