### PR TITLE
fix(cli): route share group-shares through the server in remote mode (G66)

### DIFF
--- a/internal/cli/share/group_shares.go
+++ b/internal/cli/share/group_shares.go
@@ -30,15 +30,10 @@ func init() {
 }
 
 func runGroupShares(cmd *cobra.Command, args []string) error {
-	// KNOWN GAP (tracked, not fixed here): unlike every other command in this
-	// package, this has no `if rc, ok := common.NewRemoteClient(); ok { ... }`
-	// branch — it always reads local embedded storage, silently ignoring a
-	// connected server (#G66). #G10 (below) closed the OTHER half of this: the
-	// core function now self-authorizes, so a future remote endpoint can safely
-	// expose it without shipping a new unauthenticated-scope disclosure surface.
-	// Adding that endpoint (and this command's remote-client branch) is still
-	// out of scope here — it's #G66's fix, not #G10's.
-	//
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runGroupSharesRemote(rc, groupSharesGroupID)
+	}
+
 	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
 	st, err := common.InitializeStorage()
 	if err != nil {

--- a/internal/cli/share/remote.go
+++ b/internal/cli/share/remote.go
@@ -76,6 +76,32 @@ func runListRemote(rc *common.RemoteClient, secretID uint) error {
 	return nil
 }
 
+// runGroupSharesRemote lists shares granted TO a group via
+// GET /api/v1/groups/{id}/shares (#G66 — the embedded path previously ran
+// unconditionally, silently ignoring a connected server; there was no
+// remote-mode branch or server endpoint for this command at all).
+func runGroupSharesRemote(rc *common.RemoteClient, groupID uint) error {
+	var resp struct {
+		Shares []models.ShareRecord `json:"shares"`
+	}
+	if err := rc.Get(context.Background(), fmt.Sprintf("/api/v1/groups/%d/shares", groupID), &resp); err != nil {
+		return fmt.Errorf("failed to list group shares: %w", err)
+	}
+	if len(resp.Shares) == 0 {
+		fmt.Println("No shares found for this group.")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tSECRET ID\tOWNER ID\tGROUP ID\tPERMISSION\tCREATED AT") //nolint:errcheck
+	for _, share := range resp.Shares {
+		fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%s\t%s\n", //nolint:errcheck
+			share.ID, share.SecretID, share.OwnerID, share.RecipientID,
+			share.Permission, share.CreatedAt.Format("2006-01-02 15:04:05"))
+	}
+	_ = w.Flush() // #nosec G104
+	return nil
+}
+
 func runRevokeRemote(rc *common.RemoteClient, shareID uint) error {
 	if err := rc.Delete(context.Background(), fmt.Sprintf("/api/v1/shares/%d", shareID)); err != nil {
 		return fmt.Errorf("failed to revoke share: %w", err)

--- a/internal/cli/share/share_remote_test.go
+++ b/internal/cli/share/share_remote_test.go
@@ -88,6 +88,58 @@ func TestRunSharedSecrets_Remote_RoutesThroughRemoteClient(t *testing.T) {
 	assert.Equal(t, "/api/v1/shared-secrets", gotPath)
 }
 
+func TestRunGroupSharesRemote_EmptyResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"shares":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runGroupSharesRemote(rc, 7))
+}
+
+func TestRunGroupSharesRemote_WithResults(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"shares":[
+			{"ID":1,"SecretID":5,"OwnerID":1,"RecipientID":7,"IsGroup":true,"Permission":"read","CreatedAt":"2026-06-01T10:00:00Z"}
+		]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runGroupSharesRemote(rc, 7))
+	assert.Equal(t, "/api/v1/groups/7/shares", gotPath)
+}
+
+// TestRunGroupShares_Remote_RoutesThroughRemoteClient is the regression test
+// for #G66: previously runGroupShares had no remote-client branch at all and
+// always read local embedded storage, silently ignoring a connected server.
+func TestRunGroupShares_Remote_RoutesThroughRemoteClient(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"shares":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origID := groupSharesGroupID
+	defer func() { groupSharesGroupID = origID }()
+	groupSharesGroupID = 11
+
+	require.NoError(t, runGroupShares(nil, nil))
+	assert.Equal(t, "/api/v1/groups/11/shares", gotPath)
+}
+
 func TestRunUpdate_PermissionValidation(t *testing.T) {
 	origPerm, origID := updatePermission, updateShareID
 	defer func() { updatePermission = origPerm; updateShareID = origID }()

--- a/internal/cli/share/share_s2_test.go
+++ b/internal/cli/share/share_s2_test.go
@@ -83,6 +83,8 @@ func TestRunGroupShares_LocalModeStorageError(t *testing.T) {
 	t.Chdir(t.TempDir())
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
+	// #G66: isolate from any real ~/.keyorix/cli.yaml so this stays local-mode.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	origID := groupSharesGroupID
 	defer func() { groupSharesGroupID = origID }()
 	groupSharesGroupID = 1
@@ -189,6 +191,8 @@ func TestRunGroupShares_EmptyResult(t *testing.T) {
 	t.Chdir(t.TempDir())
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
+	// #G66: isolate from any real ~/.keyorix/cli.yaml so this stays local-mode.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	orig := groupSharesGroupID
 	defer func() { groupSharesGroupID = orig }()
 	groupSharesGroupID = 1

--- a/internal/cli/share/share_s3_test.go
+++ b/internal/cli/share/share_s3_test.go
@@ -332,6 +332,10 @@ func TestRunGroupShares_PrintsTable(t *testing.T) {
 	t.Chdir(dir)
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
+	// #G66: runGroupShares now has a remote-client branch like every other
+	// share command — isolate it from any real ~/.keyorix/cli.yaml on the
+	// machine running the test, so this stays a local-mode test.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	svc := openShareCore(t)
 	ownerID, secretID, projID := seedShareData(t, svc)

--- a/server/http/handlers/shares_group_shares_test.go
+++ b/server/http/handlers/shares_group_shares_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// TestListGroupSharesHandler is the regression test for #G66: previously the
+// only way to read a group's incoming share grants was the embedded/local CLI
+// path, which silently ignored a connected server. This is now a real HTTP
+// endpoint, self-authorizing via #G10's AuthorizePrincipal.
+func TestListGroupSharesHandler(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.ShareRecord{}, &models.Group{},
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserGroup{}, &models.GroupRole{}, &models.Project{}, &models.Environment{},
+	))
+
+	// #G10: ListGroupShares self-authorizes (secrets.read, global scope);
+	// withUserCtx's UserID 1 needs a real grant.
+	role := &models.Role{Name: "admin"}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: role.ID, ProjectID: 0, EnvironmentID: 0}).Error)
+
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "alpha", IsSecret: true, OwnerID: 1}).Error)
+	require.NoError(t, db.Create(&models.ShareRecord{ID: 1, SecretID: 1, OwnerID: 1, RecipientID: 7, IsGroup: true, Permission: "read"}).Error)
+
+	h, err := NewShareHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+
+	t.Run("returns the group's share grants", func(t *testing.T) {
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/7/shares", nil), "id", "7"))
+		w := httptest.NewRecorder()
+		h.ListGroupShares(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		data := decodeData(t, w)
+		shares := data["shares"].([]interface{})
+		require.Len(t, shares, 1)
+		share := shares[0].(map[string]interface{})
+		assert.Equal(t, float64(1), share["SecretID"])
+		assert.Equal(t, float64(7), share["RecipientID"])
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/7/shares", nil), "id", "7")
+		w := httptest.NewRecorder()
+		h.ListGroupShares(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("rejects an invalid group id", func(t *testing.T) {
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/not-a-number/shares", nil), "id", "not-a-number"))
+		w := httptest.NewRecorder()
+		h.ListGroupShares(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("a group with no shares returns an empty list", func(t *testing.T) {
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/99/shares", nil), "id", "99"))
+		w := httptest.NewRecorder()
+		h.ListGroupShares(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Empty(t, decodeData(t, w)["shares"].([]interface{}))
+	})
+}
+
+// TestListGroupSharesHandler_Unauthorized proves the endpoint refuses a caller
+// with no secrets.read grant at all, not just an unauthenticated one.
+func TestListGroupSharesHandler_Unauthorized(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.ShareRecord{}, &models.Group{},
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserGroup{}, &models.GroupRole{}, &models.Project{}, &models.Environment{},
+	))
+
+	h, err := NewShareHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/7/shares", nil), "id", "7"))
+	w := httptest.NewRecorder()
+	h.ListGroupShares(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/server/http/handlers/shares_query.go
+++ b/server/http/handlers/shares_query.go
@@ -242,6 +242,44 @@ func (h *ShareHandler) ListGroupSharedSecrets(w http.ResponseWriter, r *http.Req
 	h.sendSuccess(w, map[string]interface{}{"secrets": secrets}, "")
 }
 
+// ListGroupShares handles GET /api/v1/groups/{id}/shares — the share grants
+// made TO a group (as opposed to ListGroupSharedSecrets' resolved-secrets
+// view). #G66: previously only the embedded/local CLI path
+// (`keyorix share group-shares`) could reach this data at all, silently
+// ignoring a connected server; there was no HTTP endpoint to route it
+// through. Mirrors ListGroupSharedSecrets' actor-threading exactly — #G10
+// already made the core function self-authorize, so this can safely expose
+// it without shipping a new unauthenticated-scope disclosure surface.
+func (h *ShareHandler) ListGroupShares(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+
+	groupID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid group ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	shares, err := h.coreService.ListGroupShares(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), uint(groupID))
+	if err != nil {
+		if strings.Contains(err.Error(), "permission") || strings.Contains(err.Error(), "not authorized") {
+			h.sendError(w, "Forbidden", err.Error(), http.StatusForbidden, nil)
+			return
+		}
+		log.Printf("Error listing group shares: %v", err)
+		h.sendError(w, "InternalError", "Failed to list group shares", http.StatusInternalServerError, nil)
+		return
+	}
+	if shares == nil {
+		shares = []*models.ShareRecord{}
+	}
+
+	h.sendSuccess(w, map[string]interface{}{"shares": shares}, "")
+}
+
 // GetSharingStatusWithIndicators handles GET /api/v1/secrets/{id}/sharing-status
 func (h *ShareHandler) GetSharingStatusWithIndicators(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -935,6 +935,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// Secrets a group can reach via shares — reveals secret names, so it needs
 			// secrets.read on top of the group-level users.read above.
 			r.With(customMiddleware.RequirePermission(permSecretsRead)).Get("/{id}/shared-secrets", shareHandler.ListGroupSharedSecrets)
+			// Share grants made TO the group (owner/secret IDs, not resolved secret
+			// content) — same sensitivity tier as shared-secrets above, same gate.
+			r.With(customMiddleware.RequirePermission(permSecretsRead)).Get("/{id}/shares", shareHandler.ListGroupShares)
 			// Adding/removing a group member confers (or revokes) every role the group
 			// holds — the same blast radius as a role grant, so gate on roles.assign
 			// (matching the group's role-grant routes below), not users.read.


### PR DESCRIPTION
## Summary
- `keyorix share group-shares` was the one command in the `share` package
  with no `common.NewRemoteClient()` branch — it always read local embedded
  storage, silently ignoring a connected server. This was deferred pending
  G10, since exposing the underlying core function over HTTP without
  authorization would have introduced a new unauthenticated-scope
  disclosure. G10 (#1413, merged) now self-authorizes `ListGroupShares`, so
  this ships safely.
- Adds `GET /api/v1/groups/{id}/shares` (mirrors `ListGroupSharedSecrets`'s
  actor threading exactly) and a `runGroupSharesRemote` CLI dispatcher,
  matching every sibling share command's dual-mode shape.

## Test plan
- [x] New HTTP handler tests (auth required, forbidden without
      `secrets.read`, happy path, invalid id, empty group).
- [x] New CLI tests (remote dispatch, empty response).
- [x] Hardened 3 pre-existing local-mode tests with `XDG_CONFIG_HOME`
      isolation — now that this command is dual-mode, they could otherwise
      pick up a real developer machine's `~/.keyorix/cli.yaml`.
- [x] `go build`/`go vet`/`gofmt` clean
- [x] `gosec -severity medium` clean
