### PR TITLE
feat(storage): add Connect connector project-binding storage primitives (ADR-082) [3/8]

### DIFF
--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1027,6 +1027,25 @@ type Storage interface {
 	CreateConnectRefGrant(ctx context.Context, grant *models.ConnectRefGrant) (*models.ConnectRefGrant, error)
 	DeleteConnectRefGrant(ctx context.Context, id uint) error
 
+	// GetProjectByName resolves a project by name, case-insensitively, matching the
+	// same LOWER(name) WHERE deleted_at IS NULL partial unique index Project.Name's
+	// own uniqueness is enforced by (ensureProjectNameIndex) — a soft-deleted
+	// project's name must not resolve here, consistent with it being freed for reuse.
+	// Returns a "not found"-substring error (matching GetProject's own convention)
+	// when no live project matches.
+	GetProjectByName(ctx context.Context, name string) (*models.Project, error)
+
+	// GetConnectorProjectBinding returns the persisted project-ID binding for a
+	// Connect connector (ADR-082) — see ConnectorProjectBinding's own doc comment for
+	// why boot-time resolution is pinned by ID rather than re-resolved by name on
+	// every boot. Returns a "not found"-substring error if the connector has no
+	// binding yet (first boot for that connector).
+	GetConnectorProjectBinding(ctx context.Context, connector string) (*models.ConnectorProjectBinding, error)
+	// CreateConnectorProjectBinding persists a connector's first-boot project
+	// resolution (ADR-082): the connector name, the resolved project ID, and the
+	// project's name at resolution time (for later rename detection).
+	CreateConnectorProjectBinding(ctx context.Context, binding *models.ConnectorProjectBinding) (*models.ConnectorProjectBinding, error)
+
 	// Group-Role assignments. Assign/Remove bind a role to a group at the given
 	// Scope (zero Scope = global).
 	GetGroupRoles(ctx context.Context, groupID uint) ([]*models.Role, error)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -952,6 +952,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	loginAttemptExists := tableExists(db, "login_attempts")
 	auditCkptExists := tableExists(db, "audit_checkpoints")
 	connectRefGrantExists := tableExists(db, "connect_ref_grants")
+	connectorProjectBindingsExists := tableExists(db, "connector_project_bindings")
 	groupsExists := tableExists(db, "groups")
 	secretACLExists := tableExists(db, "secret_acls")
 	scheduleExists := tableExists(db, "secret_access_schedules")
@@ -1095,6 +1096,16 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	if !connectRefGrantExists {
 		if err := db.AutoMigrate(&models.ConnectRefGrant{}); err != nil {
 			return fmt.Errorf("failed to migrate connect_ref_grants table: %w", err)
+		}
+	}
+
+	// Create connector_project_bindings if missing (ADR-082 branch 2, additive, safe
+	// on existing DBs) — pins each Connect connector to the Keyorix project it
+	// resolved to at first boot, by ID, so a later project rename can't silently
+	// reassign ownership (see ConnectorProjectBinding's own doc comment).
+	if !connectorProjectBindingsExists {
+		if err := db.AutoMigrate(&models.ConnectorProjectBinding{}); err != nil {
+			return fmt.Errorf("failed to migrate connector_project_bindings table: %w", err)
 		}
 	}
 

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -586,6 +586,32 @@ type ConnectRefGrant struct {
 	CreatedAt time.Time
 }
 
+// ConnectorProjectBinding pins a Connect connector (ADR-082) to the Keyorix project
+// it resolved to at first boot, BY ID — not by name, and never re-resolved by name on
+// a later boot. Project.Name's own doc comment establishes that a project's name is
+// mutable and a soft-deleted project's name is freed for reuse; re-resolving a
+// connector's configured `project:` name against live Project rows on every boot
+// would let an ordinary project rename (or a delete-and-recreate under the same name)
+// silently reassign which project owns a connector, with no config change and no
+// operator awareness. Pinning by ID and treating any later name mismatch as a boot
+// failure (see the resolution logic in server/main.go) makes that reassignment a
+// deliberate, visible operator action instead.
+type ConnectorProjectBinding struct {
+	ID uint `gorm:"primaryKey"`
+	// Connector is the connector's config name (ConnectorConfig.Name) — one binding
+	// per connector.
+	Connector string `gorm:"not null;uniqueIndex"`
+	// ProjectID is the Keyorix project this connector is bound to, resolved once at
+	// first boot and never re-derived from ProjectName afterward.
+	ProjectID uint `gorm:"not null"`
+	// ProjectName is a SNAPSHOT of the project's name at the moment of binding — used
+	// only to detect a rename on a later boot (compare against the CURRENT name of the
+	// project at ProjectID); it is never itself re-resolved to find a project.
+	ProjectName string `gorm:"not null"`
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
 type Group struct {
 	ID uint `gorm:"primaryKey"`
 	// Name uniqueness is enforced by a PARTIAL unique index (name WHERE deleted_at

--- a/internal/storage/store/local_connector_project_bindings.go
+++ b/internal/storage/store/local_connector_project_bindings.go
@@ -1,0 +1,41 @@
+// local_connector_project_bindings.go — persistence for Connect connector→project
+// ID bindings (ADR-082 branch 2). See models.ConnectorProjectBinding's own doc
+// comment for why boot-time resolution is pinned by ID and never re-resolved by name
+// on a later boot. This file only stores and reads the binding rows; the
+// resolve-or-create decision and the rename/deleted-project detection live in
+// server/main.go's boot-time wiring.
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
+)
+
+// GetConnectorProjectBinding returns the persisted binding for connector, or a
+// "not found"-substring error if none exists yet (first boot for that connector).
+func (ls *LocalStorage) GetConnectorProjectBinding(ctx context.Context, connector string) (*models.ConnectorProjectBinding, error) {
+	var binding models.ConnectorProjectBinding
+	if err := ls.db.WithContext(ctx).Where("connector = ?", connector).First(&binding).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("connector project binding not found")
+		}
+		return nil, fmt.Errorf("failed to get connector project binding: %w", err)
+	}
+	return &binding, nil
+}
+
+// CreateConnectorProjectBinding persists a connector's first-boot project
+// resolution. The unique index on Connector makes re-creating a binding for an
+// already-bound connector a conflict — callers must check
+// GetConnectorProjectBinding first, exactly like the boot-time resolution logic
+// does.
+func (ls *LocalStorage) CreateConnectorProjectBinding(ctx context.Context, binding *models.ConnectorProjectBinding) (*models.ConnectorProjectBinding, error) {
+	if err := ls.db.WithContext(ctx).Create(binding).Error; err != nil {
+		return nil, fmt.Errorf("failed to create connector project binding: %w", err)
+	}
+	return binding, nil
+}

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -146,6 +146,24 @@ func (ls *LocalStorage) GetProject(ctx context.Context, id uint) (*models.Projec
 	return &project, nil
 }
 
