### PR TITLE
feat(connect): land remaining ADR-082 stack (branches 3-4: ownership, audit, platform-use permission)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ All notable changes to Keyorix are documented here. This project follows
   `scope: project` or `scope: platform` (ADR-082)** — an existing deployment with
   `connect.enabled: true` and one or more configured connectors **will fail to boot**
   after upgrading unless every connector in `connect.connectors` gains an explicit
-  `scope:` (and `project:` when `scope: project`). Set `connect.allow_unscoped: true`
-  as a temporary, deployment-wide stopgap to boot anyway — every connector still
-  missing `scope:` then logs a `WARN` on every boot until it's fixed. This is the
-  config-schema/boot-validation part of ADR-082 only; connector ownership is not yet
-  enforced on the read path (a later change) — see
+  `scope:` (and `project:` when `scope: project`). **There is no escape hatch and no
+  deployment-wide bypass** — adding `scope:` to an existing connector takes minutes,
+  and an unscoped connector would deny every read anyway once ownership enforcement
+  evaluates it (see below), so a bypass would only defer the failure from boot time
+  to read time, not restore access. Connector ownership is enforced on the read path
+  as of this same change: a caller must be a member of the connector's owning
+  project (or hold a matching `ConnectRefGrant`) to read through it — see
   `docs/adr-082-connect-connector-tenant-scoping.md`.
 - **BREAKING: keyorix-operator default RBAC/watch scope narrowed to own-namespace-only
   (ADR-076)** — an unmodified `helm install deploy/helm/keyorix-operator` now binds a

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1159,11 +1159,11 @@ with no connectors the `/connect` endpoints are not served.
 ```yaml
 connect:
   enabled: true
-  # allow_unscoped is a temporary, deployment-wide escape hatch (ADR-082): with it
-  # unset (the default), any connector below with no scope: fails server boot. Set
-  # it true only while migrating an existing config — every connector missing scope:
-  # then logs a WARN, every boot, until you set scope: on it and remove this flag.
-  allow_unscoped: false
+  # Every connector below MUST declare scope: — a missing or unrecognized value
+  # fails server boot unconditionally (ADR-082). There is no escape hatch: adding
+  # scope: to an existing connector takes minutes, and an unscoped connector would
+  # deny every read anyway (ownership has no entry for it), so a bypass would only
+  # defer the failure from "boot" to "every read," not actually restore access.
   connectors:
     - name: prod-aws            # API path key (unique); GET /api/v1/connect/prod-aws/secret?ref=…
       type: aws-secrets-manager # aws-secrets-manager | gcp-secret-manager | azure-key-vault | vault

--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -11,8 +11,9 @@ what is deliberately deferred to implementation-phase follow-up work.
 
 Four separate branches, one logical change each:
 
-1. Config schema (`scope`, `project`, `environment`, `connect.allow_unscoped`)
-   and boot validation (C).
+1. Config schema (`scope`, `project`, `environment`) and boot validation (C).
+   (`connect.allow_unscoped` was part of the original schema; removed by
+   amendment — see (C).)
 2. Ownership enforcement (E) and `ListConnectors` filtering.
 3. Audit changes (H) — the three-way decision reason, the switch to
    `writeAuditEventFull`, `AuditEvent.ProjectID` population.
@@ -224,26 +225,64 @@ There is no `legacy_unscoped` value and no phased default-flip release (a
 real revision from the prior draft of this ADR, per direct instruction).
 Instead:
 
-### C. Missing `scope` fails boot; the only escape hatch is explicit and per-deployment, not per-connector
+### C. Missing `scope` fails boot, unconditionally — no escape hatch
 
 A connector config entry with no `scope` key **fails server boot**, with an
 error naming every offending connector by its config-file name (not just
 the first one found — an operator fixing config should not have to
-restart-and-discover connectors one at a time).
+restart-and-discover connectors one at a time). There is no per-connector
+opt-out and no deployment-wide bypass of any kind — absence of `scope` is a
+hard failure, full stop. This is the same "explicit value required, absence
+denies" shape already established in this codebase (most recently
+ADR-076's `POD_NAMESPACE` hard-fail-on-empty).
 
-The only way to boot anyway is a single, explicit, deployment-wide config
-flag: `connect.allow_unscoped: true`. When set, boot proceeds, but **every**
-connector missing a `scope` emits a `WARN`-level log line naming it, at
-every boot, for as long as the flag stays set. There is no per-connector
-opt-out and no silent variant — `connect.allow_unscoped` unset (the
-default) means absence of `scope` is a hard failure, full stop. This is the
-same "explicit value required, absence denies" shape already established in
-this codebase (most recently ADR-076's `POD_NAMESPACE` hard-fail-on-empty),
-simplified here to a single boot-time gate rather than a phased migration
-because — unlike ADR-076's operator RBAC default, which had to preserve a
-*running* cluster's existing behavior across an upgrade — Connect connector
-config is edited and the server restarted as one atomic operator action;
-there is no live-traffic window a phased flip would need to protect.
+**Amended: the original design here included a single, explicit,
+deployment-wide escape hatch, `connect.allow_unscoped: true` — removed.**
+When set, boot proceeded, and every connector still missing a `scope`
+emitted a `WARN`-level log line naming it, at every boot, for as long as
+the flag stayed set. On implementation and verification (branch 2, ownership
+enforcement), this turned out not to be an escape hatch at all: an unscoped
+connector has no entry in the ownership map `connectOwnershipSatisfied` (§E)
+consults, and that function's own missing-entry-denies rule — the same rule
+that makes a connector absent from the map deny for every caller rather than
+silently allow or silently skip — applied to it exactly as it would to any
+other connector with no ownership data. The flag let the *server* boot, but
+every *read* against an unscoped connector was denied regardless (unless a
+caller separately held an unrelated `ConnectRefGrant`, ADR-045's delegation
+mechanism, which an operator mid-migration would have no particular reason
+to have configured). The WARN it produced was accurate but misleading in
+effect: it read as "this still works, fix it soon," when the true state was
+"this doesn't work at all, and nothing here will tell you that until a read
+fails." A flag that defers a failure from boot time to read time, silently,
+is not a migration aid — it just moves where the operator discovers the
+problem, later and less legibly (a `502`, not a boot-time error naming the
+connector). The actual migration path — this ADR's own boot-fail-with-an-
+aggregated-list-of-every-offending-connector — already tells an operator
+exactly what to fix in one pass, and fixing it (adding `scope:` to a
+connector entry) takes minutes; there was nothing here worth an escape
+hatch for.
+
+Removing the flag also removes the one exemption the boot-time key-set
+consistency check (§E) carried: with `resolveConnectorOwnership` no longer
+skipping any connector (there is no longer an "expected to have no
+ownership entry" case), a connector present in `connect.Manager` but absent
+from the resolved ownership map — for any reason, including what used to be
+the deliberately-unscoped case — is now, unconditionally, a boot-failing
+key-set mismatch. This closes a real gap the removed exemption was
+carrying, not obviously connected to `allow_unscoped` itself: the mismatch
+check's fail-closed guarantee no longer depends on `cfg.Validate()` having
+already run and enforced "empty scope implies the flag was set" as an
+external precondition it trusted rather than re-verified — a future code
+path reaching either function without that precondition (a refactor, a new
+call site, a test) can no longer be silently misread as "legitimately
+unscoped."
+
+This is simplified to a single, unconditional boot-time gate rather than a
+phased migration because — unlike ADR-076's operator RBAC default, which
+had to preserve a *running* cluster's existing behavior across an upgrade
+— Connect connector config is edited and the server restarted as one
+atomic operator action; there is no live-traffic window a phased flip
+would need to protect.
 
 ### D. Ownership is derived server-side from role assignments. No new request parameter, no proto change, no signature change.
 
@@ -691,16 +730,17 @@ repository's existing versioning (`v0.91.0` is current at time of writing;
 `v0.92.0` is the earliest this could ship in, not a fixed commitment ahead
 of implementation). Any existing deployment with `connect.enabled: true`
 and one or more configured connectors **will fail to boot** after upgrading
-unless every connector gains an explicit `scope`, or the deployment sets
-`connect.allow_unscoped: true` as an explicit, intentional stopgap (with the
-every-boot `WARN` noise that implies). This requires a **`BREAKING`**-labeled
+unless every connector gains an explicit `scope` — **there is no bypass**
+(C, amended): the original `connect.allow_unscoped` stopgap is removed,
+since it never actually restored a connector's usability, only deferred the
+failure from boot time to read time. This requires a **`BREAKING`**-labeled
 CHANGELOG entry for that release — the same handling ADR-076 gave its own
 default-scope change (that ADR's Consequences section: "Two separate
 CHANGELOG entries, not one" — `BREAKING` for the behavior change itself).
 The entry must state the required pre-upgrade config change plainly, not
 just "review your config" (ADR-076's own precedent for what counts as
-adequate here), and must name the exact new keys (`scope`, `project`,
-`connect.allow_unscoped`) an operator needs to act on.
+adequate here), and must name the exact new keys (`scope`, `project`) an
+operator needs to act on.
 
 **Why config-only was chosen over a DB mirror.** Stated directly in (A):
 there is no runtime connector-CRUD capability today, so a DB row would add

--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -20,7 +20,11 @@ Four separate branches, one logical change each:
 4. The new `connect.platform.use` permission (B) and its addition to
    `adminPermissions`.
 
-**No branch has been started as of this ADR's acceptance.**
+**Branches 1-3 are implemented; branch 4 (`connect.platform.use`) is not
+started.** Branch 3 (H) also closes issue #1477's audit half: every
+`ConnectorProjectBinding` write is now audited, not only the `connect.secret_read`
+path — see (H) below for the full, as-implemented design (the text below
+reflects what shipped, superseding the plan-time description that preceded it).
 
 ## Context
 
@@ -564,28 +568,113 @@ so:
   control — the doc/config comments for this key must say "reserved,
   not yet enforced" plainly, not merely omit mention of enforcement.
 
-### H. Audit surface: switch to `writeAuditEventFull`, populate the connector's owning project, record which gate authorized the read
+### H. Audit surface: switch to `writeAuditEventFull`/`writeAuditEventFailed`, populate the connector's owning project, record which gate decided the outcome, audit every write to `ConnectorProjectBinding`
 
-Every Connect audit event (`connect.secret_read`, success and denial alike)
-switches from `writeAuditEvent` to `writeAuditEventFull`, populating the
-existing `AuditEvent.ProjectID` column with the connector's **owning**
-project (from its config `scope`/`project`) — zero schema change, this
-column already exists and is simply unpopulated by Connect today. A
-successful read additionally carries a distinct, greppable decision-reason
-marker naming which gate in (E)'s order actually resolved ownership:
-`project_membership` (caller is a genuine member of the connector's owning
-project), `global_scope` (caller's scope set carried the `{0,0}`
-global-scope wildcard entry — (E), any role name), or `delegation` (caller
-had no ownership claim at all, resolved instead via a matching
-`ConnectRefGrant`) — exact
-string tokens are an implementation detail, not a design axis. This makes a
-cross-project delegation read, and an admin reaching a connector they are
-not a genuine member of, both distinguishable from an ordinary same-project
-read in an audit review, rather than all three being indistinguishable
-successful reads. This mirrors the numeric-at-storage, resolved-at-export-layer
-split already established for `impersonated_by`/`acting_as` (numeric FK at
-the `AuditEvent` row, resolved to an email string only at the HTTP
-export/API layer) — the same convention, not a new one.
+Every Connect audit event on the read path (`connect.secret_read` — every
+outcome, allow or deny, including the two paths that were silent through
+branch 2: `connect.read` disabled and a genuinely unknown connector) is
+written with `AuditEvent.ProjectID` populated to the connector's **owning**
+project (from its config `scope`/`project`; `nil` for a `scope: platform`
+connector, since `ProjectID` is meaningless there) — zero schema change,
+this column already existed and was simply unpopulated by Connect before
+this branch. `writeAuditEventFailed` was extended with a `projectID`
+parameter (previously it took none) to make this possible for deny events;
+this touched 6 pre-existing non-Connect call sites
+(`auth.login_failed`, risk-exception approval denial ×2, legal-hold
+place/lift denial ×2, compliance-digest broadcast failure), all mechanically
+updated to pass `nil` — none of those events carry project context.
+
+**Success is `true` only for the read that actually returned a value.**
+Every other outcome — the two RBAC denials (E)'s call order can reach,
+`connect.read` disabled, unknown connector, and a failed upstream call to
+the connector's backend — is written with `Success: false`.
+
+**Decision reason: a fixed `reason=<value>` token, closed set, at a
+consistent position in every event's `Description`.** There is no
+structured, enum-typed column for this on `AuditEvent` — none exists today
+(verified directly against the model, not assumed), and the design that
+would have been the closest precedent (ADR-075's "closed `key_source`
+enum") was never actually implemented under that name anywhere in the
+codebase; see the issue filed alongside this branch for that specific
+drift. Given that, the token goes into free-text `Description`, using the
+SAME fixed format at every one of the eight call sites below, specifically
+so a future structured column is a parse-and-backfill against this closed
+set, not a rewrite:
+
+Allow (`Success: true`):
+- `project_membership` — caller holds a role scoped to the connector's
+  owning project specifically.
+- `global_scope` — caller holds a role at the true global (`{0,0}`) scope,
+  which wildcards every project-scoped connector (E), regardless of role
+  name.
+- `platform_scope` — the connector itself is `scope: platform`; ownership
+  passes for any `connect.read` holder (branch 4's `connect.platform.use`
+  narrows this further, not yet implemented).
+- `delegation` — caller had no ownership claim at all on the connector's
+  project, resolved instead via a matching `ConnectRefGrant` (F).
+
+Deny (`Success: false`):
+- `connect_disabled` — no `connect.Manager` configured at all.
+- `unknown_connector` — the named connector does not exist in config.
+- `ref_not_permitted` — caller IS owned, but a `ConnectRefGrant` scoped to
+  this connector exists and none of the caller's roles hold a grant
+  matching the requested ref (ADR-045, unchanged).
+- `ownership_denied` — caller is NOT owned, and the connector has ZERO
+  `ConnectRefGrant`s configured at all — no delegation path exists.
+- `delegation_denied` — caller is NOT owned; the connector DOES have
+  `ConnectRefGrant`(s), but none matched this caller's roles/ref.
+- `backend_error` — ownership (or delegation) was satisfied, but the
+  upstream connector call itself failed (network, credentials, etc.); the
+  raw upstream error is logged server-side only, never persisted into the
+  audit trail (backlog #116, pre-existing G50 protection, unchanged).
+
+`ownership_denied` and `delegation_denied` are the SAME code branch in
+`ReadFederatedSecret` — (E) still returns the identical
+`ErrConnectUnknownConnector` shape to the caller for both, deliberately
+(existence-hiding, per (E)'s own rationale) — but the audit event
+distinguishes them, because this is the only place an operator can learn
+which gate actually closed. This is the concrete case this branch exists
+for: an admin reaching a connector they are not a genuine member of, and a
+cross-project delegation read, and a hard deny, are all indistinguishable
+to the caller by design, but are fully distinguishable in an audit review.
+
+This mirrors the numeric-at-storage, resolved-at-export-layer split already
+established for `impersonated_by`/`acting_as` (numeric FK at the
+`AuditEvent` row, resolved to an email string only at the HTTP export/API
+layer) — the same convention, not a new one.
+
+**`ConnectRefGrant` management events** (`connect.ref_grant_create`,
+`connect.ref_grant_delete`) also switch to `writeAuditEventFull`, populating
+`ProjectID` from the grant's connector's owning project (looked up the same
+way; for delete, via a best-effort `ListConnectRefGrants` scan by id before
+the delete call, since the storage interface has no fetch-by-id or
+delete-returning-row primitive and adding one is out of scope here).
+
+**`ListConnectors` discovery filtering is deliberately NOT audited** — a
+caller listing connectors and having some silently omitted (E) is
+high-volume, low-signal, and would make a routine discovery poll into an
+audit write. Any actual attempt to read a hidden connector is already
+captured by the `connect.secret_read` deny path above; that is the
+meaningful signal, not the list operation itself.
+
+**`ConnectorProjectBinding` writes are audited at both call sites**
+(closing issue #1477's audit half): the boot-time first-resolution write in
+`server/main.go`'s `resolveConnectorOwnership`, and the RemoteStorage proxy
+write in `CreateConnectorProjectBindingProxy`
+(`server/http/handlers/connector_project_bindings_proxy.go`). Both use a new
+event type, `connect.project_binding_create`, and are actored as `"system"`
+(`core.ActorTypeSystem`) — neither call site has a human session or
+machine-identity principal behind it: the boot-time write is unattended, and
+the proxy endpoint is reached only by a node-credential/`system.write`
+caller. `#1477`'s wording named only the proxy write; this branch covers
+both, because the binding is an authorization input (it feeds
+`core.ConnectOwnership`, and from there `connectOwnershipSatisfied`)
+regardless of which door the write comes through, and the boot-time path is
+the more consequential of the two since nothing is watching it interactively.
+A failure to persist the audit event does NOT fail the boot or the request —
+the binding itself already persisted — but is logged loudly
+(`SECURITY`-prefixed), matching `emitAudit`'s own convention for a failed
+audit write.
 
 ### I. ADR-045 is explicitly amended, not silently superseded
 

--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -143,9 +143,8 @@ GCP one's boot-warning-only enforcement gap is out of scope for this ADR
 
 Connectors remain pure server configuration, exactly as today. Each
 connector config entry gains a required `scope` field (see (B)) and an
-optional `project` reference (a Keyorix project's numeric ID or unique
-name, config-file-resolvable at boot the same way every other
-config-time reference in this codebase is — implementation detail).
+optional `project` reference — a Keyorix project's **name**, not a numeric
+ID (see the subsection immediately below for why).
 
 **Explicitly decided: no DB table mirrors connector metadata.** There is no
 runtime connector-management API today (creating/updating a connector
@@ -156,6 +155,44 @@ connectors by the same bare name string it already uses; nothing about this
 ADR requires a stable numeric connector ID. **Revisit only if/when runtime
 connector CRUD ships** — that is the point at which a DB-backed identity
 would earn its keep, not before.
+
+#### A.1 Project names are mutable and freed on soft-delete — why `project:` pins by ID, once, and a rename is a deliberate boot failure
+
+Verified directly against the schema and the update path, not assumed:
+`Project.Name` (`models.go:9-17`) carries no immutability — `UpdateProject`
+(`catalog.go:120,132`) directly reassigns `project.Name = name` with no
+restriction — and its own doc comment states explicitly that uniqueness is
+enforced by a **partial** index, `LOWER(name) WHERE deleted_at IS NULL`,
+"so a soft-deleted project's name is still freed for reuse." Both facts
+combine into a real risk: if a connector's ownership were re-resolved by
+name on every boot, an ordinary project rename — or a delete-and-recreate
+under the same name, by a different admin, for an unrelated reason — would
+silently reassign which project owns a connector, with no config change and
+no operator awareness that Connect was affected at all.
+
+**The fix: `project:` names the project by string, but is resolved to a
+numeric project ID exactly ONCE — at the first boot after a connector is
+configured — and pinned via a new persisted row,
+`ConnectorProjectBinding` (`connector`, `project_id`, `project_name`).
+Every later boot resolves by the STORED ID, never by re-reading the config's
+`project:` name against live `Project` rows.** If the bound project's
+CURRENT name (looked up by the stored ID) no longer matches the name
+recorded in the binding at first-boot time, boot fails, naming both the
+stored and current name — this is a **deliberate** boot failure, not a
+silent reassignment: a rename that happened between boots is exactly the
+ambiguous case (intentional relabeling vs. an unrelated project stealing the
+name) this ADR refuses to resolve automatically. The same applies if the
+bound project no longer exists (deleted). There is no operator-facing
+binding-management surface in this branch (out of scope, see below); the
+remediation path today is to remove the stale `connector_project_bindings`
+row (a direct DB action) once the rename is confirmed intentional, then
+restart — a real if unpolished escape hatch, not a dead end.
+
+This mirrors, at a smaller scale, the same "explicit value required,
+absence/ambiguity denies" shape (C) already establishes for `scope` itself
+— a `project:` name is a human-friendly config-time label, not a security
+identifier; the security identifier is the persisted numeric ID it resolves
+to once, not the string re-derived from it on every boot.
 
 ### B. `scope: project | platform` — exactly two values, no third state
 
@@ -439,6 +476,24 @@ matching ConnectRefGrant for one of the caller's roles?  → yes: allow (reason:
   own name — e.g. `TestConnectOwnership_ZeroScopeEntryMustSurvive` — so a
   future removal fails with a message pointing at this ADR's design, not a
   silently-discovered production authorization regression.
+- **A read denied by ownership (with no matching `ConnectRefGrant`
+  delegation) returns the exact same shape as an unknown connector**
+  (`ErrConnectUnknownConnector` — `502`/HTTP, `codes.FailedPrecondition`/
+  gRPC, same message text) — a deliberate choice, not an oversight.
+  `ListConnectors` already omits a connector the caller cannot reach from
+  discovery (E); returning a distinguishable "exists, but you can't read
+  it" response on the single-connector read path would let a caller probe
+  for a connector's existence by trying names one at a time, defeating that
+  omission. **This costs operator debuggability**: a caller who genuinely
+  mistyped a connector name and a caller who is correctly denied ownership
+  see an identical error, so a legitimate misconfiguration (a typo in
+  `connector:`) cannot be distinguished from a correct denial by the
+  response alone. The audit event (branch 3) is the intended remedy for
+  this: the three-way decision reason (`project_membership` /
+  `global_scope` / `delegation`) never populated on a genuine denial is
+  visible to whoever can read the audit trail (an operator debugging their
+  own misconfiguration, or a security reviewer), even though it is
+  invisible to the caller who received the response.
 
 ### F. `ConnectRefGrant` (ADR-045) retained unchanged as the cross-project delegation path
 
@@ -568,6 +623,11 @@ design, with (D) added.)
 - Web UI / CLI surfaces for viewing a connector's `scope`/`project` or the
   boot-time unscoped-connector warning list — follow mechanically from
   (A)-(C) once shipped, not a design question this ADR resolves.
+- An operator-facing `ConnectorProjectBinding` management surface (view/
+  clear a stale binding after a confirmed intentional project rename — see
+  (A.1)). The remediation path today is a direct DB action (remove the
+  stale `connector_project_bindings` row, then restart); a proper admin
+  surface for this is a real follow-up, not decided or built here.
 - Regenerating the gRPC proto is **not needed** — (D) explicitly keeps the
   wire shape unchanged.
 - **Splitting "read across all projects" from "administer all projects"

