### PR TITLE
feat(connect): add scope/project config schema and boot validation (ADR-082 1/4) [2/8]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Keyorix are documented here. This project follows
 ## Unreleased
 
 ### Changed
+- **BREAKING (targeting v0.92.0): every Keyorix Connect connector must declare
+  `scope: project` or `scope: platform` (ADR-082)** — an existing deployment with
+  `connect.enabled: true` and one or more configured connectors **will fail to boot**
+  after upgrading unless every connector in `connect.connectors` gains an explicit
+  `scope:` (and `project:` when `scope: project`). Set `connect.allow_unscoped: true`
+  as a temporary, deployment-wide stopgap to boot anyway — every connector still
+  missing `scope:` then logs a `WARN` on every boot until it's fixed. This is the
+  config-schema/boot-validation part of ADR-082 only; connector ownership is not yet
+  enforced on the read path (a later change) — see
+  `docs/adr-082-connect-connector-tenant-scoping.md`.
 - **BREAKING: keyorix-operator default RBAC/watch scope narrowed to own-namespace-only
   (ADR-076)** — an unmodified `helm install deploy/helm/keyorix-operator` now binds a
   namespace-scoped `RoleBinding` in its own release namespace and watches only that

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1159,27 +1159,42 @@ with no connectors the `/connect` endpoints are not served.
 ```yaml
 connect:
   enabled: true
+  # allow_unscoped is a temporary, deployment-wide escape hatch (ADR-082): with it
+  # unset (the default), any connector below with no scope: fails server boot. Set
+  # it true only while migrating an existing config — every connector missing scope:
+  # then logs a WARN, every boot, until you set scope: on it and remove this flag.
+  allow_unscoped: false
   connectors:
     - name: prod-aws            # API path key (unique); GET /api/v1/connect/prod-aws/secret?ref=…
       type: aws-secrets-manager # aws-secrets-manager | gcp-secret-manager | azure-key-vault | vault
       region: eu-west-1         # AWS region (aws-secrets-manager)
+      scope: project             # project | platform (ADR-082) — required
+      project: payments          # Keyorix project name (not ID) that owns this connector;
+                                  # required when scope is "project", omit when "platform"
       allowed_refs:             # optional prefix allowlist — a ref must match one
         - keyorix/              # (defense-in-depth on top of the backend's IAM scope)
     - name: prod-gcp
       type: gcp-secret-manager  # ref is the version resource name (creds from ADC)
       project_id: my-proj       # recommended: pins the connector to one GCP project (#431);
                                  # a ref naming a different project is rejected before the backend call
+                                 # (a GCP project ID — unrelated to Keyorix's own project: below)
+      scope: project
+      project: payments
       allowed_refs:
         - projects/my-proj/secrets/keyorix-
     - name: prod-azure
       type: azure-key-vault     # ref is the secret name (or name/version); creds from DefaultAzureCredential
       address: https://myvault.vault.azure.net/   # the Key Vault URL
+      scope: project
+      project: payments
       allowed_refs:
         - keyorix-
-    - name: prod-vault
+    - name: shared-vault
       type: vault               # ref is the read path; KV v2 is unwrapped
       address: https://vault.example.com:8200
       token_env: VAULT_TOKEN    # env var holding the Vault token (default VAULT_TOKEN)
+      scope: platform           # org-wide connector — no project:; requires the caller
+                                 # to hold connect.platform.use in addition to connect.read
       allowed_refs:
         - secret/data/keyorix/
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,6 +167,13 @@ func (c *Config) LicenseGrace() time.Duration {
 type ConnectConfig struct {
 	Enabled    bool              `yaml:"enabled"`
 	Connectors []ConnectorConfig `yaml:"connectors"`
+	// AllowUnscoped is the single deployment-wide escape hatch (ADR-082 §C) that lets
+	// the server boot despite one or more connectors missing scope. Every boot under
+	// this flag logs a WARN naming each unscoped connector (server/main.go, not here —
+	// Validate() itself never logs). Default false: a missing scope fails boot. Does
+	// NOT rescue an unrecognized scope value or the project/platform contradiction
+	// checks — those always fail boot regardless of this flag.
+	AllowUnscoped bool `yaml:"allow_unscoped"`
 }
 
 // ConnectorConfig describes one external-store connector. Name is the API path key
@@ -189,6 +196,7 @@ type ConnectorConfig struct {
 	// the ambient ADC identity it runs under) address secrets in ANY project that
 	// identity can reach, relying solely on AllowedRefs to scope reach. Strongly
 	// recommended; left empty only for backward compatibility with an existing config.
+	// Unrelated to Project below — this is a GCP-side identifier, Project is Keyorix's.
 	ProjectID string `yaml:"project_id"`
 	// TokenEnv names the environment variable holding the backend token for type
 	// "vault" (default "VAULT_TOKEN"). The token is read from the environment, never
@@ -200,6 +208,30 @@ type ConnectorConfig struct {
 	// empty list places no restriction here — the backend IAM scope is then the only
 	// bound, so prefer setting both.
 	AllowedRefs []string `yaml:"allowed_refs"`
+	// Scope declares this connector's tenant boundary (ADR-082): "project" (owned by
+	// exactly one Keyorix project — requires Project) or "platform" (org-wide; requires
+	// the connect.platform.use permission at authorization time, must NOT set Project).
+	// Required: a missing value fails boot unless ConnectConfig.AllowUnscoped is set; an
+	// unrecognized value (anything other than "project"/"platform") always fails boot,
+	// AllowUnscoped does not rescue it.
+	Scope string `yaml:"scope"`
+	// Project names the Keyorix project that owns this connector, by NAME — not a
+	// numeric ID. A numeric project ID differs per deployment (the same logical project
+	// has a different row ID in every install's database), which would break config
+	// portability across environments and air-gap bundles; a name travels with the
+	// config unchanged. Required when Scope is "project"; must be empty when Scope is
+	// "platform" (a platform connector is not owned by any single project — setting
+	// both is a contradiction, and fails boot). This branch only checks presence — the
+	// name is resolved to a real project ID at boot in a later branch (ADR-082 §A/§D);
+	// an unresolvable name fails boot at that point, not here.
+	Project string `yaml:"project"`
+	// Environment optionally further scopes a "project"-scoped connector to one
+	// environment within Project, by name. Reserved (ADR-082 §G): accepted and stored,
+	// but NOT enforced — every environment within Project is currently treated
+	// identically for authorization purposes regardless of this field. Enforcement
+	// semantics are a real design question deferred to a follow-up ADR, not decided
+	// here.
+	Environment string `yaml:"environment"`
 }
 
 // PasswordPolicyConfig mirrors the password rules from ADR-025: synchronous
@@ -1907,6 +1939,56 @@ func (c *Config) Validate() error { // NOSONAR -- cognitive complexity 32, suppr
 		return fmt.Errorf("unsupported fallback language: %s. Supported languages: en, ru, es, fr, de", c.Locale.FallbackLanguage)
 	}
 
+	if err := validateConnectScopes(c.Connect); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateConnectScopes enforces ADR-082 §B/§C on cfg.Connect.Connectors — pure
+// config-shape validation, no DB/network access, no logging (Validate() never logs;
+// the allow_unscoped WARNs are emitted where the connectors are actually wired,
+// server/main.go, matching this codebase's existing log-at-the-point-of-use style).
+// Every check aggregates across ALL offending connectors into one error naming each
+// by config name, rather than failing on (and hiding) the first one found — an
+// operator fixing config should not have to restart-and-discover connectors one at a
+// time. Checks run in this order, each independent of the others by construction
+// (a connector can only land in one bucket): unrecognized scope (never rescued by
+// AllowUnscoped — a typo is not "intentionally unscoped"), missing scope (rescued by
+// AllowUnscoped), scope "project" without a Project name, scope "platform" with a
+// Project name set (a platform connector is not owned by any single project).
+func validateConnectScopes(cc ConnectConfig) error {
+	var missing, invalid, projectNeedsProject, platformRejectsProject []string
+	for _, connector := range cc.Connectors {
+		switch connector.Scope {
+		case "":
+			missing = append(missing, connector.Name)
+		case "project":
+			if connector.Project == "" {
+				projectNeedsProject = append(projectNeedsProject, connector.Name)
+			}
+		case "platform":
+			if connector.Project != "" {
+				platformRejectsProject = append(platformRejectsProject, connector.Name)
+			}
+		default:
+			invalid = append(invalid, connector.Name)
+		}
+	}
+
+	if len(invalid) > 0 {
+		return fmt.Errorf("connect: connector(s) with unrecognized scope (must be \"project\" or \"platform\"): %s", strings.Join(invalid, ", "))
+	}
+	if len(missing) > 0 && !cc.AllowUnscoped {
+		return fmt.Errorf("connect: connector(s) missing required \"scope\" (must be \"project\" or \"platform\"; set connect.allow_unscoped: true to boot anyway — ADR-082): %s", strings.Join(missing, ", "))
+	}
+	if len(projectNeedsProject) > 0 {
+		return fmt.Errorf("connect: connector(s) with scope \"project\" missing required \"project\": %s", strings.Join(projectNeedsProject, ", "))
+	}
+	if len(platformRejectsProject) > 0 {
+		return fmt.Errorf("connect: connector(s) with scope \"platform\" must not set \"project\" (a platform connector is not owned by any single project): %s", strings.Join(platformRejectsProject, ", "))
+	}
 	return nil
 }
 

--- a/internal/config/connect_config_test.go
+++ b/internal/config/connect_config_test.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateConnectScopes covers ADR-082 §B/§C boot validation: missing/
+// unrecognized scope, the project/platform contradiction checks, both
+// allow_unscoped states, and valid project/platform entries. Each failure
+// case asserts the aggregated error names every offending connector, not
+// just the first one found.
+func TestValidateConnectScopes(t *testing.T) {
+	tests := []struct {
+		name      string
+		cc        ConnectConfig
+		wantErr   bool
+		wantNames []string // every name that must appear in the error message
+	}{
+		{
+			name: "missing scope, single connector, fails boot",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "c1", Type: "vault"},
+			}},
+			wantErr:   true,
+			wantNames: []string{"c1"},
+		},
+		{
+			name: "missing scope, multiple connectors, aggregated in one error",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "c1", Type: "vault"},
+				{Name: "c2", Type: "aws-secrets-manager"},
+				{Name: "c3", Type: "azure-key-vault", Scope: "platform"}, // valid — must not appear
+			}},
+			wantErr:   true,
+			wantNames: []string{"c1", "c2"},
+		},
+		{
+			name: "unrecognized scope value fails boot",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "typo", Type: "vault", Scope: "projects"},
+			}},
+			wantErr:   true,
+			wantNames: []string{"typo"},
+		},
+		{
+			name: "unrecognized scope, multiple connectors, aggregated",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "bad1", Type: "vault", Scope: "Project"}, // wrong case
+				{Name: "bad2", Type: "vault", Scope: "org"},
+			}},
+			wantErr:   true,
+			wantNames: []string{"bad1", "bad2"},
+		},
+		{
+			name: "unrecognized scope is NOT rescued by allow_unscoped",
+			cc: ConnectConfig{
+				AllowUnscoped: true,
+				Connectors: []ConnectorConfig{
+					{Name: "typo", Type: "vault", Scope: "projekt"},
+				},
+			},
+			wantErr:   true,
+			wantNames: []string{"typo"},
+		},
+		{
+			name: "scope project without project name fails boot",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "noproj", Type: "vault", Scope: "project"},
+			}},
+			wantErr:   true,
+			wantNames: []string{"noproj"},
+		},
+		{
+			name: "scope project without project name, multiple, aggregated",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "noproj1", Type: "vault", Scope: "project"},
+				{Name: "noproj2", Type: "aws-secrets-manager", Scope: "project"},
+				{Name: "ok", Type: "vault", Scope: "project", Project: "payments"}, // valid — must not appear
+			}},
+			wantErr:   true,
+			wantNames: []string{"noproj1", "noproj2"},
+		},
+		{
+			name: "scope platform with project set fails boot (contradiction)",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "bad-platform", Type: "vault", Scope: "platform", Project: "payments"},
+			}},
+			wantErr:   true,
+			wantNames: []string{"bad-platform"},
+		},
+		{
+			name: "scope platform with project set, multiple, aggregated",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "bad1", Type: "vault", Scope: "platform", Project: "payments"},
+				{Name: "bad2", Type: "aws-secrets-manager", Scope: "platform", Project: "billing"},
+			}},
+			wantErr:   true,
+			wantNames: []string{"bad1", "bad2"},
+		},
+		{
+			name: "missing scope rescued by allow_unscoped: true",
+			cc: ConnectConfig{
+				AllowUnscoped: true,
+				Connectors: []ConnectorConfig{
+					{Name: "c1", Type: "vault"},
+					{Name: "c2", Type: "aws-secrets-manager"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing scope NOT rescued when allow_unscoped is false (default)",
+			cc: ConnectConfig{
+				AllowUnscoped: false,
+				Connectors: []ConnectorConfig{
+					{Name: "c1", Type: "vault"},
+				},
+			},
+			wantErr:   true,
+			wantNames: []string{"c1"},
+		},
+		{
+			name:    "no connectors is valid",
+			cc:      ConnectConfig{},
+			wantErr: false,
+		},
+		{
+			name: "valid project-scoped entry",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "aws", Type: "aws-secrets-manager", Scope: "project", Project: "payments"},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "valid platform-scoped entry, no project",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "shared-vault", Type: "vault", Scope: "platform"},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "mixed valid project and platform entries",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "aws", Type: "aws-secrets-manager", Scope: "project", Project: "payments"},
+				{Name: "gcp", Type: "gcp-secret-manager", Scope: "project", Project: "billing"},
+				{Name: "shared-vault", Type: "vault", Scope: "platform"},
+			}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConnectScopes(tt.cc)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, name := range tt.wantNames {
+				assert.Contains(t, err.Error(), name, "error must name every offending connector")
+			}
+		})
+	}
+}
+
+// TestValidateConnectScopes_ValidEntriesExcludedFromAggregation asserts that a
+// validly-scoped connector never appears in another connector's failure
+// message — the aggregation groups only the connectors that actually fail
+// each check.
+func TestValidateConnectScopes_ValidEntriesExcludedFromAggregation(t *testing.T) {
+	cc := ConnectConfig{Connectors: []ConnectorConfig{
+		{Name: "broken", Type: "vault"}, // missing scope
+		{Name: "fine", Type: "vault", Scope: "platform"},
+	}}
+	err := validateConnectScopes(cc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "broken")
+	assert.NotContains(t, err.Error(), "fine")
+}
+
+// TestValidate_ConnectScopesWired confirms Config.Validate() itself surfaces
+// a connector scope error — not just the unexported helper in isolation —
+// so the boot path (server/main.go's cfg.Validate() call) actually enforces
+// ADR-082 §C.
+func TestValidate_ConnectScopesWired(t *testing.T) {
+	c := &Config{
+		Storage: StorageConfig{Type: "remote"}, // skip local DB path requirement
+		Connect: ConnectConfig{Connectors: []ConnectorConfig{
+			{Name: "unscoped-connector", Type: "vault"},
+		}},
+	}
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unscoped-connector")
+	assert.Contains(t, err.Error(), "allow_unscoped")
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -111,6 +112,19 @@ func (m *MockStorage) GetProject(ctx context.Context, id uint) (*models.Project,
 
 func (m *MockStorage) UpdateProject(_ context.Context, project *models.Project) (*models.Project, error) {
 	return project, nil
+}
+
+func (m *MockStorage) GetProjectByName(ctx context.Context, name string) (*models.Project, error) {
+	for _, c := range m.ExpectedCalls {
+		if c.Method == "GetProjectByName" {
+			args := m.Called(ctx, name)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).(*models.Project), args.Error(1)
+		}
+	}
+	return nil, errors.New("project not found")
 }
 
 func (m *MockStorage) DeleteProject(_ context.Context, _ uint) error {
@@ -1735,6 +1749,15 @@ func (m *MockStorage) CreateConnectRefGrant(_ context.Context, grant *models.Con
 }
 func (m *MockStorage) DeleteConnectRefGrant(_ context.Context, _ uint) error {
 	return nil
+}
+
+// Keyorix Connect connector->project bindings (ADR-082) — core enforcement is
+// tested against real SQLite, so these mock stubs just satisfy the interface.
+func (m *MockStorage) GetConnectorProjectBinding(_ context.Context, _ string) (*models.ConnectorProjectBinding, error) {
+	return nil, errors.New("connector project binding not found")
+}
+func (m *MockStorage) CreateConnectorProjectBinding(_ context.Context, binding *models.ConnectorProjectBinding) (*models.ConnectorProjectBinding, error) {
+	return binding, nil
 }
 
 // Group-Role assignments

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1027,6 +1027,25 @@ type Storage interface {
 	CreateConnectRefGrant(ctx context.Context, grant *models.ConnectRefGrant) (*models.ConnectRefGrant, error)
 	DeleteConnectRefGrant(ctx context.Context, id uint) error
 
+	// GetProjectByName resolves a project by name, case-insensitively, matching the
+	// same LOWER(name) WHERE deleted_at IS NULL partial unique index Project.Name's
+	// own uniqueness is enforced by (ensureProjectNameIndex) — a soft-deleted
+	// project's name must not resolve here, consistent with it being freed for reuse.
+	// Returns a "not found"-substring error (matching GetProject's own convention)
+	// when no live project matches.
+	GetProjectByName(ctx context.Context, name string) (*models.Project, error)
+
+	// GetConnectorProjectBinding returns the persisted project-ID binding for a
+	// Connect connector (ADR-082) — see ConnectorProjectBinding's own doc comment for
+	// why boot-time resolution is pinned by ID rather than re-resolved by name on
+	// every boot. Returns a "not found"-substring error if the connector has no
+	// binding yet (first boot for that connector).
+	GetConnectorProjectBinding(ctx context.Context, connector string) (*models.ConnectorProjectBinding, error)
+	// CreateConnectorProjectBinding persists a connector's first-boot project
+	// resolution (ADR-082): the connector name, the resolved project ID, and the
+	// project's name at resolution time (for later rename detection).
+	CreateConnectorProjectBinding(ctx context.Context, binding *models.ConnectorProjectBinding) (*models.ConnectorProjectBinding, error)
+
 	// Group-Role assignments. Assign/Remove bind a role to a group at the given
 	// Scope (zero Scope = global).
 	GetGroupRoles(ctx context.Context, groupID uint) ([]*models.Role, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -952,6 +952,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	loginAttemptExists := tableExists(db, "login_attempts")
 	auditCkptExists := tableExists(db, "audit_checkpoints")
 	connectRefGrantExists := tableExists(db, "connect_ref_grants")
+	connectorProjectBindingsExists := tableExists(db, "connector_project_bindings")
 	groupsExists := tableExists(db, "groups")
 	secretACLExists := tableExists(db, "secret_acls")
 	scheduleExists := tableExists(db, "secret_access_schedules")
@@ -1095,6 +1096,16 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	if !connectRefGrantExists {
 		if err := db.AutoMigrate(&models.ConnectRefGrant{}); err != nil {
 			return fmt.Errorf("failed to migrate connect_ref_grants table: %w", err)
+		}
+	}
+
+	// Create connector_project_bindings if missing (ADR-082 branch 2, additive, safe
+	// on existing DBs) — pins each Connect connector to the Keyorix project it
+	// resolved to at first boot, by ID, so a later project rename can't silently
+	// reassign ownership (see ConnectorProjectBinding's own doc comment).
+	if !connectorProjectBindingsExists {
+		if err := db.AutoMigrate(&models.ConnectorProjectBinding{}); err != nil {
+			return fmt.Errorf("failed to migrate connector_project_bindings table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -586,6 +586,32 @@ type ConnectRefGrant struct {
 	CreatedAt time.Time
 }
 
+// ConnectorProjectBinding pins a Connect connector (ADR-082) to the Keyorix project
+// it resolved to at first boot, BY ID — not by name, and never re-resolved by name on
+// a later boot. Project.Name's own doc comment establishes that a project's name is
+// mutable and a soft-deleted project's name is freed for reuse; re-resolving a
+// connector's configured `project:` name against live Project rows on every boot
+// would let an ordinary project rename (or a delete-and-recreate under the same name)
+// silently reassign which project owns a connector, with no config change and no
+// operator awareness. Pinning by ID and treating any later name mismatch as a boot
+// failure (see the resolution logic in server/main.go) makes that reassignment a
+// deliberate, visible operator action instead.
+type ConnectorProjectBinding struct {
+	ID uint `gorm:"primaryKey"`
+	// Connector is the connector's config name (ConnectorConfig.Name) — one binding
+	// per connector.
+	Connector string `gorm:"not null;uniqueIndex"`
+	// ProjectID is the Keyorix project this connector is bound to, resolved once at
+	// first boot and never re-derived from ProjectName afterward.
+	ProjectID uint `gorm:"not null"`
+	// ProjectName is a SNAPSHOT of the project's name at the moment of binding — used
+	// only to detect a rename on a later boot (compare against the CURRENT name of the
+	// project at ProjectID); it is never itself re-resolved to find a project.
+	ProjectName string `gorm:"not null"`
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
 type Group struct {
 	ID uint `gorm:"primaryKey"`
 	// Name uniqueness is enforced by a PARTIAL unique index (name WHERE deleted_at

--- a/internal/storage/store/local_connector_project_bindings.go
+++ b/internal/storage/store/local_connector_project_bindings.go
@@ -1,0 +1,41 @@
+// local_connector_project_bindings.go — persistence for Connect connector→project
+// ID bindings (ADR-082 branch 2). See models.ConnectorProjectBinding's own doc
+// comment for why boot-time resolution is pinned by ID and never re-resolved by name
+// on a later boot. This file only stores and reads the binding rows; the
+// resolve-or-create decision and the rename/deleted-project detection live in
+// server/main.go's boot-time wiring.
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// GetConnectorProjectBinding returns the persisted binding for connector, or a
+// "not found"-substring error if none exists yet (first boot for that connector).
+func (ls *LocalStorage) GetConnectorProjectBinding(ctx context.Context, connector string) (*models.ConnectorProjectBinding, error) {
+	var binding models.ConnectorProjectBinding
+	if err := ls.db.WithContext(ctx).Where("connector = ?", connector).First(&binding).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("connector project binding not found")
+		}
+		return nil, fmt.Errorf("failed to get connector project binding: %w", err)
+	}
+	return &binding, nil
+}
+
+// CreateConnectorProjectBinding persists a connector's first-boot project
+// resolution. The unique index on Connector makes re-creating a binding for an
+// already-bound connector a conflict — callers must check
+// GetConnectorProjectBinding first, exactly like the boot-time resolution logic
+// does.
+func (ls *LocalStorage) CreateConnectorProjectBinding(ctx context.Context, binding *models.ConnectorProjectBinding) (*models.ConnectorProjectBinding, error) {
+	if err := ls.db.WithContext(ctx).Create(binding).Error; err != nil {
+		return nil, fmt.Errorf("failed to create connector project binding: %w", err)
+	}
+	return binding, nil
+}

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -146,6 +146,24 @@ func (ls *LocalStorage) GetProject(ctx context.Context, id uint) (*models.Projec
 	return &project, nil
 }
 
+// GetProjectByName resolves a project by name, case-insensitively — matching
+// ensureProjectNameIndex's LOWER(name) partial unique index exactly, so this can
+// never resolve two different rows for names differing only in case. GORM's
+// soft-delete scoping (Project.DeletedAt) already excludes a soft-deleted project
+// from this query without an explicit deleted_at clause, consistent with a deleted
+// project's name being freed for reuse (see Project.Name's own doc comment) — this
+// must never resolve a name to a row that no longer legitimately holds it.
+func (ls *LocalStorage) GetProjectByName(ctx context.Context, name string) (*models.Project, error) {
+	var project models.Project
+	if err := ls.db.WithContext(ctx).Where("LOWER(name) = LOWER(?)", name).First(&project).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("project not found")
+		}
+		return nil, fmt.Errorf("failed to get project by name: %w", err)
+	}
+	return &project, nil
+}
+
 func (ls *LocalStorage) UpdateProject(ctx context.Context, project *models.Project) (*models.Project, error) {
 	if err := ls.db.WithContext(ctx).Save(project).Error; err != nil {
 		if isDuplicateProjectNameViolation(err) {

--- a/internal/storage/store/remote_connector_project_bindings.go
+++ b/internal/storage/store/remote_connector_project_bindings.go
@@ -1,0 +1,92 @@
+// remote_connector_project_bindings.go — RemoteStorage passthrough for Connect
+// connector→project ID bindings (ADR-082 branch 2). A downstream Keyorix server
+// booted with storage.type: remote (ADR-049) proxies these to whichever upstream
+// server it's configured against, through routes registered in
+// server/http/router.go under /api/v1/system/connector-project-bindings (gated on
+// the existing system.write RBAC permission — the same credential a RemoteStorage
+// client already needs for every other proxied call, so this introduces no new
+// privilege class). This is a real, DB-backed implementation, not a stub: backlog
+// #527 already documented the failure shape a "not supported in remote storage"
+// stub produces here — the calling boot-time resolution logic (server/main.go)
+// would treat the resulting error as an unresolvable connector and fail boot on
+// every connector, on every storage.type: remote node with Connect configured.
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// connectorProjectBindingWire mirrors models.ConnectorProjectBinding's fields
+// exactly (snake_case) — the wire shape the proxy handler
+// (server/http/handlers/connector_project_bindings_proxy.go) sends/expects.
+type connectorProjectBindingWire struct {
+	ID          uint      `json:"id"`
+	Connector   string    `json:"connector"`
+	ProjectID   uint      `json:"project_id"`
+	ProjectName string    `json:"project_name"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func newConnectorProjectBindingWire(b *models.ConnectorProjectBinding) connectorProjectBindingWire {
+	return connectorProjectBindingWire{
+		ID:          b.ID,
+		Connector:   b.Connector,
+		ProjectID:   b.ProjectID,
+		ProjectName: b.ProjectName,
+		CreatedAt:   b.CreatedAt,
+		UpdatedAt:   b.UpdatedAt,
+	}
+}
+
+func (w connectorProjectBindingWire) toModel() *models.ConnectorProjectBinding {
+	return &models.ConnectorProjectBinding{
+		ID:          w.ID,
+		Connector:   w.Connector,
+		ProjectID:   w.ProjectID,
+		ProjectName: w.ProjectName,
+		CreatedAt:   w.CreatedAt,
+		UpdatedAt:   w.UpdatedAt,
+	}
+}
+
+// GetConnectorProjectBinding retrieves a connector's binding via GET
+// /api/v1/system/connector-project-bindings/{connector}.
+func (rs *RemoteStorage) GetConnectorProjectBinding(ctx context.Context, connector string) (*models.ConnectorProjectBinding, error) {
+	path := "/api/v1/system/connector-project-bindings/" + url.PathEscape(connector)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connector project binding: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get connector project binding failed: %s", resp.Error.Error())
+	}
+	var wire connectorProjectBindingWire
+	if err := json.Unmarshal(resp.Data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
+}
+
+// CreateConnectorProjectBinding persists a connector's first-boot project
+// resolution via POST /api/v1/system/connector-project-bindings.
+func (rs *RemoteStorage) CreateConnectorProjectBinding(ctx context.Context, binding *models.ConnectorProjectBinding) (*models.ConnectorProjectBinding, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/connector-project-bindings", newConnectorProjectBindingWire(binding))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connector project binding: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create connector project binding failed: %s", resp.Error.Error())
+	}
+	var wire connectorProjectBindingWire
+	if err := json.Unmarshal(resp.Data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
+}

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -838,6 +838,25 @@ func (rs *RemoteStorage) GetProject(ctx context.Context, id uint) (*models.Proje
 	return decodeProjectResponse(resp.Data)
 }
 
