### PR TITLE
feat(connect): audit every ReadFederatedSecret outcome and ConnectorProjectBinding write (ADR-082 branch 3) [7/8]

### DIFF
--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -20,7 +20,11 @@ Four separate branches, one logical change each:
 4. The new `connect.platform.use` permission (B) and its addition to
    `adminPermissions`.
 
-**No branch has been started as of this ADR's acceptance.**
+**Branches 1-3 are implemented; branch 4 (`connect.platform.use`) is not
+started.** Branch 3 (H) also closes issue #1477's audit half: every
+`ConnectorProjectBinding` write is now audited, not only the `connect.secret_read`
+path — see (H) below for the full, as-implemented design (the text below
+reflects what shipped, superseding the plan-time description that preceded it).
 
 ## Context
 
@@ -564,28 +568,113 @@ so:
   control — the doc/config comments for this key must say "reserved,
   not yet enforced" plainly, not merely omit mention of enforcement.
 
-### H. Audit surface: switch to `writeAuditEventFull`, populate the connector's owning project, record which gate authorized the read
+### H. Audit surface: switch to `writeAuditEventFull`/`writeAuditEventFailed`, populate the connector's owning project, record which gate decided the outcome, audit every write to `ConnectorProjectBinding`
 
-Every Connect audit event (`connect.secret_read`, success and denial alike)
-switches from `writeAuditEvent` to `writeAuditEventFull`, populating the
-existing `AuditEvent.ProjectID` column with the connector's **owning**
-project (from its config `scope`/`project`) — zero schema change, this
-column already exists and is simply unpopulated by Connect today. A
-successful read additionally carries a distinct, greppable decision-reason
-marker naming which gate in (E)'s order actually resolved ownership:
-`project_membership` (caller is a genuine member of the connector's owning
-project), `global_scope` (caller's scope set carried the `{0,0}`
-global-scope wildcard entry — (E), any role name), or `delegation` (caller
-had no ownership claim at all, resolved instead via a matching
-`ConnectRefGrant`) — exact
-string tokens are an implementation detail, not a design axis. This makes a
-cross-project delegation read, and an admin reaching a connector they are
-not a genuine member of, both distinguishable from an ordinary same-project
-read in an audit review, rather than all three being indistinguishable
-successful reads. This mirrors the numeric-at-storage, resolved-at-export-layer
-split already established for `impersonated_by`/`acting_as` (numeric FK at
-the `AuditEvent` row, resolved to an email string only at the HTTP
-export/API layer) — the same convention, not a new one.
+Every Connect audit event on the read path (`connect.secret_read` — every
+outcome, allow or deny, including the two paths that were silent through
+branch 2: `connect.read` disabled and a genuinely unknown connector) is
+written with `AuditEvent.ProjectID` populated to the connector's **owning**
+project (from its config `scope`/`project`; `nil` for a `scope: platform`
+connector, since `ProjectID` is meaningless there) — zero schema change,
+this column already existed and was simply unpopulated by Connect before
+this branch. `writeAuditEventFailed` was extended with a `projectID`
+parameter (previously it took none) to make this possible for deny events;
+this touched 6 pre-existing non-Connect call sites
+(`auth.login_failed`, risk-exception approval denial ×2, legal-hold
+place/lift denial ×2, compliance-digest broadcast failure), all mechanically
+updated to pass `nil` — none of those events carry project context.
+
+**Success is `true` only for the read that actually returned a value.**
+Every other outcome — the two RBAC denials (E)'s call order can reach,
+`connect.read` disabled, unknown connector, and a failed upstream call to
+the connector's backend — is written with `Success: false`.
+
+**Decision reason: a fixed `reason=<value>` token, closed set, at a
+consistent position in every event's `Description`.** There is no
+structured, enum-typed column for this on `AuditEvent` — none exists today
+(verified directly against the model, not assumed), and the design that
+would have been the closest precedent (ADR-075's "closed `key_source`
+enum") was never actually implemented under that name anywhere in the
+codebase; see the issue filed alongside this branch for that specific
+drift. Given that, the token goes into free-text `Description`, using the
+SAME fixed format at every one of the eight call sites below, specifically
+so a future structured column is a parse-and-backfill against this closed
+set, not a rewrite:
+
+Allow (`Success: true`):
+- `project_membership` — caller holds a role scoped to the connector's
+  owning project specifically.
+- `global_scope` — caller holds a role at the true global (`{0,0}`) scope,
+  which wildcards every project-scoped connector (E), regardless of role
+  name.
+- `platform_scope` — the connector itself is `scope: platform`; ownership
+  passes for any `connect.read` holder (branch 4's `connect.platform.use`
+  narrows this further, not yet implemented).
+- `delegation` — caller had no ownership claim at all on the connector's
+  project, resolved instead via a matching `ConnectRefGrant` (F).
+
+Deny (`Success: false`):
+- `connect_disabled` — no `connect.Manager` configured at all.
+- `unknown_connector` — the named connector does not exist in config.
+- `ref_not_permitted` — caller IS owned, but a `ConnectRefGrant` scoped to
+  this connector exists and none of the caller's roles hold a grant
+  matching the requested ref (ADR-045, unchanged).
+- `ownership_denied` — caller is NOT owned, and the connector has ZERO
+  `ConnectRefGrant`s configured at all — no delegation path exists.
+- `delegation_denied` — caller is NOT owned; the connector DOES have
+  `ConnectRefGrant`(s), but none matched this caller's roles/ref.
+- `backend_error` — ownership (or delegation) was satisfied, but the
+  upstream connector call itself failed (network, credentials, etc.); the
+  raw upstream error is logged server-side only, never persisted into the
+  audit trail (backlog #116, pre-existing G50 protection, unchanged).
+
+`ownership_denied` and `delegation_denied` are the SAME code branch in
+`ReadFederatedSecret` — (E) still returns the identical
+`ErrConnectUnknownConnector` shape to the caller for both, deliberately
+(existence-hiding, per (E)'s own rationale) — but the audit event
+distinguishes them, because this is the only place an operator can learn
+which gate actually closed. This is the concrete case this branch exists
+for: an admin reaching a connector they are not a genuine member of, and a
+cross-project delegation read, and a hard deny, are all indistinguishable
+to the caller by design, but are fully distinguishable in an audit review.
+
+This mirrors the numeric-at-storage, resolved-at-export-layer split already
+established for `impersonated_by`/`acting_as` (numeric FK at the
+`AuditEvent` row, resolved to an email string only at the HTTP export/API
+layer) — the same convention, not a new one.
+
+**`ConnectRefGrant` management events** (`connect.ref_grant_create`,
+`connect.ref_grant_delete`) also switch to `writeAuditEventFull`, populating
+`ProjectID` from the grant's connector's owning project (looked up the same
+way; for delete, via a best-effort `ListConnectRefGrants` scan by id before
+the delete call, since the storage interface has no fetch-by-id or
+delete-returning-row primitive and adding one is out of scope here).
+
+**`ListConnectors` discovery filtering is deliberately NOT audited** — a
+caller listing connectors and having some silently omitted (E) is
+high-volume, low-signal, and would make a routine discovery poll into an
+audit write. Any actual attempt to read a hidden connector is already
+captured by the `connect.secret_read` deny path above; that is the
+meaningful signal, not the list operation itself.
+
+**`ConnectorProjectBinding` writes are audited at both call sites**
+(closing issue #1477's audit half): the boot-time first-resolution write in
+`server/main.go`'s `resolveConnectorOwnership`, and the RemoteStorage proxy
+write in `CreateConnectorProjectBindingProxy`
+(`server/http/handlers/connector_project_bindings_proxy.go`). Both use a new
+event type, `connect.project_binding_create`, and are actored as `"system"`
+(`core.ActorTypeSystem`) — neither call site has a human session or
+machine-identity principal behind it: the boot-time write is unattended, and
+the proxy endpoint is reached only by a node-credential/`system.write`
+caller. `#1477`'s wording named only the proxy write; this branch covers
+both, because the binding is an authorization input (it feeds
+`core.ConnectOwnership`, and from there `connectOwnershipSatisfied`)
+regardless of which door the write comes through, and the boot-time path is
+the more consequential of the two since nothing is watching it interactively.
+A failure to persist the audit event does NOT fail the boot or the request —
+the binding itself already persisted — but is logged loudly
+(`SECURITY`-prefixed), matching `emitAudit`'s own convention for a failed
+audit write.
 
 ### I. ADR-045 is explicitly amended, not silently superseded
 

--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -652,7 +652,7 @@ would have been the closest precedent (ADR-075's "closed `key_source`
 enum") was never actually implemented under that name anywhere in the
 codebase; see the issue filed alongside this branch for that specific
 drift. Given that, the token goes into free-text `Description`, using the
-SAME fixed format at every one of the eight call sites below, specifically
+SAME fixed format at every one of the seven call sites below, specifically
 so a future structured column is a parse-and-backfill against this closed
 set, not a rewrite:
 

--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -20,11 +20,16 @@ Four separate branches, one logical change each:
 4. The new `connect.platform.use` permission (B) and its addition to
    `adminPermissions`.
 
-**Branches 1-3 are implemented; branch 4 (`connect.platform.use`) is not
-started.** Branch 3 (H) also closes issue #1477's audit half: every
-`ConnectorProjectBinding` write is now audited, not only the `connect.secret_read`
-path — see (H) below for the full, as-implemented design (the text below
-reflects what shipped, superseding the plan-time description that preceded it).
+**All four branches are implemented.** Branch 3 (H) also closes issue
+#1477's audit half: every `ConnectorProjectBinding` write is now audited, not
+only the `connect.secret_read` path. Branch 4 adds `connect.platform.use`
+(B) and gates it as a TERMINAL deny with no `ConnectRefGrant` delegation
+fallback (E) — a deliberate fork from the `scope: project` ownership-miss
+path, not a later revision toward consistency with it. See (E) and (H) below
+for the full, as-implemented design (the text in those sections reflects
+what shipped, superseding the plan-time description that preceded it, most
+notably (E)'s diagram, which originally said a platform-permission denial
+fell through to delegation — it does not).
 
 ## Context
 
@@ -457,9 +462,12 @@ admin-*named* role globally (unaffected by this ADR either way), now
 extended consistently to Connect ownership specifically.
 
 ```
-connect.read granted?                                    → no:  deny
+connect.read granted?                                    → no:  deny (reason: connect_disabled / unknown_connector)
 connector.scope == platform?
-  → yes: connect.platform.use granted?  → yes: allow (reason: capability)  → no: fall through to delegation check below
+  → yes: connect.platform.use granted (checked at Scope{}, global)?
+      → yes: allow (reason: platform_scope)
+      → no:  TERMINAL deny (reason: platform_permission_denied) — no
+             ConnectRefGrant fallback; see below for why
 connector.scope == project?
   → caller's RAW scope set (GetUserRoleScopes/GetMachineRoleScopes,
     including any {0,0} entry) contains connector.project?
@@ -468,8 +476,51 @@ connector.scope == project?
     role grant, any role name — see above)?
                                                           → yes: allow (reason: global_scope)
 matching ConnectRefGrant for one of the caller's roles?  → yes: allow (reason: delegation)
-                                                          → else: deny
+                                                          → no:  deny (reason: ownership_denied /
+                                                                 delegation_denied)
 ```
+
+**A denied `connect.platform.use` check is TERMINAL — it does NOT fall
+through to `ConnectRefGrant` delegation, unlike an ordinary `scope: project`
+ownership miss (this ADR's own earlier draft of this diagram said it did;
+corrected here on implementation, not a later change of mind — see "Out of
+scope"/(H) history).** This is a deliberate fork, not an oversight, and must
+not later be "reconciled" toward consistency with the project-scope path.
+Two independent reasons, both load-bearing:
+
+1. **A `ConnectRefGrant` targeting a `platform`-scope connector's name would
+   not be narrowing access — it would be granting it.** `ConnectRefGrant`
+   is keyed on role + connector name + ref-prefix alone; it has no concept
+   of the connector's `scope`, and nothing in `CreateConnectRefGrant`
+   currently rejects creating one against a platform connector (a known,
+   separately-tracked gap — see the issue filed alongside this branch: such
+   a grant is dead configuration under this design, consulted by nothing).
+   If a platform-scope ownership miss fell through to the SAME delegation
+   check a project-scope miss does, then any principal able to create a
+   `ConnectRefGrant` (an ordinary RBAC-gated management action, not itself
+   gated on `connect.platform.use`) could hand any other principal read
+   access to a platform-wide connector, entirely bypassing
+   `connect.platform.use`. For a project-scoped connector this isn't a
+   bypass — delegation is explicitly scoped to ONE connector's ONE
+   project, a narrower grant than project ownership itself would confer.
+   For a platform connector there is no narrower boundary below "the whole
+   connector" for a grant to sit inside of — delegation and the permission
+   it would be bypassing would cover the exact same surface.
+2. **A platform connector has no owning project for "delegation" to be
+   relative to.** `ConnectOwnership.ProjectID` is meaningless when
+   `Scope == "platform"` (its own doc comment says so); `ConnectRefGrant`
+   delegation (F) is conceptually "an explicit administrator-authorized
+   exception to a project-ownership boundary a caller doesn't otherwise
+   clear" — there is no such boundary here for an exception to be relative
+   to.
+
+`ConnectReadableConnectorNames` (`ListConnectors`) applies the identical
+terminal rule via the same per-connector loop, not a separate branch: a
+caller lacking `connect.platform.use` never reaches the delegation-fallback
+check for a platform connector there either — otherwise a
+(dead-configuration) `ConnectRefGrant` against a platform connector's name
+could make it appear in discovery for a caller whose actual read would
+always be denied, the exact leak this whole section exists to prevent.
 
 - **`ListConnectors` filters**: unchanged in shape from the prior draft —
   the returned list contains only connectors the caller can reach under
@@ -498,10 +549,14 @@ matching ConnectRefGrant for one of the caller's roles?  → yes: allow (reason:
   bypass wherever it's granted, but **not** the ownership wildcard outside
   that scope. This decoupling is deliberate, not a bug — see the two
   paragraphs above.
-- **Audit records which gate authorized the read**, as a distinct
-  decision reason per branch of the flowchart above: `project_membership`,
-  `global_scope`, or `delegation` (exact string tokens are an
-  implementation detail, not a design axis — see "Out of scope" and (H)).
+- **Audit records which gate authorized (or denied) the read**, as a
+  distinct decision reason per branch of the flowchart above: allow —
+  `project_membership`, `global_scope`, `platform_scope`, `delegation`;
+  deny — `connect_disabled`, `unknown_connector`, `ref_not_permitted`,
+  `ownership_denied`, `delegation_denied`, `platform_permission_denied`,
+  `backend_error` (exact string tokens are an implementation detail, not a
+  design axis — see "Out of scope" and (H) for the full closed set and its
+  fixed `reason=<value>` format).
   A read authorized via the *permission-check* bypass (step 1/2 above)
   does not by itself change which ownership reason gets recorded — the
   reason names the gate that resolved ownership, not whether `connect.read`
@@ -607,11 +662,13 @@ Allow (`Success: true`):
 - `global_scope` — caller holds a role at the true global (`{0,0}`) scope,
   which wildcards every project-scoped connector (E), regardless of role
   name.
-- `platform_scope` — the connector itself is `scope: platform`; ownership
-  passes for any `connect.read` holder (branch 4's `connect.platform.use`
-  narrows this further, not yet implemented).
+- `platform_scope` — the connector itself is `scope: platform` and the
+  caller holds `connect.platform.use` (branch 4; checked at `Scope{}`,
+  global — a platform connector has no owning project to check a
+  project-scoped grant against).
 - `delegation` — caller had no ownership claim at all on the connector's
-  project, resolved instead via a matching `ConnectRefGrant` (F).
+  project, resolved instead via a matching `ConnectRefGrant` (F). Never
+  reached for a `scope: platform` connector — see below.
 
 Deny (`Success: false`):
 - `connect_disabled` — no `connect.Manager` configured at all.
@@ -619,10 +676,24 @@ Deny (`Success: false`):
 - `ref_not_permitted` — caller IS owned, but a `ConnectRefGrant` scoped to
   this connector exists and none of the caller's roles hold a grant
   matching the requested ref (ADR-045, unchanged).
-- `ownership_denied` — caller is NOT owned, and the connector has ZERO
-  `ConnectRefGrant`s configured at all — no delegation path exists.
-- `delegation_denied` — caller is NOT owned; the connector DOES have
-  `ConnectRefGrant`(s), but none matched this caller's roles/ref.
+- `ownership_denied` — caller is NOT owned (`scope: project`), and the
+  connector has ZERO `ConnectRefGrant`s configured at all — no delegation
+  path exists.
+- `delegation_denied` — caller is NOT owned (`scope: project`); the
+  connector DOES have `ConnectRefGrant`(s), but none matched this caller's
+  roles/ref.
+- `platform_permission_denied` — connector is `scope: platform` and the
+  caller lacks `connect.platform.use` (branch 4). **Terminal** — unlike
+  `ownership_denied`/`delegation_denied`, this reason never falls through
+  to a `ConnectRefGrant` delegation attempt; see (E)'s "TERMINAL deny" note
+  for the full reasoning (a delegation fallback here would be a
+  `connect.platform.use` bypass, not a narrowing — `ConnectRefGrant` has no
+  concept of connector `scope` at all). This fork between the two `scope`
+  values' deny handling is deliberate and permanent — do not "reconcile"
+  `platform_permission_denied` toward `ownership_denied`/
+  `delegation_denied`'s delegation-fallback behavior later; they are
+  answering structurally different questions (project membership vs. a
+  global capability grant for an install-wide resource).
 - `backend_error` — ownership (or delegation) was satisfied, but the
   upstream connector call itself failed (network, credentials, etc.); the
   raw upstream error is logged server-side only, never persisted into the

--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -207,12 +207,16 @@ func (c *KeyorixCore) writeAuditEventDiff(ctx context.Context, eventType string,
 	c.emitAudit(ctx, event)
 }
 
-// writeAuditEventFailed persists a failed audit event (Success=false).
-func (c *KeyorixCore) writeAuditEventFailed(ctx context.Context, eventType string, userID *uint, ip string, description string) {
+// writeAuditEventFailed persists a failed audit event (Success=false), with
+// project context — added for ADR-082 branch 3, whose Connect deny-path events
+// need both Success=false and a populated ProjectID (the connector's owning
+// project), which no prior helper supported simultaneously.
+func (c *KeyorixCore) writeAuditEventFailed(ctx context.Context, eventType string, userID *uint, projectID *uint, ip string, description string) {
 	f := false
 	event := &models.AuditEvent{
 		EventType:   eventType,
 		UserID:      userID,
+		ProjectID:   projectID,
 		IPAddress:   ip,
 		Description: sanitizeAuditText(description),
 		Success:     &f,
@@ -366,7 +370,7 @@ func (c *KeyorixCore) LogAuthLogin(ctx context.Context, userID uint, username, i
 
 // LogAuthFailure writes an auth.login_failed audit event (Success=false).
 func (c *KeyorixCore) LogAuthFailure(ctx context.Context, username, ip string) {
-	c.writeAuditEventFailed(ctx, "auth.login_failed", nil, ip,
+	c.writeAuditEventFailed(ctx, "auth.login_failed", nil, nil, ip,
 		fmt.Sprintf("Failed login attempt for username: %s", username))
 }
 

--- a/internal/core/audit_actor_type_test.go
+++ b/internal/core/audit_actor_type_test.go
@@ -61,7 +61,7 @@ func TestWriteAuditEventFailed_StampsActorTypeFromContext(t *testing.T) {
 	})).Return(nil)
 
 	ctx := WithActorType(context.Background(), ActorTypeSystem)
-	c.writeAuditEventFailed(ctx, "auth.login_failed", nil, "1.2.3.4", "x")
+	c.writeAuditEventFailed(ctx, "auth.login_failed", nil, nil, "1.2.3.4", "x")
 
 	store.AssertExpectations(t)
 	if got != ActorTypeSystem {

--- a/internal/core/auth_bootstrap.go
+++ b/internal/core/auth_bootstrap.go
@@ -83,6 +83,12 @@ var defaultPermissions = []bootstrapPermissionDef{
 	// explicitly bundled into their role.
 	{"system.write", "Manage audit checkpoints/alerts, legal holds, risk exceptions, SoD policies, and admin job triggers", "system", "write"},
 	{"connect.read", "Read secrets from external stores via Keyorix Connect (ADR-043)", "connect", "read"},
+	// ADR-082 branch 4: narrows scope: platform connector reads, which connect.read
+	// alone permitted for any holder through branch 3 (an interim fail-open, marked
+	// by a TODO). Distinct from connect.read (which still gates the whole Connect
+	// surface, project-scoped connectors included) — this only narrows the
+	// platform-scoped subset.
+	{"connect.platform.use", "Read secrets from platform-scoped Keyorix Connect connectors (ADR-082 §B/§H)", "connect", "platform.use"},
 }
 
 // adminPermissions lists the permission names granted to the admin role.
@@ -91,7 +97,7 @@ var adminPermissions = []string{
 	permUsersRead, "users.write", "users.delete",
 	permRolesRead, "roles.write", permRolesAssign,
 	permAuditRead, permSystemRead, "system.write",
-	"connect.read",
+	"connect.read", "connect.platform.use",
 }
 
 // editorPermissions lists the permission names granted to the editor role.

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -81,6 +81,40 @@ func TestBootstrapSeedsTwoTierRoleCatalog(t *testing.T) {
 	}
 }
 
+// TestBootstrapGrantsConnectPlatformUseToAdminRoles proves a fresh install's
+// seeded admin/system_admin roles hold connect.platform.use (ADR-082 branch 4)
+// via ordinary BootstrapSystem seeding — no reconcile pass needed on first
+// boot. Roles without connect.read at all (editor/viewer/etc.) must not hold
+// it either (least privilege — mirrors connect.read's own baseline).
+func TestBootstrapGrantsConnectPlatformUseToAdminRoles(t *testing.T) {
+	c, _ := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"admin", "system_admin"} {
+		role, err := c.storage.GetRoleByName(ctx, name)
+		require.NoError(t, err)
+		perms, err := c.storage.GetRolePermissions(ctx, role.ID)
+		require.NoError(t, err)
+		var has bool
+		for _, p := range perms {
+			if p.Name == "connect.platform.use" {
+				has = true
+			}
+		}
+		assert.Truef(t, has, "role %q must hold connect.platform.use on a fresh install", name)
+	}
+
+	for _, name := range []string{"editor", "viewer", "system_auditor", "system_viewer", "project_admin"} {
+		role, err := c.storage.GetRoleByName(ctx, name)
+		require.NoError(t, err)
+		perms, err := c.storage.GetRolePermissions(ctx, role.ID)
+		require.NoError(t, err)
+		for _, p := range perms {
+			assert.NotEqualf(t, "connect.platform.use", p.Name, "role %q must not hold connect.platform.use (least privilege — it doesn't hold connect.read either)", name)
+		}
+	}
+}
+
 // #227: system.write's catalog description must name its full real footprint —
 // audit checkpoints/alerts, legal holds, risk exceptions, SoD policies, and
 // admin job triggers — not just the legacy service-account/API-token routes

--- a/internal/core/compliance_digest.go
+++ b/internal/core/compliance_digest.go
@@ -127,7 +127,7 @@ func (c *KeyorixCore) SendComplianceDigest(ctx context.Context, actorID uint) (b
 	}
 	if !attempted {
 		log.Printf("compliance digest: notification channel(s) configured but none accepted the broadcast (e.g. email-only with no broadcast destination) — digest was NOT delivered")
-		c.writeAuditEventFailed(auditCtx, EventComplianceDigestSent, userID, "", "compliance digest broadcast attempted but no configured channel could accept it")
+		c.writeAuditEventFailed(auditCtx, EventComplianceDigestSent, userID, nil, "", "compliance digest broadcast attempted but no configured channel could accept it")
 		return false, nil
 	}
 	c.writeAuditEvent(auditCtx, EventComplianceDigestSent, userID, nil, "compliance digest broadcast to notification channels")

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -78,7 +78,18 @@ const (
 	// same opaque unknown-connector shape either way, so the audit trail is
 	// the only place an operator can learn which gate closed.
 	connectDenyReasonDelegationDenied = "delegation_denied"
-	connectDenyReasonBackendError     = "backend_error"
+	// connectDenyReasonPlatformPermissionDenied: connector is scope: platform,
+	// but the caller lacks connect.platform.use (ADR-082 branch 4). Deliberately
+	// terminal — does NOT fall through to ConnectRefGrant delegation the way a
+	// project-scope ownership miss does. See connectOwnershipSatisfied's
+	// platform branch and ADR-082 §H: ConnectRefGrant is keyed on role +
+	// connector name + ref-prefix alone, with no scope awareness, so treating it
+	// as a fallback here would let anyone able to create a grant against a
+	// platform connector's name bypass connect.platform.use for anyone else —
+	// that would be a bypass, not a narrowing. This fork is deliberate; do not
+	// "reconcile" it toward the project-scope delegation path later.
+	connectDenyReasonPlatformPermissionDenied = "platform_permission_denied"
+	connectDenyReasonBackendError             = "backend_error"
 	// connectAllowReasonDelegation: caller is not owned, but an explicit
 	// ConnectRefGrant covering their role and this ref allows the read
 	// (ADR-082 §F).
@@ -168,6 +179,21 @@ func (c *KeyorixCore) ConnectReadableConnectorNames(ctx context.Context, actorTy
 			readable = append(readable, name)
 			continue
 		}
+		if c.connectOwnership[name].Scope == "platform" {
+			// ADR-082 branch 4: a platform-scope caller who lacks connect.platform.use
+			// is a TERMINAL deny in ReadFederatedSecret — it never attempts
+			// ConnectRefGrant delegation for platform scope (see
+			// connectDenyReasonPlatformPermissionDenied's doc comment for why a
+			// delegation fallback there would be a bypass). Discovery must agree: the
+			// delegation-fallback branch below exists for project-scope connectors,
+			// where it's true that ReadFederatedSecret would also honor it — reaching
+			// it for a platform connector here would show a connector in ListConnectors
+			// that an actual read will always deny, the exact leak ADR-082 §E exists to
+			// prevent. (A ConnectRefGrant CAN currently be created against a platform
+			// connector's name regardless — that's dead configuration, not a live
+			// delegation path; see the issue filed alongside this branch.)
+			continue
+		}
 		// Not owned — a connector reachable only via an explicit ConnectRefGrant
 		// still belongs in discovery; ReadSecret still applies the ref-prefix match
 		// per-read. actorRoleIDs (not connectRefGrantDelegates) is the right check
@@ -203,12 +229,22 @@ func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType s
 		return false, "", nil
 	}
 	if owner.Scope == "platform" {
-		// TODO(ADR-082 branch 4): gate platform connectors on connect.platform.use,
-		// not connect.read alone. Every caller who reaches this function has
-		// already cleared connect.read (checked by the transport layer before
-		// ReadFederatedSecret/ConnectReadableConnectorNames is ever called), so this
-		// is a deliberate interim "any connect.read holder" pass-through, not an
-		// oversight.
+		// ADR-082 branch 4: platform connectors need connect.platform.use, not just
+		// connect.read (which the transport layer already enforced before this
+		// function was ever called, and which still gates the whole Connect surface
+		// — connect.read alone was only ever a fail-open interim for platform scope
+		// specifically, through branch 3). Checked at Scope{} (global), matching
+		// connect.read's own scope — a platform connector has no owning project to
+		// check against. A denial here is terminal, not a fall-through to
+		// ConnectRefGrant delegation — see connectDenyReasonPlatformPermissionDenied
+		// and ADR-082 §H for why.
+		allowed, err := c.AuthorizePrincipal(ctx, actorType, principalID, "connect.platform.use", Scope{})
+		if err != nil {
+			return false, "", fmt.Errorf("connect ownership: check connect.platform.use: %w", err)
+		}
+		if !allowed {
+			return false, "", nil
+		}
 		return true, ConnectOwnershipReasonPlatformScope, nil
 	}
 	// scope == "project": raw scope set, NOT GetReadableScopes (D) — the {0,0}
@@ -277,7 +313,8 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 		return "", err
 	}
 	var allowReason ConnectOwnershipReason
-	if owned {
+	switch {
+	case owned:
 		allowReason = ownReason
 		// Per-reference RBAC (ADR-045): once a connector has any ref-grant, the read
 		// is permitted only if one of the caller's roles holds a matching grant. A
@@ -294,8 +331,19 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 				fmt.Sprintf("federated read DENIED by per-reference policy: connector %q (%s) ref %q reason=%s", connectorName, conn.Type(), ref, connectDenyReasonRefNotPermitted))
 			return "", fmt.Errorf("ref %q %w %q", ref, ErrConnectRefNotPermitted, connectorName)
 		}
-	} else {
-		// Not owned — ConnectRefGrant is the explicit cross-project delegation path
+	case owner.Scope == "platform":
+		// ADR-082 branch 4: caller lacks connect.platform.use. TERMINAL — no
+		// ConnectRefGrant delegation attempt, deliberately (see
+		// connectDenyReasonPlatformPermissionDenied's doc comment). This is its own
+		// case, not folded into the not-owned/delegation branch below, precisely so
+		// it never reaches connectRefGrantDelegates.
+		c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, projectID, "",
+			fmt.Sprintf("federated read DENIED: connector %q (%s) ref %q reason=%s", connectorName, conn.Type(), ref, connectDenyReasonPlatformPermissionDenied))
+		return "", fmt.Errorf("%w %q", ErrConnectUnknownConnector, connectorName)
+	default:
+		// Not owned, project scope (or a connector absent from the ownership map
+		// entirely — the structural-invariant edge case, unchanged from before this
+		// branch) — ConnectRefGrant is the explicit cross-project delegation path
 		// (ADR-082 §F). connectRefGrantDelegates (unlike connectRefAllowed) treats
 		// "no grants configured" as "no delegation," not "allow": that shortcut only
 		// makes sense for an already-owned caller.

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -16,7 +16,8 @@ import (
 )
 
 // EventConnectSecretRead is audited on every federated read (success or failure is
-// distinguished by the description).
+// distinguished by Success and by the description's reason= token — see
+// ConnectOwnershipReason and the deny-path reason constants below).
 const EventConnectSecretRead = "connect.secret_read"
 
 // Per-reference grant management events (ADR-045).
@@ -24,6 +25,78 @@ const (
 	EventConnectRefGrantCreate = "connect.ref_grant_create"
 	EventConnectRefGrantDelete = "connect.ref_grant_delete"
 )
+
+// EventConnectorProjectBindingCreate is audited on every persisted
+// ConnectorProjectBinding write (ADR-082 branch 3, issue #1477's audit half) —
+// both the boot-time first-resolution write (server/main.go's
+// resolveConnectorOwnership) and the RemoteStorage proxy write
+// (server/http/handlers/connector_project_bindings_proxy.go's
+// CreateConnectorProjectBindingProxy). The binding is an authorization input
+// (it feeds connectOwnershipSatisfied) regardless of which door the write comes
+// through, so both call sites use the same event type.
+const EventConnectorProjectBindingCreate = "connect.project_binding_create" // #nosec G101 -- audit event type, not a credential
+
+// ConnectOwnershipReason and the deny-path reason values below form ONE closed
+// set (ADR-082 §E) that appears as a "reason=<value>" token at a fixed position
+// in every ReadFederatedSecret audit Description — allow and deny outcomes
+// alike. There is no structured column for this (AuditEvent has none, and
+// ADR-075's "closed key_source enum" describing one was never actually
+// implemented — see backlog issue filed alongside this branch), so the fixed
+// token format is what keeps this parseable, and what makes a future
+// structured column a parse-and-backfill rather than a rewrite.
+type ConnectOwnershipReason string
+
+const (
+	// ConnectOwnershipReasonProjectMembership: caller holds a role scoped to
+	// the connector's owning project specifically.
+	ConnectOwnershipReasonProjectMembership ConnectOwnershipReason = "project_membership"
+	// ConnectOwnershipReasonGlobalScope: caller holds a role at the true
+	// global ({0,0}) scope, which wildcards every project-scoped connector.
+	ConnectOwnershipReasonGlobalScope ConnectOwnershipReason = "global_scope"
+	// ConnectOwnershipReasonPlatformScope: the connector itself is
+	// platform-scoped (ADR-082 §B) — ownership passes for any connect.read
+	// holder, independent of the caller's role scopes (TODO ADR-082 branch 4:
+	// connect.platform.use narrows this).
+	ConnectOwnershipReasonPlatformScope ConnectOwnershipReason = "platform_scope"
+)
+
+// Deny-path reason values (ADR-082 §E), same closed set / same token
+// convention as ConnectOwnershipReason above, kept as plain strings rather
+// than folded into ConnectOwnershipReason since they describe a DENIAL, not an
+// ownership outcome connectOwnershipSatisfied itself produces.
+const (
+	connectDenyReasonDisabled         = "connect_disabled"
+	connectDenyReasonUnknownConnector = "unknown_connector"
+	connectDenyReasonRefNotPermitted  = "ref_not_permitted"
+	// connectDenyReasonOwnershipDenied: caller is not owned AND the connector
+	// has no ConnectRefGrant at all — no delegation path exists.
+	connectDenyReasonOwnershipDenied = "ownership_denied"
+	// connectDenyReasonDelegationDenied: caller is not owned; the connector
+	// DOES have ConnectRefGrant(s), but none matched this caller's roles/ref.
+	// Distinguishing this from connectDenyReasonOwnershipDenied is the reason
+	// this audit event exists at all (ADR-082): the HTTP/gRPC response is the
+	// same opaque unknown-connector shape either way, so the audit trail is
+	// the only place an operator can learn which gate closed.
+	connectDenyReasonDelegationDenied = "delegation_denied"
+	connectDenyReasonBackendError     = "backend_error"
+	// connectAllowReasonDelegation: caller is not owned, but an explicit
+	// ConnectRefGrant covering their role and this ref allows the read
+	// (ADR-082 §F).
+	connectAllowReasonDelegation = "delegation"
+)
+
+// connectAuditProjectID returns the connector's owning project for the audit
+// trail, or nil when the connector is platform-scoped (ADR-082: ProjectID is
+// meaningless there — see ConnectOwnership's own doc comment) or has no
+// ownership entry at all (e.g. an unknown connector, audited before any
+// ownership lookup is possible).
+func connectAuditProjectID(owner ConnectOwnership) *uint {
+	if owner.Scope != "project" || owner.ProjectID == 0 {
+		return nil
+	}
+	p := owner.ProjectID
+	return &p
+}
 
 // SetConnectManager wires the configured external-store connectors (ADR-043). nil
 // (the default) leaves Keyorix Connect disabled.
@@ -87,7 +160,7 @@ func (c *KeyorixCore) ConnectReadableConnectorNames(ctx context.Context, actorTy
 	}
 	var readable []string
 	for _, name := range c.connectManager.Names() {
-		owned, err := c.connectOwnershipSatisfied(ctx, actorType, principalID, name)
+		owned, _, err := c.connectOwnershipSatisfied(ctx, actorType, principalID, name)
 		if err != nil {
 			return nil, err
 		}
@@ -119,10 +192,15 @@ func (c *KeyorixCore) ConnectReadableConnectorNames(ctx context.Context, actorTy
 // structural invariant server/main.go's boot-time key-set check exists to
 // guarantee never happens in a correctly-booted server; this is the runtime
 // backstop).
-func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType string, principalID uint, connectorName string) (bool, error) {
+// The second return value names WHICH check satisfied ownership (meaningless
+// when the first return is false) — ADR-082 branch 3 needs this for the audit
+// trail's three-way allow reason. It is a named type, not a string, precisely
+// so the string formatting stays at the audit call site (ReadFederatedSecret),
+// not here: this function reports a fact, not a description.
+func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType string, principalID uint, connectorName string) (bool, ConnectOwnershipReason, error) {
 	owner, ok := c.connectOwnership[connectorName]
 	if !ok {
-		return false, nil
+		return false, "", nil
 	}
 	if owner.Scope == "platform" {
 		// TODO(ADR-082 branch 4): gate platform connectors on connect.platform.use,
@@ -131,7 +209,7 @@ func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType s
 		// ReadFederatedSecret/ConnectReadableConnectorNames is ever called), so this
 		// is a deliberate interim "any connect.read holder" pass-through, not an
 		// oversight.
-		return true, nil
+		return true, ConnectOwnershipReasonPlatformScope, nil
 	}
 	// scope == "project": raw scope set, NOT GetReadableScopes (D) — the {0,0}
 	// global entry must survive so the loop below can match it as the wildcard
@@ -144,14 +222,17 @@ func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType s
 		scopes, err = c.storage.GetUserRoleScopes(ctx, principalID)
 	}
 	if err != nil {
-		return false, fmt.Errorf("connect ownership: enumerate role scopes: %w", err)
+		return false, "", fmt.Errorf("connect ownership: enumerate role scopes: %w", err)
 	}
 	for _, sc := range scopes {
-		if sc.ProjectID == owner.ProjectID || sc.ProjectID == 0 {
-			return true, nil
+		if sc.ProjectID == owner.ProjectID {
+			return true, ConnectOwnershipReasonProjectMembership, nil
+		}
+		if sc.ProjectID == 0 {
+			return true, ConnectOwnershipReasonGlobalScope, nil
 		}
 	}
-	return false, nil
+	return false, "", nil
 }
 
 // ReadFederatedSecret proxies a read of ref from the named external-store connector
@@ -164,25 +245,40 @@ func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType s
 // function with an untagged context, not silently default to "user". The value is
 // returned to the caller and never persisted.
 func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string, principalID uint, connectorName, ref string) (string, error) {
+	ctx = WithActorType(ctx, actorType)
+	uid := principalID
+
 	if c.connectManager == nil {
+		c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, nil, "",
+			fmt.Sprintf("federated read DENIED: connect is disabled ref %q reason=%s", ref, connectDenyReasonDisabled))
 		return "", ErrConnectDisabled
 	}
 	conn, ok := c.connectManager.Get(connectorName)
 	if !ok {
+		c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, nil, "",
+			fmt.Sprintf("federated read DENIED: unknown connector %q ref %q reason=%s", connectorName, ref, connectDenyReasonUnknownConnector))
 		return "", fmt.Errorf("%w %q", ErrConnectUnknownConnector, connectorName)
 	}
-	ctx = WithActorType(ctx, actorType)
-	uid := principalID
+	// Every outcome below (allow or deny) is for a KNOWN connector, so its owning
+	// project (nil for platform scope) is the audit ProjectID throughout —
+	// resolved once here rather than per-branch. This is a direct map read on the
+	// SAME connectOwnership data connectOwnershipSatisfied consults below, not a
+	// second authorization decision.
+	owner := c.connectOwnership[connectorName]
+	projectID := connectAuditProjectID(owner)
 
 	// ADR-082 §E authorization order: connect.read (enforced by the transport layer
 	// before this function is ever called) → ownership → ConnectRefGrant delegation
-	// → deny. No audit call on either branch below — audit is branch 3 (ADR-082);
-	// this branch's denials are deliberately unaudited, same as ADR-082 itself notes.
-	owned, err := c.connectOwnershipSatisfied(ctx, actorType, principalID, connectorName)
+	// → deny. Every branch below is now audited (ADR-082 branch 3) — the deny
+	// branches were deliberately unaudited through branch 2; that gap is what this
+	// branch closes.
+	owned, ownReason, err := c.connectOwnershipSatisfied(ctx, actorType, principalID, connectorName)
 	if err != nil {
 		return "", err
 	}
+	var allowReason ConnectOwnershipReason
 	if owned {
+		allowReason = ownReason
 		// Per-reference RBAC (ADR-045): once a connector has any ref-grant, the read
 		// is permitted only if one of the caller's roles holds a matching grant. A
 		// connector with no grants is governed solely by connect.read + allowed_refs
@@ -194,8 +290,8 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 			return "", err
 		}
 		if !allowed {
-			c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
-				fmt.Sprintf("federated read DENIED by per-reference policy: connector %q (%s) ref %q", connectorName, conn.Type(), ref))
+			c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, projectID, "",
+				fmt.Sprintf("federated read DENIED by per-reference policy: connector %q (%s) ref %q reason=%s", connectorName, conn.Type(), ref, connectDenyReasonRefNotPermitted))
 			return "", fmt.Errorf("ref %q %w %q", ref, ErrConnectRefNotPermitted, connectorName)
 		}
 	} else {
@@ -203,17 +299,26 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 		// (ADR-082 §F). connectRefGrantDelegates (unlike connectRefAllowed) treats
 		// "no grants configured" as "no delegation," not "allow": that shortcut only
 		// makes sense for an already-owned caller.
-		delegated, err := c.connectRefGrantDelegates(ctx, actorType, principalID, connectorName, ref)
+		delegated, hasGrants, err := c.connectRefGrantDelegates(ctx, actorType, principalID, connectorName, ref)
 		if err != nil {
 			return "", err
 		}
 		if !delegated {
 			// Ownership denied and no delegation grant: reuse the unknown-connector
-			// shape (ADR-082) — do not confirm this connector's existence to a caller
-			// who cannot reach it. ListConnectors already omits it from discovery;
-			// this keeps the single-connector read path consistent with that.
+			// shape in the RETURNED ERROR (ADR-082) — do not confirm this connector's
+			// existence to a caller who cannot reach it. The audit event is the only
+			// place the real reason is recorded; it distinguishes "no grants at all"
+			// from "grants exist, none matched" (the two denial reasons ADR-082
+			// branch 3 requires), which the opaque response deliberately does not.
+			reason := connectDenyReasonOwnershipDenied
+			if hasGrants {
+				reason = connectDenyReasonDelegationDenied
+			}
+			c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, projectID, "",
+				fmt.Sprintf("federated read DENIED: connector %q (%s) ref %q reason=%s", connectorName, conn.Type(), ref, reason))
 			return "", fmt.Errorf("%w %q", ErrConnectUnknownConnector, connectorName)
 		}
+		allowReason = connectAllowReasonDelegation
 	}
 
 	value, err := conn.GetSecret(ctx, ref)
@@ -225,12 +330,12 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 		// HTTP layer separately applies clientSafe()/isSafeConnectError to what it
 		// returns to the caller.
 		log.Printf("federated read failed via connector %q (%s) ref %q: %v", connectorName, conn.Type(), ref, err)
-		c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
-			fmt.Sprintf("federated read FAILED via connector %q (%s) ref %q: an internal error occurred; see server logs", connectorName, conn.Type(), ref))
+		c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, projectID, "",
+			fmt.Sprintf("federated read FAILED via connector %q (%s) ref %q: an internal error occurred; see server logs reason=%s", connectorName, conn.Type(), ref, connectDenyReasonBackendError))
 		return "", err
 	}