--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -652,7 +652,7 @@ would have been the closest precedent (ADR-075's "closed `key_source`
 enum") was never actually implemented under that name anywhere in the
 codebase; see the issue filed alongside this branch for that specific
 drift. Given that, the token goes into free-text `Description`, using the
-SAME fixed format at every one of the eight call sites below, specifically
+SAME fixed format at every one of the seven call sites below, specifically
 so a future structured column is a parse-and-backfill against this closed
 set, not a rewrite:
 

--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -20,11 +20,16 @@ Four separate branches, one logical change each:
 4. The new `connect.platform.use` permission (B) and its addition to
    `adminPermissions`.
 
-**Branches 1-3 are implemented; branch 4 (`connect.platform.use`) is not
-started.** Branch 3 (H) also closes issue #1477's audit half: every
-`ConnectorProjectBinding` write is now audited, not only the `connect.secret_read`
-path — see (H) below for the full, as-implemented design (the text below
-reflects what shipped, superseding the plan-time description that preceded it).
+**All four branches are implemented.** Branch 3 (H) also closes issue
+#1477's audit half: every `ConnectorProjectBinding` write is now audited, not
+only the `connect.secret_read` path. Branch 4 adds `connect.platform.use`
+(B) and gates it as a TERMINAL deny with no `ConnectRefGrant` delegation
+fallback (E) — a deliberate fork from the `scope: project` ownership-miss
+path, not a later revision toward consistency with it. See (E) and (H) below
+for the full, as-implemented design (the text in those sections reflects
+what shipped, superseding the plan-time description that preceded it, most
+notably (E)'s diagram, which originally said a platform-permission denial
+fell through to delegation — it does not).
 
 ## Context
 
@@ -457,9 +462,12 @@ admin-*named* role globally (unaffected by this ADR either way), now
 extended consistently to Connect ownership specifically.
 
 ```
-connect.read granted?                                    → no:  deny
+connect.read granted?                                    → no:  deny (reason: connect_disabled / unknown_connector)
 connector.scope == platform?
-  → yes: connect.platform.use granted?  → yes: allow (reason: capability)  → no: fall through to delegation check below
+  → yes: connect.platform.use granted (checked at Scope{}, global)?
+      → yes: allow (reason: platform_scope)
+      → no:  TERMINAL deny (reason: platform_permission_denied) — no
+             ConnectRefGrant fallback; see below for why
 connector.scope == project?
   → caller's RAW scope set (GetUserRoleScopes/GetMachineRoleScopes,
     including any {0,0} entry) contains connector.project?
@@ -468,8 +476,51 @@ connector.scope == project?
     role grant, any role name — see above)?
                                                           → yes: allow (reason: global_scope)
 matching ConnectRefGrant for one of the caller's roles?  → yes: allow (reason: delegation)
-                                                          → else: deny
+                                                          → no:  deny (reason: ownership_denied /
+                                                                 delegation_denied)
 ```
+
+**A denied `connect.platform.use` check is TERMINAL — it does NOT fall
+through to `ConnectRefGrant` delegation, unlike an ordinary `scope: project`
+ownership miss (this ADR's own earlier draft of this diagram said it did;
+corrected here on implementation, not a later change of mind — see "Out of
+scope"/(H) history).** This is a deliberate fork, not an oversight, and must
+not later be "reconciled" toward consistency with the project-scope path.
+Two independent reasons, both load-bearing:
+
+1. **A `ConnectRefGrant` targeting a `platform`-scope connector's name would
+   not be narrowing access — it would be granting it.** `ConnectRefGrant`
+   is keyed on role + connector name + ref-prefix alone; it has no concept
+   of the connector's `scope`, and nothing in `CreateConnectRefGrant`
+   currently rejects creating one against a platform connector (a known,
+   separately-tracked gap — see the issue filed alongside this branch: such
+   a grant is dead configuration under this design, consulted by nothing).
+   If a platform-scope ownership miss fell through to the SAME delegation
+   check a project-scope miss does, then any principal able to create a
+   `ConnectRefGrant` (an ordinary RBAC-gated management action, not itself
+   gated on `connect.platform.use`) could hand any other principal read
+   access to a platform-wide connector, entirely bypassing
+   `connect.platform.use`. For a project-scoped connector this isn't a
+   bypass — delegation is explicitly scoped to ONE connector's ONE
+   project, a narrower grant than project ownership itself would confer.
+   For a platform connector there is no narrower boundary below "the whole
+   connector" for a grant to sit inside of — delegation and the permission
+   it would be bypassing would cover the exact same surface.
+2. **A platform connector has no owning project for "delegation" to be
+   relative to.** `ConnectOwnership.ProjectID` is meaningless when
+   `Scope == "platform"` (its own doc comment says so); `ConnectRefGrant`
+   delegation (F) is conceptually "an explicit administrator-authorized
+   exception to a project-ownership boundary a caller doesn't otherwise
+   clear" — there is no such boundary here for an exception to be relative
+   to.
+
+`ConnectReadableConnectorNames` (`ListConnectors`) applies the identical
+terminal rule via the same per-connector loop, not a separate branch: a
+caller lacking `connect.platform.use` never reaches the delegation-fallback
+check for a platform connector there either — otherwise a
+(dead-configuration) `ConnectRefGrant` against a platform connector's name
+could make it appear in discovery for a caller whose actual read would
+always be denied, the exact leak this whole section exists to prevent.
 
 - **`ListConnectors` filters**: unchanged in shape from the prior draft —
   the returned list contains only connectors the caller can reach under
@@ -498,10 +549,14 @@ matching ConnectRefGrant for one of the caller's roles?  → yes: allow (reason:
   bypass wherever it's granted, but **not** the ownership wildcard outside
   that scope. This decoupling is deliberate, not a bug — see the two
   paragraphs above.
-- **Audit records which gate authorized the read**, as a distinct
-  decision reason per branch of the flowchart above: `project_membership`,
-  `global_scope`, or `delegation` (exact string tokens are an
-  implementation detail, not a design axis — see "Out of scope" and (H)).
+- **Audit records which gate authorized (or denied) the read**, as a
+  distinct decision reason per branch of the flowchart above: allow —
+  `project_membership`, `global_scope`, `platform_scope`, `delegation`;
+  deny — `connect_disabled`, `unknown_connector`, `ref_not_permitted`,
+  `ownership_denied`, `delegation_denied`, `platform_permission_denied`,
+  `backend_error` (exact string tokens are an implementation detail, not a
+  design axis — see "Out of scope" and (H) for the full closed set and its
+  fixed `reason=<value>` format).
   A read authorized via the *permission-check* bypass (step 1/2 above)
   does not by itself change which ownership reason gets recorded — the
   reason names the gate that resolved ownership, not whether `connect.read`
@@ -607,11 +662,13 @@ Allow (`Success: true`):
 - `global_scope` — caller holds a role at the true global (`{0,0}`) scope,
   which wildcards every project-scoped connector (E), regardless of role
   name.
-- `platform_scope` — the connector itself is `scope: platform`; ownership
-  passes for any `connect.read` holder (branch 4's `connect.platform.use`
-  narrows this further, not yet implemented).
+- `platform_scope` — the connector itself is `scope: platform` and the
+  caller holds `connect.platform.use` (branch 4; checked at `Scope{}`,
+  global — a platform connector has no owning project to check a
+  project-scoped grant against).
 - `delegation` — caller had no ownership claim at all on the connector's
-  project, resolved instead via a matching `ConnectRefGrant` (F).
+  project, resolved instead via a matching `ConnectRefGrant` (F). Never
+  reached for a `scope: platform` connector — see below.
 
 Deny (`Success: false`):
 - `connect_disabled` — no `connect.Manager` configured at all.
@@ -619,10 +676,24 @@ Deny (`Success: false`):
 - `ref_not_permitted` — caller IS owned, but a `ConnectRefGrant` scoped to
   this connector exists and none of the caller's roles hold a grant
   matching the requested ref (ADR-045, unchanged).
-- `ownership_denied` — caller is NOT owned, and the connector has ZERO
-  `ConnectRefGrant`s configured at all — no delegation path exists.
-- `delegation_denied` — caller is NOT owned; the connector DOES have
-  `ConnectRefGrant`(s), but none matched this caller's roles/ref.
+- `ownership_denied` — caller is NOT owned (`scope: project`), and the
+  connector has ZERO `ConnectRefGrant`s configured at all — no delegation
+  path exists.
+- `delegation_denied` — caller is NOT owned (`scope: project`); the
+  connector DOES have `ConnectRefGrant`(s), but none matched this caller's
+  roles/ref.
+- `platform_permission_denied` — connector is `scope: platform` and the
+  caller lacks `connect.platform.use` (branch 4). **Terminal** — unlike
+  `ownership_denied`/`delegation_denied`, this reason never falls through
+  to a `ConnectRefGrant` delegation attempt; see (E)'s "TERMINAL deny" note
+  for the full reasoning (a delegation fallback here would be a
+  `connect.platform.use` bypass, not a narrowing — `ConnectRefGrant` has no
+  concept of connector `scope` at all). This fork between the two `scope`
+  values' deny handling is deliberate and permanent — do not "reconcile"
+  `platform_permission_denied` toward `ownership_denied`/
+  `delegation_denied`'s delegation-fallback behavior later; they are
+  answering structurally different questions (project membership vs. a
+  global capability grant for an install-wide resource).
 - `backend_error` — ownership (or delegation) was satisfied, but the
   upstream connector call itself failed (network, credentials, etc.); the
   raw upstream error is logged server-side only, never persisted into the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,13 +167,6 @@ func (c *Config) LicenseGrace() time.Duration {
 type ConnectConfig struct {
 	Enabled    bool              `yaml:"enabled"`
 	Connectors []ConnectorConfig `yaml:"connectors"`
-	// AllowUnscoped is the single deployment-wide escape hatch (ADR-082 §C) that lets
-	// the server boot despite one or more connectors missing scope. Every boot under
-	// this flag logs a WARN naming each unscoped connector (server/main.go, not here —
-	// Validate() itself never logs). Default false: a missing scope fails boot. Does
-	// NOT rescue an unrecognized scope value or the project/platform contradiction
-	// checks — those always fail boot regardless of this flag.
-	AllowUnscoped bool `yaml:"allow_unscoped"`
 }
 
 // ConnectorConfig describes one external-store connector. Name is the API path key
@@ -211,9 +204,10 @@ type ConnectorConfig struct {
 	// Scope declares this connector's tenant boundary (ADR-082): "project" (owned by
 	// exactly one Keyorix project — requires Project) or "platform" (org-wide; requires
 	// the connect.platform.use permission at authorization time, must NOT set Project).
-	// Required: a missing value fails boot unless ConnectConfig.AllowUnscoped is set; an
-	// unrecognized value (anything other than "project"/"platform") always fails boot,
-	// AllowUnscoped does not rescue it.
+	// Required, unconditionally: a missing or unrecognized value (anything other than
+	// "project"/"platform") always fails boot. There is no escape hatch — an operator
+	// migrating an existing config adds scope: to every connector before upgrading; see
+	// ADR-082 §C for why that boot-fail-loud requirement has no deployment-wide bypass.
 	Scope string `yaml:"scope"`
 	// Project names the Keyorix project that owns this connector, by NAME — not a
 	// numeric ID. A numeric project ID differs per deployment (the same logical project
@@ -1947,17 +1941,17 @@ func (c *Config) Validate() error { // NOSONAR -- cognitive complexity 32, suppr
 }
 
 // validateConnectScopes enforces ADR-082 §B/§C on cfg.Connect.Connectors — pure
-// config-shape validation, no DB/network access, no logging (Validate() never logs;
-// the allow_unscoped WARNs are emitted where the connectors are actually wired,
-// server/main.go, matching this codebase's existing log-at-the-point-of-use style).
-// Every check aggregates across ALL offending connectors into one error naming each
-// by config name, rather than failing on (and hiding) the first one found — an
-// operator fixing config should not have to restart-and-discover connectors one at a
-// time. Checks run in this order, each independent of the others by construction
-// (a connector can only land in one bucket): unrecognized scope (never rescued by
-// AllowUnscoped — a typo is not "intentionally unscoped"), missing scope (rescued by
-// AllowUnscoped), scope "project" without a Project name, scope "platform" with a
-// Project name set (a platform connector is not owned by any single project).
+// config-shape validation, no DB/network access, no logging. Every check aggregates
+// across ALL offending connectors into one error naming each by config name, rather
+// than failing on (and hiding) the first one found — an operator fixing config
+// should not have to restart-and-discover connectors one at a time. There is no
+// deployment-wide escape hatch (ADR-082 §C, amended): a missing scope fails boot
+// unconditionally, the same as an unrecognized value — the migration path for an
+// existing deployment is to add scope: to every connector, not to opt out of the
+// check. Checks run in this order, each independent of the others by construction
+// (a connector can only land in one bucket): unrecognized scope, missing scope,
+// scope "project" without a Project name, scope "platform" with a Project name set
+// (a platform connector is not owned by any single project).
 func validateConnectScopes(cc ConnectConfig) error {
 	var missing, invalid, projectNeedsProject, platformRejectsProject []string
 	for _, connector := range cc.Connectors {
@@ -1980,8 +1974,8 @@ func validateConnectScopes(cc ConnectConfig) error {
 	if len(invalid) > 0 {
 		return fmt.Errorf("connect: connector(s) with unrecognized scope (must be \"project\" or \"platform\"): %s", strings.Join(invalid, ", "))
 	}
-	if len(missing) > 0 && !cc.AllowUnscoped {
-		return fmt.Errorf("connect: connector(s) missing required \"scope\" (must be \"project\" or \"platform\"; set connect.allow_unscoped: true to boot anyway — ADR-082): %s", strings.Join(missing, ", "))
+	if len(missing) > 0 {
+		return fmt.Errorf("connect: connector(s) missing required \"scope\" (must be \"project\" or \"platform\" — ADR-082, no exceptions): %s", strings.Join(missing, ", "))
 	}
 	if len(projectNeedsProject) > 0 {
 		return fmt.Errorf("connect: connector(s) with scope \"project\" missing required \"project\": %s", strings.Join(projectNeedsProject, ", "))

--- a/internal/config/connect_config_test.go
+++ b/internal/config/connect_config_test.go
@@ -8,10 +8,12 @@ import (
 )
 
 // TestValidateConnectScopes covers ADR-082 §B/§C boot validation: missing/
-// unrecognized scope, the project/platform contradiction checks, both
-// allow_unscoped states, and valid project/platform entries. Each failure
-// case asserts the aggregated error names every offending connector, not
-// just the first one found.
+// unrecognized scope, the project/platform contradiction checks, and valid
+// project/platform entries. There is no escape hatch (amended — the original
+// connect.allow_unscoped flag was removed: it let the server boot, but an
+// unscoped connector still denied on every read, so it never restored actual
+// usability). Each failure case asserts the aggregated error names every
+// offending connector, not just the first one found.
 func TestValidateConnectScopes(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -55,17 +57,6 @@ func TestValidateConnectScopes(t *testing.T) {
 			wantNames: []string{"bad1", "bad2"},
 		},
 		{
-			name: "unrecognized scope is NOT rescued by allow_unscoped",
-			cc: ConnectConfig{
-				AllowUnscoped: true,
-				Connectors: []ConnectorConfig{
-					{Name: "typo", Type: "vault", Scope: "projekt"},
-				},
-			},
-			wantErr:   true,
-			wantNames: []string{"typo"},
-		},
-		{
 			name: "scope project without project name fails boot",
 			cc: ConnectConfig{Connectors: []ConnectorConfig{
 				{Name: "noproj", Type: "vault", Scope: "project"},
@@ -99,28 +90,6 @@ func TestValidateConnectScopes(t *testing.T) {
 			}},
 			wantErr:   true,
 			wantNames: []string{"bad1", "bad2"},
-		},
-		{
-			name: "missing scope rescued by allow_unscoped: true",
-			cc: ConnectConfig{
-				AllowUnscoped: true,
-				Connectors: []ConnectorConfig{
-					{Name: "c1", Type: "vault"},
-					{Name: "c2", Type: "aws-secrets-manager"},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "missing scope NOT rescued when allow_unscoped is false (default)",
-			cc: ConnectConfig{
-				AllowUnscoped: false,
-				Connectors: []ConnectorConfig{
-					{Name: "c1", Type: "vault"},
-				},
-			},
-			wantErr:   true,
-			wantNames: []string{"c1"},
 		},
 		{
 			name:    "no connectors is valid",
@@ -196,5 +165,4 @@ func TestValidate_ConnectScopesWired(t *testing.T) {
 	err := c.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unscoped-connector")
-	assert.Contains(t, err.Error(), "allow_unscoped")
 }

--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -207,12 +207,16 @@ func (c *KeyorixCore) writeAuditEventDiff(ctx context.Context, eventType string,
 	c.emitAudit(ctx, event)
 }
 
-// writeAuditEventFailed persists a failed audit event (Success=false).
-func (c *KeyorixCore) writeAuditEventFailed(ctx context.Context, eventType string, userID *uint, ip string, description string) {
+// writeAuditEventFailed persists a failed audit event (Success=false), with
+// project context — added for ADR-082 branch 3, whose Connect deny-path events
+// need both Success=false and a populated ProjectID (the connector's owning
+// project), which no prior helper supported simultaneously.
+func (c *KeyorixCore) writeAuditEventFailed(ctx context.Context, eventType string, userID *uint, projectID *uint, ip string, description string) {
 	f := false
 	event := &models.AuditEvent{
 		EventType:   eventType,
 		UserID:      userID,
+		ProjectID:   projectID,
 		IPAddress:   ip,
 		Description: sanitizeAuditText(description),
 		Success:     &f,
@@ -366,7 +370,7 @@ func (c *KeyorixCore) LogAuthLogin(ctx context.Context, userID uint, username, i
 
 // LogAuthFailure writes an auth.login_failed audit event (Success=false).
 func (c *KeyorixCore) LogAuthFailure(ctx context.Context, username, ip string) {
-	c.writeAuditEventFailed(ctx, "auth.login_failed", nil, ip,
+	c.writeAuditEventFailed(ctx, "auth.login_failed", nil, nil, ip,
 		fmt.Sprintf("Failed login attempt for username: %s", username))
 }
 

--- a/internal/core/audit_actor_type_test.go
+++ b/internal/core/audit_actor_type_test.go
@@ -61,7 +61,7 @@ func TestWriteAuditEventFailed_StampsActorTypeFromContext(t *testing.T) {
 	})).Return(nil)
 
 	ctx := WithActorType(context.Background(), ActorTypeSystem)
-	c.writeAuditEventFailed(ctx, "auth.login_failed", nil, "1.2.3.4", "x")
+	c.writeAuditEventFailed(ctx, "auth.login_failed", nil, nil, "1.2.3.4", "x")
 
 	store.AssertExpectations(t)
 	if got != ActorTypeSystem {

--- a/internal/core/auth_bootstrap.go
+++ b/internal/core/auth_bootstrap.go
@@ -83,6 +83,12 @@ var defaultPermissions = []bootstrapPermissionDef{
 	// explicitly bundled into their role.
 	{"system.write", "Manage audit checkpoints/alerts, legal holds, risk exceptions, SoD policies, and admin job triggers", "system", "write"},
 	{"connect.read", "Read secrets from external stores via Keyorix Connect (ADR-043)", "connect", "read"},
+	// ADR-082 branch 4: narrows scope: platform connector reads, which connect.read
+	// alone permitted for any holder through branch 3 (an interim fail-open, marked
+	// by a TODO). Distinct from connect.read (which still gates the whole Connect
+	// surface, project-scoped connectors included) — this only narrows the
+	// platform-scoped subset.
+	{"connect.platform.use", "Read secrets from platform-scoped Keyorix Connect connectors (ADR-082 §B/§H)", "connect", "platform.use"},
 }
 
 // adminPermissions lists the permission names granted to the admin role.
@@ -91,7 +97,7 @@ var adminPermissions = []string{
 	permUsersRead, "users.write", "users.delete",
 	permRolesRead, "roles.write", permRolesAssign,
 	permAuditRead, permSystemRead, "system.write",
-	"connect.read",
+	"connect.read", "connect.platform.use",
 }
 
 // editorPermissions lists the permission names granted to the editor role.

--- a/internal/core/auth_bootstrap_rbac_test.go
+++ b/internal/core/auth_bootstrap_rbac_test.go
@@ -81,6 +81,40 @@ func TestBootstrapSeedsTwoTierRoleCatalog(t *testing.T) {
 	}
 }
 
+// TestBootstrapGrantsConnectPlatformUseToAdminRoles proves a fresh install's
+// seeded admin/system_admin roles hold connect.platform.use (ADR-082 branch 4)
+// via ordinary BootstrapSystem seeding — no reconcile pass needed on first
+// boot. Roles without connect.read at all (editor/viewer/etc.) must not hold
+// it either (least privilege — mirrors connect.read's own baseline).
+func TestBootstrapGrantsConnectPlatformUseToAdminRoles(t *testing.T) {
+	c, _ := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"admin", "system_admin"} {
+		role, err := c.storage.GetRoleByName(ctx, name)
+		require.NoError(t, err)
+		perms, err := c.storage.GetRolePermissions(ctx, role.ID)
+		require.NoError(t, err)
+		var has bool
+		for _, p := range perms {
+			if p.Name == "connect.platform.use" {
+				has = true
+			}
+		}
+		assert.Truef(t, has, "role %q must hold connect.platform.use on a fresh install", name)
+	}
+
+	for _, name := range []string{"editor", "viewer", "system_auditor", "system_viewer", "project_admin"} {
+		role, err := c.storage.GetRoleByName(ctx, name)
+		require.NoError(t, err)
+		perms, err := c.storage.GetRolePermissions(ctx, role.ID)
+		require.NoError(t, err)
+		for _, p := range perms {
+			assert.NotEqualf(t, "connect.platform.use", p.Name, "role %q must not hold connect.platform.use (least privilege — it doesn't hold connect.read either)", name)
+		}
+	}
+}
+
 // #227: system.write's catalog description must name its full real footprint —
 // audit checkpoints/alerts, legal holds, risk exceptions, SoD policies, and
 // admin job triggers — not just the legacy service-account/API-token routes

--- a/internal/core/compliance_digest.go
+++ b/internal/core/compliance_digest.go
@@ -127,7 +127,7 @@ func (c *KeyorixCore) SendComplianceDigest(ctx context.Context, actorID uint) (b
 	}
 	if !attempted {
 		log.Printf("compliance digest: notification channel(s) configured but none accepted the broadcast (e.g. email-only with no broadcast destination) — digest was NOT delivered")
-		c.writeAuditEventFailed(auditCtx, EventComplianceDigestSent, userID, "", "compliance digest broadcast attempted but no configured channel could accept it")
+		c.writeAuditEventFailed(auditCtx, EventComplianceDigestSent, userID, nil, "", "compliance digest broadcast attempted but no configured channel could accept it")
 		return false, nil
 	}
 	c.writeAuditEvent(auditCtx, EventComplianceDigestSent, userID, nil, "compliance digest broadcast to notification channels")

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -78,7 +78,18 @@ const (
 	// same opaque unknown-connector shape either way, so the audit trail is
 	// the only place an operator can learn which gate closed.
 	connectDenyReasonDelegationDenied = "delegation_denied"
-	connectDenyReasonBackendError     = "backend_error"
+	// connectDenyReasonPlatformPermissionDenied: connector is scope: platform,
+	// but the caller lacks connect.platform.use (ADR-082 branch 4). Deliberately
+	// terminal — does NOT fall through to ConnectRefGrant delegation the way a
+	// project-scope ownership miss does. See connectOwnershipSatisfied's
+	// platform branch and ADR-082 §H: ConnectRefGrant is keyed on role +
+	// connector name + ref-prefix alone, with no scope awareness, so treating it
+	// as a fallback here would let anyone able to create a grant against a
+	// platform connector's name bypass connect.platform.use for anyone else —
+	// that would be a bypass, not a narrowing. This fork is deliberate; do not
+	// "reconcile" it toward the project-scope delegation path later.
+	connectDenyReasonPlatformPermissionDenied = "platform_permission_denied"
+	connectDenyReasonBackendError             = "backend_error"
 	// connectAllowReasonDelegation: caller is not owned, but an explicit
 	// ConnectRefGrant covering their role and this ref allows the read
 	// (ADR-082 §F).
@@ -168,6 +179,21 @@ func (c *KeyorixCore) ConnectReadableConnectorNames(ctx context.Context, actorTy
 			readable = append(readable, name)
 			continue
 		}
+		if c.connectOwnership[name].Scope == "platform" {
+			// ADR-082 branch 4: a platform-scope caller who lacks connect.platform.use
+			// is a TERMINAL deny in ReadFederatedSecret — it never attempts
+			// ConnectRefGrant delegation for platform scope (see
+			// connectDenyReasonPlatformPermissionDenied's doc comment for why a
+			// delegation fallback there would be a bypass). Discovery must agree: the
+			// delegation-fallback branch below exists for project-scope connectors,
+			// where it's true that ReadFederatedSecret would also honor it — reaching
+			// it for a platform connector here would show a connector in ListConnectors
+			// that an actual read will always deny, the exact leak ADR-082 §E exists to
+			// prevent. (A ConnectRefGrant CAN currently be created against a platform
+			// connector's name regardless — that's dead configuration, not a live
+			// delegation path; see the issue filed alongside this branch.)
+			continue
+		}
 		// Not owned — a connector reachable only via an explicit ConnectRefGrant
 		// still belongs in discovery; ReadSecret still applies the ref-prefix match
 		// per-read. actorRoleIDs (not connectRefGrantDelegates) is the right check
@@ -203,12 +229,22 @@ func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType s
 		return false, "", nil
 	}
 	if owner.Scope == "platform" {
-		// TODO(ADR-082 branch 4): gate platform connectors on connect.platform.use,
-		// not connect.read alone. Every caller who reaches this function has
-		// already cleared connect.read (checked by the transport layer before
-		// ReadFederatedSecret/ConnectReadableConnectorNames is ever called), so this
-		// is a deliberate interim "any connect.read holder" pass-through, not an
-		// oversight.
+		// ADR-082 branch 4: platform connectors need connect.platform.use, not just
+		// connect.read (which the transport layer already enforced before this
+		// function was ever called, and which still gates the whole Connect surface
+		// — connect.read alone was only ever a fail-open interim for platform scope
+		// specifically, through branch 3). Checked at Scope{} (global), matching
+		// connect.read's own scope — a platform connector has no owning project to
+		// check against. A denial here is terminal, not a fall-through to
+		// ConnectRefGrant delegation — see connectDenyReasonPlatformPermissionDenied
+		// and ADR-082 §H for why.
+		allowed, err := c.AuthorizePrincipal(ctx, actorType, principalID, "connect.platform.use", Scope{})
+		if err != nil {
+			return false, "", fmt.Errorf("connect ownership: check connect.platform.use: %w", err)
+		}
+		if !allowed {
+			return false, "", nil
+		}
 		return true, ConnectOwnershipReasonPlatformScope, nil
 	}
 	// scope == "project": raw scope set, NOT GetReadableScopes (D) — the {0,0}
@@ -277,7 +313,8 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 		return "", err
 	}
 	var allowReason ConnectOwnershipReason
-	if owned {
+	switch {
+	case owned:
 		allowReason = ownReason
 		// Per-reference RBAC (ADR-045): once a connector has any ref-grant, the read
 		// is permitted only if one of the caller's roles holds a matching grant. A
@@ -294,8 +331,19 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 				fmt.Sprintf("federated read DENIED by per-reference policy: connector %q (%s) ref %q reason=%s", connectorName, conn.Type(), ref, connectDenyReasonRefNotPermitted))
 			return "", fmt.Errorf("ref %q %w %q", ref, ErrConnectRefNotPermitted, connectorName)
 		}
-	} else {
-		// Not owned — ConnectRefGrant is the explicit cross-project delegation path
+	case owner.Scope == "platform":
+		// ADR-082 branch 4: caller lacks connect.platform.use. TERMINAL — no
+		// ConnectRefGrant delegation attempt, deliberately (see
+		// connectDenyReasonPlatformPermissionDenied's doc comment). This is its own
+		// case, not folded into the not-owned/delegation branch below, precisely so
+		// it never reaches connectRefGrantDelegates.
+		c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, projectID, "",
+			fmt.Sprintf("federated read DENIED: connector %q (%s) ref %q reason=%s", connectorName, conn.Type(), ref, connectDenyReasonPlatformPermissionDenied))
+		return "", fmt.Errorf("%w %q", ErrConnectUnknownConnector, connectorName)
+	default:
+		// Not owned, project scope (or a connector absent from the ownership map
+		// entirely — the structural-invariant edge case, unchanged from before this
+		// branch) — ConnectRefGrant is the explicit cross-project delegation path
 		// (ADR-082 §F). connectRefGrantDelegates (unlike connectRefAllowed) treats
 		// "no grants configured" as "no delegation," not "allow": that shortcut only
 		// makes sense for an already-owned caller.

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -16,7 +16,8 @@ import (
 )
 
 // EventConnectSecretRead is audited on every federated read (success or failure is
-// distinguished by the description).
+// distinguished by Success and by the description's reason= token — see
+// ConnectOwnershipReason and the deny-path reason constants below).
 const EventConnectSecretRead = "connect.secret_read"
 
 // Per-reference grant management events (ADR-045).
@@ -24,6 +25,78 @@ const (
 	EventConnectRefGrantCreate = "connect.ref_grant_create"
 	EventConnectRefGrantDelete = "connect.ref_grant_delete"
 )
+
+// EventConnectorProjectBindingCreate is audited on every persisted
+// ConnectorProjectBinding write (ADR-082 branch 3, issue #1477's audit half) —
+// both the boot-time first-resolution write (server/main.go's
+// resolveConnectorOwnership) and the RemoteStorage proxy write
+// (server/http/handlers/connector_project_bindings_proxy.go's
+// CreateConnectorProjectBindingProxy). The binding is an authorization input
+// (it feeds connectOwnershipSatisfied) regardless of which door the write comes
+// through, so both call sites use the same event type.
+const EventConnectorProjectBindingCreate = "connect.project_binding_create" // #nosec G101 -- audit event type, not a credential
+
+// ConnectOwnershipReason and the deny-path reason values below form ONE closed
+// set (ADR-082 §E) that appears as a "reason=<value>" token at a fixed position
+// in every ReadFederatedSecret audit Description — allow and deny outcomes
+// alike. There is no structured column for this (AuditEvent has none, and
+// ADR-075's "closed key_source enum" describing one was never actually
+// implemented — see backlog issue filed alongside this branch), so the fixed
+// token format is what keeps this parseable, and what makes a future
+// structured column a parse-and-backfill rather than a rewrite.
+type ConnectOwnershipReason string
+
+const (
+	// ConnectOwnershipReasonProjectMembership: caller holds a role scoped to
+	// the connector's owning project specifically.
+	ConnectOwnershipReasonProjectMembership ConnectOwnershipReason = "project_membership"
+	// ConnectOwnershipReasonGlobalScope: caller holds a role at the true
+	// global ({0,0}) scope, which wildcards every project-scoped connector.
+	ConnectOwnershipReasonGlobalScope ConnectOwnershipReason = "global_scope"
+	// ConnectOwnershipReasonPlatformScope: the connector itself is
+	// platform-scoped (ADR-082 §B) — ownership passes for any connect.read
+	// holder, independent of the caller's role scopes (TODO ADR-082 branch 4:
+	// connect.platform.use narrows this).
+	ConnectOwnershipReasonPlatformScope ConnectOwnershipReason = "platform_scope"
+)
+
+// Deny-path reason values (ADR-082 §E), same closed set / same token
+// convention as ConnectOwnershipReason above, kept as plain strings rather
+// than folded into ConnectOwnershipReason since they describe a DENIAL, not an
+// ownership outcome connectOwnershipSatisfied itself produces.
+const (
+	connectDenyReasonDisabled         = "connect_disabled"
+	connectDenyReasonUnknownConnector = "unknown_connector"
+	connectDenyReasonRefNotPermitted  = "ref_not_permitted"
+	// connectDenyReasonOwnershipDenied: caller is not owned AND the connector
+	// has no ConnectRefGrant at all — no delegation path exists.
+	connectDenyReasonOwnershipDenied = "ownership_denied"
+	// connectDenyReasonDelegationDenied: caller is not owned; the connector
+	// DOES have ConnectRefGrant(s), but none matched this caller's roles/ref.
+	// Distinguishing this from connectDenyReasonOwnershipDenied is the reason
+	// this audit event exists at all (ADR-082): the HTTP/gRPC response is the
+	// same opaque unknown-connector shape either way, so the audit trail is
+	// the only place an operator can learn which gate closed.
+	connectDenyReasonDelegationDenied = "delegation_denied"
+	connectDenyReasonBackendError     = "backend_error"
+	// connectAllowReasonDelegation: caller is not owned, but an explicit
+	// ConnectRefGrant covering their role and this ref allows the read
+	// (ADR-082 §F).
+	connectAllowReasonDelegation = "delegation"
+)
+
+// connectAuditProjectID returns the connector's owning project for the audit
+// trail, or nil when the connector is platform-scoped (ADR-082: ProjectID is
+// meaningless there — see ConnectOwnership's own doc comment) or has no
+// ownership entry at all (e.g. an unknown connector, audited before any
+// ownership lookup is possible).
+func connectAuditProjectID(owner ConnectOwnership) *uint {
+	if owner.Scope != "project" || owner.ProjectID == 0 {
+		return nil
+	}
+	p := owner.ProjectID
+	return &p
+}
 
 // SetConnectManager wires the configured external-store connectors (ADR-043). nil
 // (the default) leaves Keyorix Connect disabled.
@@ -87,7 +160,7 @@ func (c *KeyorixCore) ConnectReadableConnectorNames(ctx context.Context, actorTy
 	}
 	var readable []string
 	for _, name := range c.connectManager.Names() {
-		owned, err := c.connectOwnershipSatisfied(ctx, actorType, principalID, name)
+		owned, _, err := c.connectOwnershipSatisfied(ctx, actorType, principalID, name)
 		if err != nil {
 			return nil, err
 		}
@@ -119,10 +192,15 @@ func (c *KeyorixCore) ConnectReadableConnectorNames(ctx context.Context, actorTy
 // structural invariant server/main.go's boot-time key-set check exists to
 // guarantee never happens in a correctly-booted server; this is the runtime
 // backstop).
-func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType string, principalID uint, connectorName string) (bool, error) {
+// The second return value names WHICH check satisfied ownership (meaningless
+// when the first return is false) — ADR-082 branch 3 needs this for the audit
+// trail's three-way allow reason. It is a named type, not a string, precisely
+// so the string formatting stays at the audit call site (ReadFederatedSecret),
+// not here: this function reports a fact, not a description.
+func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType string, principalID uint, connectorName string) (bool, ConnectOwnershipReason, error) {
 	owner, ok := c.connectOwnership[connectorName]
 	if !ok {
-		return false, nil
+		return false, "", nil
 	}
 	if owner.Scope == "platform" {
 		// TODO(ADR-082 branch 4): gate platform connectors on connect.platform.use,
@@ -131,7 +209,7 @@ func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType s
 		// ReadFederatedSecret/ConnectReadableConnectorNames is ever called), so this
 		// is a deliberate interim "any connect.read holder" pass-through, not an
 		// oversight.
-		return true, nil
+		return true, ConnectOwnershipReasonPlatformScope, nil
 	}
 	// scope == "project": raw scope set, NOT GetReadableScopes (D) — the {0,0}
 	// global entry must survive so the loop below can match it as the wildcard
@@ -144,14 +222,17 @@ func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType s
 		scopes, err = c.storage.GetUserRoleScopes(ctx, principalID)
 	}
 	if err != nil {
-		return false, fmt.Errorf("connect ownership: enumerate role scopes: %w", err)
+		return false, "", fmt.Errorf("connect ownership: enumerate role scopes: %w", err)
 	}
 	for _, sc := range scopes {
-		if sc.ProjectID == owner.ProjectID || sc.ProjectID == 0 {
-			return true, nil
+		if sc.ProjectID == owner.ProjectID {
+			return true, ConnectOwnershipReasonProjectMembership, nil
+		}
+		if sc.ProjectID == 0 {
+			return true, ConnectOwnershipReasonGlobalScope, nil
 		}
 	}
-	return false, nil
+	return false, "", nil
 }
 
 // ReadFederatedSecret proxies a read of ref from the named external-store connector
@@ -164,25 +245,40 @@ func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType s
 // function with an untagged context, not silently default to "user". The value is
 // returned to the caller and never persisted.
 func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string, principalID uint, connectorName, ref string) (string, error) {
+	ctx = WithActorType(ctx, actorType)
+	uid := principalID
+
 	if c.connectManager == nil {
+		c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, nil, "",
+			fmt.Sprintf("federated read DENIED: connect is disabled ref %q reason=%s", ref, connectDenyReasonDisabled))
 		return "", ErrConnectDisabled
 	}
 	conn, ok := c.connectManager.Get(connectorName)
 	if !ok {
+		c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, nil, "",
+			fmt.Sprintf("federated read DENIED: unknown connector %q ref %q reason=%s", connectorName, ref, connectDenyReasonUnknownConnector))
 		return "", fmt.Errorf("%w %q", ErrConnectUnknownConnector, connectorName)
 	}
-	ctx = WithActorType(ctx, actorType)
-	uid := principalID
+	// Every outcome below (allow or deny) is for a KNOWN connector, so its owning
+	// project (nil for platform scope) is the audit ProjectID throughout —
+	// resolved once here rather than per-branch. This is a direct map read on the
+	// SAME connectOwnership data connectOwnershipSatisfied consults below, not a
+	// second authorization decision.
+	owner := c.connectOwnership[connectorName]
+	projectID := connectAuditProjectID(owner)
 
 	// ADR-082 §E authorization order: connect.read (enforced by the transport layer
 	// before this function is ever called) → ownership → ConnectRefGrant delegation
-	// → deny. No audit call on either branch below — audit is branch 3 (ADR-082);
-	// this branch's denials are deliberately unaudited, same as ADR-082 itself notes.
-	owned, err := c.connectOwnershipSatisfied(ctx, actorType, principalID, connectorName)
+	// → deny. Every branch below is now audited (ADR-082 branch 3) — the deny
+	// branches were deliberately unaudited through branch 2; that gap is what this
+	// branch closes.
+	owned, ownReason, err := c.connectOwnershipSatisfied(ctx, actorType, principalID, connectorName)
 	if err != nil {
 		return "", err
 	}
+	var allowReason ConnectOwnershipReason
 	if owned {
+		allowReason = ownReason
 		// Per-reference RBAC (ADR-045): once a connector has any ref-grant, the read
 		// is permitted only if one of the caller's roles holds a matching grant. A
 		// connector with no grants is governed solely by connect.read + allowed_refs
@@ -194,8 +290,8 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 			return "", err
 		}
 		if !allowed {
-			c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
-				fmt.Sprintf("federated read DENIED by per-reference policy: connector %q (%s) ref %q", connectorName, conn.Type(), ref))
+			c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, projectID, "",
+				fmt.Sprintf("federated read DENIED by per-reference policy: connector %q (%s) ref %q reason=%s", connectorName, conn.Type(), ref, connectDenyReasonRefNotPermitted))
 			return "", fmt.Errorf("ref %q %w %q", ref, ErrConnectRefNotPermitted, connectorName)
 		}
 	} else {
@@ -203,17 +299,26 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 		// (ADR-082 §F). connectRefGrantDelegates (unlike connectRefAllowed) treats
 		// "no grants configured" as "no delegation," not "allow": that shortcut only
 		// makes sense for an already-owned caller.
-		delegated, err := c.connectRefGrantDelegates(ctx, actorType, principalID, connectorName, ref)
+		delegated, hasGrants, err := c.connectRefGrantDelegates(ctx, actorType, principalID, connectorName, ref)
 		if err != nil {
 			return "", err
 		}
 		if !delegated {
 			// Ownership denied and no delegation grant: reuse the unknown-connector
-			// shape (ADR-082) — do not confirm this connector's existence to a caller
-			// who cannot reach it. ListConnectors already omits it from discovery;
-			// this keeps the single-connector read path consistent with that.
+			// shape in the RETURNED ERROR (ADR-082) — do not confirm this connector's
+			// existence to a caller who cannot reach it. The audit event is the only
+			// place the real reason is recorded; it distinguishes "no grants at all"
+			// from "grants exist, none matched" (the two denial reasons ADR-082
+			// branch 3 requires), which the opaque response deliberately does not.
+			reason := connectDenyReasonOwnershipDenied
+			if hasGrants {
+				reason = connectDenyReasonDelegationDenied
+			}
+			c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, projectID, "",
+				fmt.Sprintf("federated read DENIED: connector %q (%s) ref %q reason=%s", connectorName, conn.Type(), ref, reason))
 			return "", fmt.Errorf("%w %q", ErrConnectUnknownConnector, connectorName)
 		}
+		allowReason = connectAllowReasonDelegation
 	}
 
 	value, err := conn.GetSecret(ctx, ref)
@@ -225,12 +330,12 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 		// HTTP layer separately applies clientSafe()/isSafeConnectError to what it
 		// returns to the caller.
 		log.Printf("federated read failed via connector %q (%s) ref %q: %v", connectorName, conn.Type(), ref, err)
-		c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
-			fmt.Sprintf("federated read FAILED via connector %q (%s) ref %q: an internal error occurred; see server logs", connectorName, conn.Type(), ref))
+		c.writeAuditEventFailed(ctx, EventConnectSecretRead, &uid, projectID, "",
+			fmt.Sprintf("federated read FAILED via connector %q (%s) ref %q: an internal error occurred; see server logs reason=%s", connectorName, conn.Type(), ref, connectDenyReasonBackendError))
 		return "", err
 	}
-	c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
-		fmt.Sprintf("federated read via connector %q (%s) ref %q", connectorName, conn.Type(), ref))
+	c.writeAuditEventFull(ctx, EventConnectSecretRead, &uid, nil, projectID, "",
+		fmt.Sprintf("federated read via connector %q (%s) ref %q reason=%s", connectorName, conn.Type(), ref, allowReason))
 	return value, nil
 }
 
@@ -266,18 +371,32 @@ func (c *KeyorixCore) CreateConnectRefGrant(ctx context.Context, actorID, roleID
 		return nil, err
 	}
 	uid := actorID
-	c.writeAuditEvent(ctx, EventConnectRefGrantCreate, &uid, nil,
+	c.writeAuditEventFull(ctx, EventConnectRefGrantCreate, &uid, nil, connectAuditProjectID(c.connectOwnership[connectorName]), "",
 		fmt.Sprintf("connect ref-grant: role %d may read ref-prefix %q on connector %q", roleID, refPrefix, connectorName))
 	return g, nil
 }
 
 // DeleteConnectRefGrant removes a per-reference grant by id. Audited.
 func (c *KeyorixCore) DeleteConnectRefGrant(ctx context.Context, actorID, id uint) error {
+	// Best-effort lookup of the grant's connector (for the audit ProjectID) BEFORE
+	// deleting — the storage interface has no fetch-by-id or delete-returning-row
+	// primitive, and adding one is out of scope here (ADR-082 branch 3 must not
+	// change ConnectRefGrant's own storage shape). If this lookup fails or finds
+	// nothing, the event is still written, just without a ProjectID.
+	var projectID *uint
+	if grants, gerr := c.storage.ListConnectRefGrants(ctx); gerr == nil {
+		for _, g := range grants {
+			if g.ID == id {
+				projectID = connectAuditProjectID(c.connectOwnership[g.Connector])
+				break
+			}
+		}
+	}
 	if err := c.storage.DeleteConnectRefGrant(ctx, id); err != nil {
 		return err
 	}
 	uid := actorID
-	c.writeAuditEvent(ctx, EventConnectRefGrantDelete, &uid, nil,
+	c.writeAuditEventFull(ctx, EventConnectRefGrantDelete, &uid, nil, projectID, "",
 		fmt.Sprintf("connect ref-grant %d deleted", id))
 	return nil
 }
@@ -322,25 +441,30 @@ func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorType string, p
 // ConnectRefGrant's own schema, matching rules (refMatches), and expiry logic
 // (connectGrantActive) are unchanged (ADR-082) — only which caller populations
 // reach this delegation check is new.
-func (c *KeyorixCore) connectRefGrantDelegates(ctx context.Context, actorType string, principalID uint, connectorName, ref string) (bool, error) {
+// The second return value reports whether the connector had ANY ConnectRefGrant
+// configured at all (regardless of whether one matched) — ADR-082 branch 3
+// needs this to distinguish the audit trail's two deny reasons
+// (connectDenyReasonOwnershipDenied vs connectDenyReasonDelegationDenied),
+// which a bare "delegated bool" cannot.
+func (c *KeyorixCore) connectRefGrantDelegates(ctx context.Context, actorType string, principalID uint, connectorName, ref string) (bool, bool, error) {
 	grants, err := c.storage.ListConnectRefGrantsByConnector(ctx, connectorName)
 	if err != nil {
-		return false, fmt.Errorf("connect ref-grant lookup: %w", err)
+		return false, false, fmt.Errorf("connect ref-grant lookup: %w", err)
 	}
 	if len(grants) == 0 {
-		return false, nil // no delegation grant configured — no delegation path
+		return false, false, nil // no delegation grant configured — no delegation path
 	}
 	roleSet, err := c.actorRoleIDs(ctx, actorType, principalID)
 	if err != nil {
-		return false, err
+		return false, true, err
 	}
 	now := time.Now()
 	for _, g := range grants {
 		if roleSet[g.RoleID] && connectGrantActive(g, now) && refMatches(g.RefPrefix, ref) {
-			return true, nil
+			return true, true, nil
 		}
 	}
-	return false, nil
+	return false, true, nil
 }
 
 // connectorHasAnyDelegationForActor reports whether principalID holds a role with

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -31,17 +31,127 @@ func (c *KeyorixCore) SetConnectManager(m *connect.Manager) {
 	c.connectManager = m
 }
 
+// ConnectOwnership is one connector's resolved tenant-scoping data (ADR-082 §A),
+// built by server/main.go's boot-time resolution and set via SetConnectOwnership —
+// see connectManager's own doc comment for why this lives here rather than on
+// *connect.Manager or the Connector interface. Exported so server/main.go (a
+// different package) can construct it.
+type ConnectOwnership struct {
+	// Scope is "project" or "platform" (ADR-082 §B) — boot validation
+	// (internal/config.validateConnectScopes) already guarantees no other value
+	// reaches here.
+	Scope string
+	// ProjectID is the connector's owning Keyorix project, resolved via the
+	// connector→project binding (ADR-082, ConnectorProjectBinding). Meaningless
+	// (zero) when Scope is "platform".
+	ProjectID uint
+}
+
+// SetConnectOwnership wires each connector's resolved tenant-scoping data
+// (ADR-082), built in the same boot pass as SetConnectManager's *connect.Manager,
+// from the same config. Must be called with an ownership entry for EVERY connector
+// name SetConnectManager was given — server/main.go enforces this key-set match at
+// boot (a mismatch fails boot, aggregated) before either setter is called, so this
+// is a precondition, not something re-checked here.
+func (c *KeyorixCore) SetConnectOwnership(ownership map[string]ConnectOwnership) {
+	c.connectOwnership = ownership
+}
+
 // ConnectEnabled reports whether any external-store connector is configured.
 func (c *KeyorixCore) ConnectEnabled() bool {
 	return c.connectManager != nil && len(c.connectManager.Names()) > 0
 }
 
-// ConnectConnectorNames lists the configured connector names (for discovery).
+// ConnectConnectorNames lists every configured connector name, unfiltered — used
+// internally by boot-time resolution (server/main.go) and tests. Caller-facing
+// discovery (HTTP/gRPC ListConnectors) must use ConnectReadableConnectorNames
+// instead (ADR-082 §E): this method does not filter by ownership, and would leak
+// the existence of connectors the caller cannot reach.
 func (c *KeyorixCore) ConnectConnectorNames() []string {
 	if c.connectManager == nil {
 		return nil
 	}
 	return c.connectManager.Names()
+}
+
+// ConnectReadableConnectorNames lists the configured connectors the caller can
+// actually reach (ADR-082 §E) — the caller-facing discovery surface for both HTTP
+// and gRPC ListConnectors, so both transports filter identically through this one
+// core method rather than duplicating the ownership comparison per transport. A
+// connector the caller cannot reach is omitted entirely, not merely marked
+// unreachable — the existing behavior for a caller with no readable connectors at
+// all is an empty list, not an error.
+func (c *KeyorixCore) ConnectReadableConnectorNames(ctx context.Context, actorType string, principalID uint) ([]string, error) {
+	if c.connectManager == nil {
+		return nil, nil
+	}
+	var readable []string
+	for _, name := range c.connectManager.Names() {
+		owned, err := c.connectOwnershipSatisfied(ctx, actorType, principalID, name)
+		if err != nil {
+			return nil, err
+		}
+		if owned {
+			readable = append(readable, name)
+			continue
+		}
+		// Not owned — a connector reachable only via an explicit ConnectRefGrant
+		// still belongs in discovery; ReadSecret still applies the ref-prefix match
+		// per-read. actorRoleIDs (not connectRefGrantDelegates) is the right check
+		// here: delegation for LISTING purposes only needs "does the caller hold a
+		// role with ANY grant on this connector," not a specific ref match.
+		delegated, err := c.connectorHasAnyDelegationForActor(ctx, actorType, principalID, name)
+		if err != nil {
+			return nil, err
+		}
+		if delegated {
+			readable = append(readable, name)
+		}
+	}
+	return readable, nil
+}
+
+// connectOwnershipSatisfied reports whether principalID owns the connector's
+// project (ADR-082 §E) — the same comparison every caller's ownership check runs
+// through, admin included: a global-scoped role's {0,0} entry (see below) is a
+// wildcard in the INPUT, not a different code path. A connector absent from
+// connectOwnership is denied, never silently skipped or treated as owned (a
+// structural invariant server/main.go's boot-time key-set check exists to
+// guarantee never happens in a correctly-booted server; this is the runtime
+// backstop).
+func (c *KeyorixCore) connectOwnershipSatisfied(ctx context.Context, actorType string, principalID uint, connectorName string) (bool, error) {
+	owner, ok := c.connectOwnership[connectorName]
+	if !ok {
+		return false, nil
+	}
+	if owner.Scope == "platform" {
+		// TODO(ADR-082 branch 4): gate platform connectors on connect.platform.use,
+		// not connect.read alone. Every caller who reaches this function has
+		// already cleared connect.read (checked by the transport layer before
+		// ReadFederatedSecret/ConnectReadableConnectorNames is ever called), so this
+		// is a deliberate interim "any connect.read holder" pass-through, not an
+		// oversight.
+		return true, nil
+	}
+	// scope == "project": raw scope set, NOT GetReadableScopes (D) — the {0,0}
+	// global entry must survive so the loop below can match it as the wildcard
+	// (E), not be stripped before comparison.
+	var scopes []Scope
+	var err error
+	if actorType == ActorTypeMachine {
+		scopes, err = c.storage.GetMachineRoleScopes(ctx, principalID)
+	} else {
+		scopes, err = c.storage.GetUserRoleScopes(ctx, principalID)
+	}
+	if err != nil {
+		return false, fmt.Errorf("connect ownership: enumerate role scopes: %w", err)
+	}
+	for _, sc := range scopes {
+		if sc.ProjectID == owner.ProjectID || sc.ProjectID == 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // ReadFederatedSecret proxies a read of ref from the named external-store connector
@@ -64,17 +174,46 @@ func (c *KeyorixCore) ReadFederatedSecret(ctx context.Context, actorType string,
 	ctx = WithActorType(ctx, actorType)
 	uid := principalID
 
-	// Per-reference RBAC (ADR-045): once a connector has any ref-grant, the read is
-	// permitted only if one of the caller's roles holds a matching grant. A connector
-	// with no grants is governed solely by connect.read + allowed_refs (unchanged).
-	allowed, err := c.connectRefAllowed(ctx, actorType, principalID, connectorName, ref)
+	// ADR-082 §E authorization order: connect.read (enforced by the transport layer
+	// before this function is ever called) → ownership → ConnectRefGrant delegation
+	// → deny. No audit call on either branch below — audit is branch 3 (ADR-082);
+	// this branch's denials are deliberately unaudited, same as ADR-082 itself notes.
+	owned, err := c.connectOwnershipSatisfied(ctx, actorType, principalID, connectorName)
 	if err != nil {
 		return "", err
 	}
-	if !allowed {
-		c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
-			fmt.Sprintf("federated read DENIED by per-reference policy: connector %q (%s) ref %q", connectorName, conn.Type(), ref))
-		return "", fmt.Errorf("ref %q %w %q", ref, ErrConnectRefNotPermitted, connectorName)
+	if owned {
+		// Per-reference RBAC (ADR-045): once a connector has any ref-grant, the read
+		// is permitted only if one of the caller's roles holds a matching grant. A
+		// connector with no grants is governed solely by connect.read + allowed_refs
+		// (unchanged) — this still applies to an OWNED caller exactly as it did
+		// before ownership existed; ownership does not bypass ADR-045's own
+		// per-ref narrowing.
+		allowed, err := c.connectRefAllowed(ctx, actorType, principalID, connectorName, ref)
+		if err != nil {
+			return "", err
+		}
+		if !allowed {
+			c.writeAuditEvent(ctx, EventConnectSecretRead, &uid, nil,
+				fmt.Sprintf("federated read DENIED by per-reference policy: connector %q (%s) ref %q", connectorName, conn.Type(), ref))
+			return "", fmt.Errorf("ref %q %w %q", ref, ErrConnectRefNotPermitted, connectorName)
+		}
+	} else {
+		// Not owned — ConnectRefGrant is the explicit cross-project delegation path
+		// (ADR-082 §F). connectRefGrantDelegates (unlike connectRefAllowed) treats
+		// "no grants configured" as "no delegation," not "allow": that shortcut only
+		// makes sense for an already-owned caller.
+		delegated, err := c.connectRefGrantDelegates(ctx, actorType, principalID, connectorName, ref)
+		if err != nil {
+			return "", err
+		}
+		if !delegated {
+			// Ownership denied and no delegation grant: reuse the unknown-connector
+			// shape (ADR-082) — do not confirm this connector's existence to a caller
+			// who cannot reach it. ListConnectors already omits it from discovery;
+			// this keeps the single-connector read path consistent with that.
+			return "", fmt.Errorf("%w %q", ErrConnectUnknownConnector, connectorName)
+		}
 	}
 
 	value, err := conn.GetSecret(ctx, ref)
@@ -164,6 +303,66 @@ func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorType string, p
 	now := time.Now()
 	for _, g := range grants {
 		if roleSet[g.RoleID] && connectGrantActive(g, now) && refMatches(g.RefPrefix, ref) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// connectRefGrantDelegates reports whether principalID may read ref from
+// connectorName via an explicit ConnectRefGrant (ADR-082 §F), for a caller who did
+// NOT satisfy ownership (connectOwnershipSatisfied). This is deliberately a
+// SEPARATE function from connectRefAllowed, not a modified version of it: for an
+// OWNED caller, connectRefAllowed's "no grants configured on this connector" case
+// correctly means "no additional per-ref narrowing — allow" (ADR-045's original,
+// unchanged semantics). For a NOT-owned caller, "no grants configured" means there
+// is no delegation path at all — the opposite polarity. Reusing connectRefAllowed
+// for both would either wrongly grant a non-owned caller access to every
+// grant-less connector, or wrongly narrow an owned caller's existing access;
+// ConnectRefGrant's own schema, matching rules (refMatches), and expiry logic
+// (connectGrantActive) are unchanged (ADR-082) — only which caller populations
+// reach this delegation check is new.
+func (c *KeyorixCore) connectRefGrantDelegates(ctx context.Context, actorType string, principalID uint, connectorName, ref string) (bool, error) {
+	grants, err := c.storage.ListConnectRefGrantsByConnector(ctx, connectorName)
+	if err != nil {
+		return false, fmt.Errorf("connect ref-grant lookup: %w", err)
+	}
+	if len(grants) == 0 {
+		return false, nil // no delegation grant configured — no delegation path
+	}
+	roleSet, err := c.actorRoleIDs(ctx, actorType, principalID)
+	if err != nil {
+		return false, err
+	}
+	now := time.Now()
+	for _, g := range grants {
+		if roleSet[g.RoleID] && connectGrantActive(g, now) && refMatches(g.RefPrefix, ref) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// connectorHasAnyDelegationForActor reports whether principalID holds a role with
+// ANY active ConnectRefGrant on connectorName, regardless of ref prefix — used only
+// by ConnectReadableConnectorNames (listing), where there is no specific ref to
+// match against; a per-read call still applies the exact ref-prefix match via
+// connectRefGrantDelegates.
+func (c *KeyorixCore) connectorHasAnyDelegationForActor(ctx context.Context, actorType string, principalID uint, connectorName string) (bool, error) {
+	grants, err := c.storage.ListConnectRefGrantsByConnector(ctx, connectorName)
+	if err != nil {
+		return false, fmt.Errorf("connect ref-grant lookup: %w", err)
+	}
+	if len(grants) == 0 {
+		return false, nil
+	}
+	roleSet, err := c.actorRoleIDs(ctx, actorType, principalID)
+	if err != nil {
+		return false, err
+	}
+	now := time.Now()
+	for _, g := range grants {
+		if roleSet[g.RoleID] && connectGrantActive(g, now) {
 			return true, nil
 		}
 	}

--- a/internal/core/connect_audit_reason_test.go
+++ b/internal/core/connect_audit_reason_test.go
@@ -1,0 +1,233 @@
+// connect_audit_reason_test.go — ADR-082 branch 3: asserts the exact
+// "reason=<value>" token ReadFederatedSecret's audit Description carries for
+// every allow and deny outcome, plus Success and ProjectID population. The
+// fixed token format (documented in ADR-082 §E) is what lets a future
+// structured column be a parse-and-backfill rather than a rewrite, so these
+// tests pin the literal values, not just "an event was written."
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// lastConnectSecretReadEvent returns the most recently written
+// connect.secret_read audit row.
+func lastConnectSecretReadEvent(t *testing.T, db *gorm.DB) models.AuditEvent {
+	t.Helper()
+	var event models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventConnectSecretRead).Order("id DESC").First(&event).Error)
+	return event
+}
+
+// TestReadFederatedSecret_AuditReasons_Allow covers the three allow reasons
+// (ADR-082 §E: project_membership, global_scope, platform_scope) plus
+// delegation (§F) — each must produce Success=true, the exact reason= token,
+// and a ProjectID matching the connector's OWNING project (nil for a
+// platform-scoped connector, per ConnectOwnership's own doc comment).
+func TestReadFederatedSecret_AuditReasons_Allow(t *testing.T) {
+	t.Run("project_membership", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+		seedRoleForUserAtProject(t, db, 1, 10, "project-member", 42)
+
+		val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
+		require.NoError(t, err)
+		assert.Equal(t, "v", val)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.True(t, *event.Success)
+		require.NotNil(t, event.ProjectID)
+		assert.EqualValues(t, 42, *event.ProjectID)
+		assert.Contains(t, event.Description, "reason=project_membership")
+	})
+
+	t.Run("global_scope", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+		seedRoleForUser(t, db, 2, 20, "global-role")
+
+		val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 2, "aws", "ref")
+		require.NoError(t, err)
+		assert.Equal(t, "v", val)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.True(t, *event.Success)
+		require.NotNil(t, event.ProjectID)
+		assert.EqualValues(t, 42, *event.ProjectID)
+		assert.Contains(t, event.Description, "reason=global_scope")
+	})
+
+	t.Run("platform_scope", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+
+		val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
+		require.NoError(t, err)
+		assert.Equal(t, "v", val)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.True(t, *event.Success)
+		assert.Nil(t, event.ProjectID, "a platform-scoped connector's ProjectID is meaningless and must not be audited as a real project")
+		assert.Contains(t, event.Description, "reason=platform_scope")
+	})
+
+	t.Run("delegation", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+		seedRoleForUserAtProject(t, db, 5, 30, "borrower", 99) // NOT owner (different project)
+		seedGrant(t, c, 30, "aws", "prod/")
+
+		val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 5, "aws", "prod/db")
+		require.NoError(t, err)
+		assert.Equal(t, "v", val)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.True(t, *event.Success)
+		require.NotNil(t, event.ProjectID, "delegation still audits the connector's OWNING project, not the caller's")
+		assert.EqualValues(t, 42, *event.ProjectID)
+		assert.Contains(t, event.Description, "reason=delegation")
+	})
+}
+
+// TestReadFederatedSecret_AuditReasons_Deny covers every deny path (ADR-082
+// branch 3): all must be Success=false, and each must carry its own distinct
+// reason= token — ownership_denied and delegation_denied in particular are
+// the ONLY place these two outcomes are distinguishable at all, since both
+// return the identical opaque unknown-connector error to the caller.
+func TestReadFederatedSecret_AuditReasons_Deny(t *testing.T) {
+	t.Run("connect_disabled", func(t *testing.T) {
+		ms := new(MockStorage)
+		var got *models.AuditEvent
+		ms.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+			got = e
+			return true
+		})).Return(nil)
+		c := &KeyorixCore{storage: ms}
+
+		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrConnectDisabled)
+
+		require.NotNil(t, got)
+		require.NotNil(t, got.Success)
+		assert.False(t, *got.Success)
+		assert.Nil(t, got.ProjectID)
+		assert.Contains(t, got.Description, "reason=connect_disabled")
+	})
+
+	t.Run("unknown_connector", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "nope", "ref")
+		require.Error(t, err)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.False(t, *event.Success)
+		assert.Nil(t, event.ProjectID)
+		assert.Contains(t, event.Description, "reason=unknown_connector")
+	})
+
+	t.Run("ref_not_permitted", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+		seedRoleForUserAtProject(t, db, 1, 10, "project-member", 42)
+		seedGrant(t, c, 10, "aws", "prod/") // scopes the connector to prod/ only
+
+		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "dev/db")
+		require.Error(t, err)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.False(t, *event.Success)
+		require.NotNil(t, event.ProjectID)
+		assert.EqualValues(t, 42, *event.ProjectID)
+		assert.Contains(t, event.Description, "reason=ref_not_permitted")
+	})
+
+	t.Run("ownership_denied_no_grants_at_all", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+		seedRoleForUserAtProject(t, db, 6, 31, "not-owner", 99) // different project, no grant seeded
+
+		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 6, "aws", "ref")
+		require.Error(t, err)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.False(t, *event.Success)
+		require.NotNil(t, event.ProjectID)
+		assert.EqualValues(t, 42, *event.ProjectID)
+		assert.Contains(t, event.Description, "reason=ownership_denied")
+	})
+
+	t.Run("delegation_denied_grants_exist_but_no_match", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+		seedRoleForUserAtProject(t, db, 5, 30, "borrower", 99) // not owner
+		seedGrant(t, c, 30, "aws", "prod/")                    // a grant exists...
+
+		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 5, "aws", "dev/db") // ...but ref is outside it
+		require.Error(t, err)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.False(t, *event.Success)
+		require.NotNil(t, event.ProjectID)
+		assert.EqualValues(t, 42, *event.ProjectID)
+		assert.Contains(t, event.Description, "reason=delegation_denied")
+	})
+
+	t.Run("backend_error", func(t *testing.T) {
+		c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", err: assert.AnError})
+		c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+
+		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "shared-vault", "ref")
+		require.Error(t, err)
+
+		event := lastConnectSecretReadEvent(t, db)
+		require.NotNil(t, event.Success)
+		assert.False(t, *event.Success)
+		assert.Contains(t, event.Description, "reason=backend_error")
+	})
+}
+
+// TestReadFederatedSecret_OwnershipDenialProducesAuditEventDespiteOpaqueHTTPShape
+// proves the exact property ADR-082 branch 3 exists for: the RETURNED ERROR is
+// identical (ErrConnectUnknownConnector) for an ownership denial and a
+// genuinely unknown connector — but the audit trail still records which one
+// actually happened, distinctly and correctly.
+func TestReadFederatedSecret_OwnershipDenialProducesAuditEventDespiteOpaqueHTTPShape(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+	seedRoleForUserAtProject(t, db, 6, 31, "not-owner", 99)
+
+	_, ownershipDenialErr := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 6, "aws", "ref")
+	require.Error(t, ownershipDenialErr)
+	require.ErrorIs(t, ownershipDenialErr, ErrConnectUnknownConnector)
+
+	_, unknownConnectorErr := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 6, "does-not-exist", "ref")
+	require.Error(t, unknownConnectorErr)
+	require.ErrorIs(t, unknownConnectorErr, ErrConnectUnknownConnector)
+
+	// The two errors are indistinguishable to the caller...
+	assert.ErrorIs(t, ownershipDenialErr, ErrConnectUnknownConnector)
+	assert.ErrorIs(t, unknownConnectorErr, ErrConnectUnknownConnector)
+
+	// ...but the audit trail is not: two distinct events, with distinct reasons.
+	var events []models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventConnectSecretRead).Order("id ASC").Find(&events).Error)
+	require.Len(t, events, 2)
+	assert.Contains(t, events[0].Description, "reason=ownership_denied")
+	assert.Contains(t, events[1].Description, "reason=unknown_connector")
+}

