### PR TITLE
fix(security): route test harness through cfg.Validate(), reject unrecognized connector types (#1475, #1476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ All notable changes to Keyorix are documented here. This project follows
   as of this same change: a caller must be a member of the connector's owning
   project (or hold a matching `ConnectRefGrant`) to read through it — see
   `docs/adr-082-connect-connector-tenant-scoping.md`.
+- **BREAKING (targeting v0.92.0): a Keyorix Connect connector with an unrecognized
+  `type` now fails boot instead of booting with that connector silently skipped
+  (#1476)** — previously, `server/main.go`'s Connect-wiring loop logged a warning
+  and continued for any `connect.connectors` entry whose `type` didn't match one
+  of the four recognized backends (`aws-secrets-manager`, `gcp-secret-manager`,
+  `azure-key-vault`, `vault`), so a typo'd or removed connector type produced a
+  deployment that looked healthy but silently had one fewer working connector
+  than configured. `type` is now validated at config-load time, before boot
+  reaches the connector-wiring loop, and aggregates every offending connector
+  into one error. **If you have a connector with a misspelled or unsupported
+  `type`, fix it before upgrading** — this is the same fail-open shape ADR-082
+  closed for a missing/invalid connector `scope` above.
 - **BREAKING (targeting v0.92.0): `storage.type: remote` combined with
   `server.http.enabled` or `server.grpc.enabled` no longer boots (ADR-083)** —
   `storage.type: remote` is a CLI/client mode only; RemoteStorage never

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/connect"
 	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"gopkg.in/yaml.v3"
@@ -1936,10 +1937,46 @@ func (c *Config) Validate() error { // NOSONAR -- cognitive complexity 32, suppr
 		return fmt.Errorf("unsupported fallback language: %s. Supported languages: en, ru, es, fr, de", c.Locale.FallbackLanguage)
 	}
 
+	if err := validateConnectTypes(c.Connect); err != nil {
+		return err
+	}
+
 	if err := validateConnectScopes(c.Connect); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+// validateConnectTypes enforces #1476: every cfg.Connect.Connectors entry's Type
+// must be one of connect.KnownTypes, the single source of truth for recognized
+// connector types (see that var's own doc comment for why server/main.go's
+// dispatch switch stays a literal switch rather than deriving from this list, and
+// how the two are kept from drifting apart). Runs BEFORE validateConnectScopes:
+// an unrecognized type is a more fundamental problem than a scope-shape issue on
+// a connector Keyorix would never actually construct. Aggregates every offending
+// connector into one error, mirroring validateConnectScopes's own aggregation —
+// an operator fixing config should not have to restart-and-discover connectors
+// one at a time.
+//
+// This closes the same fail-open shape ADR-082 closed for scope: server/main.go's
+// Connect-wiring switch used to silently skip (log.Printf, keep booting) a
+// connector whose Type matched no case label — see the v0.92.0 CHANGELOG entry.
+func validateConnectTypes(cc ConnectConfig) error {
+	known := make(map[string]bool, len(connect.KnownTypes))
+	for _, t := range connect.KnownTypes {
+		known[t] = true
+	}
+	var invalid []string
+	for _, connector := range cc.Connectors {
+		if !known[connector.Type] {
+			invalid = append(invalid, fmt.Sprintf("%s (type: %q)", connector.Name, connector.Type))
+		}
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("connect: connector(s) with unrecognized type (must be one of %s): %s",
+			strings.Join(connect.KnownTypes, ", "), strings.Join(invalid, ", "))
+	}
 	return nil
 }
 

--- a/internal/config/connect_config_test.go
+++ b/internal/config/connect_config_test.go
@@ -166,3 +166,120 @@ func TestValidate_ConnectScopesWired(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unscoped-connector")
 }
+
+// TestValidateConnectTypes covers #1476 boot validation: a connector's Type
+// must be one of connect.KnownTypes. Mirrors TestValidateConnectScopes's own
+// structure and aggregation-assertion style — every failure case asserts the
+// aggregated error names every offending connector, not just the first.
+func TestValidateConnectTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		cc        ConnectConfig
+		wantErr   bool
+		wantNames []string // every name that must appear in the error message
+	}{
+		{
+			name: "unrecognized type, single connector, fails boot",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "c1", Type: "aws-secrets-mangler", Scope: "platform"}, // typo
+			}},
+			wantErr:   true,
+			wantNames: []string{"c1"},
+		},
+		{
+			name: "unrecognized type, multiple connectors, aggregated in one error",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "c1", Type: "bogus-type-1", Scope: "platform"},
+				{Name: "c2", Type: "bogus-type-2", Scope: "platform"},
+				{Name: "c3", Type: "vault", Scope: "platform"}, // valid — must not appear
+			}},
+			wantErr:   true,
+			wantNames: []string{"c1", "c2"},
+		},
+		{
+			name: "empty type fails boot",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "no-type", Scope: "platform"},
+			}},
+			wantErr:   true,
+			wantNames: []string{"no-type"},
+		},
+		{
+			name:    "no connectors is valid",
+			cc:      ConnectConfig{},
+			wantErr: false,
+		},
+		{
+			name: "every recognized type is valid",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "aws", Type: "aws-secrets-manager", Scope: "platform"},
+				{Name: "gcp", Type: "gcp-secret-manager", Scope: "platform"},
+				{Name: "azure", Type: "azure-key-vault", Scope: "platform"},
+				{Name: "vault", Type: "vault", Scope: "platform"},
+			}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConnectTypes(tt.cc)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, name := range tt.wantNames {
+				assert.Contains(t, err.Error(), name, "error must name every offending connector")
+			}
+		})
+	}
+}
+
+// TestValidateConnectTypes_ValidEntriesExcludedFromAggregation mirrors
+// TestValidateConnectScopes_ValidEntriesExcludedFromAggregation: a
+// recognized-type connector never appears in another connector's failure
+// message.
+func TestValidateConnectTypes_ValidEntriesExcludedFromAggregation(t *testing.T) {
+	cc := ConnectConfig{Connectors: []ConnectorConfig{
+		{Name: "broken", Type: "bogus-type", Scope: "platform"},
+		{Name: "fine", Type: "vault", Scope: "platform"},
+	}}
+	err := validateConnectTypes(cc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "broken")
+	assert.NotContains(t, err.Error(), "fine")
+}
+
+// TestValidate_ConnectTypesWired confirms Config.Validate() itself surfaces a
+// connector type error — not just the unexported helper in isolation — so the
+// boot path actually enforces #1476.
+func TestValidate_ConnectTypesWired(t *testing.T) {
+	c := &Config{
+		Storage: StorageConfig{Type: "remote"}, // skip local DB path requirement
+		Connect: ConnectConfig{Connectors: []ConnectorConfig{
+			{Name: "mistyped-connector", Type: "aws-secrets-mangler", Scope: "platform"},
+		}},
+	}
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mistyped-connector")
+}
+
+// TestValidate_ConnectTypesRunsBeforeScopes confirms validateConnectTypes runs
+// before validateConnectScopes in Config.Validate() (see that function's own
+// comment for why: an unrecognized type is more fundamental than a scope-shape
+// issue on a connector Keyorix would never construct). A connector with BOTH
+// an unrecognized type AND a missing scope must surface the type error, not
+// the scope error.
+func TestValidate_ConnectTypesRunsBeforeScopes(t *testing.T) {
+	c := &Config{
+		Storage: StorageConfig{Type: "remote"},
+		Connect: ConnectConfig{Connectors: []ConnectorConfig{
+			{Name: "doubly-broken", Type: "bogus-type"}, // no Type match AND no Scope
+		}},
+	}
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unrecognized type", "expected the type error to surface first, got: %v", err)
+}

