### PR TITLE
feat(connect): add ownership enforcement and ListConnectors filtering (ADR-082 2/4) [4/8]

### DIFF
--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -143,9 +143,8 @@ GCP one's boot-warning-only enforcement gap is out of scope for this ADR
 
 Connectors remain pure server configuration, exactly as today. Each
 connector config entry gains a required `scope` field (see (B)) and an
-optional `project` reference (a Keyorix project's numeric ID or unique
-name, config-file-resolvable at boot the same way every other
-config-time reference in this codebase is — implementation detail).
+optional `project` reference — a Keyorix project's **name**, not a numeric
+ID (see the subsection immediately below for why).
 
 **Explicitly decided: no DB table mirrors connector metadata.** There is no
 runtime connector-management API today (creating/updating a connector
@@ -156,6 +155,44 @@ connectors by the same bare name string it already uses; nothing about this
 ADR requires a stable numeric connector ID. **Revisit only if/when runtime
 connector CRUD ships** — that is the point at which a DB-backed identity
 would earn its keep, not before.
+
+#### A.1 Project names are mutable and freed on soft-delete — why `project:` pins by ID, once, and a rename is a deliberate boot failure
+
+Verified directly against the schema and the update path, not assumed:
+`Project.Name` (`models.go:9-17`) carries no immutability — `UpdateProject`
+(`catalog.go:120,132`) directly reassigns `project.Name = name` with no
+restriction — and its own doc comment states explicitly that uniqueness is
+enforced by a **partial** index, `LOWER(name) WHERE deleted_at IS NULL`,
+"so a soft-deleted project's name is still freed for reuse." Both facts
+combine into a real risk: if a connector's ownership were re-resolved by
+name on every boot, an ordinary project rename — or a delete-and-recreate
+under the same name, by a different admin, for an unrelated reason — would
+silently reassign which project owns a connector, with no config change and
+no operator awareness that Connect was affected at all.
+
+**The fix: `project:` names the project by string, but is resolved to a
+numeric project ID exactly ONCE — at the first boot after a connector is
+configured — and pinned via a new persisted row,
+`ConnectorProjectBinding` (`connector`, `project_id`, `project_name`).
+Every later boot resolves by the STORED ID, never by re-reading the config's
+`project:` name against live `Project` rows.** If the bound project's
+CURRENT name (looked up by the stored ID) no longer matches the name
+recorded in the binding at first-boot time, boot fails, naming both the
+stored and current name — this is a **deliberate** boot failure, not a
+silent reassignment: a rename that happened between boots is exactly the
+ambiguous case (intentional relabeling vs. an unrelated project stealing the
+name) this ADR refuses to resolve automatically. The same applies if the
+bound project no longer exists (deleted). There is no operator-facing
+binding-management surface in this branch (out of scope, see below); the
+remediation path today is to remove the stale `connector_project_bindings`
+row (a direct DB action) once the rename is confirmed intentional, then
+restart — a real if unpolished escape hatch, not a dead end.
+
+This mirrors, at a smaller scale, the same "explicit value required,
+absence/ambiguity denies" shape (C) already establishes for `scope` itself
+— a `project:` name is a human-friendly config-time label, not a security
+identifier; the security identifier is the persisted numeric ID it resolves
+to once, not the string re-derived from it on every boot.
 
 ### B. `scope: project | platform` — exactly two values, no third state
 
@@ -439,6 +476,24 @@ matching ConnectRefGrant for one of the caller's roles?  → yes: allow (reason:
   own name — e.g. `TestConnectOwnership_ZeroScopeEntryMustSurvive` — so a
   future removal fails with a message pointing at this ADR's design, not a
   silently-discovered production authorization regression.
+- **A read denied by ownership (with no matching `ConnectRefGrant`
+  delegation) returns the exact same shape as an unknown connector**
+  (`ErrConnectUnknownConnector` — `502`/HTTP, `codes.FailedPrecondition`/
+  gRPC, same message text) — a deliberate choice, not an oversight.
+  `ListConnectors` already omits a connector the caller cannot reach from
+  discovery (E); returning a distinguishable "exists, but you can't read
+  it" response on the single-connector read path would let a caller probe
+  for a connector's existence by trying names one at a time, defeating that
+  omission. **This costs operator debuggability**: a caller who genuinely
+  mistyped a connector name and a caller who is correctly denied ownership
+  see an identical error, so a legitimate misconfiguration (a typo in
+  `connector:`) cannot be distinguished from a correct denial by the
+  response alone. The audit event (branch 3) is the intended remedy for
+  this: the three-way decision reason (`project_membership` /
+  `global_scope` / `delegation`) never populated on a genuine denial is
+  visible to whoever can read the audit trail (an operator debugging their
+  own misconfiguration, or a security reviewer), even though it is
+  invisible to the caller who received the response.
 
 ### F. `ConnectRefGrant` (ADR-045) retained unchanged as the cross-project delegation path
 
@@ -568,6 +623,11 @@ design, with (D) added.)
 - Web UI / CLI surfaces for viewing a connector's `scope`/`project` or the
   boot-time unscoped-connector warning list — follow mechanically from
   (A)-(C) once shipped, not a design question this ADR resolves.
+- An operator-facing `ConnectorProjectBinding` management surface (view/
+  clear a stale binding after a confirmed intentional project rename — see
+  (A.1)). The remediation path today is a direct DB action (remove the
+  stale `connector_project_bindings` row, then restart); a proper admin
+  surface for this is a real follow-up, not decided or built here.
 - Regenerating the gRPC proto is **not needed** — (D) explicitly keeps the
   wire shape unchanged.
 - **Splitting "read across all projects" from "administer all projects"

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -31,17 +31,127 @@ func (c *KeyorixCore) SetConnectManager(m *connect.Manager) {
 	c.connectManager = m
 }
 
+// ConnectOwnership is one connector's resolved tenant-scoping data (ADR-082 §A),
+// built by server/main.go's boot-time resolution and set via SetConnectOwnership —
+// see connectManager's own doc comment for why this lives here rather than on
+// *connect.Manager or the Connector interface. Exported so server/main.go (a
+// different package) can construct it.
+type ConnectOwnership struct {
+	// Scope is "project" or "platform" (ADR-082 §B) — boot validation
+	// (internal/config.validateConnectScopes) already guarantees no other value
+	// reaches here.
+	Scope string
+	// ProjectID is the connector's owning Keyorix project, resolved via the
+	// connector→project binding (ADR-082, ConnectorProjectBinding). Meaningless
+	// (zero) when Scope is "platform".
+	ProjectID uint
+}
+
+// SetConnectOwnership wires each connector's resolved tenant-scoping data
+// (ADR-082), built in the same boot pass as SetConnectManager's *connect.Manager,
+// from the same config. Must be called with an ownership entry for EVERY connector
+// name SetConnectManager was given — server/main.go enforces this key-set match at
+// boot (a mismatch fails boot, aggregated) before either setter is called, so this
+// is a precondition, not something re-checked here.
+func (c *KeyorixCore) SetConnectOwnership(ownership map[string]ConnectOwnership) {
+	c.connectOwnership = ownership
+}
+
 // ConnectEnabled reports whether any external-store connector is configured.
 func (c *KeyorixCore) ConnectEnabled() bool {
 	return c.connectManager != nil && len(c.connectManager.Names()) > 0
 }
 