-	c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
-		fmt.Sprintf("federated read via connector %q (%s) ref %q", connectorName, conn.Type(), ref))
+	c.writeAuditEventFull(ctx, EventConnectSecretRead, &uid, nil, projectID, "",
+		fmt.Sprintf("federated read via connector %q (%s) ref %q reason=%s", connectorName, conn.Type(), ref, allowReason))
 	return value, nil
 }
 
@@ -266,18 +371,32 @@ func (c *KeyorixCore) CreateConnectRefGrant(ctx context.Context, actorID, roleID
 		return nil, err
 	}
 	uid := actorID
-	c.writeAuditEvent(ctx, EventConnectRefGrantCreate, &uid, nil,
+	c.writeAuditEventFull(ctx, EventConnectRefGrantCreate, &uid, nil, connectAuditProjectID(c.connectOwnership[connectorName]), "",
 		fmt.Sprintf("connect ref-grant: role %d may read ref-prefix %q on connector %q", roleID, refPrefix, connectorName))
 	return g, nil
 }
 
 // DeleteConnectRefGrant removes a per-reference grant by id. Audited.
 func (c *KeyorixCore) DeleteConnectRefGrant(ctx context.Context, actorID, id uint) error {
+	// Best-effort lookup of the grant's connector (for the audit ProjectID) BEFORE
+	// deleting — the storage interface has no fetch-by-id or delete-returning-row
+	// primitive, and adding one is out of scope here (ADR-082 branch 3 must not
+	// change ConnectRefGrant's own storage shape). If this lookup fails or finds
+	// nothing, the event is still written, just without a ProjectID.
+	var projectID *uint
+	if grants, gerr := c.storage.ListConnectRefGrants(ctx); gerr == nil {
+		for _, g := range grants {
+			if g.ID == id {
+				projectID = connectAuditProjectID(c.connectOwnership[g.Connector])
+				break
+			}
+		}
+	}
 	if err := c.storage.DeleteConnectRefGrant(ctx, id); err != nil {
 		return err
 	}
 	uid := actorID
-	c.writeAuditEvent(ctx, EventConnectRefGrantDelete, &uid, nil,
+	c.writeAuditEventFull(ctx, EventConnectRefGrantDelete, &uid, nil, projectID, "",
 		fmt.Sprintf("connect ref-grant %d deleted", id))
 	return nil
 }
@@ -322,25 +441,30 @@ func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorType string, p
 // ConnectRefGrant's own schema, matching rules (refMatches), and expiry logic
 // (connectGrantActive) are unchanged (ADR-082) — only which caller populations
 // reach this delegation check is new.
-func (c *KeyorixCore) connectRefGrantDelegates(ctx context.Context, actorType string, principalID uint, connectorName, ref string) (bool, error) {
+// The second return value reports whether the connector had ANY ConnectRefGrant
+// configured at all (regardless of whether one matched) — ADR-082 branch 3
+// needs this to distinguish the audit trail's two deny reasons
+// (connectDenyReasonOwnershipDenied vs connectDenyReasonDelegationDenied),
+// which a bare "delegated bool" cannot.
+func (c *KeyorixCore) connectRefGrantDelegates(ctx context.Context, actorType string, principalID uint, connectorName, ref string) (bool, bool, error) {
 	grants, err := c.storage.ListConnectRefGrantsByConnector(ctx, connectorName)
 	if err != nil {
-		return false, fmt.Errorf("connect ref-grant lookup: %w", err)
+		return false, false, fmt.Errorf("connect ref-grant lookup: %w", err)
 	}
 	if len(grants) == 0 {
-		return false, nil // no delegation grant configured — no delegation path
+		return false, false, nil // no delegation grant configured — no delegation path
 	}
 	roleSet, err := c.actorRoleIDs(ctx, actorType, principalID)
 	if err != nil {
-		return false, err
+		return false, true, err
 	}
 	now := time.Now()
 	for _, g := range grants {
 		if roleSet[g.RoleID] && connectGrantActive(g, now) && refMatches(g.RefPrefix, ref) {
-			return true, nil
+			return true, true, nil
 		}
 	}
-	return false, nil
+	return false, true, nil
 }
 
 // connectorHasAnyDelegationForActor reports whether principalID holds a role with

--- a/internal/core/connect_audit_reason_test.go
+++ b/internal/core/connect_audit_reason_test.go
@@ -1,0 +1,233 @@
+// connect_audit_reason_test.go — ADR-082 branch 3: asserts the exact
+// "reason=<value>" token ReadFederatedSecret's audit Description carries for
+// every allow and deny outcome, plus Success and ProjectID population. The
+// fixed token format (documented in ADR-082 §E) is what lets a future
+// structured column be a parse-and-backfill rather than a rewrite, so these
+// tests pin the literal values, not just "an event was written."
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// lastConnectSecretReadEvent returns the most recently written
+// connect.secret_read audit row.
+func lastConnectSecretReadEvent(t *testing.T, db *gorm.DB) models.AuditEvent {
+	t.Helper()
+	var event models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventConnectSecretRead).Order("id DESC").First(&event).Error)
+	return event
+}
+
+// TestReadFederatedSecret_AuditReasons_Allow covers the three allow reasons
+// (ADR-082 §E: project_membership, global_scope, platform_scope) plus
+// delegation (§F) — each must produce Success=true, the exact reason= token,
+// and a ProjectID matching the connector's OWNING project (nil for a
+// platform-scoped connector, per ConnectOwnership's own doc comment).
+func TestReadFederatedSecret_AuditReasons_Allow(t *testing.T) {
+	t.Run("project_membership", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+		seedRoleForUserAtProject(t, db, 1, 10, "project-member", 42)
+
+		val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
+		require.NoError(t, err)
+		assert.Equal(t, "v", val)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.True(t, *event.Success)
+		require.NotNil(t, event.ProjectID)
+		assert.EqualValues(t, 42, *event.ProjectID)
+		assert.Contains(t, event.Description, "reason=project_membership")
+	})
+
+	t.Run("global_scope", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+		seedRoleForUser(t, db, 2, 20, "global-role")
+
+		val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 2, "aws", "ref")
+		require.NoError(t, err)
+		assert.Equal(t, "v", val)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.True(t, *event.Success)
+		require.NotNil(t, event.ProjectID)
+		assert.EqualValues(t, 42, *event.ProjectID)
+		assert.Contains(t, event.Description, "reason=global_scope")
+	})
+
+	t.Run("platform_scope", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+
+		val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
+		require.NoError(t, err)
+		assert.Equal(t, "v", val)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.True(t, *event.Success)
+		assert.Nil(t, event.ProjectID, "a platform-scoped connector's ProjectID is meaningless and must not be audited as a real project")
+		assert.Contains(t, event.Description, "reason=platform_scope")
+	})
+
+	t.Run("delegation", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+		seedRoleForUserAtProject(t, db, 5, 30, "borrower", 99) // NOT owner (different project)
+		seedGrant(t, c, 30, "aws", "prod/")
+
+		val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 5, "aws", "prod/db")
+		require.NoError(t, err)
+		assert.Equal(t, "v", val)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.True(t, *event.Success)
+		require.NotNil(t, event.ProjectID, "delegation still audits the connector's OWNING project, not the caller's")
+		assert.EqualValues(t, 42, *event.ProjectID)
+		assert.Contains(t, event.Description, "reason=delegation")
+	})
+}
+
+// TestReadFederatedSecret_AuditReasons_Deny covers every deny path (ADR-082
+// branch 3): all must be Success=false, and each must carry its own distinct
+// reason= token — ownership_denied and delegation_denied in particular are
+// the ONLY place these two outcomes are distinguishable at all, since both
+// return the identical opaque unknown-connector error to the caller.
+func TestReadFederatedSecret_AuditReasons_Deny(t *testing.T) {
+	t.Run("connect_disabled", func(t *testing.T) {
+		ms := new(MockStorage)
+		var got *models.AuditEvent
+		ms.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+			got = e
+			return true
+		})).Return(nil)
+		c := &KeyorixCore{storage: ms}
+
+		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrConnectDisabled)
+
+		require.NotNil(t, got)
+		require.NotNil(t, got.Success)
+		assert.False(t, *got.Success)
+		assert.Nil(t, got.ProjectID)
+		assert.Contains(t, got.Description, "reason=connect_disabled")
+	})
+
+	t.Run("unknown_connector", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "nope", "ref")
+		require.Error(t, err)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.False(t, *event.Success)
+		assert.Nil(t, event.ProjectID)
+		assert.Contains(t, event.Description, "reason=unknown_connector")
+	})
+
+	t.Run("ref_not_permitted", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+		seedRoleForUserAtProject(t, db, 1, 10, "project-member", 42)
+		seedGrant(t, c, 10, "aws", "prod/") // scopes the connector to prod/ only
+
+		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "dev/db")
+		require.Error(t, err)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.False(t, *event.Success)
+		require.NotNil(t, event.ProjectID)
+		assert.EqualValues(t, 42, *event.ProjectID)
+		assert.Contains(t, event.Description, "reason=ref_not_permitted")
+	})
+
+	t.Run("ownership_denied_no_grants_at_all", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+		seedRoleForUserAtProject(t, db, 6, 31, "not-owner", 99) // different project, no grant seeded
+
+		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 6, "aws", "ref")
+		require.Error(t, err)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.False(t, *event.Success)
+		require.NotNil(t, event.ProjectID)
+		assert.EqualValues(t, 42, *event.ProjectID)
+		assert.Contains(t, event.Description, "reason=ownership_denied")
+	})
+
+	t.Run("delegation_denied_grants_exist_but_no_match", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+		seedRoleForUserAtProject(t, db, 5, 30, "borrower", 99) // not owner
+		seedGrant(t, c, 30, "aws", "prod/")                    // a grant exists...
+
+		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 5, "aws", "dev/db") // ...but ref is outside it
+		require.Error(t, err)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.False(t, *event.Success)
+		require.NotNil(t, event.ProjectID)
+		assert.EqualValues(t, 42, *event.ProjectID)
+		assert.Contains(t, event.Description, "reason=delegation_denied")
+	})
+
+	t.Run("backend_error", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", err: assert.AnError})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+
+		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "shared-vault", "ref")
+		require.Error(t, err)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.False(t, *event.Success)
+		assert.Contains(t, event.Description, "reason=backend_error")
+	})
+}
+
+// TestReadFederatedSecret_OwnershipDenialProducesAuditEventDespiteOpaqueHTTPShape
+// proves the exact property ADR-082 branch 3 exists for: the RETURNED ERROR is
+// identical (ErrConnectUnknownConnector) for an ownership denial and a
+// genuinely unknown connector — but the audit trail still records which one
+// actually happened, distinctly and correctly.
+func TestReadFederatedSecret_OwnershipDenialProducesAuditEventDespiteOpaqueHTTPShape(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+	seedRoleForUserAtProject(t, db, 6, 31, "not-owner", 99)
+
+	_, ownershipDenialErr := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 6, "aws", "ref")
+	require.Error(t, ownershipDenialErr)
+	require.ErrorIs(t, ownershipDenialErr, ErrConnectUnknownConnector)
+
+	_, unknownConnectorErr := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 6, "does-not-exist", "ref")
+	require.Error(t, unknownConnectorErr)
+	require.ErrorIs(t, unknownConnectorErr, ErrConnectUnknownConnector)
+
+	// The two errors are indistinguishable to the caller...
+	assert.ErrorIs(t, ownershipDenialErr, ErrConnectUnknownConnector)
+	assert.ErrorIs(t, unknownConnectorErr, ErrConnectUnknownConnector)
+
+	// ...but the audit trail is not: two distinct events, with distinct reasons.
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventConnectSecretRead).Order("id ASC").Find(&events).Error)
+	require.Len(t, events, 2)
+	assert.Contains(t, events[0].Description, "reason=ownership_denied")
+	assert.Contains(t, events[1].Description, "reason=unknown_connector")
+}

