### PR TITLE
feat(connect): connect.platform.use permission for scope: platform connectors (ADR-082 branch 4) [8/8]

### DIFF
--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -652,7 +652,7 @@ would have been the closest precedent (ADR-075's "closed `key_source`
 enum") was never actually implemented under that name anywhere in the
 codebase; see the issue filed alongside this branch for that specific
 drift. Given that, the token goes into free-text `Description`, using the
-SAME fixed format at every one of the eight call sites below, specifically
+SAME fixed format at every one of the seven call sites below, specifically
 so a future structured column is a parse-and-backfill against this closed
 set, not a rewrite:
 

--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -20,11 +20,16 @@ Four separate branches, one logical change each:
 4. The new `connect.platform.use` permission (B) and its addition to
    `adminPermissions`.
 
-**Branches 1-3 are implemented; branch 4 (`connect.platform.use`) is not
-started.** Branch 3 (H) also closes issue #1477's audit half: every
-`ConnectorProjectBinding` write is now audited, not only the `connect.secret_read`
-path — see (H) below for the full, as-implemented design (the text below
-reflects what shipped, superseding the plan-time description that preceded it).
+**All four branches are implemented.** Branch 3 (H) also closes issue
+#1477's audit half: every `ConnectorProjectBinding` write is now audited, not
+only the `connect.secret_read` path. Branch 4 adds `connect.platform.use`
+(B) and gates it as a TERMINAL deny with no `ConnectRefGrant` delegation
+fallback (E) — a deliberate fork from the `scope: project` ownership-miss
+path, not a later revision toward consistency with it. See (E) and (H) below
+for the full, as-implemented design (the text in those sections reflects
+what shipped, superseding the plan-time description that preceded it, most
+notably (E)'s diagram, which originally said a platform-permission denial
+fell through to delegation — it does not).
 
 ## Context
 
@@ -457,9 +462,12 @@ admin-*named* role globally (unaffected by this ADR either way), now
 extended consistently to Connect ownership specifically.
 
 ```
-connect.read granted?                                    → no:  deny
+connect.read granted?                                    → no:  deny (reason: connect_disabled / unknown_connector)
 connector.scope == platform?
-  → yes: connect.platform.use granted?  → yes: allow (reason: capability)  → no: fall through to delegation check below
+  → yes: connect.platform.use granted (checked at Scope{}, global)?
+      → yes: allow (reason: platform_scope)
+      → no:  TERMINAL deny (reason: platform_permission_denied) — no
+             ConnectRefGrant fallback; see below for why
 connector.scope == project?
   → caller's RAW scope set (GetUserRoleScopes/GetMachineRoleScopes,
     including any {0,0} entry) contains connector.project?
@@ -468,8 +476,51 @@ connector.scope == project?
     role grant, any role name — see above)?
                                                           → yes: allow (reason: global_scope)
 matching ConnectRefGrant for one of the caller's roles?  → yes: allow (reason: delegation)
-                                                          → else: deny
+                                                          → no:  deny (reason: ownership_denied /
+                                                                 delegation_denied)
 ```
+
+**A denied `connect.platform.use` check is TERMINAL — it does NOT fall
+through to `ConnectRefGrant` delegation, unlike an ordinary `scope: project`
+ownership miss (this ADR's own earlier draft of this diagram said it did;
+corrected here on implementation, not a later change of mind — see "Out of
+scope"/(H) history).** This is a deliberate fork, not an oversight, and must
+not later be "reconciled" toward consistency with the project-scope path.
+Two independent reasons, both load-bearing:
+
+1. **A `ConnectRefGrant` targeting a `platform`-scope connector's name would
+   not be narrowing access — it would be granting it.** `ConnectRefGrant`
+   is keyed on role + connector name + ref-prefix alone; it has no concept
+   of the connector's `scope`, and nothing in `CreateConnectRefGrant`
+   currently rejects creating one against a platform connector (a known,
+   separately-tracked gap — see the issue filed alongside this branch: such
+   a grant is dead configuration under this design, consulted by nothing).
+   If a platform-scope ownership miss fell through to the SAME delegation
+   check a project-scope miss does, then any principal able to create a
+   `ConnectRefGrant` (an ordinary RBAC-gated management action, not itself
+   gated on `connect.platform.use`) could hand any other principal read
+   access to a platform-wide connector, entirely bypassing
+   `connect.platform.use`. For a project-scoped connector this isn't a
+   bypass — delegation is explicitly scoped to ONE connector's ONE
+   project, a narrower grant than project ownership itself would confer.
+   For a platform connector there is no narrower boundary below "the whole
+   connector" for a grant to sit inside of — delegation and the permission
+   it would be bypassing would cover the exact same surface.
+2. **A platform connector has no owning project for "delegation" to be
+   relative to.** `ConnectOwnership.ProjectID` is meaningless when
+   `Scope == "platform"` (its own doc comment says so); `ConnectRefGrant`
+   delegation (F) is conceptually "an explicit administrator-authorized
+   exception to a project-ownership boundary a caller doesn't otherwise
+   clear" — there is no such boundary here for an exception to be relative
+   to.
+
+`ConnectReadableConnectorNames` (`ListConnectors`) applies the identical
+terminal rule via the same per-connector loop, not a separate branch: a
+caller lacking `connect.platform.use` never reaches the delegation-fallback
+check for a platform connector there either — otherwise a
+(dead-configuration) `ConnectRefGrant` against a platform connector's name
+could make it appear in discovery for a caller whose actual read would
+always be denied, the exact leak this whole section exists to prevent.
 
 - **`ListConnectors` filters**: unchanged in shape from the prior draft —
   the returned list contains only connectors the caller can reach under
@@ -498,10 +549,14 @@ matching ConnectRefGrant for one of the caller's roles?  → yes: allow (reason:
   bypass wherever it's granted, but **not** the ownership wildcard outside
   that scope. This decoupling is deliberate, not a bug — see the two
   paragraphs above.
-- **Audit records which gate authorized the read**, as a distinct
-  decision reason per branch of the flowchart above: `project_membership`,
-  `global_scope`, or `delegation` (exact string tokens are an
-  implementation detail, not a design axis — see "Out of scope" and (H)).
+- **Audit records which gate authorized (or denied) the read**, as a
+  distinct decision reason per branch of the flowchart above: allow —
+  `project_membership`, `global_scope`, `platform_scope`, `delegation`;
+  deny — `connect_disabled`, `unknown_connector`, `ref_not_permitted`,
+  `ownership_denied`, `delegation_denied`, `platform_permission_denied`,
+  `backend_error` (exact string tokens are an implementation detail, not a
+  design axis — see "Out of scope" and (H) for the full closed set and its
+  fixed `reason=<value>` format).
   A read authorized via the *permission-check* bypass (step 1/2 above)
   does not by itself change which ownership reason gets recorded — the
   reason names the gate that resolved ownership, not whether `connect.read`
@@ -607,11 +662,13 @@ Allow (`Success: true`):
 - `global_scope` — caller holds a role at the true global (`{0,0}`) scope,
   which wildcards every project-scoped connector (E), regardless of role
   name.
-- `platform_scope` — the connector itself is `scope: platform`; ownership
-  passes for any `connect.read` holder (branch 4's `connect.platform.use`
-  narrows this further, not yet implemented).
+- `platform_scope` — the connector itself is `scope: platform` and the
+  caller holds `connect.platform.use` (branch 4; checked at `Scope{}`,
+  global — a platform connector has no owning project to check a
+  project-scoped grant against).
 - `delegation` — caller had no ownership claim at all on the connector's
-  project, resolved instead via a matching `ConnectRefGrant` (F).
+  project, resolved instead via a matching `ConnectRefGrant` (F). Never
+  reached for a `scope: platform` connector — see below.
 
 Deny (`Success: false`):
 - `connect_disabled` — no `connect.Manager` configured at all.
@@ -619,10 +676,24 @@ Deny (`Success: false`):
 - `ref_not_permitted` — caller IS owned, but a `ConnectRefGrant` scoped to
   this connector exists and none of the caller's roles hold a grant
   matching the requested ref (ADR-045, unchanged).
-- `ownership_denied` — caller is NOT owned, and the connector has ZERO
-  `ConnectRefGrant`s configured at all — no delegation path exists.
-- `delegation_denied` — caller is NOT owned; the connector DOES have
-  `ConnectRefGrant`(s), but none matched this caller's roles/ref.
+- `ownership_denied` — caller is NOT owned (`scope: project`), and the
+  connector has ZERO `ConnectRefGrant`s configured at all — no delegation
+  path exists.
+- `delegation_denied` — caller is NOT owned (`scope: project`); the
+  connector DOES have `ConnectRefGrant`(s), but none matched this caller's
+  roles/ref.
+- `platform_permission_denied` — connector is `scope: platform` and the
+  caller lacks `connect.platform.use` (branch 4). **Terminal** — unlike
+  `ownership_denied`/`delegation_denied`, this reason never falls through
+  to a `ConnectRefGrant` delegation attempt; see (E)'s "TERMINAL deny" note
+  for the full reasoning (a delegation fallback here would be a
+  `connect.platform.use` bypass, not a narrowing — `ConnectRefGrant` has no
+  concept of connector `scope` at all). This fork between the two `scope`
+  values' deny handling is deliberate and permanent — do not "reconcile"
+  `platform_permission_denied` toward `ownership_denied`/
+  `delegation_denied`'s delegation-fallback behavior later; they are
+  answering structurally different questions (project membership vs. a
+  global capability grant for an install-wide resource).
 - `backend_error` — ownership (or delegation) was satisfied, but the
   upstream connector call itself failed (network, credentials, etc.); the
   raw upstream error is logged server-side only, never persisted into the

--- a/internal/core/auth_bootstrap.go
+++ b/internal/core/auth_bootstrap.go
@@ -83,6 +83,12 @@ var defaultPermissions = []bootstrapPermissionDef{
 	// explicitly bundled into their role.
 	{"system.write", "Manage audit checkpoints/alerts, legal holds, risk exceptions, SoD policies, and admin job triggers", "system", "write"},
 	{"connect.read", "Read secrets from external stores via Keyorix Connect (ADR-043)", "connect", "read"},
+	// ADR-082 branch 4: narrows scope: platform connector reads, which connect.read
+	// alone permitted for any holder through branch 3 (an interim fail-open, marked
+	// by a TODO). Distinct from connect.read (which still gates the whole Connect
+	// surface, project-scoped connectors included) — this only narrows the
+	// platform-scoped subset.
+	{"connect.platform.use", "Read secrets from platform-scoped Keyorix Connect connectors (ADR-082 §B/§H)", "connect", "platform.use"},
 }
 
 // adminPermissions lists the permission names granted to the admin role.
@@ -91,7 +97,7 @@ var adminPermissions = []string{
 	permUsersRead, "users.write", "users.delete",
 	permRolesRead, "roles.write", permRolesAssign,
 	permAuditRead, permSystemRead, "system.write",
-	"connect.read",
+	"connect.read", "connect.platform.use",
 }
 
 // editorPermissions lists the permission names granted to the editor role.

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -81,6 +81,40 @@ func TestBootstrapSeedsTwoTierRoleCatalog(t *testing.T) {
 	}
 }
 
+// TestBootstrapGrantsConnectPlatformUseToAdminRoles proves a fresh install's
+// seeded admin/system_admin roles hold connect.platform.use (ADR-082 branch 4)
+// via ordinary BootstrapSystem seeding — no reconcile pass needed on first
+// boot. Roles without connect.read at all (editor/viewer/etc.) must not hold
+// it either (least privilege — mirrors connect.read's own baseline).
+func TestBootstrapGrantsConnectPlatformUseToAdminRoles(t *testing.T) {
+	c, _ := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"admin", "system_admin"} {
+		role, err := c.storage.GetRoleByName(ctx, name)
+		require.NoError(t, err)
+		perms, err := c.storage.GetRolePermissions(ctx, role.ID)
+		require.NoError(t, err)
+		var has bool
+		for _, p := range perms {
+			if p.Name == "connect.platform.use" {
+				has = true
+			}
+		}
+		assert.Truef(t, has, "role %q must hold connect.platform.use on a fresh install", name)
+	}
+
+	for _, name := range []string{"editor", "viewer", "system_auditor", "system_viewer", "project_admin"} {
+		role, err := c.storage.GetRoleByName(ctx, name)
+		require.NoError(t, err)
+		perms, err := c.storage.GetRolePermissions(ctx, role.ID)
+		require.NoError(t, err)
+		for _, p := range perms {
+			assert.NotEqualf(t, "connect.platform.use", p.Name, "role %q must not hold connect.platform.use (least privilege — it doesn't hold connect.read either)", name)
+		}
+	}
+}
+
 // #227: system.write's catalog description must name its full real footprint —
 // audit checkpoints/alerts, legal holds, risk exceptions, SoD policies, and
 // admin job triggers — not just the legacy service-account/API-token routes

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -78,7 +78,18 @@ const (
 	// same opaque unknown-connector shape either way, so the audit trail is
 	// the only place an operator can learn which gate closed.
 	connectDenyReasonDelegationDenied = "delegation_denied"
-	connectDenyReasonBackendError     = "backend_error"
+	// connectDenyReasonPlatformPermissionDenied: connector is scope: platform,
+	// but the caller lacks connect.platform.use (ADR-082 branch 4). Deliberately
+	// terminal — does NOT fall through to ConnectRefGrant delegation the way a
+	// project-scope ownership miss does. See connectOwnershipSatisfied's
+	// platform branch and ADR-082 §H: ConnectRefGrant is keyed on role +
+	// connector name + ref-prefix alone, with no scope awareness, so treating it
+	// as a fallback here would let anyone able to create a grant against a
+	// platform connector's name bypass connect.platform.use for anyone else —
+	// that would be a bypass, not a narrowing. This fork is deliberate; do not
+	// "reconcile" it toward the project-scope delegation path later.
+	connectDenyReasonPlatformPermissionDenied = "platform_permission_denied"
+	connectDenyReasonBackendError             = "backend_error"
 	// connectAllowReasonDelegation: caller is not owned, but an explicit
 	// ConnectRefGrant covering their role and this ref allows the read
 	// (ADR-082 §F).
@@ -168,6 +179,21 @@ func (c *KeyorixCore) ConnectReadableConnectorNames(ctx context.Context, actorTy
 			readable = append(readable, name)
 			continue
 		}
+		if c.connectOwnership[name].Scope == "platform" {
+			// ADR-082 branch 4: a platform-scope caller who lacks connect.platform.use
+			// is a TERMINAL deny in ReadFederatedSecret — it never attempts
+			// ConnectRefGrant delegation for platform scope (see
+			// connectDenyReasonPlatformPermissionDenied's doc comment for why a
+			// delegation fallback there would be a bypass). Discovery must agree: the
+			// delegation-fallback branch below exists for project-scope connectors,
+			// where it's true that ReadFederatedSecret would also honor it — reaching
+			// it for a platform connector here would show a connector in ListConnectors
+			// that an actual read will always deny, the exact leak ADR-082 §E exists to
+			// prevent. (A ConnectRefGrant CAN currently be created against a platform
+			// connector's name regardless — that's dead configuration, not a live
+			// delegation path; see the issue filed alongside this branch.)
+			continue
+		}
 		// Not owned — a connector reachable only via an explicit ConnectRefGrant
 		// still belongs in discovery; ReadSecret still applies the ref-prefix match
 		// per-read. actorRoleIDs (not connectRefGrantDelegates) is the right check
@@ -203,12 +229,22 @@ func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType s
 		return false, "", nil
 	}
 	if owner.Scope == "platform" {
-		// TODO(ADR-082 branch 4): gate platform connectors on connect.platform.use,
-		// not connect.read alone. Every caller who reaches this function has
-		// already cleared connect.read (checked by the transport layer before
-		// ReadFederatedSecret/ConnectReadableConnectorNames is ever called), so this
-		// is a deliberate interim "any connect.read holder" pass-through, not an
-		// oversight.
+		// ADR-082 branch 4: platform connectors need connect.platform.use, not just
+		// connect.read (which the transport layer already enforced before this
+		// function was ever called, and which still gates the whole Connect surface
+		// — connect.read alone was only ever a fail-open interim for platform scope
+		// specifically, through branch 3). Checked at Scope{} (global), matching
+		// connect.read's own scope — a platform connector has no owning project to
+		// check against. A denial here is terminal, not a fall-through to
+		// ConnectRefGrant delegation — see connectDenyReasonPlatformPermissionDenied
+		// and ADR-082 §H for why.
+		allowed, err := c.AuthorizePrincipal(ctx, actorType, principalID, "connect.platform.use", Scope{})
+		if err != nil {
+			return false, "", fmt.Errorf("connect ownership: check connect.platform.use: %w", err)
+		}
+		if !allowed {
+			return false, "", nil
+		}
 		return true, ConnectOwnershipReasonPlatformScope, nil
 	}
 	// scope == "project": raw scope set, NOT GetReadableScopes (D) — the {0,0}