-// ConnectConnectorNames lists the configured connector names (for discovery).
+// ConnectConnectorNames lists every configured connector name, unfiltered — used
+// internally by boot-time resolution (server/main.go) and tests. Caller-facing
+// discovery (HTTP/gRPC ListConnectors) must use ConnectReadableConnectorNames
+// instead (ADR-082 §E): this method does not filter by ownership, and would leak
+// the existence of connectors the caller cannot reach.
 func (c *KeyorixCore) ConnectConnectorNames() []string {
 	if c.connectManager == nil {
 		return nil
 	}
 	return c.connectManager.Names()
+}
+
+// ConnectReadableConnectorNames lists the configured connectors the caller can
+// actually reach (ADR-082 §E) — the caller-facing discovery surface for both HTTP
+// and gRPC ListConnectors, so both transports filter identically through this one
+// core method rather than duplicating the ownership comparison per transport. A
+// connector the caller cannot reach is omitted entirely, not merely marked
+// unreachable — the existing behavior for a caller with no readable connectors at
+// all is an empty list, not an error.
+func (c *KeyorixCore) ConnectReadableConnectorNames(ctx context.Context, actorType string, principalID uint) ([]string, error) {
+	if c.connectManager == nil {
+		return nil, nil
+	}
+	var readable []string
+	for _, name := range c.connectManager.Names() {
+		owned, err := c.connectOwnershipSatisfied(ctx, actorType, principalID, name)
+		if err != nil {
+			return nil, err
+		}
+		if owned {
+			readable = append(readable, name)
+			continue
+		}
+		// Not owned — a connector reachable only via an explicit ConnectRefGrant
+		// still belongs in discovery; ReadSecret still applies the ref-prefix match
+		// per-read. actorRoleIDs (not connectRefGrantDelegates) is the right check
+		// here: delegation for LISTING purposes only needs "does the caller hold a
+		// role with ANY grant on this connector," not a specific ref match.
+		delegated, err := c.connectorHasAnyDelegationForActor(ctx, actorType, principalID, name)
+		if err != nil {
+			return nil, err
+		}
+		if delegated {
+			readable = append(readable, name)
+		}
+	}
+	return readable, nil
+}
+
+// connectOwnershipSatisfied reports whether principalID owns the connector's
+// project (ADR-082 §E) — the same comparison every caller's ownership check runs
+// through, admin included: a global-scoped role's {0,0} entry (see below) is a
+// wildcard in the INPUT, not a different code path. A connector absent from
+// connectOwnership is denied, never silently skipped or treated as owned (a
+// structural invariant server/main.go's boot-time key-set check exists to
+// guarantee never happens in a correctly-booted server; this is the runtime
+// backstop).
+func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType string, principalID uint, connectorName string) (bool, error) {
+	owner, ok := c.connectOwnership[connectorName]
+	if !ok {
+		return false, nil
+	}
+	if owner.Scope == "platform" {
+		// TODO(ADR-082 branch 4): gate platform connectors on connect.platform.use,
+		// not connect.read alone. Every caller who reaches this function has
+		// already cleared connect.read (checked by the transport layer before
+		// ReadFederatedSecret/ConnectReadableConnectorNames is ever called), so this
+		// is a deliberate interim "any connect.read holder" pass-through, not an
+		// oversight.
+		return true, nil
+	}
+	// scope == "project": raw scope set, NOT GetReadableScopes (D) — the {0,0}
+	// global entry must survive so the loop below can match it as the wildcard
+	// (E), not be stripped before comparison.
+	var scopes []Scope
+	var err error
+	if actorType == ActorTypeMachine {
+		scopes, err = c.storage.GetMachineRoleScopes(ctx, principalID)
+	} else {
+		scopes, err = c.storage.GetUserRoleScopes(ctx, principalID)
+	}
+	if err != nil {
+		return false, fmt.Errorf("connect ownership: enumerate role scopes: %w", err)
+	}
+	for _, sc := range scopes {
+		if sc.ProjectID == owner.ProjectID || sc.ProjectID == 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // ReadFederatedSecret proxies a read of ref from the named external-store connector
@@ -64,17 +174,46 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 	ctx = WithActorType(ctx, actorType)
 	uid := principalID
 
-	// Per-reference RBAC (ADR-045): once a connector has any ref-grant, the read is
-	// permitted only if one of the caller's roles holds a matching grant. A connector
-	// with no grants is governed solely by connect.read + allowed_refs (unchanged).
-	allowed, err := c.connectRefAllowed(ctx, actorType, principalID, connectorName, ref)
+	// ADR-082 §E authorization order: connect.read (enforced by the transport layer
+	// before this function is ever called) → ownership → ConnectRefGrant delegation
+	// → deny. No audit call on either branch below — audit is branch 3 (ADR-082);
+	// this branch's denials are deliberately unaudited, same as ADR-082 itself notes.
+	owned, err := c.connectOwnershipSatisfied(ctx, actorType, principalID, connectorName)
 	if err != nil {
 		return "", err
 	}
-	if !allowed {
-		c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
-			fmt.Sprintf("federated read DENIED by per-reference policy: connector %q (%s) ref %q", connectorName, conn.Type(), ref))
-		return "", fmt.Errorf("ref %q %w %q", ref, ErrConnectRefNotPermitted, connectorName)
+	if owned {
+		// Per-reference RBAC (ADR-045): once a connector has any ref-grant, the read
+		// is permitted only if one of the caller's roles holds a matching grant. A
+		// connector with no grants is governed solely by connect.read + allowed_refs
+		// (unchanged) — this still applies to an OWNED caller exactly as it did
+		// before ownership existed; ownership does not bypass ADR-045's own
+		// per-ref narrowing.
+		allowed, err := c.connectRefAllowed(ctx, actorType, principalID, connectorName, ref)
+		if err != nil {
+			return "", err
+		}
+		if !allowed {
+			c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
+				fmt.Sprintf("federated read DENIED by per-reference policy: connector %q (%s) ref %q", connectorName, conn.Type(), ref))
+			return "", fmt.Errorf("ref %q %w %q", ref, ErrConnectRefNotPermitted, connectorName)
+		}
+	} else {
+		// Not owned — ConnectRefGrant is the explicit cross-project delegation path
+		// (ADR-082 §F). connectRefGrantDelegates (unlike connectRefAllowed) treats
+		// "no grants configured" as "no delegation," not "allow": that shortcut only
+		// makes sense for an already-owned caller.
+		delegated, err := c.connectRefGrantDelegates(ctx, actorType, principalID, connectorName, ref)
+		if err != nil {
+			return "", err
+		}
+		if !delegated {
+			// Ownership denied and no delegation grant: reuse the unknown-connector
+			// shape (ADR-082) — do not confirm this connector's existence to a caller
+			// who cannot reach it. ListConnectors already omits it from discovery;
+			// this keeps the single-connector read path consistent with that.
+			return "", fmt.Errorf("%w %q", ErrConnectUnknownConnector, connectorName)
+		}
 	}
 
 	value, err := conn.GetSecret(ctx, ref)
@@ -164,6 +303,66 @@ func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorType string, p
 	now := time.Now()
 	for _, g := range grants {
 		if roleSet[g.RoleID] && connectGrantActive(g, now) && refMatches(g.RefPrefix, ref) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// connectRefGrantDelegates reports whether principalID may read ref from
+// connectorName via an explicit ConnectRefGrant (ADR-082 §F), for a caller who did
+// NOT satisfy ownership (connectOwnershipSatisfied). This is deliberately a
+// SEPARATE function from connectRefAllowed, not a modified version of it: for an
+// OWNED caller, connectRefAllowed's "no grants configured on this connector" case
+// correctly means "no additional per-ref narrowing — allow" (ADR-045's original,
+// unchanged semantics). For a NOT-owned caller, "no grants configured" means there
+// is no delegation path at all — the opposite polarity. Reusing connectRefAllowed
+// for both would either wrongly grant a non-owned caller access to every
+// grant-less connector, or wrongly narrow an owned caller's existing access;
+// ConnectRefGrant's own schema, matching rules (refMatches), and expiry logic
+// (connectGrantActive) are unchanged (ADR-082) — only which caller populations
+// reach this delegation check is new.
+func (c *KeyorixCore) connectRefGrantDelegates(ctx context.Context, actorType string, principalID uint, connectorName, ref string) (bool, error) {
+	grants, err := c.storage.ListConnectRefGrantsByConnector(ctx, connectorName)
+	if err != nil {
+		return false, fmt.Errorf("connect ref-grant lookup: %w", err)
+	}
+	if len(grants) == 0 {
+		return false, nil // no delegation grant configured — no delegation path
+	}
+	roleSet, err := c.actorRoleIDs(ctx, actorType, principalID)
+	if err != nil {
+		return false, err
+	}
+	now := time.Now()
+	for _, g := range grants {
+		if roleSet[g.RoleID] && connectGrantActive(g, now) && refMatches(g.RefPrefix, ref) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// connectorHasAnyDelegationForActor reports whether principalID holds a role with
+// ANY active ConnectRefGrant on connectorName, regardless of ref prefix — used only
+// by ConnectReadableConnectorNames (listing), where there is no specific ref to
+// match against; a per-read call still applies the exact ref-prefix match via
+// connectRefGrantDelegates.
+func (c *KeyorixCore) connectorHasAnyDelegationForActor(ctx context.Context, actorType string, principalID uint, connectorName string) (bool, error) {
+	grants, err := c.storage.ListConnectRefGrantsByConnector(ctx, connectorName)
+	if err != nil {
+		return false, fmt.Errorf("connect ref-grant lookup: %w", err)
+	}
+	if len(grants) == 0 {
+		return false, nil
+	}
+	roleSet, err := c.actorRoleIDs(ctx, actorType, principalID)
+	if err != nil {
+		return false, err
+	}
+	now := time.Now()
+	for _, g := range grants {
+		if roleSet[g.RoleID] && connectGrantActive(g, now) {
 			return true, nil
 		}
 	}

--- a/internal/core/connect_ownership_test.go
+++ b/internal/core/connect_ownership_test.go
@@ -1,0 +1,267 @@
+// connect_ownership_test.go — ADR-082 branch 2: ownership enforcement in
+// ReadFederatedSecret and ConnectReadableConnectorNames. Uses connectRBACCore
+// (connect_rbac_test.go) so role scopes actually resolve through GetUserRoleScopes/
+// GetMachineRoleScopes against a real (in-memory) store, exactly like production.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// TestConnectOwnership_ZeroScopeEntryMustSurvive is the ADR-082 invariant test: a
+// caller's {0,0} (global-scope) role-scope entry must survive from
+// GetUserRoleScopes all the way into the ownership comparison, unfiltered. A
+// future "cleanup" that strips ProjectID==0 entries before the comparison —
+// exactly what the pre-ADR-082 design did — would silently and completely remove
+// every global-scoped caller's Connect reach, with no compile error, and no other
+// test in this file would catch it (every other ownership test here uses a caller
+// with an explicit project-scoped role). If this test fails, the fix is almost
+// never "strip the {0,0} entry, it looks like noise" — read ADR-082 §D/§E first.
+func TestConnectOwnership_ZeroScopeEntryMustSurvive(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 99}})
+
+	// The caller holds ONLY a role granted at the GLOBAL scope (ProjectID 0) — no
+	// role at project 99 specifically, and the role is deliberately NOT one of the
+	// admin-named roles, proving this is a scope check, not a name check.
+	seedRoleForUser(t, db, 1, 10, "billing-viewer")
+
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
+	require.NoError(t, err, "a caller with only a global-scoped role must reach a project-scoped connector via the {0,0} wildcard (ADR-082 §E) — if this fails, check whether the raw scope list is being filtered to ProjectID != 0 before the ownership comparison runs")
+	assert.Equal(t, "v3ry-secret", val)
+}
+
+// TestConnectOwnership_ReadFederatedSecret is the table-driven ownership suite
+// (ADR-082 §E): project-scope matching, the {0,0} wildcard, no relevant scope,
+// platform connectors, and ConnectRefGrant delegation for an otherwise-denied
+// connector.
+func TestConnectOwnership_ReadFederatedSecret(t *testing.T) {
+	const connectorProjectID = 42
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, c *KeyorixCore, db *gorm.DB)
+		userID    uint
+		wantErr   bool
+		wantValue string
+	}{
+		{
+			name: "caller with matching project scope is allowed",
+			setup: func(t *testing.T, c *KeyorixCore, db *gorm.DB) {
+				seedRoleForUserAtProject(t, db, 1, 20, "project-member", connectorProjectID)
+			},
+			userID:    1,
+			wantValue: "v3ry-secret",
+		},
+		{
+			name: "caller with non-matching project scope is denied",
+			setup: func(t *testing.T, c *KeyorixCore, db *gorm.DB) {
+				seedRoleForUserAtProject(t, db, 2, 21, "other-project-member", connectorProjectID+1)
+			},
+			userID:  2,
+			wantErr: true,
+		},
+		{
+			name: "caller with global {0,0} scope against a project-scoped connector is allowed via the wildcard",
+			setup: func(t *testing.T, c *KeyorixCore, db *gorm.DB) {
+				seedRoleForUser(t, db, 3, 22, "global-scoped-role")
+			},
+			userID:    3,
+			wantValue: "v3ry-secret",
+		},
+		{
+			name:    "caller with no relevant scope at all is denied",
+			setup:   func(t *testing.T, c *KeyorixCore, db *gorm.DB) {},
+			userID:  4,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+			c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: connectorProjectID}})
+			tt.setup(t, c, db)
+
+			val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, tt.userID, "aws", "ref")
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unknown connector", "ownership denial must reuse the unknown-connector shape (ADR-082) — do not confirm existence to an unauthorized caller")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantValue, val)
+		})
+	}
+}
+
+// TestConnectOwnership_PlatformConnectorAnyCaller proves a platform-scoped
+// connector passes ownership for any caller in THIS branch — TODO(ADR-082 branch
+// 4) is the connect.platform.use gate; until then any connect.read holder (the
+// transport layer's job, not this function's) reaches it, even with zero roles.
+func TestConnectOwnership_PlatformConnectorAnyCaller(t *testing.T) {
+	c, _ := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "shared-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
+	require.NoError(t, err, "a platform-scoped connector must pass ownership for any caller in this branch")
+	assert.Equal(t, "shared-secret", val)
+}
+
+// TestConnectOwnership_ConnectRefGrantDelegatesForNonOwnedCaller proves the
+// delegation path (ADR-082 §F): a caller with NO ownership claim on the
+// connector's project is still allowed through an explicit ConnectRefGrant
+// covering their role and the requested ref.
+func TestConnectOwnership_ConnectRefGrantDelegatesForNonOwnedCaller(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+
+	// Caller has a role at a DIFFERENT project — not owned.
+	seedRoleForUserAtProject(t, db, 5, 30, "borrower", 99)
+	// But that role holds an explicit delegation grant on "aws".
+	seedGrant(t, c, 30, "aws", "prod/")
+
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 5, "aws", "prod/db")
+	require.NoError(t, err, "a non-owned caller with a matching ConnectRefGrant must be allowed (ADR-082 §F delegation)")
+	assert.Equal(t, "v3ry-secret", val)
+
+	// The same caller, same role, but a ref OUTSIDE the grant's prefix: no
+	// ownership and no matching delegation — denied. connectRefGrantDelegates
+	// (unlike connectRefAllowed) must not treat "grants exist but none match" as
+	// an allow for a non-owned caller.
+	_, err = c.ReadFederatedSecret(context.Background(), ActorTypeUser, 5, "aws", "dev/db")
+	require.Error(t, err)
+}
+
+// TestConnectOwnership_NonOwnedCallerNoGrantsAtAllIsDenied proves
+// connectRefGrantDelegates' polarity is the OPPOSITE of connectRefAllowed's: for
+// a non-owned caller, a connector with ZERO ref-grants configured means NO
+// delegation path (deny), not "no additional narrowing" (allow) — the shortcut
+// that's correct only for an already-owned caller.
+func TestConnectOwnership_NonOwnedCallerNoGrantsAtAllIsDenied(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+	seedRoleForUserAtProject(t, db, 6, 31, "not-owner", 99) // no grant seeded at all
+
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 6, "aws", "ref")
+	require.Error(t, err, "a non-owned caller must be denied when the connector has no ref-grants at all — no grants means no delegation path, not an automatic allow")
+}
+
+// TestConnectOwnership_MissingFromOwnershipMapDenies proves the structural
+// invariant (ADR-082 §E): a connector absent from the ownership map is denied,
+// never silently skipped or treated as owned. server/main.go's boot-time key-set
+// check exists to guarantee this never happens for a correctly-booted server;
+// this proves connectOwnershipSatisfied's own runtime backstop independently.
+func TestConnectOwnership_MissingFromOwnershipMapDenies(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	// connectRBACCore defaults every connector to scope: platform (always-owned) —
+	// explicitly clear that here to exercise the genuinely-missing-entry case.
+	c.SetConnectOwnership(nil)
+	seedRoleForUser(t, db, 1, 10, "global-role") // even a global-scoped caller...
+
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
+	require.Error(t, err, "a connector missing from the ownership map must deny, never fall back to allow")
+}
+
+// TestConnectOwnership_MachineIdentityProjectScopedRoleNotGlobal proves ADR-082
+// §E's machine-identity composition claim in code: a machine identity holding an
+// admin-equivalent role at a SPECIFIC project's scope produces that project's
+// scope entry from GetMachineRoleScopes, not {0,0} — so it does NOT get the
+// global wildcard, and is correctly bounded to that one project.
+func TestConnectOwnership_MachineIdentityProjectScopedRoleNotGlobal(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+
+	require.NoError(t, db.Create(&models.Role{ID: 40, Name: "admin"}).Error) // admin-NAMED, but scoped below
+	require.NoError(t, db.Create(&models.MachineIdentityRole{
+		MachineIdentityID: 7, RoleID: 40, ProjectID: 99, // a DIFFERENT project than the connector's
+	}).Error)
+
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeMachine, 7, "aws", "ref")
+	require.Error(t, err, "a machine identity holding an admin-named role at a SPECIFIC project's scope must be bounded to that project, not treated as global — GetMachineRoleScopes must return {ProjectID:99}, not {0,0}, for this grant")
+
+	// The same machine identity DOES reach the connector once its role is granted
+	// at the connector's OWN project — proving the denial above is genuinely
+	// about scope, not a broken machine-identity path in general.
+	require.NoError(t, db.Create(&models.MachineIdentityRole{
+		MachineIdentityID: 7, RoleID: 40, ProjectID: 42,
+	}).Error)
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeMachine, 7, "aws", "ref")
+	require.NoError(t, err)
+	assert.Equal(t, "v3ry-secret", val)
+}
+
+// TestConnectOwnership_MachineIdentityGlobalRoleGetsWildcard is the machine-
+// identity counterpart to TestConnectOwnership_ZeroScopeEntryMustSurvive: a
+// machine identity granted a role at the TRUE global scope ({0,0}) receives the
+// same ownership wildcard a user would (ADR-082 §E) — roleSetContainsAdmin-style
+// actor-agnostic behavior extended consistently to Connect ownership.
+func TestConnectOwnership_MachineIdentityGlobalRoleGetsWildcard(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+
+	require.NoError(t, db.Create(&models.Role{ID: 41, Name: "global-machine-role"}).Error)
+	require.NoError(t, db.Create(&models.MachineIdentityRole{
+		MachineIdentityID: 8, RoleID: 41, ProjectID: 0, // global scope
+	}).Error)
+
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeMachine, 8, "aws", "ref")
+	require.NoError(t, err)
+	assert.Equal(t, "v3ry-secret", val)
+}
+
+// TestConnectReadableConnectorNames_FiltersToOwnedSubset proves ListConnectors
+// discovery (ADR-082 §E) filters by ownership: a caller who is a member of only
+// one of two connectors' owning projects sees just that one connector, not both —
+// a discovery endpoint that lists an unreachable connector leaks its existence to
+// a caller who cannot use it.
+func TestConnectReadableConnectorNames_FiltersToOwnedSubset(t *testing.T) {
+	c, db := connectRBACCore(t,
+		fakeConnector{name: "aws-payments", val: "v1"},
+		fakeConnector{name: "aws-billing", val: "v2"},
+	)
+	c.SetConnectOwnership(map[string]ConnectOwnership{
+		"aws-payments": {Scope: "project", ProjectID: 42},
+		"aws-billing":  {Scope: "project", ProjectID: 99},
+	})
+	seedRoleForUserAtProject(t, db, 1, 10, "payments-member", 42)
+
+	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"aws-payments"}, names, "caller must see only the connector whose project they're a member of")
+}
+
+// TestConnectReadableConnectorNames_GlobalScopedCallerSeesAll proves a
+// global-scoped caller (the {0,0} wildcard — ADR-082 §E) sees every
+// scope: project connector via the SAME per-connector filter loop, not a
+// separate "if admin, return everything" branch — ConnectReadableConnectorNames
+// has no such branch, so this is exercising the loop's actual behavior.
+func TestConnectReadableConnectorNames_GlobalScopedCallerSeesAll(t *testing.T) {
+	c, db := connectRBACCore(t,
+		fakeConnector{name: "aws-payments", val: "v1"},
+		fakeConnector{name: "aws-billing", val: "v2"},
+	)
+	c.SetConnectOwnership(map[string]ConnectOwnership{
+		"aws-payments": {Scope: "project", ProjectID: 42},
+		"aws-billing":  {Scope: "project", ProjectID: 99},
+	})
+	seedRoleForUser(t, db, 2, 20, "global-scoped-role")
+
+	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 2)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"aws-payments", "aws-billing"}, names, "a global-scoped caller must see every project-scoped connector via the {0,0} wildcard")
+}
+
+// seedRoleForUserAtProject mirrors seedRoleForUser (connect_rbac_test.go) but
+// grants the role at a specific project scope instead of global.
+func seedRoleForUserAtProject(t *testing.T, db *gorm.DB, userID, roleID uint, name string, projectID uint) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.Role{ID: roleID, Name: name}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: userID, RoleID: roleID, ProjectID: projectID}).Error)
+}

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -16,7 +16,12 @@ import (
 )
 
 // connectRBACCore builds a core backed by a real (in-memory) store so per-reference
