### PR TITLE
ci: trigger pull_request workflows on stacked-PR branch conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # main plus the stacked-PR branch conventions used for multi-PR review
+    # chains (each PR in a stack targets its predecessor's branch, not main
+    # directly, until it's that PR's turn to land) — without these, a PR
+    # based on a sibling feature branch never triggers CI at all.
+    branches: [main, 'adr082/**', 'feat/**', 'fix/**']
 
 # Workflow-level default: zero permissions. No job here writes to the repo,
 # comments on PRs, or publishes anything — a compromised dependency/action in

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # See ci.yml's own comment: also covers stacked-PR review chains.
+    branches: [main, 'adr082/**', 'feat/**', 'fix/**']
   schedule:
     # Weekly deep scan: catches newly-published CodeQL query packs against
     # unchanged code, not just what a push/PR diff touches.

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -2,7 +2,8 @@ name: DCO
 
 on:
   pull_request:
-    branches: [main]
+    # See ci.yml's own comment: also covers stacked-PR review chains.
+    branches: [main, 'adr082/**', 'feat/**', 'fix/**']
 
 # Read-only: this job only inspects commit metadata already in the PR, it
 # never needs to write anything.

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -5,7 +5,8 @@ on:
     branches: [main]
     paths-ignore: ['**/*.md', 'docs/**']
   pull_request:
-    branches: [main]
+    # See ci.yml's own comment: also covers stacked-PR review chains.
+    branches: [main, 'adr082/**', 'feat/**', 'fix/**']
     paths-ignore: ['**/*.md', 'docs/**']
   schedule:
     - cron: '26 12 * * 5'

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -2,7 +2,8 @@ name: OSV-Scanner
 
 on:
   pull_request:
-    branches: [main]
+    # See ci.yml's own comment: also covers stacked-PR review chains.
+    branches: [main, 'adr082/**', 'feat/**', 'fix/**']
     paths-ignore: ['**/*.md', 'docs/**']
   push:
     branches: [main]

--- a/.github/workflows/security-fix-regression-test.yml
+++ b/.github/workflows/security-fix-regression-test.yml
@@ -2,7 +2,8 @@ name: Security Fix Regression Test
 
 on:
   pull_request:
-    branches: [main]
+    # See ci.yml's own comment: also covers stacked-PR review chains.
+    branches: [main, 'adr082/**', 'feat/**', 'fix/**']
 
 # Read-only: this job only inspects PR metadata and the diff already in the
 # PR, it never needs to write anything.

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -5,7 +5,8 @@ on:
     branches: [main]
     paths-ignore: ['**/*.md', 'docs/**']
   pull_request:
-    branches: [main]
+    # See ci.yml's own comment: also covers stacked-PR review chains.
+    branches: [main, 'adr082/**', 'feat/**', 'fix/**']
     paths-ignore: ['**/*.md', 'docs/**']
   schedule:
     - cron: '34 7 * * 4'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -5,7 +5,11 @@ on:
     branches: [main]
     paths-ignore: ['**/*.md', 'docs/**']
   pull_request:
-    branches: [main]
+    # See ci.yml's own comment: also covers stacked-PR review chains. Note:
+    # SonarCloud's new-code baseline comparison is tuned for a main-targeted
+    # PR; a PR targeting a feature branch still runs the scan, but the
+    # "new code since" comparison point may be less meaningful mid-stack.
+    branches: [main, 'adr082/**', 'feat/**', 'fix/**']
     paths-ignore: ['**/*.md', 'docs/**']
 
 permissions: {}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -5,7 +5,8 @@ on:
     branches: [main]
     paths-ignore: ['**/*.md', 'docs/**']
   pull_request:
-    branches: [main]
+    # See ci.yml's own comment: also covers stacked-PR review chains.
+    branches: [main, 'adr082/**', 'feat/**', 'fix/**']
     paths-ignore: ['**/*.md', 'docs/**']
   schedule:
     - cron: '17 9 * * 3'

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -21,7 +21,8 @@ on:
     branches: [main]
     paths: ['web/**']
   pull_request:
-    branches: [main]
+    # See ci.yml's own comment: also covers stacked-PR review chains.
+    branches: [main, 'adr082/**', 'feat/**', 'fix/**']
     paths: ['web/**']
 
 # Workflow-level default: zero permissions, matching ci.yml's own least-privilege

--- a/.github/workflows/web-dependency-review.yml
+++ b/.github/workflows/web-dependency-review.yml
@@ -10,7 +10,8 @@ name: Web Dependency Review
 
 on:
   pull_request:
-    branches: [main]
+    # See ci.yml's own comment: also covers stacked-PR review chains.
+    branches: [main, 'adr082/**', 'feat/**', 'fix/**']
     paths: ['web/**']
 
 permissions: {}


### PR DESCRIPTION
## Summary

Every workflow with a `pull_request` trigger in this repo restricted to `branches: [main]` — confirmed across all 11 files that have one (`ci`, `codeql`, `dco`, `hadolint`, `osv-scanner`, `security-fix-regression-test`, `semgrep`, `sonarcloud`, `trivy`, `web-ci`, `web-dependency-review`). A PR whose base is a sibling feature branch never triggered any of them: not pending, not delayed — genuinely zero checks ever registered. Confirmed via both the Checks API and the raw commit-status API before concluding this, not assumed from the workflow config alone.

This was discovered opening a 9-PR stacked review chain for ADR-082/ADR-083: the two PRs targeting `main` directly got full CI; the seven PRs targeting each other's branches showed `mergeable: MERGEABLE` (no conflicts) but had literally never run a single check, which reads as "green" in the GitHub UI's merge-conflict indicator even though nothing was ever verified.

## Change

Adds `'adr082/**'`, `'feat/**'`, and `'fix/**'` to each `pull_request.branches` list alongside `main` — covering the current ADR-082 stack's branch names plus the general worktree-branch naming convention already in use in this repo, without opening these checks to arbitrary/every branch (CI cost and fork-PR exposure considered).

## Note

`sonarcloud.yml`: SonarCloud's new-code baseline comparison is tuned for a main-targeted PR; a PR targeting a feature branch still runs the scan, but the "new code since" comparison point may be less meaningful mid-stack. Flagged in the workflow's own comment, not resolved here.

## Test plan

- [x] `actionlint` clean on all 11 edited files
- [x] This PR itself targets `main`, so it will get full CI under the *current* (pre-fix) config — a real, verifiable pass/fail
- [ ] After merge: verify empirically (via the checks API, not by re-reading the config) whether CI now fires on the existing stacked PRs at their current bases, since GitHub evaluates a `pull_request` workflow using the version of the file on the PR's *base* ref, not `main` — merging this alone may not be sufficient for branches that existed before this fix