+// GetProjectByName resolves a project by name via GET
+// /api/v1/system/projects/by-name/{name} (ADR-082 branch 2's boot-time connector
+// resolution) — a real, DB-backed lookup on the upstream server, not a stub. Backlog
+// #527 already fixed exactly this failure shape once for ConnectRefGrant: a
+// RemoteStorage primitive with no server endpoint to call at all made every
+// Keyorix Connect federated read fail closed on every storage.type: remote node
+// with Connect configured. This follows the same #510 setup-token-proxy pattern.
+func (rs *RemoteStorage) GetProjectByName(ctx context.Context, name string) (*models.Project, error) {
+	path := "/api/v1/system/projects/by-name/" + url.PathEscape(name)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get project by name: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get project by name failed: %s", resp.Error.Error())
+	}
+	return decodeProjectResponse(resp.Data)
+}
+
 // UpdateProject updates an existing project via PUT /api/v1/system/projects/{id}.
 func (rs *RemoteStorage) UpdateProject(ctx context.Context, project *models.Project) (*models.Project, error) {
 	path := fmt.Sprintf("/api/v1/system/projects/%d", project.ID)

--- a/server/http/handlers/connector_project_bindings_proxy.go
+++ b/server/http/handlers/connector_project_bindings_proxy.go
@@ -1,0 +1,121 @@
+// connector_project_bindings_proxy.go — server-side endpoints backing
+// RemoteStorage's GetConnectorProjectBinding/CreateConnectorProjectBinding
+// (ADR-082 branch 2). See connect_grants_proxy.go's package doc (backlog #527) for
+// why a downstream Keyorix server booted with storage.type: remote needs a real
+// server endpoint here rather than a stub: the calling boot-time resolution logic
+// (server/main.go) treats any error from these primitives as an unresolvable
+// connector and fails boot, so a stub would fail boot on every connector on every
+// remote-storage node with Connect configured — the exact failure shape #527 fixed
+// once already for ConnectRefGrant.
+//
+// These routes (registered in server/http/router.go under
+// /api/v1/system/connector-project-bindings, gated on the existing system.write RBAC
+// permission — the same credential a RemoteStorage client already needs for every
+// other proxied call, so this introduces no new privilege class) are thin
+// passthroughs onto the SAME storage.Storage primitives server/main.go's boot-time
+// resolution already uses against a local backend — no policy decision (which
+// project a name resolves to, whether a mismatch is a rename) is made here.
+//
+// Response envelope: like connect_grants_proxy.go, these do NOT use the package's
+// generic sendSuccess/sendError helpers — they construct the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses.
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// connectorProjectBindingProxyWire mirrors models.ConnectorProjectBinding's fields
+// exactly (snake_case) — the wire shape
+// internal/storage/store/remote_connector_project_bindings.go's
+// connectorProjectBindingWire sends/expects.
+type connectorProjectBindingProxyWire struct {
+	ID          uint      `json:"id"`
+	Connector   string    `json:"connector"`
+	ProjectID   uint      `json:"project_id"`
+	ProjectName string    `json:"project_name"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func newConnectorProjectBindingProxyWire(b *models.ConnectorProjectBinding) connectorProjectBindingProxyWire {
+	return connectorProjectBindingProxyWire{
+		ID:          b.ID,
+		Connector:   b.Connector,
+		ProjectID:   b.ProjectID,
+		ProjectName: b.ProjectName,
+		CreatedAt:   b.CreatedAt,
+		UpdatedAt:   b.UpdatedAt,
+	}
+}
+
+// isConnectorProjectBindingNotFound reports whether err is the "not found"
+// sentinel LocalStorage's GetConnectorProjectBinding uses.
+func isConnectorProjectBindingNotFound(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
+}
+
+// GetConnectorProjectBindingProxy handles GET
+// /api/v1/system/connector-project-bindings/{connector}.
+func (h *AuthHandler) GetConnectorProjectBindingProxy(w http.ResponseWriter, r *http.Request) {
+	connector := chi.URLParam(r, "connector")
+	if connector == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "connector is required")
+		return
+	}
+	binding, err := h.coreService.Storage().GetConnectorProjectBinding(r.Context(), connector)
+	if err != nil {
+		if isConnectorProjectBindingNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "connector project binding not found")
+			return
+		}
+		log.Printf("connector-project-bindings proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newConnectorProjectBindingProxyWire(binding))
+}
+
+// connectorProjectBindingCreateBody is the wire body for POST
+// /api/v1/system/connector-project-bindings. The server assigns ID/CreatedAt/
+// UpdatedAt, so the body carries only the fields the caller has already resolved.
+type connectorProjectBindingCreateBody struct {
+	Connector   string `json:"connector"`
+	ProjectID   uint   `json:"project_id"`
+	ProjectName string `json:"project_name"`
+}
+
+// CreateConnectorProjectBindingProxy handles POST
+// /api/v1/system/connector-project-bindings. The caller (the downstream server's
+// own boot-time resolution) has already resolved the connector's project: name to
+// an ID; this is a raw persist, no re-resolution.
+func (h *AuthHandler) CreateConnectorProjectBindingProxy(w http.ResponseWriter, r *http.Request) {
+	var body connectorProjectBindingCreateBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Connector == "" || body.ProjectID == 0 || body.ProjectName == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "connector, project_id, and project_name are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateConnectorProjectBinding(r.Context(), &models.ConnectorProjectBinding{
+		Connector:   body.Connector,
+		ProjectID:   body.ProjectID,
+		ProjectName: body.ProjectName,
+	})
+	if err != nil {
+		log.Printf("connector-project-bindings proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newConnectorProjectBindingProxyWire(created))
+}

--- a/server/http/handlers/project_catalog_proxy.go
+++ b/server/http/handlers/project_catalog_proxy.go
@@ -154,6 +154,30 @@ func (h *CatalogHandler) GetProjectProxy(w http.ResponseWriter, r *http.Request)
 	writeRemoteAPISuccess(w, newProjectProxyWire(p))
 }
 
+// GetProjectByNameProxy handles GET /api/v1/system/projects/by-name/{name} —
+// ADR-082 branch 2's boot-time connector resolution (server/main.go), proxied so a
+// storage.type: remote node can resolve a connector's configured project: name
+// against the upstream server's real Project table instead of RemoteStorage's
+// GetProjectByName having no server endpoint to call at all.
+func (h *CatalogHandler) GetProjectByNameProxy(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	if name == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "name is required")
+		return
+	}
+	p, err := h.coreService.Storage().GetProjectByName(r.Context(), name)
+	if err != nil {
+		if isProjectNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errProjectNotFound)
+			return
+		}
+		log.Printf("project catalog proxy: get by name failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newProjectProxyWire(p))
+}
+
 // UpdateProjectProxy handles PUT /api/v1/system/projects/{id}. Like the group/
 // invitation proxies' raw persist, this trusts the caller's already-fully-resolved
 // final desired state (the calling core.KeyorixCore.UpdateProject already merged the

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1353,6 +1353,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Post("/connect-grants", authHandler.CreateConnectRefGrantProxy)
 			r.Delete("/connect-grants/{id}", authHandler.DeleteConnectRefGrantProxy)
 
+			// Connect connector→project ID binding storage-primitive proxy (ADR-082
+			// branch 2). Same rationale and pattern as the connect-grants block above
+			// (backlog #527): boot-time connector resolution (server/main.go) treats
+			// any error from these primitives as an unresolvable connector and fails
+			// boot, so RemoteStorage needs a real endpoint here, not a stub.
+			r.Get("/connector-project-bindings/{connector}", authHandler.GetConnectorProjectBindingProxy)
+			r.Post("/connector-project-bindings", authHandler.CreateConnectorProjectBindingProxy)
+
 			// SSO login-state storage-primitive proxy (#521). Lets a downstream
 			// Keyorix server booted with storage.type: remote (ADR-049) proxy
 			// CreateSSOLoginState/ConsumeSSOLoginState to THIS server's real storage
@@ -1955,6 +1963,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// "/projects/{id}/environments/{envId}/copy-secrets" vs
 			// "/projects/{projectId}/environments/{id}/restore" routes already do.
 			r.Get("/projects/with-counts", catalogHandler.ListProjectsWithCountsProxy)
+			// /projects/by-name/{name} (ADR-082 branch 2): a static "by-name" segment
+			// ahead of the {id} wildcard below, same precedence pattern as
+			// "with-counts" above — boot-time connector resolution (server/main.go)
+			// resolves a connector's configured project: name against this route on a
+			// storage.type: remote node.
+			r.Get("/projects/by-name/{name}", catalogHandler.GetProjectByNameProxy)
 			r.Get(pathProjects, catalogHandler.ListProjectsProxy)
 			r.Get(pathProjectsID, catalogHandler.GetProjectProxy)
 			r.Put(pathProjectsID, catalogHandler.UpdateProjectProxy)

--- a/server/main.go
+++ b/server/main.go
@@ -561,6 +561,23 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 
 	// Wire Keyorix Connect (ADR-043) read-through federation if enabled.
 	if cc := cfg.Connect; cc.Enabled && len(cc.Connectors) > 0 {
+		// ADR-082 §C: cfg.Validate() already refused to boot with a missing/invalid
+		// connector scope unless connect.allow_unscoped is set — Validate() itself never
+		// logs (internal/config/validateConnectScopes), so if we're here under that flag,
+		// warn loudly, per connector and once as a summary, at the point the connectors
+		// are actually wired.
+		if cc.AllowUnscoped {
+			var unscoped []string
+			for _, cn := range cc.Connectors {
+				if cn.Scope == "" {
+					unscoped = append(unscoped, cn.Name)
+					log.Printf("Keyorix Connect: connector %q has no scope configured and is booting under connect.allow_unscoped — set scope: project or scope: platform (ADR-082)", cn.Name)
+				}
+			}
+			if len(unscoped) > 0 {
+				log.Printf("Keyorix Connect: %d connector(s) booted unscoped under connect.allow_unscoped — this is a temporary escape hatch; set an explicit scope on each before removing it (ADR-082)", len(unscoped))
+			}
+		}
 		var connectors []connect.Connector
 		for _, cn := range cc.Connectors {
 			switch cn.Type {

--- a/server/server_s22_test.go
+++ b/server/server_s22_test.go
@@ -237,6 +237,8 @@ func TestInitializeCoreService_S22_VaultCustomTokenEnv(t *testing.T) {
 				Address:     "http://vault.example.com:8200",
 				TokenEnv:    customEnv,
 				AllowedRefs: []string{"prod/*"},
+				Scope:       "project",
+				Project:     "payments",
 			},
 		},
 	}

--- a/server/server_s23_test.go
+++ b/server/server_s23_test.go
@@ -241,6 +241,8 @@ func TestInitializeCoreService_S23_VaultDefaultTokenEnv(t *testing.T) {
 				Address:     "http://vault.example.com:8200",
 				TokenEnv:    "", // empty → code substitutes "VAULT_TOKEN"
 				AllowedRefs: []string{"prod/*"},
+				Scope:       "project",
+				Project:     "payments",
 			},
 		},
 	}

--- a/server/server_s4_test.go
+++ b/server/server_s4_test.go
@@ -399,7 +399,7 @@ func TestInitializeCoreService_Connect_UnknownType(t *testing.T) {
 	cfg.Connect = config.ConnectConfig{
 		Enabled: true,
 		Connectors: []config.ConnectorConfig{
-			{Name: "c1", Type: "unknown-type"},
+			{Name: "c1", Type: "unknown-type", Scope: "project", Project: "payments"},
 		},
 	}
 
@@ -417,9 +417,9 @@ func TestInitializeCoreService_Connect_KnownTypes(t *testing.T) {
 	cfg.Connect = config.ConnectConfig{
 		Enabled: true,
 		Connectors: []config.ConnectorConfig{
-			{Name: "aws", Type: "aws-secrets-manager", AllowedRefs: []string{"prod/*"}},
-			{Name: "gcp", Type: "gcp-secret-manager", ProjectID: "my-proj", AllowedRefs: []string{"prod/*"}},
-			{Name: "vault", Type: "vault", Address: "http://vault:8200", AllowedRefs: []string{"prod/*"}},
+			{Name: "aws", Type: "aws-secrets-manager", AllowedRefs: []string{"prod/*"}, Scope: "project", Project: "payments"},
+			{Name: "gcp", Type: "gcp-secret-manager", ProjectID: "my-proj", AllowedRefs: []string{"prod/*"}, Scope: "project", Project: "payments"},
+			{Name: "vault", Type: "vault", Address: "http://vault:8200", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
 		},
 	}
 
@@ -437,7 +437,7 @@ func TestInitializeCoreService_Connect_GCP_NoProjectID(t *testing.T) {
 	cfg.Connect = config.ConnectConfig{
 		Enabled: true,
 		Connectors: []config.ConnectorConfig{
-			{Name: "gcp-noproj", Type: "gcp-secret-manager", ProjectID: "", AllowedRefs: []string{"prod/*"}},
+			{Name: "gcp-noproj", Type: "gcp-secret-manager", ProjectID: "", AllowedRefs: []string{"prod/*"}, Scope: "project", Project: "payments"},
 		},
 	}
 
@@ -455,7 +455,7 @@ func TestInitializeCoreService_Connect_AzureKeyVault(t *testing.T) {
 	cfg.Connect = config.ConnectConfig{
 		Enabled: true,
 		Connectors: []config.ConnectorConfig{
-			{Name: "azure-kv", Type: "azure-key-vault", Address: "https://vault.vault.azure.net", AllowedRefs: []string{"prod/*"}},
+			{Name: "azure-kv", Type: "azure-key-vault", Address: "https://vault.vault.azure.net", AllowedRefs: []string{"prod/*"}, Scope: "project", Project: "payments"},
 		},
 	}
 


### PR DESCRIPTION
## Summary

ADR-082 branch 1: adds the `scope`/`project` config schema for Connect connectors and boot-time validation (`Config.Validate()`). A connector config entry with no `scope` fails boot, unconditionally, naming every offending connector in one aggregated error (not fail-on-first).

Stacked on #1482 (the ADR-082 doc) — review that first for the design this implements.

## Scope

- `ConnectorConfig` gains `Scope`/`Project` (and reserved, not-yet-enforced `Environment` per ADR-082 §G).
- `validateConnectScopes`: unrecognized scope, missing scope, `scope: project` without `project:`, `scope: platform` with `project:` set — each a boot-time error naming every offending connector.
- No deployment-wide bypass.

Note: this branch's original schema included `connect.allow_unscoped` as an escape hatch. It's removed later in this stack (PR 6/8) once branch 4's ownership enforcement proved it non-functional — see that PR's description and ADR-082 §C's amendment.

## Test plan

- [x] `go build ./...` clean at this commit (part of a verified 8-commit bisect-compile — no non-compiling intermediate in the stack)
- [x] Existing + new config validation tests pass