### PR TITLE
fix(security): gcpkms AAD injectivity, CRC32C verification, AAD-fallback audit (crypto-gcpkms-01/02/03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ All notable changes to Keyorix are documented here. This project follows
   own client mode (`keyorix connect <server>`, or `storage.type: remote` in
   `~/.keyorix/cli.yaml` with no server enabled) is unaffected — see
   `docs/adr-083-remote-storage-cli-only.md`.
+- **BREAKING (targeting v0.92.0): GCP KMS `kms_encryption_context` AAD wire format
+  changed (crypto-gcpkms-01)** — `encContextAAD`'s canonicalisation of
+  `kms_encryption_context` switched from an unescaped `"key=value\n"` join (where
+  adversarial `=`/`\n` content in a key or value could let two structurally
+  different context maps serialise to identical AdditionalAuthenticatedData,
+  undermining the cross-install isolation the feature exists to provide) to a
+  length-prefixed encoding that cannot collide. **Only installs configuring
+  `kms_encryption_context` with a GCP KMS key provider are affected** — a KEK
+  wrapped under the old AAD bytes will fail to decrypt after upgrading, since the
+  new AAD no longer matches what it was wrapped under. To re-wrap: temporarily set
+  `kms_allow_context_fallback: true`, run `keyorix encryption migrate-provider
+  --to-kms-encryption-context=...` to re-wrap the KEK under the new AAD encoding,
+  then **disable `kms_allow_context_fallback` again** (leaving it enabled makes
+  the AAD binding advisory rather than enforced).
 - **BREAKING: keyorix-operator default RBAC/watch scope narrowed to own-namespace-only
   (ADR-076)** — an unmodified `helm install deploy/helm/keyorix-operator` now binds a
   namespace-scoped `RoleBinding` in its own release namespace and watches only that

--- a/internal/crypto/gcpkms/gcpkms.go
+++ b/internal/crypto/gcpkms/gcpkms.go
@@ -9,14 +9,19 @@ package gcpkms
 import (
 	"context"
 	"fmt"
+	"hash/crc32"
 	"log"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
 	gax "github.com/googleapis/gax-go/v2"
 	keyorixcrypto "github.com/keyorixhq/keyorix/internal/crypto"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // gcpKMSAPI is the slice of the KMS client the provider uses — an interface seam so
@@ -26,11 +31,48 @@ type gcpKMSAPI interface {
 	Decrypt(ctx context.Context, req *kmspb.DecryptRequest, opts ...gax.CallOption) (*kmspb.DecryptResponse, error)
 }
 
+// AuditSink is a minimal audit-write hook, matching storage.Storage's
+// LogAuditEvent method signature exactly (the identically-shaped type in
+// internal/encryption/key_provider_downgrade.go is the precedent this mirrors) so
+// a caller can pass that method value directly (e.g. after converting it, see
+// encryption.Service.wireKMSAuditSink) without this package importing the full
+// storage.Storage interface — internal/crypto sits below internal/storage in the
+// dependency graph, so importing it here would be a cycle. Only
+// internal/storage/models (plain structs, no storage-layer imports) is safe to
+// depend on.
+type AuditSink func(ctx context.Context, event *models.AuditEvent) error
+
+// EventGCPKMSAADFallback is the audit event type recorded when
+// kms_allow_context_fallback lets a context-bound Decrypt fall back to, and
+// succeed against, an unbound (or differently-bound) ciphertext. This is a
+// meaningful security-relevant event — the decrypted blob is not proven to
+// belong to this install — so it is worth more than a process log line; see
+// SetAuditSink.
+const EventGCPKMSAADFallback = "crypto.gcpkms_aad_fallback" // #nosec G101 -- audit event type, not a credential
+
 type client struct {
 	kms           gcpKMSAPI
 	keyName       string // projects/P/locations/L/keyRings/R/cryptoKeys/K
 	aad           []byte // AdditionalAuthenticatedData binding the wrapped KEK (nil = none)
 	allowFallback bool   // #123: opt-in, see KMSAllowContextFallback's doc comment
+	// auditSink optionally records the AAD-fallback event (see
+	// EventGCPKMSAADFallback) as a queryable audit event, in addition to the
+	// unconditional log.Printf. Guarded by its own mutex since SetAuditSink may be
+	// called concurrently with Decrypt (e.g. wired asynchronously after
+	// construction).
+	auditSink   AuditSink
+	auditSinkMu sync.RWMutex
+}
+
+// SetAuditSink wires the audit sink this client uses to record the AAD-fallback
+// security event (EventGCPKMSAADFallback) as more than a log line. Optional and
+// safe to leave unset: the event is still always reported via the loud
+// "gcp-kms:" log line Decrypt emits on a successful fallback either way. Safe to
+// call concurrently with Decrypt.
+func (c *client) SetAuditSink(sink AuditSink) {
+	c.auditSinkMu.Lock()
+	defer c.auditSinkMu.Unlock()
+	c.auditSink = sink
 }
 
 // New builds a GCP-KMS-backed crypto.KMSClient for the given crypto-key resource
@@ -73,36 +115,99 @@ func encContextAAD(m map[string]string) []byte {
 	return []byte(b.String())
 }
 
+// crc32cSum computes the CRC32C (Castagnoli) checksum GCP KMS's Encrypt/Decrypt
+// API uses for request/response integrity verification.
+func crc32cSum(b []byte) uint32 {
+	return crc32.Checksum(b, crc32.MakeTable(crc32.Castagnoli))
+}
+
 func (c *client) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
-	req := &kmspb.EncryptRequest{Name: c.keyName, Plaintext: plaintext}
+	req := &kmspb.EncryptRequest{
+		Name:            c.keyName,
+		Plaintext:       plaintext,
+		PlaintextCrc32C: wrapperspb.Int64(int64(crc32cSum(plaintext))),
+	}
 	if len(c.aad) > 0 {
 		req.AdditionalAuthenticatedData = c.aad
+		req.AdditionalAuthenticatedDataCrc32C = wrapperspb.Int64(int64(crc32cSum(c.aad)))
 	}
 	resp, err := c.kms.Encrypt(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("gcp-kms: encrypt: %w", err)
 	}
-	return resp.GetCiphertext(), nil
+	// Per Google's Cloud KMS client guidance: a request checksum that KMS did not
+	// report back as verified means the server either never received it correctly
+	// or never used it, either of which is grounds to distrust this response rather
+	// than silently trust plaintext that may have been corrupted in transit.
+	if !resp.GetVerifiedPlaintextCrc32C() {
+		return nil, fmt.Errorf("gcp-kms: encrypt: server did not report the plaintext checksum as verified (possible request corruption)")
+	}
+	if len(c.aad) > 0 && !resp.GetVerifiedAdditionalAuthenticatedDataCrc32C() {
+		return nil, fmt.Errorf("gcp-kms: encrypt: server did not report the AAD checksum as verified (possible request corruption)")
+	}
+	ciphertext := resp.GetCiphertext()
+	if got := resp.GetCiphertextCrc32C(); got == nil || int64(crc32cSum(ciphertext)) != got.GetValue() {
+		return nil, fmt.Errorf("gcp-kms: encrypt: ciphertext checksum mismatch (possible response corruption)")
+	}
+	return ciphertext, nil
 }
 
 func (c *client) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
-	req := &kmspb.DecryptRequest{Name: c.keyName, Ciphertext: ciphertext}
+	ciphertextCRC := wrapperspb.Int64(int64(crc32cSum(ciphertext)))
+	req := &kmspb.DecryptRequest{Name: c.keyName, Ciphertext: ciphertext, CiphertextCrc32C: ciphertextCRC}
 	if len(c.aad) > 0 {
 		req.AdditionalAuthenticatedData = c.aad
+		req.AdditionalAuthenticatedDataCrc32C = wrapperspb.Int64(int64(crc32cSum(c.aad)))
 	}
 	resp, err := c.kms.Decrypt(ctx, req)
 	// #123: the no-AAD retry is now OPT-IN (allowFallback) rather than automatic on any
 	// failure — see awskms.Decrypt's comment for the full rationale (identical here: an
 	// unconditional fallback makes the AAD binding advisory, since a blob an attacker
 	// planted with no AAD at all always succeeds on the fallback attempt).
+	fellBack := false
 	if err != nil && len(c.aad) > 0 && c.allowFallback {
-		resp, err = c.kms.Decrypt(ctx, &kmspb.DecryptRequest{Name: c.keyName, Ciphertext: ciphertext})
-		if err == nil {
-			log.Printf("gcp-kms: decrypted a wrapped KEK WITHOUT its configured AAD (kms_allow_context_fallback is on) — this blob is not bound to this install; re-wrap it under the context via 'keyorix encryption migrate-provider --to-kms-encryption-context=...' and disable kms_allow_context_fallback")
-		}
+		resp, err = c.kms.Decrypt(ctx, &kmspb.DecryptRequest{
+			Name:             c.keyName,
+			Ciphertext:       ciphertext,
+			CiphertextCrc32C: ciphertextCRC,
+		})
+		fellBack = err == nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("gcp-kms: decrypt: %w", err)
 	}
-	return resp.GetPlaintext(), nil
+	plaintext := resp.GetPlaintext()
+	if got := resp.GetPlaintextCrc32C(); got == nil || int64(crc32cSum(plaintext)) != got.GetValue() {
+		return nil, fmt.Errorf("gcp-kms: decrypt: plaintext checksum mismatch (possible response corruption)")
+	}
+	if fellBack {
+		msg := "gcp-kms: decrypted a wrapped KEK WITHOUT its configured AAD (kms_allow_context_fallback is on) — this blob is not bound to this install; re-wrap it under the context via 'keyorix encryption migrate-provider --to-kms-encryption-context=...' and disable kms_allow_context_fallback"
+		log.Printf("%s", msg)
+		c.emitFallbackAudit(ctx, msg)
+	}
+	return plaintext, nil
+}
+
+// emitFallbackAudit records the AAD-fallback event (see EventGCPKMSAADFallback)
+// through the wired audit sink, if any. Best-effort: a sink write failure is
+// logged but never propagated — the decrypt it's reporting on already succeeded
+// by the time this runs and must not be undone by an audit-logging failure.
+func (c *client) emitFallbackAudit(ctx context.Context, description string) {
+	c.auditSinkMu.RLock()
+	sink := c.auditSink
+	c.auditSinkMu.RUnlock()
+	if sink == nil {
+		return
+	}
+	failed := false // the event itself reports a security-negative condition, not a success
+	event := &models.AuditEvent{
+		EventType:   EventGCPKMSAADFallback,
+		Description: description,
+		Success:     &failed,
+		ActorType:   "system",
+		EventTime:   time.Now(),
+	}
+	if err := sink(ctx, event); err != nil {
+		log.Printf("gcp-kms: SECURITY: AAD fallback: failed to write audit event: %v", err)
+	}
 }