+// GetProjectByName resolves a project by name, case-insensitively — matching
+// ensureProjectNameIndex's LOWER(name) partial unique index exactly, so this can
+// never resolve two different rows for names differing only in case. GORM's
+// soft-delete scoping (Project.DeletedAt) already excludes a soft-deleted project
+// from this query without an explicit deleted_at clause, consistent with a deleted
+// project's name being freed for reuse (see Project.Name's own doc comment) — this
+// must never resolve a name to a row that no longer legitimately holds it.
+func (ls *LocalStorage) GetProjectByName(ctx context.Context, name string) (*models.Project, error) {
+	var project models.Project
+	if err := ls.db.WithContext(ctx).Where("LOWER(name) = LOWER(?)", name).First(&project).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("project not found")
+		}
+		return nil, fmt.Errorf("failed to get project by name: %w", err)
+	}
+	return &project, nil
+}
+
 func (ls *LocalStorage) UpdateProject(ctx context.Context, project *models.Project) (*models.Project, error) {
 	if err := ls.db.WithContext(ctx).Save(project).Error; err != nil {
 		if isDuplicateProjectNameViolation(err) {

--- a/internal/storage/store/remote_connector_project_bindings.go
+++ b/internal/storage/store/remote_connector_project_bindings.go
@@ -1,0 +1,92 @@
+// remote_connector_project_bindings.go — RemoteStorage passthrough for Connect
+// connector→project ID bindings (ADR-082 branch 2). A downstream Keyorix server
+// booted with storage.type: remote (ADR-049) proxies these to whichever upstream
+// server it's configured against, through routes registered in
+// server/http/router.go under /api/v1/system/connector-project-bindings (gated on
+// the existing system.write RBAC permission — the same credential a RemoteStorage
+// client already needs for every other proxied call, so this introduces no new
+// privilege class). This is a real, DB-backed implementation, not a stub: backlog
+// #527 already documented the failure shape a "not supported in remote storage"
+// stub produces here — the calling boot-time resolution logic (server/main.go)
+// would treat the resulting error as an unresolvable connector and fail boot on
+// every connector, on every storage.type: remote node with Connect configured.
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// connectorProjectBindingWire mirrors models.ConnectorProjectBinding's fields
+// exactly (snake_case) — the wire shape the proxy handler
+// (server/http/handlers/connector_project_bindings_proxy.go) sends/expects.
+type connectorProjectBindingWire struct {
+	ID          uint      `json:"id"`
+	Connector   string    `json:"connector"`
+	ProjectID   uint      `json:"project_id"`
+	ProjectName string    `json:"project_name"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func newConnectorProjectBindingWire(b *models.ConnectorProjectBinding) connectorProjectBindingWire {
+	return connectorProjectBindingWire{
+		ID:          b.ID,
+		Connector:   b.Connector,
+		ProjectID:   b.ProjectID,
+		ProjectName: b.ProjectName,
+		CreatedAt:   b.CreatedAt,
+		UpdatedAt:   b.UpdatedAt,
+	}
+}
+
+func (w connectorProjectBindingWire) toModel() *models.ConnectorProjectBinding {
+	return &models.ConnectorProjectBinding{
+		ID:          w.ID,
+		Connector:   w.Connector,
+		ProjectID:   w.ProjectID,
+		ProjectName: w.ProjectName,
+		CreatedAt:   w.CreatedAt,
+		UpdatedAt:   w.UpdatedAt,
+	}
+}
+
+// GetConnectorProjectBinding retrieves a connector's binding via GET
+// /api/v1/system/connector-project-bindings/{connector}.
+func (rs *RemoteStorage) GetConnectorProjectBinding(ctx context.Context, connector string) (*models.ConnectorProjectBinding, error) {
+	path := "/api/v1/system/connector-project-bindings/" + url.PathEscape(connector)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connector project binding: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get connector project binding failed: %s", resp.Error.Error())
+	}
+	var wire connectorProjectBindingWire
+	if err := json.Unmarshal(resp.Data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
+}
+
+// CreateConnectorProjectBinding persists a connector's first-boot project
+// resolution via POST /api/v1/system/connector-project-bindings.
+func (rs *RemoteStorage) CreateConnectorProjectBinding(ctx context.Context, binding *models.ConnectorProjectBinding) (*models.ConnectorProjectBinding, error) {
+	resp, err := rs.client.Post(ctx, "/api/v1/system/connector-project-bindings", newConnectorProjectBindingWire(binding))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connector project binding: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("create connector project binding failed: %s", resp.Error.Error())
+	}
+	var wire connectorProjectBindingWire
+	if err := json.Unmarshal(resp.Data, &wire); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return wire.toModel(), nil
+}

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -838,6 +838,25 @@ func (rs *RemoteStorage) GetProject(ctx context.Context, id uint) (*models.Proje
 	return decodeProjectResponse(resp.Data)
 }
 
+// GetProjectByName resolves a project by name via GET
+// /api/v1/system/projects/by-name/{name} (ADR-082 branch 2's boot-time connector
+// resolution) — a real, DB-backed lookup on the upstream server, not a stub. Backlog
+// #527 already fixed exactly this failure shape once for ConnectRefGrant: a
+// RemoteStorage primitive with no server endpoint to call at all made every
+// Keyorix Connect federated read fail closed on every storage.type: remote node
+// with Connect configured. This follows the same #510 setup-token-proxy pattern.
+func (rs *RemoteStorage) GetProjectByName(ctx context.Context, name string) (*models.Project, error) {
+	path := "/api/v1/system/projects/by-name/" + url.PathEscape(name)
+	resp, err := rs.client.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get project by name: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("get project by name failed: %s", resp.Error.Error())
+	}
+	return decodeProjectResponse(resp.Data)
+}
+
 // UpdateProject updates an existing project via PUT /api/v1/system/projects/{id}.
 func (rs *RemoteStorage) UpdateProject(ctx context.Context, project *models.Project) (*models.Project, error) {
 	path := fmt.Sprintf("/api/v1/system/projects/%d", project.ID)

--- a/server/http/handlers/connector_project_bindings_proxy.go
+++ b/server/http/handlers/connector_project_bindings_proxy.go
@@ -1,0 +1,121 @@
+// connector_project_bindings_proxy.go — server-side endpoints backing
+// RemoteStorage's GetConnectorProjectBinding/CreateConnectorProjectBinding
+// (ADR-082 branch 2). See connect_grants_proxy.go's package doc (backlog #527) for
+// why a downstream Keyorix server booted with storage.type: remote needs a real
+// server endpoint here rather than a stub: the calling boot-time resolution logic
+// (server/main.go) treats any error from these primitives as an unresolvable
+// connector and fails boot, so a stub would fail boot on every connector on every
+// remote-storage node with Connect configured — the exact failure shape #527 fixed
+// once already for ConnectRefGrant.
+//
+// These routes (registered in server/http/router.go under
+// /api/v1/system/connector-project-bindings, gated on the existing system.write RBAC
+// permission — the same credential a RemoteStorage client already needs for every
+// other proxied call, so this introduces no new privilege class) are thin
+// passthroughs onto the SAME storage.Storage primitives server/main.go's boot-time
+// resolution already uses against a local backend — no policy decision (which
+// project a name resolves to, whether a mismatch is a rename) is made here.
+//
+// Response envelope: like connect_grants_proxy.go, these do NOT use the package's
+// generic sendSuccess/sendError helpers — they construct the exact
+// {"success":bool,"data":...,"error":{"code","message"}} shape
+// internal/storage/remote.HTTPClient parses.
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// connectorProjectBindingProxyWire mirrors models.ConnectorProjectBinding's fields
+// exactly (snake_case) — the wire shape
+// internal/storage/store/remote_connector_project_bindings.go's
+// connectorProjectBindingWire sends/expects.
+type connectorProjectBindingProxyWire struct {
+	ID          uint      `json:"id"`
+	Connector   string    `json:"connector"`
+	ProjectID   uint      `json:"project_id"`
+	ProjectName string    `json:"project_name"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func newConnectorProjectBindingProxyWire(b *models.ConnectorProjectBinding) connectorProjectBindingProxyWire {
+	return connectorProjectBindingProxyWire{
+		ID:          b.ID,
+		Connector:   b.Connector,
+		ProjectID:   b.ProjectID,
+		ProjectName: b.ProjectName,
+		CreatedAt:   b.CreatedAt,
+		UpdatedAt:   b.UpdatedAt,
+	}
+}
+
+// isConnectorProjectBindingNotFound reports whether err is the "not found"
+// sentinel LocalStorage's GetConnectorProjectBinding uses.
+func isConnectorProjectBindingNotFound(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
+}
+
+// GetConnectorProjectBindingProxy handles GET
+// /api/v1/system/connector-project-bindings/{connector}.
+func (h *AuthHandler) GetConnectorProjectBindingProxy(w http.ResponseWriter, r *http.Request) {
+	connector := chi.URLParam(r, "connector")
+	if connector == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "connector is required")
+		return
+	}
+	binding, err := h.coreService.Storage().GetConnectorProjectBinding(r.Context(), connector)
+	if err != nil {
+		if isConnectorProjectBindingNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "connector project binding not found")
+			return
+		}
+		log.Printf("connector-project-bindings proxy: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newConnectorProjectBindingProxyWire(binding))
+}
+
+// connectorProjectBindingCreateBody is the wire body for POST
+// /api/v1/system/connector-project-bindings. The server assigns ID/CreatedAt/
+// UpdatedAt, so the body carries only the fields the caller has already resolved.
+type connectorProjectBindingCreateBody struct {
+	Connector   string `json:"connector"`
+	ProjectID   uint   `json:"project_id"`
+	ProjectName string `json:"project_name"`
+}
+
+// CreateConnectorProjectBindingProxy handles POST
+// /api/v1/system/connector-project-bindings. The caller (the downstream server's
+// own boot-time resolution) has already resolved the connector's project: name to
+// an ID; this is a raw persist, no re-resolution.
+func (h *AuthHandler) CreateConnectorProjectBindingProxy(w http.ResponseWriter, r *http.Request) {
+	var body connectorProjectBindingCreateBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.Connector == "" || body.ProjectID == 0 || body.ProjectName == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "connector, project_id, and project_name are required")
+		return
+	}
+	created, err := h.coreService.Storage().CreateConnectorProjectBinding(r.Context(), &models.ConnectorProjectBinding{
+		Connector:   body.Connector,
+		ProjectID:   body.ProjectID,
+		ProjectName: body.ProjectName,
+	})
+	if err != nil {
+		log.Printf("connector-project-bindings proxy: create failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newConnectorProjectBindingProxyWire(created))
+}

--- a/server/http/handlers/project_catalog_proxy.go
+++ b/server/http/handlers/project_catalog_proxy.go
@@ -154,6 +154,30 @@ func (h *CatalogHandler) GetProjectProxy(w http.ResponseWriter, r *http.Request)
 	writeRemoteAPISuccess(w, newProjectProxyWire(p))
 }
 
+// GetProjectByNameProxy handles GET /api/v1/system/projects/by-name/{name} —
+// ADR-082 branch 2's boot-time connector resolution (server/main.go), proxied so a
+// storage.type: remote node can resolve a connector's configured project: name
+// against the upstream server's real Project table instead of RemoteStorage's
+// GetProjectByName having no server endpoint to call at all.
+func (h *CatalogHandler) GetProjectByNameProxy(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	if name == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "name is required")
+		return
+	}
+	p, err := h.coreService.Storage().GetProjectByName(r.Context(), name)
+	if err != nil {
+		if isProjectNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errProjectNotFound)
+			return
+		}
+		log.Printf("project catalog proxy: get by name failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	writeRemoteAPISuccess(w, newProjectProxyWire(p))
+}
+
 // UpdateProjectProxy handles PUT /api/v1/system/projects/{id}. Like the group/
 // invitation proxies' raw persist, this trusts the caller's already-fully-resolved
 // final desired state (the calling core.KeyorixCore.UpdateProject already merged the

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1353,6 +1353,14 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Post("/connect-grants", authHandler.CreateConnectRefGrantProxy)
 			r.Delete("/connect-grants/{id}", authHandler.DeleteConnectRefGrantProxy)
 