--- a/internal/core/connect_audit_reason_test.go
+++ b/internal/core/connect_audit_reason_test.go
@@ -69,6 +69,8 @@ func TestReadFederatedSecret_AuditReasons_Allow(t *testing.T) {
 	t.Run("platform_scope", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "v"})
 		c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+		seedRoleForUser(t, db, 999, 50, "platform-caller")
+		seedConnectPlatformUsePermission(t, db, 50) // ADR-082 branch 4: platform scope now requires this
 
 		val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
 		require.NoError(t, err)
@@ -191,6 +193,8 @@ func TestReadFederatedSecret_AuditReasons_Deny(t *testing.T) {
 	t.Run("backend_error", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", err: assert.AnError})
 		c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+		seedRoleForUser(t, db, 1, 50, "platform-caller")
+		seedConnectPlatformUsePermission(t, db, 50) // ADR-082 branch 4: must clear the platform gate to reach the backend call and fail there instead
 
 		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "shared-vault", "ref")
 		require.Error(t, err)

--- a/internal/core/connect_ownership_test.go
+++ b/internal/core/connect_ownership_test.go
@@ -101,16 +101,32 @@ func TestConnectOwnership_ReadFederatedSecret(t *testing.T) {
 	}
 }
 
-// TestConnectOwnership_PlatformConnectorAnyCaller proves a platform-scoped
-// connector passes ownership for any caller in THIS branch — TODO(ADR-082 branch
-// 4) is the connect.platform.use gate; until then any connect.read holder (the
-// transport layer's job, not this function's) reaches it, even with zero roles.
-func TestConnectOwnership_PlatformConnectorAnyCaller(t *testing.T) {
+// TestConnectOwnership_PlatformConnectorRequiresPlatformUse supersedes the
+// pre-branch-4 "any connect.read holder reaches it" behavior this test used to
+// assert (its own prior docstring named this as the TODO(ADR-082 branch 4) gap
+// explicitly). Now: a caller with zero roles — including no connect.platform.use
+// — is denied, terminally (no ConnectRefGrant delegation fallback; see
+// connectDenyReasonPlatformPermissionDenied).
+func TestConnectOwnership_PlatformConnectorRequiresPlatformUse(t *testing.T) {
 	c, _ := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "shared-secret"})
 	c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
 
