### PR TITLE
fix(audit): add opt-in CLI migration for the hash-chain encoding break

### DIFF
--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -58,6 +58,8 @@ var (
 	searchUntil        string
 	searchLimit        int
 	searchOffset       int
+
+	flagMigrateConfirm bool
 )
 
 func init() {
@@ -90,7 +92,10 @@ func init() {
 	searchCmd.Flags().IntVar(&searchLimit, "limit", 100, "Max results (1–1000)")
 	searchCmd.Flags().IntVar(&searchOffset, "offset", 0, "Pagination offset")
 
-	AuditCmd.AddCommand(verifyCmd, exportCmd, checkpointCmd, logsCmd, searchCmd)
+	migrateChainCmd.Flags().BoolVar(&flagMigrateConfirm, "confirm", false,
+		"Apply the migration for real. Without this flag, the command only previews what would change — nothing is written.")
+
+	AuditCmd.AddCommand(verifyCmd, exportCmd, checkpointCmd, logsCmd, searchCmd, migrateChainCmd)
 }
 
 func client() (*common.RemoteClient, error) {
@@ -358,6 +363,73 @@ verify (broken, or a prior signed checkpoint proves a truncation).`,
 			if !out.AnchorTrustRootConfigured {
 				fmt.Println("  anchor verified: NO — no TSA trust root (ca_cert_path) is configured; this token was recorded but never checked against any root of trust")
 			}
+		}
+		return nil
+	},
+}
+
+// migrateChainResult mirrors the /audit/migrate-chain-encoding payload.
+type migrateChainResult struct {
+	DryRun               bool   `json:"dry_run"`
+	RowsMigrated         int64  `json:"rows_migrated"`
+	UnchainedRowsSkipped int64  `json:"unchained_rows_skipped"`
+	HeadID               uint   `json:"head_id"`
+	HeadHash             string `json:"head_hash"`
+	AnchorRowID          uint   `json:"anchor_row_id,omitempty"`
+	AnchorNewEntryHash   string `json:"anchor_new_entry_hash,omitempty"`
+}
+
+var migrateChainCmd = &cobra.Command{
+	Use:   "migrate-chain-encoding",
+	Short: "One-time re-derivation of the audit hash chain under the current encoding",
+	Long: `Re-derives entry_hash/prev_hash for every chained audit_events row under the
+server's current hash encoding. This closes a breaking hash-format change: any
+deployment with pre-existing chained audit rows will otherwise see 'audit verify'
+report the chain broken starting at the first pre-upgrade row, indistinguishable
+from tampering.
+
+SAFETY: without --confirm this only PREVIEWS what would change — nothing is
+written. Review the preview's row count before re-running with --confirm.
+
+This rewrites the tamper-evidence dataset itself. Before running with --confirm:
+  - Stop all other server instances (or otherwise ensure nothing else is writing
+    audit events) for the duration of the run — a concurrently appended event
+    can be hashed against a partially-migrated chain otherwise.
+  - Prefer running during a maintenance window.
+  - Consider taking a database backup first.
+
+Requires system.write (same privilege bar as 'audit checkpoint').`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		path := "/api/v1/audit/migrate-chain-encoding?dry_run=true"
+		if flagMigrateConfirm {
+			path = "/api/v1/audit/migrate-chain-encoding?dry_run=false"
+		}
+		var out migrateChainResult
+		if err := c.Post(context.Background(), path, nil, &out); err != nil {
+			return err
+		}
+
+		if out.DryRun {
+			fmt.Println("DRY RUN — nothing was written. Re-run with --confirm to apply.")
+		} else {
+			fmt.Println("Audit chain encoding migration applied:")
+		}
+		fmt.Printf("  rows migrated:          %d\n", out.RowsMigrated)
+		fmt.Printf("  unchained rows skipped: %d\n", out.UnchainedRowsSkipped)
+		fmt.Printf("  new head id:            %d\n", out.HeadID)
+		fmt.Printf("  new head hash:          %s\n", out.HeadHash)
+		if out.AnchorRowID != 0 {
+			fmt.Printf("  retention anchor row:   %d (re-signed with the migrated entry_hash)\n", out.AnchorRowID)
+		}
+		if out.DryRun {
+			fmt.Println("\nRun 'keyorix audit migrate-chain-encoding --confirm' to apply.")
+		} else {
+			fmt.Println("\nRun 'keyorix audit verify' to confirm the chain now verifies end to end.")
 		}
 		return nil
 	},

--- a/internal/cli/audit/audit_migrate_chain_test.go
+++ b/internal/cli/audit/audit_migrate_chain_test.go
@@ -1,0 +1,70 @@
+package audit
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateChainEncoding_CommandWiring(t *testing.T) {
+	names := map[string]bool{}
+	for _, sub := range AuditCmd.Commands() {
+		names[sub.Name()] = true
+	}
+	assert.True(t, names["migrate-chain-encoding"], "missing subcommand migrate-chain-encoding")
+	assert.NotNil(t, migrateChainCmd.Flags().Lookup("confirm"), "migrate-chain-encoding missing --confirm")
+}
+
+func TestMigrateChainEncoding_DefaultIsDryRun(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":{"dry_run":true,"rows_migrated":42,"unchained_rows_skipped":3,"head_id":45,"head_hash":"abc123"}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	var out bytes.Buffer
+	migrateChainCmd.SetOut(&out)
+	flagMigrateConfirm = false
+	require.NoError(t, migrateChainCmd.RunE(migrateChainCmd, nil))
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v1/audit/migrate-chain-encoding", gotPath)
+	assert.Equal(t, "dry_run=true", gotQuery, "without --confirm the call must request the safe dry-run path, never omit dry_run")
+}
+
+func TestMigrateChainEncoding_ConfirmAppliesForReal(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":{"dry_run":false,"rows_migrated":42,"unchained_rows_skipped":3,"head_id":45,"head_hash":"abc123","anchor_row_id":9,"anchor_new_entry_hash":"def456"}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	var out bytes.Buffer
+	migrateChainCmd.SetOut(&out)
+	flagMigrateConfirm = true
+	defer func() { flagMigrateConfirm = false }()
+	require.NoError(t, migrateChainCmd.RunE(migrateChainCmd, nil))
+
+	assert.Equal(t, "dry_run=false", gotQuery, "--confirm must explicitly opt out of the safe default")
+}
+
+func TestMigrateChainEncoding_ServerErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"insufficient permissions"}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	flagMigrateConfirm = false
+	err := migrateChainCmd.RunE(migrateChainCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/audit/audit_test.go
+++ b/internal/cli/audit/audit_test.go
@@ -16,7 +16,7 @@ func TestCommandWiring(t *testing.T) {
 	for _, sub := range AuditCmd.Commands() {
 		names[sub.Name()] = true
 	}
-	for _, want := range []string{"verify", "export", "checkpoint", "logs"} {
+	for _, want := range []string{"verify", "export", "checkpoint", "logs", "migrate-chain-encoding"} {
 		assert.True(t, names[want], "missing subcommand %q", want)
 	}
 	assert.NotNil(t, verifyCmd.Flags().Lookup("json"), "verify missing --json")

--- a/internal/core/audit_chain_migrate.go
+++ b/internal/core/audit_chain_migrate.go
@@ -1,0 +1,64 @@
+// audit_chain_migrate.go — one-time re-encoding of the audit hash chain
+// (ADR-029) after computeAuditEntryHash's length-prefixed-encoding fix, a
+// breaking hash-format change (see local_audit_chain.go's doc comment for
+// why the old NUL-delimited encoding was non-injective and had to change).
+//
+// This is deliberately an operator-triggered maintenance operation, not
+// something that runs automatically at startup or on a schedule: rewriting
+// every historical row of the one dataset whose entire purpose is tamper
+// evidence is exactly the kind of change that should happen with an operator
+// watching, during a maintenance window, not silently on the next deploy.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// MigrateAuditChainEncoding re-derives entry_hash/prev_hash for every chained
+// audit_events row under the current hash encoding. See
+// storage.Storage.MigrateAuditChainEncoding's doc for the full contract,
+// including why the caller MUST ensure no other process is concurrently
+// writing to this database's audit_events table for the duration of a
+// non-dry-run call (stop the server, or run during a maintenance window —
+// this call's own transaction only protects against concurrent writes
+// through this SAME storage backend's LogAuditEvent path).
+//
+// dryRun computes and returns the result WITHOUT persisting anything.
+//
+// On a real (non-dry-run) run: if a retention-anchored row was migrated, the
+// anchor is re-signed and persisted under the row's newly computed
+// entry_hash (its PrevHash is unchanged — it represents an already-purged
+// predecessor that cannot be recomputed under any encoding). A new audit
+// event recording the migration is then appended, chained under the new
+// encoding — becoming the chain's fresh, self-consistent head.
+func (c *KeyorixCore) MigrateAuditChainEncoding(ctx context.Context, actorID uint, dryRun bool) (*storage.AuditChainMigrationResult, error) {
+	anchor, err := c.loadAuditRetentionAnchor(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load audit chain re-anchor: %w", err)
+	}
+
+	result, err := c.storage.MigrateAuditChainEncoding(ctx, dryRun, anchor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to migrate audit chain encoding: %w", err)
+	}
+	if dryRun {
+		return result, nil
+	}
+
+	if result.AnchorRowID != 0 {
+		if err := c.persistAuditRetentionAnchor(ctx, c.storage, result.AnchorRowID, anchor.PrevHash, result.AnchorNewEntryHash); err != nil {
+			return nil, fmt.Errorf(
+				"audit chain rows were migrated successfully, but re-signing the retention anchor failed (%w) — "+
+					"re-run the migration to retry; row hashes are already correct and re-running is safe", err)
+		}
+	}
+
+	c.writeAuditEventFull(ctx, "audit.chain_migrated", &actorID, nil, nil, "",
+		fmt.Sprintf("audit hash-chain re-encoded: %d rows migrated, %d unchained legacy rows skipped, new head id %d",
+			result.RowsMigrated, result.UnchainedRowsSkipped, result.HeadID))
+
+	return result, nil
+}

--- a/internal/core/audit_chain_migrate_test.go
+++ b/internal/core/audit_chain_migrate_test.go
@@ -1,0 +1,124 @@
+// audit_chain_migrate_test.go — regression coverage for
+// KeyorixCore.MigrateAuditChainEncoding (ADR-029 hash-format migration).
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateAuditChainEncoding_Core_AppliesAndVerifiesAfterward(t *testing.T) {
+	ctx := context.Background()
+	c, db, fixed := newReanchorTestCore(t)
+
+	e1 := logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -3))
+	e2 := logChainedEvent(t, c, "secret.updated", fixed.AddDate(0, 0, -2))
+	e3 := logChainedEvent(t, c, "secret.deleted", fixed.AddDate(0, 0, -1))
+
+	// Simulate a legacy-encoded pre-existing chain by rewriting the stored
+	// hashes directly, matching the storage-layer test's approach.
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e1.ID).
+		Updates(map[string]interface{}{"entry_hash": "legacy-" + e1.EntryHash[:16]}).Error)
+	var reload2, reload3 models.AuditEvent
+	require.NoError(t, db.First(&reload2, e2.ID).Error)
+	require.NoError(t, db.First(&reload3, e3.ID).Error)
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e2.ID).
+		Updates(map[string]interface{}{"prev_hash": "legacy-" + e1.EntryHash[:16], "entry_hash": "legacy-" + e2.EntryHash[:16]}).Error)
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e3.ID).
+		Updates(map[string]interface{}{"prev_hash": "legacy-" + e2.EntryHash[:16], "entry_hash": "legacy-" + e3.EntryHash[:16]}).Error)
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "sanity: legacy-encoded rows must not verify before migration")
+
+	result, err := c.MigrateAuditChainEncoding(ctx, 1, false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), result.RowsMigrated)
+	assert.NotEmpty(t, result.HeadHash)
+
+	v2, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.True(t, v2.Valid, "chain must verify after a real migration run: %s", v2.Reason)
+
+	// A completion event was appended, chained under the new encoding —
+	// becoming the chain's fresh head.
+	var head models.AuditEvent
+	require.NoError(t, db.Order("id DESC").First(&head).Error)
+	assert.Equal(t, "audit.chain_migrated", head.EventType)
+	assert.Equal(t, head.ID, v2.HeadID, "the completion event itself must verify as the new head")
+}
+
+func TestMigrateAuditChainEncoding_Core_DryRunPersistsNothing(t *testing.T) {
+	ctx := context.Background()
+	c, db, fixed := newReanchorTestCore(t)
+
+	e1 := logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -1))
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e1.ID).
+		Updates(map[string]interface{}{"entry_hash": "legacy-" + e1.EntryHash[:16]}).Error)
+
+	var before models.AuditEvent
+	require.NoError(t, db.First(&before, e1.ID).Error)
+
+	result, err := c.MigrateAuditChainEncoding(ctx, 1, true)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), result.RowsMigrated, "dry run still reports what would change")
+
+	var after models.AuditEvent
+	require.NoError(t, db.First(&after, e1.ID).Error)
+	assert.Equal(t, before.EntryHash, after.EntryHash, "dry run must not persist row changes")
+
+	// No completion event is appended on a dry run — nothing to record.
+	var count int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "audit.chain_migrated").Count(&count).Error)
+	assert.Equal(t, int64(0), count, "a dry run must not append a completion audit event")
+}
+
+// TestMigrateAuditChainEncoding_Core_ReSignsAnchorAfterPurge covers the
+// interaction with a preceding retention purge: the earliest surviving row
+// carries an anchor (its real predecessor was purged). A real migration run
+// must re-sign that anchor with the row's newly computed hash so
+// VerifyAuditChain (which authenticates the anchor against the signing key)
+// keeps accepting it after the migration.
+func TestMigrateAuditChainEncoding_Core_ReSignsAnchorAfterPurge(t *testing.T) {
+	ctx := context.Background()
+	c, db, fixed := newReanchorTestCore(t)
+
+	for i := 0; i < 3; i++ {
+		logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -(40+i)))
+	}
+	for i := 0; i < 2; i++ {
+		logChainedEvent(t, c, "secret.updated", fixed.AddDate(0, 0, -1))
+	}
+
+	_, err := c.PurgeAuditLogs(ctx, AuditLogRetentionConfig{RetentionDays: 30})
+	require.NoError(t, err)
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	require.True(t, v.Valid, "sanity: purge alone must not break verification")
+
+	// Simulate the anchored (earliest surviving) row being legacy-encoded:
+	// rewrite its entry_hash directly (its prev_hash — the anchor's PrevHash —
+	// must stay untouched, since it represents an already-purged predecessor).
+	var earliest models.AuditEvent
+	require.NoError(t, db.Where("event_type != ?", "system.audit_purge").Order("id ASC").First(&earliest).Error)
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", earliest.ID).
+		Updates(map[string]interface{}{"entry_hash": "legacy-" + earliest.EntryHash[:16]}).Error)
+
+	v2, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v2.Valid, "sanity: legacy-encoded anchored row must not verify before migration")
+
+	result, err := c.MigrateAuditChainEncoding(ctx, 1, false)
+	require.NoError(t, err)
+	require.Equal(t, earliest.ID, result.AnchorRowID, "the anchored row must be reported for re-signing")
+	assert.NotEmpty(t, result.AnchorNewEntryHash)
+
+	v3, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.True(t, v3.Valid, "chain must verify after the anchor is re-signed by the migration: %s", v3.Reason)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1314,6 +1314,14 @@ func (m *MockStorage) VerifyAuditChain(ctx context.Context, anchor *storage.Audi
 	return args.Get(0).(*storage.AuditChainVerification), args.Error(1)
 }
 
+func (m *MockStorage) MigrateAuditChainEncoding(ctx context.Context, dryRun bool, anchor *storage.AuditChainAnchor) (*storage.AuditChainMigrationResult, error) {
+	args := m.Called(ctx, dryRun, anchor)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.AuditChainMigrationResult), args.Error(1)
+}
+
 func (m *MockStorage) CreateAuditCheckpoint(ctx context.Context, cp *models.AuditCheckpoint) error {
 	args := m.Called(ctx, cp)
 	return args.Error(0)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1191,6 +1191,34 @@ type Storage interface {
 	// that already starts at genesis (the purge only removed the legacy
 	// unchained prefix, or the table is now empty) ignores a non-nil anchor.
 	VerifyAuditChain(ctx context.Context, anchor *AuditChainAnchor) (*AuditChainVerification, error)
+	// MigrateAuditChainEncoding re-derives entry_hash/prev_hash for every chained
+	// audit_events row, in ascending id order, under computeAuditEntryHash's
+	// current (length-prefixed) encoding — closing the gap left when that
+	// encoding replaced the prior NUL-delimited one (a breaking, non-content-
+	// preserving hash-format change; see computeAuditEntryHash's doc comment).
+	// The unchained legacy prefix (pre-ADR-029 rows with an empty entry_hash) is
+	// left untouched.
+	//
+	// anchor has EXACTLY the same meaning and applicability rule as
+	// VerifyAuditChain's own anchor parameter: when non-nil AND the earliest
+	// chained row's CURRENTLY STORED prev_hash is not auditGenesisHash (a prior
+	// sanctioned retention purge moved the chain start), the walk seeds from
+	// anchor.PrevHash instead of genesis. The caller MUST have already
+	// authenticated anchor; this layer trusts it literally.
+	//
+	// Holds the same cross-process exclusivity LogAuditEvent uses (Postgres
+	// advisory lock; SQLite's own single-writer semantics) for the ENTIRE
+	// migration, in one transaction — not just per batch — so no concurrently
+	// appended row can be hashed against a partially-migrated chain. Callers
+	// MUST ensure no other process can reach this database's audit_events table
+	// for the duration (this transaction only prevents concurrent writes
+	// THROUGH this same storage backend's own LogAuditEvent path, not from an
+	// entirely separate process/connection pool bypassing it).
+	//
+	// dryRun computes and returns the same result WITHOUT persisting anything
+	// (the transaction is rolled back), so an operator can preview row/anchor
+	// counts before committing.
+	MigrateAuditChainEncoding(ctx context.Context, dryRun bool, anchor *AuditChainAnchor) (*AuditChainMigrationResult, error)
 	// CreateAuditCheckpoint appends a signed checkpoint of the chain head (ADR-029).
 	CreateAuditCheckpoint(ctx context.Context, cp *models.AuditCheckpoint) error
 	// UpdateAuditCheckpointAnchor stores the external-notary anchor (RFC 3161 token,
@@ -1903,6 +1931,27 @@ type AuditChainAnchor struct {
 	RowID     uint
 	PrevHash  string
 	EntryHash string
+}
+
+// AuditChainMigrationResult reports the outcome of MigrateAuditChainEncoding.
+type AuditChainMigrationResult struct {
+	// RowsMigrated is the number of chained rows whose entry_hash/prev_hash
+	// were (or, under dry-run, would be) rewritten.
+	RowsMigrated int64
+	// UnchainedRowsSkipped is the legacy pre-ADR-029 prefix left untouched.
+	UnchainedRowsSkipped int64
+	// HeadID/HeadHash are the migrated chain's final row id and its newly
+	// computed entry_hash (auditGenesisHash-derived if RowsMigrated is 0).
+	HeadID   uint
+	HeadHash string
+	// AnchorRowID/AnchorNewEntryHash are set when the earliest migrated row's
+	// id matches the anchor the caller seeded this call with (seedPrevHash
+	// came from a real retention anchor, not genesis) — the caller must re-sign
+	// and persist an updated anchor for AnchorRowID using AnchorNewEntryHash
+	// (its PrevHash is unchanged; it represents an already-purged predecessor
+	// that cannot be recomputed). Zero/empty when no anchor applies.
+	AnchorRowID        uint
+	AnchorNewEntryHash string
 }
 
 // UnusedSecretStat is one row of the unused-secrets report. LastRead is nil when

--- a/internal/storage/store/local_audit_chain.go
+++ b/internal/storage/store/local_audit_chain.go
@@ -15,6 +15,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"strconv"
 	"time"
 
@@ -257,6 +258,113 @@ func (ls *LocalStorage) VerifyAuditChain(ctx context.Context, anchor *storage.Au
 	result.HeadID = headID
 	return result, nil
 }
+
+// MigrateAuditChainEncoding re-derives entry_hash/prev_hash for every chained
+// audit_events row under computeAuditEntryHash's current encoding, in one
+// transaction spanning the whole migration (holding the same cross-process
+// exclusivity LogAuditEvent uses for its own append, so no concurrently
+// appended row can interleave against a partially-migrated chain). See the
+// storage.Storage interface doc for the full contract, including why callers
+// must still ensure no other process reaches this database concurrently.
+func (ls *LocalStorage) MigrateAuditChainEncoding(ctx context.Context, dryRun bool, anchor *storage.AuditChainAnchor) (*storage.AuditChainMigrationResult, error) {
+	result := &storage.AuditChainMigrationResult{}
+
+	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if tx.Dialector.Name() == "postgres" {
+			if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", int64(auditAdvisoryLockKey)).Error; err != nil {
+				return err
+			}
+		}
+
+		prevHash := auditGenesisHash
+		started := false
+		var lastID uint
+		firstBatch := true
+		firstChainedID := uint(0)
+		firstChainedNewHash := ""
+		anchorApplies := false
+
+		for {
+			var batch []*models.AuditEvent
+			if err := tx.
+				Where("id > ?", lastID).
+				Order("id ASC").
+				Limit(auditChainVerifyBatch).
+				Find(&batch).Error; err != nil {
+				return err
+			}
+			if len(batch) == 0 {
+				break
+			}
+			if firstBatch {
+				firstBatch = false
+				// Mirror VerifyAuditChain's exact applicability rule: only seed from
+				// the anchor if the earliest row that WOULD start the chain (first
+				// non-empty-entry_hash row) currently carries a non-genesis
+				// prev_hash — i.e. a prior purge genuinely moved the chain start.
+				for _, e := range batch {
+					if e.EntryHash == "" {
+						continue
+					}
+					if anchor != nil && e.PrevHash != auditGenesisHash {
+						prevHash = anchor.PrevHash
+						anchorApplies = true
+					}
+					break
+				}
+			}
+			for _, e := range batch {
+				if !started {
+					if e.EntryHash == "" {
+						result.UnchainedRowsSkipped++
+						continue
+					}
+					started = true
+					firstChainedID = e.ID
+				}
+				newHash := computeAuditEntryHash(e, prevHash)
+				if e.ID == firstChainedID {
+					firstChainedNewHash = newHash
+				}
+				if e.PrevHash != prevHash || e.EntryHash != newHash {
+					if err := tx.Model(&models.AuditEvent{}).Where("id = ?", e.ID).
+						Updates(map[string]interface{}{"prev_hash": prevHash, "entry_hash": newHash}).Error; err != nil {
+						return err
+					}
+				}
+				prevHash = newHash
+				result.HeadID = e.ID
+				result.RowsMigrated++
+			}
+			lastID = batch[len(batch)-1].ID
+			if len(batch) < auditChainVerifyBatch {
+				break
+			}
+		}
+
+		result.HeadHash = prevHash
+		if anchorApplies && firstChainedID != 0 {
+			// The earliest migrated row is the anchor's row; the caller must
+			// re-sign the anchor with this row's newly computed entry_hash (its
+			// PrevHash is unchanged — it represents an already-purged predecessor
+			// that cannot be recomputed under any encoding).
+			result.AnchorRowID = firstChainedID
+			result.AnchorNewEntryHash = firstChainedNewHash
+		}
+		if dryRun {
+			return errAuditMigrationDryRun
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errAuditMigrationDryRun) {
+		return nil, err
+	}
+	return result, nil
+}
+
+// errAuditMigrationDryRun is a sentinel used to force MigrateAuditChainEncoding's
+// transaction to roll back after computing (but never persisting) its result.
+var errAuditMigrationDryRun = errors.New("audit chain migration dry run")
 
 // verifyBatchEvents processes one page of audit events against the running hash chain.
 // Returns the new prevHash, the last verified headID, the updated started flag, and

--- a/internal/storage/store/local_audit_chain_migrate_test.go
+++ b/internal/storage/store/local_audit_chain_migrate_test.go
@@ -1,0 +1,179 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// appendLegacyEncodedEvent inserts a row already stored with a hash chain,
+// then rewrites its prev_hash/entry_hash to simulate a row that was chained
+// under a DIFFERENT (older) encoding than computeAuditEntryHash currently
+// produces — exactly the state MigrateAuditChainEncoding exists to repair.
+func appendLegacyEncodedEvent(t *testing.T, ls *LocalStorage, desc string, at time.Time, prevHash string) *models.AuditEvent {
+	t.Helper()
+	e := appendEvent(t, ls, "secret.read", desc, at)
+	legacyEntryHash := "legacy-" + e.EntryHash[:16]
+	require.NoError(t, ls.db.Model(&models.AuditEvent{}).Where("id = ?", e.ID).
+		Updates(map[string]interface{}{"prev_hash": prevHash, "entry_hash": legacyEntryHash}).Error)
+	e.PrevHash = prevHash
+	e.EntryHash = legacyEntryHash
+	return e
+}
+
+func TestMigrateAuditChainEncoding_RechainsUnderCurrentEncoding(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	e1 := appendLegacyEncodedEvent(t, ls, "first", base, auditGenesisHash)
+	e2 := appendLegacyEncodedEvent(t, ls, "second", base.Add(time.Second), e1.EntryHash)
+	e3 := appendLegacyEncodedEvent(t, ls, "third", base.Add(2*time.Second), e2.EntryHash)
+
+	// Sanity: as stored, the chain does NOT verify under the current encoding.
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "legacy-encoded rows must not verify under the current encoding before migration")
+
+	result, err := ls.MigrateAuditChainEncoding(context.Background(), false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), result.RowsMigrated)
+	assert.Equal(t, int64(0), result.UnchainedRowsSkipped)
+	assert.Equal(t, e3.ID, result.HeadID)
+	assert.NotEmpty(t, result.HeadHash)
+	assert.Equal(t, uint(0), result.AnchorRowID, "no anchor supplied, none should be reported")
+
+	v2, err := ls.VerifyAuditChain(context.Background(), nil)
+	require.NoError(t, err)
+	assert.True(t, v2.Valid, "chain must verify under the current encoding after migration: %s", v2.Reason)
+	assert.Equal(t, int64(3), v2.ChainedEvents)
+	assert.Equal(t, result.HeadHash, v2.HeadHash)
+	assert.Equal(t, result.HeadID, v2.HeadID)
+}
+
+func TestMigrateAuditChainEncoding_DryRunMakesNoChanges(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	e1 := appendLegacyEncodedEvent(t, ls, "first", base, auditGenesisHash)
+	e2 := appendLegacyEncodedEvent(t, ls, "second", base.Add(time.Second), e1.EntryHash)
+
+	result, err := ls.MigrateAuditChainEncoding(context.Background(), true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.RowsMigrated, "dry run still computes what WOULD change")
+	assert.NotEmpty(t, result.HeadHash)
+
+	// Nothing was actually persisted: the stored rows are unchanged, and the
+	// chain still fails verification exactly as before the call.
+	var stored1, stored2 models.AuditEvent
+	require.NoError(t, ls.db.First(&stored1, e1.ID).Error)
+	require.NoError(t, ls.db.First(&stored2, e2.ID).Error)
+	assert.Equal(t, e1.EntryHash, stored1.EntryHash, "dry run must not persist row 1")
+	assert.Equal(t, e2.EntryHash, stored2.EntryHash, "dry run must not persist row 2")
+
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "chain must still fail verification after a dry run")
+}
+
+func TestMigrateAuditChainEncoding_LeavesUnchainedLegacyPrefixAlone(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	// Two pre-ADR-029 rows: no hash chain at all (empty entry_hash).
+	tr := true
+	for i, d := range []string{"unchained-1", "unchained-2"} {
+		require.NoError(t, ls.db.Create(&models.AuditEvent{
+			EventType: "secret.read", Description: d, Success: &tr,
+			EventTime: base.Add(time.Duration(i) * time.Second), ActorType: "user",
+		}).Error)
+	}
+	c1 := appendLegacyEncodedEvent(t, ls, "chained-1", base.Add(10*time.Second), auditGenesisHash)
+	_ = appendLegacyEncodedEvent(t, ls, "chained-2", base.Add(11*time.Second), c1.EntryHash)
+
+	result, err := ls.MigrateAuditChainEncoding(context.Background(), false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.RowsMigrated, "only the chained rows are migrated")
+	assert.Equal(t, int64(2), result.UnchainedRowsSkipped, "the unchained legacy prefix is left untouched")
+
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "chain must verify after migration: %s", v.Reason)
+	assert.Equal(t, int64(2), v.UnchainedEvents)
+	assert.Equal(t, int64(2), v.ChainedEvents)
+}
+
+// TestMigrateAuditChainEncoding_ReSignsRetentionAnchor covers the interaction
+// with a retention purge that ran BEFORE the migration: the earliest
+// surviving row's prev_hash is a non-genesis anchor value (its real
+// predecessor was purged and can never be recomputed under any encoding).
+// The migration must recompute that row's entry_hash under the current
+// encoding while leaving its prev_hash exactly as the anchor says, and
+// report it back to the caller so the anchor itself can be re-signed.
+func TestMigrateAuditChainEncoding_ReSignsRetentionAnchor(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	const purgedPredecessorHash = "purged-predecessor-hash"
+	anchored := appendLegacyEncodedEvent(t, ls, "first-surviving", base, purgedPredecessorHash)
+	_ = appendLegacyEncodedEvent(t, ls, "second", base.Add(time.Second), anchored.EntryHash)
+
+	anchor := &storage.AuditChainAnchor{
+		RowID:     anchored.ID,
+		PrevHash:  purgedPredecessorHash,
+		EntryHash: anchored.EntryHash,
+	}
+
+	result, err := ls.MigrateAuditChainEncoding(context.Background(), false, anchor)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.RowsMigrated)
+	require.Equal(t, anchored.ID, result.AnchorRowID, "the earliest migrated row must be reported for anchor re-signing")
+	assert.NotEmpty(t, result.AnchorNewEntryHash)
+	assert.NotEqual(t, anchored.EntryHash, result.AnchorNewEntryHash, "the anchor row's hash changed under the new encoding")
+
+	var stored models.AuditEvent
+	require.NoError(t, ls.db.First(&stored, anchored.ID).Error)
+	assert.Equal(t, purgedPredecessorHash, stored.PrevHash, "the purged predecessor's hash is preserved verbatim, not recomputed")
+	assert.Equal(t, result.AnchorNewEntryHash, stored.EntryHash)
+
+	// A re-signed anchor (matching what the caller is expected to persist)
+	// must let the migrated chain verify from that point forward.
+	newAnchor := &storage.AuditChainAnchor{
+		RowID:     anchored.ID,
+		PrevHash:  purgedPredecessorHash,
+		EntryHash: result.AnchorNewEntryHash,
+	}
+	v, err := ls.VerifyAuditChain(context.Background(), newAnchor)
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "chain must verify against the re-signed anchor: %s", v.Reason)
+}
+
+func TestMigrateAuditChainEncoding_Empty(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	result, err := ls.MigrateAuditChainEncoding(context.Background(), false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), result.RowsMigrated)
+	assert.Equal(t, int64(0), result.UnchainedRowsSkipped)
+	assert.Equal(t, uint(0), result.HeadID)
+}
+
+func TestMigrateAuditChainEncoding_AlreadyCurrentEncodingIsIdempotent(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+	appendEvent(t, ls, "auth.login", "first", base)
+	appendEvent(t, ls, "secret.read", "second", base.Add(time.Second))
+
+	// Rows already chained under the CURRENT encoding: migration should be a
+	// no-op in effect (same hashes recomputed) and the chain stays valid.
+	result, err := ls.MigrateAuditChainEncoding(context.Background(), false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.RowsMigrated, "rows are re-walked and rewritten even if already current")
+
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "re-migrating already-current rows must not break the chain: %s", v.Reason)
+}

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -175,6 +175,14 @@ func (rs *RemoteStorage) VerifyAuditChain(_ context.Context, _ *storage.AuditCha
 	return nil, fmt.Errorf("VerifyAuditChain not available in remote mode")
 }
 
+// MigrateAuditChainEncoding is not available in remote mode: a spoke has no
+// direct access to the hub's audit_events table, and this migration must hold
+// an exclusive, whole-migration lock only the actual database owner can take.
+// Run this against the primary/hub server's own storage backend directly.
+func (rs *RemoteStorage) MigrateAuditChainEncoding(_ context.Context, _ bool, _ *storage.AuditChainAnchor) (*storage.AuditChainMigrationResult, error) {
+	return nil, fmt.Errorf("MigrateAuditChainEncoding not available in remote mode — run it against the primary server directly")
+}
+
 // GetSecretReadCounts is server-side only; read aggregation runs against the
 // local audit table and is never proxied over a remote HTTP call.
 func (rs *RemoteStorage) GetSecretReadCounts(_ context.Context, _ uint, _, _ time.Time, _ int) ([]storage.SecretReadEntry, error) {

--- a/internal/storage/store/remote_audit_test.go
+++ b/internal/storage/store/remote_audit_test.go
@@ -251,6 +251,15 @@ func TestRemoteStorage_VerifyAuditChain_Unsupported(t *testing.T) {
 	assert.Contains(t, err.Error(), "not available in remote mode")
 }
 
+func TestRemoteStorage_MigrateAuditChainEncoding_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.MigrateAuditChainEncoding(context.Background(), true, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
 // --- CreateAuditCheckpoint (unsupported) ---
 
 func TestRemoteStorage_CreateAuditCheckpoint_Unsupported(t *testing.T) {

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -464,3 +464,56 @@ func (h *AuditHandler) WriteAuditCheckpoint(w http.ResponseWriter, r *http.Reque
 	}
 	sendSuccess(w, resp, "audit checkpoint written")
 }
+
+// MigrateAuditChainEncoding handles POST /api/v1/audit/migrate-chain-encoding —
+// a one-time, operator-triggered re-derivation of entry_hash/prev_hash for
+// every chained audit_events row under the current hash encoding (see
+// internal/core/audit_chain_migrate.go's doc comment for why this exists and
+// why it is deliberately NOT automatic). Privileged (system.write, same bar
+// as /checkpoint): this rewrites the one dataset whose entire purpose is
+// tamper evidence.
+//
+// ?dry_run=true (the default when the query param is absent) computes and
+// returns the result WITHOUT persisting anything, so an operator can preview
+// row/anchor counts before committing. A real run requires the query param
+// set explicitly to "false" — there is no way to trigger a real run by
+// omission or typo, only by deliberately opting out of the safe default.
+//
+// The caller is responsible for ensuring no other process can reach this
+// server's audit_events table for the duration of a real run (stop the
+// server's OTHER instances if load-balanced, or run during a maintenance
+// window) — this endpoint's own transaction only serializes against this
+// process's own LogAuditEvent path, not an entirely separate connection.
+func (h *AuditHandler) MigrateAuditChainEncoding(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+
+	dryRun := r.URL.Query().Get("dry_run") != "false"
+
+	result, err := h.coreService.MigrateAuditChainEncoding(r.Context(), userCtx.UserID, dryRun)
+	if err != nil {
+		log.Printf("Error migrating audit chain encoding: %v", err)
+		sendError(w, "InternalError", clientSafe(err), http.StatusInternalServerError, nil)
+		return
+	}
+
+	resp := map[string]interface{}{
+		"dry_run":                dryRun,
+		"rows_migrated":          result.RowsMigrated,
+		"unchained_rows_skipped": result.UnchainedRowsSkipped,
+		"head_id":                result.HeadID,
+		"head_hash":              result.HeadHash,
+	}
+	if result.AnchorRowID != 0 {
+		resp["anchor_row_id"] = result.AnchorRowID
+		resp["anchor_new_entry_hash"] = result.AnchorNewEntryHash
+	}
+	msg := "audit chain encoding migration preview (dry run — nothing was written; re-run with ?dry_run=false to apply)"
+	if !dryRun {
+		msg = "audit chain encoding migration applied"
+	}
+	sendSuccess(w, resp, msg)
+}

--- a/server/http/handlers/audit_migrate_chain_handler_test.go
+++ b/server/http/handlers/audit_migrate_chain_handler_test.go
@@ -1,0 +1,105 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// openAuditChainTestDB opens a fresh in-memory SQLite DB migrated for the
+// audit hash-chain tables only — this handler's underlying core/storage call
+// touches audit_events and system_metadata (for the retention anchor), not
+// the RBAC tables openTestDB sets up for other handlers.
+func openAuditChainTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.SystemMetadata{}))
+	return db
+}
+
+func TestAuditHandler_MigrateChainEncoding_RequiresUserContext(t *testing.T) {
+	db := openAuditChainTestDB(t)
+	h := NewAuditHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/migrate-chain-encoding", nil)
+	w := httptest.NewRecorder()
+	h.MigrateAuditChainEncoding(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// No query string at all must behave identically to the safe default
+// (dry_run=true) — an operator who omits the parameter, or mistypes it,
+// still only gets a preview.
+func TestAuditHandler_MigrateChainEncoding_DefaultsToDryRun(t *testing.T) {
+	db := openAuditChainTestDB(t)
+	h := NewAuditHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/audit/migrate-chain-encoding", nil))
+	w := httptest.NewRecorder()
+	h.MigrateAuditChainEncoding(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var body struct {
+		Data struct {
+			DryRun bool `json:"dry_run"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.True(t, body.Data.DryRun, "no dry_run query param must default to a preview, never a real run")
+}
+
+// A typo'd or unrecognized dry_run value must still fail SAFE (preview), not
+// accidentally opt into a real run — only the literal string "false" does.
+func TestAuditHandler_MigrateChainEncoding_UnrecognizedDryRunValueStaysDryRun(t *testing.T) {
+	db := openAuditChainTestDB(t)
+	h := NewAuditHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/audit/migrate-chain-encoding?dry_run=nope", nil))
+	w := httptest.NewRecorder()
+	h.MigrateAuditChainEncoding(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var body struct {
+		Data struct {
+			DryRun bool `json:"dry_run"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.True(t, body.Data.DryRun)
+}
+
+func TestAuditHandler_MigrateChainEncoding_ExplicitFalseAppliesForReal(t *testing.T) {
+	db := openAuditChainTestDB(t)
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h := NewAuditHandler(c)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/audit/migrate-chain-encoding?dry_run=false", nil))
+	w := httptest.NewRecorder()
+	h.MigrateAuditChainEncoding(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var body struct {
+		Data struct {
+			DryRun               bool   `json:"dry_run"`
+			RowsMigrated         int64  `json:"rows_migrated"`
+			UnchainedRowsSkipped int64  `json:"unchained_rows_skipped"`
+			HeadID               uint   `json:"head_id"`
+			HeadHash             string `json:"head_hash"`
+		} `json:"data"`
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.False(t, body.Data.DryRun)
+	assert.Contains(t, body.Message, "applied")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1032,6 +1032,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// Writing a checkpoint is a privileged integrity-control action — gate it
 			// above the group's audit.read with system.write (admin-level).
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/checkpoint", auditHandler.WriteAuditCheckpoint)
+			// A one-time, operator-triggered migration of the audit hash chain's
+			// encoding (see internal/core/audit_chain_migrate.go) — same privilege
+			// bar as /checkpoint: it rewrites the tamper-evidence dataset itself.
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/migrate-chain-encoding", auditHandler.MigrateAuditChainEncoding)
 			// ANOMALY-04: anomaly alerts expose SecretName/AccessedBy/IPAddress — raise
 			// the gate above the group's audit.read so the base viewer/system_viewer role
 			// cannot enumerate them and check whether their own access patterns were flagged.


### PR DESCRIPTION
## Summary
`computeAuditEntryHash`'s length-prefixed encoding fix (already merged) is a
documented breaking hash-format change: a deployment with pre-existing
chained `audit_events` rows sees `VerifyAuditChain` report the chain broken
starting at the first pre-upgrade row after upgrading, indistinguishable
from tampering. That fix intentionally left the migration to a follow-up.

Adds `keyorix audit migrate-chain-encoding`, an operator-triggered,
safe-by-default (dry-run unless `--confirm`) command that re-derives
entry_hash/prev_hash for every chained row under the current encoding.

- New `storage.Storage.MigrateAuditChainEncoding` (LocalStorage: one
  whole-migration transaction holding the same advisory lock
  `LogAuditEvent` uses; RemoteStorage: clear unsupported-in-remote-mode
  error).
- New `POST /api/v1/audit/migrate-chain-encoding` endpoint, gated at
  `system.write` (same bar as `/audit/checkpoint`), dry-run unless
  `?dry_run=false`.
- Core-layer wrapper re-signs the retention anchor (mirroring
  `VerifyAuditChain`'s own anchor-applicability check) when the earliest
  migrated row is anchor-covered, then appends a completion audit event.

## Test plan
- [x] 13 new regression tests across storage/core/handler/CLI layers: rows
      correctly re-chained, dry-run makes no persisted changes, anchor
      re-signing after a retention purge, unchained legacy prefix untouched,
      dry-run-by-default including an unrecognized `dry_run` value staying
      safe.
- [x] `go build`/`go vet`/`gofmt` clean
- [x] `gosec -severity medium` clean