--- a/internal/core/connect_audit_reason_test.go
+++ b/internal/core/connect_audit_reason_test.go
@@ -69,6 +69,8 @@ func TestReadFederatedSecret_AuditReasons_Allow(t *testing.T) {
 	t.Run("platform_scope", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "v"})
 		c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+		seedRoleForUser(t, db, 999, 50, "platform-caller")
+		seedConnectPlatformUsePermission(t, db, 50) // ADR-082 branch 4: platform scope now requires this
 
 		val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
 		require.NoError(t, err)
@@ -191,6 +193,8 @@ func TestReadFederatedSecret_AuditReasons_Deny(t *testing.T) {
 	t.Run("backend_error", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", err: assert.AnError})
 		c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+		seedRoleForUser(t, db, 1, 50, "platform-caller")
+		seedConnectPlatformUsePermission(t, db, 50) // ADR-082 branch 4: must clear the platform gate to reach the backend call and fail there instead
 
 		_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "shared-vault", "ref")
 		require.Error(t, err)

--- a/internal/core/connect_ownership_test.go
+++ b/internal/core/connect_ownership_test.go
@@ -1,0 +1,267 @@
+// connect_ownership_test.go — ADR-082 branch 2: ownership enforcement in
+// ReadFederatedSecret and ConnectReadableConnectorNames. Uses connectRBACCore
+// (connect_rbac_test.go) so role scopes actually resolve through GetUserRoleScopes/
+// GetMachineRoleScopes against a real (in-memory) store, exactly like production.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// TestConnectOwnership_ZeroScopeEntryMustSurvive is the ADR-082 invariant test: a
+// caller's {0,0} (global-scope) role-scope entry must survive from
+// GetUserRoleScopes all the way into the ownership comparison, unfiltered. A
+// future "cleanup" that strips ProjectID==0 entries before the comparison —
+// exactly what the pre-ADR-082 design did — would silently and completely remove
+// every global-scoped caller's Connect reach, with no compile error, and no other
+// test in this file would catch it (every other ownership test here uses a caller
+// with an explicit project-scoped role). If this test fails, the fix is almost
+// never "strip the {0,0} entry, it looks like noise" — read ADR-082 §D/§E first.
+func TestConnectOwnership_ZeroScopeEntryMustSurvive(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 99}})
+
+	// The caller holds ONLY a role granted at the GLOBAL scope (ProjectID 0) — no
+	// role at project 99 specifically, and the role is deliberately NOT one of the
+	// admin-named roles, proving this is a scope check, not a name check.
+	seedRoleForUser(t, db, 1, 10, "billing-viewer")
+
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
+	require.NoError(t, err, "a caller with only a global-scoped role must reach a project-scoped connector via the {0,0} wildcard (ADR-082 §E) — if this fails, check whether the raw scope list is being filtered to ProjectID != 0 before the ownership comparison runs")
+	assert.Equal(t, "v3ry-secret", val)
+}
+
+// TestConnectOwnership_ReadFederatedSecret is the table-driven ownership suite
+// (ADR-082 §E): project-scope matching, the {0,0} wildcard, no relevant scope,
+// platform connectors, and ConnectRefGrant delegation for an otherwise-denied
+// connector.
+func TestConnectOwnership_ReadFederatedSecret(t *testing.T) {
+	const connectorProjectID = 42
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, c *KeyorixCore, db *gorm.DB)
+		userID    uint
+		wantErr   bool
+		wantValue string
+	}{
+		{
+			name: "caller with matching project scope is allowed",
+			setup: func(t *testing.T, c *KeyorixCore, db *gorm.DB) {
+				seedRoleForUserAtProject(t, db, 1, 20, "project-member", connectorProjectID)
+			},
+			userID:    1,
+			wantValue: "v3ry-secret",
+		},
+		{
+			name: "caller with non-matching project scope is denied",
+			setup: func(t *testing.T, c *KeyorixCore, db *gorm.DB) {
+				seedRoleForUserAtProject(t, db, 2, 21, "other-project-member", connectorProjectID+1)
+			},
+			userID:  2,
+			wantErr: true,
+		},
+		{
+			name: "caller with global {0,0} scope against a project-scoped connector is allowed via the wildcard",
+			setup: func(t *testing.T, c *KeyorixCore, db *gorm.DB) {
+				seedRoleForUser(t, db, 3, 22, "global-scoped-role")
+			},
+			userID:    3,
+			wantValue: "v3ry-secret",
+		},
+		{
+			name:    "caller with no relevant scope at all is denied",
+			setup:   func(t *testing.T, c *KeyorixCore, db *gorm.DB) {},
+			userID:  4,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+			c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: connectorProjectID}})
+			tt.setup(t, c, db)
+
+			val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, tt.userID, "aws", "ref")
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unknown connector", "ownership denial must reuse the unknown-connector shape (ADR-082) — do not confirm existence to an unauthorized caller")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantValue, val)
+		})
+	}
+}
+
+// TestConnectOwnership_PlatformConnectorAnyCaller proves a platform-scoped
+// connector passes ownership for any caller in THIS branch — TODO(ADR-082 branch
+// 4) is the connect.platform.use gate; until then any connect.read holder (the
+// transport layer's job, not this function's) reaches it, even with zero roles.
+func TestConnectOwnership_PlatformConnectorAnyCaller(t *testing.T) {
+	c, _ := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "shared-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
+	require.NoError(t, err, "a platform-scoped connector must pass ownership for any caller in this branch")
+	assert.Equal(t, "shared-secret", val)
+}
+
+// TestConnectOwnership_ConnectRefGrantDelegatesForNonOwnedCaller proves the
+// delegation path (ADR-082 §F): a caller with NO ownership claim on the
+// connector's project is still allowed through an explicit ConnectRefGrant
+// covering their role and the requested ref.
+func TestConnectOwnership_ConnectRefGrantDelegatesForNonOwnedCaller(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+
+	// Caller has a role at a DIFFERENT project — not owned.
+	seedRoleForUserAtProject(t, db, 5, 30, "borrower", 99)
+	// But that role holds an explicit delegation grant on "aws".
+	seedGrant(t, c, 30, "aws", "prod/")
+
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 5, "aws", "prod/db")
+	require.NoError(t, err, "a non-owned caller with a matching ConnectRefGrant must be allowed (ADR-082 §F delegation)")
+	assert.Equal(t, "v3ry-secret", val)
+
+	// The same caller, same role, but a ref OUTSIDE the grant's prefix: no
+	// ownership and no matching delegation — denied. connectRefGrantDelegates
+	// (unlike connectRefAllowed) must not treat "grants exist but none match" as
+	// an allow for a non-owned caller.
+	_, err = c.ReadFederatedSecret(context.Background(), ActorTypeUser, 5, "aws", "dev/db")
+	require.Error(t, err)
+}
+
+// TestConnectOwnership_NonOwnedCallerNoGrantsAtAllIsDenied proves
+// connectRefGrantDelegates' polarity is the OPPOSITE of connectRefAllowed's: for
+// a non-owned caller, a connector with ZERO ref-grants configured means NO
+// delegation path (deny), not "no additional narrowing" (allow) — the shortcut
+// that's correct only for an already-owned caller.
+func TestConnectOwnership_NonOwnedCallerNoGrantsAtAllIsDenied(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+	seedRoleForUserAtProject(t, db, 6, 31, "not-owner", 99) // no grant seeded at all
+
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 6, "aws", "ref")
+	require.Error(t, err, "a non-owned caller must be denied when the connector has no ref-grants at all — no grants means no delegation path, not an automatic allow")
+}
+
+// TestConnectOwnership_MissingFromOwnershipMapDenies proves the structural
+// invariant (ADR-082 §E): a connector absent from the ownership map is denied,
+// never silently skipped or treated as owned. server/main.go's boot-time key-set
+// check exists to guarantee this never happens for a correctly-booted server;
+// this proves connectOwnershipSatisfied's own runtime backstop independently.
+func TestConnectOwnership_MissingFromOwnershipMapDenies(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	// connectRBACCore defaults every connector to scope: platform (always-owned) —
+	// explicitly clear that here to exercise the genuinely-missing-entry case.
+	c.SetConnectOwnership(nil)
+	seedRoleForUser(t, db, 1, 10, "global-role") // even a global-scoped caller...
+
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
+	require.Error(t, err, "a connector missing from the ownership map must deny, never fall back to allow")
+}
+
+// TestConnectOwnership_MachineIdentityProjectScopedRoleNotGlobal proves ADR-082
+// §E's machine-identity composition claim in code: a machine identity holding an
+// admin-equivalent role at a SPECIFIC project's scope produces that project's
+// scope entry from GetMachineRoleScopes, not {0,0} — so it does NOT get the
+// global wildcard, and is correctly bounded to that one project.
+func TestConnectOwnership_MachineIdentityProjectScopedRoleNotGlobal(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+
+	require.NoError(t, db.Create(&models.Role{ID: 40, Name: "admin"}).Error) // admin-NAMED, but scoped below
+	require.NoError(t, db.Create(&models.MachineIdentityRole{
+		MachineIdentityID: 7, RoleID: 40, ProjectID: 99, // a DIFFERENT project than the connector's
+	}).Error)
+
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeMachine, 7, "aws", "ref")
+	require.Error(t, err, "a machine identity holding an admin-named role at a SPECIFIC project's scope must be bounded to that project, not treated as global — GetMachineRoleScopes must return {ProjectID:99}, not {0,0}, for this grant")
+
+	// The same machine identity DOES reach the connector once its role is granted
+	// at the connector's OWN project — proving the denial above is genuinely
+	// about scope, not a broken machine-identity path in general.
+	require.NoError(t, db.Create(&models.MachineIdentityRole{
+		MachineIdentityID: 7, RoleID: 40, ProjectID: 42,
+	}).Error)
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeMachine, 7, "aws", "ref")
+	require.NoError(t, err)
+	assert.Equal(t, "v3ry-secret", val)
+}
+
+// TestConnectOwnership_MachineIdentityGlobalRoleGetsWildcard is the machine-
+// identity counterpart to TestConnectOwnership_ZeroScopeEntryMustSurvive: a
+// machine identity granted a role at the TRUE global scope ({0,0}) receives the
+// same ownership wildcard a user would (ADR-082 §E) — roleSetContainsAdmin-style
+// actor-agnostic behavior extended consistently to Connect ownership.
+func TestConnectOwnership_MachineIdentityGlobalRoleGetsWildcard(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 42}})
+
+	require.NoError(t, db.Create(&models.Role{ID: 41, Name: "global-machine-role"}).Error)
+	require.NoError(t, db.Create(&models.MachineIdentityRole{
+		MachineIdentityID: 8, RoleID: 41, ProjectID: 0, // global scope
+	}).Error)
+
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeMachine, 8, "aws", "ref")
+	require.NoError(t, err)
+	assert.Equal(t, "v3ry-secret", val)
+}
+
+// TestConnectReadableConnectorNames_FiltersToOwnedSubset proves ListConnectors
+// discovery (ADR-082 §E) filters by ownership: a caller who is a member of only
+// one of two connectors' owning projects sees just that one connector, not both —
+// a discovery endpoint that lists an unreachable connector leaks its existence to
+// a caller who cannot use it.
+func TestConnectReadableConnectorNames_FiltersToOwnedSubset(t *testing.T) {
+	c, db := connectRBACCore(t,
+		fakeConnector{name: "aws-payments", val: "v1"},
+		fakeConnector{name: "aws-billing", val: "v2"},
+	)
+	c.SetConnectOwnership(map[string]ConnectOwnership{
+		"aws-payments": {Scope: "project", ProjectID: 42},
+		"aws-billing":  {Scope: "project", ProjectID: 99},
+	})
+	seedRoleForUserAtProject(t, db, 1, 10, "payments-member", 42)
+
+	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"aws-payments"}, names, "caller must see only the connector whose project they're a member of")
+}
+
+// TestConnectReadableConnectorNames_GlobalScopedCallerSeesAll proves a
+// global-scoped caller (the {0,0} wildcard — ADR-082 §E) sees every
+// scope: project connector via the SAME per-connector filter loop, not a
+// separate "if admin, return everything" branch — ConnectReadableConnectorNames
+// has no such branch, so this is exercising the loop's actual behavior.
+func TestConnectReadableConnectorNames_GlobalScopedCallerSeesAll(t *testing.T) {
+	c, db := connectRBACCore(t,
+		fakeConnector{name: "aws-payments", val: "v1"},
+		fakeConnector{name: "aws-billing", val: "v2"},
+	)
+	c.SetConnectOwnership(map[string]ConnectOwnership{
+		"aws-payments": {Scope: "project", ProjectID: 42},
+		"aws-billing":  {Scope: "project", ProjectID: 99},
+	})
+	seedRoleForUser(t, db, 2, 20, "global-scoped-role")
+
+	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 2)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"aws-payments", "aws-billing"}, names, "a global-scoped caller must see every project-scoped connector via the {0,0} wildcard")
+}
+
+// seedRoleForUserAtProject mirrors seedRoleForUser (connect_rbac_test.go) but
+// grants the role at a specific project scope instead of global.
+func seedRoleForUserAtProject(t *testing.T, db *gorm.DB, userID, roleID uint, name string, projectID uint) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.Role{ID: roleID, Name: name}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: userID, RoleID: roleID, ProjectID: projectID}).Error)
+}