-	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
-	require.NoError(t, err, "a platform-scoped connector must pass ownership for any caller in this branch")
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
+	require.Error(t, err, "a platform-scoped connector must now deny a caller with no connect.platform.use grant")
+	assert.ErrorIs(t, err, ErrConnectUnknownConnector, "the denial must reuse the opaque unknown-connector shape (ADR-082)")
+}
+
+// TestConnectOwnership_PlatformConnectorAllowsHolderOfPlatformUse is the allow
+// counterpart: a caller who DOES hold connect.platform.use reaches the platform
+// connector, same as any other allow path.
+func TestConnectOwnership_PlatformConnectorAllowsHolderOfPlatformUse(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "shared-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+	seedRoleForUser(t, db, 1, 10, "platform-caller")
+	seedConnectPlatformUsePermission(t, db, 10)
+
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "shared-vault", "ref")
+	require.NoError(t, err)
 	assert.Equal(t, "shared-secret", val)
 }
 
@@ -256,6 +272,41 @@ func TestConnectReadableConnectorNames_GlobalScopedCallerSeesAll(t *testing.T) {
 	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 2)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"aws-payments", "aws-billing"}, names, "a global-scoped caller must see every project-scoped connector via the {0,0} wildcard")
+}
+
+// TestConnectReadableConnectorNames_PlatformFilteredWithoutPlatformUse proves
+// ListConnectors filtering (ADR-082 branch 4) via the SAME per-connector filter
+// ReadFederatedSecret uses (connectOwnershipSatisfied) — no separate branch: a
+// caller lacking connect.platform.use sees a platform connector disappear from
+// discovery, exactly like ReadFederatedSecret would deny an actual read of it.
+func TestConnectReadableConnectorNames_PlatformFilteredWithoutPlatformUse(t *testing.T) {
+	c, db := connectRBACCore(t,
+		fakeConnector{name: "shared-vault", val: "v1"},
+		fakeConnector{name: "aws-payments", val: "v2"},
+	)
+	c.SetConnectOwnership(map[string]ConnectOwnership{
+		"shared-vault": {Scope: "platform"},
+		"aws-payments": {Scope: "project", ProjectID: 42},
+	})
+	seedRoleForUserAtProject(t, db, 1, 10, "payments-member", 42) // no connect.platform.use
+
+	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"aws-payments"}, names, "the platform connector must be filtered out without connect.platform.use, even though the project connector (a genuine ownership match) is still visible")
+}
+
+// TestConnectReadableConnectorNames_PlatformVisibleWithPlatformUse is the allow
+// counterpart: a caller holding connect.platform.use sees the platform
+// connector in discovery too.
+func TestConnectReadableConnectorNames_PlatformVisibleWithPlatformUse(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "v1"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+	seedRoleForUser(t, db, 1, 10, "platform-caller")
+	seedConnectPlatformUsePermission(t, db, 10)
+
+	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"shared-vault"}, names)
 }
 
 // seedRoleForUserAtProject mirrors seedRoleForUser (connect_rbac_test.go) but