--- a/internal/connect/types.go
+++ b/internal/connect/types.go
@@ -1,0 +1,21 @@
+package connect
+
+// KnownTypes is the exhaustive set of recognized ConnectorConfig.Type values —
+// the single source of truth for "what is a valid Keyorix Connect connector
+// type" (#1476). internal/config.Validate() checks every configured
+// connector's Type against this list (validateConnectTypes,
+// internal/config/config.go) so an unrecognized type fails boot instead of
+// being silently skipped — the same fail-open shape ADR-082 closed for a
+// missing/invalid connector scope. server/main.go's initializeCoreService
+// still dispatches on a literal switch (each type needs a different
+// constructor call, some with type-specific side effects — e.g. the
+// gcp-secret-manager case's project_id Fatal/warn, the vault case's token TTL
+// check — that don't reduce to a uniform map[string]func lookup), but
+// server/connector_type_registry_test.go asserts that switch's case set is
+// always exactly this list, so the two cannot silently drift apart.
+var KnownTypes = []string{
+	"aws-secrets-manager",
+	"gcp-secret-manager",
+	"azure-key-vault",
+	"vault",
+}

--- a/server/connector_type_registry_test.go
+++ b/server/connector_type_registry_test.go
@@ -1,0 +1,187 @@
+// connector_type_registry_test.go — regression test for #1476's structural
+// concern: initializeCoreService's Connect-wiring switch (main.go, "switch
+// cn.Type") dispatches on literal case labels rather than deriving from
+// connect.KnownTypes (each case needs a different constructor call, some with
+// type-specific side effects that don't reduce to a uniform map[string]func
+// lookup — see connect.KnownTypes' own doc comment). Nothing stops that switch's
+// case set from silently drifting away from connect.KnownTypes, the list
+// internal/config.Validate()'s validateConnectTypes checks a configured
+// connector's Type against — a case added to one without the other would
+// either make a Validate()-accepted type fall through to the switch's Fatal
+// default (a boot-time crash for a config that was supposed to be legal), or
+// make the switch accept a type Validate() should have already rejected (dead
+// code, but a sign the two have drifted).
+//
+// Rather than hand-maintain a second literal copy of the case-label set here
+// (exactly the duplication this test exists to prevent), this parses
+// server/main.go's own source via go/ast and extracts the actual case string
+// literals from the switch inside initializeCoreService, then diffs that
+// discovered set against connect.KnownTypes.
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/connect"
+)
+
+// TestConnectorTypeRegistry_SwitchMatchesKnownTypes is the regression test
+// described above.
+func TestConnectorTypeRegistry_SwitchMatchesKnownTypes(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed — cannot locate server/main.go relative to this test file")
+	}
+	mainGoPath := filepath.Join(filepath.Dir(thisFile), "main.go")
+	if _, err := os.Stat(mainGoPath); err != nil {
+		t.Fatalf("server/main.go not found at %s: %v", mainGoPath, err)
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, mainGoPath, nil, 0)
+	if err != nil {
+		t.Fatalf("failed to parse %s: %v", mainGoPath, err)
+	}
+
+	discovered := discoverConnectorTypeSwitchCases(t, file)
+	if len(discovered) == 0 {
+		t.Fatal("discovered zero case labels on the Connect-wiring switch in server/main.go — " +
+			"the AST walk is almost certainly broken (the switch has 4 cases today), not that the switch was removed")
+	}
+
+	known := map[string]bool{}
+	for _, typ := range connect.KnownTypes {
+		known[typ] = true
+	}
+
+	var missingFromRegistry, missingFromSwitch []string
+	for c := range discovered {
+		if !known[c] {
+			missingFromRegistry = append(missingFromRegistry, c)
+		}
+	}
+	for _, k := range connect.KnownTypes {
+		if !discovered[k] {
+			missingFromSwitch = append(missingFromSwitch, k)
+		}
+	}
+	sort.Strings(missingFromRegistry)
+	sort.Strings(missingFromSwitch)
+
+	if len(missingFromRegistry) > 0 {
+		t.Errorf("server/main.go's Connect-wiring switch has case(s) not present in connect.KnownTypes: %v\n"+
+			"internal/config.Validate() would reject a connector with this Type before boot reaches the switch, "+
+			"making the case dead code — add the type to connect.KnownTypes if it's genuinely supported.", missingFromRegistry)
+	}
+	if len(missingFromSwitch) > 0 {
+		t.Errorf("connect.KnownTypes lists type(s) with no matching case in server/main.go's Connect-wiring switch: %v\n"+
+			"A connector with this Type would pass cfg.Validate() but then hit the switch's Fatal default at boot — "+
+			"add a case for it (with the right constructor call), or remove it from connect.KnownTypes.", missingFromSwitch)
+	}
+}
+
+// TestInitializeCoreService_UnrecognizedConnectorType_FailsBoot is #1476's
+// pairing test: before #1475 (cfg.Validate() at the top of
+// initializeCoreService) landed, this config booted successfully — nothing
+// called Validate() at all. Before THIS commit's validateConnectTypes existed,
+// Validate() would run (once #1475 landed) but never inspect connector Type,
+// so this would still boot successfully. Both preconditions are required for
+// this test to fail as intended — that pairing is the point.
+func TestInitializeCoreService_UnrecognizedConnectorType_FailsBoot(t *testing.T) {
+	initI18n(t)
+	cfg := newMinimalCfg(t)
+	cfg.Connect = config.ConnectConfig{
+		Enabled: true,
+		Connectors: []config.ConnectorConfig{
+			{Name: "typo-connector", Type: "aws-secrets-mangler", Scope: "platform"},
+		},
+	}
+	_, _, err := initializeCoreService(cfg)
+	if err == nil {
+		t.Fatal("expected initializeCoreService to refuse to boot with an unrecognized connector type")
+	}
+	if !strings.Contains(err.Error(), "typo-connector") {
+		t.Fatalf("expected error to name the offending connector, got: %v", err)
+	}
+}
+
+// TestInitializeCoreService_UnrecognizedConnectorType_AggregatesMultiple
+// confirms the boot-time error names every offending connector in one message,
+// not just the first, and excludes a validly-typed connector from that list —
+// mirroring validateConnectScopes's own aggregation behavior (ADR-082).
+func TestInitializeCoreService_UnrecognizedConnectorType_AggregatesMultiple(t *testing.T) {
+	initI18n(t)
+	cfg := newMinimalCfg(t)
+	cfg.Connect = config.ConnectConfig{
+		Enabled: true,
+		Connectors: []config.ConnectorConfig{
+			{Name: "bad1", Type: "bogus-type-1", Scope: "platform"},
+			{Name: "bad2", Type: "bogus-type-2", Scope: "platform"},
+			{Name: "ok", Type: "vault", Scope: "platform"},
+		},
+	}
+	_, _, err := initializeCoreService(cfg)
+	if err == nil {
+		t.Fatal("expected initializeCoreService to refuse to boot")
+	}
+	for _, want := range []string{"bad1", "bad2"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to name %q, got: %v", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), `"ok"`) {
+		t.Fatalf("validly-typed connector must not appear in the error, got: %v", err)
+	}
+}
+
+// discoverConnectorTypeSwitchCases walks file looking for a *ast.SwitchStmt whose
+// tag is exactly `cn.Type` (matching server/main.go's Connect-wiring switch,
+// `switch cn.Type { ... }`), and returns the set of string literal values across
+// all of its non-default case clauses.
+func discoverConnectorTypeSwitchCases(t *testing.T, file *ast.File) map[string]bool {
+	t.Helper()
+	discovered := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		sw, ok := n.(*ast.SwitchStmt)
+		if !ok || sw.Tag == nil {
+			return true
+		}
+		sel, ok := sw.Tag.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Type" {
+			return true
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if !ok || ident.Name != "cn" {
+			return true
+		}
+		for _, stmt := range sw.Body.List {
+			cc, ok := stmt.(*ast.CaseClause)
+			if !ok {
+				continue
+			}
+			for _, expr := range cc.List { // nil List = the `default:` clause, skipped
+				lit, ok := expr.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				val, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					continue
+				}
+				discovered[val] = true
+			}
+		}
+		return true
+	})
+	return discovered
+}