@@ -277,7 +313,8 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 		return "", err
 	}
 	var allowReason ConnectOwnershipReason
-	if owned {
+	switch {
+	case owned:
 		allowReason = ownReason
 		// Per-reference RBAC (ADR-045): once a connector has any ref-grant, the read
 		// is permitted only if one of the caller's roles holds a matching grant. A
@@ -294,8 +331,19 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 				fmt.Sprintf("federated read DENIED by per-reference policy: connector %q (%s) ref %q reason=%s", connectorName, conn.Type(), ref, connectDenyReasonRefNotPermitted))
 			return "", fmt.Errorf("ref %q %w %q", ref, ErrConnectRefNotPermitted, connectorName)
 		}
-	} else {
-		// Not owned — ConnectRefGrant is the explicit cross-project delegation path
+	case owner.Scope == "platform":
+		// ADR-082 branch 4: caller lacks connect.platform.use. TERMINAL — no
+		// ConnectRefGrant delegation attempt, deliberately (see
+		// connectDenyReasonPlatformPermissionDenied's doc comment). This is its own
+		// case, not folded into the not-owned/delegation branch below, precisely so
+		// it never reaches connectRefGrantDelegates.
+		c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, projectID, "",
+			fmt.Sprintf("federated read DENIED: connector %q (%s) ref %q reason=%s", connectorName, conn.Type(), ref, connectDenyReasonPlatformPermissionDenied))
+		return "", fmt.Errorf("%w %q", ErrConnectUnknownConnector, connectorName)
+	default:
+		// Not owned, project scope (or a connector absent from the ownership map
+		// entirely — the structural-invariant edge case, unchanged from before this
+		// branch) — ConnectRefGrant is the explicit cross-project delegation path
 		// (ADR-082 §F). connectRefGrantDelegates (unlike connectRefAllowed) treats
 		// "no grants configured" as "no delegation," not "allow": that shortcut only
 		// makes sense for an already-owned caller.