--- a/internal/core/connect_rbac_admin_test.go
+++ b/internal/core/connect_rbac_admin_test.go
@@ -21,6 +21,10 @@ func TestConnectRefRBAC_NoAdminBypass(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 
 	// User 1 is a GLOBAL super_admin — the role that bypasses core RBAC.
+	// ADR-082 branch 4: no explicit connect.platform.use grant is needed here —
+	// super_admin's role-NAME bypass (roleSetContainsAdmin) satisfies ANY
+	// permission check, this new one included, exactly like the connect.read
+	// precondition check just below already demonstrates.
 	seedRoleForUser(t, db, 1, 1, "super_admin")
 	// The connector is ref-scoped, but only for a DIFFERENT role (reader = role 2).
 	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "reader"}).Error)

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -32,6 +32,7 @@ func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *g
 		&models.ConnectRefGrant{}, &models.AuditEvent{},
 		&models.Project{}, &models.Environment{},
 		&models.ConnectorProjectBinding{},
+		&models.Permission{}, &models.RolePermission{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	if len(conns) > 0 {
@@ -51,6 +52,21 @@ func seedRoleForUser(t *testing.T, db *gorm.DB, userID, roleID uint, name string
 	require.NoError(t, db.Create(&models.UserRole{UserID: userID, RoleID: roleID}).Error)
 }
 
+// seedConnectPlatformUsePermission grants roleID the connect.platform.use
+// permission (ADR-082 branch 4). Every connectRBACCore-based test defaults its
+// connectors to scope: platform, and a platform-scope read now requires this
+// permission — call this wherever a test's role is meant to actually reach a
+// platform connector (i.e. it is exercising something OTHER than the
+// platform-permission gate itself, such as ADR-045 ref-grant behavior). Each
+// test gets its own in-memory DB (connectRBACCore), so there's no cross-test
+// collision creating the same permission name twice.
+func seedConnectPlatformUsePermission(t *testing.T, db *gorm.DB, roleID uint) {
+	t.Helper()
+	perm := models.Permission{Name: "connect.platform.use", Description: "test", Resource: "connect", Action: "platform.use"}
+	require.NoError(t, db.Create(&perm).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: roleID, PermissionID: perm.ID}).Error)
+}
+
 func seedGrant(t *testing.T, c *KeyorixCore, roleID uint, connector, prefix string) {
 	t.Helper()
 	_, err := c.storage.CreateConnectRefGrant(context.Background(), &models.ConnectRefGrant{RoleID: roleID, Connector: connector, RefPrefix: prefix})
@@ -68,6 +84,7 @@ func seedGrantExpiring(t *testing.T, c *KeyorixCore, roleID uint, connector, pre
 func TestConnectRefRBAC_NoGrantsAllows(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045, not the platform gate
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "anything/at/all")
 	require.NoError(t, err)
 	assert.Equal(t, "v", val)
@@ -78,6 +95,7 @@ func TestConnectRefRBAC_NoGrantsAllows(t *testing.T) {
 func TestConnectRefRBAC_PrefixScopes(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "metrics-reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045, not the platform gate
 	seedGrant(t, c, 5, "aws", "metrics/")
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
@@ -94,7 +112,8 @@ func TestConnectRefRBAC_PrefixScopes(t *testing.T) {
 func TestConnectRefRBAC_RoleMismatchDenied(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "reader")
-	seedGrant(t, c, 9, "aws", "metrics/") // granted to role 9, not the user's role 5
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: role 5 must reach the ref-grant check to prove the ROLE mismatch, not the platform gate, is what denies it
+	seedGrant(t, c, 9, "aws", "metrics/")      // granted to role 9, not the user's role 5
 
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
 	require.Error(t, err)
@@ -105,6 +124,7 @@ func TestConnectRefRBAC_RoleMismatchDenied(t *testing.T) {
 func TestConnectRefRBAC_EmptyPrefixAllowsAll(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "broad-reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045, not the platform gate
 	seedGrant(t, c, 5, "aws", "")
 
 	for _, ref := range []string{"metrics/x", "db/y", "anything"} {
@@ -121,7 +141,8 @@ func TestConnectRefRBAC_OtherConnectorUnaffected(t *testing.T) {
 		fakeConnector{name: "gcp", val: "g"},
 	)
 	seedRoleForUser(t, db, 1, 5, "reader")
-	seedGrant(t, c, 5, "aws", "metrics/") // scopes aws only
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045, not the platform gate — covers both connectors, gcp included
+	seedGrant(t, c, 5, "aws", "metrics/")      // scopes aws only
 
 	// gcp has no grants → unaffected.
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "gcp", "projects/p/secrets/x/versions/latest")
@@ -140,7 +161,8 @@ func TestConnectRefRBAC_MultiRoleUnion(t *testing.T) {
 	require.NoError(t, db.Create(&models.Role{ID: 6, Name: "db"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 5}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 6}).Error)
-	seedGrant(t, c, 6, "aws", "db/") // only the db role grants db/
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045 role-union matching, not the platform gate — either held role suffices for platform.use
+	seedGrant(t, c, 6, "aws", "db/")           // only the db role grants db/
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "db/password")
 	require.NoError(t, err)
@@ -153,6 +175,7 @@ func TestConnectRefRBAC_MachineIdentityRoles(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	require.NoError(t, db.Create(&models.Role{ID: 7, Name: "ci-metrics"}).Error)
 	require.NoError(t, db.Create(&models.MachineIdentityRole{MachineIdentityID: 42, RoleID: 7}).Error)
+	seedConnectPlatformUsePermission(t, db, 7) // ADR-082 branch 4: this test is about ADR-045, not the platform gate
 	seedGrant(t, c, 7, "aws", "metrics/")
 	ctx := context.Background()
 
@@ -166,10 +189,15 @@ func TestConnectRefRBAC_MachineIdentityRoles(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not permitted")
 
-	// A different machine with no matching role → denied (deny-by-default).
+	// A different machine holds NO role at all — including no connect.platform.use —
+	// so it is now denied at the platform-permission gate itself (ADR-082 branch 4),
+	// before ever reaching the per-ref grant check this test otherwise exercises. It
+	// is still "deny-by-default", just via an earlier gate than the sibling assertion
+	// above; the opaque unknown-connector shape is deliberate (ADR-082 §H), so this
+	// no longer asserts "not permitted" specifically.
 	_, err = c.ReadFederatedSecret(ctx, ActorTypeMachine, 99, "aws", "metrics/qps")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not permitted")
+	assert.ErrorIs(t, err, ErrConnectUnknownConnector)
 }
 
 // A grant for a role the caller holds only VIA GROUP MEMBERSHIP must authorize them —
@@ -183,6 +211,7 @@ func TestConnectRefRBAC_GroupDerivedRole(t *testing.T) {
 	require.NoError(t, db.Create(&models.Group{ID: 3, Name: "analytics"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 1, GroupID: 3}).Error)
 	require.NoError(t, db.Create(&models.GroupRole{GroupID: 3, RoleID: 5}).Error)
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045 group-derived role resolution, not the platform gate — scopedRoleIDs unions group-derived roles the same way for both checks
 	seedGrant(t, c, 5, "aws", "metrics/")
 
 	// The user reaches the grant through their group-derived role.
@@ -200,7 +229,8 @@ func TestConnectRefRBAC_GroupDerivedRole(t *testing.T) {
 func TestConnectRefRBAC_GlobPatterns(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "reader")
-	seedGrant(t, c, 5, "aws", "prod/*/db") // exactly one segment between prod/ and /db
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045 glob matching, not the platform gate
+	seedGrant(t, c, 5, "aws", "prod/*/db")     // exactly one segment between prod/ and /db
 	ctx := context.Background()
 
 	val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/eu/db")
@@ -250,6 +280,7 @@ func TestRefMatches(t *testing.T) {
 func TestConnectRefRBAC_CrossTenantTraversalDenied(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "vault", val: "myapp-secret"})
 	seedRoleForUser(t, db, 1, 5, "myapp-reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045/#326 traversal handling, not the platform gate
 	seedGrant(t, c, 5, "vault", "secret/data/myapp/")
 	ctx := context.Background()
 
@@ -270,6 +301,7 @@ func TestConnectRefRBAC_CrossTenantTraversalDenied(t *testing.T) {
 func TestConnectRefRBAC_ExpiredGrantDenied(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "temp-reader")
+	seedConnectPlatformUsePermission(t, db, 5)                                  // ADR-082 branch 4: this test is about ADR-045 grant expiry, not the platform gate
 	seedGrantExpiring(t, c, 5, "aws", "metrics/", time.Now().Add(-time.Minute)) // already expired
 	ctx := context.Background()
 
@@ -286,6 +318,7 @@ func TestConnectRefRBAC_ExpiredGrantDenied(t *testing.T) {
 func TestConnectRefRBAC_UnexpiredGrantAllowed(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "temp-reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045 grant expiry, not the platform gate
 	seedGrantExpiring(t, c, 5, "aws", "metrics/", time.Now().Add(time.Hour))
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
@@ -294,6 +327,9 @@ func TestConnectRefRBAC_UnexpiredGrantAllowed(t *testing.T) {
 }
 
 // CreateConnectRefGrant plumbs an optional expiresAt through to the persisted grant.
+// ADR-082 branch 4: unaffected by the connect.platform.use gate — this test never
+// calls ReadFederatedSecret/connectOwnershipSatisfied at all, only the grant-
+// management path.
 func TestCreateConnectRefGrant_PersistsExpiresAt(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	require.NoError(t, db.Create(&models.Role{ID: 5, Name: "temp-reader"}).Error)
@@ -324,6 +360,17 @@ func TestConnectRefRBAC_MachineIdentityProjectScopedRole(t *testing.T) {
 	// Granted to the machine ONLY at project 10 — deliberately no global grant.
 	require.NoError(t, db.Create(&models.MachineIdentityRole{MachineIdentityID: 42, RoleID: 7, ProjectID: 10}).Error)
 	seedGrant(t, c, 7, "aws", "metrics/")
+	// ADR-082 branch 4: connect.platform.use is checked at Scope{} (global) —
+	// intentionally: a platform connector is install-wide, so a purely
+	// project-scoped grant of the permission (like role 7 above, deliberately) is
+	// a category error and correctly does NOT satisfy it. This test's whole point
+	// is proving role 7's PROJECT-scoped grant is honoured for the ref-grant
+	// check specifically, so platform.use is granted here via a SEPARATE role
+	// held at the true global scope, decoupled from role 7 — not by making role 7
+	// global, which would defeat the test.
+	require.NoError(t, db.Create(&models.Role{ID: 21, Name: "platform-access"}).Error)
+	require.NoError(t, db.Create(&models.MachineIdentityRole{MachineIdentityID: 42, RoleID: 21}).Error)
+	seedConnectPlatformUsePermission(t, db, 21)
 	ctx := context.Background()
 
 	val, err := c.ReadFederatedSecret(ctx, ActorTypeMachine, 42, "aws", "metrics/qps")
@@ -338,6 +385,8 @@ func TestConnectRefRBAC_MachineIdentityProjectScopedRole(t *testing.T) {
 // actorRoleIDs (G33's detection_idea): a machine identity's project-scoped role
 // grant must resolve into the SAME role-ID set as an equivalent human user
 // holding the identical role at the identical project scope.
+// ADR-082 branch 4: unaffected — calls actorRoleIDs directly, never reaching
+// connectOwnershipSatisfied/the platform gate.
 func TestActorRoleIDs_MachineMatchesEquivalentUser_ProjectScoped(t *testing.T) {
 	c, db := connectRBACCore(t)
 	require.NoError(t, db.Create(&models.Project{ID: 10, Name: "proj-a"}).Error)
@@ -355,6 +404,8 @@ func TestActorRoleIDs_MachineMatchesEquivalentUser_ProjectScoped(t *testing.T) {
 	assert.Equal(t, userRoles, machineRoles, "a machine identity holding the same project-scoped role as a human user must resolve to an identical role-ID set")
 }
 
+// ADR-082 branch 4: unaffected — calls connectRefAllowed directly, never
+// reaching connectOwnershipSatisfied/the platform gate.
 func TestConnectRefAllowed_Direct(t *testing.T) {
 	c, db := connectRBACCore(t)
 	seedRoleForUser(t, db, 1, 5, "reader")

--- a/internal/core/connect_ref_prefix_boundary_test.go
+++ b/internal/core/connect_ref_prefix_boundary_test.go
@@ -56,7 +56,8 @@ func TestConnectRefRBAC_SegmentBoundaryEnforced(t *testing.T) {
 	t.Run("bare prefix does not leak into the sibling namespace", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 		seedRoleForUser(t, db, 1, 5, "prod-reader")
-		seedGrant(t, c, 5, "aws", "prod") // bare prefix — NO trailing slash
+		seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045/#326 boundary matching, not the platform gate
+		seedGrant(t, c, 5, "aws", "prod")          // bare prefix — NO trailing slash
 
 		val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/db")
 		require.NoError(t, err)
@@ -71,7 +72,8 @@ func TestConnectRefRBAC_SegmentBoundaryEnforced(t *testing.T) {
 	t.Run("trailing-slash prefix confines the grant", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 		seedRoleForUser(t, db, 1, 5, "prod-reader")
-		seedGrant(t, c, 5, "aws", "prod/") // safe form — trailing slash
+		seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045/#326 boundary matching, not the platform gate
+		seedGrant(t, c, 5, "aws", "prod/")         // safe form — trailing slash
 
 		val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/db")
 		require.NoError(t, err)
@@ -86,7 +88,8 @@ func TestConnectRefRBAC_SegmentBoundaryEnforced(t *testing.T) {
 	t.Run("exact ref match on the bare prefix is permitted", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 		seedRoleForUser(t, db, 1, 5, "prod-reader")
-		seedGrant(t, c, 5, "aws", "prod/db") // exact ref as prefix
+		seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045/#326 boundary matching, not the platform gate
+		seedGrant(t, c, 5, "aws", "prod/db")       // exact ref as prefix
 
 		val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/db")
 		require.NoError(t, err)

--- a/internal/core/connect_test.go
+++ b/internal/core/connect_test.go
@@ -64,11 +64,15 @@ func TestReadFederatedSecret_UnknownConnector(t *testing.T) {
 }
 
 func TestReadFederatedSecret_DisabledWhenNoManager(t *testing.T) {
-	c := &KeyorixCore{storage: new(MockStorage)}
+	ms := new(MockStorage)
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	c := &KeyorixCore{storage: ms}
 	assert.False(t, c.ConnectEnabled())
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not enabled")
+	// ADR-082 branch 3: the disabled path is now audited too (previously silent).
+	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 }
 
 func TestReadFederatedSecret_BackendErrorAudited(t *testing.T) {
@@ -130,7 +134,9 @@ func TestReadFederatedSecret_UserAuditedAsUser(t *testing.T) {
 // what lets the HTTP layer's isSafeConnectError classify safe vs. unsafe errors by
 // type instead of by substring-matching err.Error() against caller-influenced text.
 func TestConnectErrors_AreTypedSentinels(t *testing.T) {
-	c := &KeyorixCore{storage: new(MockStorage)}
+	ms := new(MockStorage)
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	c := &KeyorixCore{storage: ms}
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrConnectDisabled)

--- a/internal/core/connect_test.go
+++ b/internal/core/connect_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/connect"
@@ -24,15 +25,18 @@ func (f fakeConnector) GetSecret(_ context.Context, _ string) (string, error) {
 	return f.val, f.err
 }
 
-// connectTestCore wires every connector as scope: platform by default (ADR-082) —
-// a platform connector passes ownership for any caller in this branch, matching
-// this suite's pre-ADR-082 assumption that any caller can reach a configured test
-// connector. Tests that specifically exercise ownership/scope behavior use their
-// own setup (see connect_ownership_test.go) instead of this helper.
-func connectTestCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *MockStorage) {
+// connectTestCore wires every connector as scope: platform by default (ADR-082).
+// platformUseGranted controls whether principal 1 (the actor every test in this
+// file reads as) genuinely holds connect.platform.use (ADR-082 branch 4) — see
+// stubConnectPlatformUseCheckUser's own doc comment for why this is a real,
+// fixture-driven check and not a blanket allow. Tests that specifically exercise
+// ownership/scope behavior use their own setup (see connect_ownership_test.go)
+// instead of this helper.
+func connectTestCore(t *testing.T, platformUseGranted bool, conns ...connect.Connector) (*KeyorixCore, *MockStorage) {
 	t.Helper()
 	ms := new(MockStorage)
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	stubConnectPlatformUseCheckUser(ms, 1, platformUseGranted)
 	c := &KeyorixCore{storage: ms}
 	if len(conns) > 0 {
 		c.SetConnectManager(connect.NewManager(conns))
@@ -45,8 +49,39 @@ func connectTestCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *M
 	return c, ms
 }
 
+// stubConnectPlatformUseCheckUser configures ms so AuthorizePrincipal's
+// connect.platform.use check (ADR-082 branch 4, ActorTypeUser path) resolves
+// deterministically to granted for principalID — NOT a blanket "always
+// authorize" stub. Only RoleSetHasPermission's return value depends on
+// granted; every other call in the chain (GetUserRoleIDsAt,
+// GetUserGroupRoleIDsAt, the four GetRoleByName admin-bypass lookups) resolves
+// to "the principal holds one arbitrary non-admin role" — the same shape a
+// real fixture (a seeded role with, or without, the permission granted) would
+// produce, so a test declaring granted=false genuinely exercises a deny, not a
+// mock that happens to always say yes.
+func stubConnectPlatformUseCheckUser(ms *MockStorage, principalID uint, granted bool) {
+	const testRoleID = 9001
+	ms.On("GetUserRoleIDsAt", mock.Anything, principalID, mock.Anything).Return([]uint{testRoleID}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, principalID, mock.Anything).Return([]uint{}, nil)
+	for _, name := range adminRoleNames {
+		ms.On("GetRoleByName", mock.Anything, name).Return((*models.Role)(nil), errNotFoundStub)
+	}
+	ms.On("RoleSetHasPermission", mock.Anything, []uint{testRoleID}, "connect.platform.use").Return(granted, nil)
+}
+
+// stubConnectPlatformUseCheckMachine is stubConnectPlatformUseCheckUser's
+// machine-identity counterpart — the machine path (AuthorizePrincipal) has no
+// admin-role bypass at all, so it needs fewer stubs.
+func stubConnectPlatformUseCheckMachine(ms *MockStorage, principalID uint, granted bool) {
+	const testRoleID = 9002
+	ms.On("GetMachineRoleIDsAt", mock.Anything, principalID, mock.Anything).Return([]uint{testRoleID}, nil)
+	ms.On("RoleSetHasPermission", mock.Anything, []uint{testRoleID}, "connect.platform.use").Return(granted, nil)
+}
+
+var errNotFoundStub = errors.New("not found (test stub)")
+
 func TestReadFederatedSecret_Success(t *testing.T) {
-	c, ms := connectTestCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c, ms := connectTestCore(t, true, fakeConnector{name: "aws", val: "v3ry-secret"})
 	require.True(t, c.ConnectEnabled())
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "prod/db")
@@ -56,8 +91,28 @@ func TestReadFederatedSecret_Success(t *testing.T) {
 	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 }
 
+// TestReadFederatedSecret_PlatformUseDeniedByMockFixture proves
+// stubConnectPlatformUseCheckUser genuinely drives a deny, not a rubber-stamped
+// allow: granted=false on a real platform connector (unlike
+// TestReadFederatedSecret_UnknownConnector, where the connector itself doesn't
+// exist) must produce a terminal deny with the platform-specific reason.
+func TestReadFederatedSecret_PlatformUseDeniedByMockFixture(t *testing.T) {
+	c, ms := connectTestCore(t, false, fakeConnector{name: "aws", val: "v3ry-secret"})
+
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "prod/db")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrConnectUnknownConnector)
+
+	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return strings.Contains(e.Description, "reason=platform_permission_denied")
+	}))
+}
+
 func TestReadFederatedSecret_UnknownConnector(t *testing.T) {
-	c, _ := connectTestCore(t, fakeConnector{name: "aws", val: "x"})
+	// granted=false: the requested connector "nope" doesn't exist, so this never
+	// even reaches the platform-permission check — using false here (not true)
+	// proves that, since a wrongly-reached check would deny for the wrong reason.
+	c, _ := connectTestCore(t, false, fakeConnector{name: "aws", val: "x"})
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "nope", "ref")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown connector")
@@ -76,7 +131,7 @@ func TestReadFederatedSecret_DisabledWhenNoManager(t *testing.T) {
 }
 
 func TestReadFederatedSecret_BackendErrorAudited(t *testing.T) {
-	c, ms := connectTestCore(t, fakeConnector{name: "aws", err: errors.New("AccessDenied")})
+	c, ms := connectTestCore(t, true, fakeConnector{name: "aws", err: errors.New("AccessDenied")})
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
 	require.Error(t, err)
 	// A failed read is still audited (with FAILED in the description).
@@ -96,6 +151,7 @@ func TestReadFederatedSecret_MachineIdentityAuditedAsMachine(t *testing.T) {
 		got = e
 		return true
 	})).Return(nil)
+	stubConnectPlatformUseCheckMachine(ms, 42, true)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{fakeConnector{name: "aws", val: "v"}}))
 	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
@@ -118,6 +174,7 @@ func TestReadFederatedSecret_UserAuditedAsUser(t *testing.T) {
 		got = e
 		return true
 	})).Return(nil)
+	stubConnectPlatformUseCheckUser(ms, 7, true)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{fakeConnector{name: "aws", val: "v"}}))
 	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
@@ -141,7 +198,9 @@ func TestConnectErrors_AreTypedSentinels(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrConnectDisabled)
 
-	c2, _ := connectTestCore(t, fakeConnector{name: "aws"})
+	// granted=false: c2 is only used below for unknown-connector and
+	// CreateConnectRefGrant checks, never a successful "aws" platform read.
+	c2, _ := connectTestCore(t, false, fakeConnector{name: "aws"})
 	_, err = c2.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "nope", "ref")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrConnectUnknownConnector)
@@ -173,6 +232,7 @@ func TestReadFederatedSecret_AuditDescriptionRedactsRawUpstreamError(t *testing.
 		got = e
 		return true
 	})).Return(nil)
+	stubConnectPlatformUseCheckUser(ms, 1, true)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{
 		fakeConnector{name: "aws", err: rawUpstreamErr},

--- a/internal/core/legal_hold.go
+++ b/internal/core/legal_hold.go
@@ -78,7 +78,7 @@ func (c *KeyorixCore) PlaceLegalHold(ctx context.Context, actorID uint, reason s
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a reason is required to place a legal hold")
 	}
 	if c.isGlobalAdminRoleName(ctx, actorID) == "" {
-		c.writeAuditEventFailed(ctx, EventLegalHoldPlaced, actorPtr(actorID), "",
+		c.writeAuditEventFailed(ctx, EventLegalHoldPlaced, actorPtr(actorID), nil, "",
 			fmt.Sprintf("legal hold placement DENIED: actor %d is not an admin-tier principal", actorID))
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
 			"only an admin-tier principal may place a legal hold")
@@ -134,7 +134,7 @@ func (c *KeyorixCore) LiftLegalHold(ctx context.Context, actorID uint, reason st
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "no legal hold is active")
 	}
 	if actorID != hold.PlacedBy && c.isGlobalAdminRoleName(ctx, actorID) == "" {
-		c.writeAuditEventFailed(ctx, EventLegalHoldLifted, actorPtr(actorID), "",
+		c.writeAuditEventFailed(ctx, EventLegalHoldLifted, actorPtr(actorID), nil, "",
 			fmt.Sprintf("legal hold %d lift DENIED: actor %d is neither the placer (%d) nor an admin-tier principal", hold.ID, actorID, hold.PlacedBy))
 		return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
 			"only the placing admin or an admin-tier principal may lift this legal hold")

--- a/internal/core/rbac_reconcile_test.go
+++ b/internal/core/rbac_reconcile_test.go
@@ -82,6 +82,54 @@ func TestReconcileRBAC_AddsNewPermissionToBaselineRoles(t *testing.T) {
 	assert.False(t, roleHasPerm(t, c, "system_viewer", "connect.read"))
 }
 
+// seedOldCatalogWithoutPlatformUse mirrors seedOldCatalog but simulates an
+// install seeded BEFORE connect.platform.use existed (ADR-082 branch 4) — the
+// same precedent connect.read's own reconcile test (above) established for the
+// previous new permission.
+func seedOldCatalogWithoutPlatformUse(t *testing.T, c *KeyorixCore, db *gorm.DB) {
+	t.Helper()
+	ctx := context.Background()
+	for _, def := range defaultPermissions {
+		if def.Name == "connect.platform.use" {
+			continue
+		}
+		_, err := c.storage.CreatePermission(ctx, &models.Permission{Name: def.Name, Description: def.Description, Resource: def.Resource, Action: def.Action})
+		require.NoError(t, err)
+	}
+	for _, rdef := range defaultRoles {
+		role, err := c.storage.CreateRole(ctx, &models.Role{Name: rdef.Name, Description: rdef.Description})
+		require.NoError(t, err)
+		for _, permName := range rdef.Permissions {
+			if permName == "connect.platform.use" {
+				continue
+			}
+			var p models.Permission
+			require.NoError(t, db.Where("name = ?", permName).First(&p).Error)
+			require.NoError(t, c.storage.AssignPermissionToRole(ctx, role.ID, p.ID))
+		}
+	}
+}
+
+// TestReconcileRBAC_AddsConnectPlatformUseToBaselineRoles mirrors
+// TestReconcileRBAC_AddsNewPermissionToBaselineRoles for connect.platform.use
+// specifically (ADR-082 branch 4): a pre-existing admin/system_admin role row
+// gains it on the next reconcile pass, with no manual migration, exactly like
+// connect.read did when it was added.
+func TestReconcileRBAC_AddsConnectPlatformUseToBaselineRoles(t *testing.T) {
+	c, db := newRBACReconcileCore(t)
+	seedOldCatalogWithoutPlatformUse(t, c, db)
+	ctx := context.Background()
+
+	require.False(t, roleHasPerm(t, c, "admin", "connect.platform.use"))
+
+	require.NoError(t, c.ReconcileRBACPermissions(ctx))
+
+	assert.True(t, roleHasPerm(t, c, "admin", "connect.platform.use"))
+	assert.True(t, roleHasPerm(t, c, "system_admin", "connect.platform.use"))
+	assert.False(t, roleHasPerm(t, c, "viewer", "connect.platform.use"))
+	assert.False(t, roleHasPerm(t, c, "editor", "connect.platform.use"), "editor holds no connect.read either — least privilege")
+}
+
 func TestReconcileRBAC_DoesNotClobberExistingGrants(t *testing.T) {
 	c, db := newRBACReconcileCore(t)
 	seedOldCatalog(t, c, db)

--- a/internal/core/risk_exceptions.go
+++ b/internal/core/risk_exceptions.go
@@ -232,7 +232,7 @@ func (c *KeyorixCore) ApproveRiskException(ctx context.Context, actorID, id uint
 		return fmt.Errorf("risk exception %d is already approved", id)
 	}
 	if actorID == e.CreatedBy {
-		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), "",
+		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), nil, "",
 			fmt.Sprintf("risk exception %d approval DENIED: creator %d cannot self-approve", id, actorID))
 		return fmt.Errorf("the exception's creator cannot approve it (dual control); a different system.write holder must approve")
 	}
@@ -242,7 +242,7 @@ func (c *KeyorixCore) ApproveRiskException(ctx context.Context, actorID, id uint
 	// different approver reviews it — a stale or bogus reference must not be
 	// rubber-stamped either.
 	if err := c.validateSoDReferenceIsLiveViolation(ctx, e.Category, e.Reference); err != nil {
-		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), "",
+		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), nil, "",
 			fmt.Sprintf("risk exception %d approval DENIED: %v", id, err))
 		return err
 	}

--- a/server/connect_ownership_resolution_test.go
+++ b/server/connect_ownership_resolution_test.go
@@ -24,7 +24,7 @@ func connectOwnershipResolutionStorage(t *testing.T) (*store.LocalStorage, *gorm
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.ConnectorProjectBinding{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.ConnectorProjectBinding{}, &models.AuditEvent{}))
 	return store.NewLocalStorage(db), db
 }
 
@@ -49,6 +49,18 @@ func TestResolveConnectorOwnership_FirstBootResolvesAndPersists(t *testing.T) {
 	require.NoError(t, db.Where("connector = ?", "aws").First(&binding).Error)
 	assert.Equal(t, project.ID, binding.ProjectID)
 	assert.Equal(t, "payments", binding.ProjectName)
+
+	// ADR-082 branch 3 / issue #1477's audit half: the boot-time first-resolution
+	// write is itself an authorization-input change and must be audited, same as
+	// the RemoteStorage proxy's equivalent write.
+	var event models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", core.EventConnectorProjectBindingCreate).First(&event).Error)
+	require.NotNil(t, event.ProjectID)
+	assert.Equal(t, project.ID, *event.ProjectID)
+	assert.True(t, *event.Success)
+	assert.Equal(t, core.ActorTypeSystem, event.ActorType)
+	assert.Contains(t, event.Description, "aws")
+	assert.Contains(t, event.Description, "payments")
 }
 
 // TestResolveConnectorOwnership_SubsequentBootResolvesByStoredID proves a later

--- a/server/http/handlers/connector_project_bindings_proxy.go
+++ b/server/http/handlers/connector_project_bindings_proxy.go
@@ -24,12 +24,14 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -116,6 +118,26 @@ func (h *AuthHandler) CreateConnectorProjectBindingProxy(w http.ResponseWriter, 
 		log.Printf("connector-project-bindings proxy: create failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
+	}
+	// ADR-082 branch 3 / issue #1477's audit half: this write is an authorization
+	// input (it feeds core.ConnectOwnership downstream), so it's audited the same
+	// way as the boot-time first-resolution write (server/main.go's
+	// resolveConnectorOwnership) — same event type, same "system" actor type,
+	// since this endpoint is reached only by node-credential/system.write callers,
+	// never a human session. A logging failure here does not fail the request —
+	// the binding already persisted — but is surfaced loudly, matching
+	// internal/core's own emitAudit convention for a failed audit write.
+	t := true
+	auditEvent := &models.AuditEvent{
+		EventType:   core.EventConnectorProjectBindingCreate,
+		ProjectID:   &created.ProjectID,
+		Description: fmt.Sprintf("connector project binding created (remote proxy): connector %q bound to project %q (id %d)", created.Connector, created.ProjectName, created.ProjectID),
+		Success:     &t,
+		EventTime:   time.Now(),
+		ActorType:   core.ActorTypeSystem,
+	}
+	if aerr := h.coreService.Storage().LogAuditEvent(r.Context(), auditEvent); aerr != nil {
+		log.Printf("SECURITY: failed to persist audit event %q for connector %q: %v", core.EventConnectorProjectBindingCreate, created.Connector, aerr)
 	}
 	writeRemoteAPISuccess(w, newConnectorProjectBindingProxyWire(created))
 }

--- a/server/http/handlers/connector_project_bindings_proxy_test.go
+++ b/server/http/handlers/connector_project_bindings_proxy_test.go
@@ -1,0 +1,96 @@
+// connector_project_bindings_proxy_test.go — ADR-082 branch 3 / issue #1477's
+// audit half: CreateConnectorProjectBindingProxy previously had zero test
+// coverage (verified during branch 3's Stage 1 investigation) and, before this
+// branch, wrote a ConnectorProjectBinding with no audit event at all despite it
+// being an authorization input (it feeds core.ConnectOwnership downstream).
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func newConnectorProjectBindingProxyHandler(t *testing.T) (*AuthHandler, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.ConnectorProjectBinding{}, &models.AuditEvent{}))
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	return NewAuthHandler(cs, false), db
+}
+
+// TestCreateConnectorProjectBindingProxy_Audited proves the remote-proxy write
+// path (the literal subject of issue #1477) persists an audit event alongside
+// the binding itself: same event type as the boot-time write
+// (server/connect_ownership_resolution_test.go's counterpart), ProjectID
+// populated with the bound project (not left nil), Success=true, and actored
+// as "system" since this endpoint is reached only by a node-credential/
+// system.write caller, never a human session.
+func TestCreateConnectorProjectBindingProxy_Audited(t *testing.T) {
+	h, db := newConnectorProjectBindingProxyHandler(t)
+
+	body, err := json.Marshal(map[string]any{
+		"connector":    "aws",
+		"project_id":   7,
+		"project_name": "payments",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/connector-project-bindings", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.CreateConnectorProjectBindingProxy(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var event models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", core.EventConnectorProjectBindingCreate).First(&event).Error)
+	require.NotNil(t, event.ProjectID, "the binding's owning project must be recorded on the audit event, not left nil")
+	assert.EqualValues(t, 7, *event.ProjectID)
+	require.NotNil(t, event.Success)
+	assert.True(t, *event.Success)
+	assert.Equal(t, core.ActorTypeSystem, event.ActorType)
+	assert.Contains(t, event.Description, "aws")
+	assert.Contains(t, event.Description, "payments")
+}
+
+// TestCreateConnectorProjectBindingProxy_StorageFailureStillReturnsError proves
+// a storage-level create failure (e.g. a duplicate connector) still surfaces as
+// an error response — no audit event should be written for a write that never
+// actually persisted.
+func TestCreateConnectorProjectBindingProxy_StorageFailureStillReturnsError(t *testing.T) {
+	h, db := newConnectorProjectBindingProxyHandler(t)
+
+	body, err := json.Marshal(map[string]any{
+		"connector":    "aws",
+		"project_id":   7,
+		"project_name": "payments",
+	})
+	require.NoError(t, err)
+
+	// First create succeeds.
+	req1 := httptest.NewRequest(http.MethodPost, "/api/v1/system/connector-project-bindings", bytes.NewReader(body))
+	w1 := httptest.NewRecorder()
+	h.CreateConnectorProjectBindingProxy(w1, req1)
+	require.Equal(t, http.StatusOK, w1.Code)
+
+	// A second create for the SAME connector violates the unique index.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/system/connector-project-bindings", bytes.NewReader(body))
+	w2 := httptest.NewRecorder()
+	h.CreateConnectorProjectBindingProxy(w2, req2)
+	require.Equal(t, http.StatusInternalServerError, w2.Code)
+
+	var count int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", core.EventConnectorProjectBindingCreate).Count(&count).Error)
+	assert.EqualValues(t, 1, count, "only the successful create should be audited, not the failed duplicate attempt")
+}

--- a/server/http/remote_storage_connect_grants_test.go
+++ b/server/http/remote_storage_connect_grants_test.go
@@ -19,9 +19,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
-	"github.com/keyorixhq/keyorix/internal/connect"
 	"github.com/keyorixhq/keyorix/internal/core"
-	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
@@ -29,19 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// fakeConnectGrantsConnector is a minimal connect.Connector for exercising
-// ReadFederatedSecret end-to-end without a real external secret store.
-type fakeConnectGrantsConnector struct {
-	name string
-	val  string
-}
-
-func (f fakeConnectGrantsConnector) Name() string { return f.name }
-func (f fakeConnectGrantsConnector) Type() string { return "fake" }
-func (f fakeConnectGrantsConnector) GetSecret(_ context.Context, _ string) (string, error) {
-	return f.val, nil
-}
 
 // newUpstreamDownstreamForConnectGrants builds the standard #510/#527-style
 // two-server harness: an "upstream" exercised through the REAL production
@@ -147,76 +132,16 @@ func TestRemoteStorageConnectGrants_CreateListDeleteByConnector_RealServer(t *te
 	assert.Equal(t, g2.ID, awsGrantsAfter[0].ID)
 }
 
-// TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer is the core
-// #527 regression test: before this fix, ReadFederatedSecret failed
-// UNCONDITIONALLY on a storage.type: remote node whenever Connect was
-// configured, even for a connector with NO ref-grants at all, because
-// connectRefAllowed's ListConnectRefGrantsByConnector call hard-errored on
-// RemoteStorage's stub. This proves the read now succeeds end-to-end over a
-// real HTTP hop.
-func TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer(t *testing.T) {
-	_, downstream := newUpstreamDownstreamForConnectGrants(t)
-	downstream.SetConnectManager(connect.NewManager([]connect.Connector{
-		fakeConnectGrantsConnector{name: "aws", val: "v3ry-secret"},
-	}))
-	downstream.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "platform"}})
-	require.True(t, downstream.ConnectEnabled())
-
-	val, err := downstream.ReadFederatedSecret(context.Background(), core.ActorTypeUser, 1, "aws", "prod/db")
-	require.NoError(t, err, "a federated read on storage.type: remote must not fail closed for a connector with no ref-grants (backlog #527)")
-	assert.Equal(t, "v3ry-secret", val)
-}
-
-// TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer proves the
-// per-reference RBAC policy (ADR-045) itself round-trips correctly over
-// storage.type: remote once a connector has a ref-grant: a machine identity
-// holding the granted role can read a ref under the granted prefix, but is
-// denied a ref outside it — enforced via the real upstream, not a protocol
-// mock. Uses a machine-identity actor (not a user) because actorRoleIDs's
-// underlying GetMachineRoleIDsAt is already proxied for RemoteStorage; the
-// user-role equivalent (GetUserRoleIDsAt/GetUserGroupRoleIDsAt) is a separate,
-// pre-existing, out-of-scope gap this fix does not touch.
-func TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer(t *testing.T) {
-	upstream, downstream := newUpstreamDownstreamForConnectGrants(t)
-	ctx := context.Background()
-
-	downstream.SetConnectManager(connect.NewManager([]connect.Connector{
-		fakeConnectGrantsConnector{name: "aws", val: "v3ry-secret"},
-	}))
-	downstream.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "platform"}})
-
-	project, err := upstream.CreateProject(ctx, "Connect Grants Test Project", "")
-	require.NoError(t, err)
-
-	m, err := downstream.Storage().CreateMachineIdentity(ctx, &models.MachineIdentity{
-		ProjectID:    project.ID,
-		Name:         "connect-grant-machine",
-		IdentityType: core.MachineTypeCI,
-		State:        core.MachineActive,
-	})
-	require.NoError(t, err)
-
-	role, err := upstream.Storage().CreateRole(ctx, &models.Role{Name: "connect-grant-enforcement-role"})
-	require.NoError(t, err)
-
-	// Connect ref-grants are resolved at GLOBAL scope (internal/core/connect.go's
-	// actorRoleIDs), mirroring the production grant scope exactly.
-	globalScope := corestorage.Scope{}
-	require.NoError(t, downstream.Storage().AssignMachineRole(ctx, m.ID, role.ID, globalScope))
-
-	_, err = downstream.Storage().CreateConnectRefGrant(ctx, &models.ConnectRefGrant{
-		RoleID: role.ID, Connector: "aws", RefPrefix: "prod/",
-	})
-	require.NoError(t, err)
-
-	// A ref under the granted prefix succeeds.
-	val, err := downstream.ReadFederatedSecret(ctx, core.ActorTypeMachine, m.ID, "aws", "prod/db")
-	require.NoError(t, err)
-	assert.Equal(t, "v3ry-secret", val)
-
-	// A ref outside the granted prefix is denied — deny-by-default once the
-	// connector is scoped.
-	_, err = downstream.ReadFederatedSecret(ctx, core.ActorTypeMachine, m.ID, "aws", "dev/db")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not permitted")
-}
+// TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer and
+// TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer (which
+// exercised ReadFederatedSecret's ownership/platform-permission gate against a
+// storage.type: remote downstream serving real HTTP traffic) were deleted here,
+// not weakened or fixed: ADR-083 established that this topology — a server
+// with server.http.enabled/server.grpc.enabled backed by storage.type: remote —
+// never actually worked (AuthorizePrincipal could not complete against
+// RemoteStorage's stubbed RBAC primitives for any permission, any actor) and
+// now refuses to boot at all (Config.Validate()). The remaining test in this
+// file is unaffected: it calls RemoteStorage's ConnectRefGrant CRUD methods
+// directly, the same in-process pattern the CLI's own (sanctioned, unaffected)
+// use of storage.type: remote uses — it never boots an HTTP/gRPC server on the
+// RemoteStorage-backed side.