--- a/server/main.go
+++ b/server/main.go
@@ -613,7 +613,18 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 				}
 				connectors = append(connectors, vc)
 			default:
-				log.Printf("Keyorix Connect: skipping connector %q with unknown type %q", cn.Name, cn.Type)
+				// #1476: unreachable via a config that passed cfg.Validate() —
+				// validateConnectTypes (internal/config/config.go) already refused
+				// to boot with a connector Type outside connect.KnownTypes, before
+				// this function is ever reached (see the cfg.Validate() call at the
+				// top of initializeCoreService). Fail loud rather than silently
+				// skip if this is somehow reached anyway (e.g. a future caller of
+				// this loop that bypasses Validate()) — the old behavior let a
+				// misconfigured connector boot invisibly, the same fail-open shape
+				// ADR-082 closed for scope. See
+				// server/connector_type_registry_test.go for the test keeping this
+				// switch's case set and connect.KnownTypes from drifting apart.
+				log.Fatalf("Keyorix Connect: connector %q has unrecognized type %q (must be one of %s) — this should have been caught by cfg.Validate()", cn.Name, cn.Type, strings.Join(connect.KnownTypes, ", "))
 			}
 		}
 		if len(connectors) > 0 {

--- a/server/main.go
+++ b/server/main.go
@@ -293,6 +293,15 @@ func loadCertPool(path string) (*x509.CertPool, error) {
 }
 
 func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.Service, error) { // NOSONAR -- cognitive complexity 159, suppress go:S3776
+	// #1475: mirrors main()'s own cfg.Validate() call above — a test or any other
+	// caller that builds a *config.Config by hand and skips straight to this
+	// function bypassed schema/sanity validation entirely, letting fixtures encode
+	// configs production boot would refuse (e.g. autocert enabled with no domains).
+	// Enforcing it here means "this function accepted the config" is only ever true
+	// for a config production would actually boot with.
+	if err := cfg.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("invalid configuration: %w", err)
+	}
 	// Use storage factory to support SQLite, PostgreSQL, and remote storage
 	factory := appstorage.NewStorageFactory()
 	store, err := factory.CreateStorage(cfg)

