### PR TITLE
fix(core): batch-load group membership in GetPermissionBaseline (G44)

### DIFF
--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1008,6 +1008,14 @@ func (m *MockStorage) GetUserGroups(ctx context.Context, userID uint) ([]*models
 	return args.Get(0).([]*models.Group), args.Error(1)
 }
 
+func (m *MockStorage) ListAllUserGroupMemberships(ctx context.Context) ([]storage.UserGroupMembership, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]storage.UserGroupMembership), args.Error(1)
+}
+
 func (m *MockStorage) AddPasswordHistory(ctx context.Context, userID uint, hash string, at time.Time) error {
 	args := m.Called(ctx, userID, hash, at)
 	return args.Error(0)

--- a/internal/core/permission_baseline.go
+++ b/internal/core/permission_baseline.go
@@ -157,21 +157,20 @@ func (b *permBaselineBuilder) directGrantRows(ctx context.Context, allGrants []*
 // and expiry ride along instead of the caller re-deriving them — the fix for
 // #G25's scope-misrepresentation and missing-expiry-flag gaps on the
 // group-inherited path specifically (GetGroupRoles alone carries neither).
-func (b *permBaselineBuilder) groupGrantRowsForUser(ctx context.Context, u *models.User, groupGrantsByGroup map[uint][]*models.GroupRole, now time.Time) ([]PermissionBaselineRow, error) {
+// groupIDs is u's membership, pre-resolved by the caller from one
+// deployment-wide ListAllUserGroupMemberships query (#G44) instead of a
+// per-user GetUserGroups call — see GetPermissionBaseline's doc for why.
+func (b *permBaselineBuilder) groupGrantRowsForUser(ctx context.Context, u *models.User, groupIDs []uint, groupGrantsByGroup map[uint][]*models.GroupRole, now time.Time) ([]PermissionBaselineRow, error) {
 	var rows []PermissionBaselineRow
-	groups, err := b.k.storage.GetUserGroups(ctx, u.ID)
-	if err != nil {
-		return nil, fmt.Errorf("permission baseline: get groups for user %d: %w", u.ID, err)
-	}
-	for _, g := range groups {
-		for _, grant := range groupGrantsByGroup[g.ID] {
+	for _, groupID := range groupIDs {
+		for _, grant := range groupGrantsByGroup[groupID] {
 			name, err := b.roleName(ctx, grant.RoleID)
 			if err != nil {
-				return nil, fmt.Errorf("permission baseline: get role %d (group %d): %w", grant.RoleID, g.ID, err)
+				return nil, fmt.Errorf("permission baseline: get role %d (group %d): %w", grant.RoleID, groupID, err)
 			}
 			perms, err := b.rolePermNames(ctx, grant.RoleID)
 			if err != nil {
-				return nil, fmt.Errorf("permission baseline: get permissions for role %d (group %d): %w", grant.RoleID, g.ID, err)
+				return nil, fmt.Errorf("permission baseline: get permissions for role %d (group %d): %w", grant.RoleID, groupID, err)
 			}
 			scope := scopeLabel(grant.ProjectID, grant.EnvironmentID)
 			expired := grantExpired(grant.ExpiresAt, now)
@@ -202,15 +201,14 @@ func (b *permBaselineBuilder) groupGrantRowsForUser(ctx context.Context, u *mode
 // than dropped. Each row's Scope reflects the grant's real (project, environment)
 // pair, not just its project.
 //
-// #G44: groupGrantRowsForUser below still runs one GetUserGroups call PER
-// USER — a genuine N+1 whose cost scales with the deployment's own user
-// count, not with any caller-controlled input. Fixing #G25's scope/expiry gap
-// replaced the FORMER per-GROUP GetGroupRoles call with one deployment-wide
-// ListAllGroupRoleGrants query below, but the per-user group-MEMBERSHIP
-// lookup remains. Unlike this group's other members, there's no bound to add
-// here that wouldn't just silently drop users from a compliance/audit report;
-// the real fix is restructuring to batch-load every user's group membership in
-// one or two queries up front. Left unfixed — see REMEDIATION-STATUS.md G44.
+// #G44: group-inherited grant resolution used to run one GetUserGroups call
+// PER USER — a genuine N+1 whose cost scaled with the deployment's own user
+// count, not with any caller-controlled input (unlike this group's other
+// members, there was no bound that wouldn't just silently drop users from a
+// compliance/audit report). Fixed by batch-loading every user's group
+// membership in one ListAllUserGroupMemberships query up front (step 2
+// below), mirroring the ListAllGroupRoleGrants batch-load this function
+// already did for #G25.
 func (k *KeyorixCore) GetPermissionBaseline(ctx context.Context) (*PermissionBaseline, error) {
 	// 1. Load all users, INCLUDING soft-deleted ones (no filter otherwise — we
 	//    want every principal that ever held a grant). See the #G25 doc above:
@@ -240,6 +238,17 @@ func (k *KeyorixCore) GetPermissionBaseline(ctx context.Context) (*PermissionBas
 		groupGrantsByGroup[g.GroupID] = append(groupGrantsByGroup[g.GroupID], g)
 	}
 
+	// One deployment-wide user→group membership query (#G44), pre-grouped by
+	// UserID, instead of one GetUserGroups call per user below.
+	allMemberships, err := k.storage.ListAllUserGroupMemberships(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("permission baseline: list user group memberships: %w", err)
+	}
+	groupIDsByUser := make(map[uint][]uint, len(users))
+	for _, m := range allMemberships {
+		groupIDsByUser[m.UserID] = append(groupIDsByUser[m.UserID], m.GroupID)
+	}
+
 	// Build quick lookup map (direct-grant path only — the group-inherited path
 	// already has the full *models.User in hand from `users`).
 	userByID := make(map[uint]*userBaseline, len(users))
@@ -262,7 +271,7 @@ func (k *KeyorixCore) GetPermissionBaseline(ctx context.Context) (*PermissionBas
 
 	// 4. Group-inherited grants.
 	for _, u := range users {
-		groupRows, err := b.groupGrantRowsForUser(ctx, u, groupGrantsByGroup, now)
+		groupRows, err := b.groupGrantRowsForUser(ctx, u, groupIDsByUser[u.ID], groupGrantsByGroup, now)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/core/permission_baseline_test.go
+++ b/internal/core/permission_baseline_test.go
@@ -37,6 +37,7 @@ func TestGetPermissionBaseline_Empty(t *testing.T) {
 		Return([]*models.User{}, int64(0), nil)
 	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{}, nil)
 	store.On("ListAllGroupRoleGrants", mock.Anything).Return([]*models.GroupRole{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)
@@ -58,7 +59,7 @@ func TestGetPermissionBaseline_DirectGrant_GlobalScope(t *testing.T) {
 	store.On("GetRole", mock.Anything, uint(5)).Return(&models.Role{ID: 5, Name: "Admin"}, nil)
 	store.On("GetRolePermissions", mock.Anything, uint(5)).
 		Return([]*models.Permission{{Name: "secrets.read"}, {Name: "secrets.write"}}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(10)).Return([]*models.Group{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)
@@ -89,7 +90,7 @@ func TestGetPermissionBaseline_DirectGrant_ProjectScope(t *testing.T) {
 	store.On("GetRole", mock.Anything, uint(7)).Return(&models.Role{ID: 7, Name: "Viewer"}, nil)
 	store.On("GetRolePermissions", mock.Anything, uint(7)).
 		Return([]*models.Permission{{Name: "secrets.read"}}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(11)).Return([]*models.Group{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)
@@ -115,7 +116,7 @@ func TestGetPermissionBaseline_DirectGrant_EnvironmentScope(t *testing.T) {
 	store.On("GetRole", mock.Anything, uint(7)).Return(&models.Role{ID: 7, Name: "Viewer"}, nil)
 	store.On("GetRolePermissions", mock.Anything, uint(7)).
 		Return([]*models.Permission{{Name: "secrets.read"}}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(15)).Return([]*models.Group{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)
@@ -129,14 +130,14 @@ func TestGetPermissionBaseline_GroupInheritedGrant(t *testing.T) {
 	ctx := context.Background()
 
 	user := &models.User{ID: 12, Username: "carol", Email: "carol@example.com"}
-	group := &models.Group{ID: 20}
 	groupGrant := &models.GroupRole{GroupID: 20, RoleID: 9}
 
 	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
 		Return([]*models.User{user}, int64(1), nil)
 	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{}, nil)
 	store.On("ListAllGroupRoleGrants", mock.Anything).Return([]*models.GroupRole{groupGrant}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(12)).Return([]*models.Group{group}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).
+		Return([]stg.UserGroupMembership{{UserID: 12, GroupID: 20}}, nil)
 	store.On("GetRole", mock.Anything, uint(9)).Return(&models.Role{ID: 9, Name: "Operator"}, nil)
 	store.On("GetRolePermissions", mock.Anything, uint(9)).
 		Return([]*models.Permission{{Name: "audit.read"}}, nil)
@@ -162,14 +163,14 @@ func TestGetPermissionBaseline_GroupInheritedGrant_EnvironmentScope(t *testing.T
 	ctx := context.Background()
 
 	user := &models.User{ID: 16, Username: "grace", Email: "grace@example.com"}
-	group := &models.Group{ID: 21}
 	groupGrant := &models.GroupRole{GroupID: 21, RoleID: 9, ProjectID: 5, EnvironmentID: 2}
 
 	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
 		Return([]*models.User{user}, int64(1), nil)
 	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{}, nil)
 	store.On("ListAllGroupRoleGrants", mock.Anything).Return([]*models.GroupRole{groupGrant}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(16)).Return([]*models.Group{group}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).
+		Return([]stg.UserGroupMembership{{UserID: 16, GroupID: 21}}, nil)
 	store.On("GetRole", mock.Anything, uint(9)).Return(&models.Role{ID: 9, Name: "Operator"}, nil)
 	store.On("GetRolePermissions", mock.Anything, uint(9)).
 		Return([]*models.Permission{{Name: "audit.read"}}, nil)
@@ -198,14 +199,16 @@ func TestGetPermissionBaseline_RolePermissionsCached(t *testing.T) {
 	store.On("GetRole", mock.Anything, uint(5)).Return(&models.Role{ID: 5, Name: "Admin"}, nil)
 	store.On("GetRolePermissions", mock.Anything, uint(5)).
 		Return([]*models.Permission{{Name: "secrets.read"}}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(13)).Return([]*models.Group{}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(14)).Return([]*models.Group{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)
 	assert.Len(t, baseline.Rows, 2)
 	// GetRolePermissions should have been called exactly once for the cached role.
 	store.AssertNumberOfCalls(t, "GetRolePermissions", 1)
+	// #G44: ListAllUserGroupMemberships must be called exactly once — the whole
+	// point of the batch-load fix is NOT one GetUserGroups call per user.
+	store.AssertNumberOfCalls(t, "ListAllUserGroupMemberships", 1)
 }
 
 func TestGetPermissionBaseline_SkipsGrantsForMissingUsers(t *testing.T) {
@@ -223,6 +226,7 @@ func TestGetPermissionBaseline_SkipsGrantsForMissingUsers(t *testing.T) {
 		Return([]*models.User{}, int64(0), nil)
 	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{grant}, nil)
 	store.On("ListAllGroupRoleGrants", mock.Anything).Return([]*models.GroupRole{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)
@@ -268,6 +272,68 @@ func TestGetPermissionBaseline_ListGroupGrantsError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestGetPermissionBaseline_ListUserGroupMembershipsError(t *testing.T) {
+	store := new(MockStorage)
+	c := newBaselineCore(store)
+	ctx := context.Background()
+
+	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
+		Return([]*models.User{}, int64(0), nil)
+	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{}, nil)
+	store.On("ListAllGroupRoleGrants", mock.Anything).Return([]*models.GroupRole{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return(nil, errors.New("membership error"))
+
+	_, err := c.GetPermissionBaseline(ctx)
+	require.Error(t, err)
+}
+
+// TestGetPermissionBaseline_BatchLoadsMembershipOnceForManyUsers is the
+// regression test for #G44: group-inherited grant resolution used to call
+// GetUserGroups once PER USER. With three users — one in two admin-conferring
+// groups, one in a single group, one in no group at all — ListAllUserGroupMemberships
+// must be called exactly ONCE (not three times), and each user's rows must
+// still resolve to exactly their own group memberships, not another user's.
+func TestGetPermissionBaseline_BatchLoadsMembershipOnceForManyUsers(t *testing.T) {
+	store := new(MockStorage)
+	c := newBaselineCore(store)
+	ctx := context.Background()
+
+	userMultiGroup := &models.User{ID: 60, Username: "multi", Email: "multi@example.com"}
+	userOneGroup := &models.User{ID: 61, Username: "one", Email: "one@example.com"}
+	userNoGroup := &models.User{ID: 62, Username: "none", Email: "none@example.com"}
+
+	groupGrantA := &models.GroupRole{GroupID: 70, RoleID: 90}
+	groupGrantB := &models.GroupRole{GroupID: 71, RoleID: 91}
+
+	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
+		Return([]*models.User{userMultiGroup, userOneGroup, userNoGroup}, int64(3), nil)
+	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{}, nil)
+	store.On("ListAllGroupRoleGrants", mock.Anything).Return([]*models.GroupRole{groupGrantA, groupGrantB}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{
+		{UserID: 60, GroupID: 70},
+		{UserID: 60, GroupID: 71},
+		{UserID: 61, GroupID: 70},
+	}, nil)
+	store.On("GetRole", mock.Anything, uint(90)).Return(&models.Role{ID: 90, Name: "RoleA"}, nil)
+	store.On("GetRolePermissions", mock.Anything, uint(90)).
+		Return([]*models.Permission{{Name: "perm.a"}}, nil)
+	store.On("GetRole", mock.Anything, uint(91)).Return(&models.Role{ID: 91, Name: "RoleB"}, nil)
+	store.On("GetRolePermissions", mock.Anything, uint(91)).
+		Return([]*models.Permission{{Name: "perm.b"}}, nil)
+
+	baseline, err := c.GetPermissionBaseline(ctx)
+	require.NoError(t, err)
+	store.AssertNumberOfCalls(t, "ListAllUserGroupMemberships", 1)
+
+	rowsByUser := make(map[uint][]PermissionBaselineRow)
+	for _, row := range baseline.Rows {
+		rowsByUser[row.UserID] = append(rowsByUser[row.UserID], row)
+	}
+	require.Len(t, rowsByUser[60], 2, "user in two groups gets both groups' rows")
+	require.Len(t, rowsByUser[61], 1, "user in one group gets only that group's row")
+	assert.Empty(t, rowsByUser[62], "user in no group gets no group-inherited rows")
+}
+
 func TestScopeLabel(t *testing.T) {
 	assert.Equal(t, "global", scopeLabel(0, 0))
 	assert.Equal(t, "project:7", scopeLabel(7, 0))
@@ -304,7 +370,6 @@ func TestGetPermissionBaseline_G25Regression(t *testing.T) {
 	directGrantA := &models.UserRole{UserID: 30, RoleID: 40} // permanent, global
 	directGrantB := &models.UserRole{UserID: 31, RoleID: 40, ExpiresAt: &pastExpiry}
 
-	groupG := &models.Group{ID: 50}
 	groupGrant := &models.GroupRole{GroupID: 50, RoleID: 41, ProjectID: 6, EnvironmentID: 8}
 
 	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
@@ -320,9 +385,8 @@ func TestGetPermissionBaseline_G25Regression(t *testing.T) {
 	store.On("GetRolePermissions", mock.Anything, uint(41)).
 		Return([]*models.Permission{{Name: "audit.read"}}, nil)
 
-	store.On("GetUserGroups", mock.Anything, uint(30)).Return([]*models.Group{}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(31)).Return([]*models.Group{}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(32)).Return([]*models.Group{groupG}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).
+		Return([]stg.UserGroupMembership{{UserID: 32, GroupID: 50}}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -898,6 +898,15 @@ type Storage interface {
 	// (RFC 7644). Returns the not-found error when no user carries that external id.
 	GetUserByExternalID(ctx context.Context, externalID string) (*models.User, error)
 	GetUserGroups(ctx context.Context, userID uint) ([]*models.Group, error)
+	// ListAllUserGroupMemberships returns every user_groups row in the
+	// deployment, unfiltered by project scope (#G44) — the batch-load
+	// counterpart to GetUserGroups: GetPermissionBaseline uses this to load
+	// every user's group membership in one query instead of one GetUserGroups
+	// call per user, a genuine N+1 whose cost scales with the deployment's own
+	// user count. Preserves GetUserGroups' exact per-user multiplicity (a user
+	// with both a global and a project-scoped membership row for the same
+	// group yields two rows here too, matching GetUserGroups' unfiltered JOIN).
+	ListAllUserGroupMemberships(ctx context.Context) ([]UserGroupMembership, error)
 
 	// Password history (ADR-025 history_count). AddPasswordHistory records a
 	// bcrypt hash; RecentPasswordHashes returns the most recent `limit` hashes
@@ -1947,6 +1956,13 @@ type RoleAssignment struct {
 	RoleID        uint   `json:"role_id"`
 	ProjectID     uint   `json:"project_id"`
 	EnvironmentID uint   `json:"environment_id"`
+}
+
+// UserGroupMembership is one user→group membership row, as returned by
+// ListAllUserGroupMemberships.
+type UserGroupMembership struct {
+	UserID  uint `json:"user_id"`
+	GroupID uint `json:"group_id"`
 }
 
 // GroupRoleGrant is a role assigned to a group together with the grant's optional

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -400,6 +400,20 @@ func (ls *LocalStorage) GetUserGroups(ctx context.Context, userID uint) ([]*mode
 	return groups, nil
 }
 
+// ListAllUserGroupMemberships returns every user_groups row in the
+// deployment, unfiltered by project scope — see the storage.Storage interface
+// doc (#G44) for why this exists alongside GetUserGroups.
+func (ls *LocalStorage) ListAllUserGroupMemberships(ctx context.Context) ([]storage.UserGroupMembership, error) {
+	var rows []storage.UserGroupMembership
+	err := ls.db.WithContext(ctx).Model(&models.UserGroup{}).
+		Select("user_id", "group_id").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
 // --- Groups ---
 
 func (ls *LocalStorage) CreateGroup(ctx context.Context, group *models.Group) (*models.Group, error) {

--- a/internal/storage/store/remote_permission_baseline_completeness_test.go
+++ b/internal/storage/store/remote_permission_baseline_completeness_test.go
@@ -1,0 +1,19 @@
+package store
+
+// This file registers remote_users.go's ListAllUserGroupMemberships
+// remoteUnsupported stub into remoteUnsupportedAllowlist (declared in
+// remote_unsupported_completeness_test.go). See that file's NEW FEATURE
+// PATTERN doc comment — new entries belong in a feature-scoped file like this
+// one, not in the shared registry.
+
+func init() {
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		"ListAllUserGroupMemberships": {statusIntentional,
+			"#G44: the batch-load counterpart to GetUserGroups (which IS remote-" +
+				"implemented), used only by core.GetPermissionBaseline — a raw, " +
+				"unscoped membership-table dump. That caller already calls " +
+				"ListAllUserRoleGrants/ListAllGroupRoleGrants first (both already " +
+				"allowlisted above with the same reasoning) and fails closed under " +
+				"storage.type: remote before this method is ever reached"},
+	})
+}

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -821,6 +821,15 @@ func (rs *RemoteStorage) GetUserGroups(ctx context.Context, userID uint) ([]*mod
 	return groups, nil
 }
 
+// ListAllUserGroupMemberships is not available in remote mode: its only
+// caller (GetPermissionBaseline, #G44) already can't run remotely either —
+// ListAllUserRoleGrants/ListAllGroupRoleGrants above are both
+// remoteUnsupported for the same reason (a deployment-wide unfiltered export,
+// not a per-request query the hub can answer through a spoke).
+func (rs *RemoteStorage) ListAllUserGroupMemberships(_ context.Context) ([]storage.UserGroupMembership, error) {
+	return nil, remoteUnsupported("ListAllUserGroupMemberships")
+}
+
 // --- Groups ---
 
 // CreateGroup creates a new group via POST /api/v1/system/groups — a raw

--- a/internal/storage/store/store_s4_test.go
+++ b/internal/storage/store/store_s4_test.go
@@ -528,6 +528,13 @@ func TestGroup_UserMembership(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, groups, 1)
 
+	// ListAllUserGroupMemberships (#G44 batch-load counterpart of GetUserGroups).
+	memberships, err := ls.ListAllUserGroupMemberships(ctx)
+	require.NoError(t, err)
+	require.Len(t, memberships, 1)
+	assert.Equal(t, u.ID, memberships[0].UserID)
+	assert.Equal(t, g.ID, memberships[0].GroupID)
+
 	// RemoveUserFromGroup (global: projectID=0).
 	err = ls.RemoveUserFromGroup(ctx, u.ID, g.ID, 0)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Group-inherited grant resolution in `GetPermissionBaseline` called
  `GetUserGroups` once PER USER — a genuine N+1 whose cost scaled with the
  deployment's own user count, not any caller-controlled input. Unlike this
  root-cause group's other members, there was no bound to add here that
  wouldn't just silently drop users from a compliance/audit report.
- Adds `storage.ListAllUserGroupMemberships` (LocalStorage: one query over
  the whole `user_groups` table; RemoteStorage: unsupported, matching its
  sole caller's existing remote-mode limitation via
  `ListAllUserRoleGrants`/`ListAllGroupRoleGrants`) and batch-loads
  membership once per `GetPermissionBaseline` call, mirroring the
  `ListAllGroupRoleGrants` batch-load this function already did for #G25.

## Test plan
- [x] Regression test asserts the batch call happens exactly once across
      multiple users with varying group counts (0/1/2 groups), and that each
      user's rows resolve to exactly their own group memberships.
- [x] Real-storage smoke test (`ListAllUserGroupMemberships` against
      LocalStorage).
- [x] `go build`/`go vet`/`gofmt` clean
- [x] `gosec -severity medium` clean
- [x] Full repo suite shows only the established pre-existing failures
