### PR TITLE
test(core): enforce defaultPermissions/adminPermissions invariants (#1497)

### DIFF
--- a/internal/core/default_roles_permission_catalog_test.go
+++ b/internal/core/default_roles_permission_catalog_test.go
@@ -1,0 +1,123 @@
+// default_roles_permission_catalog_test.go — regression test for #1497:
+// defaultPermissions (auth_bootstrap.go:47) and adminPermissions
+// (auth_bootstrap.go:95) matched 14/14 by coincidence, with nothing
+// enforcing it. Two distinct invariants, checked separately so a failure
+// names which one broke:
+//
+//   - Identity: adminPermissions (shared by the "admin" and "system_admin"
+//     defaultRoles entries — the two roles whose own description promises
+//     "full access") must contain every permission in defaultPermissions,
+//     exactly. A permission added to defaultPermissions without a matching
+//     addition to adminPermissions would be created in the catalog by
+//     ReconcileRBACPermissions but never granted to admin/system_admin,
+//     silently narrowing "full access" (see #1496's investigation).
+//   - Subset: every OTHER defaultRoles entry's Permissions list must
+//     reference only names that exist in defaultPermissions. A dangling
+//     reference there would be a live bug (a role definition naming a
+//     permission that's never created), not just a missing test — verified
+//     absent today by direct enumeration during #1497's investigation, but
+//     nothing stopped a future entry from introducing one silently.
+package core
+
+import (
+	"sort"
+	"testing"
+)
+
+// defaultPermissionNames returns the set of permission names defaultPermissions
+// declares.
+func defaultPermissionNames() map[string]bool {
+	names := make(map[string]bool, len(defaultPermissions))
+	for _, p := range defaultPermissions {
+		names[p.Name] = true
+	}
+	return names
+}
+
+// TestAdminPermissions_MatchesDefaultPermissionsCatalogExactly encodes the
+// identity invariant: adminPermissions must be exactly defaultPermissions,
+// no more, no less. Fails naming any permission missing from adminPermissions
+// (admin/system_admin would silently lose "full access" to it) and any extra
+// permission in adminPermissions that isn't in defaultPermissions (a typo or
+// stale name — the grant would fail at bootstrap since AssignPermissionToRole
+// resolves it against the created catalog).
+func TestAdminPermissions_MatchesDefaultPermissionsCatalogExactly(t *testing.T) {
+	catalog := defaultPermissionNames()
+
+	admin := make(map[string]bool, len(adminPermissions))
+	for _, name := range adminPermissions {
+		admin[name] = true
+	}
+
+	var missingFromAdmin, extraInAdmin []string
+	for name := range catalog {
+		if !admin[name] {
+			missingFromAdmin = append(missingFromAdmin, name)
+		}
+	}
+	for name := range admin {
+		if !catalog[name] {
+			extraInAdmin = append(extraInAdmin, name)
+		}
+	}
+	sort.Strings(missingFromAdmin)
+	sort.Strings(extraInAdmin)
+
+	if len(missingFromAdmin) > 0 {
+		t.Errorf("adminPermissions is missing permission(s) present in defaultPermissions: %v\n"+
+			"admin/system_admin are documented as \"full access\" — add the permission to adminPermissions "+
+			"(auth_bootstrap.go), or ReconcileRBACPermissions will create it in the catalog but never grant "+
+			"it to admin/system_admin on an upgraded install.", missingFromAdmin)
+	}
+	if len(extraInAdmin) > 0 {
+		t.Errorf("adminPermissions references permission(s) not present in defaultPermissions: %v\n"+
+			"this is a dangling name (typo, or a permission removed from defaultPermissions without "+
+			"updating adminPermissions) — the grant would fail to resolve against the created catalog.", extraInAdmin)
+	}
+}
+
+// TestDefaultRoles_NonAdminEntriesReferenceOnlyCatalogedPermissions encodes
+// the subset invariant for every defaultRoles entry OTHER than "admin" and
+// "system_admin" (covered by the identity invariant above, since they share
+// adminPermissions): every permission name in the role's list must exist in
+// defaultPermissions. A failure here means a role definition names a
+// permission that's never created — a live bug, not a missing test, since
+// AssignPermissionToRole would fail to resolve it during bootstrap.
+func TestDefaultRoles_NonAdminEntriesReferenceOnlyCatalogedPermissions(t *testing.T) {
+	catalog := defaultPermissionNames()
+
+	// "admin" and "system_admin" both use adminPermissions and are covered by
+	// the identity invariant test above — skip them here so a genuine subset
+	// violation isn't masked by (or duplicated with) that test's own failure.
+	adminTierRoles := map[string]bool{"admin": true, "system_admin": true}
+
+	checked := 0
+	for _, rdef := range defaultRoles {
+		if adminTierRoles[rdef.Name] {
+			continue
+		}
+		checked++
+		var undefined []string
+		for _, permName := range rdef.Permissions {
+			if !catalog[permName] {
+				undefined = append(undefined, permName)
+			}
+		}
+		if len(undefined) > 0 {
+			sort.Strings(undefined)
+			t.Errorf("defaultRoles entry %q references permission(s) absent from defaultPermissions: %v\n"+
+				"this role would fail to seed correctly at bootstrap — either add the permission to "+
+				"defaultPermissions (auth_bootstrap.go) or remove the dangling reference from this role's list.",
+				rdef.Name, undefined)
+		}
+	}
+
+	// The two admin-tier roles are the only defaultRoles entries expected to
+	// be skipped; if that ever changes (a role renamed, a new admin-tier role
+	// added under a different name), this catches the coverage gap rather
+	// than silently checking fewer roles than defaultRoles actually has.
+	if want := len(defaultRoles) - len(adminTierRoles); checked != want {
+		t.Fatalf("expected to check %d non-admin-tier defaultRoles entries, checked %d — "+
+			"defaultRoles or adminTierRoles changed without updating this test", want, checked)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1497

`adminPermissions` (`auth_bootstrap.go:95`) currently matches `defaultPermissions` (`auth_bootstrap.go:47`) 14/14, but coincidentally — nothing enforced it. A future permission addition that updated `defaultPermissions` without a matching addition to `adminPermissions` would silently narrow `admin`/`system_admin`'s "full access": `ReconcileRBACPermissions` creates the new permission in the catalog but only ever grants it to a role whose *static* list already names it.

Investigated first and confirmed no live bug exists today: every permission name referenced by every `defaultRoles` entry — not just the two admin-tier ones — resolves to an entry in `defaultPermissions`, checked by direct enumeration against the actual resolved constants, not assumed.

## Two invariants, and why they differ

- **Identity**, for `admin`/`system_admin` (both use the shared `adminPermissions` list): these two roles are documented as "full access" and meant to hold complete permission coverage *independent of* the separate name-based admin bypass (`roleSetContainsAdmin`) — their explicit grants should never fall short of the canonical catalog on their own. `TestAdminPermissions_MatchesDefaultPermissionsCatalogExactly` reports missing and extra permissions independently, so a failure names which direction broke.
- **Subset**, for the other eight `defaultRoles` entries (`editor`, `viewer`, `system_auditor`, `system_viewer`, `project_admin`, `project_developer`, `project_viewer`, `project_auditor`): these are deliberately narrower than the full catalog by design, so the only invariant that applies is that every permission they reference actually exists — a dangling reference would be a real bootstrap-time bug (`AssignPermissionToRole` failing to resolve it), not just a missing test. `TestDefaultRoles_NonAdminEntriesReferenceOnlyCatalogedPermissions` names the exact role and the exact dangling permission on failure, plus a count assertion that catches the coverage gap itself if `defaultRoles` or the admin-tier role set ever changes without updating this test.

Both verified non-vacuous: temporarily broke each invariant (removed a permission from `adminPermissions` and added a bogus one; added a bogus permission to `editorPermissions`), confirmed each test failed with the expected message naming the exact break, then restored before committing.

## #1496 — investigated, not fixed here

`ReconcileRBACPermissions`'s additive-on-create-only behavior was investigated as a possible companion fix and found to be **documented intent, not a defect** — closed separately (`#1496`) with a comment quoting ADR-044's own "Alternatives considered" section, which already rejected convergent reconciliation for exactly the reason traced here: `RemovePermissionFromRole` has no built-in-role guard, so an operator can legitimately (and today, silently) revoke a permission from a seeded role, and reconcile deliberately never undoes that. ADR-082 branch 4's upgrade reasoning for `connect.platform.use` remains valid and unaffected — that was the newly-created-permission case reconcile does handle.

The investigation did surface a real, separate gap — `RemovePermissionFromRole`'s missing guard means that legitimate revocation happens with no distinct audit signal and no warning, unlike `UpdateRole`'s equivalent guard. Filed as its own issue: `#1500`.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- `gosec -severity medium -exclude-generated` on `internal/core` — 0 issues
- Full `internal/core` suite passes
- `server/http`'s 18 failures are byte-for-byte the established pre-existing baseline (zero new, zero resolved)