### PR TITLE
fix(core): guard project-scoped group admin authority on delete/removal (G02)

### DIFF
--- a/internal/core/core_s24_test.go
+++ b/internal/core/core_s24_test.go
@@ -1000,6 +1000,9 @@ func TestDeprovisionSCIMGroup_StorageError(t *testing.T) {
 	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
+	// guardLastProjectAdminGroupDelete (core-project-members.json#3) runs next;
+	// no group role assignments in this fixture, so it's a no-op too.
+	ms.On("ListGroupRoleAssignments", mock.Anything, uint(10)).Return([]storage.RoleAssignment{}, nil)
 	ms.On("DeleteGroup", mock.Anything, uint(10)).Return(errors.New("not found"))
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 	c := NewKeyorixCore(ms)
@@ -1012,6 +1015,7 @@ func TestDeprovisionSCIMGroup_Success(t *testing.T) {
 	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
+	ms.On("ListGroupRoleAssignments", mock.Anything, uint(10)).Return([]storage.RoleAssignment{}, nil)
 	ms.On("DeleteGroup", mock.Anything, uint(10)).Return(nil)
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 	c := NewKeyorixCore(ms)

--- a/internal/core/core_s27_test.go
+++ b/internal/core/core_s27_test.go
@@ -574,6 +574,9 @@ func TestDeprovisionSCIMGroup_DeleteGroupError_s27(t *testing.T) {
 	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
+	// guardLastProjectAdminGroupDelete (core-project-members.json#3) runs next;
+	// no group role assignments in this fixture, so it's a no-op too.
+	ms.On("ListGroupRoleAssignments", mock.Anything, uint(5)).Return([]storage.RoleAssignment{}, nil)
 	ms.On("DeleteGroup", mock.Anything, uint(5)).Return(errors.New("not found"))
 	c := NewKeyorixCore(ms)
 	err := c.DeprovisionSCIMGroup(context.Background(), 0, 5)

--- a/internal/core/core_s32_test.go
+++ b/internal/core/core_s32_test.go
@@ -90,6 +90,10 @@ func TestApplyGroupMembershipChanges_RemoveAndAdd(t *testing.T) {
 	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
+	// guardLastProjectAdminGroupMembership (core-project-members.json#3) precheck
+	// for user 1's removal — no group role assignments in this fixture, so it's a
+	// no-op too.
+	ms.On("ListGroupRoleAssignments", mock.Anything, uint(10)).Return([]storage.RoleAssignment{}, nil)
 	// user 1 is in current but NOT in want → RemoveUserFromGroup (global: projectID=0).
 	ms.On("RemoveUserFromGroup", mock.Anything, uint(1), uint(10), uint(0)).Return(nil)
 	// user 2 is in current AND in want → no-op.

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -76,8 +76,9 @@ func (c *KeyorixCore) UpdateGroup(ctx context.Context, actorID uint, req *Update
 
 // DeleteGroup deletes a group by ID. See CreateGroup for actorID semantics. It
 // refuses to delete a group holding the install's last global-admin-conferring
-// role grant (#107; see guardLastGlobalAdminGroupDelete) — deleting a group
-// cascades to remove every role grant it holds.
+// role grant (#107; see guardLastGlobalAdminGroupDelete) OR any project's last
+// roles.assign-conferring grant (see guardLastProjectAdminGroupDelete) —
+// deleting a group cascades to remove every role grant it holds, at every scope.
 func (c *KeyorixCore) DeleteGroup(ctx context.Context, actorID, id uint) error {
 	if id == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "group ID is required")
@@ -87,6 +88,9 @@ func (c *KeyorixCore) DeleteGroup(ctx context.Context, actorID, id uint) error {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	if err := c.guardLastGlobalAdminGroupDelete(ctx, id); err != nil {
+		return err
+	}
+	if err := c.guardLastProjectAdminGroupDelete(ctx, id); err != nil {
 		return err
 	}
 	if err := c.storage.DeleteGroup(ctx, id); err != nil {
@@ -255,12 +259,17 @@ func (c *KeyorixCore) AddUserToGroupGlobal(ctx context.Context, actorID, userID,
 // RemoveUserFromGroup removes a user from a group at the given projectID scope.
 // See AddUserToGroup for actorID semantics. It refuses to remove a user whose
 // global admin-tier authority comes solely from this group's role grant when no
-// other admin route remains (#107; see guardLastGlobalAdminMembership).
+// other admin route remains (#107; see guardLastGlobalAdminMembership), OR whose
+// removal would leave some project this group administers with no roles.assign
+// holder (see guardLastProjectAdminGroupMembership).
 func (c *KeyorixCore) RemoveUserFromGroup(ctx context.Context, actorID, userID, groupID, projectID uint) error {
 	if userID == 0 || groupID == 0 {
 		return fmt.Errorf("%s: user ID and group ID are required", i18n.T("ErrorValidation", nil))
 	}
 	if err := c.guardLastGlobalAdminMembership(ctx, userID, groupID); err != nil {
+		return err
+	}
+	if err := c.guardLastProjectAdminGroupMembership(ctx, userID, groupID); err != nil {
 		return err
 	}
 	if err := c.storage.RemoveUserFromGroup(ctx, userID, groupID, projectID); err != nil {

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -245,3 +245,125 @@ func (c *KeyorixCore) resolveProjectAdminHolders(ctx context.Context, targetID u
 	}
 	return c.filterActiveHolders(ctx, holders)
 }
+
+// guardLastProjectAdminGroupDelete is guardLastProjectAdmin's group-deletion
+// counterpart (findings-core/core-project-members.json#3): generalizes
+// guardLastGlobalAdminGroupDelete (#107, global scope only) to every PROJECT
+// scope the group holds a roles.assign-granting role at. Deleting a group
+// cascades to remove EVERY role grant it holds — if one of those grants is a
+// project's last roles.assign holder, deleting the group leaves that project
+// ungoverned (no one able to manage its membership), a gap the global-only
+// guard cannot see.
+func (c *KeyorixCore) guardLastProjectAdminGroupDelete(ctx context.Context, groupID uint) error {
+	projectIDs, err := c.projectAdminScopesHeldByGroup(ctx, groupID)
+	if err != nil {
+		return err
+	}
+	for projectID := range projectIDs {
+		if err := c.guardProjectAdminSurvivesGroupChange(ctx, projectID, func(a storage.RoleAssignment) bool {
+			return a.PrincipalType == "group" && a.PrincipalID == groupID
+		}, nil); err != nil {
+			return fmt.Errorf("refusing to delete group %d: %w", groupID, err)
+		}
+	}
+	return nil
+}
+
+// guardLastProjectAdminGroupMembership is guardLastProjectAdmin's group-
+// membership-removal counterpart (findings-core/core-project-members.json#3):
+// refuses to remove userID from groupID when groupID's project-scoped
+// roles.assign grant is userID's only remaining route to administering that
+// project and no other holder survives either. Unlike a group deletion, the
+// group's own grant row survives a membership removal — only that one
+// member's derived authority through THIS group disappears.
+func (c *KeyorixCore) guardLastProjectAdminGroupMembership(ctx context.Context, userID, groupID uint) error {
+	projectIDs, err := c.projectAdminScopesHeldByGroup(ctx, groupID)
+	if err != nil {
+		return err
+	}
+	for projectID := range projectIDs {
+		if err := c.guardProjectAdminSurvivesGroupChange(ctx, projectID, nil, func(gID, uID uint) bool {
+			return gID == groupID && uID == userID
+		}); err != nil {
+			return fmt.Errorf("refusing to remove user %d from group %d: %w", userID, groupID, err)
+		}
+	}
+	return nil
+}
+
+// projectAdminScopesHeldByGroup returns the project IDs at which groupID
+// holds a project-level (environment_id = 0) role granting roles.assign —
+// every project whose governance depends, at least in part, on this group.
+// A group with no such grant anywhere returns an empty set, so the group-path
+// project-admin guards above are a cheap no-op for the common case (most
+// groups never hold project-admin authority at all).
+func (c *KeyorixCore) projectAdminScopesHeldByGroup(ctx context.Context, groupID uint) (map[uint]bool, error) {
+	assignments, err := c.storage.ListGroupRoleAssignments(ctx, groupID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve group role assignments: %w", err)
+	}
+	checked := make(map[uint]bool, len(assignments))
+	projectIDs := make(map[uint]bool)
+	for _, a := range assignments {
+		if a.EnvironmentID != 0 || a.ProjectID == 0 {
+			continue // not a project-level grant; the global scope has its own guard
+		}
+		hasAssign, ok := checked[a.RoleID]
+		if !ok {
+			var herr error
+			hasAssign, herr = c.storage.RoleSetHasPermission(ctx, []uint{a.RoleID}, permRolesAssign)
+			if herr != nil {
+				return nil, herr
+			}
+			checked[a.RoleID] = hasAssign
+		}
+		if hasAssign {
+			projectIDs[a.ProjectID] = true
+		}
+	}
+	return projectIDs, nil
+}
+
+// guardProjectAdminSurvivesGroupChange checks whether projectID still has a
+// live roles.assign holder after the given group-scoped exclusion — a grant
+// removal (group deletion) or one member's derived authority (membership
+// removal). Reuses resolveGlobalAdminHolders (internal/core/authz.go)
+// verbatim for the group-expansion/exclusion/active-filtering machinery;
+// despite its name that function is scope-agnostic — it only cares which
+// assignment rows are passed in and which role IDs count as "admin". Here the
+// admin-role test is "does this role carry roles.assign" (a permission
+// check, since project administration isn't tied to a specific role name),
+// not the fixed install-admin role-ID set the global guards use.
+func (c *KeyorixCore) guardProjectAdminSurvivesGroupChange(ctx context.Context, projectID uint, excludeAssignment func(storage.RoleAssignment) bool, excludeMember func(groupID, userID uint) bool) error {
+	all, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to check project %d administrators: %w", projectID, err)
+	}
+	projectLevel := make([]storage.RoleAssignment, 0, len(all))
+	assignAdminIDs := make(map[uint]bool)
+	checked := make(map[uint]bool, len(all))
+	for _, a := range all {
+		if a.EnvironmentID != 0 {
+			continue // not project-level; can't administer /projects/{id}/members
+		}
+		projectLevel = append(projectLevel, a)
+		hasAssign, ok := checked[a.RoleID]
+		if !ok {
+			var herr error
+			hasAssign, herr = c.storage.RoleSetHasPermission(ctx, []uint{a.RoleID}, permRolesAssign)
+			if herr != nil {
+				return herr
+			}
+			checked[a.RoleID] = hasAssign
+		}
+		assignAdminIDs[a.RoleID] = hasAssign
+	}
+	holders, err := c.resolveGlobalAdminHolders(ctx, assignAdminIDs, projectLevel, excludeAssignment, excludeMember)
+	if err != nil {
+		return fmt.Errorf("failed to check project %d administrators: %w", projectID, err)
+	}
+	if len(holders) == 0 {
+		return fmt.Errorf("project %d's last administrative role grant would be lost, leaving no roles.assign holder", projectID)
+	}
+	return nil
+}

--- a/internal/core/project_scoped_group_admin_guard_test.go
+++ b/internal/core/project_scoped_group_admin_guard_test.go
@@ -1,0 +1,194 @@
+// project_scoped_group_admin_guard_test.go — regression coverage for
+// core-project-members.json#3 (groups.go:89): DeleteGroup / RemoveUserFromGroup
+// (and their SCIM counterparts) previously only invoked the GLOBAL last-admin
+// guard (guardLastGlobalAdminGroupDelete/Membership, #107) — a group holding a
+// project's last roles.assign-conferring grant could be deleted, or have its
+// last live member removed, with no guard at all, silently leaving that
+// project with zero administrators. guardLastProjectAdminGroupDelete/
+// Membership close that gap by generalizing guardLastProjectAdmin (the
+// existing direct-user-removal guard, project_members.go) to the group path,
+// mirroring guardLastGlobalAdminGroupDelete/Membership's own shape exactly.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteGroup_RefusesLastProjectAdmin(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+
+	err = c.DeleteGroup(ctx, actor, group.ID)
+	require.Error(t, err, "must refuse to delete a group holding project 7's last roles.assign grant")
+	assert.Contains(t, err.Error(), "last administrative role grant")
+
+	_, getErr := st.GetGroup(ctx, group.ID)
+	require.NoError(t, getErr, "group must not have been deleted when the guard refuses")
+}
+
+func TestDeleteGroup_AllowsWhenAnotherProjectAdminExists(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+	other, err := st.CreateUser(ctx, &models.User{Username: "raj", Email: "raj@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+	// An independent, direct project_admin grant at the same project survives
+	// the group's deletion.
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, other.ID, "project_admin"))
+
+	err = c.DeleteGroup(ctx, actor, group.ID)
+	require.NoError(t, err, "deleting the group is fine when another project admin survives")
+}
+
+func TestDeleteGroup_AllowsWhenGroupHoldsNoProjectAdminRole(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "engineering"})
+	require.NoError(t, err)
+
+	err = c.DeleteGroup(ctx, actor, group.ID)
+	require.NoError(t, err, "deleting a group that confers no admin role at any scope must still work")
+}
+
+func TestDeleteGroup_RefusesWhenGroupAdminsMultipleProjects(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const projA, projB = uint(7), uint(8)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+	other, err := st.CreateUser(ctx, &models.User{Username: "raj", Email: "raj@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "multi-proj-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: projA}))
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: projB}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+	// projB has an independent survivor; projA does not.
+	require.NoError(t, c.AddProjectMember(ctx, actor, projB, other.ID, "project_admin"))
+
+	err = c.DeleteGroup(ctx, actor, group.ID)
+	require.Error(t, err, "must refuse when even ONE of the group's administered projects would be left with no admin")
+	assert.Contains(t, err.Error(), "last administrative role grant")
+}
+
+func TestRemoveUserFromGroup_RefusesLastProjectAdminMember(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+
+	err = c.RemoveUserFromGroup(ctx, actor, u.ID, group.ID, 0)
+	require.Error(t, err, "must refuse to remove the group's only member when that member is project 7's last admin route")
+	assert.Contains(t, err.Error(), "last administrative role grant")
+
+	members, mErr := st.ListGroupMembers(ctx, group.ID)
+	require.NoError(t, mErr)
+	require.Len(t, members, 1, "membership must not have been removed when the guard refuses")
+}
+
+func TestRemoveUserFromGroup_AllowsWhenAnotherGroupMemberSurvives(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u1, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+	u2, err := st.CreateUser(ctx, &models.User{Username: "raj", Email: "raj@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u1.ID, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u2.ID, group.ID, 0))
+
+	err = c.RemoveUserFromGroup(ctx, actor, u1.ID, group.ID, 0)
+	require.NoError(t, err, "removing one of two group members is fine — the other still derives project-admin authority")
+
+	members, mErr := st.ListGroupMembers(ctx, group.ID)
+	require.NoError(t, mErr)
+	require.Len(t, members, 1)
+	assert.Equal(t, u2.ID, members[0].ID)
+}
+
+// TestDeprovisionSCIMGroup_RefusesLastProjectAdmin proves the SCIM path (which
+// bypasses core.DeleteGroup entirely — see scim_groups.go's own inline guard
+// calls) got the same project-scope fix, not just the native path.
+func TestDeprovisionSCIMGroup_RefusesLastProjectAdmin(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true, ExternalID: "okta|priya"})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "scim-proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+
+	err = c.DeprovisionSCIMGroup(ctx, actor, group.ID)
+	require.Error(t, err, "SCIM group deprovisioning must also refuse to strip project 7's last admin route")
+
+	_, getErr := st.GetGroup(ctx, group.ID)
+	require.NoError(t, getErr, "group must not have been deleted when the guard refuses")
+}

--- a/internal/core/scim_groups.go
+++ b/internal/core/scim_groups.go
@@ -198,10 +198,16 @@ func (c *KeyorixCore) PatchSCIMGroup(ctx context.Context, actorID, groupID uint,
 	// Check every removal against guardLastGlobalAdminMembership (#G02) BEFORE
 	// applying any of them, so a PATCH that would strip the install's last route
 	// to global-admin authority is refused atomically — see
-	// applyGroupMembershipChanges's identical precheck-then-apply shape.
+	// applyGroupMembershipChanges's identical precheck-then-apply shape. Also
+	// checked against guardLastProjectAdminGroupMembership (core-project-
+	// members.json#3) so a removal can't strip a project's last roles.assign
+	// holder either — SCIM group management previously only saw the global case.
 	toRemove := filterNonZero(removeIDs)
 	for _, id := range toRemove {
 		if err := c.guardLastGlobalAdminMembership(ctx, id, groupID); err != nil {
+			return nil, err
+		}
+		if err := c.guardLastProjectAdminGroupMembership(ctx, id, groupID); err != nil {
 			return nil, err
 		}
 	}
@@ -277,13 +283,18 @@ func filterNonZero(ids []uint) []uint {
 
 // applyGroupMembershipChanges applies the add/remove sets computed by the
 // caller. Every removal is checked against guardLastGlobalAdminMembership
-// (#G02) BEFORE any storage write happens, so a SCIM PUT that would strip the
-// install's last route to global-admin authority is refused atomically — not
-// applied member-by-member with some removals already committed.
+// (#G02) and guardLastProjectAdminGroupMembership (core-project-members.json#3)
+// BEFORE any storage write happens, so a SCIM PUT that would strip the
+// install's last route to global-admin authority, or a project's last
+// roles.assign holder, is refused atomically — not applied member-by-member
+// with some removals already committed.
 func (c *KeyorixCore) applyGroupMembershipChanges(ctx context.Context, groupID uint, want map[uint]bool, current []*models.User, toAdd []uint) error {
 	for _, u := range current {
 		if !want[u.ID] {
 			if err := c.guardLastGlobalAdminMembership(ctx, u.ID, groupID); err != nil {
+				return err
+			}
+			if err := c.guardLastProjectAdminGroupMembership(ctx, u.ID, groupID); err != nil {
 				return err
 			}
 		}
@@ -301,10 +312,15 @@ func (c *KeyorixCore) applyGroupMembershipChanges(ctx context.Context, groupID u
 
 // DeprovisionSCIMGroup handles a SCIM DELETE — removes the group (membership links
 // go with it). Refuses to delete a group holding the install's last
-// global-admin-conferring role grant (guardLastGlobalAdminGroupDelete, #G02) —
-// the same guard the native DeleteGroup already applies.
+// global-admin-conferring role grant (guardLastGlobalAdminGroupDelete, #G02) or
+// any project's last roles.assign-conferring grant
+// (guardLastProjectAdminGroupDelete, core-project-members.json#3) — the same
+// guards the native DeleteGroup already applies.
 func (c *KeyorixCore) DeprovisionSCIMGroup(ctx context.Context, actorID, groupID uint) error {
 	if err := c.guardLastGlobalAdminGroupDelete(ctx, groupID); err != nil {
+		return err
+	}
+	if err := c.guardLastProjectAdminGroupDelete(ctx, groupID); err != nil {
 		return err
 	}
 	// Storage-direct: the SCIM path emits scim.group_deprovisioned below, not the


### PR DESCRIPTION
## Summary
- `DeleteGroup`/`RemoveUserFromGroup` (and their SCIM counterparts, which
  bypass the native functions with their own inline guard calls) only
  invoked `guardLastGlobalAdminGroupDelete/Membership` — the GLOBAL-scope
  last-admin guard. A group holding a project's last `roles.assign`
  -conferring grant could be deleted, or have its last live member removed,
  with no guard at all, silently leaving that project with zero
  administrators.
- Adds `guardLastProjectAdminGroupDelete/Membership`, generalizing the
  existing `guardLastProjectAdmin` (the direct-user-removal guard) to the
  group path across every project the group administers — reusing
  `resolveGlobalAdminHolders` verbatim, since despite its name it's
  scope-agnostic; only the admin-role test differs (`roles.assign`
  permission check vs. a fixed install-admin role-ID set).

## Test plan
- [x] 7 new regression tests (single-project refusal/allowed, multi-project
      refusal, non-admin-group no-op, SCIM path).
- [x] Fixed 3 MockStorage-based tests whose fixtures had no
      `ListGroupRoleAssignments` expectation for the new guard call (one of
      which crashed the whole `internal/core` test binary via an unrecovered
      mock panic, masking a second failure until fixed).
- [x] `go build`/`go vet`/`gofmt` clean
- [x] `gosec -severity medium` clean
- [x] Full repo suite shows only the established pre-existing failures