-// grants and role assignments actually resolve through the enforcement path.
+// grants and role assignments actually resolve through the enforcement path. Every
+// connector is wired as scope: platform by default (ADR-082) — a platform
+// connector passes ownership for any caller in this branch, matching this suite's
+// pre-ADR-082 assumption that any connect.read holder can reach a configured test
+// connector; ownership-specific behavior is covered separately
+// (connect_ownership_test.go).
 func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -26,10 +31,16 @@ func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *g
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.ConnectRefGrant{}, &models.AuditEvent{},
 		&models.Project{}, &models.Environment{},
+		&models.ConnectorProjectBinding{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	if len(conns) > 0 {
 		c.SetConnectManager(connect.NewManager(conns))
+		ownership := make(map[string]ConnectOwnership, len(conns))
+		for _, conn := range conns {
+			ownership[conn.Name()] = ConnectOwnership{Scope: "platform"}
+		}
+		c.SetConnectOwnership(ownership)
 	}
 	return c, db
 }

--- a/internal/core/connect_test.go
+++ b/internal/core/connect_test.go
@@ -24,6 +24,11 @@ func (f fakeConnector) GetSecret(_ context.Context, _ string) (string, error) {
 	return f.val, f.err
 }
 
+// connectTestCore wires every connector as scope: platform by default (ADR-082) —
+// a platform connector passes ownership for any caller in this branch, matching
+// this suite's pre-ADR-082 assumption that any caller can reach a configured test
+// connector. Tests that specifically exercise ownership/scope behavior use their
+// own setup (see connect_ownership_test.go) instead of this helper.
 func connectTestCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *MockStorage) {
 	t.Helper()
 	ms := new(MockStorage)
@@ -31,6 +36,11 @@ func connectTestCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *M
 	c := &KeyorixCore{storage: ms}
 	if len(conns) > 0 {
 		c.SetConnectManager(connect.NewManager(conns))
+		ownership := make(map[string]ConnectOwnership, len(conns))
+		for _, conn := range conns {
+			ownership[conn.Name()] = ConnectOwnership{Scope: "platform"}
+		}
+		c.SetConnectOwnership(ownership)
 	}
 	return c, ms
 }