--- a/internal/crypto/gcpkms/gcpkms.go
+++ b/internal/crypto/gcpkms/gcpkms.go
@@ -8,11 +8,11 @@ package gcpkms
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"hash/crc32"
 	"log"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -93,9 +93,16 @@ func New(ctx context.Context, keyName string, encContext map[string]string, allo
 	return &client{kms: c, keyName: keyName, aad: encContextAAD(encContext), allowFallback: allowFallback}, nil
 }
 
-// encContextAAD canonicalises an encryption-context map into deterministic bytes
-// (sorted key=value lines) for use as GCP AdditionalAuthenticatedData. Returns nil for
-// an empty map so the no-binding path is byte-identical to the prior behaviour.
+// encContextAAD canonicalises an encryption-context map into deterministic,
+// unambiguous bytes for use as GCP AdditionalAuthenticatedData. Returns nil for an
+// empty map so the no-binding path is byte-identical to the prior behaviour.
+//
+// Each sorted (key, value) pair is written as a length-prefixed field
+// (uvarint(len(s)) || s) with no separator byte between fields, so the encoding is
+// injective over the sequence of strings: unlike a "key=value\n" join, no key or
+// value content (including literal '=' or '\n' bytes) can shift a byte to look
+// like it belongs to a neighbouring field, so two structurally different maps can
+// never serialise to the same bytes. See TestEncContextAAD_NoCollisionOnAdversarialInput.
 func encContextAAD(m map[string]string) []byte {
 	if len(m) == 0 {
 		return nil
@@ -105,14 +112,25 @@ func encContextAAD(m map[string]string) []byte {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	var b strings.Builder
+
+	// Upper bound: 2 fields per entry, each up to binary.MaxVarintLen64 prefix
+	// bytes plus its content.
+	size := 0
 	for _, k := range keys {
-		b.WriteString(k)
-		b.WriteByte('=')
-		b.WriteString(m[k])
-		b.WriteByte('\n')
+		size += binary.MaxVarintLen64 + len(k) + binary.MaxVarintLen64 + len(m[k])
 	}
-	return []byte(b.String())
+	buf := make([]byte, 0, size)
+	var lenBuf [binary.MaxVarintLen64]byte
+	writeField := func(s string) {
+		n := binary.PutUvarint(lenBuf[:], uint64(len(s)))
+		buf = append(buf, lenBuf[:n]...)
+		buf = append(buf, s...)
+	}
+	for _, k := range keys {
+		writeField(k)
+		writeField(m[k])
+	}
+	return buf
 }
 
 // crc32cSum computes the CRC32C (Castagnoli) checksum GCP KMS's Encrypt/Decrypt

--- a/internal/crypto/gcpkms/gcpkms_s2_test.go
+++ b/internal/crypto/gcpkms/gcpkms_s2_test.go
@@ -141,16 +141,27 @@ func TestDecrypt_KMSError_IsPrefixed(t *testing.T) {
 	assert.ErrorIs(t, err, kmsErr)
 }
 
-// TestEncContextAAD_SingleEntry verifies the canonical form for a single-entry map.
+// TestEncContextAAD_SingleEntry verifies the canonical form for a single-entry
+// map: a uvarint length prefix followed by the raw bytes, for the key then the
+// value, with no separator byte (crypto-gcpkms-01 — a "key=value\n" join with no
+// escaping let adversarial '='/'\n' content in a key or value collide across
+// structurally different maps; see TestEncContextAAD_NoCollisionOnAdversarialInput).
 func TestEncContextAAD_SingleEntry(t *testing.T) {
 	got := encContextAAD(map[string]string{"env": "production"})
-	assert.Equal(t, []byte("env=production\n"), got)
+	want := []byte{3, 'e', 'n', 'v', 10, 'p', 'r', 'o', 'd', 'u', 'c', 't', 'i', 'o', 'n'}
+	assert.Equal(t, want, got)
 }
 
-// TestEncContextAAD_MultipleEntries verifies that output is sorted by key.
+// TestEncContextAAD_MultipleEntries verifies that output is sorted by key, with
+// each (key, value) pair length-prefixed as above.
 func TestEncContextAAD_MultipleEntries(t *testing.T) {
 	got := encContextAAD(map[string]string{"z": "last", "a": "first", "m": "middle"})
-	assert.Equal(t, []byte("a=first\nm=middle\nz=last\n"), got)
+	want := []byte{
+		1, 'a', 5, 'f', 'i', 'r', 's', 't',
+		1, 'm', 6, 'm', 'i', 'd', 'd', 'l', 'e',
+		1, 'z', 4, 'l', 'a', 's', 't',
+	}
+	assert.Equal(t, want, got)
 }
 
 // TestEncrypt_NoAAD_SuccessPath exercises Encrypt with no AAD (the aad branch

--- a/internal/crypto/gcpkms/gcpkms_test.go
+++ b/internal/crypto/gcpkms/gcpkms_test.go
@@ -178,6 +178,40 @@ func TestEncContextAAD_DeterministicAndEmpty(t *testing.T) {
 	}
 }
 
+// crypto-gcpkms-01: the old "key=value\n" join let two structurally different
+// maps collide on the key/value boundary — e.g. {"a=b":"c"} and {"a":"b=c"} both
+// produced "a=b=c\n". The length-prefixed encoding must not have that property.
+func TestEncContextAAD_NoCollisionOnAdversarialInput(t *testing.T) {
+	cases := []map[string]string{
+		{"a=b": "c"},
+		{"a": "b=c"},
+		{"a\nb": "c"},
+		{"a": "b\nc"},
+		{"a=": "=b"},
+		{"": "a=b"},
+		{"a=b": ""},
+		{"k": "v\n=extra"},
+	}
+	seen := make(map[string][]int) // encoded bytes -> indices of cases producing them
+	for i, m := range cases {
+		enc := string(encContextAAD(m))
+		seen[enc] = append(seen[enc], i)
+	}
+	for enc, idxs := range seen {
+		if len(idxs) > 1 {
+			t.Fatalf("distinct maps at indices %v collided to the same AAD %q", idxs, enc)
+		}
+	}
+
+	// The two maps from the original finding, spelled out explicitly.
+	a := encContextAAD(map[string]string{"a=b": "c"})
+	b := encContextAAD(map[string]string{"a": "b=c"})
+	if bytes.Equal(a, b) {
+		t.Fatalf("known-collision pair {%q:%q} and {%q:%q} must not produce equal AAD, got %q for both",
+			"a=b", "c", "a", "b=c", a)
+	}
+}
+
 // crypto-gcpkms-02: Encrypt must populate PlaintextCrc32C (and the AAD checksum
 // when AAD is set) on the outgoing request.
 func TestGCPKMS_Encrypt_PopulatesRequestChecksums(t *testing.T) {

--- a/internal/crypto/gcpkms/gcpkms_test.go
+++ b/internal/crypto/gcpkms/gcpkms_test.go
@@ -9,11 +9,15 @@ import (
 
 	"cloud.google.com/go/kms/apiv1/kmspb"
 	gax "github.com/googleapis/gax-go/v2"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-// fakeKMS models GCP KMS AAD semantics: a blob decrypts only with the exact
-// AdditionalAuthenticatedData it was encrypted under. The AAD is embedded in the
-// ciphertext so the fake is stateless.
+// fakeKMS models GCP KMS AAD and CRC32C semantics: a blob decrypts only with the
+// exact AdditionalAuthenticatedData it was encrypted under, and both Encrypt and
+// Decrypt responses carry correct checksums/verified-flags, matching what a real
+// KMS endpoint returns for a request it received uncorrupted. The AAD is embedded
+// in the ciphertext so the fake is stateless.
 type fakeKMS struct{}
 
 type fakeBlob struct {
@@ -23,7 +27,12 @@ type fakeBlob struct {
 
 func (fakeKMS) Encrypt(_ context.Context, req *kmspb.EncryptRequest, _ ...gax.CallOption) (*kmspb.EncryptResponse, error) {
 	b, _ := json.Marshal(fakeBlob{Plaintext: req.Plaintext, AAD: req.AdditionalAuthenticatedData})
-	return &kmspb.EncryptResponse{Ciphertext: b}, nil
+	return &kmspb.EncryptResponse{
+		Ciphertext:              b,
+		CiphertextCrc32C:        wrapperspb.Int64(int64(crc32cSum(b))),
+		VerifiedPlaintextCrc32C: req.GetPlaintextCrc32C() != nil,
+		VerifiedAdditionalAuthenticatedDataCrc32C: req.GetAdditionalAuthenticatedDataCrc32C() != nil || len(req.AdditionalAuthenticatedData) == 0,
+	}, nil
 }
 
 func (fakeKMS) Decrypt(_ context.Context, req *kmspb.DecryptRequest, _ ...gax.CallOption) (*kmspb.DecryptResponse, error) {
@@ -34,7 +43,62 @@ func (fakeKMS) Decrypt(_ context.Context, req *kmspb.DecryptRequest, _ ...gax.Ca
 	if !bytes.Equal(b.AAD, req.AdditionalAuthenticatedData) {
 		return nil, errors.New("decryption failed: AAD mismatch")
 	}
-	return &kmspb.DecryptResponse{Plaintext: b.Plaintext}, nil
+	return &kmspb.DecryptResponse{
+		Plaintext:       b.Plaintext,
+		PlaintextCrc32C: wrapperspb.Int64(int64(crc32cSum(b.Plaintext))),
+	}, nil
+}
+
+// corruptChecksumKMS wraps fakeKMS but returns a response whose checksum field
+// does not match its payload, modelling transport corruption between the client
+// and the KMS service.
+type corruptChecksumKMS struct {
+	corruptEncryptResp bool
+	corruptDecryptResp bool
+	dropVerifiedFlags  bool
+}
+
+func (c corruptChecksumKMS) Encrypt(ctx context.Context, req *kmspb.EncryptRequest, opts ...gax.CallOption) (*kmspb.EncryptResponse, error) {
+	resp, err := (fakeKMS{}).Encrypt(ctx, req, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if c.corruptEncryptResp {
+		resp.CiphertextCrc32C = wrapperspb.Int64(resp.CiphertextCrc32C.GetValue() + 1)
+	}
+	if c.dropVerifiedFlags {
+		resp.VerifiedPlaintextCrc32C = false
+	}
+	return resp, nil
+}
+
+func (c corruptChecksumKMS) Decrypt(ctx context.Context, req *kmspb.DecryptRequest, opts ...gax.CallOption) (*kmspb.DecryptResponse, error) {
+	resp, err := (fakeKMS{}).Decrypt(ctx, req, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if c.corruptDecryptResp {
+		resp.PlaintextCrc32C = wrapperspb.Int64(resp.PlaintextCrc32C.GetValue() + 1)
+	}
+	return resp, nil
+}
+
+// capturingKMS records the last request it saw so tests can assert on the
+// checksum fields the client populated.
+type capturingKMS struct {
+	fakeKMS
+	lastEncryptReq *kmspb.EncryptRequest
+	lastDecryptReq *kmspb.DecryptRequest
+}
+
+func (c *capturingKMS) Encrypt(ctx context.Context, req *kmspb.EncryptRequest, opts ...gax.CallOption) (*kmspb.EncryptResponse, error) {
+	c.lastEncryptReq = req
+	return c.fakeKMS.Encrypt(ctx, req, opts...)
+}
+
+func (c *capturingKMS) Decrypt(ctx context.Context, req *kmspb.DecryptRequest, opts ...gax.CallOption) (*kmspb.DecryptResponse, error) {
+	c.lastDecryptReq = req
+	return c.fakeKMS.Decrypt(ctx, req, opts...)
 }
 
 func newTestClient(encCtx map[string]string, allowFallback bool) *client {
@@ -111,5 +175,149 @@ func TestEncContextAAD_DeterministicAndEmpty(t *testing.T) {
 	b := encContextAAD(map[string]string{"a": "1", "b": "2"})
 	if !bytes.Equal(a, b) {
 		t.Fatal("AAD must be deterministic regardless of map iteration order")
+	}
+}
+
+// crypto-gcpkms-02: Encrypt must populate PlaintextCrc32C (and the AAD checksum
+// when AAD is set) on the outgoing request.
+func TestGCPKMS_Encrypt_PopulatesRequestChecksums(t *testing.T) {
+	kms := &capturingKMS{}
+	c := &client{kms: kms, keyName: "k", aad: encContextAAD(map[string]string{"install": "i1"})}
+	if _, err := c.Encrypt(context.Background(), []byte("payload")); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if kms.lastEncryptReq.GetPlaintextCrc32C() == nil {
+		t.Fatal("PlaintextCrc32C was not set on the EncryptRequest")
+	}
+	if got, want := kms.lastEncryptReq.GetPlaintextCrc32C().GetValue(), int64(crc32cSum([]byte("payload"))); got != want {
+		t.Fatalf("PlaintextCrc32C = %d, want %d", got, want)
+	}
+	if kms.lastEncryptReq.GetAdditionalAuthenticatedDataCrc32C() == nil {
+		t.Fatal("AdditionalAuthenticatedDataCrc32C was not set on the EncryptRequest despite AAD being set")
+	}
+}
+
+// crypto-gcpkms-02: Decrypt must populate CiphertextCrc32C (and the AAD checksum
+// when AAD is set) on the outgoing request.
+func TestGCPKMS_Decrypt_PopulatesRequestChecksums(t *testing.T) {
+	kms := &capturingKMS{}
+	c := &client{kms: kms, keyName: "k", aad: encContextAAD(map[string]string{"install": "i1"})}
+	ct, err := c.Encrypt(context.Background(), []byte("payload"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if _, err := c.Decrypt(context.Background(), ct); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if kms.lastDecryptReq.GetCiphertextCrc32C() == nil {
+		t.Fatal("CiphertextCrc32C was not set on the DecryptRequest")
+	}
+	if got, want := kms.lastDecryptReq.GetCiphertextCrc32C().GetValue(), int64(crc32cSum(ct)); got != want {
+		t.Fatalf("CiphertextCrc32C = %d, want %d", got, want)
+	}
+	if kms.lastDecryptReq.GetAdditionalAuthenticatedDataCrc32C() == nil {
+		t.Fatal("AdditionalAuthenticatedDataCrc32C was not set on the DecryptRequest despite AAD being set")
+	}
+}
+
+// crypto-gcpkms-02: a corrupted EncryptResponse.ciphertext_crc32c must be
+// detected and rejected rather than silently trusted.
+func TestGCPKMS_Encrypt_RejectsCorruptedResponseChecksum(t *testing.T) {
+	c := &client{kms: corruptChecksumKMS{corruptEncryptResp: true}, keyName: "k"}
+	if _, err := c.Encrypt(context.Background(), []byte("payload")); err == nil {
+		t.Fatal("Encrypt must reject a response whose ciphertext_crc32c does not match its ciphertext")
+	}
+}
+
+// crypto-gcpkms-02: an EncryptResponse that never reports the plaintext checksum
+// as verified (e.g. an intermediary dropped/ignored the request checksum) must
+// also be rejected — a false verified flag is exactly what an undetected
+// request-side corruption looks like.
+func TestGCPKMS_Encrypt_RejectsUnverifiedPlaintextChecksum(t *testing.T) {
+	c := &client{kms: corruptChecksumKMS{dropVerifiedFlags: true}, keyName: "k"}
+	if _, err := c.Encrypt(context.Background(), []byte("payload")); err == nil {
+		t.Fatal("Encrypt must reject a response that does not report the plaintext checksum as verified")
+	}
+}
+
+// crypto-gcpkms-02: a corrupted DecryptResponse.plaintext_crc32c must be detected
+// and rejected rather than silently trusted.
+func TestGCPKMS_Decrypt_RejectsCorruptedResponseChecksum(t *testing.T) {
+	enc := &client{kms: fakeKMS{}, keyName: "k"}
+	ct, err := enc.Encrypt(context.Background(), []byte("payload"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	c := &client{kms: corruptChecksumKMS{corruptDecryptResp: true}, keyName: "k"}
+	if _, err := c.Decrypt(context.Background(), ct); err == nil {
+		t.Fatal("Decrypt must reject a response whose plaintext_crc32c does not match its plaintext")
+	}
+}
+
+// crypto-gcpkms-03: a successful AAD-fallback decrypt must be reported through
+// the wired audit sink, not just log.Printf.
+func TestGCPKMS_Decrypt_FallbackEmitsAuditEvent(t *testing.T) {
+	legacy := newTestClient(nil, false)
+	ct, err := legacy.Encrypt(context.Background(), []byte("kek"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	bound := newTestClient(map[string]string{"keyorix-install": "inst-1"}, true)
+
+	var got []*models.AuditEvent
+	bound.SetAuditSink(func(_ context.Context, event *models.AuditEvent) error {
+		got = append(got, event)
+		return nil
+	})
+
+	if _, err := bound.Decrypt(context.Background(), ct); err != nil {
+		t.Fatalf("decrypt via fallback: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one audit event from the fallback decrypt, got %d", len(got))
+	}
+	if got[0].EventType != EventGCPKMSAADFallback {
+		t.Fatalf("EventType = %q, want %q", got[0].EventType, EventGCPKMSAADFallback)
+	}
+	if got[0].Success == nil || *got[0].Success {
+		t.Fatal("fallback audit event must report Success=false (it is a security-negative condition)")
+	}
+}
+
+// The audit sink must NOT fire on an ordinary bound decrypt that never falls back.
+func TestGCPKMS_Decrypt_NoFallback_NoAuditEvent(t *testing.T) {
+	c := newTestClient(map[string]string{"keyorix-install": "inst-1"}, true)
+	ct, err := c.Encrypt(context.Background(), []byte("kek"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	fired := false
+	c.SetAuditSink(func(_ context.Context, _ *models.AuditEvent) error {
+		fired = true
+		return nil
+	})
+	if _, err := c.Decrypt(context.Background(), ct); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if fired {
+		t.Fatal("audit sink must not fire when the decrypt succeeds without falling back")
+	}
+}
+
+// SetAuditSink is a no-op when unset — the fallback must still succeed and only
+// log, never error, when no sink is wired.
+func TestGCPKMS_Decrypt_FallbackWithoutSinkStillSucceeds(t *testing.T) {
+	legacy := newTestClient(nil, false)
+	ct, err := legacy.Encrypt(context.Background(), []byte("kek"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	bound := newTestClient(map[string]string{"keyorix-install": "inst-1"}, true)
+	pt, err := bound.Decrypt(context.Background(), ct)
+	if err != nil {
+		t.Fatalf("decrypt via fallback without a sink: %v", err)
+	}
+	if string(pt) != "kek" {
+		t.Fatalf("got %q", pt)
 	}
 }

--- a/internal/crypto/kms_provider.go
+++ b/internal/crypto/kms_provider.go
@@ -45,6 +45,13 @@ func NewKMSKeyProvider(client KMSClient, name, baseDir, wrappedKeyPath string) *
 
 func (p *KMSKeyProvider) Name() string { return p.name }
 
+// Client returns the underlying KMSClient this provider wraps, so a caller that
+// needs backend-specific behavior unavailable through the KeyProvider interface
+// (e.g. wiring an audit sink onto a *gcpkms client for its AAD-fallback event, see
+// encryption.Service.wireKMSAuditSink) can type-assert it to the concrete
+// backend's client type.
+func (p *KMSKeyProvider) Client() KMSClient { return p.client }
+
 func (p *KMSKeyProvider) KEK() ([]byte, error) {
 	if p.client == nil {
 		return nil, fmt.Errorf("%s key provider: no KMS client configured", p.name)

--- a/internal/encryption/gcpkms_audit_sink_wiring_test.go
+++ b/internal/encryption/gcpkms_audit_sink_wiring_test.go
@@ -1,0 +1,91 @@
+// gcpkms_audit_sink_wiring_test.go — verifies wireKMSAuditSink (service.go)
+// actually connects a Service's audit sink to a directly-configured KMS key
+// provider's underlying client, mirroring TestNewKeyProviderFromConfig_WeakFallback_RuntimeAuditEvent's
+// coverage of the sibling MultiKeyProvider downgrade-hook wiring. This is the
+// production-wiring counterpart to gcpkms's own package-level fallback-audit
+// tests: those prove the client emits the event when a sink IS wired; this
+// proves Service actually wires one for the gcp-kms provider shape, using a fake
+// client (real gcpkms.New() needs live GCP ADC credentials, unavailable in CI —
+// same constraint documented in encryption_s17_test.go).
+package encryption
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
+	"github.com/keyorixhq/keyorix/internal/crypto/gcpkms"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// fakeGCPKMSClient stands in for the real *gcpkms client: it implements
+// crypto.KMSClient and, like the real client, an optional SetAuditSink hook.
+type fakeGCPKMSClient struct {
+	sink gcpkms.AuditSink
+}
+
+func (f *fakeGCPKMSClient) Encrypt(_ context.Context, plaintext []byte) ([]byte, error) {
+	return plaintext, nil
+}
+
+func (f *fakeGCPKMSClient) Decrypt(_ context.Context, ciphertext []byte) ([]byte, error) {
+	return ciphertext, nil
+}
+
+func (f *fakeGCPKMSClient) SetAuditSink(sink gcpkms.AuditSink) {
+	f.sink = sink
+}
+
+// TestWireKMSAuditSink_ConnectsSinkToGCPKMSClient asserts that a Service with an
+// audit sink set wires that sink onto a gcp-kms-shaped KMSKeyProvider's
+// underlying client, and that invoking the wired sink actually reaches the
+// Service's sink function.
+func TestWireKMSAuditSink_ConnectsSinkToGCPKMSClient(t *testing.T) {
+	fake := &fakeGCPKMSClient{}
+	provider := crypto.NewKMSKeyProvider(fake, "gcp-kms", t.TempDir(), "wrapped.key")
+
+	svc := NewService(&config.EncryptionConfig{Enabled: true}, t.TempDir())
+	var got *models.AuditEvent
+	svc.SetAuditSink(func(_ context.Context, event *models.AuditEvent) error {
+		got = event
+		return nil
+	})
+
+	svc.wireKMSAuditSink(provider)
+
+	if fake.sink == nil {
+		t.Fatal("wireKMSAuditSink did not wire a sink onto the underlying gcp-kms client")
+	}
+	event := &models.AuditEvent{EventType: gcpkms.EventGCPKMSAADFallback}
+	if err := fake.sink(context.Background(), event); err != nil {
+		t.Fatalf("wired sink returned an error: %v", err)
+	}
+	if got != event {
+		t.Fatal("invoking the wired sink did not reach the Service's own audit sink")
+	}
+}
+
+// TestWireKMSAuditSink_NoSinkConfigured_NoWiring asserts that with no Service
+// audit sink set, wireKMSAuditSink leaves the client's sink unset (nil is a
+// legitimate steady state: the client falls back to log.Printf only).
+func TestWireKMSAuditSink_NoSinkConfigured_NoWiring(t *testing.T) {
+	fake := &fakeGCPKMSClient{}
+	provider := crypto.NewKMSKeyProvider(fake, "gcp-kms", t.TempDir(), "wrapped.key")
+
+	svc := NewService(&config.EncryptionConfig{Enabled: true}, t.TempDir())
+	svc.wireKMSAuditSink(provider)
+
+	if fake.sink != nil {
+		t.Fatal("wireKMSAuditSink must not wire anything when the Service has no audit sink configured")
+	}
+}
+
+// TestWireKMSAuditSink_NonKMSProvider_NoPanic asserts that a non-KMS provider
+// (e.g. the password provider) is simply skipped, not a panic or error.
+func TestWireKMSAuditSink_NonKMSProvider_NoPanic(t *testing.T) {
+	svc := NewService(&config.EncryptionConfig{Enabled: true}, t.TempDir())
+	svc.SetAuditSink(func(_ context.Context, _ *models.AuditEvent) error { return nil })
+	provider := crypto.NewPasswordKeyProvider("pw", t.TempDir(), "salt")
+	svc.wireKMSAuditSink(provider) // must not panic
+}

--- a/internal/encryption/service.go
+++ b/internal/encryption/service.go
@@ -94,7 +94,35 @@ func (s *Service) buildKeyProvider(passphrase string) (crypto.KeyProvider, error
 	if mp, ok := provider.(*crypto.MultiKeyProvider); ok {
 		mp.SetDowngradeHook(s.auditKeyProviderDowngrade)
 	}
+	s.wireKMSAuditSink(provider)
 	return provider, nil
+}
+
+// wireKMSAuditSink connects this Service's audit sink (if any) to a directly-
+// configured KMS-backed key provider's underlying client, so a security-relevant
+// runtime event the client itself detects (currently just gcpkms's AAD-fallback
+// decrypt, see gcpkms.AuditSink / gcpkms.EventGCPKMSAADFallback) is recorded as a
+// queryable audit event, not just a log line — mirroring auditKeyProviderDowngrade's
+// wiring for MultiKeyProvider fallback-chain downgrades just above. Only wires the
+// single, non-fallback-chain case: a KMS provider nested inside a Fallbacks chain
+// is not reachable here since MultiKeyProvider does not expose its member
+// providers, and that gap is no worse than the pre-existing log-only behavior.
+func (s *Service) wireKMSAuditSink(provider crypto.KeyProvider) {
+	kp, ok := provider.(*crypto.KMSKeyProvider)
+	if !ok {
+		return
+	}
+	sinkable, ok := kp.Client().(interface{ SetAuditSink(gcpkms.AuditSink) })
+	if !ok {
+		return
+	}
+	s.auditSinkMu.RLock()
+	sink := s.auditSink
+	s.auditSinkMu.RUnlock()
+	if sink == nil {
+		return
+	}
+	sinkable.SetAuditSink(gcpkms.AuditSink(sink))
 }
 
 // NewKeyProviderFromConfig builds the KEK source described by an EncryptionConfig


### PR DESCRIPTION
## Summary

Closes the last held-back finding from the adversarial-review corpus: **crypto-gcpkms-01**, held since batch 1 pending a breaking-change decision. That decision is now made — it ships in **v0.92.0**, alongside ADR-082's and ADR-083's existing BREAKING entries already in the `Unreleased` CHANGELOG section, deliberately consolidating this release's breaking changes into one place rather than trickling them across releases.

This supersedes `f715567f` (the original combined commit on the now-stale `fix-wave6-gcpkms-hardening` branch) as a **two-commit split by breaking-ness**:

1. **Non-breaking** — CRC32C request/response verification (crypto-gcpkms-02) + AAD-fallback audit sink (crypto-gcpkms-03), plus their `kms_provider.go`/`service.go` wiring.
2. **BREAKING** — the `encContextAAD` length-prefixed encoding (crypto-gcpkms-01), alone, with its own CHANGELOG entry.

## crypto-gcpkms-01 (BREAKING)

`encContextAAD`'s old `"key=value\n"` join had no escaping: adversarial `=`/`\n` content in a key or value let two structurally different context maps serialize to identical AdditionalAuthenticatedData — e.g. `{"a=b":"c"}` and `{"a":"b=c"}` both produced `"a=b=c\n"`. This undermines the cross-install isolation `kms_encryption_context` exists to provide.

**Demonstrated, not just asserted**: `TestEncContextAAD_NoCollisionOnAdversarialInput` was confirmed to genuinely fail against the pre-fix implementation — temporarily reverted `encContextAAD` to the old `strings.Builder` join, reran the test, reproduced the exact `a=b=c\n` collision from the finding, then restored the fix. See the commit message on `9e2ec413` for the full before/after.

Replaced with a length-prefixed (uvarint) encoding that is injective over the sorted `(key, value)` sequence — no two distinct maps can collide.

**Impact**: only installs configuring `kms_encryption_context` with a GCP KMS key provider are affected. A KEK wrapped under the old AAD bytes will fail to decrypt after upgrading, since the new AAD no longer matches what it was wrapped under.

**Re-wrap path**: enable `kms_allow_context_fallback: true` temporarily, run `keyorix encryption migrate-provider --to-kms-encryption-context=...` to re-wrap the KEK under the new AAD encoding, then **disable `kms_allow_context_fallback` again** — leaving it enabled makes the AAD binding advisory rather than enforced.

## crypto-gcpkms-02 / crypto-gcpkms-03 (non-breaking)

- CRC32C request/response checksum population and verification on `Encrypt`/`Decrypt`, per Google's Cloud KMS client guidance — transport corruption of KEK material was previously indistinguishable from a correct round-trip.
- A successful `kms_allow_context_fallback` retry is now recorded through the same tamper-evident audit chain every other security event uses (`storage.LogAuditEvent`), not just `log.Printf`.

## Out of scope, filed separately

Investigation surfaced that `models.AuditEvent` has no UTC-normalizing `BeforeSave` hook — the same query-comparison bug class G81 fixed twice already (#1448). Filed as [#1492](https://github.com/keyorixhq/keyorix/issues/1492) rather than fixed here, since it's systemic (~16 call sites) and deserves a hook + full sweep, not another one-off patch inside this PR.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean on both commits individually and combined
- `gosec -severity medium -exclude-generated` on `internal/crypto/...` and `internal/encryption/...` — 0 issues
- Full `internal/crypto/...` and `internal/encryption/...` suites pass (27/27 in `gcpkms` alone)
- `server/http` baseline: 18 failing test names, byte-for-byte identical to the pre-existing baseline already verified against a clean `origin/main` checkout — zero new failures, zero resolved