--- a/server/server_s27_test.go
+++ b/server/server_s27_test.go
@@ -37,6 +37,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -754,12 +755,26 @@ func TestStartHTTPServer_S27_AutoCertTLS(t *testing.T) {
 				TLS: config.TLSConfig{
 					Enabled:  true,
 					AutoCert: true, // createTLSConfig returns nil,nil → TLSConfig=nil
+					// #1475: cfg.Validate() (now enforced by initializeCoreService)
+					// requires at least one domain when AutoCert is set. Never
+					// resolved here — the test cancels before any real ACME
+					// handshake — so a placeholder satisfies Validate() without
+					// touching what this test actually exercises (createTLSConfig's
+					// nil,nil AutoCert return, verified below via TLSConfig).
+					Domains: []string{"s27-autocert-tls.test.invalid"},
 				},
 			},
 		},
 	}
 
 	coreService := mustInitCoreService(t, cfg)
+
+	// #1475: confirm this fixture's placeholder Domains didn't change what the
+	// test actually exercises — AutoCert must still make createTLSConfig return a
+	// nil *tls.Config, independent of Domains being set.
+	if tlsCfg, err := createTLSConfig(cfg); err != nil || tlsCfg != nil {
+		t.Fatalf("createTLSConfig with AutoCert must still return (nil, nil), got (%v, %v)", tlsCfg, err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel so the server exits immediately after <-ctx.Done()
@@ -1056,12 +1071,29 @@ func TestStartHTTPServer_S27_AutoCertBadCipher(t *testing.T) {
 					Enabled:        true,
 					AutoCert:       true,
 					AllowedCiphers: []string{"INVALID_CIPHER_XYZ_S27"}, // not a recognised cipher suite
+					// #1475: cfg.Validate() (now enforced by initializeCoreService)
+					// requires at least one domain when AutoCert is set. Validate()
+					// never inspects AllowedCiphers, so this placeholder only
+					// satisfies the domains check — buildAutoCertTLSConfig still
+					// fails at applyTLSHardening's cipher-suite resolution, BEFORE
+					// domains/HostWhitelist ever matter (verified below), for the
+					// same reason as before.
+					Domains: []string{"s27-autocert-badcipher.test.invalid"},
 				},
 			},
 		},
 	}
 
 	coreService := mustInitCoreService(t, cfg)