@@ -84,6 +94,7 @@ func TestReadFederatedSecret_MachineIdentityAuditedAsMachine(t *testing.T) {
 	})).Return(nil)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{fakeConnector{name: "aws", val: "v"}}))
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeMachine, 42, "aws", "ref")
 	require.NoError(t, err)
@@ -105,6 +116,7 @@ func TestReadFederatedSecret_UserAuditedAsUser(t *testing.T) {
 	})).Return(nil)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{fakeConnector{name: "aws", val: "v"}}))
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
 
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 7, "aws", "ref")
 	require.NoError(t, err)
@@ -159,6 +171,7 @@ func TestReadFederatedSecret_AuditDescriptionRedactsRawUpstreamError(t *testing.
 	c.SetConnectManager(connect.NewManager([]connect.Connector{
 		fakeConnector{name: "aws", err: rawUpstreamErr},
 	}))
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
 
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", ref)
 	require.Error(t, err)

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -1719,6 +1720,22 @@ func (m *MockStorage) CreateConnectRefGrant(_ context.Context, grant *models.Con
 }
 func (m *MockStorage) DeleteConnectRefGrant(_ context.Context, _ uint) error {
 	return nil
+}
+
+// ADR-082 branch 2: connector project-binding storage — core enforcement is tested
+// against real SQLite (connect_rbac_test.go, connect_ownership_test.go), so these
+// mock stubs just satisfy the interface. GetProjectByName/GetConnectorProjectBinding
+// default to "not found" (the substring convention every caller of these checks
+// against) rather than a zero value, since a zero-value *models.Project/
+// *models.ConnectorProjectBinding would misrepresent a real, resolvable result.
+func (m *MockStorage) GetProjectByName(_ context.Context, _ string) (*models.Project, error) {
+	return nil, fmt.Errorf("project not found")
+}
+func (m *MockStorage) GetConnectorProjectBinding(_ context.Context, _ string) (*models.ConnectorProjectBinding, error) {
+	return nil, fmt.Errorf("connector project binding not found")
+}
+func (m *MockStorage) CreateConnectorProjectBinding(_ context.Context, binding *models.ConnectorProjectBinding) (*models.ConnectorProjectBinding, error) {
+	return binding, nil
 }
 
 // Group-Role assignments

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -242,6 +242,15 @@ type KeyorixCore struct {
 	// connectManager proxies read-through federation to external secret stores
 	// (ADR-043). nil = Keyorix Connect disabled. Set via SetConnectManager.
 	connectManager *connect.Manager
+	// connectOwnership maps each configured connector's name to its resolved
+	// tenant-scoping data (ADR-082 §A/§E) — built in the same boot pass as
+	// connectManager, from the same config, by server/main.go, then set via
+	// SetConnectOwnership. Deliberately NOT part of *connect.Manager/the Connector
+	// interface (internal/connect stays a pure backend-read abstraction with no
+	// ownership concept) — see ADR-082's Decision (D) for the option analysis. A
+	// connector name absent from this map is denied ownership, never silently
+	// skipped or treated as owned — see connectOwnershipSatisfied.
+	connectOwnership map[string]ConnectOwnership
 	// rotationManager holds the backend rotation executors (ADR-047) that apply a new
 	// credential to an upstream system during rotation. nil = no backends configured.
 	rotationManager *rotation.Manager

--- a/server/connect_ownership_resolution_test.go
+++ b/server/connect_ownership_resolution_test.go
@@ -1,0 +1,191 @@
+// connect_ownership_resolution_test.go — ADR-082 branch 2: resolveConnectorOwnership
+// (connector→project ID binding resolution) and connectOwnershipKeySetMismatch
+// (the Manager/ownership key-set boot-time invariant). Uses a real (in-memory)
+// SQLite-backed LocalStorage so GetProjectByName/GetConnectorProjectBinding/
+// CreateConnectorProjectBinding/GetProject all resolve exactly as they would in
+// production — no mocks.
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func connectOwnershipResolutionStorage(t *testing.T) (*store.LocalStorage, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.ConnectorProjectBinding{}))
+	return store.NewLocalStorage(db), db
+}
+
+// TestResolveConnectorOwnership_FirstBootResolvesAndPersists proves the first-boot
+// path: a "project"-scoped connector with no existing binding resolves its
+// configured project: name via GetProjectByName and persists a
+// ConnectorProjectBinding pinning it by ID.
+func TestResolveConnectorOwnership_FirstBootResolvesAndPersists(t *testing.T) {
+	st, db := connectOwnershipResolutionStorage(t)
+	ctx := context.Background()
+	project, err := st.CreateProject(ctx, &models.Project{Name: "payments"})
+	require.NoError(t, err)
+
+	ownership, err := resolveConnectorOwnership(ctx, st, []config.ConnectorConfig{
+		{Name: "aws", Scope: "project", Project: "payments"},
+	})
+	require.NoError(t, err)
+	require.Contains(t, ownership, "aws")
+	assert.Equal(t, core.ConnectOwnership{Scope: "project", ProjectID: project.ID}, ownership["aws"])
+
+	var binding models.ConnectorProjectBinding
+	require.NoError(t, db.Where("connector = ?", "aws").First(&binding).Error)
+	assert.Equal(t, project.ID, binding.ProjectID)
+	assert.Equal(t, "payments", binding.ProjectName)
+}
+
+// TestResolveConnectorOwnership_SubsequentBootResolvesByStoredID proves a later
+// boot (a binding already exists) resolves by the STORED ID, not by re-resolving
+// the config's project: name — even if a DIFFERENT project happens to now hold
+// that same name (the exact silent-reassignment scenario ADR-082 pins against).
+func TestResolveConnectorOwnership_SubsequentBootResolvesByStoredID(t *testing.T) {
+	st, _ := connectOwnershipResolutionStorage(t)
+	ctx := context.Background()
+	original, err := st.CreateProject(ctx, &models.Project{Name: "payments"})
+	require.NoError(t, err)
+	_, err = st.CreateConnectorProjectBinding(ctx, &models.ConnectorProjectBinding{
+		Connector: "aws", ProjectID: original.ID, ProjectName: "payments",
+	})
+	require.NoError(t, err)
+
+	// A second, unrelated project now also happens to be named "payments" is not
+	// possible under the live unique index — but a rename creating this exact
+	// ambiguity IS possible in principle; what matters here is that the resolver
+	// never even calls GetProjectByName once a binding exists.
+	ownership, err := resolveConnectorOwnership(ctx, st, []config.ConnectorConfig{
+		{Name: "aws", Scope: "project", Project: "payments"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, core.ConnectOwnership{Scope: "project", ProjectID: original.ID}, ownership["aws"])
+}
+
+// TestResolveConnectorOwnership_RenameFailsBoot proves a project rename since
+// first boot is a deliberate boot failure (ADR-082), not a silent reassignment:
+// the binding's stored ProjectName no longer matches the project's CURRENT name.
+func TestResolveConnectorOwnership_RenameFailsBoot(t *testing.T) {
+	st, _ := connectOwnershipResolutionStorage(t)
+	ctx := context.Background()
+	project, err := st.CreateProject(ctx, &models.Project{Name: "payments"})
+	require.NoError(t, err)
+	_, err = st.CreateConnectorProjectBinding(ctx, &models.ConnectorProjectBinding{
+		Connector: "aws", ProjectID: project.ID, ProjectName: "payments",
+	})
+	require.NoError(t, err)
+
+	// Rename the project after the binding was recorded.
+	project.Name = "payments-renamed"
+	_, err = st.UpdateProject(ctx, project)
+	require.NoError(t, err)
+
+	_, err = resolveConnectorOwnership(ctx, st, []config.ConnectorConfig{
+		{Name: "aws", Scope: "project", Project: "payments"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "payments")
+	assert.Contains(t, err.Error(), "payments-renamed", "the error must name both the stored and current project names")
+}
+
+// TestResolveConnectorOwnership_DeletedProjectFailsBoot proves a bound project
+// that no longer exists (soft-deleted) is a boot failure, not a silent ownership
+// gap.
+func TestResolveConnectorOwnership_DeletedProjectFailsBoot(t *testing.T) {
+	st, db := connectOwnershipResolutionStorage(t)
+	ctx := context.Background()
+	project, err := st.CreateProject(ctx, &models.Project{Name: "payments"})
+	require.NoError(t, err)
+	_, err = st.CreateConnectorProjectBinding(ctx, &models.ConnectorProjectBinding{
+		Connector: "aws", ProjectID: project.ID, ProjectName: "payments",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, db.Delete(&models.Project{}, project.ID).Error) // soft delete
+
+	_, err = resolveConnectorOwnership(ctx, st, []config.ConnectorConfig{
+		{Name: "aws", Scope: "project", Project: "payments"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aws")
+}
+
+// TestResolveConnectorOwnership_UnresolvableNameFailsBoot proves a first-boot
+// connector whose configured project: name resolves to no live project fails
+// boot.
+func TestResolveConnectorOwnership_UnresolvableNameFailsBoot(t *testing.T) {
+	st, _ := connectOwnershipResolutionStorage(t)
+	_, err := resolveConnectorOwnership(context.Background(), st, []config.ConnectorConfig{
+		{Name: "aws", Scope: "project", Project: "does-not-exist"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aws")
+	assert.Contains(t, err.Error(), "does-not-exist")
+}
+
+// TestResolveConnectorOwnership_AggregatesMultipleFailures proves every
+// offending connector is named in ONE combined error, matching branch 1's
+// aggregation style — not a fail-on-first-found error that hides the rest.
+func TestResolveConnectorOwnership_AggregatesMultipleFailures(t *testing.T) {
+	st, _ := connectOwnershipResolutionStorage(t)
+	_, err := resolveConnectorOwnership(context.Background(), st, []config.ConnectorConfig{
+		{Name: "unresolvable-1", Scope: "project", Project: "nope-1"},
+		{Name: "unresolvable-2", Scope: "project", Project: "nope-2"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unresolvable-1")
+	assert.Contains(t, err.Error(), "unresolvable-2")
+}
+
+// TestResolveConnectorOwnership_PlatformNeedsNoResolution proves a
+// "platform"-scoped connector resolves with no project lookup at all.
+func TestResolveConnectorOwnership_PlatformNeedsNoResolution(t *testing.T) {
+	st, _ := connectOwnershipResolutionStorage(t)
+	ownership, err := resolveConnectorOwnership(context.Background(), st, []config.ConnectorConfig{
+		{Name: "shared-vault", Scope: "platform"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, core.ConnectOwnership{Scope: "platform"}, ownership["shared-vault"])
+}
+
+// TestConnectOwnershipKeySetMismatch_DetectsGenuineDivergence proves a connector
+// present in the manager but absent from ownership (or vice versa) — WITHOUT the
+// legitimate allow_unscoped exception — is reported as a mismatch.
+func TestConnectOwnershipKeySetMismatch_DetectsGenuineDivergence(t *testing.T) {
+	ownership := map[string]core.ConnectOwnership{
+		"aws": {Scope: "project", ProjectID: 1},
+	}
+	connectors := []config.ConnectorConfig{
+		{Name: "aws", Scope: "project", Project: "payments"},
+		{Name: "gcp", Scope: "project", Project: "payments"}, // built, but ownership resolution never ran for it in this test
+	}
+	mismatch := connectOwnershipKeySetMismatch([]string{"aws", "gcp"}, ownership, connectors)
+	assert.Equal(t, []string{"gcp"}, mismatch)
+}
+
+// TestConnectOwnershipKeySetMismatch_AllowsExpectedUnscopedGap proves the ONE
+// legitimate divergence — a connector booted with an empty scope under
+// connect.allow_unscoped is built into the manager but deliberately never given
+// an ownership entry — is NOT reported as a mismatch.
+func TestConnectOwnershipKeySetMismatch_AllowsExpectedUnscopedGap(t *testing.T) {
+	ownership := map[string]core.ConnectOwnership{} // resolveConnectorOwnership skips empty-scope connectors
+	connectors := []config.ConnectorConfig{
+		{Name: "unscoped-aws", Scope: ""}, // booted under connect.allow_unscoped
+	}
+	mismatch := connectOwnershipKeySetMismatch([]string{"unscoped-aws"}, ownership, connectors)
+	assert.Empty(t, mismatch, "a connector booted unscoped under allow_unscoped must not be reported as a key-set mismatch")
+}

--- a/server/grpc/services/connect_service.go
+++ b/server/grpc/services/connect_service.go
@@ -27,7 +27,9 @@ func NewConnectService(coreService *core.KeyorixCore) *ConnectGRPCService {
 	return &ConnectGRPCService{core: coreService}
 }
 
-// ListConnectors returns the configured connector names.
+// ListConnectors returns the connector names the caller can reach (ADR-082 §E) —
+// discovery is filtered by ownership so a caller never sees a connector name they
+// cannot subsequently read.
 func (s *ConnectGRPCService) ListConnectors(ctx context.Context, _ *emptypb.Empty) (*pb.ConnectorList, error) {
 	actor, err := requireUser(ctx)
 	if err != nil {
@@ -36,7 +38,12 @@ func (s *ConnectGRPCService) ListConnectors(ctx context.Context, _ *emptypb.Empt
 	if err := authorizeGlobal(ctx, s.core, actor, "connect.read"); err != nil {
 		return nil, err
 	}
-	return &pb.ConnectorList{Connectors: s.core.ConnectConnectorNames()}, nil
+	names, err := s.core.ConnectReadableConnectorNames(ctx, actor.ActorKind(), actor.PrincipalID())
+	if err != nil {
+		log.Printf("Error listing readable connectors: %v", err)
+		return nil, status.Error(codes.Internal, clientSafe(err))
+	}
+	return &pb.ConnectorList{Connectors: names}, nil
 }
 
 // ReadSecret proxies a read-through of a secret's current value from a connector.

--- a/server/grpc/services/connect_service_test.go
+++ b/server/grpc/services/connect_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/connect"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,7 @@ func newConnectService(t *testing.T) *ConnectGRPCService {
 	h.CoreService.SetConnectManager(connect.NewManager([]connect.Connector{
 		fakeConnector{name: "aws", value: "s3cr3t"},
 	}))
+	h.CoreService.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "platform"}})
 	return NewConnectService(h.CoreService)
 }
 

--- a/server/grpc/services/coverage_s21b_test.go
+++ b/server/grpc/services/coverage_s21b_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/connect"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
@@ -509,6 +510,7 @@ func newFailingConnectService(t *testing.T) *ConnectGRPCService {
 	t.Cleanup(h.Cleanup)
 	h.AssignUserRole(t, 1, 1, nil)
 	h.CoreService.SetConnectManager(connect.NewManager([]connect.Connector{errConnector{}}))
+	h.CoreService.SetConnectOwnership(map[string]core.ConnectOwnership{"failing": {Scope: "platform"}})
 	return NewConnectService(h.CoreService)
 }
 

--- a/server/http/handlers/connect.go
+++ b/server/http/handlers/connect.go
@@ -47,13 +47,22 @@ func NewConnectHandler(coreService *core.KeyorixCore) *ConnectHandler {
 	return &ConnectHandler{coreService: coreService}
 }
 
-// ListConnectors returns the configured connector names (discovery).
+// ListConnectors returns the connector names the caller can reach (ADR-082 §E) —
+// discovery is filtered by ownership so a caller never sees a connector name they
+// cannot subsequently read.
 func (h *ConnectHandler) ListConnectors(w http.ResponseWriter, r *http.Request) {
-	if middleware.GetUserFromContext(r.Context()) == nil {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
 		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{"connectors": h.coreService.ConnectConnectorNames()}, "")
+	names, err := h.coreService.ConnectReadableConnectorNames(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID())
+	if err != nil {
+		log.Printf("Error listing readable connectors: %v", err)
+		sendError(w, "ConnectError", clientSafe(err), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"connectors": names}, "")
 }
 
 // GetSecret proxies a read-through of ?ref=… from the named connector.

--- a/server/http/handlers/handlers_s13_connect_dynamic_test.go
+++ b/server/http/handlers/handlers_s13_connect_dynamic_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/keyorixhq/keyorix/internal/connect"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -451,6 +452,7 @@ func TestConnect_GetSecret_UnknownConnector_S13(t *testing.T) {
 func TestConnect_GetSecret_SpoofedUnsafeErrorIsSanitized_G50(t *testing.T) {
 	cs, _ := freshCoreS12WithAdmin(t)
 	cs.SetConnectManager(connect.NewManager([]connect.Connector{fakeSpoofConnector{name: "spoof"}}))
+	cs.SetConnectOwnership(map[string]core.ConnectOwnership{"spoof": {Scope: "platform"}})
 	h := NewConnectHandler(cs)
 
 	req := withUserCtx(withChiParam(

--- a/server/http/remote_storage_connect_grants_test.go
+++ b/server/http/remote_storage_connect_grants_test.go
@@ -159,6 +159,7 @@ func TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer(t *testin
 	downstream.SetConnectManager(connect.NewManager([]connect.Connector{
 		fakeConnectGrantsConnector{name: "aws", val: "v3ry-secret"},
 	}))
+	downstream.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "platform"}})
 	require.True(t, downstream.ConnectEnabled())
 
 	val, err := downstream.ReadFederatedSecret(context.Background(), core.ActorTypeUser, 1, "aws", "prod/db")
@@ -182,6 +183,7 @@ func TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer(t *testi
 	downstream.SetConnectManager(connect.NewManager([]connect.Connector{
 		fakeConnectGrantsConnector{name: "aws", val: "v3ry-secret"},
 	}))
+	downstream.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "platform"}})
 
 	project, err := upstream.CreateProject(ctx, "Connect Grants Test Project", "")
 	require.NoError(t, err)

--- a/server/main.go
+++ b/server/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/connect"
 	"github.com/keyorixhq/keyorix/internal/core"
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/evidencesink"
@@ -53,6 +54,7 @@ import (
 	samlpkg "github.com/keyorixhq/keyorix/internal/saml"
 	"github.com/keyorixhq/keyorix/internal/startup"
 	appstorage "github.com/keyorixhq/keyorix/internal/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/trust"
 	"github.com/keyorixhq/keyorix/server/grpc"
 	httpServer "github.com/keyorixhq/keyorix/server/http"
@@ -615,7 +617,32 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			}
 		}
 		if len(connectors) > 0 {
-			coreService.SetConnectManager(connect.NewManager(connectors))
+			mgr := connect.NewManager(connectors)
+
+			// ADR-082 branch 2: resolve each connector's tenant-scoping data (project
+			// binding for scope: project; nothing to resolve for scope: platform)
+			// BEFORE wiring the manager in, so a resolution failure blocks boot
+			// entirely rather than leaving Connect half-wired.
+			ownership, err := resolveConnectorOwnership(context.Background(), coreService.Storage(), cc.Connectors)
+			if err != nil {
+				log.Fatalf("Keyorix Connect: %v", err)
+			}
+
+			// Defense-in-depth: ownership was resolved from the FULL cc.Connectors
+			// config, but mgr was built only from connectors the type-switch above
+			// actually recognized (an unrecognized type is skipped with a WARN, not a
+			// hard failure — the `default` case above). If a connector's ownership
+			// resolved successfully but it never made it into mgr (e.g. an
+			// unrecognized type), or vice versa, that is a key-set mismatch this ADR
+			// requires to fail boot loudly rather than silently deny (a missing
+			// ownership entry, connectOwnershipSatisfied's own fallback) or silently
+			// skip ownership entirely (a connector with no check at all).
+			if mismatch := connectOwnershipKeySetMismatch(mgr.Names(), ownership, cc.Connectors); len(mismatch) > 0 {
+				log.Fatalf("Keyorix Connect: connector(s) present in config but whose manager/ownership resolution disagree on which connectors exist — this must never happen in a correctly-booted server; investigate before proceeding (ADR-082): %s", strings.Join(mismatch, ", "))
+			}
+
+			coreService.SetConnectManager(mgr)
+			coreService.SetConnectOwnership(ownership)
 			log.Printf("Keyorix Connect enabled (%d connector(s))", len(connectors))
 		}
 	}
@@ -914,6 +941,129 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	}
 
 	return coreService, encSvc, nil
+}
+
+// isNotFoundStorageErr reports whether err is a "not found"-substring error, the
+// convention every LocalStorage/RemoteStorage Get* method in this codebase uses
+// (see local_secrets.go's GetProject, project_catalog_proxy.go's
+// isProjectNotFound).
+func isNotFoundStorageErr(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
+}
+
+// resolveConnectorOwnership resolves each connector's tenant-scoping data
+// (ADR-082 §A/§E) from its config entry. A "platform"-scoped connector needs no
+// resolution. A "project"-scoped connector's project: name is pinned to a real
+// Keyorix project ID via ConnectorProjectBinding, never re-resolved by name on a
+// later boot — see that model's own doc comment for why (project names are
+// mutable and a soft-deleted project's name is freed for reuse, so re-resolving
+// by name every boot would let an ordinary rename silently reassign ownership):
+//
+//   - First boot for a connector (no binding row yet): resolve config's project:
+//     name to a project via storage.GetProjectByName, persist the binding.
+//   - A later boot (binding row exists): resolve the project by the STORED ID
+//     (storage.GetProject), never by name. If that project no longer exists
+//     (deleted), or its CURRENT name no longer matches the name recorded in the
+//     binding at first-boot time, this fails boot — a rename or delete is
+//     something server/main.go treats as requiring deliberate operator action,
+//     not something to silently follow or silently ignore.
+//
+// Every problem across every connector is collected into ONE aggregated error
+// (branch 1's validateConnectScopes style), naming each offending connector and
+// its specific reason, rather than failing on the first one found.
+func resolveConnectorOwnership(ctx context.Context, st corestorage.Storage, connectors []config.ConnectorConfig) (map[string]core.ConnectOwnership, error) {
+	ownership := make(map[string]core.ConnectOwnership, len(connectors))
+	var problems []string
+	for _, cn := range connectors {
+		if cn.Scope == "platform" {
+			ownership[cn.Name] = core.ConnectOwnership{Scope: "platform"}
+			continue
+		}
+		// cn.Scope == "project" here: internal/config.validateConnectScopes already
+		// guaranteed no other value reached boot (or allow_unscoped let an empty
+		// scope through, in which case there is nothing to resolve — an unscoped
+		// connector gets no ownership entry at all, which is exactly the deny-by-
+		// default behavior connectOwnershipSatisfied's missing-entry case wants).
+		if cn.Scope == "" {
+			continue
+		}
+		binding, err := st.GetConnectorProjectBinding(ctx, cn.Name)
+		switch {
+		case err != nil && isNotFoundStorageErr(err):
+			// First boot for this connector: resolve name -> ID, persist.
+			project, perr := st.GetProjectByName(ctx, cn.Project)
+			if perr != nil {
+				problems = append(problems, fmt.Sprintf("%s: project %q not found: %v", cn.Name, cn.Project, perr))
+				continue
+			}
+			created, cerr := st.CreateConnectorProjectBinding(ctx, &models.ConnectorProjectBinding{
+				Connector:   cn.Name,
+				ProjectID:   project.ID,
+				ProjectName: project.Name,
+			})
+			if cerr != nil {
+				problems = append(problems, fmt.Sprintf("%s: failed to persist project binding: %v", cn.Name, cerr))
+				continue
+			}
+			ownership[cn.Name] = core.ConnectOwnership{Scope: "project", ProjectID: created.ProjectID}
+		case err != nil:
+			problems = append(problems, fmt.Sprintf("%s: %v", cn.Name, err))
+		default:
+			// Binding exists: resolve by the stored ID, never by name.
+			project, perr := st.GetProject(ctx, binding.ProjectID)
+			if perr != nil {
+				problems = append(problems, fmt.Sprintf("%s: bound to project id %d, which no longer exists (deleted?): %v", cn.Name, binding.ProjectID, perr))
+				continue
+			}
+			if project.Name != binding.ProjectName {
+				problems = append(problems, fmt.Sprintf(
+					"%s: bound project (id %d) was renamed from %q to %q since this connector was first configured — this is a deliberate boot failure (ADR-082), not a silent reassignment; if the rename was intentional, update connect.connectors[].project to %q and clear the stale connector_project_bindings row for %q before restarting",
+					cn.Name, binding.ProjectID, binding.ProjectName, project.Name, project.Name, cn.Name))
+				continue
+			}
+			ownership[cn.Name] = core.ConnectOwnership{Scope: "project", ProjectID: binding.ProjectID}
+		}
+	}
+	if len(problems) > 0 {
+		return nil, fmt.Errorf("connector(s) with unresolvable project binding: %s", strings.Join(problems, "; "))
+	}
+	return ownership, nil
+}
+
+// connectOwnershipKeySetMismatch returns every connector name whose presence in
+// connect.Manager (builtNames) and in the resolved ownership map disagree, EXCEPT
+// for the one expected, legitimate disagreement: a connector booted with an empty
+// scope under connect.allow_unscoped (ADR-082 §C) is deliberately never given an
+// ownership entry (resolveConnectorOwnership skips it — connectOwnershipSatisfied
+// then denies it by default, exactly like any other absent entry), while it IS
+// still built into the manager (allow_unscoped only bypasses the boot-validation
+// gate, not connector wiring). connectors carries the full config so this can tell
+// that expected case apart from a genuine divergence — e.g. an unrecognized
+// connector Type, which resolves ownership successfully but never makes it into
+// the manager.
+func connectOwnershipKeySetMismatch(builtNames []string, ownership map[string]core.ConnectOwnership, connectors []config.ConnectorConfig) []string {
+	built := make(map[string]bool, len(builtNames))
+	for _, name := range builtNames {
+		built[name] = true
+	}
+	expectedUnscoped := make(map[string]bool)
+	for _, cn := range connectors {
+		if cn.Scope == "" {
+			expectedUnscoped[cn.Name] = true
+		}
+	}
+	var mismatch []string
+	for name := range built {
+		if _, ok := ownership[name]; !ok && !expectedUnscoped[name] {
+			mismatch = append(mismatch, name)
+		}
+	}
+	for name := range ownership {
+		if !built[name] {
+			mismatch = append(mismatch, name)
+		}
+	}
+	return mismatch
 }
 
 // cmpOr returns a if non-empty, else b (a tiny local helper to avoid a new import).


### PR DESCRIPTION
## Summary

ADR-082 branch 2: the actual ownership enforcement. `connectOwnershipSatisfied` derives a caller's ownership from their raw role scopes (`GetUserRoleScopes`/`GetMachineRoleScopes`) — a `{0,0}` global-scope entry acts as a wildcard, deliberately not filtered out before comparison. `ReadFederatedSecret` now checks ownership before falling through to `ConnectRefGrant` delegation; `ListConnectors` filters to only the connectors a caller can actually reach, via the same per-connector comparison (no separate "if admin" branch).

Stacked on #1484 (storage primitives).

## Scope

- `resolveConnectorOwnership` (boot time): resolves each `project`-scoped connector's `project:` name to a numeric ID via `ConnectorProjectBinding`, first-boot-only; a later boot resolves by the stored ID, never re-reading the name. A rename or delete since binding is a deliberate boot failure, not a silent reassignment.
- `connectOwnershipSatisfied`: the {0,0} wildcard is structural (scope of the grant), not name-based (not keyed on `adminRoleNames`) — see ADR-082 §E for why.
- `ConnectReadableConnectorNames` filters `ListConnectors` through the identical per-connector check.
- A denial reuses the exact unknown-connector response shape (no existence-probing oracle) — ADR-082 §E.

## Test plan

- [x] `go build ./...` clean at this commit (part of a verified 8-commit bisect-compile)
- [x] New ownership tests, including the `{0,0}`-survives-unfiltered invariant test and the missing-from-ownership-map-denies structural-invariant test