--- a/internal/core/connect_ownership_test.go
+++ b/internal/core/connect_ownership_test.go
@@ -101,16 +101,32 @@ func TestConnectOwnership_ReadFederatedSecret(t *testing.T) {
 	}
 }
 
-// TestConnectOwnership_PlatformConnectorAnyCaller proves a platform-scoped
-// connector passes ownership for any caller in THIS branch — TODO(ADR-082 branch
-// 4) is the connect.platform.use gate; until then any connect.read holder (the
-// transport layer's job, not this function's) reaches it, even with zero roles.
-func TestConnectOwnership_PlatformConnectorAnyCaller(t *testing.T) {
+// TestConnectOwnership_PlatformConnectorRequiresPlatformUse supersedes the
+// pre-branch-4 "any connect.read holder reaches it" behavior this test used to
+// assert (its own prior docstring named this as the TODO(ADR-082 branch 4) gap
+// explicitly). Now: a caller with zero roles — including no connect.platform.use
+// — is denied, terminally (no ConnectRefGrant delegation fallback; see
+// connectDenyReasonPlatformPermissionDenied).
+func TestConnectOwnership_PlatformConnectorRequiresPlatformUse(t *testing.T) {
 	c, _ := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "shared-secret"})
 	c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
 
-	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
-	require.NoError(t, err, "a platform-scoped connector must pass ownership for any caller in this branch")
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 999, "shared-vault", "ref")
+	require.Error(t, err, "a platform-scoped connector must now deny a caller with no connect.platform.use grant")
+	assert.ErrorIs(t, err, ErrConnectUnknownConnector, "the denial must reuse the opaque unknown-connector shape (ADR-082)")
+}
+
+// TestConnectOwnership_PlatformConnectorAllowsHolderOfPlatformUse is the allow
+// counterpart: a caller who DOES hold connect.platform.use reaches the platform
+// connector, same as any other allow path.
+func TestConnectOwnership_PlatformConnectorAllowsHolderOfPlatformUse(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "shared-secret"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+	seedRoleForUser(t, db, 1, 10, "platform-caller")
+	seedConnectPlatformUsePermission(t, db, 10)
+
+	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "shared-vault", "ref")
+	require.NoError(t, err)
 	assert.Equal(t, "shared-secret", val)
 }
 