--- a/internal/core/connect_audit_reason_test.go
+++ b/internal/core/connect_audit_reason_test.go
@@ -69,6 +69,8 @@ func TestReadFederatedSecret_AuditReasons_Allow(t *testing.T) {
 	t.Run("platform_scope", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "v"})
 		c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+		seedRoleForUser(t, db, 999, 50, "platform-caller")
+		seedConnectPlatformUsePermission(t, db, 50) // ADR-082 branch 4: platform scope now requires this
 
 		val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
 		require.NoError(t, err)
@@ -191,6 +193,8 @@ func TestReadFederatedSecret_AuditReasons_Deny(t *testing.T) {
 	t.Run("backend_error", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", err: assert.AnError})
 		c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+		seedRoleForUser(t, db, 1, 50, "platform-caller")
+		seedConnectPlatformUsePermission(t, db, 50) // ADR-082 branch 4: must clear the platform gate to reach the backend call and fail there instead
 
 		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "shared-vault", "ref")
 		require.Error(t, err)

--- a/internal/core/connect_ownership_test.go
+++ b/internal/core/connect_ownership_test.go
@@ -101,16 +101,32 @@ func TestConnectOwnership_ReadFederatedSecret(t *testing.T) {
 	}
 }
 
-// TestConnectOwnership_PlatformConnectorAnyCaller proves a platform-scoped
-// connector passes ownership for any caller in THIS branch — TODO(ADR-082 branch
-// 4) is the connect.platform.use gate; until then any connect.read holder (the
-// transport layer's job, not this function's) reaches it, even with zero roles.
-func TestConnectOwnership_PlatformConnectorAnyCaller(t *testing.T) {
+// TestConnectOwnership_PlatformConnectorRequiresPlatformUse supersedes the
+// pre-branch-4 "any connect.read holder reaches it" behavior this test used to
+// assert (its own prior docstring named this as the TODO(ADR-082 branch 4) gap
+// explicitly). Now: a caller with zero roles — including no connect.platform.use
+// — is denied, terminally (no ConnectRefGrant delegation fallback; see
+// connectDenyReasonPlatformPermissionDenied).
+func TestConnectOwnership_PlatformConnectorRequiresPlatformUse(t *testing.T) {
 	c, _ := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "shared-secret"})
 	c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
 