--- a/server/main.go
+++ b/server/main.go
@@ -995,6 +995,7 @@ func resolveConnectorOwnership(ctx context.Context, st corestorage.Storage, conn
 				problems = append(problems, fmt.Sprintf("%s: failed to persist project binding: %v", cn.Name, cerr))
 				continue
 			}
+			auditConnectorProjectBindingCreate(ctx, st, created, "boot-time first resolution")
 			ownership[cn.Name] = core.ConnectOwnership{Scope: "project", ProjectID: created.ProjectID}
 		case err != nil:
 			problems = append(problems, fmt.Sprintf("%s: %v", cn.Name, err))
@@ -1018,6 +1019,33 @@ func resolveConnectorOwnership(ctx context.Context, st corestorage.Storage, conn
 		return nil, fmt.Errorf("connector(s) with unresolvable project binding: %s", strings.Join(problems, "; "))
 	}
 	return ownership, nil
+}
+
+// auditConnectorProjectBindingCreate records a ConnectorProjectBinding write
+// (ADR-082 branch 3, issue #1477's audit half): the binding is an
+// authorization input (it feeds core.ConnectOwnership, and from there
+// connectOwnershipSatisfied) regardless of which door the write comes through,
+// so the unattended boot-time path here uses the SAME event type as the
+// RemoteStorage proxy's write (server/http/handlers/connector_project_bindings_proxy.go).
+// source distinguishes the two call sites in the Description. A logging
+// failure here does not fail boot — the binding itself already persisted
+// successfully — but is surfaced loudly (SECURITY-prefixed, matching
+// internal/core's own emitAudit convention) since a silently-dropped audit
+// write for an authorization-input change is exactly the kind of gap this
+// branch exists to close.
+func auditConnectorProjectBindingCreate(ctx context.Context, st corestorage.Storage, b *models.ConnectorProjectBinding, source string) {
+	t := true
+	event := &models.AuditEvent{
+		EventType:   core.EventConnectorProjectBindingCreate,
+		ProjectID:   &b.ProjectID,
+		Description: fmt.Sprintf("connector project binding created (%s): connector %q bound to project %q (id %d)", source, b.Connector, b.ProjectName, b.ProjectID),
+		Success:     &t,
+		EventTime:   time.Now(),
+		ActorType:   core.ActorTypeSystem,
+	}
+	if err := st.LogAuditEvent(ctx, event); err != nil {
+		log.Printf("SECURITY: failed to persist audit event %q for connector %q: %v", core.EventConnectorProjectBindingCreate, b.Connector, err)
+	}
 }
 
 // connectOwnershipKeySetMismatch returns every connector name whose presence in


