### PR TITLE
config: gate storage.type: remote to CLI/client mode only (ADR-083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to Keyorix are documented here. This project follows
 ## Unreleased
 
 ### Changed
+- **BREAKING (targeting v0.92.0): `storage.type: remote` combined with
+  `server.http.enabled` or `server.grpc.enabled` no longer boots (ADR-083)** —
+  `storage.type: remote` is a CLI/client mode only; RemoteStorage never
+  implemented the RBAC primitives a server needs to check ANY permission for
+  ANY caller (`GetUserRoleIDsAt`, `GetUserGroupRoleIDsAt`, `RoleSetHasPermission`
+  are all unconditional "not supported" stubs), so a server booted this way
+  could never actually serve a permission-gated request — every request to
+  every RBAC-gated route failed closed. If you were relying on this
+  combination to run a "downstream Keyorix server" against `storage.type:
+  remote`, it never functioned for ordinary API traffic; switch that
+  deployment to `storage.type: local` or `storage.type: postgres`. The CLI's
+  own client mode (`keyorix connect <server>`, or `storage.type: remote` in
+  `~/.keyorix/cli.yaml` with no server enabled) is unaffected — see
+  `docs/adr-083-remote-storage-cli-only.md`.
 - **BREAKING: keyorix-operator default RBAC/watch scope narrowed to own-namespace-only
   (ADR-076)** — an unmodified `helm install deploy/helm/keyorix-operator` now binds a
   namespace-scoped `RoleBinding` in its own release namespace and watches only that

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -108,6 +108,13 @@ storage:
 section of the client config. Remote TLS verification is **on by default** —
 an omitted `tls_verify` does not disable certificate checks.
 
+**`type: remote` is a CLI/client mode only.** It cannot back a running Keyorix
+server: `Config.Validate()` refuses to boot when `storage.type: remote` is
+combined with `server.http.enabled` or `server.grpc.enabled` (ADR-083) — none
+of RemoteStorage's RBAC primitives are implemented, so every permission check
+on every route would fail closed for every caller. Use `type: local` or
+`type: postgres` for a deployed server.
+
 ---
 
 ## Encryption & KEK providers

--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -8,6 +8,11 @@ The Keyorix CLI supports two storage modes:
 - **Local Mode**: Stores secrets in a local SQLite database (default)
 - **Remote Mode**: Connects to a remote Keyorix server via HTTP API
 
+Remote Mode (`storage.type: remote`) is a **CLI/client mode only** — it cannot
+back a running Keyorix server (`server.http.enabled`/`server.grpc.enabled`
+both refuse to boot on it, ADR-083). It is exclusively for the CLI process
+itself delegating its storage to a real server it talks to over the API.
+
 ## Quick Start
 
 ### 1. Check Current Status
@@ -72,7 +77,7 @@ storage:
 > **`storage.remote.api_key` should be an admin-tier user credential (a PAT or
 > session token)** — the SAME kind of credential `keyorix connect <server>` uses,
 > just held by whatever principal you dedicate to running the sync. `storage:
-> {type: "remote"}` makes the CLI (or a full downstream Keyorix server) delegate
+> {type: "remote"}` is a **CLI/client mode only** — it makes the CLI delegate
 > its ENTIRE storage backend to the target server over HTTP, including several
 > administrative primitives (invitations, access requests, dynamic-secret configs,
 > groups, machine identities, and more) that have no ordinary REST route and are

--- a/docs/adr-049-cli-storage-via-factory.md
+++ b/docs/adr-049-cli-storage-via-factory.md
@@ -5,6 +5,17 @@
 Accepted. (ADR-048 was assigned to the CGO-free SQLite driver decision; this
 decision took the next free number.)
 
+**Partially superseded by ADR-083** (`storage.type: remote` is CLI/client mode
+only, **Accepted**): this ADR's own Decision — CLI commands must obtain
+storage via the shared factory — is unaffected and remains in force. What
+ADR-083 retires is a *later* assumption, never actually decided here, that
+grew up around this ADR number in code comments: that `storage.type: remote`
+also supports "a full downstream Keyorix server." This ADR never made that
+claim (re-read above — it is scoped entirely to CLI subcommands bypassing the
+factory); ADR-083 is the explicit, formal retirement of that assumption
+wherever it was informally anchored to this ADR number. See ADR-083 for the
+investigation.
+
 ## Context
 
 Keyorix has a single storage seam: `storage.NewStorageFactory().CreateStorage(cfg)`

--- a/docs/adr-083-remote-storage-cli-only.md
+++ b/docs/adr-083-remote-storage-cli-only.md
@@ -1,0 +1,179 @@
+# ADR-083: `storage.type: remote` is a CLI/client mode only
+
+## Status
+
+**Accepted.** Supersedes the "full downstream Keyorix server" framing that
+had informally grown up around ADR-049 in later code comments (`server/http/
+router.go`, `internal/storage/store/remote_rbac.go`, `docs/
+REMOTE_CLI_SETUP.md`) — ADR-049 itself never made that claim; see its own
+Status header for the explicit correction. This ADR gates the topology at
+config-validation time. Full removal of the topology's now-dead-weight code
+(route registrations, the `/system` proxy tier's server-side half, the CLI
+factory itself remaining valid for its actual use) is explicitly **deferred**
+to its own branch — see "Deferred work" below.
+
+## Context
+
+ADR-082 branch 4 (`connect.platform.use`) added a new `AuthorizePrincipal`
+call to Keyorix Connect's platform-scope read path. Two new integration
+tests exercising that call against a real `storage.type: remote` downstream
+(`server/http/remote_storage_connect_grants_test.go`) failed —
+`connect ownership: check connect.platform.use: not supported in remote
+storage` — for both a user actor and a machine actor. Investigating why
+uncovered a platform-level gap, not a Connect-specific one.
+
+### Evidence
+
+`AuthorizePrincipal` (`internal/core/authz.go:189`) is the general-purpose
+RBAC entry point every `RequirePermission`/`RequireScopedPermission`-gated
+HTTP route and gRPC RPC uses — not something specific to Connect. Traced in
+full, both actor paths:
+
+- **User**: `Authorize` → `scopedRoleIDs` → `storage.GetUserRoleIDsAt` +
+  `storage.GetUserGroupRoleIDsAt` → (if any roles resolved)
+  `roleSetContainsAdmin` (4× `storage.GetRoleByName`) →
+  `storage.RoleSetHasPermission`.
+- **Machine**: `storage.GetMachineRoleIDsAt` → `storage.RoleSetHasPermission`.
+
+`RemoteStorage`'s actual implementation of each, read directly:
+
+| Method | Status |
+|---|---|
+| `GetUserRoleIDsAt` | Hard stub — `return nil, fmt.Errorf("not supported in remote storage")` |
+| `GetUserGroupRoleIDsAt` | Hard stub, same shape |
+| `GetRoleByName` | Genuinely proxied (real HTTP call) |
+| `GetMachineRoleIDsAt` | Genuinely proxied (real HTTP call) |
+| `RoleSetHasPermission` | Hard stub — **both** actor paths depend on it |
+
+The user path fails immediately at `GetUserRoleIDsAt`. The machine path gets
+further (its role-ID lookup is real) but dies at the same final
+`RoleSetHasPermission` stub. **`AuthorizePrincipal` cannot complete against a
+`storage.type: remote`-backed `core.KeyorixCore`, for any permission, for
+any actor.** This is not new, and not something ADR-082 branch 4 introduced
+— branch 4 was simply the first thing to make Connect's platform-scope path
+exercise a call this topology could never satisfy. `RequirePermission`
+gates nearly the entire HTTP/gRPC API surface (project/secret/role/user
+management, Connect, etc.) the same way — the gap is general, not local to
+one route.
+
+Confirmed via topology tracing, not assumed: `server/main.go` registers the
+full router/gRPC server unconditionally on `server.http.enabled`/
+`server.grpc.enabled`, with no branch on `storage.Type` anywhere in that
+path. The one genuinely-working, storage-independent authorization
+mechanism found — `RequireNodeCredentialOrPermission`'s `isNodeCredential`
+check, gating the `/system` server-to-server proxy tier — is deliberately
+**not** used by ordinary routes like Connect's `/connect/{name}/secret`
+(confirmed directly in `router.go`, whose own comment draws this exact
+line: that group is "the RemoteStorage server-to-server proxy API (machine
+credentials only, system.write-gated)... these are human-facing reads"
+elsewhere). No existing test — including every `#527`
+`remote_storage_*_test.go` file and the two new branch-4 tests that
+surfaced this — exercises a real HTTP router on a `RemoteStorage`-backed
+core; every one of them calls core/storage methods directly, in-process,
+bypassing `RequirePermission` entirely. Nothing has ever verified this
+topology serves a real authorized request.
+
+### This is a broken feature, not a vulnerability
+
+Traced the error handling at every layer, HTTP and gRPC, both actor paths:
+the stub's error is propagated verbatim at each step (`scopedRoleIDs` →
+`Authorize` → `AuthorizePrincipal` → `finishScopedPermissionRequest`/
+`authorizeScoped`), never swallowed, logged-and-continued, or converted to
+an empty role set that falls through to a permissive default. HTTP maps it
+to `403 Insufficient permissions`; gRPC maps it to
+`codes.PermissionDenied`. **Fails closed at every layer, both transports.**
+Every request to every gated route on a `storage.type: remote` server
+errors or 403s — this has always been a broken feature (nothing works),
+not a fail-open vulnerability (nothing was ever incorrectly allowed). No
+separate security disclosure is warranted for previously-published releases
+on this basis.
+
+### Who is actually affected
+
+Every consumer of `RemoteStorage` in the tree was checked:
+
+| Consumer | Serves HTTP/gRPC routes on a `RemoteStorage`-backed core? |
+|---|---|
+| `server/main.go` (the server binary) | **Yes — unconditionally, whenever `storage.type: remote` + a server is enabled** |
+| CLI (`internal/cli/modes.go`'s client mode, `internal/cli/common.InitializeCoreService`) | No — one-shot commands calling core methods directly in-process, no router/gRPC server ever constructed |
+| `operator/` (k8s controller, separate module) | No `RemoteStorage`/`core.KeyorixCore` references at all |
+| Helm charts, `docker-compose.yml`, `configs/*.yaml.tpl` | None demonstrate `storage.type: remote` at all |
+| Existing tests (12 files reference `storage.type: "remote"`) | None also enable `Server.HTTP`/`Server.GRPC` |
+
+Only `server/main.go`'s own boot path is affected. The CLI's actual,
+working use of `storage.type: remote` — the entire reason this storage type
+exists — is untouched.
+
+## Decision
+
+**`storage.type: remote` is a CLI/client mode only.** A process with
+`server.http.enabled` or `server.grpc.enabled` **cannot boot** on it —
+`Config.Validate()` (`internal/config/config.go`) rejects the combination,
+in the existing `case "remote":` branch, via a new extracted function,
+`validateRemoteStorageNotServer`, mirroring `validateConnectScopes`'s
+pattern from ADR-082 §C (a `Config.Validate()`-time, boot-fail-loud check,
+no deployment-wide bypass). The error message states plainly that remote
+storage is a CLI/client mode and cannot back a server that serves API
+routes, and points here.
+
+## Rationale
+
+- **No customer requested this topology.** It was never a delivered,
+  requested capability — it grew from an informal assumption layered onto
+  ADR-049's actual (narrower, CLI-only) decision, in code comments, over
+  time, without ever being verified end-to-end.
+- **It contradicts Keyorix's own deployment model.** A server that
+  delegates its ENTIRE storage backend to an upstream server over HTTP is
+  the opposite of the self-contained, air-gap-capable deployment story
+  Keyorix is built around (ADR-062 and others) — a "downstream server"
+  topology would mean a customer's secret-serving node depends on live
+  network reachability to a separate Keyorix instance for every RBAC
+  decision, the exact dependency air-gapped/on-prem deployments exist to
+  avoid.
+- **Gating first, not deleting, is deliberate.** Removing the topology's
+  now-provably-dead code (see below) is a larger, separate change; gating
+  it closes the actual risk (an operator accidentally believing this
+  combination works) immediately, without deleting code under the time
+  pressure of this investigation.
+
+## Deferred work
+
+Full removal of the `storage.type: remote`-as-server topology's now-dead
+code is **out of scope for this ADR** and deferred to its own branch:
+
+- The route registrations and `/system` proxy tier's server-side plumbing
+  that exist specifically to let a "downstream" node proxy through to an
+  upstream (login/MFA/WebAuthn proxy-verification, machine-identity role
+  lookups, `ConnectRefGrant`/`ConnectorProjectBinding` CRUD, project/
+  environment catalog, login-attempt counters, etc.) — all built under the
+  assumption a full downstream server was a real, reachable target.
+- The ~18 `server/http/remote_storage_*_test.go` files, which test that
+  proxying machinery in isolation (in-process, bypassing `RequirePermission`
+  entirely, per the Evidence section above) — worth keeping as coverage for
+  the CLI's own use of these primitives, but their framing/naming should be
+  revisited once it's clear they were never proving a working server
+  topology.
+- Whether ADR-082 branch 2's `0a4194ce` (the `ConnectorProjectBinding`
+  RemoteStorage storage-primitive commit, built to let Connect ownership
+  resolution proxy correctly on a "downstream" node) becomes unnecessary
+  work, given that topology never functioned as a server in the first
+  place — needs its own assessment, not decided here.
+
+None of this is committed to in this ADR. The gate in `Config.Validate()`
+is the only enforcement change; everything else stays as-is, reachable only
+by the CLI's actual (correct, unaffected) use of `storage.type: remote`,
+until the deferred branch addresses it.
+
+## Consequences
+
+**Positive.** Closes an operator-facing trap: a `storage.type: remote` +
+`server.http.enabled: true` config now fails loud at boot, instead of
+starting a server that silently 403s every request. No previously-published
+release needs a security disclosure (fail-closed, confirmed above).
+
+**Negative.** Any config genuinely relying on this combination — evidence
+found none in the tree, and it could never have served a real authorized
+request — will now fail to boot instead of starting into a broken state.
+This is the intended effect: fail at boot, loudly, rather than fail per
+request, silently (from the operator's perspective — "why does every API
+call 403").

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1871,6 +1871,9 @@ func (c *Config) Validate() error { // NOSONAR -- cognitive complexity 32, suppr
 	switch c.Storage.Type {
 	case "remote":
 		// remote storage uses its own connection — no local DB config required
+		if err := validateRemoteStorageNotServer(c); err != nil {
+			return err
+		}
 	case "postgres", "postgresql":
 		db := c.Storage.Database
 		if db.DSN == "" && (db.Host == "" || db.Name == "" || db.User == "") {
@@ -1907,6 +1910,26 @@ func (c *Config) Validate() error { // NOSONAR -- cognitive complexity 32, suppr
 		return fmt.Errorf("unsupported fallback language: %s. Supported languages: en, ru, es, fr, de", c.Locale.FallbackLanguage)
 	}
 
+	return nil
+}
+
+// validateRemoteStorageNotServer enforces ADR-083: storage.type: remote is a
+// CLI/client mode only — it delegates the ENTIRE storage backend to an upstream
+// server over HTTP, and RemoteStorage never implements the primitives
+// AuthorizePrincipal needs to resolve a permission for ANY caller (GetUserRoleIDsAt,
+// GetUserGroupRoleIDsAt, RoleSetHasPermission are all hard "not supported in
+// remote storage" stubs). A process with server.http.enabled or
+// server.grpc.enabled registers the full RequirePermission-gated route set
+// regardless of storage backend — on storage.type: remote, every one of those
+// checks would fail closed, for every permission, for every caller, making the
+// combination a broken feature, not a smaller one. See ADR-083 for the full
+// investigation (which supersedes ADR-049's "downstream Keyorix server" framing)
+// before ever considering lifting this gate.
+func validateRemoteStorageNotServer(c *Config) error {
+	if c.Server.HTTP.Enabled || c.Server.GRPC.Enabled {
+		return fmt.Errorf("storage.type: remote cannot back a server with server.http.enabled or server.grpc.enabled: " +
+			"remote storage is a CLI/client mode only, not a deployable server backend — see ADR-083")
+	}
 	return nil
 }
 

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -155,6 +155,77 @@ func TestValidate_AcceptsExplicitAllowedOrigins(t *testing.T) {
 // everywhere downstream — in a multi-replica HA deployment intending shared
 // Postgres/remote storage, that produces per-replica split-brain SQLite
 // instances with no operator-visible signal. Validate must reject it clearly.
+// ADR-083: storage.type: remote is a CLI/client mode only — it cannot back a
+// server that serves HTTP or gRPC API routes, since RemoteStorage never
+// implements the RBAC primitives AuthorizePrincipal needs (GetUserRoleIDsAt,
+// GetUserGroupRoleIDsAt, RoleSetHasPermission), so every permission check would
+// fail closed for every caller.
+func TestValidate_RejectsRemoteStorageWithHTTPEnabled(t *testing.T) {
+	c := &Config{}
+	c.Storage.Type = "remote"
+	c.Server.HTTP.Enabled = true
+	c.Server.HTTP.Port = "8080"
+	err := c.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "storage.type: remote")
+	require.Contains(t, err.Error(), "ADR-083")
+}
+
+func TestValidate_RejectsRemoteStorageWithGRPCEnabled(t *testing.T) {
+	c := &Config{}
+	c.Storage.Type = "remote"
+	c.Server.GRPC.Enabled = true
+	c.Server.GRPC.Port = "9090"
+	err := c.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "storage.type: remote")
+	require.Contains(t, err.Error(), "ADR-083")
+}
+
+func TestValidate_RejectsRemoteStorageWithBothHTTPAndGRPCEnabled(t *testing.T) {
+	c := &Config{}
+	c.Storage.Type = "remote"
+	c.Server.HTTP.Enabled = true
+	c.Server.HTTP.Port = "8080"
+	c.Server.GRPC.Enabled = true
+	c.Server.GRPC.Port = "9090"
+	err := c.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "storage.type: remote")
+}
+
+// The CLI/client case must still validate cleanly: storage.type: remote with
+// NEITHER server enabled is exactly what a CLI in client mode looks like.
+func TestValidate_AcceptsRemoteStorageWithNoServerEnabled(t *testing.T) {
+	c := &Config{}
+	c.Storage.Type = "remote"
+	err := c.Validate()
+	require.NoError(t, err)
+}
+
+// A validation change here must be scoped to storage.type: remote specifically —
+// local/postgres storage with servers enabled is the ordinary, fully-supported
+// deployment shape and must remain unaffected.
+func TestValidate_AcceptsLocalAndPostgresStorageWithServersEnabled(t *testing.T) {
+	c := &Config{}
+	c.Storage.Type = "local"
+	c.Storage.Database.Path = "/tmp/keyorix.db"
+	c.Server.HTTP.Enabled = true
+	c.Server.HTTP.Port = "8080"
+	c.Server.GRPC.Enabled = true
+	c.Server.GRPC.Port = "9090"
+	require.NoError(t, c.Validate())
+
+	c2 := &Config{}
+	c2.Storage.Type = "postgres"
+	c2.Storage.Database.DSN = "postgres://user:pass@localhost/db"
+	c2.Server.HTTP.Enabled = true
+	c2.Server.HTTP.Port = "8080"
+	c2.Server.GRPC.Enabled = true
+	c2.Server.GRPC.Port = "9090"
+	require.NoError(t, c2.Validate())
+}
+
 func TestValidate_RejectsUnknownStorageType(t *testing.T) {
 	c := &Config{}
 	c.Storage.Type = "postgres_typo"


### PR DESCRIPTION
## Summary

`storage.type: remote` combined with `server.http.enabled` or `server.grpc.enabled` now fails `Config.Validate()` at boot, instead of starting a server that can never actually authorize a request.

## The stub trace

`AuthorizePrincipal` is the general-purpose RBAC entry point every `RequirePermission`/`RequireScopedPermission`-gated HTTP route and gRPC RPC uses — not specific to any one feature. Traced both actor paths directly against `RemoteStorage`'s actual implementation:

| Method | `RemoteStorage` status |
|---|---|
| `GetUserRoleIDsAt` | Hard stub — `return nil, fmt.Errorf("not supported in remote storage")` |
| `GetUserGroupRoleIDsAt` | Hard stub, same shape |
| `GetRoleByName` | Genuinely proxied (real HTTP call) |
| `GetMachineRoleIDsAt` | Genuinely proxied (real HTTP call) |
| `RoleSetHasPermission` | Hard stub — **both** the user and machine paths depend on it for the actual permission bit |

The user path fails immediately at `GetUserRoleIDsAt`. The machine path gets further (its role-ID lookup is real) but dies at the same final `RoleSetHasPermission` stub. **`AuthorizePrincipal` cannot complete against a `storage.type: remote`-backed `core.KeyorixCore`, for any permission, for any actor.**

## Fails closed — a broken feature, not a vulnerability

Traced the error handling at every layer, both transports: the stub's error propagates verbatim (`scopedRoleIDs` → `Authorize`/`AuthorizePrincipal` → `finishScopedPermissionRequest` on HTTP, `authorizeScoped` on gRPC), never swallowed, logged-and-continued, or converted to an empty role set that falls through to a permissive default. HTTP maps it to `403`, gRPC to `codes.PermissionDenied`. Every request to every gated route on a server booted this way errors or 403s — this has always been a broken feature (nothing works), not a fail-open vulnerability (nothing was ever incorrectly allowed). No separate disclosure is warranted for previously-published releases on this basis.

## Consumer audit

Checked every consumer of `RemoteStorage` in the tree:

| Consumer | Serves routes on a `RemoteStorage`-backed core? |
|---|---|
| `server/main.go` (the server binary) | **Yes — unconditionally, whenever a server is enabled** |
| CLI (`internal/cli/modes.go` client mode, `internal/cli/common.InitializeCoreService`) | No — one-shot commands calling core methods directly in-process, no router/gRPC server ever constructed |
| `operator/` (k8s controller, separate module) | No `RemoteStorage`/`core.KeyorixCore` references at all |
| Helm charts, `docker-compose.yml`, config templates | None demonstrate `storage.type: remote` at all |
| Existing tests referencing `storage.type: "remote"` (12 files) | None also enable a server |

**Only `server/main.go`'s own boot path is affected.** The CLI's actual, working use of `storage.type: remote` — the entire reason this storage type exists — is untouched.

## Deferred

Full removal of the topology's now-dead server-side code (route registrations, the `/system` proxy tier's downstream-facing half, the `remote_storage_*_test.go` files, whether ADR-082 branch 2's `ConnectorProjectBinding` RemoteStorage primitives become unnecessary) is explicitly **out of scope here** and deferred to its own branch — see `docs/adr-083-remote-storage-cli-only.md`'s "Deferred work" section. This PR gates the risk immediately; it does not delete anything.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] New tests: rejects `remote`+HTTP, `remote`+gRPC, `remote`+both; accepts `remote`+neither (the CLI case); accepts `local`/`postgres`+both servers enabled
- [x] `TestValidate_AcceptsValidStorageTypes` (pre-existing) still passes
- [x] `gosec -severity medium`: 0 issues
- [x] End-to-end: booted a real server with `storage.type: remote` + `server.http.enabled: true`, confirmed exit 1 with the expected error text naming ADR-083