-	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
-	require.NoError(t, err, "a platform-scoped connector must pass ownership for any caller in this branch")
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
+	require.Error(t, err, "a platform-scoped connector must now deny a caller with no connect.platform.use grant")
+	assert.ErrorIs(t, err, ErrConnectUnknownConnector, "the denial must reuse the opaque unknown-connector shape (ADR-082)")
+}
+
+// TestConnectOwnership_PlatformConnectorAllowsHolderOfPlatformUse is the allow
+// counterpart: a caller who DOES hold connect.platform.use reaches the platform
+// connector, same as any other allow path.
+func TestConnectOwnership_PlatformConnectorAllowsHolderOfPlatformUse(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "shared-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+	seedRoleForUser(t, db, 1, 10, "platform-caller")
+	seedConnectPlatformUsePermission(t, db, 10)
+
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "shared-vault", "ref")
+	require.NoError(t, err)
 	assert.Equal(t, "shared-secret", val)
 }
 
@@ -256,6 +272,41 @@ func TestConnectReadableConnectorNames_GlobalScopedCallerSeesAll(t *testing.T) {
 	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 2)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"aws-payments", "aws-billing"}, names, "a global-scoped caller must see every project-scoped connector via the {0,0} wildcard")
+}
+
+// TestConnectReadableConnectorNames_PlatformFilteredWithoutPlatformUse proves
+// ListConnectors filtering (ADR-082 branch 4) via the SAME per-connector filter
+// ReadFederatedSecret uses (connectOwnershipSatisfied) — no separate branch: a
+// caller lacking connect.platform.use sees a platform connector disappear from
+// discovery, exactly like ReadFederatedSecret would deny an actual read of it.
+func TestConnectReadableConnectorNames_PlatformFilteredWithoutPlatformUse(t *testing.T) {
+	c, db := connectRBACCore(t,
+		fakeConnector{name: "shared-vault", val: "v1"},
+		fakeConnector{name: "aws-payments", val: "v2"},
+	)
+	c.SetConnectOwnership(map[string]ConnectOwnership{
+		"shared-vault": {Scope: "platform"},
+		"aws-payments": {Scope: "project", ProjectID: 42},
+	})
+	seedRoleForUserAtProject(t, db, 1, 10, "payments-member", 42) // no connect.platform.use
+
+	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"aws-payments"}, names, "the platform connector must be filtered out without connect.platform.use, even though the project connector (a genuine ownership match) is still visible")
+}
+
+// TestConnectReadableConnectorNames_PlatformVisibleWithPlatformUse is the allow
+// counterpart: a caller holding connect.platform.use sees the platform
+// connector in discovery too.
+func TestConnectReadableConnectorNames_PlatformVisibleWithPlatformUse(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "v1"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+	seedRoleForUser(t, db, 1, 10, "platform-caller")
+	seedConnectPlatformUsePermission(t, db, 10)
+
+	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"shared-vault"}, names)
 }
 
 // seedRoleForUserAtProject mirrors seedRoleForUser (connect_rbac_test.go) but

--- a/internal/core/connect_rbac_admin_test.go
+++ b/internal/core/connect_rbac_admin_test.go
@@ -21,6 +21,10 @@ func TestConnectRefRBAC_NoAdminBypass(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 
 	// User 1 is a GLOBAL super_admin — the role that bypasses core RBAC.
+	// ADR-082 branch 4: no explicit connect.platform.use grant is needed here —
+	// super_admin's role-NAME bypass (roleSetContainsAdmin) satisfies ANY
+	// permission check, this new one included, exactly like the connect.read
+	// precondition check just below already demonstrates.
 	seedRoleForUser(t, db, 1, 1, "super_admin")
 	// The connector is ref-scoped, but only for a DIFFERENT role (reader = role 2).
 	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "reader"}).Error)

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -32,6 +32,7 @@ func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *g
 		&models.ConnectRefGrant{}, &models.AuditEvent{},
 		&models.Project{}, &models.Environment{},
 		&models.ConnectorProjectBinding{},