+			// Connect connector→project ID binding storage-primitive proxy (ADR-082
+			// branch 2). Same rationale and pattern as the connect-grants block above
+			// (backlog #527): boot-time connector resolution (server/main.go) treats
+			// any error from these primitives as an unresolvable connector and fails
+			// boot, so RemoteStorage needs a real endpoint here, not a stub.
+			r.Get("/connector-project-bindings/{connector}", authHandler.GetConnectorProjectBindingProxy)
+			r.Post("/connector-project-bindings", authHandler.CreateConnectorProjectBindingProxy)
+
 			// SSO login-state storage-primitive proxy (#521). Lets a downstream
 			// Keyorix server booted with storage.type: remote (ADR-049) proxy
 			// CreateSSOLoginState/ConsumeSSOLoginState to THIS server's real storage
@@ -1955,6 +1963,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// "/projects/{id}/environments/{envId}/copy-secrets" vs
 			// "/projects/{projectId}/environments/{id}/restore" routes already do.
 			r.Get("/projects/with-counts", catalogHandler.ListProjectsWithCountsProxy)
+			// /projects/by-name/{name} (ADR-082 branch 2): a static "by-name" segment
+			// ahead of the {id} wildcard below, same precedence pattern as
+			// "with-counts" above — boot-time connector resolution (server/main.go)
+			// resolves a connector's configured project: name against this route on a
+			// storage.type: remote node.
+			r.Get("/projects/by-name/{name}", catalogHandler.GetProjectByNameProxy)
 			r.Get(pathProjects, catalogHandler.ListProjectsProxy)
 			r.Get(pathProjectsID, catalogHandler.GetProjectProxy)
 			r.Put(pathProjectsID, catalogHandler.UpdateProjectProxy)


### PR DESCRIPTION
## Summary

ADR-082: adds the `ConnectorProjectBinding` model and storage primitives (`GetConnectorProjectBinding`/`CreateConnectorProjectBinding`, both `LocalStorage` and `RemoteStorage`) that pin a connector's owning project by numeric ID, once, at first boot. No consumers yet — that's the next PR.

Stacked on #1483 (config schema).

## Why this is its own commit/PR

Declare-and-implement across both storage backends, no consumers yet — the seam that keeps every commit in this stack independently buildable (Go interface satisfaction is all-or-nothing: a new interface method must land in the same commit as every concrete type implementing it). References backlog #527 for why the `RemoteStorage` side is a real proxy implementation, not a stub: a downstream node booted with `storage.type: remote` needs to be able to resolve connector ownership too, and stubbing this primitive would fail boot on every connector on every such node.

## Test plan

- [x] `go build ./...` clean at this commit (part of a verified 8-commit bisect-compile)
- [x] New storage-primitive tests (both backends) pass