### PR DESCRIPTION
## Summary

ADR-082 branch 3 — the audit surface. Every `connect.secret_read` outcome (allow or deny, including the three paths that were previously silent) now carries the connector's owning `ProjectID` and a closed-set `reason=<value>` token identifying which gate decided the outcome. Also closes issue #1477's audit half: both `ConnectorProjectBinding` write call sites (boot-time first resolution, and the RemoteStorage proxy) are now audited.

Stacked on #1487 (allow_unscoped removal).

## Scope

- `writeAuditEventFailed` gained a `projectID` parameter (6 pre-existing non-Connect call sites updated mechanically to pass `nil`).
- `connectOwnershipSatisfied` returns a named `ConnectOwnershipReason`, not a bare bool — the string formatting stays at the audit call site, not in the ownership function.
- Every deny path in `ReadFederatedSecret` audited, including the ownership/delegation denial that was silent through branch 2 — the audit trail is the only place an operator can distinguish "not a project member" from "delegation grant existed but didn't match," since both return the identical opaque unknown-connector response (ADR-082 §E, deliberately, to avoid an existence-probing oracle).
- `ListConnectors` filtering deliberately **not** audited (high-volume, low-signal; an actual attempt to read a hidden connector is already captured by the read-path deny event) — recorded in ADR-082 as a deliberate decision.
- Fixture hazard checked directly: reproduced against branch 2's HEAD to confirm no fixture regression predated this change; none found.

## Test plan

- [x] `go build ./...` clean at this commit (part of a verified 8-commit bisect-compile)
- [x] New tests assert the exact `reason=` value for every allow/deny outcome, that `ProjectID` is the connector's owning project (not the caller's), and that an ownership denial produces an audit event despite the opaque HTTP response
- [x] `server/http` baseline diff by failing-test-name: identical to the pre-existing baseline, zero new failures
- [x] `gosec -severity medium`: 0 issues