### PR TITLE
fix(security): roleSetContainsAdmin fails closed on a genuine storage error (#1494)

### DIFF
--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -226,7 +226,11 @@ func (c *KeyorixCore) Authorize(ctx context.Context, userID uint, permission str
 	if len(roleIDs) == 0 {
 		return false, nil
 	}
-	if c.roleSetContainsAdmin(ctx, roleIDs) {
+	containsAdmin, err := c.roleSetContainsAdmin(ctx, roleIDs)
+	if err != nil {
+		return false, err
+	}
+	if containsAdmin {
 		return true, nil
 	}
 	return c.storage.RoleSetHasPermission(ctx, roleIDs, permission)
@@ -244,7 +248,11 @@ func (c *KeyorixCore) principalHasScopedPermission(ctx context.Context, userID u
 	if len(roleIDs) == 0 {
 		return false, nil
 	}
-	if c.roleSetContainsAdmin(ctx, roleIDs) {
+	containsAdmin, err := c.roleSetContainsAdmin(ctx, roleIDs)
+	if err != nil {
+		return false, err
+	}
+	if containsAdmin {
 		return true, nil
 	}
 	return c.storage.RoleSetHasPermission(ctx, roleIDs, permission)
@@ -325,7 +333,7 @@ func (c *KeyorixCore) IsGlobalAdmin(ctx context.Context, userID uint) (bool, err
 	if err != nil {
 		return false, err
 	}
-	return c.roleSetContainsAdmin(ctx, roleIDs), nil
+	return c.roleSetContainsAdmin(ctx, roleIDs)
 }
 
 // scopedRoleIDs returns the de-duplicated set of role IDs that apply to userID
@@ -342,10 +350,21 @@ func (c *KeyorixCore) scopedRoleIDs(ctx context.Context, userID uint, scope Scop
 	return dedupeUints(append(direct, viaGroups...)), nil
 }
 
-// roleSetContainsAdmin reports whether any role ID in the set is an admin role.
-func (c *KeyorixCore) roleSetContainsAdmin(ctx context.Context, roleIDs []uint) bool { // nosemgrep: keyorix-unbounded-bulk-slice-param -- roleIDs is a principal's resolved current role set (scopedRoleIDs/GetUserRoleIDsAt), not a raw client-supplied array; every call site passes an internally-computed list
+// roleSetContainsAdmin reports whether any role ID in the set is an admin
+// role. Fails closed on a genuine resolution error: a GetRoleByName failure
+// that is NOT "not found" (a transient storage error, a cancelled context) is
+// returned to the caller rather than silently treated as "no admin role
+// found" here — #G17 (enforceProjectMFA/ProjectMFABlocked,
+// server/grpc/services/conversions.go and server/middleware/auth.go) is the
+// precedent this mirrors: a lookup error on a security-relevant path must not
+// be indistinguishable from a legitimate negative result, or a caller can
+// trigger the same lookup error to silently bypass whatever the error would
+// otherwise have blocked. "Role not seeded in this deployment" (the NotFound
+// case) is not an error condition here and keeps its current meaning — every
+// other admin-tier name is still checked.
+func (c *KeyorixCore) roleSetContainsAdmin(ctx context.Context, roleIDs []uint) (bool, error) { // nosemgrep: keyorix-unbounded-bulk-slice-param -- roleIDs is a principal's resolved current role set (scopedRoleIDs/GetUserRoleIDsAt), not a raw client-supplied array; every call site passes an internally-computed list
 	if len(roleIDs) == 0 {
-		return false
+		return false, nil
 	}
 	idSet := make(map[uint]struct{}, len(roleIDs))
 	for _, id := range roleIDs {
@@ -354,13 +373,16 @@ func (c *KeyorixCore) roleSetContainsAdmin(ctx context.Context, roleIDs []uint) 
 	for _, name := range adminRoleNames {
 		role, err := c.storage.GetRoleByName(ctx, name)
 		if err != nil {
-			continue // role not seeded in this deployment
+			if strings.Contains(err.Error(), "not found") {
+				continue // role not seeded in this deployment
+			}
+			return false, err
 		}
 		if _, ok := idSet[role.ID]; ok {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // requireGlobalAdminToReinstateAdminRoles refuses to reinstate roleIDs unless
@@ -376,7 +398,11 @@ func (c *KeyorixCore) roleSetContainsAdmin(ctx context.Context, roleIDs []uint) 
 // (e.g. an incident-response revocation), the same escalation-by-proxy shape
 // requireAuthorityForRole closes for direct grants.
 func (c *KeyorixCore) requireGlobalAdminToReinstateAdminRoles(ctx context.Context, actorID uint, roleIDs []uint, objectDesc string) error {
-	if !c.roleSetContainsAdmin(ctx, roleIDs) {
+	containsAdmin, err := c.roleSetContainsAdmin(ctx, roleIDs)
+	if err != nil {
+		return fmt.Errorf("failed to resolve role authority: %w", err)
+	}
+	if !containsAdmin {
 		return nil
 	}
 	isAdmin, err := c.IsGlobalAdmin(ctx, actorID)
@@ -450,7 +476,11 @@ func (c *KeyorixCore) requireMachinePrivilegeCeiling(ctx context.Context, actorI
 	for i, r := range roles {
 		roleIDs[i] = r.ID
 	}
-	if !c.roleSetContainsAdmin(ctx, roleIDs) {
+	containsAdmin, err := c.roleSetContainsAdmin(ctx, roleIDs)
+	if err != nil {
+		return fmt.Errorf("failed to check machine privilege ceiling: %w", err)
+	}
+	if !containsAdmin {
 		return nil
 	}
 	isAdmin, err := c.IsGlobalAdmin(ctx, actorID)

--- a/internal/core/authz_mock_test.go
+++ b/internal/core/authz_mock_test.go
@@ -3,7 +3,6 @@ package core
 import (
 	"errors"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -16,10 +15,14 @@ func stubAuthorizedPrincipal(ms *MockStorage, actorID uint, scope Scope, perm st
 	const roleID = uint(10)
 	ms.On("GetUserRoleIDsAt", mock.Anything, actorID, scope).Return([]uint{roleID}, nil).Maybe()
 	ms.On("GetUserGroupRoleIDsAt", mock.Anything, actorID, scope).Return([]uint{}, nil).Maybe()
-	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, assert.AnError).Maybe()
-	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, assert.AnError).Maybe()
-	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, assert.AnError).Maybe()
-	ms.On("GetRoleByName", mock.Anything, "project_admin").Return(nil, assert.AnError).Maybe()
+	// "not found", not a generic error: roleSetContainsAdmin distinguishes a genuine
+	// storage error (propagated, fails closed) from a role simply not being seeded in
+	// this deployment (skipped, checks the next admin-tier name) — see #G17. This stub
+	// means "none of the four admin-tier roles are seeded/held", not "storage is down".
+	ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found")).Maybe()
+	ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found")).Maybe()
+	ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found")).Maybe()
+	ms.On("GetRoleByName", mock.Anything, "project_admin").Return(nil, errors.New("not found")).Maybe()
 	ms.On("RoleSetHasPermission", mock.Anything, []uint{roleID}, perm).Return(true, nil).Maybe()
 }
 

--- a/internal/core/authz_pat_test.go
+++ b/internal/core/authz_pat_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -90,11 +91,12 @@ func TestAuthorize_PATRestriction(t *testing.T) {
 		// Context carries the restriction, so match on Anything for ctx.
 		ms.On("GetUserRoleIDsAt", mock.Anything, uint(1), scope).Return([]uint{10}, nil)
 		ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(1), scope).Return([]uint{}, nil)
-		// Not an admin role set — every admin-name lookup misses.
-		ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, assert.AnError)
-		ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, assert.AnError)
-		ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, assert.AnError)
-		ms.On("GetRoleByName", mock.Anything, "project_admin").Return(nil, assert.AnError)
+		// Not an admin role set — every admin-name lookup misses (not found, not a
+		// genuine storage error — roleSetContainsAdmin distinguishes the two).
+		ms.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, errors.New("not found"))
+		ms.On("GetRoleByName", mock.Anything, "admin").Return(nil, errors.New("not found"))
+		ms.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, errors.New("not found"))
+		ms.On("GetRoleByName", mock.Anything, "project_admin").Return(nil, errors.New("not found"))
 		ms.On("RoleSetHasPermission", mock.Anything, []uint{10}, "secrets.read").Return(true, nil)
 
 		rctx := WithPATRestriction(ctx, &PATRestriction{Permissions: []string{"secrets.read"}, ProjectID: 5})
@@ -109,10 +111,10 @@ func TestAuthorize_PATRestriction(t *testing.T) {
 		scope := storage.Scope{ProjectID: 5}
 		ms.On("GetUserRoleIDsAt", ctx, uint(1), scope).Return([]uint{10}, nil)
 		ms.On("GetUserGroupRoleIDsAt", ctx, uint(1), scope).Return([]uint{}, nil)
-		ms.On("GetRoleByName", ctx, "super_admin").Return(nil, assert.AnError)
-		ms.On("GetRoleByName", ctx, "admin").Return(nil, assert.AnError)
-		ms.On("GetRoleByName", ctx, "system_admin").Return(nil, assert.AnError)
-		ms.On("GetRoleByName", ctx, "project_admin").Return(nil, assert.AnError)
+		ms.On("GetRoleByName", ctx, "super_admin").Return(nil, errors.New("not found"))
+		ms.On("GetRoleByName", ctx, "admin").Return(nil, errors.New("not found"))
+		ms.On("GetRoleByName", ctx, "system_admin").Return(nil, errors.New("not found"))
+		ms.On("GetRoleByName", ctx, "project_admin").Return(nil, errors.New("not found"))
 		ms.On("RoleSetHasPermission", ctx, []uint{10}, "secrets.write").Return(true, nil)
 
 		allowed, err := c.Authorize(ctx, 1, "secrets.write", Scope{ProjectID: 5})

--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -322,7 +322,11 @@ func (c *KeyorixCore) requireDynamicSecretAdminAuthority(ctx context.Context, ac
 	if err != nil {
 		return fmt.Errorf("failed to resolve actor authority: %w", err)
 	}
-	if !c.roleSetContainsAdmin(ctx, ids) {
+	containsAdmin, err := c.roleSetContainsAdmin(ctx, ids)
+	if err != nil {
+		return fmt.Errorf("failed to resolve actor authority: %w", err)
+	}
+	if !containsAdmin {
 		return fmt.Errorf("binding a dynamic-secret backend requires admin authority on this project")
 	}
 	return nil

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -79,7 +79,11 @@ func (c *KeyorixCore) requireAdminAuthorityAt(ctx context.Context, actorID, proj
 	if err != nil {
 		return fmt.Errorf("failed to resolve actor authority: %w", err)
 	}
-	if !c.roleSetContainsAdmin(ctx, ids) {
+	containsAdmin, err := c.roleSetContainsAdmin(ctx, ids)
+	if err != nil {
+		return fmt.Errorf("failed to resolve actor authority: %w", err)
+	}
+	if !containsAdmin {
 		return fmt.Errorf("admin authority is required")
 	}
 	return nil

--- a/internal/core/role_set_contains_admin_error_test.go
+++ b/internal/core/role_set_contains_admin_error_test.go
@@ -1,0 +1,62 @@
+// role_set_contains_admin_error_test.go — regression tests for the
+// roleSetContainsAdmin error-swallowing fix, independent of ADR-084.
+//
+// roleSetContainsAdmin used to treat any GetRoleByName failure — a genuine
+// storage error, not just "role not seeded in this deployment" — identically
+// via a bare `continue`, silently returning false. At
+// requireGlobalAdminToReinstateAdminRoles and requireMachinePrivilegeCeiling,
+// that false is the DANGEROUS direction: it skips a privilege-escalation
+// ceiling check rather than denying, the same "lookup error indistinguishable
+// from a legitimate negative result" shape #G17 fixed for
+// enforceProjectMFA/ProjectMFABlocked. These tests force a genuine
+// (non-not-found) GetRoleByName error and assert both functions now deny
+// rather than silently allow.
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequireGlobalAdminToReinstateAdminRoles_StorageErrorFailsClosed forces
+// a genuine GetRoleByName error (not "not found") while resolving whether the
+// set being reinstated contains an admin-tier role, and asserts the
+// reinstatement is denied rather than silently allowed.
+func TestRequireGlobalAdminToReinstateAdminRoles_StorageErrorFailsClosed(t *testing.T) {
+	mockStorage := &MockStorage{}
+	for _, name := range adminRoleNames {
+		mockStorage.On("GetRoleByName", mock.Anything, name).
+			Return(nil, errors.New("connection reset by peer"))
+	}
+
+	c := NewKeyorixCore(mockStorage)
+	ctx := context.Background()
+
+	err := c.requireGlobalAdminToReinstateAdminRoles(ctx, 1, []uint{42}, "group")
+	require.Error(t, err, "a storage error resolving admin-tier membership must deny the reinstatement, not silently allow it")
+}
+
+// TestRequireMachinePrivilegeCeiling_StorageErrorFailsClosed forces a genuine
+// GetRoleByName error while resolving whether a machine's role set contains an
+// admin-tier role, and asserts token issuance is denied rather than silently
+// allowed.
+func TestRequireMachinePrivilegeCeiling_StorageErrorFailsClosed(t *testing.T) {
+	mockStorage := &MockStorage{}
+	mockStorage.On("GetMachineRoles", mock.Anything, uint(7)).
+		Return([]*models.Role{{ID: 42, Name: "some-custom-role"}}, nil)
+	for _, name := range adminRoleNames {
+		mockStorage.On("GetRoleByName", mock.Anything, name).
+			Return(nil, errors.New("connection reset by peer"))
+	}
+
+	c := NewKeyorixCore(mockStorage)
+	ctx := context.Background()
+
+	err := c.requireMachinePrivilegeCeiling(ctx, 1, 7)
+	require.Error(t, err, "a storage error resolving the machine's admin-tier membership must deny token issuance, not silently allow it")
+}

--- a/internal/core/scim_groups.go
+++ b/internal/core/scim_groups.go
@@ -224,8 +224,10 @@ func (c *KeyorixCore) PatchSCIMGroup(ctx context.Context, actorID, groupID uint,
 
 // scimGroupConfersAdmin reports whether membership in groupID grants an admin role, so
 // the SCIM group-sync paths can refuse to add members to it. Fails CLOSED (treats the
-// group as admin-bearing) on a lookup error, so an inability to verify never opens the
-// privilege grant.
+// group as admin-bearing) on a lookup error — either GetGroupRoles' own, or a genuine
+// roleSetContainsAdmin resolution error (#G17-style: a lookup failure must not be
+// indistinguishable from a legitimate negative result) — so an inability to verify
+// never opens the privilege grant.
 func (c *KeyorixCore) scimGroupConfersAdmin(ctx context.Context, groupID uint) bool {
 	roles, err := c.storage.GetGroupRoles(ctx, groupID)
 	if err != nil {
@@ -235,7 +237,11 @@ func (c *KeyorixCore) scimGroupConfersAdmin(ctx context.Context, groupID uint) b
 	for _, r := range roles {
 		ids = append(ids, r.ID)
 	}
-	return c.roleSetContainsAdmin(ctx, ids)
+	containsAdmin, err := c.roleSetContainsAdmin(ctx, ids)
+	if err != nil {
+		return true
+	}
+	return containsAdmin
 }
 
 func buildSCIMMemberMaps(memberIDs []uint, current []*models.User) (want, have map[uint]bool) {


### PR DESCRIPTION
## Summary

`roleSetContainsAdmin` used to swallow every `GetRoleByName` error identically via a bare `continue` — a genuine transient storage error (a dropped connection, a cancelled context) was treated exactly the same as "this role isn't seeded in this deployment", silently returning `false` either way.

At two of the function's call sites — `requireGlobalAdminToReinstateAdminRoles` (`authz.go:379`) and `requireMachinePrivilegeCeiling` (`authz.go:453`) — `false` is the dangerous direction: both **skip a privilege-escalation ceiling check** on `false`, rather than deny. A storage error during admin-tier role resolution could therefore silently allow:
- reinstating a soft-deleted principal's admin-conferring role grant, or
- issuing a token for a machine identity holding admin-tier roles

without ever checking the actor is a global admin.

## Precedent

Same shape as **#G17** (`enforceProjectMFA`/`ProjectMFABlocked`, `server/grpc/services/conversions.go` and `server/middleware/auth.go`, commit `10371788`): a lookup error on a security-relevant path must not be indistinguishable from a legitimate negative result, or a caller can trigger the same lookup error to bypass whatever the error would otherwise have blocked. Cited directly in the new function's doc comment.

## Fix

`roleSetContainsAdmin` now returns `(bool, error)`, distinguishing `GetRoleByName`'s "not found" branch (kept — same meaning as before, role genuinely not seeded, check the next admin-tier name) from any other error (propagated). Every call site updated to fail closed on that error.

**Eight call sites, not the six originally scoped** (`authz.go`/`dynamic_secrets.go`) — two more surfaced once the build broke on the new signature: `invitations.go`'s `requireAdminAuthorityAt` and `scim_groups.go`'s `scimGroupConfersAdmin` (which already failed closed on its own `GetGroupRoles` error; extended the same fail-closed return to a `roleSetContainsAdmin` error).

## Fixtures

Two pre-existing test fixtures broke once the fix ran end-to-end — caught before push, matching #G17's own experience. The shared `stubAuthorizedPrincipal` helper (`authz_mock_test.go`) and two inline stubs in `authz_pat_test.go` used `assert.AnError` as a stand-in for "this admin-tier role isn't seeded". `assert.AnError`'s message ("assert.AnError general error for testing") doesn't contain "not found", so with the fix distinguishing the two, it's now correctly treated as a genuine error rather than silently swallowed. **This means the "not found" path through these fixtures was never actually genuinely exercised before** — the tests happened to pass because the old code didn't care what kind of error it got. Fixed to `errors.New("not found")`, matching an existing convention already used elsewhere in the suite (`core_s24_test.go`).

Confirmed a superficially similar `assert.AnError` stub in `sso_test.go` is unrelated — it backs `installAdminRoleIDSet` (`rbac_management.go`), a separate, out-of-scope function this fix doesn't touch.

## Tests

New tests (`role_set_contains_admin_error_test.go`) force a genuine, non-"not found" `GetRoleByName` error at both dangerous-polarity sites and assert denial. Verified both fail against the pre-fix code (temporarily reverted the four changed non-test files, confirmed "An error is expected but got nil" on both, restored the fix) before trusting them.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- `gosec -severity medium -exclude-generated` on `internal/core` — 0 issues
- Full `internal/core` suite passes
- Full `server/grpc` and `server/http/handlers` suites pass
- `server/http`'s 18 failures are byte-for-byte the established pre-existing baseline (zero new, zero resolved)