@@ -256,6 +272,41 @@ func TestConnectReadableConnectorNames_GlobalScopedCallerSeesAll(t *testing.T) {
 	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 2)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"aws-payments", "aws-billing"}, names, "a global-scoped caller must see every project-scoped connector via the {0,0} wildcard")
+}
+
+// TestConnectReadableConnectorNames_PlatformFilteredWithoutPlatformUse proves
+// ListConnectors filtering (ADR-082 branch 4) via the SAME per-connector filter
+// ReadFederatedSecret uses (connectOwnershipSatisfied) — no separate branch: a
+// caller lacking connect.platform.use sees a platform connector disappear from
+// discovery, exactly like ReadFederatedSecret would deny an actual read of it.
+func TestConnectReadableConnectorNames_PlatformFilteredWithoutPlatformUse(t *testing.T) {
+	c, db := connectRBACCore(t,
+		fakeConnector{name: "shared-vault", val: "v1"},
+		fakeConnector{name: "aws-payments", val: "v2"},
+	)
+	c.SetConnectOwnership(map[string]ConnectOwnership{
+		"shared-vault": {Scope: "platform"},
+		"aws-payments": {Scope: "project", ProjectID: 42},
+	})
+	seedRoleForUserAtProject(t, db, 1, 10, "payments-member", 42) // no connect.platform.use
+
+	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"aws-payments"}, names, "the platform connector must be filtered out without connect.platform.use, even though the project connector (a genuine ownership match) is still visible")
+}
+
+// TestConnectReadableConnectorNames_PlatformVisibleWithPlatformUse is the allow
+// counterpart: a caller holding connect.platform.use sees the platform
+// connector in discovery too.
+func TestConnectReadableConnectorNames_PlatformVisibleWithPlatformUse(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "shared-vault", val: "v1"})
+	c.SetConnectOwnership(map[string]ConnectOwnership{"shared-vault": {Scope: "platform"}})
+	seedRoleForUser(t, db, 1, 10, "platform-caller")
+	seedConnectPlatformUsePermission(t, db, 10)
+
+	names, err := c.ConnectReadableConnectorNames(context.Background(), ActorTypeUser, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"shared-vault"}, names)
 }
 
 // seedRoleForUserAtProject mirrors seedRoleForUser (connect_rbac_test.go) but

--- a/internal/core/connect_rbac_admin_test.go
+++ b/internal/core/connect_rbac_admin_test.go
@@ -21,6 +21,10 @@ func TestConnectRefRBAC_NoAdminBypass(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 
 	// User 1 is a GLOBAL super_admin — the role that bypasses core RBAC.
+	// ADR-082 branch 4: no explicit connect.platform.use grant is needed here —
+	// super_admin's role-NAME bypass (roleSetContainsAdmin) satisfies ANY
+	// permission check, this new one included, exactly like the connect.read
+	// precondition check just below already demonstrates.
 	seedRoleForUser(t, db, 1, 1, "super_admin")
 	// The connector is ref-scoped, but only for a DIFFERENT role (reader = role 2).
 	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "reader"}).Error)

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -16,7 +16,12 @@ import (
 )
 
 // connectRBACCore builds a core backed by a real (in-memory) store so per-reference