+
+	// #1475: confirm this fixture's placeholder Domains didn't change what the
+	// test actually exercises — the invalid cipher name must still make
+	// buildAutoCertTLSConfig fail at cipher-suite resolution.
+	if _, err := buildAutoCertTLSConfig(cfg.Server.HTTP.TLS.Domains, cfg.Server.HTTP.TLS); err == nil {
+		t.Fatal("buildAutoCertTLSConfig must still fail for an unrecognised cipher suite name")
+	} else if !strings.Contains(err.Error(), "invalid TLS configuration") {
+		t.Fatalf("expected a cipher-resolution error, got: %v", err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	time.AfterFunc(200*time.Millisecond, cancel)

--- a/server/server_s4_test.go
+++ b/server/server_s4_test.go
@@ -391,8 +391,12 @@ func TestInitializeCoreService_RotationBackend_Various(t *testing.T) {
 	}
 }
 
-// ── initializeCoreService — Connect (unknown type skipped) ───────────────────
+// ── initializeCoreService — Connect (unknown type rejected) ──────────────────
 
+// #1476: an unknown connector Type used to be silently skipped (this test's
+// own name and assertion, until this change, encoded exactly that now-obsolete
+// behavior) — the same fail-open shape ADR-082 closed for scope. It now fails
+// cfg.Validate() before initializeCoreService reaches its Connect-wiring loop.
 func TestInitializeCoreService_Connect_UnknownType(t *testing.T) {
 	initI18n(t)
 	cfg := newMinimalCfg(t)
@@ -404,8 +408,8 @@ func TestInitializeCoreService_Connect_UnknownType(t *testing.T) {
 	}
 
 	_, _, err := initializeCoreService(cfg)
-	if err != nil {
-		t.Fatalf("initializeCoreService with unknown connector type: %v", err)
+	if err == nil {
+		t.Fatal("expected initializeCoreService to refuse to boot with an unrecognized connector type")
 	}
 }
 


### PR DESCRIPTION
## Summary

Two paired findings from the adversarial-review corpus, landed as two commits.

### #1475 — test harness never exercised `cfg.Validate()`

`initializeCoreService` is server boot's actual entry point, but 82 test call sites across 6 files called it directly, bypassing `cfg.Validate()` entirely — unlike `main()`, which validates before ever reaching this function. A test asserting `initializeCoreService` succeeds with a config production would refuse to boot with was asserting the wrong thing; `Validate()` itself was never exercised by any of that harness.

Fixed by adding `cfg.Validate()` at the top of `initializeCoreService`, mirroring `main()`'s own call. Empirically verified (not assumed) exactly which of the 82 call sites broke: 2, both in `server_s27_test.go`, both AutoCert-TLS fixtures missing a `Domains` value. Each was fixed individually with a placeholder value, and verified — via a direct call to the exact function under test (`createTLSConfig`, `buildAutoCertTLSConfig`) — to still exercise its original documented target path, not just pass.

### #1476 — unrecognized connector type silently skipped (BREAKING)

`server/main.go`'s Connect-wiring switch silently skipped (`log.Printf`, keep booting) any connector whose `type` matched no case label — the same fail-open shape ADR-082 closed for a missing/invalid connector `scope`. A typo'd or removed connector type produced a deployment that looked healthy but silently had one fewer working connector than configured.

Fixed with a single source of truth (`connect.KnownTypes`, `internal/connect/types.go`) for the four recognized connector types, checked from `internal/config.Validate()` via a new `validateConnectTypes` sibling to `validateConnectScopes`, reusing its exact aggregation style — every offending connector named in one error, not just the first.

**BREAKING, targeting v0.92.0**, alongside ADR-082's and ADR-083's existing BREAKING entries in the same `Unreleased` CHANGELOG section — this release deliberately consolidates its breaking changes into one place. If you have a connector with a misspelled or unsupported `type`, fix it before upgrading.

### Why paired

`server/main.go`'s switch still dispatches on literal case labels — each connector type needs a different constructor call, some with type-specific side effects (the `gcp-secret-manager` case's `project_id` Fatal/warn, the `vault` case's token TTL check) that don't reduce to a uniform `map[string]func` lookup, so it can't cleanly derive from `connect.KnownTypes`. Instead, `server/connector_type_registry_test.go` parses `server/main.go`'s own source via `go/ast`, extracts the switch's actual case-label string literals, and asserts that set is exactly `connect.KnownTypes` in both directions — a case with no registry entry, or a registry entry with no case, both fail with a message naming the mismatch. This is the mechanism keeping the switch and the registry from silently drifting apart, verified non-vacuous by temporarily injecting a bogus registry entry and confirming the test catches it.

#1476's new tests (`TestInitializeCoreService_UnrecognizedConnectorType_FailsBoot`/`_AggregatesMultiple`) only run meaningfully once #1475 lands — before #1475, `initializeCoreService` never calls `Validate()` at all, so these tests would pass for the wrong reason (or rather, fail to demonstrate anything, since the whole boot path they exercise doesn't exist yet). Verified empirically against an isolated commit-1-only checkout: without #1476's `validateConnectTypes`, the config boots successfully (old `log.Printf`-skip default still in place) and the pairing test fails cleanly, confirming both commits are required together.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean on both commits
- `gosec -severity medium -exclude-generated` on `internal/config`, `internal/connect`, `server` — 0 issues
- Full `internal/config`, `internal/connect`, and `server` suites pass
- `server/http`'s 18 known pre-existing failures are byte-for-byte the same test names as the established baseline — zero new failures, zero resolved