+		&models.Permission{}, &models.RolePermission{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	if len(conns) > 0 {
@@ -51,6 +52,21 @@ func seedRoleForUser(t *testing.T, db *gorm.DB, userID, roleID uint, name string
 	require.NoError(t, db.Create(&models.UserRole{UserID: userID, RoleID: roleID}).Error)
 }
 
+// seedConnectPlatformUsePermission grants roleID the connect.platform.use
+// permission (ADR-082 branch 4). Every connectRBACCore-based test defaults its
+// connectors to scope: platform, and a platform-scope read now requires this
+// permission — call this wherever a test's role is meant to actually reach a
+// platform connector (i.e. it is exercising something OTHER than the
+// platform-permission gate itself, such as ADR-045 ref-grant behavior). Each
+// test gets its own in-memory DB (connectRBACCore), so there's no cross-test
+// collision creating the same permission name twice.
+func seedConnectPlatformUsePermission(t *testing.T, db *gorm.DB, roleID uint) {
+	t.Helper()
+	perm := models.Permission{Name: "connect.platform.use", Description: "test", Resource: "connect", Action: "platform.use"}
+	require.NoError(t, db.Create(&perm).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: roleID, PermissionID: perm.ID}).Error)
+}
+
 func seedGrant(t *testing.T, c *KeyorixCore, roleID uint, connector, prefix string) {
 	t.Helper()
 	_, err := c.storage.CreateConnectRefGrant(context.Background(), &models.ConnectRefGrant{RoleID: roleID, Connector: connector, RefPrefix: prefix})
@@ -68,6 +84,7 @@ func seedGrantExpiring(t *testing.T, c *KeyorixCore, roleID uint, connector, pre
 func TestConnectRefRBAC_NoGrantsAllows(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045, not the platform gate
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "anything/at/all")
 	require.NoError(t, err)
 	assert.Equal(t, "v", val)
@@ -78,6 +95,7 @@ func TestConnectRefRBAC_NoGrantsAllows(t *testing.T) {
 func TestConnectRefRBAC_PrefixScopes(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "metrics-reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045, not the platform gate
 	seedGrant(t, c, 5, "aws", "metrics/")
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
@@ -94,7 +112,8 @@ func TestConnectRefRBAC_PrefixScopes(t *testing.T) {
 func TestConnectRefRBAC_RoleMismatchDenied(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "reader")
-	seedGrant(t, c, 9, "aws", "metrics/") // granted to role 9, not the user's role 5
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: role 5 must reach the ref-grant check to prove the ROLE mismatch, not the platform gate, is what denies it
+	seedGrant(t, c, 9, "aws", "metrics/")      // granted to role 9, not the user's role 5
 
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
 	require.Error(t, err)
@@ -105,6 +124,7 @@ func TestConnectRefRBAC_RoleMismatchDenied(t *testing.T) {
 func TestConnectRefRBAC_EmptyPrefixAllowsAll(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "broad-reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045, not the platform gate
 	seedGrant(t, c, 5, "aws", "")
 
 	for _, ref := range []string{"metrics/x", "db/y", "anything"} {
@@ -121,7 +141,8 @@ func TestConnectRefRBAC_OtherConnectorUnaffected(t *testing.T) {
 		fakeConnector{name: "gcp", val: "g"},
 	)
 	seedRoleForUser(t, db, 1, 5, "reader")
-	seedGrant(t, c, 5, "aws", "metrics/") // scopes aws only
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045, not the platform gate — covers both connectors, gcp included
+	seedGrant(t, c, 5, "aws", "metrics/")      // scopes aws only
 
 	// gcp has no grants → unaffected.
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "gcp", "projects/p/secrets/x/versions/latest")
@@ -140,7 +161,8 @@ func TestConnectRefRBAC_MultiRoleUnion(t *testing.T) {
 	require.NoError(t, db.Create(&models.Role{ID: 6, Name: "db"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 5}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 6}).Error)
-	seedGrant(t, c, 6, "aws", "db/") // only the db role grants db/
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045 role-union matching, not the platform gate — either held role suffices for platform.use
+	seedGrant(t, c, 6, "aws", "db/")           // only the db role grants db/
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "db/password")
 	require.NoError(t, err)
@@ -153,6 +175,7 @@ func TestConnectRefRBAC_MachineIdentityRoles(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	require.NoError(t, db.Create(&models.Role{ID: 7, Name: "ci-metrics"}).Error)
 	require.NoError(t, db.Create(&models.MachineIdentityRole{MachineIdentityID: 42, RoleID: 7}).Error)
+	seedConnectPlatformUsePermission(t, db, 7) // ADR-082 branch 4: this test is about ADR-045, not the platform gate
 	seedGrant(t, c, 7, "aws", "metrics/")
 	ctx := context.Background()
 
@@ -166,10 +189,15 @@ func TestConnectRefRBAC_MachineIdentityRoles(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not permitted")
 
-	// A different machine with no matching role → denied (deny-by-default).
+	// A different machine holds NO role at all — including no connect.platform.use —
+	// so it is now denied at the platform-permission gate itself (ADR-082 branch 4),
+	// before ever reaching the per-ref grant check this test otherwise exercises. It
+	// is still "deny-by-default", just via an earlier gate than the sibling assertion
+	// above; the opaque unknown-connector shape is deliberate (ADR-082 §H), so this
+	// no longer asserts "not permitted" specifically.
 	_, err = c.ReadFederatedSecret(ctx, ActorTypeMachine, 99, "aws", "metrics/qps")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not permitted")
+	assert.ErrorIs(t, err, ErrConnectUnknownConnector)
 }
 
 // A grant for a role the caller holds only VIA GROUP MEMBERSHIP must authorize them —
@@ -183,6 +211,7 @@ func TestConnectRefRBAC_GroupDerivedRole(t *testing.T) {
 	require.NoError(t, db.Create(&models.Group{ID: 3, Name: "analytics"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 1, GroupID: 3}).Error)
 	require.NoError(t, db.Create(&models.GroupRole{GroupID: 3, RoleID: 5}).Error)
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045 group-derived role resolution, not the platform gate — scopedRoleIDs unions group-derived roles the same way for both checks
 	seedGrant(t, c, 5, "aws", "metrics/")
 
 	// The user reaches the grant through their group-derived role.
@@ -200,7 +229,8 @@ func TestConnectRefRBAC_GroupDerivedRole(t *testing.T) {
 func TestConnectRefRBAC_GlobPatterns(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "reader")
-	seedGrant(t, c, 5, "aws", "prod/*/db") // exactly one segment between prod/ and /db
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045 glob matching, not the platform gate
+	seedGrant(t, c, 5, "aws", "prod/*/db")     // exactly one segment between prod/ and /db
 	ctx := context.Background()
 
 	val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/eu/db")
@@ -250,6 +280,7 @@ func TestRefMatches(t *testing.T) {
 func TestConnectRefRBAC_CrossTenantTraversalDenied(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "vault", val: "myapp-secret"})
 	seedRoleForUser(t, db, 1, 5, "myapp-reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045/#326 traversal handling, not the platform gate
 	seedGrant(t, c, 5, "vault", "secret/data/myapp/")
 	ctx := context.Background()
 
@@ -270,6 +301,7 @@ func TestConnectRefRBAC_CrossTenantTraversalDenied(t *testing.T) {
 func TestConnectRefRBAC_ExpiredGrantDenied(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "temp-reader")
+	seedConnectPlatformUsePermission(t, db, 5)                                  // ADR-082 branch 4: this test is about ADR-045 grant expiry, not the platform gate
 	seedGrantExpiring(t, c, 5, "aws", "metrics/", time.Now().Add(-time.Minute)) // already expired
 	ctx := context.Background()
 
@@ -286,6 +318,7 @@ func TestConnectRefRBAC_ExpiredGrantDenied(t *testing.T) {
 func TestConnectRefRBAC_UnexpiredGrantAllowed(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "temp-reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045 grant expiry, not the platform gate
 	seedGrantExpiring(t, c, 5, "aws", "metrics/", time.Now().Add(time.Hour))
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
@@ -294,6 +327,9 @@ func TestConnectRefRBAC_UnexpiredGrantAllowed(t *testing.T) {
 }
 
 // CreateConnectRefGrant plumbs an optional expiresAt through to the persisted grant.
+// ADR-082 branch 4: unaffected by the connect.platform.use gate — this test never
+// calls ReadFederatedSecret/connectOwnershipSatisfied at all, only the grant-
+// management path.
 func TestCreateConnectRefGrant_PersistsExpiresAt(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	require.NoError(t, db.Create(&models.Role{ID: 5, Name: "temp-reader"}).Error)
@@ -324,6 +360,17 @@ func TestConnectRefRBAC_MachineIdentityProjectScopedRole(t *testing.T) {
 	// Granted to the machine ONLY at project 10 — deliberately no global grant.
 	require.NoError(t, db.Create(&models.MachineIdentityRole{MachineIdentityID: 42, RoleID: 7, ProjectID: 10}).Error)
 	seedGrant(t, c, 7, "aws", "metrics/")
+	// ADR-082 branch 4: connect.platform.use is checked at Scope{} (global) —
+	// intentionally: a platform connector is install-wide, so a purely
+	// project-scoped grant of the permission (like role 7 above, deliberately) is
+	// a category error and correctly does NOT satisfy it. This test's whole point
+	// is proving role 7's PROJECT-scoped grant is honoured for the ref-grant
+	// check specifically, so platform.use is granted here via a SEPARATE role
+	// held at the true global scope, decoupled from role 7 — not by making role 7
+	// global, which would defeat the test.
+	require.NoError(t, db.Create(&models.Role{ID: 21, Name: "platform-access"}).Error)
+	require.NoError(t, db.Create(&models.MachineIdentityRole{MachineIdentityID: 42, RoleID: 21}).Error)
+	seedConnectPlatformUsePermission(t, db, 21)
 	ctx := context.Background()
 
 	val, err := c.ReadFederatedSecret(ctx, ActorTypeMachine, 42, "aws", "metrics/qps")
@@ -338,6 +385,8 @@ func TestConnectRefRBAC_MachineIdentityProjectScopedRole(t *testing.T) {
 // actorRoleIDs (G33's detection_idea): a machine identity's project-scoped role
 // grant must resolve into the SAME role-ID set as an equivalent human user
 // holding the identical role at the identical project scope.
+// ADR-082 branch 4: unaffected — calls actorRoleIDs directly, never reaching
+// connectOwnershipSatisfied/the platform gate.
 func TestActorRoleIDs_MachineMatchesEquivalentUser_ProjectScoped(t *testing.T) {
 	c, db := connectRBACCore(t)
 	require.NoError(t, db.Create(&models.Project{ID: 10, Name: "proj-a"}).Error)
@@ -355,6 +404,8 @@ func TestActorRoleIDs_MachineMatchesEquivalentUser_ProjectScoped(t *testing.T) {
 	assert.Equal(t, userRoles, machineRoles, "a machine identity holding the same project-scoped role as a human user must resolve to an identical role-ID set")
 }
 
+// ADR-082 branch 4: unaffected — calls connectRefAllowed directly, never
+// reaching connectOwnershipSatisfied/the platform gate.
 func TestConnectRefAllowed_Direct(t *testing.T) {
 	c, db := connectRBACCore(t)
 	seedRoleForUser(t, db, 1, 5, "reader")

--- a/internal/core/connect_ref_prefix_boundary_test.go
+++ b/internal/core/connect_ref_prefix_boundary_test.go
@@ -56,7 +56,8 @@ func TestConnectRefRBAC_SegmentBoundaryEnforced(t *testing.T) {
 	t.Run("bare prefix does not leak into the sibling namespace", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 		seedRoleForUser(t, db, 1, 5, "prod-reader")
-		seedGrant(t, c, 5, "aws", "prod") // bare prefix — NO trailing slash
+		seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045/#326 boundary matching, not the platform gate
+		seedGrant(t, c, 5, "aws", "prod")          // bare prefix — NO trailing slash
 
 		val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/db")
 		require.NoError(t, err)
@@ -71,7 +72,8 @@ func TestConnectRefRBAC_SegmentBoundaryEnforced(t *testing.T) {
 	t.Run("trailing-slash prefix confines the grant", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 		seedRoleForUser(t, db, 1, 5, "prod-reader")
-		seedGrant(t, c, 5, "aws", "prod/") // safe form — trailing slash
+		seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045/#326 boundary matching, not the platform gate
+		seedGrant(t, c, 5, "aws", "prod/")         // safe form — trailing slash
 
 		val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/db")
 		require.NoError(t, err)
@@ -86,7 +88,8 @@ func TestConnectRefRBAC_SegmentBoundaryEnforced(t *testing.T) {
 	t.Run("exact ref match on the bare prefix is permitted", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 		seedRoleForUser(t, db, 1, 5, "prod-reader")
-		seedGrant(t, c, 5, "aws", "prod/db") // exact ref as prefix
+		seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045/#326 boundary matching, not the platform gate
+		seedGrant(t, c, 5, "aws", "prod/db")       // exact ref as prefix
 
 		val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/db")
 		require.NoError(t, err)

--- a/internal/core/connect_test.go
+++ b/internal/core/connect_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/connect"
@@ -24,15 +25,18 @@ func (f fakeConnector) GetSecret(_ context.Context, _ string) (string, error) {
 	return f.val, f.err
 }
 
-// connectTestCore wires every connector as scope: platform by default (ADR-082) —
-// a platform connector passes ownership for any caller in this branch, matching
-// this suite's pre-ADR-082 assumption that any caller can reach a configured test
-// connector. Tests that specifically exercise ownership/scope behavior use their
-// own setup (see connect_ownership_test.go) instead of this helper.
-func connectTestCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *MockStorage) {
+// connectTestCore wires every connector as scope: platform by default (ADR-082).
+// platformUseGranted controls whether principal 1 (the actor every test in this
+// file reads as) genuinely holds connect.platform.use (ADR-082 branch 4) — see
+// stubConnectPlatformUseCheckUser's own doc comment for why this is a real,
+// fixture-driven check and not a blanket allow. Tests that specifically exercise
+// ownership/scope behavior use their own setup (see connect_ownership_test.go)
+// instead of this helper.
+func connectTestCore(t *testing.T, platformUseGranted bool, conns ...connect.Connector) (*KeyorixCore, *MockStorage) {
 	t.Helper()
 	ms := new(MockStorage)
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	stubConnectPlatformUseCheckUser(ms, 1, platformUseGranted)
 	c := &KeyorixCore{storage: ms}
 	if len(conns) > 0 {
 		c.SetConnectManager(connect.NewManager(conns))
@@ -45,8 +49,39 @@ func connectTestCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *M
 	return c, ms
 }
 
+// stubConnectPlatformUseCheckUser configures ms so AuthorizePrincipal's
+// connect.platform.use check (ADR-082 branch 4, ActorTypeUser path) resolves
+// deterministically to granted for principalID — NOT a blanket "always
+// authorize" stub. Only RoleSetHasPermission's return value depends on
+// granted; every other call in the chain (GetUserRoleIDsAt,
+// GetUserGroupRoleIDsAt, the four GetRoleByName admin-bypass lookups) resolves
+// to "the principal holds one arbitrary non-admin role" — the same shape a
+// real fixture (a seeded role with, or without, the permission granted) would
+// produce, so a test declaring granted=false genuinely exercises a deny, not a
+// mock that happens to always say yes.
+func stubConnectPlatformUseCheckUser(ms *MockStorage, principalID uint, granted bool) {
+	const testRoleID = 9001
+	ms.On("GetUserRoleIDsAt", mock.Anything, principalID, mock.Anything).Return([]uint{testRoleID}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, principalID, mock.Anything).Return([]uint{}, nil)
+	for _, name := range adminRoleNames {
+		ms.On("GetRoleByName", mock.Anything, name).Return((*models.Role)(nil), errNotFoundStub)
+	}
+	ms.On("RoleSetHasPermission", mock.Anything, []uint{testRoleID}, "connect.platform.use").Return(granted, nil)
+}
+
+// stubConnectPlatformUseCheckMachine is stubConnectPlatformUseCheckUser's
+// machine-identity counterpart — the machine path (AuthorizePrincipal) has no
+// admin-role bypass at all, so it needs fewer stubs.
+func stubConnectPlatformUseCheckMachine(ms *MockStorage, principalID uint, granted bool) {
+	const testRoleID = 9002
+	ms.On("GetMachineRoleIDsAt", mock.Anything, principalID, mock.Anything).Return([]uint{testRoleID}, nil)
+	ms.On("RoleSetHasPermission", mock.Anything, []uint{testRoleID}, "connect.platform.use").Return(granted, nil)
+}
+
+var errNotFoundStub = errors.New("not found (test stub)")
+
 func TestReadFederatedSecret_Success(t *testing.T) {
-	c, ms := connectTestCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c, ms := connectTestCore(t, true, fakeConnector{name: "aws", val: "v3ry-secret"})
 	require.True(t, c.ConnectEnabled())
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "prod/db")
@@ -56,8 +91,28 @@ func TestReadFederatedSecret_Success(t *testing.T) {
 	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 }
 
+// TestReadFederatedSecret_PlatformUseDeniedByMockFixture proves
+// stubConnectPlatformUseCheckUser genuinely drives a deny, not a rubber-stamped
+// allow: granted=false on a real platform connector (unlike
+// TestReadFederatedSecret_UnknownConnector, where the connector itself doesn't
+// exist) must produce a terminal deny with the platform-specific reason.
+func TestReadFederatedSecret_PlatformUseDeniedByMockFixture(t *testing.T) {
+	c, ms := connectTestCore(t, false, fakeConnector{name: "aws", val: "v3ry-secret"})
+
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "prod/db")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrConnectUnknownConnector)
+
+	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return strings.Contains(e.Description, "reason=platform_permission_denied")
+	}))
+}
+
 func TestReadFederatedSecret_UnknownConnector(t *testing.T) {
-	c, _ := connectTestCore(t, fakeConnector{name: "aws", val: "x"})
+	// granted=false: the requested connector "nope" doesn't exist, so this never
+	// even reaches the platform-permission check — using false here (not true)
+	// proves that, since a wrongly-reached check would deny for the wrong reason.
+	c, _ := connectTestCore(t, false, fakeConnector{name: "aws", val: "x"})
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "nope", "ref")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown connector")
@@ -76,7 +131,7 @@ func TestReadFederatedSecret_DisabledWhenNoManager(t *testing.T) {
 }
 
 func TestReadFederatedSecret_BackendErrorAudited(t *testing.T) {
-	c, ms := connectTestCore(t, fakeConnector{name: "aws", err: errors.New("AccessDenied")})
+	c, ms := connectTestCore(t, true, fakeConnector{name: "aws", err: errors.New("AccessDenied")})
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
 	require.Error(t, err)
 	// A failed read is still audited (with FAILED in the description).
@@ -96,6 +151,7 @@ func TestReadFederatedSecret_MachineIdentityAuditedAsMachine(t *testing.T) {
 		got = e
 		return true
 	})).Return(nil)
+	stubConnectPlatformUseCheckMachine(ms, 42, true)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{fakeConnector{name: "aws", val: "v"}}))
 	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
@@ -118,6 +174,7 @@ func TestReadFederatedSecret_UserAuditedAsUser(t *testing.T) {
 		got = e
 		return true
 	})).Return(nil)
+	stubConnectPlatformUseCheckUser(ms, 7, true)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{fakeConnector{name: "aws", val: "v"}}))
 	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
@@ -141,7 +198,9 @@ func TestConnectErrors_AreTypedSentinels(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrConnectDisabled)
 
-	c2, _ := connectTestCore(t, fakeConnector{name: "aws"})
+	// granted=false: c2 is only used below for unknown-connector and
+	// CreateConnectRefGrant checks, never a successful "aws" platform read.
+	c2, _ := connectTestCore(t, false, fakeConnector{name: "aws"})
 	_, err = c2.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "nope", "ref")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrConnectUnknownConnector)
@@ -173,6 +232,7 @@ func TestReadFederatedSecret_AuditDescriptionRedactsRawUpstreamError(t *testing.
 		got = e
 		return true
 	})).Return(nil)
+	stubConnectPlatformUseCheckUser(ms, 1, true)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{
 		fakeConnector{name: "aws", err: rawUpstreamErr},

--- a/internal/core/rbac_reconcile_test.go
+++ b/internal/core/rbac_reconcile_test.go
@@ -82,6 +82,54 @@ func TestReconcileRBAC_AddsNewPermissionToBaselineRoles(t *testing.T) {
 	assert.False(t, roleHasPerm(t, c, "system_viewer", "connect.read"))
 }
 
+// seedOldCatalogWithoutPlatformUse mirrors seedOldCatalog but simulates an
+// install seeded BEFORE connect.platform.use existed (ADR-082 branch 4) — the
+// same precedent connect.read's own reconcile test (above) established for the
+// previous new permission.
+func seedOldCatalogWithoutPlatformUse(t *testing.T, c *KeyorixCore, db *gorm.DB) {
+	t.Helper()
+	ctx := context.Background()
+	for _, def := range defaultPermissions {
+		if def.Name == "connect.platform.use" {
+			continue
+		}
+		_, err := c.storage.CreatePermission(ctx, &models.Permission{Name: def.Name, Description: def.Description, Resource: def.Resource, Action: def.Action})
+		require.NoError(t, err)
+	}
+	for _, rdef := range defaultRoles {
+		role, err := c.storage.CreateRole(ctx, &models.Role{Name: rdef.Name, Description: rdef.Description})
+		require.NoError(t, err)
+		for _, permName := range rdef.Permissions {
+			if permName == "connect.platform.use" {
+				continue
+			}
+			var p models.Permission
+			require.NoError(t, db.Where("name = ?", permName).First(&p).Error)
+			require.NoError(t, c.storage.AssignPermissionToRole(ctx, role.ID, p.ID))
+		}
+	}
+}
+
+// TestReconcileRBAC_AddsConnectPlatformUseToBaselineRoles mirrors
+// TestReconcileRBAC_AddsNewPermissionToBaselineRoles for connect.platform.use
+// specifically (ADR-082 branch 4): a pre-existing admin/system_admin role row
+// gains it on the next reconcile pass, with no manual migration, exactly like
+// connect.read did when it was added.
+func TestReconcileRBAC_AddsConnectPlatformUseToBaselineRoles(t *testing.T) {
+	c, db := newRBACReconcileCore(t)
+	seedOldCatalogWithoutPlatformUse(t, c, db)
+	ctx := context.Background()
+
+	require.False(t, roleHasPerm(t, c, "admin", "connect.platform.use"))
+
+	require.NoError(t, c.ReconcileRBACPermissions(ctx))
+
+	assert.True(t, roleHasPerm(t, c, "admin", "connect.platform.use"))
+	assert.True(t, roleHasPerm(t, c, "system_admin", "connect.platform.use"))
+	assert.False(t, roleHasPerm(t, c, "viewer", "connect.platform.use"))
+	assert.False(t, roleHasPerm(t, c, "editor", "connect.platform.use"), "editor holds no connect.read either — least privilege")
+}
+
 func TestReconcileRBAC_DoesNotClobberExistingGrants(t *testing.T) {
 	c, db := newRBACReconcileCore(t)
 	seedOldCatalog(t, c, db)

--- a/server/http/remote_storage_connect_grants_test.go
+++ b/server/http/remote_storage_connect_grants_test.go
@@ -19,9 +19,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
-	"github.com/keyorixhq/keyorix/internal/connect"
 	"github.com/keyorixhq/keyorix/internal/core"
-	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
@@ -29,19 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// fakeConnectGrantsConnector is a minimal connect.Connector for exercising
-// ReadFederatedSecret end-to-end without a real external secret store.
-type fakeConnectGrantsConnector struct {
-	name string
-	val  string
-}
-
-func (f fakeConnectGrantsConnector) Name() string { return f.name }
-func (f fakeConnectGrantsConnector) Type() string { return "fake" }
-func (f fakeConnectGrantsConnector) GetSecret(_ context.Context, _ string) (string, error) {
-	return f.val, nil
-}
 
 // newUpstreamDownstreamForConnectGrants builds the standard #510/#527-style
 // two-server harness: an "upstream" exercised through the REAL production
@@ -147,76 +132,16 @@ func TestRemoteStorageConnectGrants_CreateListDeleteByConnector_RealServer(t *te
 	assert.Equal(t, g2.ID, awsGrantsAfter[0].ID)
 }
 
-// TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer is the core
-// #527 regression test: before this fix, ReadFederatedSecret failed
-// UNCONDITIONALLY on a storage.type: remote node whenever Connect was
-// configured, even for a connector with NO ref-grants at all, because
-// connectRefAllowed's ListConnectRefGrantsByConnector call hard-errored on
-// RemoteStorage's stub. This proves the read now succeeds end-to-end over a
-// real HTTP hop.
-func TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer(t *testing.T) {
-	_, downstream := newUpstreamDownstreamForConnectGrants(t)
-	downstream.SetConnectManager(connect.NewManager([]connect.Connector{
-		fakeConnectGrantsConnector{name: "aws", val: "v3ry-secret"},
-	}))
-	downstream.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "platform"}})
-	require.True(t, downstream.ConnectEnabled())
-
-	val, err := downstream.ReadFederatedSecret(context.Background(), core.ActorTypeUser, 1, "aws", "prod/db")
-	require.NoError(t, err, "a federated read on storage.type: remote must not fail closed for a connector with no ref-grants (backlog #527)")
-	assert.Equal(t, "v3ry-secret", val)
-}
-
-// TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer proves the
-// per-reference RBAC policy (ADR-045) itself round-trips correctly over
-// storage.type: remote once a connector has a ref-grant: a machine identity
-// holding the granted role can read a ref under the granted prefix, but is
-// denied a ref outside it — enforced via the real upstream, not a protocol
-// mock. Uses a machine-identity actor (not a user) because actorRoleIDs's
-// underlying GetMachineRoleIDsAt is already proxied for RemoteStorage; the
-// user-role equivalent (GetUserRoleIDsAt/GetUserGroupRoleIDsAt) is a separate,
-// pre-existing, out-of-scope gap this fix does not touch.
-func TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer(t *testing.T) {
-	upstream, downstream := newUpstreamDownstreamForConnectGrants(t)
-	ctx := context.Background()
-
-	downstream.SetConnectManager(connect.NewManager([]connect.Connector{
-		fakeConnectGrantsConnector{name: "aws", val: "v3ry-secret"},
-	}))
-	downstream.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "platform"}})
-
-	project, err := upstream.CreateProject(ctx, "Connect Grants Test Project", "")
-	require.NoError(t, err)
-
-	m, err := downstream.Storage().CreateMachineIdentity(ctx, &models.MachineIdentity{
-		ProjectID:    project.ID,
-		Name:         "connect-grant-machine",
-		IdentityType: core.MachineTypeCI,
-		State:        core.MachineActive,
-	})
-	require.NoError(t, err)
-
-	role, err := upstream.Storage().CreateRole(ctx, &models.Role{Name: "connect-grant-enforcement-role"})
-	require.NoError(t, err)
-
-	// Connect ref-grants are resolved at GLOBAL scope (internal/core/connect.go's
-	// actorRoleIDs), mirroring the production grant scope exactly.
-	globalScope := corestorage.Scope{}
-	require.NoError(t, downstream.Storage().AssignMachineRole(ctx, m.ID, role.ID, globalScope))
-
-	_, err = downstream.Storage().CreateConnectRefGrant(ctx, &models.ConnectRefGrant{
-		RoleID: role.ID, Connector: "aws", RefPrefix: "prod/",
-	})
-	require.NoError(t, err)
-
-	// A ref under the granted prefix succeeds.
-	val, err := downstream.ReadFederatedSecret(ctx, core.ActorTypeMachine, m.ID, "aws", "prod/db")
-	require.NoError(t, err)
-	assert.Equal(t, "v3ry-secret", val)
-
-	// A ref outside the granted prefix is denied — deny-by-default once the
-	// connector is scoped.
-	_, err = downstream.ReadFederatedSecret(ctx, core.ActorTypeMachine, m.ID, "aws", "dev/db")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not permitted")
-}
+// TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer and
+// TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer (which
+// exercised ReadFederatedSecret's ownership/platform-permission gate against a
+// storage.type: remote downstream serving real HTTP traffic) were deleted here,
+// not weakened or fixed: ADR-083 established that this topology — a server
+// with server.http.enabled/server.grpc.enabled backed by storage.type: remote —
+// never actually worked (AuthorizePrincipal could not complete against
+// RemoteStorage's stubbed RBAC primitives for any permission, any actor) and
+// now refuses to boot at all (Config.Validate()). The remaining test in this
+// file is unaffected: it calls RemoteStorage's ConnectRefGrant CRUD methods
+// directly, the same in-process pattern the CLI's own (sanctioned, unaffected)
+// use of storage.type: remote uses — it never boots an HTTP/gRPC server on the
+// RemoteStorage-backed side.


### PR DESCRIPTION
## Summary

ADR-082 branch 4 — the last branch. Closes the interim fail-open `TODO(ADR-082 branch 4)` left in `connectOwnershipSatisfied` since branch 2/3: a `scope: platform` connector was reachable by any `connect.read` holder. Now gated on a new `connect.platform.use` permission, checked via `AuthorizePrincipal` at `Scope{}` (global — a platform connector has no owning project). Also includes a one-word doc correction (§H's audit call-site count) found during pre-push verification.

Stacked on #1488 (audit surface) — the last PR in this stack.

## Scope

- **Terminal deny, deliberately not falling through to `ConnectRefGrant` delegation** the way an ordinary `scope: project` ownership miss does. `ConnectRefGrant` is keyed on role + connector name + ref-prefix with no concept of connector scope — treating it as a fallback here would let anyone able to create a grant bypass `connect.platform.use` for anyone else, not narrow access the way delegation does for `scope: project`. New closed-set audit reason, `platform_permission_denied`, documented in ADR-082 §H.
- `ListConnectors` filters platform connectors identically, via the same `connectOwnershipSatisfied` call — no separate branch — plus a matching guard in the delegation-fallback loop so a (dead-configuration) `ConnectRefGrant` against a platform connector can't make it appear reachable in discovery when an actual read would always deny it.
- `connect.platform.use` added to `defaultPermissions`/`adminPermissions`; `ReconcileRBACPermissions` (ADR-044) carries it to existing installs with no manual migration — verified only `admin`/`system_admin` hold `connect.read` among all seeded roles, so no other role needs it for parity.
- Fixture hazard (expected — branch 2's fixture defaulted every connector to `scope: platform`): all 21 `connectRBACCore` call sites either grant the permission or carry a comment explaining why the site is unaffected. The 5 `connectTestCore` (`MockStorage`) sites get a real, fixture-driven `AuthorizePrincipal` stub parameterized by a per-test-declared grant, not a blanket allow — a dedicated regression test proves the stub genuinely denies when told to.
- Confirmed (report only, not fixed): `CreateConnectRefGrant` doesn't check connector scope, so a `ConnectRefGrant` *can* be created against a platform connector's name — under the new terminal deny it's dead configuration. Filed as issue #1479.

## Test plan

- [x] `go build ./...` clean at every commit (verified 8-commit bisect-compile, plus this branch's own tip re-verified after a later ADR-083 rebase touched an adjacent branch)
- [x] Reconcile precedent test mirroring the existing `connect.read` case; fresh-install bootstrap test confirming `admin`/`system_admin` hold the permission
- [x] `server/http` baseline diff by failing-test-name: identical to the pre-existing baseline, zero new failures
- [x] `gosec -severity medium`: 0 issues
- [x] End-to-end: booted a real server with both a `scope: project` and a `scope: platform` connector together, confirmed it comes up cleanly