### PR TITLE
fix(connect): platform-scope the test-only connectors resolveConnectorOwnership can't resolve [5/8]

### DIFF
--- a/server/server_s22_test.go
+++ b/server/server_s22_test.go
@@ -237,8 +237,7 @@ func TestInitializeCoreService_S22_VaultCustomTokenEnv(t *testing.T) {
 				Address:     "http://vault.example.com:8200",
 				TokenEnv:    customEnv,
 				AllowedRefs: []string{"prod/*"},
-				Scope:       "project",
-				Project:     "payments",
+				Scope:       "platform",
 			},
 		},
 	}

--- a/server/server_s23_test.go
+++ b/server/server_s23_test.go
@@ -241,8 +241,7 @@ func TestInitializeCoreService_S23_VaultDefaultTokenEnv(t *testing.T) {
 				Address:     "http://vault.example.com:8200",
 				TokenEnv:    "", // empty → code substitutes "VAULT_TOKEN"
 				AllowedRefs: []string{"prod/*"},
-				Scope:       "project",
-				Project:     "payments",
+				Scope:       "platform",
 			},
 		},
 	}

--- a/server/server_s4_test.go
+++ b/server/server_s4_test.go
@@ -399,7 +399,7 @@ func TestInitializeCoreService_Connect_UnknownType(t *testing.T) {
 	cfg.Connect = config.ConnectConfig{
 		Enabled: true,
 		Connectors: []config.ConnectorConfig{
-			{Name: "c1", Type: "unknown-type", Scope: "project", Project: "payments"},
+			{Name: "c1", Type: "unknown-type", Scope: "platform"},
 		},
 	}
 
@@ -417,8 +417,8 @@ func TestInitializeCoreService_Connect_KnownTypes(t *testing.T) {
 	cfg.Connect = config.ConnectConfig{
 		Enabled: true,
 		Connectors: []config.ConnectorConfig{
-			{Name: "aws", Type: "aws-secrets-manager", AllowedRefs: []string{"prod/*"}, Scope: "project", Project: "payments"},
-			{Name: "gcp", Type: "gcp-secret-manager", ProjectID: "my-proj", AllowedRefs: []string{"prod/*"}, Scope: "project", Project: "payments"},
+			{Name: "aws", Type: "aws-secrets-manager", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
+			{Name: "gcp", Type: "gcp-secret-manager", ProjectID: "my-proj", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
 			{Name: "vault", Type: "vault", Address: "http://vault:8200", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
 		},
 	}
@@ -437,7 +437,7 @@ func TestInitializeCoreService_Connect_GCP_NoProjectID(t *testing.T) {
 	cfg.Connect = config.ConnectConfig{
 		Enabled: true,
 		Connectors: []config.ConnectorConfig{
-			{Name: "gcp-noproj", Type: "gcp-secret-manager", ProjectID: "", AllowedRefs: []string{"prod/*"}, Scope: "project", Project: "payments"},
+			{Name: "gcp-noproj", Type: "gcp-secret-manager", ProjectID: "", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
 		},
 	}
 
@@ -455,7 +455,7 @@ func TestInitializeCoreService_Connect_AzureKeyVault(t *testing.T) {
 	cfg.Connect = config.ConnectConfig{
 		Enabled: true,
 		Connectors: []config.ConnectorConfig{
-			{Name: "azure-kv", Type: "azure-key-vault", Address: "https://vault.vault.azure.net", AllowedRefs: []string{"prod/*"}, Scope: "project", Project: "payments"},
+			{Name: "azure-kv", Type: "azure-key-vault", Address: "https://vault.vault.azure.net", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes a regression in `server_s4_test.go`/`server_s22_test.go`/`server_s23_test.go`'s Connect test connectors, surfaced by the previous PR (#1485), not introduced by this one.

## Why this exists as its own commit

Those tests' Connect connectors were given `scope: "project", project: "payments"` back in branch 1 (#1483), **before** `resolveConnectorOwnership` (branch 2, #1485) existed to actually resolve that name against real storage. Once branch 2's real project-name resolution went live, these tests started failing with `project "payments" not found`, because none of them create a "payments" project in their minimal storage setup — branch 1's fixtures were written against a scope/project schema that had no enforcement behind it yet, and branch 2 is what first made the `project:` name need to resolve to something real.

Verified this wasn't caused by anything in this specific change before fixing it: reproduced the failure against branch 2's own HEAD (prior to this fix), confirming it predated and was independent of this PR's diff. Fixed here as its own separate, clearly-labeled commit rather than folded into either branch 1 or branch 2, so the stack's history says plainly "this was a pre-existing fixture gap branch 2 exposed," not "branch 2 shipped broken."

Fix: platform-scope these test-only connectors instead of inventing a "payments" project fixture — they don't need project-ownership semantics for what they're testing.

Stacked on #1485 (ownership enforcement).

## Test plan

- [x] `go build ./...` clean at this commit (part of a verified 8-commit bisect-compile)
- [x] The three previously-failing test files pass again