### PR TITLE
fix(connect): remove connect.allow_unscoped, no escape hatch (amends ADR-082 branch 1) [6/8]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ All notable changes to Keyorix are documented here. This project follows
   `scope: project` or `scope: platform` (ADR-082)** — an existing deployment with
   `connect.enabled: true` and one or more configured connectors **will fail to boot**
   after upgrading unless every connector in `connect.connectors` gains an explicit
-  `scope:` (and `project:` when `scope: project`). Set `connect.allow_unscoped: true`
-  as a temporary, deployment-wide stopgap to boot anyway — every connector still
-  missing `scope:` then logs a `WARN` on every boot until it's fixed. This is the
-  config-schema/boot-validation part of ADR-082 only; connector ownership is not yet
-  enforced on the read path (a later change) — see
+  `scope:` (and `project:` when `scope: project`). **There is no escape hatch and no
+  deployment-wide bypass** — adding `scope:` to an existing connector takes minutes,
+  and an unscoped connector would deny every read anyway once ownership enforcement
+  evaluates it (see below), so a bypass would only defer the failure from boot time
+  to read time, not restore access. Connector ownership is enforced on the read path
+  as of this same change: a caller must be a member of the connector's owning
+  project (or hold a matching `ConnectRefGrant`) to read through it — see
   `docs/adr-082-connect-connector-tenant-scoping.md`.
 - **BREAKING: keyorix-operator default RBAC/watch scope narrowed to own-namespace-only
   (ADR-076)** — an unmodified `helm install deploy/helm/keyorix-operator` now binds a

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1159,11 +1159,11 @@ with no connectors the `/connect` endpoints are not served.
 ```yaml
 connect:
   enabled: true
-  # allow_unscoped is a temporary, deployment-wide escape hatch (ADR-082): with it
-  # unset (the default), any connector below with no scope: fails server boot. Set
-  # it true only while migrating an existing config — every connector missing scope:
-  # then logs a WARN, every boot, until you set scope: on it and remove this flag.
-  allow_unscoped: false
+  # Every connector below MUST declare scope: — a missing or unrecognized value
+  # fails server boot unconditionally (ADR-082). There is no escape hatch: adding
+  # scope: to an existing connector takes minutes, and an unscoped connector would
+  # deny every read anyway (ownership has no entry for it), so a bypass would only
+  # defer the failure from "boot" to "every read," not actually restore access.
   connectors:
     - name: prod-aws            # API path key (unique); GET /api/v1/connect/prod-aws/secret?ref=…
       type: aws-secrets-manager # aws-secrets-manager | gcp-secret-manager | azure-key-vault | vault

--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -11,8 +11,9 @@ what is deliberately deferred to implementation-phase follow-up work.
 
 Four separate branches, one logical change each:
 
-1. Config schema (`scope`, `project`, `environment`, `connect.allow_unscoped`)
-   and boot validation (C).
+1. Config schema (`scope`, `project`, `environment`) and boot validation (C).
+   (`connect.allow_unscoped` was part of the original schema; removed by
+   amendment — see (C).)
 2. Ownership enforcement (E) and `ListConnectors` filtering.
 3. Audit changes (H) — the three-way decision reason, the switch to
    `writeAuditEventFull`, `AuditEvent.ProjectID` population.
@@ -224,26 +225,64 @@ There is no `legacy_unscoped` value and no phased default-flip release (a
 real revision from the prior draft of this ADR, per direct instruction).
 Instead:
 
-### C. Missing `scope` fails boot; the only escape hatch is explicit and per-deployment, not per-connector
+### C. Missing `scope` fails boot, unconditionally — no escape hatch
 
 A connector config entry with no `scope` key **fails server boot**, with an
 error naming every offending connector by its config-file name (not just
 the first one found — an operator fixing config should not have to
-restart-and-discover connectors one at a time).
+restart-and-discover connectors one at a time). There is no per-connector
+opt-out and no deployment-wide bypass of any kind — absence of `scope` is a
+hard failure, full stop. This is the same "explicit value required, absence
+denies" shape already established in this codebase (most recently
+ADR-076's `POD_NAMESPACE` hard-fail-on-empty).
 
-The only way to boot anyway is a single, explicit, deployment-wide config
-flag: `connect.allow_unscoped: true`. When set, boot proceeds, but **every**
-connector missing a `scope` emits a `WARN`-level log line naming it, at
-every boot, for as long as the flag stays set. There is no per-connector
-opt-out and no silent variant — `connect.allow_unscoped` unset (the
-default) means absence of `scope` is a hard failure, full stop. This is the
-same "explicit value required, absence denies" shape already established in
-this codebase (most recently ADR-076's `POD_NAMESPACE` hard-fail-on-empty),
-simplified here to a single boot-time gate rather than a phased migration
-because — unlike ADR-076's operator RBAC default, which had to preserve a
-*running* cluster's existing behavior across an upgrade — Connect connector
-config is edited and the server restarted as one atomic operator action;
-there is no live-traffic window a phased flip would need to protect.
+**Amended: the original design here included a single, explicit,
+deployment-wide escape hatch, `connect.allow_unscoped: true` — removed.**
+When set, boot proceeded, and every connector still missing a `scope`
+emitted a `WARN`-level log line naming it, at every boot, for as long as
+the flag stayed set. On implementation and verification (branch 2, ownership
+enforcement), this turned out not to be an escape hatch at all: an unscoped
+connector has no entry in the ownership map `connectOwnershipSatisfied` (§E)
+consults, and that function's own missing-entry-denies rule — the same rule
+that makes a connector absent from the map deny for every caller rather than
+silently allow or silently skip — applied to it exactly as it would to any
+other connector with no ownership data. The flag let the *server* boot, but
+every *read* against an unscoped connector was denied regardless (unless a
+caller separately held an unrelated `ConnectRefGrant`, ADR-045's delegation
+mechanism, which an operator mid-migration would have no particular reason
+to have configured). The WARN it produced was accurate but misleading in
+effect: it read as "this still works, fix it soon," when the true state was
+"this doesn't work at all, and nothing here will tell you that until a read
+fails." A flag that defers a failure from boot time to read time, silently,
+is not a migration aid — it just moves where the operator discovers the
+problem, later and less legibly (a `502`, not a boot-time error naming the
+connector). The actual migration path — this ADR's own boot-fail-with-an-
+aggregated-list-of-every-offending-connector — already tells an operator
+exactly what to fix in one pass, and fixing it (adding `scope:` to a
+connector entry) takes minutes; there was nothing here worth an escape
+hatch for.
+
+Removing the flag also removes the one exemption the boot-time key-set
+consistency check (§E) carried: with `resolveConnectorOwnership` no longer
+skipping any connector (there is no longer an "expected to have no
+ownership entry" case), a connector present in `connect.Manager` but absent
+from the resolved ownership map — for any reason, including what used to be
+the deliberately-unscoped case — is now, unconditionally, a boot-failing
+key-set mismatch. This closes a real gap the removed exemption was
+carrying, not obviously connected to `allow_unscoped` itself: the mismatch
+check's fail-closed guarantee no longer depends on `cfg.Validate()` having
+already run and enforced "empty scope implies the flag was set" as an
+external precondition it trusted rather than re-verified — a future code
+path reaching either function without that precondition (a refactor, a new
+call site, a test) can no longer be silently misread as "legitimately
+unscoped."
+
+This is simplified to a single, unconditional boot-time gate rather than a
+phased migration because — unlike ADR-076's operator RBAC default, which
+had to preserve a *running* cluster's existing behavior across an upgrade
+— Connect connector config is edited and the server restarted as one
+atomic operator action; there is no live-traffic window a phased flip
+would need to protect.
 
 ### D. Ownership is derived server-side from role assignments. No new request parameter, no proto change, no signature change.
 
@@ -691,16 +730,17 @@ repository's existing versioning (`v0.91.0` is current at time of writing;
 `v0.92.0` is the earliest this could ship in, not a fixed commitment ahead
 of implementation). Any existing deployment with `connect.enabled: true`
 and one or more configured connectors **will fail to boot** after upgrading
-unless every connector gains an explicit `scope`, or the deployment sets
-`connect.allow_unscoped: true` as an explicit, intentional stopgap (with the
-every-boot `WARN` noise that implies). This requires a **`BREAKING`**-labeled
+unless every connector gains an explicit `scope` — **there is no bypass**
+(C, amended): the original `connect.allow_unscoped` stopgap is removed,
+since it never actually restored a connector's usability, only deferred the
+failure from boot time to read time. This requires a **`BREAKING`**-labeled
 CHANGELOG entry for that release — the same handling ADR-076 gave its own
 default-scope change (that ADR's Consequences section: "Two separate
 CHANGELOG entries, not one" — `BREAKING` for the behavior change itself).
 The entry must state the required pre-upgrade config change plainly, not
 just "review your config" (ADR-076's own precedent for what counts as
-adequate here), and must name the exact new keys (`scope`, `project`,
-`connect.allow_unscoped`) an operator needs to act on.
+adequate here), and must name the exact new keys (`scope`, `project`) an
+operator needs to act on.
 
 **Why config-only was chosen over a DB mirror.** Stated directly in (A):
 there is no runtime connector-CRUD capability today, so a DB row would add

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,13 +167,6 @@ func (c *Config) LicenseGrace() time.Duration {
 type ConnectConfig struct {
 	Enabled    bool              `yaml:"enabled"`
 	Connectors []ConnectorConfig `yaml:"connectors"`
-	// AllowUnscoped is the single deployment-wide escape hatch (ADR-082 §C) that lets
-	// the server boot despite one or more connectors missing scope. Every boot under
-	// this flag logs a WARN naming each unscoped connector (server/main.go, not here —
-	// Validate() itself never logs). Default false: a missing scope fails boot. Does
-	// NOT rescue an unrecognized scope value or the project/platform contradiction
-	// checks — those always fail boot regardless of this flag.
-	AllowUnscoped bool `yaml:"allow_unscoped"`
 }
 
 // ConnectorConfig describes one external-store connector. Name is the API path key
@@ -211,9 +204,10 @@ type ConnectorConfig struct {
 	// Scope declares this connector's tenant boundary (ADR-082): "project" (owned by
 	// exactly one Keyorix project — requires Project) or "platform" (org-wide; requires
 	// the connect.platform.use permission at authorization time, must NOT set Project).
-	// Required: a missing value fails boot unless ConnectConfig.AllowUnscoped is set; an
-	// unrecognized value (anything other than "project"/"platform") always fails boot,
-	// AllowUnscoped does not rescue it.
+	// Required, unconditionally: a missing or unrecognized value (anything other than
+	// "project"/"platform") always fails boot. There is no escape hatch — an operator
+	// migrating an existing config adds scope: to every connector before upgrading; see
+	// ADR-082 §C for why that boot-fail-loud requirement has no deployment-wide bypass.
 	Scope string `yaml:"scope"`
 	// Project names the Keyorix project that owns this connector, by NAME — not a
 	// numeric ID. A numeric project ID differs per deployment (the same logical project
@@ -1947,17 +1941,17 @@ func (c *Config) Validate() error { // NOSONAR -- cognitive complexity 32, suppr
 }
 
 // validateConnectScopes enforces ADR-082 §B/§C on cfg.Connect.Connectors — pure
-// config-shape validation, no DB/network access, no logging (Validate() never logs;
-// the allow_unscoped WARNs are emitted where the connectors are actually wired,
-// server/main.go, matching this codebase's existing log-at-the-point-of-use style).
-// Every check aggregates across ALL offending connectors into one error naming each
-// by config name, rather than failing on (and hiding) the first one found — an
-// operator fixing config should not have to restart-and-discover connectors one at a
-// time. Checks run in this order, each independent of the others by construction
-// (a connector can only land in one bucket): unrecognized scope (never rescued by
-// AllowUnscoped — a typo is not "intentionally unscoped"), missing scope (rescued by
-// AllowUnscoped), scope "project" without a Project name, scope "platform" with a
-// Project name set (a platform connector is not owned by any single project).
+// config-shape validation, no DB/network access, no logging. Every check aggregates
+// across ALL offending connectors into one error naming each by config name, rather
+// than failing on (and hiding) the first one found — an operator fixing config
+// should not have to restart-and-discover connectors one at a time. There is no
+// deployment-wide escape hatch (ADR-082 §C, amended): a missing scope fails boot
+// unconditionally, the same as an unrecognized value — the migration path for an
+// existing deployment is to add scope: to every connector, not to opt out of the
+// check. Checks run in this order, each independent of the others by construction
+// (a connector can only land in one bucket): unrecognized scope, missing scope,
+// scope "project" without a Project name, scope "platform" with a Project name set
+// (a platform connector is not owned by any single project).
 func validateConnectScopes(cc ConnectConfig) error {
 	var missing, invalid, projectNeedsProject, platformRejectsProject []string
 	for _, connector := range cc.Connectors {
@@ -1980,8 +1974,8 @@ func validateConnectScopes(cc ConnectConfig) error {
 	if len(invalid) > 0 {
 		return fmt.Errorf("connect: connector(s) with unrecognized scope (must be \"project\" or \"platform\"): %s", strings.Join(invalid, ", "))
 	}
-	if len(missing) > 0 && !cc.AllowUnscoped {
-		return fmt.Errorf("connect: connector(s) missing required \"scope\" (must be \"project\" or \"platform\"; set connect.allow_unscoped: true to boot anyway — ADR-082): %s", strings.Join(missing, ", "))
+	if len(missing) > 0 {
+		return fmt.Errorf("connect: connector(s) missing required \"scope\" (must be \"project\" or \"platform\" — ADR-082, no exceptions): %s", strings.Join(missing, ", "))
 	}
 	if len(projectNeedsProject) > 0 {
 		return fmt.Errorf("connect: connector(s) with scope \"project\" missing required \"project\": %s", strings.Join(projectNeedsProject, ", "))

--- a/internal/config/connect_config_test.go
+++ b/internal/config/connect_config_test.go
@@ -8,10 +8,12 @@ import (
 )
 
 // TestValidateConnectScopes covers ADR-082 §B/§C boot validation: missing/
-// unrecognized scope, the project/platform contradiction checks, both
-// allow_unscoped states, and valid project/platform entries. Each failure
-// case asserts the aggregated error names every offending connector, not
-// just the first one found.
+// unrecognized scope, the project/platform contradiction checks, and valid
+// project/platform entries. There is no escape hatch (amended — the original
+// connect.allow_unscoped flag was removed: it let the server boot, but an
+// unscoped connector still denied on every read, so it never restored actual
+// usability). Each failure case asserts the aggregated error names every
+// offending connector, not just the first one found.
 func TestValidateConnectScopes(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -55,17 +57,6 @@ func TestValidateConnectScopes(t *testing.T) {
 			wantNames: []string{"bad1", "bad2"},
 		},
 		{
-			name: "unrecognized scope is NOT rescued by allow_unscoped",
-			cc: ConnectConfig{
-				AllowUnscoped: true,
-				Connectors: []ConnectorConfig{
-					{Name: "typo", Type: "vault", Scope: "projekt"},
-				},
-			},
-			wantErr:   true,
-			wantNames: []string{"typo"},
-		},
-		{
 			name: "scope project without project name fails boot",
 			cc: ConnectConfig{Connectors: []ConnectorConfig{
 				{Name: "noproj", Type: "vault", Scope: "project"},
@@ -99,28 +90,6 @@ func TestValidateConnectScopes(t *testing.T) {
 			}},
 			wantErr:   true,
 			wantNames: []string{"bad1", "bad2"},
-		},
-		{
-			name: "missing scope rescued by allow_unscoped: true",
-			cc: ConnectConfig{
-				AllowUnscoped: true,
-				Connectors: []ConnectorConfig{
-					{Name: "c1", Type: "vault"},
-					{Name: "c2", Type: "aws-secrets-manager"},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "missing scope NOT rescued when allow_unscoped is false (default)",
-			cc: ConnectConfig{
-				AllowUnscoped: false,
-				Connectors: []ConnectorConfig{
-					{Name: "c1", Type: "vault"},
-				},
-			},
-			wantErr:   true,
-			wantNames: []string{"c1"},
 		},
 		{
 			name:    "no connectors is valid",
@@ -196,5 +165,4 @@ func TestValidate_ConnectScopesWired(t *testing.T) {
 	err := c.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unscoped-connector")
-	assert.Contains(t, err.Error(), "allow_unscoped")
 }

--- a/server/connect_ownership_resolution_test.go
+++ b/server/connect_ownership_resolution_test.go
@@ -163,29 +163,25 @@ func TestResolveConnectorOwnership_PlatformNeedsNoResolution(t *testing.T) {
 }
 
 // TestConnectOwnershipKeySetMismatch_DetectsGenuineDivergence proves a connector
-// present in the manager but absent from ownership (or vice versa) — WITHOUT the
-// legitimate allow_unscoped exception — is reported as a mismatch.
+// present in the manager but absent from ownership (or vice versa) is reported
+// as a mismatch.
 func TestConnectOwnershipKeySetMismatch_DetectsGenuineDivergence(t *testing.T) {
 	ownership := map[string]core.ConnectOwnership{
 		"aws": {Scope: "project", ProjectID: 1},
 	}
-	connectors := []config.ConnectorConfig{
-		{Name: "aws", Scope: "project", Project: "payments"},
-		{Name: "gcp", Scope: "project", Project: "payments"}, // built, but ownership resolution never ran for it in this test
-	}
-	mismatch := connectOwnershipKeySetMismatch([]string{"aws", "gcp"}, ownership, connectors)
+	mismatch := connectOwnershipKeySetMismatch([]string{"aws", "gcp"}, ownership)
 	assert.Equal(t, []string{"gcp"}, mismatch)
 }
 
-// TestConnectOwnershipKeySetMismatch_AllowsExpectedUnscopedGap proves the ONE
-// legitimate divergence — a connector booted with an empty scope under
-// connect.allow_unscoped is built into the manager but deliberately never given
-// an ownership entry — is NOT reported as a mismatch.
-func TestConnectOwnershipKeySetMismatch_AllowsExpectedUnscopedGap(t *testing.T) {
-	ownership := map[string]core.ConnectOwnership{} // resolveConnectorOwnership skips empty-scope connectors
-	connectors := []config.ConnectorConfig{
-		{Name: "unscoped-aws", Scope: ""}, // booted under connect.allow_unscoped
-	}
-	mismatch := connectOwnershipKeySetMismatch([]string{"unscoped-aws"}, ownership, connectors)
-	assert.Empty(t, mismatch, "a connector booted unscoped under allow_unscoped must not be reported as a key-set mismatch")
+// TestConnectOwnershipKeySetMismatch_NoExemptionForAnyDivergence is the
+// regression guard for the connect.allow_unscoped removal (ADR-082 §C,
+// amended): a connector that WOULD have been exempted under the old
+// scope-based exemption (an empty Scope, built into the manager but absent
+// from ownership) is now reported as a mismatch like any other divergence —
+// resolveConnectorOwnership no longer skips any connector, and the mismatch
+// check no longer accepts a connectors argument to special-case one.
+func TestConnectOwnershipKeySetMismatch_NoExemptionForAnyDivergence(t *testing.T) {
+	ownership := map[string]core.ConnectOwnership{} // empty: nothing resolved for "aws"
+	mismatch := connectOwnershipKeySetMismatch([]string{"aws"}, ownership)
+	assert.Equal(t, []string{"aws"}, mismatch, "with allow_unscoped removed, there is no exemption — any divergence, including what used to be the unscoped case, must be reported")
 }

--- a/server/main.go
+++ b/server/main.go
@@ -564,22 +564,13 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	// Wire Keyorix Connect (ADR-043) read-through federation if enabled.
 	if cc := cfg.Connect; cc.Enabled && len(cc.Connectors) > 0 {
 		// ADR-082 §C: cfg.Validate() already refused to boot with a missing/invalid
-		// connector scope unless connect.allow_unscoped is set — Validate() itself never
-		// logs (internal/config/validateConnectScopes), so if we're here under that flag,
-		// warn loudly, per connector and once as a summary, at the point the connectors
-		// are actually wired.
-		if cc.AllowUnscoped {
-			var unscoped []string
-			for _, cn := range cc.Connectors {
-				if cn.Scope == "" {
-					unscoped = append(unscoped, cn.Name)
-					log.Printf("Keyorix Connect: connector %q has no scope configured and is booting under connect.allow_unscoped — set scope: project or scope: platform (ADR-082)", cn.Name)
-				}
-			}
-			if len(unscoped) > 0 {
-				log.Printf("Keyorix Connect: %d connector(s) booted unscoped under connect.allow_unscoped — this is a temporary escape hatch; set an explicit scope on each before removing it (ADR-082)", len(unscoped))
-			}
-		}
+		// connector scope — unconditionally, no deployment-wide escape hatch (amended:
+		// the original connect.allow_unscoped flag let the server boot, but an unscoped
+		// connector still denied on every read via connectOwnershipSatisfied's
+		// missing-entry-denies rule, so it never restored actual usability — only
+		// deferred the failure from "boot" to "every subsequent read," with a WARN an
+		// operator could easily miss. Adding scope: to a connector takes minutes; there
+		// is nothing for this migration path to bypass.
 		var connectors []connect.Connector
 		for _, cn := range cc.Connectors {
 			switch cn.Type {
@@ -636,8 +627,11 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			// unrecognized type), or vice versa, that is a key-set mismatch this ADR
 			// requires to fail boot loudly rather than silently deny (a missing
 			// ownership entry, connectOwnershipSatisfied's own fallback) or silently
-			// skip ownership entirely (a connector with no check at all).
-			if mismatch := connectOwnershipKeySetMismatch(mgr.Names(), ownership, cc.Connectors); len(mismatch) > 0 {
+			// skip ownership entirely (a connector with no check at all). No exemption
+			// of any kind (amended — the prior allow_unscoped-linked exemption is
+			// removed along with the flag): every divergence between the two sets is
+			// reported.
+			if mismatch := connectOwnershipKeySetMismatch(mgr.Names(), ownership); len(mismatch) > 0 {
 				log.Fatalf("Keyorix Connect: connector(s) present in config but whose manager/ownership resolution disagree on which connectors exist — this must never happen in a correctly-booted server; investigate before proceeding (ADR-082): %s", strings.Join(mismatch, ", "))
 			}
 
@@ -980,13 +974,9 @@ func resolveConnectorOwnership(ctx context.Context, st corestorage.Storage, conn
 			continue
 		}
 		// cn.Scope == "project" here: internal/config.validateConnectScopes already
-		// guaranteed no other value reached boot (or allow_unscoped let an empty
-		// scope through, in which case there is nothing to resolve — an unscoped
-		// connector gets no ownership entry at all, which is exactly the deny-by-
-		// default behavior connectOwnershipSatisfied's missing-entry case wants).
-		if cn.Scope == "" {
-			continue
-		}
+		// guaranteed no other value reached boot (amended — there is no longer an
+		// allow_unscoped bypass; a missing or unrecognized scope always fails boot
+		// before this function is ever reached).
 		binding, err := st.GetConnectorProjectBinding(ctx, cn.Name)
 		switch {
 		case err != nil && isNotFoundStorageErr(err):
@@ -1031,30 +1021,21 @@ func resolveConnectorOwnership(ctx context.Context, st corestorage.Storage, conn
 }
 
 // connectOwnershipKeySetMismatch returns every connector name whose presence in
-// connect.Manager (builtNames) and in the resolved ownership map disagree, EXCEPT
-// for the one expected, legitimate disagreement: a connector booted with an empty
-// scope under connect.allow_unscoped (ADR-082 §C) is deliberately never given an
-// ownership entry (resolveConnectorOwnership skips it — connectOwnershipSatisfied
-// then denies it by default, exactly like any other absent entry), while it IS
-// still built into the manager (allow_unscoped only bypasses the boot-validation
-// gate, not connector wiring). connectors carries the full config so this can tell
-// that expected case apart from a genuine divergence — e.g. an unrecognized
-// connector Type, which resolves ownership successfully but never makes it into
-// the manager.
-func connectOwnershipKeySetMismatch(builtNames []string, ownership map[string]core.ConnectOwnership, connectors []config.ConnectorConfig) []string {
+// connect.Manager (builtNames) and in the resolved ownership map disagree — no
+// exemption of any kind (amended: the prior connect.allow_unscoped-linked
+// exemption is removed along with the flag, since resolveConnectorOwnership no
+// longer skips any connector). A connector present in one set but not the other
+// must never happen in a correctly-booted server (e.g. an unrecognized connector
+// Type, which resolves ownership successfully but never makes it into the
+// manager) — every divergence is reported.
+func connectOwnershipKeySetMismatch(builtNames []string, ownership map[string]core.ConnectOwnership) []string {
 	built := make(map[string]bool, len(builtNames))
 	for _, name := range builtNames {
 		built[name] = true
 	}
-	expectedUnscoped := make(map[string]bool)
-	for _, cn := range connectors {
-		if cn.Scope == "" {
-			expectedUnscoped[cn.Name] = true
-		}
-	}
 	var mismatch []string
 	for name := range built {
-		if _, ok := ownership[name]; !ok && !expectedUnscoped[name] {
+		if _, ok := ownership[name]; !ok {
 			mismatch = append(mismatch, name)
 		}
 	}


### PR DESCRIPTION
## Summary

Removes `connect.allow_unscoped`, the deployment-wide escape hatch branch 1 (#1483) originally shipped for a connector missing `scope:`. Amends ADR-082 §C — see the doc update in this PR and the ADR's own "Amended" note.

## Why this is removed here, after branch 1, not changed in branch 1 itself

The flag was written and reviewed in branch 1, **before branch 2's ownership enforcement (#1485) existed to prove or disprove whether it actually worked as an escape hatch.** Once branch 2 landed, verification showed it wasn't one: an unscoped connector has no entry in the ownership map `connectOwnershipSatisfied` consults, and that function's own missing-entry-denies rule — the same rule that makes a connector absent from the map deny for *every* caller rather than silently allow — applied to it exactly like any other connector with no ownership data. The flag let the **server boot**, but every **read** against an unscoped connector was denied regardless (unless a caller separately held an unrelated `ConnectRefGrant`). It didn't defer a failure gracefully — it moved the failure from a clear, aggregated, boot-time error to a misleading, one-caller-at-a-time `502` discovered at read time, with a `WARN` log that read as "this still works" when the true state was "this doesn't work at all."

This dependency — needing branch 2's real enforcement to actually observe the flag's behavior — is why the removal is its own commit stacked after branch 2's fixture fix (#1486), not a branch 1 amendment made in place.

Stacked on #1486 (fixture fix).

## Scope

- `AllowUnscoped` removed from `ConnectConfig`, the `Config.Validate()` exemption, the `WARN` block in `server/main.go`, and the `cn.Scope == ""` exemptions in both `resolveConnectorOwnership` and `connectOwnershipKeySetMismatch`. Missing scope now fails boot unconditionally, no exemption anywhere.
- `docs/CONFIGURATION.md` + CHANGELOG `BREAKING` entry (targeting v0.92.0): no escape hatch, every connector must declare `scope:`.
- Regression test updated: the key-set mismatch check now asserts it fires on any divergence, with no exemption.

## Test plan

- [x] `go build ./...` clean at this commit (part of a verified 8-commit bisect-compile)
- [x] Full test run on affected packages; `server/http` baseline unchanged by failing-test-name