-// grants and role assignments actually resolve through the enforcement path.
+// grants and role assignments actually resolve through the enforcement path. Every
+// connector is wired as scope: platform by default (ADR-082) — a platform
+// connector passes ownership for any caller in this branch, matching this suite's
+// pre-ADR-082 assumption that any connect.read holder can reach a configured test
+// connector; ownership-specific behavior is covered separately
+// (connect_ownership_test.go).
 func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *gorm.DB) {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
@@ -26,10 +31,16 @@ func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *g
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.ConnectRefGrant{}, &models.AuditEvent{},
 		&models.Project{}, &models.Environment{},
+		&models.ConnectorProjectBinding{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	if len(conns) > 0 {
 		c.SetConnectManager(connect.NewManager(conns))
+		ownership := make(map[string]ConnectOwnership, len(conns))
+		for _, conn := range conns {
+			ownership[conn.Name()] = ConnectOwnership{Scope: "platform"}
+		}
+		c.SetConnectOwnership(ownership)
 	}
 	return c, db
 }

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -32,6 +32,7 @@ func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *g
 		&models.ConnectRefGrant{}, &models.AuditEvent{},
 		&models.Project{}, &models.Environment{},
 		&models.ConnectorProjectBinding{},
+		&models.Permission{}, &models.RolePermission{},
 	))
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	if len(conns) > 0 {
@@ -51,6 +52,21 @@ func seedRoleForUser(t *testing.T, db *gorm.DB, userID, roleID uint, name string
 	require.NoError(t, db.Create(&models.UserRole{UserID: userID, RoleID: roleID}).Error)
 }
 
+// seedConnectPlatformUsePermission grants roleID the connect.platform.use
+// permission (ADR-082 branch 4). Every connectRBACCore-based test defaults its
+// connectors to scope: platform, and a platform-scope read now requires this
+// permission — call this wherever a test's role is meant to actually reach a
+// platform connector (i.e. it is exercising something OTHER than the
+// platform-permission gate itself, such as ADR-045 ref-grant behavior). Each
+// test gets its own in-memory DB (connectRBACCore), so there's no cross-test
+// collision creating the same permission name twice.
+func seedConnectPlatformUsePermission(t *testing.T, db *gorm.DB, roleID uint) {
+	t.Helper()
+	perm := models.Permission{Name: "connect.platform.use", Description: "test", Resource: "connect", Action: "platform.use"}
+	require.NoError(t, db.Create(&perm).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: roleID, PermissionID: perm.ID}).Error)
+}
+
 func seedGrant(t *testing.T, c *KeyorixCore, roleID uint, connector, prefix string) {
 	t.Helper()
 	_, err := c.storage.CreateConnectRefGrant(context.Background(), &models.ConnectRefGrant{RoleID: roleID, Connector: connector, RefPrefix: prefix})
@@ -68,6 +84,7 @@ func seedGrantExpiring(t *testing.T, c *KeyorixCore, roleID uint, connector, pre
 func TestConnectRefRBAC_NoGrantsAllows(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045, not the platform gate
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "anything/at/all")
 	require.NoError(t, err)
 	assert.Equal(t, "v", val)
@@ -78,6 +95,7 @@ func TestConnectRefRBAC_NoGrantsAllows(t *testing.T) {
 func TestConnectRefRBAC_PrefixScopes(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "metrics-reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045, not the platform gate
 	seedGrant(t, c, 5, "aws", "metrics/")
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
@@ -94,7 +112,8 @@ func TestConnectRefRBAC_PrefixScopes(t *testing.T) {
 func TestConnectRefRBAC_RoleMismatchDenied(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "reader")
-	seedGrant(t, c, 9, "aws", "metrics/") // granted to role 9, not the user's role 5
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: role 5 must reach the ref-grant check to prove the ROLE mismatch, not the platform gate, is what denies it
+	seedGrant(t, c, 9, "aws", "metrics/")      // granted to role 9, not the user's role 5
 
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
 	require.Error(t, err)
@@ -105,6 +124,7 @@ func TestConnectRefRBAC_RoleMismatchDenied(t *testing.T) {
 func TestConnectRefRBAC_EmptyPrefixAllowsAll(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "broad-reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045, not the platform gate
 	seedGrant(t, c, 5, "aws", "")
 
 	for _, ref := range []string{"metrics/x", "db/y", "anything"} {
@@ -121,7 +141,8 @@ func TestConnectRefRBAC_OtherConnectorUnaffected(t *testing.T) {
 		fakeConnector{name: "gcp", val: "g"},
 	)
 	seedRoleForUser(t, db, 1, 5, "reader")
-	seedGrant(t, c, 5, "aws", "metrics/") // scopes aws only
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045, not the platform gate — covers both connectors, gcp included
+	seedGrant(t, c, 5, "aws", "metrics/")      // scopes aws only
 
 	// gcp has no grants → unaffected.
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "gcp", "projects/p/secrets/x/versions/latest")
@@ -140,7 +161,8 @@ func TestConnectRefRBAC_MultiRoleUnion(t *testing.T) {
 	require.NoError(t, db.Create(&models.Role{ID: 6, Name: "db"}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 5}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 6}).Error)
-	seedGrant(t, c, 6, "aws", "db/") // only the db role grants db/
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045 role-union matching, not the platform gate — either held role suffices for platform.use
+	seedGrant(t, c, 6, "aws", "db/")           // only the db role grants db/
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "db/password")
 	require.NoError(t, err)
@@ -153,6 +175,7 @@ func TestConnectRefRBAC_MachineIdentityRoles(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	require.NoError(t, db.Create(&models.Role{ID: 7, Name: "ci-metrics"}).Error)
 	require.NoError(t, db.Create(&models.MachineIdentityRole{MachineIdentityID: 42, RoleID: 7}).Error)
+	seedConnectPlatformUsePermission(t, db, 7) // ADR-082 branch 4: this test is about ADR-045, not the platform gate
 	seedGrant(t, c, 7, "aws", "metrics/")
 	ctx := context.Background()
 
@@ -166,10 +189,15 @@ func TestConnectRefRBAC_MachineIdentityRoles(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not permitted")
 
-	// A different machine with no matching role → denied (deny-by-default).
+	// A different machine holds NO role at all — including no connect.platform.use —
+	// so it is now denied at the platform-permission gate itself (ADR-082 branch 4),
+	// before ever reaching the per-ref grant check this test otherwise exercises. It
+	// is still "deny-by-default", just via an earlier gate than the sibling assertion
+	// above; the opaque unknown-connector shape is deliberate (ADR-082 §H), so this
+	// no longer asserts "not permitted" specifically.
 	_, err = c.ReadFederatedSecret(ctx, ActorTypeMachine, 99, "aws", "metrics/qps")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not permitted")
+	assert.ErrorIs(t, err, ErrConnectUnknownConnector)
 }
 
 // A grant for a role the caller holds only VIA GROUP MEMBERSHIP must authorize them —
@@ -183,6 +211,7 @@ func TestConnectRefRBAC_GroupDerivedRole(t *testing.T) {
 	require.NoError(t, db.Create(&models.Group{ID: 3, Name: "analytics"}).Error)
 	require.NoError(t, db.Create(&models.UserGroup{UserID: 1, GroupID: 3}).Error)
 	require.NoError(t, db.Create(&models.GroupRole{GroupID: 3, RoleID: 5}).Error)
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045 group-derived role resolution, not the platform gate — scopedRoleIDs unions group-derived roles the same way for both checks
 	seedGrant(t, c, 5, "aws", "metrics/")
 
 	// The user reaches the grant through their group-derived role.
@@ -200,7 +229,8 @@ func TestConnectRefRBAC_GroupDerivedRole(t *testing.T) {
 func TestConnectRefRBAC_GlobPatterns(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "reader")
-	seedGrant(t, c, 5, "aws", "prod/*/db") // exactly one segment between prod/ and /db
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045 glob matching, not the platform gate
+	seedGrant(t, c, 5, "aws", "prod/*/db")     // exactly one segment between prod/ and /db
 	ctx := context.Background()
 
 	val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/eu/db")
@@ -250,6 +280,7 @@ func TestRefMatches(t *testing.T) {
 func TestConnectRefRBAC_CrossTenantTraversalDenied(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "vault", val: "myapp-secret"})
 	seedRoleForUser(t, db, 1, 5, "myapp-reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045/#326 traversal handling, not the platform gate
 	seedGrant(t, c, 5, "vault", "secret/data/myapp/")
 	ctx := context.Background()
 
@@ -270,6 +301,7 @@ func TestConnectRefRBAC_CrossTenantTraversalDenied(t *testing.T) {
 func TestConnectRefRBAC_ExpiredGrantDenied(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "temp-reader")
+	seedConnectPlatformUsePermission(t, db, 5)                                  // ADR-082 branch 4: this test is about ADR-045 grant expiry, not the platform gate
 	seedGrantExpiring(t, c, 5, "aws", "metrics/", time.Now().Add(-time.Minute)) // already expired
 	ctx := context.Background()
 
@@ -286,6 +318,7 @@ func TestConnectRefRBAC_ExpiredGrantDenied(t *testing.T) {
 func TestConnectRefRBAC_UnexpiredGrantAllowed(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	seedRoleForUser(t, db, 1, 5, "temp-reader")
+	seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045 grant expiry, not the platform gate
 	seedGrantExpiring(t, c, 5, "aws", "metrics/", time.Now().Add(time.Hour))
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
@@ -294,6 +327,9 @@ func TestConnectRefRBAC_UnexpiredGrantAllowed(t *testing.T) {
 }
 
 // CreateConnectRefGrant plumbs an optional expiresAt through to the persisted grant.
+// ADR-082 branch 4: unaffected by the connect.platform.use gate — this test never
+// calls ReadFederatedSecret/connectOwnershipSatisfied at all, only the grant-
+// management path.
 func TestCreateConnectRefGrant_PersistsExpiresAt(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 	require.NoError(t, db.Create(&models.Role{ID: 5, Name: "temp-reader"}).Error)
@@ -324,6 +360,17 @@ func TestConnectRefRBAC_MachineIdentityProjectScopedRole(t *testing.T) {
 	// Granted to the machine ONLY at project 10 — deliberately no global grant.
 	require.NoError(t, db.Create(&models.MachineIdentityRole{MachineIdentityID: 42, RoleID: 7, ProjectID: 10}).Error)
 	seedGrant(t, c, 7, "aws", "metrics/")
+	// ADR-082 branch 4: connect.platform.use is checked at Scope{} (global) —
+	// intentionally: a platform connector is install-wide, so a purely
+	// project-scoped grant of the permission (like role 7 above, deliberately) is
+	// a category error and correctly does NOT satisfy it. This test's whole point
+	// is proving role 7's PROJECT-scoped grant is honoured for the ref-grant
+	// check specifically, so platform.use is granted here via a SEPARATE role
+	// held at the true global scope, decoupled from role 7 — not by making role 7
+	// global, which would defeat the test.
+	require.NoError(t, db.Create(&models.Role{ID: 21, Name: "platform-access"}).Error)
+	require.NoError(t, db.Create(&models.MachineIdentityRole{MachineIdentityID: 42, RoleID: 21}).Error)
+	seedConnectPlatformUsePermission(t, db, 21)
 	ctx := context.Background()
 
 	val, err := c.ReadFederatedSecret(ctx, ActorTypeMachine, 42, "aws", "metrics/qps")
@@ -338,6 +385,8 @@ func TestConnectRefRBAC_MachineIdentityProjectScopedRole(t *testing.T) {
 // actorRoleIDs (G33's detection_idea): a machine identity's project-scoped role
 // grant must resolve into the SAME role-ID set as an equivalent human user
 // holding the identical role at the identical project scope.
+// ADR-082 branch 4: unaffected — calls actorRoleIDs directly, never reaching
+// connectOwnershipSatisfied/the platform gate.
 func TestActorRoleIDs_MachineMatchesEquivalentUser_ProjectScoped(t *testing.T) {
 	c, db := connectRBACCore(t)
 	require.NoError(t, db.Create(&models.Project{ID: 10, Name: "proj-a"}).Error)
@@ -355,6 +404,8 @@ func TestActorRoleIDs_MachineMatchesEquivalentUser_ProjectScoped(t *testing.T) {
 	assert.Equal(t, userRoles, machineRoles, "a machine identity holding the same project-scoped role as a human user must resolve to an identical role-ID set")
 }
 
+// ADR-082 branch 4: unaffected — calls connectRefAllowed directly, never
+// reaching connectOwnershipSatisfied/the platform gate.
 func TestConnectRefAllowed_Direct(t *testing.T) {
 	c, db := connectRBACCore(t)
 	seedRoleForUser(t, db, 1, 5, "reader")

--- a/internal/core/connect_ref_prefix_boundary_test.go
+++ b/internal/core/connect_ref_prefix_boundary_test.go
@@ -56,7 +56,8 @@ func TestConnectRefRBAC_SegmentBoundaryEnforced(t *testing.T) {
 	t.Run("bare prefix does not leak into the sibling namespace", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 		seedRoleForUser(t, db, 1, 5, "prod-reader")
-		seedGrant(t, c, 5, "aws", "prod") // bare prefix — NO trailing slash
+		seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045/#326 boundary matching, not the platform gate
+		seedGrant(t, c, 5, "aws", "prod")          // bare prefix — NO trailing slash
 
 		val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/db")
 		require.NoError(t, err)
@@ -71,7 +72,8 @@ func TestConnectRefRBAC_SegmentBoundaryEnforced(t *testing.T) {
 	t.Run("trailing-slash prefix confines the grant", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 		seedRoleForUser(t, db, 1, 5, "prod-reader")
-		seedGrant(t, c, 5, "aws", "prod/") // safe form — trailing slash
+		seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045/#326 boundary matching, not the platform gate
+		seedGrant(t, c, 5, "aws", "prod/")         // safe form — trailing slash
 
 		val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/db")
 		require.NoError(t, err)
@@ -86,7 +88,8 @@ func TestConnectRefRBAC_SegmentBoundaryEnforced(t *testing.T) {
 	t.Run("exact ref match on the bare prefix is permitted", func(t *testing.T) {
 		c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
 		seedRoleForUser(t, db, 1, 5, "prod-reader")
-		seedGrant(t, c, 5, "aws", "prod/db") // exact ref as prefix
+		seedConnectPlatformUsePermission(t, db, 5) // ADR-082 branch 4: this test is about ADR-045/#326 boundary matching, not the platform gate
+		seedGrant(t, c, 5, "aws", "prod/db")       // exact ref as prefix
 
 		val, err := c.ReadFederatedSecret(ctx, ActorTypeUser, 1, "aws", "prod/db")
 		require.NoError(t, err)

--- a/internal/core/connect_test.go
+++ b/internal/core/connect_test.go
@@ -64,11 +64,15 @@ func TestReadFederatedSecret_UnknownConnector(t *testing.T) {
 }
 
 func TestReadFederatedSecret_DisabledWhenNoManager(t *testing.T) {
-	c := &KeyorixCore{storage: new(MockStorage)}
+	ms := new(MockStorage)
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	c := &KeyorixCore{storage: ms}
 	assert.False(t, c.ConnectEnabled())
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not enabled")
+	// ADR-082 branch 3: the disabled path is now audited too (previously silent).
+	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 }
 
 func TestReadFederatedSecret_BackendErrorAudited(t *testing.T) {
@@ -130,7 +134,9 @@ func TestReadFederatedSecret_UserAuditedAsUser(t *testing.T) {
 // what lets the HTTP layer's isSafeConnectError classify safe vs. unsafe errors by
 // type instead of by substring-matching err.Error() against caller-influenced text.
 func TestConnectErrors_AreTypedSentinels(t *testing.T) {
-	c := &KeyorixCore{storage: new(MockStorage)}
+	ms := new(MockStorage)
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	c := &KeyorixCore{storage: ms}
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrConnectDisabled)

--- a/internal/core/connect_test.go
+++ b/internal/core/connect_test.go
@@ -24,6 +24,11 @@ func (f fakeConnector) GetSecret(_ context.Context, _ string) (string, error) {
 	return f.val, f.err
 }
 
+// connectTestCore wires every connector as scope: platform by default (ADR-082) —
+// a platform connector passes ownership for any caller in this branch, matching
+// this suite's pre-ADR-082 assumption that any caller can reach a configured test
+// connector. Tests that specifically exercise ownership/scope behavior use their
+// own setup (see connect_ownership_test.go) instead of this helper.
 func connectTestCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *MockStorage) {
 	t.Helper()
 	ms := new(MockStorage)
@@ -31,6 +36,11 @@ func connectTestCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *M
 	c := &KeyorixCore{storage: ms}
 	if len(conns) > 0 {
 		c.SetConnectManager(connect.NewManager(conns))
+		ownership := make(map[string]ConnectOwnership, len(conns))
+		for _, conn := range conns {
+			ownership[conn.Name()] = ConnectOwnership{Scope: "platform"}
+		}
+		c.SetConnectOwnership(ownership)
 	}
 	return c, ms
 }
@@ -84,6 +94,7 @@ func TestReadFederatedSecret_MachineIdentityAuditedAsMachine(t *testing.T) {
 	})).Return(nil)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{fakeConnector{name: "aws", val: "v"}}))
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeMachine, 42, "aws", "ref")
 	require.NoError(t, err)
@@ -105,6 +116,7 @@ func TestReadFederatedSecret_UserAuditedAsUser(t *testing.T) {
 	})).Return(nil)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{fakeConnector{name: "aws", val: "v"}}))
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
 
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 7, "aws", "ref")
 	require.NoError(t, err)
@@ -159,6 +171,7 @@ func TestReadFederatedSecret_AuditDescriptionRedactsRawUpstreamError(t *testing.
 	c.SetConnectManager(connect.NewManager([]connect.Connector{
 		fakeConnector{name: "aws", err: rawUpstreamErr},
 	}))
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
 
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", ref)
 	require.Error(t, err)

--- a/internal/core/connect_test.go
+++ b/internal/core/connect_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/connect"
@@ -24,15 +25,18 @@ func (f fakeConnector) GetSecret(_ context.Context, _ string) (string, error) {
 	return f.val, f.err
 }
 
-// connectTestCore wires every connector as scope: platform by default (ADR-082) —
-// a platform connector passes ownership for any caller in this branch, matching
-// this suite's pre-ADR-082 assumption that any caller can reach a configured test
-// connector. Tests that specifically exercise ownership/scope behavior use their
-// own setup (see connect_ownership_test.go) instead of this helper.
-func connectTestCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *MockStorage) {
+// connectTestCore wires every connector as scope: platform by default (ADR-082).
+// platformUseGranted controls whether principal 1 (the actor every test in this
+// file reads as) genuinely holds connect.platform.use (ADR-082 branch 4) — see
+// stubConnectPlatformUseCheckUser's own doc comment for why this is a real,
+// fixture-driven check and not a blanket allow. Tests that specifically exercise
+// ownership/scope behavior use their own setup (see connect_ownership_test.go)
+// instead of this helper.
+func connectTestCore(t *testing.T, platformUseGranted bool, conns ...connect.Connector) (*KeyorixCore, *MockStorage) {
 	t.Helper()
 	ms := new(MockStorage)
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	stubConnectPlatformUseCheckUser(ms, 1, platformUseGranted)
 	c := &KeyorixCore{storage: ms}
 	if len(conns) > 0 {
 		c.SetConnectManager(connect.NewManager(conns))
@@ -45,8 +49,39 @@ func connectTestCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *M
 	return c, ms
 }
 
+// stubConnectPlatformUseCheckUser configures ms so AuthorizePrincipal's
+// connect.platform.use check (ADR-082 branch 4, ActorTypeUser path) resolves
+// deterministically to granted for principalID — NOT a blanket "always
+// authorize" stub. Only RoleSetHasPermission's return value depends on
+// granted; every other call in the chain (GetUserRoleIDsAt,
+// GetUserGroupRoleIDsAt, the four GetRoleByName admin-bypass lookups) resolves
+// to "the principal holds one arbitrary non-admin role" — the same shape a
+// real fixture (a seeded role with, or without, the permission granted) would
+// produce, so a test declaring granted=false genuinely exercises a deny, not a
+// mock that happens to always say yes.
+func stubConnectPlatformUseCheckUser(ms *MockStorage, principalID uint, granted bool) {
+	const testRoleID = 9001
+	ms.On("GetUserRoleIDsAt", mock.Anything, principalID, mock.Anything).Return([]uint{testRoleID}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, principalID, mock.Anything).Return([]uint{}, nil)
+	for _, name := range adminRoleNames {
+		ms.On("GetRoleByName", mock.Anything, name).Return((*models.Role)(nil), errNotFoundStub)
+	}
+	ms.On("RoleSetHasPermission", mock.Anything, []uint{testRoleID}, "connect.platform.use").Return(granted, nil)
+}
+
+// stubConnectPlatformUseCheckMachine is stubConnectPlatformUseCheckUser's
+// machine-identity counterpart — the machine path (AuthorizePrincipal) has no
+// admin-role bypass at all, so it needs fewer stubs.
+func stubConnectPlatformUseCheckMachine(ms *MockStorage, principalID uint, granted bool) {
+	const testRoleID = 9002
+	ms.On("GetMachineRoleIDsAt", mock.Anything, principalID, mock.Anything).Return([]uint{testRoleID}, nil)
+	ms.On("RoleSetHasPermission", mock.Anything, []uint{testRoleID}, "connect.platform.use").Return(granted, nil)
+}
+
+var errNotFoundStub = errors.New("not found (test stub)")
+
 func TestReadFederatedSecret_Success(t *testing.T) {
-	c, ms := connectTestCore(t, fakeConnector{name: "aws", val: "v3ry-secret"})
+	c, ms := connectTestCore(t, true, fakeConnector{name: "aws", val: "v3ry-secret"})
 	require.True(t, c.ConnectEnabled())
 
 	val, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "prod/db")
@@ -56,8 +91,28 @@ func TestReadFederatedSecret_Success(t *testing.T) {
 	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 }
 
+// TestReadFederatedSecret_PlatformUseDeniedByMockFixture proves
+// stubConnectPlatformUseCheckUser genuinely drives a deny, not a rubber-stamped
+// allow: granted=false on a real platform connector (unlike
+// TestReadFederatedSecret_UnknownConnector, where the connector itself doesn't
+// exist) must produce a terminal deny with the platform-specific reason.
+func TestReadFederatedSecret_PlatformUseDeniedByMockFixture(t *testing.T) {
+	c, ms := connectTestCore(t, false, fakeConnector{name: "aws", val: "v3ry-secret"})
+
+	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "prod/db")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrConnectUnknownConnector)
+
+	ms.AssertCalled(t, "LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return strings.Contains(e.Description, "reason=platform_permission_denied")
+	}))
+}
+
 func TestReadFederatedSecret_UnknownConnector(t *testing.T) {
-	c, _ := connectTestCore(t, fakeConnector{name: "aws", val: "x"})
+	// granted=false: the requested connector "nope" doesn't exist, so this never
+	// even reaches the platform-permission check — using false here (not true)
+	// proves that, since a wrongly-reached check would deny for the wrong reason.
+	c, _ := connectTestCore(t, false, fakeConnector{name: "aws", val: "x"})
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "nope", "ref")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown connector")
@@ -76,7 +131,7 @@ func TestReadFederatedSecret_DisabledWhenNoManager(t *testing.T) {
 }
 
 func TestReadFederatedSecret_BackendErrorAudited(t *testing.T) {
-	c, ms := connectTestCore(t, fakeConnector{name: "aws", err: errors.New("AccessDenied")})
+	c, ms := connectTestCore(t, true, fakeConnector{name: "aws", err: errors.New("AccessDenied")})
 	_, err := c.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "aws", "ref")
 	require.Error(t, err)
 	// A failed read is still audited (with FAILED in the description).
@@ -96,6 +151,7 @@ func TestReadFederatedSecret_MachineIdentityAuditedAsMachine(t *testing.T) {
 		got = e
 		return true
 	})).Return(nil)
+	stubConnectPlatformUseCheckMachine(ms, 42, true)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{fakeConnector{name: "aws", val: "v"}}))
 	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
@@ -118,6 +174,7 @@ func TestReadFederatedSecret_UserAuditedAsUser(t *testing.T) {
 		got = e
 		return true
 	})).Return(nil)
+	stubConnectPlatformUseCheckUser(ms, 7, true)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{fakeConnector{name: "aws", val: "v"}}))
 	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
@@ -141,7 +198,9 @@ func TestConnectErrors_AreTypedSentinels(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrConnectDisabled)
 
-	c2, _ := connectTestCore(t, fakeConnector{name: "aws"})
+	// granted=false: c2 is only used below for unknown-connector and
+	// CreateConnectRefGrant checks, never a successful "aws" platform read.
+	c2, _ := connectTestCore(t, false, fakeConnector{name: "aws"})
 	_, err = c2.ReadFederatedSecret(context.Background(), ActorTypeUser, 1, "nope", "ref")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrConnectUnknownConnector)
@@ -173,6 +232,7 @@ func TestReadFederatedSecret_AuditDescriptionRedactsRawUpstreamError(t *testing.
 		got = e
 		return true
 	})).Return(nil)
+	stubConnectPlatformUseCheckUser(ms, 1, true)
 	c := &KeyorixCore{storage: ms}
 	c.SetConnectManager(connect.NewManager([]connect.Connector{
 		fakeConnector{name: "aws", err: rawUpstreamErr},

--- a/internal/core/legal_hold.go
+++ b/internal/core/legal_hold.go
@@ -78,7 +78,7 @@ func (c *KeyorixCore) PlaceLegalHold(ctx context.Context, actorID uint, reason s
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a reason is required to place a legal hold")
 	}
 	if c.isGlobalAdminRoleName(ctx, actorID) == "" {
-		c.writeAuditEventFailed(ctx, EventLegalHoldPlaced, actorPtr(actorID), "",
+		c.writeAuditEventFailed(ctx, EventLegalHoldPlaced, actorPtr(actorID), nil, "",
 			fmt.Sprintf("legal hold placement DENIED: actor %d is not an admin-tier principal", actorID))
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
 			"only an admin-tier principal may place a legal hold")
@@ -134,7 +134,7 @@ func (c *KeyorixCore) LiftLegalHold(ctx context.Context, actorID uint, reason st
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "no legal hold is active")
 	}
 	if actorID != hold.PlacedBy && c.isGlobalAdminRoleName(ctx, actorID) == "" {
-		c.writeAuditEventFailed(ctx, EventLegalHoldLifted, actorPtr(actorID), "",
+		c.writeAuditEventFailed(ctx, EventLegalHoldLifted, actorPtr(actorID), nil, "",
 			fmt.Sprintf("legal hold %d lift DENIED: actor %d is neither the placer (%d) nor an admin-tier principal", hold.ID, actorID, hold.PlacedBy))
 		return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
 			"only the placing admin or an admin-tier principal may lift this legal hold")

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -1719,6 +1720,22 @@ func (m *MockStorage) CreateConnectRefGrant(_ context.Context, grant *models.Con
 }
 func (m *MockStorage) DeleteConnectRefGrant(_ context.Context, _ uint) error {
 	return nil
+}
+
+// ADR-082 branch 2: connector project-binding storage — core enforcement is tested
+// against real SQLite (connect_rbac_test.go, connect_ownership_test.go), so these
+// mock stubs just satisfy the interface. GetProjectByName/GetConnectorProjectBinding
+// default to "not found" (the substring convention every caller of these checks
+// against) rather than a zero value, since a zero-value *models.Project/
+// *models.ConnectorProjectBinding would misrepresent a real, resolvable result.
+func (m *MockStorage) GetProjectByName(_ context.Context, _ string) (*models.Project, error) {
+	return nil, fmt.Errorf("project not found")
+}
+func (m *MockStorage) GetConnectorProjectBinding(_ context.Context, _ string) (*models.ConnectorProjectBinding, error) {
+	return nil, fmt.Errorf("connector project binding not found")
+}
+func (m *MockStorage) CreateConnectorProjectBinding(_ context.Context, binding *models.ConnectorProjectBinding) (*models.ConnectorProjectBinding, error) {
+	return binding, nil
 }
 
 // Group-Role assignments

--- a/internal/core/rbac_reconcile_test.go
+++ b/internal/core/rbac_reconcile_test.go
@@ -82,6 +82,54 @@ func TestReconcileRBAC_AddsNewPermissionToBaselineRoles(t *testing.T) {
 	assert.False(t, roleHasPerm(t, c, "system_viewer", "connect.read"))
 }
 
+// seedOldCatalogWithoutPlatformUse mirrors seedOldCatalog but simulates an
+// install seeded BEFORE connect.platform.use existed (ADR-082 branch 4) — the
+// same precedent connect.read's own reconcile test (above) established for the
+// previous new permission.
+func seedOldCatalogWithoutPlatformUse(t *testing.T, c *KeyorixCore, db *gorm.DB) {
+	t.Helper()
+	ctx := context.Background()
+	for _, def := range defaultPermissions {
+		if def.Name == "connect.platform.use" {
+			continue
+		}
+		_, err := c.storage.CreatePermission(ctx, &models.Permission{Name: def.Name, Description: def.Description, Resource: def.Resource, Action: def.Action})
+		require.NoError(t, err)
+	}
+	for _, rdef := range defaultRoles {
+		role, err := c.storage.CreateRole(ctx, &models.Role{Name: rdef.Name, Description: rdef.Description})
+		require.NoError(t, err)
+		for _, permName := range rdef.Permissions {
+			if permName == "connect.platform.use" {
+				continue
+			}
+			var p models.Permission
+			require.NoError(t, db.Where("name = ?", permName).First(&p).Error)
+			require.NoError(t, c.storage.AssignPermissionToRole(ctx, role.ID, p.ID))
+		}
+	}
+}
+
+// TestReconcileRBAC_AddsConnectPlatformUseToBaselineRoles mirrors
+// TestReconcileRBAC_AddsNewPermissionToBaselineRoles for connect.platform.use
+// specifically (ADR-082 branch 4): a pre-existing admin/system_admin role row
+// gains it on the next reconcile pass, with no manual migration, exactly like
+// connect.read did when it was added.
+func TestReconcileRBAC_AddsConnectPlatformUseToBaselineRoles(t *testing.T) {
+	c, db := newRBACReconcileCore(t)
+	seedOldCatalogWithoutPlatformUse(t, c, db)
+	ctx := context.Background()
+
+	require.False(t, roleHasPerm(t, c, "admin", "connect.platform.use"))
+
+	require.NoError(t, c.ReconcileRBACPermissions(ctx))
+
+	assert.True(t, roleHasPerm(t, c, "admin", "connect.platform.use"))
+	assert.True(t, roleHasPerm(t, c, "system_admin", "connect.platform.use"))
+	assert.False(t, roleHasPerm(t, c, "viewer", "connect.platform.use"))
+	assert.False(t, roleHasPerm(t, c, "editor", "connect.platform.use"), "editor holds no connect.read either — least privilege")
+}
+
 func TestReconcileRBAC_DoesNotClobberExistingGrants(t *testing.T) {
 	c, db := newRBACReconcileCore(t)
 	seedOldCatalog(t, c, db)

--- a/internal/core/risk_exceptions.go
+++ b/internal/core/risk_exceptions.go
@@ -232,7 +232,7 @@ func (c *KeyorixCore) ApproveRiskException(ctx context.Context, actorID, id uint
 		return fmt.Errorf("risk exception %d is already approved", id)
 	}
 	if actorID == e.CreatedBy {
-		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), "",
+		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), nil, "",
 			fmt.Sprintf("risk exception %d approval DENIED: creator %d cannot self-approve", id, actorID))
 		return fmt.Errorf("the exception's creator cannot approve it (dual control); a different system.write holder must approve")
 	}
@@ -242,7 +242,7 @@ func (c *KeyorixCore) ApproveRiskException(ctx context.Context, actorID, id uint
 	// different approver reviews it — a stale or bogus reference must not be
 	// rubber-stamped either.
 	if err := c.validateSoDReferenceIsLiveViolation(ctx, e.Category, e.Reference); err != nil {
-		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), "",
+		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), nil, "",
 			fmt.Sprintf("risk exception %d approval DENIED: %v", id, err))
 		return err
 	}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -242,6 +242,15 @@ type KeyorixCore struct {
 	// connectManager proxies read-through federation to external secret stores
 	// (ADR-043). nil = Keyorix Connect disabled. Set via SetConnectManager.
 	connectManager *connect.Manager
+	// connectOwnership maps each configured connector's name to its resolved
+	// tenant-scoping data (ADR-082 §A/§E) — built in the same boot pass as
+	// connectManager, from the same config, by server/main.go, then set via
+	// SetConnectOwnership. Deliberately NOT part of *connect.Manager/the Connector
+	// interface (internal/connect stays a pure backend-read abstraction with no
+	// ownership concept) — see ADR-082's Decision (D) for the option analysis. A
+	// connector name absent from this map is denied ownership, never silently
+	// skipped or treated as owned — see connectOwnershipSatisfied.
+	connectOwnership map[string]ConnectOwnership
 	// rotationManager holds the backend rotation executors (ADR-047) that apply a new
 	// credential to an upstream system during rotation. nil = no backends configured.
 	rotationManager *rotation.Manager

--- a/server/connect_ownership_resolution_test.go
+++ b/server/connect_ownership_resolution_test.go
@@ -1,0 +1,191 @@
+// connect_ownership_resolution_test.go — ADR-082 branch 2: resolveConnectorOwnership
+// (connector→project ID binding resolution) and connectOwnershipKeySetMismatch
+// (the Manager/ownership key-set boot-time invariant). Uses a real (in-memory)
+// SQLite-backed LocalStorage so GetProjectByName/GetConnectorProjectBinding/
+// CreateConnectorProjectBinding/GetProject all resolve exactly as they would in
+// production — no mocks.
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func connectOwnershipResolutionStorage(t *testing.T) (*store.LocalStorage, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.ConnectorProjectBinding{}))
+	return store.NewLocalStorage(db), db
+}
+
+// TestResolveConnectorOwnership_FirstBootResolvesAndPersists proves the first-boot
+// path: a "project"-scoped connector with no existing binding resolves its
+// configured project: name via GetProjectByName and persists a
+// ConnectorProjectBinding pinning it by ID.
+func TestResolveConnectorOwnership_FirstBootResolvesAndPersists(t *testing.T) {
+	st, db := connectOwnershipResolutionStorage(t)
+	ctx := context.Background()
+	project, err := st.CreateProject(ctx, &models.Project{Name: "payments"})
+	require.NoError(t, err)
+
+	ownership, err := resolveConnectorOwnership(ctx, st, []config.ConnectorConfig{
+		{Name: "aws", Scope: "project", Project: "payments"},
+	})
+	require.NoError(t, err)
+	require.Contains(t, ownership, "aws")
+	assert.Equal(t, core.ConnectOwnership{Scope: "project", ProjectID: project.ID}, ownership["aws"])
+
+	var binding models.ConnectorProjectBinding
+	require.NoError(t, db.Where("connector = ?", "aws").First(&binding).Error)
+	assert.Equal(t, project.ID, binding.ProjectID)
+	assert.Equal(t, "payments", binding.ProjectName)
+}
+
+// TestResolveConnectorOwnership_SubsequentBootResolvesByStoredID proves a later
+// boot (a binding already exists) resolves by the STORED ID, not by re-resolving
+// the config's project: name — even if a DIFFERENT project happens to now hold
+// that same name (the exact silent-reassignment scenario ADR-082 pins against).
+func TestResolveConnectorOwnership_SubsequentBootResolvesByStoredID(t *testing.T) {
+	st, _ := connectOwnershipResolutionStorage(t)
+	ctx := context.Background()
+	original, err := st.CreateProject(ctx, &models.Project{Name: "payments"})
+	require.NoError(t, err)
+	_, err = st.CreateConnectorProjectBinding(ctx, &models.ConnectorProjectBinding{
+		Connector: "aws", ProjectID: original.ID, ProjectName: "payments",
+	})
+	require.NoError(t, err)
+
+	// A second, unrelated project now also happens to be named "payments" is not
+	// possible under the live unique index — but a rename creating this exact
+	// ambiguity IS possible in principle; what matters here is that the resolver
+	// never even calls GetProjectByName once a binding exists.
+	ownership, err := resolveConnectorOwnership(ctx, st, []config.ConnectorConfig{
+		{Name: "aws", Scope: "project", Project: "payments"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, core.ConnectOwnership{Scope: "project", ProjectID: original.ID}, ownership["aws"])
+}
+
+// TestResolveConnectorOwnership_RenameFailsBoot proves a project rename since
+// first boot is a deliberate boot failure (ADR-082), not a silent reassignment:
+// the binding's stored ProjectName no longer matches the project's CURRENT name.
+func TestResolveConnectorOwnership_RenameFailsBoot(t *testing.T) {
+	st, _ := connectOwnershipResolutionStorage(t)
+	ctx := context.Background()
+	project, err := st.CreateProject(ctx, &models.Project{Name: "payments"})
+	require.NoError(t, err)
+	_, err = st.CreateConnectorProjectBinding(ctx, &models.ConnectorProjectBinding{
+		Connector: "aws", ProjectID: project.ID, ProjectName: "payments",
+	})
+	require.NoError(t, err)
+
+	// Rename the project after the binding was recorded.
+	project.Name = "payments-renamed"
+	_, err = st.UpdateProject(ctx, project)
+	require.NoError(t, err)
+
+	_, err = resolveConnectorOwnership(ctx, st, []config.ConnectorConfig{
+		{Name: "aws", Scope: "project", Project: "payments"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "payments")
+	assert.Contains(t, err.Error(), "payments-renamed", "the error must name both the stored and current project names")
+}
+
+// TestResolveConnectorOwnership_DeletedProjectFailsBoot proves a bound project
+// that no longer exists (soft-deleted) is a boot failure, not a silent ownership
+// gap.
+func TestResolveConnectorOwnership_DeletedProjectFailsBoot(t *testing.T) {
+	st, db := connectOwnershipResolutionStorage(t)
+	ctx := context.Background()
+	project, err := st.CreateProject(ctx, &models.Project{Name: "payments"})
+	require.NoError(t, err)
+	_, err = st.CreateConnectorProjectBinding(ctx, &models.ConnectorProjectBinding{
+		Connector: "aws", ProjectID: project.ID, ProjectName: "payments",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, db.Delete(&models.Project{}, project.ID).Error) // soft delete
+
+	_, err = resolveConnectorOwnership(ctx, st, []config.ConnectorConfig{
+		{Name: "aws", Scope: "project", Project: "payments"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aws")
+}
+
+// TestResolveConnectorOwnership_UnresolvableNameFailsBoot proves a first-boot
+// connector whose configured project: name resolves to no live project fails
+// boot.
+func TestResolveConnectorOwnership_UnresolvableNameFailsBoot(t *testing.T) {
+	st, _ := connectOwnershipResolutionStorage(t)
+	_, err := resolveConnectorOwnership(context.Background(), st, []config.ConnectorConfig{
+		{Name: "aws", Scope: "project", Project: "does-not-exist"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aws")
+	assert.Contains(t, err.Error(), "does-not-exist")
+}
+
+// TestResolveConnectorOwnership_AggregatesMultipleFailures proves every
+// offending connector is named in ONE combined error, matching branch 1's
+// aggregation style — not a fail-on-first-found error that hides the rest.
+func TestResolveConnectorOwnership_AggregatesMultipleFailures(t *testing.T) {
+	st, _ := connectOwnershipResolutionStorage(t)
+	_, err := resolveConnectorOwnership(context.Background(), st, []config.ConnectorConfig{
+		{Name: "unresolvable-1", Scope: "project", Project: "nope-1"},
+		{Name: "unresolvable-2", Scope: "project", Project: "nope-2"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unresolvable-1")
+	assert.Contains(t, err.Error(), "unresolvable-2")
+}
+
+// TestResolveConnectorOwnership_PlatformNeedsNoResolution proves a
+// "platform"-scoped connector resolves with no project lookup at all.
+func TestResolveConnectorOwnership_PlatformNeedsNoResolution(t *testing.T) {
+	st, _ := connectOwnershipResolutionStorage(t)
+	ownership, err := resolveConnectorOwnership(context.Background(), st, []config.ConnectorConfig{
+		{Name: "shared-vault", Scope: "platform"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, core.ConnectOwnership{Scope: "platform"}, ownership["shared-vault"])
+}
+
+// TestConnectOwnershipKeySetMismatch_DetectsGenuineDivergence proves a connector
+// present in the manager but absent from ownership (or vice versa) — WITHOUT the
+// legitimate allow_unscoped exception — is reported as a mismatch.
+func TestConnectOwnershipKeySetMismatch_DetectsGenuineDivergence(t *testing.T) {
+	ownership := map[string]core.ConnectOwnership{
+		"aws": {Scope: "project", ProjectID: 1},
+	}
+	connectors := []config.ConnectorConfig{
+		{Name: "aws", Scope: "project", Project: "payments"},
+		{Name: "gcp", Scope: "project", Project: "payments"}, // built, but ownership resolution never ran for it in this test
+	}
+	mismatch := connectOwnershipKeySetMismatch([]string{"aws", "gcp"}, ownership, connectors)
+	assert.Equal(t, []string{"gcp"}, mismatch)
+}
+
+// TestConnectOwnershipKeySetMismatch_AllowsExpectedUnscopedGap proves the ONE
+// legitimate divergence — a connector booted with an empty scope under
+// connect.allow_unscoped is built into the manager but deliberately never given
+// an ownership entry — is NOT reported as a mismatch.
+func TestConnectOwnershipKeySetMismatch_AllowsExpectedUnscopedGap(t *testing.T) {
+	ownership := map[string]core.ConnectOwnership{} // resolveConnectorOwnership skips empty-scope connectors
+	connectors := []config.ConnectorConfig{
+		{Name: "unscoped-aws", Scope: ""}, // booted under connect.allow_unscoped
+	}
+	mismatch := connectOwnershipKeySetMismatch([]string{"unscoped-aws"}, ownership, connectors)
+	assert.Empty(t, mismatch, "a connector booted unscoped under allow_unscoped must not be reported as a key-set mismatch")
+}

--- a/server/connect_ownership_resolution_test.go
+++ b/server/connect_ownership_resolution_test.go
@@ -24,7 +24,7 @@ func connectOwnershipResolutionStorage(t *testing.T) (*store.LocalStorage, *gorm
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.ConnectorProjectBinding{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.ConnectorProjectBinding{}, &models.AuditEvent{}))
 	return store.NewLocalStorage(db), db
 }
 
@@ -49,6 +49,18 @@ func TestResolveConnectorOwnership_FirstBootResolvesAndPersists(t *testing.T) {
 	require.NoError(t, db.Where("connector = ?", "aws").First(&binding).Error)
 	assert.Equal(t, project.ID, binding.ProjectID)
 	assert.Equal(t, "payments", binding.ProjectName)
+
+	// ADR-082 branch 3 / issue #1477's audit half: the boot-time first-resolution
+	// write is itself an authorization-input change and must be audited, same as
+	// the RemoteStorage proxy's equivalent write.
+	var event models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", core.EventConnectorProjectBindingCreate).First(&event).Error)
+	require.NotNil(t, event.ProjectID)
+	assert.Equal(t, project.ID, *event.ProjectID)
+	assert.True(t, *event.Success)
+	assert.Equal(t, core.ActorTypeSystem, event.ActorType)
+	assert.Contains(t, event.Description, "aws")
+	assert.Contains(t, event.Description, "payments")
 }
 
 // TestResolveConnectorOwnership_SubsequentBootResolvesByStoredID proves a later

--- a/server/connect_ownership_resolution_test.go
+++ b/server/connect_ownership_resolution_test.go
@@ -163,29 +163,25 @@ func TestResolveConnectorOwnership_PlatformNeedsNoResolution(t *testing.T) {
 }
 
 // TestConnectOwnershipKeySetMismatch_DetectsGenuineDivergence proves a connector
-// present in the manager but absent from ownership (or vice versa) — WITHOUT the
-// legitimate allow_unscoped exception — is reported as a mismatch.
+// present in the manager but absent from ownership (or vice versa) is reported
+// as a mismatch.
 func TestConnectOwnershipKeySetMismatch_DetectsGenuineDivergence(t *testing.T) {
 	ownership := map[string]core.ConnectOwnership{
 		"aws": {Scope: "project", ProjectID: 1},
 	}
-	connectors := []config.ConnectorConfig{
-		{Name: "aws", Scope: "project", Project: "payments"},
-		{Name: "gcp", Scope: "project", Project: "payments"}, // built, but ownership resolution never ran for it in this test
-	}
-	mismatch := connectOwnershipKeySetMismatch([]string{"aws", "gcp"}, ownership, connectors)
+	mismatch := connectOwnershipKeySetMismatch([]string{"aws", "gcp"}, ownership)
 	assert.Equal(t, []string{"gcp"}, mismatch)
 }
 
-// TestConnectOwnershipKeySetMismatch_AllowsExpectedUnscopedGap proves the ONE
-// legitimate divergence — a connector booted with an empty scope under
-// connect.allow_unscoped is built into the manager but deliberately never given
-// an ownership entry — is NOT reported as a mismatch.
-func TestConnectOwnershipKeySetMismatch_AllowsExpectedUnscopedGap(t *testing.T) {
-	ownership := map[string]core.ConnectOwnership{} // resolveConnectorOwnership skips empty-scope connectors
-	connectors := []config.ConnectorConfig{
-		{Name: "unscoped-aws", Scope: ""}, // booted under connect.allow_unscoped
-	}
-	mismatch := connectOwnershipKeySetMismatch([]string{"unscoped-aws"}, ownership, connectors)
-	assert.Empty(t, mismatch, "a connector booted unscoped under allow_unscoped must not be reported as a key-set mismatch")
+// TestConnectOwnershipKeySetMismatch_NoExemptionForAnyDivergence is the
+// regression guard for the connect.allow_unscoped removal (ADR-082 §C,
+// amended): a connector that WOULD have been exempted under the old
+// scope-based exemption (an empty Scope, built into the manager but absent
+// from ownership) is now reported as a mismatch like any other divergence —
+// resolveConnectorOwnership no longer skips any connector, and the mismatch
+// check no longer accepts a connectors argument to special-case one.
+func TestConnectOwnershipKeySetMismatch_NoExemptionForAnyDivergence(t *testing.T) {
+	ownership := map[string]core.ConnectOwnership{} // empty: nothing resolved for "aws"
+	mismatch := connectOwnershipKeySetMismatch([]string{"aws"}, ownership)
+	assert.Equal(t, []string{"aws"}, mismatch, "with allow_unscoped removed, there is no exemption — any divergence, including what used to be the unscoped case, must be reported")
 }

--- a/server/grpc/services/connect_service.go
+++ b/server/grpc/services/connect_service.go
@@ -27,7 +27,9 @@ func NewConnectService(coreService *core.KeyorixCore) *ConnectGRPCService {
 	return &ConnectGRPCService{core: coreService}
 }
 
-// ListConnectors returns the configured connector names.
+// ListConnectors returns the connector names the caller can reach (ADR-082 §E) —
+// discovery is filtered by ownership so a caller never sees a connector name they
+// cannot subsequently read.
 func (s *ConnectGRPCService) ListConnectors(ctx context.Context, _ *emptypb.Empty) (*pb.ConnectorList, error) {
 	actor, err := requireUser(ctx)
 	if err != nil {
@@ -36,7 +38,12 @@ func (s *ConnectGRPCService) ListConnectors(ctx context.Context, _ *emptypb.Empt
 	if err := authorizeGlobal(ctx, s.core, actor, "connect.read"); err != nil {
 		return nil, err
 	}
-	return &pb.ConnectorList{Connectors: s.core.ConnectConnectorNames()}, nil
+	names, err := s.core.ConnectReadableConnectorNames(ctx, actor.ActorKind(), actor.PrincipalID())
+	if err != nil {
+		log.Printf("Error listing readable connectors: %v", err)
+		return nil, status.Error(codes.Internal, clientSafe(err))
+	}
+	return &pb.ConnectorList{Connectors: names}, nil
 }
 
 // ReadSecret proxies a read-through of a secret's current value from a connector.

--- a/server/grpc/services/connect_service_test.go
+++ b/server/grpc/services/connect_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/connect"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,7 @@ func newConnectService(t *testing.T) *ConnectGRPCService {
 	h.CoreService.SetConnectManager(connect.NewManager([]connect.Connector{
 		fakeConnector{name: "aws", value: "s3cr3t"},
 	}))
+	h.CoreService.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "platform"}})
 	return NewConnectService(h.CoreService)
 }
 

--- a/server/grpc/services/coverage_s21b_test.go
+++ b/server/grpc/services/coverage_s21b_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/connect"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
@@ -509,6 +510,7 @@ func newFailingConnectService(t *testing.T) *ConnectGRPCService {
 	t.Cleanup(h.Cleanup)
 	h.AssignUserRole(t, 1, 1, nil)
 	h.CoreService.SetConnectManager(connect.NewManager([]connect.Connector{errConnector{}}))
+	h.CoreService.SetConnectOwnership(map[string]core.ConnectOwnership{"failing": {Scope: "platform"}})
 	return NewConnectService(h.CoreService)
 }
 

--- a/server/http/handlers/connect.go
+++ b/server/http/handlers/connect.go
@@ -47,13 +47,22 @@ func NewConnectHandler(coreService *core.KeyorixCore) *ConnectHandler {
 	return &ConnectHandler{coreService: coreService}
 }
 
-// ListConnectors returns the configured connector names (discovery).
+// ListConnectors returns the connector names the caller can reach (ADR-082 §E) —
+// discovery is filtered by ownership so a caller never sees a connector name they
+// cannot subsequently read.
 func (h *ConnectHandler) ListConnectors(w http.ResponseWriter, r *http.Request) {
-	if middleware.GetUserFromContext(r.Context()) == nil {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
 		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
 		return
 	}
-	sendSuccess(w, map[string]interface{}{"connectors": h.coreService.ConnectConnectorNames()}, "")
+	names, err := h.coreService.ConnectReadableConnectorNames(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID())
+	if err != nil {
+		log.Printf("Error listing readable connectors: %v", err)
+		sendError(w, "ConnectError", clientSafe(err), http.StatusInternalServerError, nil)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{"connectors": names}, "")
 }
 
 // GetSecret proxies a read-through of ?ref=… from the named connector.

--- a/server/http/handlers/connector_project_bindings_proxy.go
+++ b/server/http/handlers/connector_project_bindings_proxy.go
@@ -24,12 +24,14 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -116,6 +118,26 @@ func (h *AuthHandler) CreateConnectorProjectBindingProxy(w http.ResponseWriter, 
 		log.Printf("connector-project-bindings proxy: create failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
+	}
+	// ADR-082 branch 3 / issue #1477's audit half: this write is an authorization
+	// input (it feeds core.ConnectOwnership downstream), so it's audited the same
+	// way as the boot-time first-resolution write (server/main.go's
+	// resolveConnectorOwnership) — same event type, same "system" actor type,
+	// since this endpoint is reached only by node-credential/system.write callers,
+	// never a human session. A logging failure here does not fail the request —
+	// the binding already persisted — but is surfaced loudly, matching
+	// internal/core's own emitAudit convention for a failed audit write.
+	t := true
+	auditEvent := &models.AuditEvent{
+		EventType:   core.EventConnectorProjectBindingCreate,
+		ProjectID:   &created.ProjectID,
+		Description: fmt.Sprintf("connector project binding created (remote proxy): connector %q bound to project %q (id %d)", created.Connector, created.ProjectName, created.ProjectID),
+		Success:     &t,
+		EventTime:   time.Now(),
+		ActorType:   core.ActorTypeSystem,
+	}
+	if aerr := h.coreService.Storage().LogAuditEvent(r.Context(), auditEvent); aerr != nil {
+		log.Printf("SECURITY: failed to persist audit event %q for connector %q: %v", core.EventConnectorProjectBindingCreate, created.Connector, aerr)
 	}
 	writeRemoteAPISuccess(w, newConnectorProjectBindingProxyWire(created))
 }

--- a/server/http/handlers/connector_project_bindings_proxy_test.go
+++ b/server/http/handlers/connector_project_bindings_proxy_test.go
@@ -1,0 +1,96 @@
+// connector_project_bindings_proxy_test.go — ADR-082 branch 3 / issue #1477's
+// audit half: CreateConnectorProjectBindingProxy previously had zero test
+// coverage (verified during branch 3's Stage 1 investigation) and, before this
+// branch, wrote a ConnectorProjectBinding with no audit event at all despite it
+// being an authorization input (it feeds core.ConnectOwnership downstream).
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func newConnectorProjectBindingProxyHandler(t *testing.T) (*AuthHandler, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.ConnectorProjectBinding{}, &models.AuditEvent{}))
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	return NewAuthHandler(cs, false), db
+}
+
+// TestCreateConnectorProjectBindingProxy_Audited proves the remote-proxy write
+// path (the literal subject of issue #1477) persists an audit event alongside
+// the binding itself: same event type as the boot-time write
+// (server/connect_ownership_resolution_test.go's counterpart), ProjectID
+// populated with the bound project (not left nil), Success=true, and actored
+// as "system" since this endpoint is reached only by a node-credential/
+// system.write caller, never a human session.
+func TestCreateConnectorProjectBindingProxy_Audited(t *testing.T) {
+	h, db := newConnectorProjectBindingProxyHandler(t)
+
+	body, err := json.Marshal(map[string]any{
+		"connector":    "aws",
+		"project_id":   7,
+		"project_name": "payments",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/connector-project-bindings", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.CreateConnectorProjectBindingProxy(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var event models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", core.EventConnectorProjectBindingCreate).First(&event).Error)
+	require.NotNil(t, event.ProjectID, "the binding's owning project must be recorded on the audit event, not left nil")
+	assert.EqualValues(t, 7, *event.ProjectID)
+	require.NotNil(t, event.Success)
+	assert.True(t, *event.Success)
+	assert.Equal(t, core.ActorTypeSystem, event.ActorType)
+	assert.Contains(t, event.Description, "aws")
+	assert.Contains(t, event.Description, "payments")
+}
+
+// TestCreateConnectorProjectBindingProxy_StorageFailureStillReturnsError proves
+// a storage-level create failure (e.g. a duplicate connector) still surfaces as
+// an error response — no audit event should be written for a write that never
+// actually persisted.
+func TestCreateConnectorProjectBindingProxy_StorageFailureStillReturnsError(t *testing.T) {
+	h, db := newConnectorProjectBindingProxyHandler(t)
+
+	body, err := json.Marshal(map[string]any{
+		"connector":    "aws",
+		"project_id":   7,
+		"project_name": "payments",
+	})
+	require.NoError(t, err)
+
+	// First create succeeds.
+	req1 := httptest.NewRequest(http.MethodPost, "/api/v1/system/connector-project-bindings", bytes.NewReader(body))
+	w1 := httptest.NewRecorder()
+	h.CreateConnectorProjectBindingProxy(w1, req1)
+	require.Equal(t, http.StatusOK, w1.Code)
+
+	// A second create for the SAME connector violates the unique index.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/system/connector-project-bindings", bytes.NewReader(body))
+	w2 := httptest.NewRecorder()
+	h.CreateConnectorProjectBindingProxy(w2, req2)
+	require.Equal(t, http.StatusInternalServerError, w2.Code)
+
+	var count int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", core.EventConnectorProjectBindingCreate).Count(&count).Error)
+	assert.EqualValues(t, 1, count, "only the successful create should be audited, not the failed duplicate attempt")
+}

--- a/server/http/handlers/handlers_s13_connect_dynamic_test.go
+++ b/server/http/handlers/handlers_s13_connect_dynamic_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/keyorixhq/keyorix/internal/connect"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -451,6 +452,7 @@ func TestConnect_GetSecret_UnknownConnector_S13(t *testing.T) {
 func TestConnect_GetSecret_SpoofedUnsafeErrorIsSanitized_G50(t *testing.T) {
 	cs, _ := freshCoreS12WithAdmin(t)
 	cs.SetConnectManager(connect.NewManager([]connect.Connector{fakeSpoofConnector{name: "spoof"}}))
+	cs.SetConnectOwnership(map[string]core.ConnectOwnership{"spoof": {Scope: "platform"}})
 	h := NewConnectHandler(cs)
 
 	req := withUserCtx(withChiParam(

--- a/server/http/remote_storage_connect_grants_test.go
+++ b/server/http/remote_storage_connect_grants_test.go
@@ -159,6 +159,7 @@ func TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer(t *testin
 	downstream.SetConnectManager(connect.NewManager([]connect.Connector{
 		fakeConnectGrantsConnector{name: "aws", val: "v3ry-secret"},
 	}))
+	downstream.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "platform"}})
 	require.True(t, downstream.ConnectEnabled())
 
 	val, err := downstream.ReadFederatedSecret(context.Background(), core.ActorTypeUser, 1, "aws", "prod/db")
@@ -182,6 +183,7 @@ func TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer(t *testi
 	downstream.SetConnectManager(connect.NewManager([]connect.Connector{
 		fakeConnectGrantsConnector{name: "aws", val: "v3ry-secret"},
 	}))
+	downstream.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "platform"}})
 
 	project, err := upstream.CreateProject(ctx, "Connect Grants Test Project", "")
 	require.NoError(t, err)

--- a/server/http/remote_storage_connect_grants_test.go
+++ b/server/http/remote_storage_connect_grants_test.go
@@ -19,9 +19,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
-	"github.com/keyorixhq/keyorix/internal/connect"
 	"github.com/keyorixhq/keyorix/internal/core"
-	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
@@ -29,19 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// fakeConnectGrantsConnector is a minimal connect.Connector for exercising
-// ReadFederatedSecret end-to-end without a real external secret store.
-type fakeConnectGrantsConnector struct {
-	name string
-	val  string
-}
-
-func (f fakeConnectGrantsConnector) Name() string { return f.name }
-func (f fakeConnectGrantsConnector) Type() string { return "fake" }
-func (f fakeConnectGrantsConnector) GetSecret(_ context.Context, _ string) (string, error) {
-	return f.val, nil
-}
 
 // newUpstreamDownstreamForConnectGrants builds the standard #510/#527-style
 // two-server harness: an "upstream" exercised through the REAL production
@@ -147,76 +132,16 @@ func TestRemoteStorageConnectGrants_CreateListDeleteByConnector_RealServer(t *te
 	assert.Equal(t, g2.ID, awsGrantsAfter[0].ID)
 }
 
-// TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer is the core
-// #527 regression test: before this fix, ReadFederatedSecret failed
-// UNCONDITIONALLY on a storage.type: remote node whenever Connect was
-// configured, even for a connector with NO ref-grants at all, because
-// connectRefAllowed's ListConnectRefGrantsByConnector call hard-errored on
-// RemoteStorage's stub. This proves the read now succeeds end-to-end over a
-// real HTTP hop.
-func TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer(t *testing.T) {
-	_, downstream := newUpstreamDownstreamForConnectGrants(t)
-	downstream.SetConnectManager(connect.NewManager([]connect.Connector{
-		fakeConnectGrantsConnector{name: "aws", val: "v3ry-secret"},
-	}))
-	downstream.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "platform"}})
-	require.True(t, downstream.ConnectEnabled())
-
-	val, err := downstream.ReadFederatedSecret(context.Background(), core.ActorTypeUser, 1, "aws", "prod/db")
-	require.NoError(t, err, "a federated read on storage.type: remote must not fail closed for a connector with no ref-grants (backlog #527)")
-	assert.Equal(t, "v3ry-secret", val)
-}
-
-// TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer proves the
-// per-reference RBAC policy (ADR-045) itself round-trips correctly over
-// storage.type: remote once a connector has a ref-grant: a machine identity
-// holding the granted role can read a ref under the granted prefix, but is
-// denied a ref outside it — enforced via the real upstream, not a protocol
-// mock. Uses a machine-identity actor (not a user) because actorRoleIDs's
-// underlying GetMachineRoleIDsAt is already proxied for RemoteStorage; the
-// user-role equivalent (GetUserRoleIDsAt/GetUserGroupRoleIDsAt) is a separate,
-// pre-existing, out-of-scope gap this fix does not touch.
-func TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer(t *testing.T) {
-	upstream, downstream := newUpstreamDownstreamForConnectGrants(t)
-	ctx := context.Background()
-
-	downstream.SetConnectManager(connect.NewManager([]connect.Connector{
-		fakeConnectGrantsConnector{name: "aws", val: "v3ry-secret"},
-	}))
-	downstream.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "platform"}})
-
-	project, err := upstream.CreateProject(ctx, "Connect Grants Test Project", "")
-	require.NoError(t, err)
-
-	m, err := downstream.Storage().CreateMachineIdentity(ctx, &models.MachineIdentity{
-		ProjectID:    project.ID,
-		Name:         "connect-grant-machine",
-		IdentityType: core.MachineTypeCI,
-		State:        core.MachineActive,
-	})
-	require.NoError(t, err)
-
-	role, err := upstream.Storage().CreateRole(ctx, &models.Role{Name: "connect-grant-enforcement-role"})
-	require.NoError(t, err)
-
-	// Connect ref-grants are resolved at GLOBAL scope (internal/core/connect.go's
-	// actorRoleIDs), mirroring the production grant scope exactly.
-	globalScope := corestorage.Scope{}
-	require.NoError(t, downstream.Storage().AssignMachineRole(ctx, m.ID, role.ID, globalScope))
-
-	_, err = downstream.Storage().CreateConnectRefGrant(ctx, &models.ConnectRefGrant{
-		RoleID: role.ID, Connector: "aws", RefPrefix: "prod/",
-	})
-	require.NoError(t, err)
-
-	// A ref under the granted prefix succeeds.
-	val, err := downstream.ReadFederatedSecret(ctx, core.ActorTypeMachine, m.ID, "aws", "prod/db")
-	require.NoError(t, err)
-	assert.Equal(t, "v3ry-secret", val)
-
-	// A ref outside the granted prefix is denied — deny-by-default once the
-	// connector is scoped.
-	_, err = downstream.ReadFederatedSecret(ctx, core.ActorTypeMachine, m.ID, "aws", "dev/db")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not permitted")
-}
+// TestReadFederatedSecret_RemoteStorage_NoGrantsSucceeds_RealServer and
+// TestReadFederatedSecret_RemoteStorage_PerRefEnforcement_RealServer (which
+// exercised ReadFederatedSecret's ownership/platform-permission gate against a
+// storage.type: remote downstream serving real HTTP traffic) were deleted here,
+// not weakened or fixed: ADR-083 established that this topology — a server
+// with server.http.enabled/server.grpc.enabled backed by storage.type: remote —
+// never actually worked (AuthorizePrincipal could not complete against
+// RemoteStorage's stubbed RBAC primitives for any permission, any actor) and
+// now refuses to boot at all (Config.Validate()). The remaining test in this
+// file is unaffected: it calls RemoteStorage's ConnectRefGrant CRUD methods
+// directly, the same in-process pattern the CLI's own (sanctioned, unaffected)
+// use of storage.type: remote uses — it never boots an HTTP/gRPC server on the
+// RemoteStorage-backed side.

--- a/server/main.go
+++ b/server/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/connect"
 	"github.com/keyorixhq/keyorix/internal/core"
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/evidencesink"
@@ -53,6 +54,7 @@ import (
 	samlpkg "github.com/keyorixhq/keyorix/internal/saml"
 	"github.com/keyorixhq/keyorix/internal/startup"
 	appstorage "github.com/keyorixhq/keyorix/internal/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/trust"
 	"github.com/keyorixhq/keyorix/server/grpc"
 	httpServer "github.com/keyorixhq/keyorix/server/http"
@@ -615,7 +617,32 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			}
 		}
 		if len(connectors) > 0 {
-			coreService.SetConnectManager(connect.NewManager(connectors))
+			mgr := connect.NewManager(connectors)
+
+			// ADR-082 branch 2: resolve each connector's tenant-scoping data (project
+			// binding for scope: project; nothing to resolve for scope: platform)
+			// BEFORE wiring the manager in, so a resolution failure blocks boot
+			// entirely rather than leaving Connect half-wired.
+			ownership, err := resolveConnectorOwnership(context.Background(), coreService.Storage(), cc.Connectors)
+			if err != nil {
+				log.Fatalf("Keyorix Connect: %v", err)
+			}
+
+			// Defense-in-depth: ownership was resolved from the FULL cc.Connectors
+			// config, but mgr was built only from connectors the type-switch above
+			// actually recognized (an unrecognized type is skipped with a WARN, not a
+			// hard failure — the `default` case above). If a connector's ownership
+			// resolved successfully but it never made it into mgr (e.g. an
+			// unrecognized type), or vice versa, that is a key-set mismatch this ADR
+			// requires to fail boot loudly rather than silently deny (a missing
+			// ownership entry, connectOwnershipSatisfied's own fallback) or silently
+			// skip ownership entirely (a connector with no check at all).
+			if mismatch := connectOwnershipKeySetMismatch(mgr.Names(), ownership, cc.Connectors); len(mismatch) > 0 {
+				log.Fatalf("Keyorix Connect: connector(s) present in config but whose manager/ownership resolution disagree on which connectors exist — this must never happen in a correctly-booted server; investigate before proceeding (ADR-082): %s", strings.Join(mismatch, ", "))
+			}
+
+			coreService.SetConnectManager(mgr)
+			coreService.SetConnectOwnership(ownership)
 			log.Printf("Keyorix Connect enabled (%d connector(s))", len(connectors))
 		}
 	}
@@ -914,6 +941,129 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	}
 
 	return coreService, encSvc, nil
+}
+
+// isNotFoundStorageErr reports whether err is a "not found"-substring error, the
+// convention every LocalStorage/RemoteStorage Get* method in this codebase uses
+// (see local_secrets.go's GetProject, project_catalog_proxy.go's
+// isProjectNotFound).
+func isNotFoundStorageErr(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
+}
+
+// resolveConnectorOwnership resolves each connector's tenant-scoping data
+// (ADR-082 §A/§E) from its config entry. A "platform"-scoped connector needs no
+// resolution. A "project"-scoped connector's project: name is pinned to a real
+// Keyorix project ID via ConnectorProjectBinding, never re-resolved by name on a
+// later boot — see that model's own doc comment for why (project names are
+// mutable and a soft-deleted project's name is freed for reuse, so re-resolving
+// by name every boot would let an ordinary rename silently reassign ownership):
+//
+//   - First boot for a connector (no binding row yet): resolve config's project:
+//     name to a project via storage.GetProjectByName, persist the binding.
+//   - A later boot (binding row exists): resolve the project by the STORED ID
+//     (storage.GetProject), never by name. If that project no longer exists
+//     (deleted), or its CURRENT name no longer matches the name recorded in the
+//     binding at first-boot time, this fails boot — a rename or delete is
+//     something server/main.go treats as requiring deliberate operator action,
+//     not something to silently follow or silently ignore.
+//
+// Every problem across every connector is collected into ONE aggregated error
+// (branch 1's validateConnectScopes style), naming each offending connector and
+// its specific reason, rather than failing on the first one found.
+func resolveConnectorOwnership(ctx context.Context, st corestorage.Storage, connectors []config.ConnectorConfig) (map[string]core.ConnectOwnership, error) {
+	ownership := make(map[string]core.ConnectOwnership, len(connectors))
+	var problems []string
+	for _, cn := range connectors {
+		if cn.Scope == "platform" {
+			ownership[cn.Name] = core.ConnectOwnership{Scope: "platform"}
+			continue
+		}
+		// cn.Scope == "project" here: internal/config.validateConnectScopes already
+		// guaranteed no other value reached boot (or allow_unscoped let an empty
+		// scope through, in which case there is nothing to resolve — an unscoped
+		// connector gets no ownership entry at all, which is exactly the deny-by-
+		// default behavior connectOwnershipSatisfied's missing-entry case wants).
+		if cn.Scope == "" {
+			continue
+		}
+		binding, err := st.GetConnectorProjectBinding(ctx, cn.Name)
+		switch {
+		case err != nil && isNotFoundStorageErr(err):
+			// First boot for this connector: resolve name -> ID, persist.
+			project, perr := st.GetProjectByName(ctx, cn.Project)
+			if perr != nil {
+				problems = append(problems, fmt.Sprintf("%s: project %q not found: %v", cn.Name, cn.Project, perr))
+				continue
+			}
+			created, cerr := st.CreateConnectorProjectBinding(ctx, &models.ConnectorProjectBinding{
+				Connector:   cn.Name,
+				ProjectID:   project.ID,
+				ProjectName: project.Name,
+			})
+			if cerr != nil {
+				problems = append(problems, fmt.Sprintf("%s: failed to persist project binding: %v", cn.Name, cerr))
+				continue
+			}
+			ownership[cn.Name] = core.ConnectOwnership{Scope: "project", ProjectID: created.ProjectID}
+		case err != nil:
+			problems = append(problems, fmt.Sprintf("%s: %v", cn.Name, err))
+		default:
+			// Binding exists: resolve by the stored ID, never by name.
+			project, perr := st.GetProject(ctx, binding.ProjectID)
+			if perr != nil {
+				problems = append(problems, fmt.Sprintf("%s: bound to project id %d, which no longer exists (deleted?): %v", cn.Name, binding.ProjectID, perr))
+				continue
+			}
+			if project.Name != binding.ProjectName {
+				problems = append(problems, fmt.Sprintf(
+					"%s: bound project (id %d) was renamed from %q to %q since this connector was first configured — this is a deliberate boot failure (ADR-082), not a silent reassignment; if the rename was intentional, update connect.connectors[].project to %q and clear the stale connector_project_bindings row for %q before restarting",
+					cn.Name, binding.ProjectID, binding.ProjectName, project.Name, project.Name, cn.Name))
+				continue
+			}
+			ownership[cn.Name] = core.ConnectOwnership{Scope: "project", ProjectID: binding.ProjectID}
+		}
+	}
+	if len(problems) > 0 {
+		return nil, fmt.Errorf("connector(s) with unresolvable project binding: %s", strings.Join(problems, "; "))
+	}
+	return ownership, nil
+}
+
+// connectOwnershipKeySetMismatch returns every connector name whose presence in
+// connect.Manager (builtNames) and in the resolved ownership map disagree, EXCEPT
+// for the one expected, legitimate disagreement: a connector booted with an empty
+// scope under connect.allow_unscoped (ADR-082 §C) is deliberately never given an
+// ownership entry (resolveConnectorOwnership skips it — connectOwnershipSatisfied
+// then denies it by default, exactly like any other absent entry), while it IS
+// still built into the manager (allow_unscoped only bypasses the boot-validation
+// gate, not connector wiring). connectors carries the full config so this can tell
+// that expected case apart from a genuine divergence — e.g. an unrecognized
+// connector Type, which resolves ownership successfully but never makes it into
+// the manager.
+func connectOwnershipKeySetMismatch(builtNames []string, ownership map[string]core.ConnectOwnership, connectors []config.ConnectorConfig) []string {
+	built := make(map[string]bool, len(builtNames))
+	for _, name := range builtNames {
+		built[name] = true
+	}
+	expectedUnscoped := make(map[string]bool)
+	for _, cn := range connectors {
+		if cn.Scope == "" {
+			expectedUnscoped[cn.Name] = true
+		}
+	}
+	var mismatch []string
+	for name := range built {
+		if _, ok := ownership[name]; !ok && !expectedUnscoped[name] {
+			mismatch = append(mismatch, name)
+		}
+	}
+	for name := range ownership {
+		if !built[name] {
+			mismatch = append(mismatch, name)
+		}
+	}
+	return mismatch
 }
 
 // cmpOr returns a if non-empty, else b (a tiny local helper to avoid a new import).

--- a/server/main.go
+++ b/server/main.go
@@ -564,22 +564,13 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	// Wire Keyorix Connect (ADR-043) read-through federation if enabled.
 	if cc := cfg.Connect; cc.Enabled && len(cc.Connectors) > 0 {
 		// ADR-082 §C: cfg.Validate() already refused to boot with a missing/invalid
-		// connector scope unless connect.allow_unscoped is set — Validate() itself never
-		// logs (internal/config/validateConnectScopes), so if we're here under that flag,
-		// warn loudly, per connector and once as a summary, at the point the connectors
-		// are actually wired.
-		if cc.AllowUnscoped {
-			var unscoped []string
-			for _, cn := range cc.Connectors {
-				if cn.Scope == "" {
-					unscoped = append(unscoped, cn.Name)
-					log.Printf("Keyorix Connect: connector %q has no scope configured and is booting under connect.allow_unscoped — set scope: project or scope: platform (ADR-082)", cn.Name)
-				}
-			}
-			if len(unscoped) > 0 {
-				log.Printf("Keyorix Connect: %d connector(s) booted unscoped under connect.allow_unscoped — this is a temporary escape hatch; set an explicit scope on each before removing it (ADR-082)", len(unscoped))
-			}
-		}
+		// connector scope — unconditionally, no deployment-wide escape hatch (amended:
+		// the original connect.allow_unscoped flag let the server boot, but an unscoped
+		// connector still denied on every read via connectOwnershipSatisfied's
+		// missing-entry-denies rule, so it never restored actual usability — only
+		// deferred the failure from "boot" to "every subsequent read," with a WARN an
+		// operator could easily miss. Adding scope: to a connector takes minutes; there
+		// is nothing for this migration path to bypass.
 		var connectors []connect.Connector
 		for _, cn := range cc.Connectors {
 			switch cn.Type {
@@ -636,8 +627,11 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			// unrecognized type), or vice versa, that is a key-set mismatch this ADR
 			// requires to fail boot loudly rather than silently deny (a missing
 			// ownership entry, connectOwnershipSatisfied's own fallback) or silently
-			// skip ownership entirely (a connector with no check at all).
-			if mismatch := connectOwnershipKeySetMismatch(mgr.Names(), ownership, cc.Connectors); len(mismatch) > 0 {
+			// skip ownership entirely (a connector with no check at all). No exemption
+			// of any kind (amended — the prior allow_unscoped-linked exemption is
+			// removed along with the flag): every divergence between the two sets is
+			// reported.
+			if mismatch := connectOwnershipKeySetMismatch(mgr.Names(), ownership); len(mismatch) > 0 {
 				log.Fatalf("Keyorix Connect: connector(s) present in config but whose manager/ownership resolution disagree on which connectors exist — this must never happen in a correctly-booted server; investigate before proceeding (ADR-082): %s", strings.Join(mismatch, ", "))
 			}
 
@@ -980,13 +974,9 @@ func resolveConnectorOwnership(ctx context.Context, st corestorage.Storage, conn
 			continue
 		}
 		// cn.Scope == "project" here: internal/config.validateConnectScopes already
-		// guaranteed no other value reached boot (or allow_unscoped let an empty
-		// scope through, in which case there is nothing to resolve — an unscoped
-		// connector gets no ownership entry at all, which is exactly the deny-by-
-		// default behavior connectOwnershipSatisfied's missing-entry case wants).
-		if cn.Scope == "" {
-			continue
-		}
+		// guaranteed no other value reached boot (amended — there is no longer an
+		// allow_unscoped bypass; a missing or unrecognized scope always fails boot
+		// before this function is ever reached).
 		binding, err := st.GetConnectorProjectBinding(ctx, cn.Name)
 		switch {
 		case err != nil && isNotFoundStorageErr(err):
@@ -1031,30 +1021,21 @@ func resolveConnectorOwnership(ctx context.Context, st corestorage.Storage, conn
 }
 
 // connectOwnershipKeySetMismatch returns every connector name whose presence in
-// connect.Manager (builtNames) and in the resolved ownership map disagree, EXCEPT
-// for the one expected, legitimate disagreement: a connector booted with an empty
-// scope under connect.allow_unscoped (ADR-082 §C) is deliberately never given an
-// ownership entry (resolveConnectorOwnership skips it — connectOwnershipSatisfied
-// then denies it by default, exactly like any other absent entry), while it IS
-// still built into the manager (allow_unscoped only bypasses the boot-validation
-// gate, not connector wiring). connectors carries the full config so this can tell
-// that expected case apart from a genuine divergence — e.g. an unrecognized
-// connector Type, which resolves ownership successfully but never makes it into
-// the manager.
-func connectOwnershipKeySetMismatch(builtNames []string, ownership map[string]core.ConnectOwnership, connectors []config.ConnectorConfig) []string {
+// connect.Manager (builtNames) and in the resolved ownership map disagree — no
+// exemption of any kind (amended: the prior connect.allow_unscoped-linked
+// exemption is removed along with the flag, since resolveConnectorOwnership no
+// longer skips any connector). A connector present in one set but not the other
+// must never happen in a correctly-booted server (e.g. an unrecognized connector
+// Type, which resolves ownership successfully but never makes it into the
+// manager) — every divergence is reported.
+func connectOwnershipKeySetMismatch(builtNames []string, ownership map[string]core.ConnectOwnership) []string {
 	built := make(map[string]bool, len(builtNames))
 	for _, name := range builtNames {
 		built[name] = true
 	}
-	expectedUnscoped := make(map[string]bool)
-	for _, cn := range connectors {
-		if cn.Scope == "" {
-			expectedUnscoped[cn.Name] = true
-		}
-	}
 	var mismatch []string
 	for name := range built {
-		if _, ok := ownership[name]; !ok && !expectedUnscoped[name] {
+		if _, ok := ownership[name]; !ok {
 			mismatch = append(mismatch, name)
 		}
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -995,6 +995,7 @@ func resolveConnectorOwnership(ctx context.Context, st corestorage.Storage, conn
 				problems = append(problems, fmt.Sprintf("%s: failed to persist project binding: %v", cn.Name, cerr))
 				continue
 			}
+			auditConnectorProjectBindingCreate(ctx, st, created, "boot-time first resolution")
 			ownership[cn.Name] = core.ConnectOwnership{Scope: "project", ProjectID: created.ProjectID}
 		case err != nil:
 			problems = append(problems, fmt.Sprintf("%s: %v", cn.Name, err))
@@ -1018,6 +1019,33 @@ func resolveConnectorOwnership(ctx context.Context, st corestorage.Storage, conn
 		return nil, fmt.Errorf("connector(s) with unresolvable project binding: %s", strings.Join(problems, "; "))
 	}
 	return ownership, nil
+}
+
+// auditConnectorProjectBindingCreate records a ConnectorProjectBinding write
+// (ADR-082 branch 3, issue #1477's audit half): the binding is an
+// authorization input (it feeds core.ConnectOwnership, and from there
+// connectOwnershipSatisfied) regardless of which door the write comes through,
+// so the unattended boot-time path here uses the SAME event type as the
+// RemoteStorage proxy's write (server/http/handlers/connector_project_bindings_proxy.go).
+// source distinguishes the two call sites in the Description. A logging
+// failure here does not fail boot — the binding itself already persisted
+// successfully — but is surfaced loudly (SECURITY-prefixed, matching
+// internal/core's own emitAudit convention) since a silently-dropped audit
+// write for an authorization-input change is exactly the kind of gap this
+// branch exists to close.
+func auditConnectorProjectBindingCreate(ctx context.Context, st corestorage.Storage, b *models.ConnectorProjectBinding, source string) {
+	t := true
+	event := &models.AuditEvent{
+		EventType:   core.EventConnectorProjectBindingCreate,
+		ProjectID:   &b.ProjectID,
+		Description: fmt.Sprintf("connector project binding created (%s): connector %q bound to project %q (id %d)", source, b.Connector, b.ProjectName, b.ProjectID),
+		Success:     &t,
+		EventTime:   time.Now(),
+		ActorType:   core.ActorTypeSystem,
+	}
+	if err := st.LogAuditEvent(ctx, event); err != nil {
+		log.Printf("SECURITY: failed to persist audit event %q for connector %q: %v", core.EventConnectorProjectBindingCreate, b.Connector, err)
+	}
 }
 
 // connectOwnershipKeySetMismatch returns every connector name whose presence in

--- a/server/server_s22_test.go
+++ b/server/server_s22_test.go
@@ -237,8 +237,7 @@ func TestInitializeCoreService_S22_VaultCustomTokenEnv(t *testing.T) {
 				Address:     "http://vault.example.com:8200",
 				TokenEnv:    customEnv,
 				AllowedRefs: []string{"prod/*"},
-				Scope:       "project",
-				Project:     "payments",
+				Scope:       "platform",
 			},
 		},
 	}

--- a/server/server_s23_test.go
+++ b/server/server_s23_test.go
@@ -241,8 +241,7 @@ func TestInitializeCoreService_S23_VaultDefaultTokenEnv(t *testing.T) {
 				Address:     "http://vault.example.com:8200",
 				TokenEnv:    "", // empty → code substitutes "VAULT_TOKEN"
 				AllowedRefs: []string{"prod/*"},
-				Scope:       "project",
-				Project:     "payments",
+				Scope:       "platform",
 			},
 		},
 	}

--- a/server/server_s4_test.go
+++ b/server/server_s4_test.go
@@ -399,7 +399,7 @@ func TestInitializeCoreService_Connect_UnknownType(t *testing.T) {
 	cfg.Connect = config.ConnectConfig{
 		Enabled: true,
 		Connectors: []config.ConnectorConfig{
-			{Name: "c1", Type: "unknown-type", Scope: "project", Project: "payments"},
+			{Name: "c1", Type: "unknown-type", Scope: "platform"},
 		},
 	}
 
@@ -417,8 +417,8 @@ func TestInitializeCoreService_Connect_KnownTypes(t *testing.T) {
 	cfg.Connect = config.ConnectConfig{
 		Enabled: true,
 		Connectors: []config.ConnectorConfig{
-			{Name: "aws", Type: "aws-secrets-manager", AllowedRefs: []string{"prod/*"}, Scope: "project", Project: "payments"},
-			{Name: "gcp", Type: "gcp-secret-manager", ProjectID: "my-proj", AllowedRefs: []string{"prod/*"}, Scope: "project", Project: "payments"},
+			{Name: "aws", Type: "aws-secrets-manager", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
+			{Name: "gcp", Type: "gcp-secret-manager", ProjectID: "my-proj", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
 			{Name: "vault", Type: "vault", Address: "http://vault:8200", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
 		},
 	}
@@ -437,7 +437,7 @@ func TestInitializeCoreService_Connect_GCP_NoProjectID(t *testing.T) {
 	cfg.Connect = config.ConnectConfig{
 		Enabled: true,
 		Connectors: []config.ConnectorConfig{
-			{Name: "gcp-noproj", Type: "gcp-secret-manager", ProjectID: "", AllowedRefs: []string{"prod/*"}, Scope: "project", Project: "payments"},
+			{Name: "gcp-noproj", Type: "gcp-secret-manager", ProjectID: "", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
 		},
 	}
 
@@ -455,7 +455,7 @@ func TestInitializeCoreService_Connect_AzureKeyVault(t *testing.T) {
 	cfg.Connect = config.ConnectConfig{
 		Enabled: true,
 		Connectors: []config.ConnectorConfig{
-			{Name: "azure-kv", Type: "azure-key-vault", Address: "https://vault.vault.azure.net", AllowedRefs: []string{"prod/*"}, Scope: "project", Project: "payments"},
+			{Name: "azure-kv", Type: "azure-key-vault", Address: "https://vault.vault.azure.net", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
 		},
 	}
 


### PR DESCRIPTION
## Summary

This lands the remainder of the ADR-082 (Connect connector tenant/project scoping) stack on `main`. Branches 1-2 already reached `main` via #1483 (which absorbed #1484's storage-primitives commit). This PR carries everything above that: PRs #1485-#1489, which had already cascaded/merged into each other along the stack (`adr082/03-storage-primitives` → `04-ownership-enforcement` → `05-fixture-platform-scope-fix` → `06-remove-allow-unscoped` → `07-audit-surface` → `08-platform-use-permission`) but whose combined tip had not yet been merged into `main`.

Contents (already individually reviewed/merged as #1485-#1489):
- Connect connector ownership enforcement + `ListConnectors` filtering (ADR-082 2/4)
- Platform-scope fix for test-only connectors `resolveConnectorOwnership` can't resolve
- Removal of `connect.allow_unscoped` (no escape hatch — see ADR-082 §C amendment)
- Audit coverage for every `ReadFederatedSecret` outcome + `ConnectorProjectBinding` writes (ADR-082 3/4)
- `connect.platform.use` permission for `scope: platform` connectors (ADR-082 4/4, closes the stack)

## Merge conflict resolution

`internal/core/mock_storage_test.go` conflicted: this branch (built before #1483's fix landed) independently added its own `GetProjectByName`/`GetConnectorProjectBinding` mock stubs to close the same `MockStorage` interface gap #1483's fix closed. Kept this branch's version (richer doc comment referencing the real test files exercising the behavior against SQLite) and removed the now-duplicate definitions from #1483's side.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `gosec -severity medium -exclude-generated ./...` — 0 issues
- `go test ./internal/core/... ./internal/config/... ./server/http/...` — all failures confirmed pre-existing on a clean `origin/main` checkout (schedule-window tests, `_RealServer`/`ConcurrentRace` tests, `TestPermissionBaseline_CSV_Headers`), verified via an isolated worktree, not assumed