### PR TITLE
fix(security): close Connect config-validation gaps for connector-project bindings and ref-grants

### DIFF
--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -395,7 +395,10 @@ func (c *KeyorixCore) ListConnectRefGrants(ctx context.Context) ([]*models.Conne
 // CreateConnectRefGrant adds a per-reference grant (ADR-045): role roleID may read any
 // ref under refPrefix ("" = all) on connectorName. The connector must be configured —
 // scoping a non-existent (typo'd) connector is rejected so an operator can't believe
-// they restricted a connector that is in fact still unscoped. expiresAt makes the
+// they restricted a connector that is in fact still unscoped. A platform-scoped
+// connector is also rejected (#1479): its ownership check is a terminal deny in
+// ReadFederatedSecret, so a grant against it would never be consulted — see
+// ErrConnectRefGrantAgainstPlatformConnector's own doc comment. expiresAt makes the
 // grant time-bound (nil = permanent), mirroring UserRole.ExpiresAt / ShareRecord.
 // ExpiresAt — a Connect grant is otherwise permanent with no way to make it JIT.
 // Audited.
@@ -405,6 +408,9 @@ func (c *KeyorixCore) CreateConnectRefGrant(ctx context.Context, actorID, roleID
 	}
 	if _, ok := c.connectManager.Get(connectorName); !ok {
 		return nil, fmt.Errorf("%w %q", ErrConnectUnknownConnector, connectorName)
+	}
+	if c.connectOwnership[connectorName].Scope == "platform" {
+		return nil, fmt.Errorf("%w %q", ErrConnectRefGrantAgainstPlatformConnector, connectorName)
 	}
 	if roleID == 0 {
 		return nil, ErrConnectRoleRequired

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -329,9 +329,15 @@ func TestConnectRefRBAC_UnexpiredGrantAllowed(t *testing.T) {
 // CreateConnectRefGrant plumbs an optional expiresAt through to the persisted grant.
 // ADR-082 branch 4: unaffected by the connect.platform.use gate — this test never
 // calls ReadFederatedSecret/connectOwnershipSatisfied at all, only the grant-
-// management path.
+// management path. #1479: connectRBACCore defaults every connector to
+// Scope: "platform", which CreateConnectRefGrant now refuses — override to
+// "project" here since this test is about expiresAt plumbing, not scope, and
+// a platform-scoped grant would be rejected before reaching the code this
+// test actually exercises.
 func TestCreateConnectRefGrant_PersistsExpiresAt(t *testing.T) {
 	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	require.NoError(t, db.Create(&models.Project{ID: 10, Name: "proj-a"}).Error)
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 10}})
 	require.NoError(t, db.Create(&models.Role{ID: 5, Name: "temp-reader"}).Error)
 	exp := time.Now().Add(time.Hour).Truncate(time.Second)
 
@@ -344,6 +350,42 @@ func TestCreateConnectRefGrant_PersistsExpiresAt(t *testing.T) {
 	g2, err := c.CreateConnectRefGrant(context.Background(), 1, 5, "aws", "db/", nil)
 	require.NoError(t, err)
 	assert.Nil(t, g2.ExpiresAt)
+}
+
+// TestCreateConnectRefGrant_RefusesAgainstPlatformConnector is #1479's fix:
+// a platform-scoped connector's ownership check is a terminal deny in
+// ReadFederatedSecret (connectOwnershipSatisfied never falls through to
+// ConnectRefGrant delegation for one), so a grant created against one would
+// be dead configuration — accepted, listed, never once consulted by a read.
+// connectRBACCore's default wiring (every connector scope: platform) is
+// exactly the case this test needs, no override required.
+func TestCreateConnectRefGrant_RefusesAgainstPlatformConnector(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	require.NoError(t, db.Create(&models.Role{ID: 5, Name: "temp-reader"}).Error)
+
+	g, err := c.CreateConnectRefGrant(context.Background(), 1, 5, "aws", "metrics/", nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrConnectRefGrantAgainstPlatformConnector)
+	assert.Nil(t, g)
+
+	grants, err := c.storage.ListConnectRefGrants(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, grants, "a refused grant must not be persisted")
+}
+
+// TestCreateConnectRefGrant_StillAllowedAgainstProjectConnector confirms the
+// #1479 fix is scope-specific, not a blanket new restriction: a project-scoped
+// connector's ConnectRefGrant creation is unaffected.
+func TestCreateConnectRefGrant_StillAllowedAgainstProjectConnector(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	require.NoError(t, db.Create(&models.Project{ID: 10, Name: "proj-a"}).Error)
+	c.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 10}})
+	require.NoError(t, db.Create(&models.Role{ID: 5, Name: "temp-reader"}).Error)
+
+	g, err := c.CreateConnectRefGrant(context.Background(), 1, 5, "aws", "metrics/", nil)
+	require.NoError(t, err)
+	require.NotNil(t, g)
+	assert.Equal(t, "aws", g.Connector)
 }
 
 // G33: a machine identity's ConnectRefGrant-referenced role held ONLY at a

--- a/internal/core/connect_test.go
+++ b/internal/core/connect_test.go
@@ -205,6 +205,11 @@ func TestConnectErrors_AreTypedSentinels(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrConnectUnknownConnector)
 
+	// #1479: connectTestCore defaults every connector to Scope: "platform",
+	// which CreateConnectRefGrant now refuses before ever reaching the
+	// roleID==0 check below — override to "project" so this assertion still
+	// isolates the roleID check it's actually testing.
+	c2.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "project", ProjectID: 1}})
 	_, err = c2.CreateConnectRefGrant(context.Background(), 1, 0, "aws", "", nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrConnectRoleRequired)
@@ -212,6 +217,14 @@ func TestConnectErrors_AreTypedSentinels(t *testing.T) {
 	_, err = c2.CreateConnectRefGrant(context.Background(), 1, 5, "nope", "", nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrConnectUnknownConnector)
+
+	_, err = c2.CreateConnectRefGrant(context.Background(), 1, 5, "aws", "", nil)
+	require.NoError(t, err, "a project-scoped connector must still allow grant creation")
+
+	c2.SetConnectOwnership(map[string]ConnectOwnership{"aws": {Scope: "platform"}})
+	_, err = c2.CreateConnectRefGrant(context.Background(), 1, 5, "aws", "", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrConnectRefGrantAgainstPlatformConnector)
 }
 
 // TestReadFederatedSecret_AuditDescriptionRedactsRawUpstreamError is the G50

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -73,6 +73,18 @@ var (
 	// ErrConnectRoleRequired is returned by CreateConnectRefGrant when roleID is 0.
 	ErrConnectRoleRequired = errors.New("a role is required for a connect ref-grant")
 
+	// ErrConnectRefGrantAgainstPlatformConnector is returned by
+	// CreateConnectRefGrant (#1479) when connectorName is platform-scoped
+	// (ADR-082 §B). A platform connector's ownership check is a TERMINAL deny in
+	// ReadFederatedSecret — a caller who lacks connect.platform.use never falls
+	// through to ConnectRefGrant delegation, deliberately (see
+	// connectOwnershipSatisfied and connectDenyReasonPlatformPermissionDenied).
+	// A grant created against one would be accepted, listed, and never once
+	// consulted by any read — dead configuration that looks live. Refused at
+	// creation, matching the sibling "connector must be configured" check one
+	// line above it.
+	ErrConnectRefGrantAgainstPlatformConnector = errors.New("connector is platform-scoped; platform connectors are a terminal deny under ADR-082 and a ref-grant against one would never take effect")
+
 	// ErrConnectRefNotPermitted is returned by ReadFederatedSecret when the
 	// per-reference RBAC policy (ADR-045) denies the read. These four Connect
 	// sentinels exist so the HTTP layer (isSafeConnectError) can classify its own

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1753,6 +1753,9 @@ func (m *MockStorage) GetConnectorProjectBinding(_ context.Context, _ string) (*
 func (m *MockStorage) CreateConnectorProjectBinding(_ context.Context, binding *models.ConnectorProjectBinding) (*models.ConnectorProjectBinding, error) {
 	return binding, nil
 }
+func (m *MockStorage) ListConnectorProjectBindings(_ context.Context) ([]*models.ConnectorProjectBinding, error) {
+	return nil, nil
+}
 
 // Group-Role assignments
 

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1054,6 +1054,12 @@ type Storage interface {
 	// resolution (ADR-082): the connector name, the resolved project ID, and the
 	// project's name at resolution time (for later rename detection).
 	CreateConnectorProjectBinding(ctx context.Context, binding *models.ConnectorProjectBinding) (*models.ConnectorProjectBinding, error)
+	// ListConnectorProjectBindings returns every persisted connector→project
+	// binding row (#1477's orphan-detection direction: a binding whose connector
+	// name is no longer in cfg.Connect.Connectors). Boot-time-diagnostic only —
+	// GetConnectorProjectBinding/CreateConnectorProjectBinding cover the
+	// per-connector resolution path this does not participate in.
+	ListConnectorProjectBindings(ctx context.Context) ([]*models.ConnectorProjectBinding, error)
 
 	// Group-Role assignments. Assign/Remove bind a role to a group at the given
 	// Scope (zero Scope = global).

--- a/internal/storage/store/local_connector_project_bindings.go
+++ b/internal/storage/store/local_connector_project_bindings.go
@@ -39,3 +39,14 @@ func (ls *LocalStorage) CreateConnectorProjectBinding(ctx context.Context, bindi
 	}
 	return binding, nil
 }
+
+// ListConnectorProjectBindings returns every persisted binding row, unfiltered
+// (#1477's orphan-detection direction — see the boot-time consistency warning
+// in server/main.go, the only caller).
+func (ls *LocalStorage) ListConnectorProjectBindings(ctx context.Context) ([]*models.ConnectorProjectBinding, error) {
+	var bindings []*models.ConnectorProjectBinding
+	if err := ls.db.WithContext(ctx).Find(&bindings).Error; err != nil {
+		return nil, fmt.Errorf("failed to list connector project bindings: %w", err)
+	}
+	return bindings, nil
+}

--- a/internal/storage/store/remote_connector_project_bindings.go
+++ b/internal/storage/store/remote_connector_project_bindings.go
@@ -74,6 +74,17 @@ func (rs *RemoteStorage) GetConnectorProjectBinding(ctx context.Context, connect
 	return wire.toModel(), nil
 }
 
+// ListConnectorProjectBindings is not supported in remote storage: it backs
+// only the boot-time orphan-detection warning (server/main.go), a diagnostic
+// that runs against the resolving server's OWN storage — the same "a server
+// on storage.type: remote never reaches this code" reasoning ADR-083
+// established for the RBAC primitives this mirrors (see remote_rbac.go),
+// not the #527 "would fail boot" failure shape Get/CreateConnectorProjectBinding
+// above are real implementations to avoid.
+func (rs *RemoteStorage) ListConnectorProjectBindings(_ context.Context) ([]*models.ConnectorProjectBinding, error) {
+	return nil, remoteUnsupported("ListConnectorProjectBindings")
+}
+
 // CreateConnectorProjectBinding persists a connector's first-boot project
 // resolution via POST /api/v1/system/connector-project-bindings.
 func (rs *RemoteStorage) CreateConnectorProjectBinding(ctx context.Context, binding *models.ConnectorProjectBinding) (*models.ConnectorProjectBinding, error) {

--- a/internal/storage/store/remote_connector_project_bindings_completeness_test.go
+++ b/internal/storage/store/remote_connector_project_bindings_completeness_test.go
@@ -1,0 +1,8 @@
+package store
+
+func init() {
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		"ListConnectorProjectBindings": {statusIntentional,
+			"#1477/#1479: backs only the boot-time drift warning (server/main.go warnConnectConfigDrift), which runs against the resolving server's own storage right after SetConnectOwnership — a server on storage.type: remote never reaches this code path (ADR-083), same reasoning as the RBAC primitives in remote_rbac.go"},
+	})
+}

--- a/server/connect_ownership_resolution_test.go
+++ b/server/connect_ownership_resolution_test.go
@@ -7,7 +7,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -196,4 +198,81 @@ func TestConnectOwnershipKeySetMismatch_NoExemptionForAnyDivergence(t *testing.T
 	ownership := map[string]core.ConnectOwnership{} // empty: nothing resolved for "aws"
 	mismatch := connectOwnershipKeySetMismatch([]string{"aws"}, ownership)
 	assert.Equal(t, []string{"aws"}, mismatch, "with allow_unscoped removed, there is no exemption — any divergence, including what used to be the unscoped case, must be reported")
+}
+
+// captureLog redirects the standard logger to a buffer for the duration of the
+// test, restoring the original writer on cleanup — matches the convention
+// already established in transport_tls_test.go for asserting on warn-only log
+// output.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(orig) })
+	return &buf
+}
+
+// TestWarnConnectConfigDrift_DeadRefGrant is #1479's boot-time half: a
+// ConnectRefGrant created while its connector was scope: project (or
+// pre-dating any scope requirement) becomes dead configuration if the config
+// is later edited to scope: platform — create-time refusal (CreateConnectRefGrant)
+// cannot catch this, since the grant already existed before the edit. Proves
+// the warning fires, names the connector, and — critically — does not fail
+// boot (no panic, no error return; warnConnectConfigDrift has no error return
+// at all, this test would simply not compile if it acquired one unexpectedly).
+func TestWarnConnectConfigDrift_DeadRefGrant(t *testing.T) {
+	st, db := connectOwnershipResolutionStorage(t)
+	require.NoError(t, db.AutoMigrate(&models.ConnectRefGrant{}))
+	require.NoError(t, db.Create(&models.ConnectRefGrant{RoleID: 5, Connector: "aws", RefPrefix: "metrics/"}).Error)
+
+	buf := captureLog(t)
+	warnConnectConfigDrift(context.Background(), st, map[string]core.ConnectOwnership{
+		"aws": {Scope: "platform"},
+	})
+
+	assert.Contains(t, buf.String(), "aws")
+	assert.Contains(t, buf.String(), "dead configuration")
+}
+
+// TestWarnConnectConfigDrift_OrphanedBinding is #1477's boot-time half: a
+// ConnectorProjectBinding row whose connector name is no longer in
+// cfg.Connect.Connectors (removed, or renamed in config) — neither side of
+// connectOwnershipKeySetMismatch enumerates DB rows, so this is the only
+// check that catches it. Proves the warning fires and names the orphaned
+// connector.
+func TestWarnConnectConfigDrift_OrphanedBinding(t *testing.T) {
+	st, db := connectOwnershipResolutionStorage(t)
+	require.NoError(t, db.Create(&models.ConnectorProjectBinding{
+		Connector: "decommissioned", ProjectID: 1, ProjectName: "payments",
+	}).Error)
+
+	buf := captureLog(t)
+	// ownership has no entry for "decommissioned" — matching a config that no
+	// longer lists it at all.
+	warnConnectConfigDrift(context.Background(), st, map[string]core.ConnectOwnership{
+		"aws": {Scope: "platform"},
+	})
+
+	assert.Contains(t, buf.String(), "decommissioned")
+	assert.Contains(t, buf.String(), "orphaned")
+}
+
+// TestWarnConnectConfigDrift_NoFalsePositives confirms a healthy state — a
+// ref-grant against a still-project-scoped connector, a binding whose
+// connector is still configured — produces neither warning.
+func TestWarnConnectConfigDrift_NoFalsePositives(t *testing.T) {
+	st, db := connectOwnershipResolutionStorage(t)
+	require.NoError(t, db.AutoMigrate(&models.ConnectRefGrant{}))
+	require.NoError(t, db.Create(&models.ConnectRefGrant{RoleID: 5, Connector: "aws", RefPrefix: "metrics/"}).Error)
+	require.NoError(t, db.Create(&models.ConnectorProjectBinding{
+		Connector: "aws", ProjectID: 1, ProjectName: "payments",
+	}).Error)
+
+	buf := captureLog(t)
+	warnConnectConfigDrift(context.Background(), st, map[string]core.ConnectOwnership{
+		"aws": {Scope: "project", ProjectID: 1},
+	})
+
+	assert.Empty(t, buf.String(), "a healthy grant/binding state must not produce any drift warning")
 }

--- a/server/grpc/services/connect_service_test.go
+++ b/server/grpc/services/connect_service_test.go
@@ -114,6 +114,11 @@ func TestConnectService_RefGrants_CRUD(t *testing.T) {
 	svc := newConnectService(t)
 	ctx := authCtx(1, "admin", "roles.write")
 
+	// #1479: newConnectService wires "aws" as Scope: "platform", which
+	// CreateConnectRefGrant now refuses — this test is about ref-grant CRUD,
+	// not connector scope, so override to "project" here.
+	svc.core.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "project", ProjectID: 1}})
+
 	// Empty to start.
 	list, err := svc.ListRefGrants(ctx, &emptypb.Empty{})
 	require.NoError(t, err)

--- a/server/grpc/services/conversions.go
+++ b/server/grpc/services/conversions.go
@@ -73,6 +73,7 @@ func isSafeConnectError(msg string) bool {
 		"keyorix connect is not enabled",
 		"unknown connector",
 		"a role is required for a connect ref-grant",
+		"connector is platform-scoped",
 		"is not permitted for your roles on connector",
 	} {
 		if strings.Contains(msg, marker) {

--- a/server/grpc/services/coverage_s23_test.go
+++ b/server/grpc/services/coverage_s23_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"github.com/stretchr/testify/assert"
@@ -528,6 +529,11 @@ func TestDeleteRefGrant_Success_S23(t *testing.T) {
 	// newConnectService seeds the "aws" fake connector so CreateRefGrant can validate it.
 	svc := newConnectService(t)
 	adminCtxConn := authCtx(1, "admin", "connect.read", "roles.read", "roles.write")
+
+	// #1479: newConnectService wires "aws" as Scope: "platform", which
+	// CreateConnectRefGrant now refuses — this test is about delete, not
+	// connector scope, so override to "project" here.
+	svc.core.SetConnectOwnership(map[string]core.ConnectOwnership{"aws": {Scope: "project", ProjectID: 1}})
 
 	// Create a grant so we can delete it.
 	g, err := svc.CreateRefGrant(adminCtxConn, &pb.CreateConnectRefGrantRequest{

--- a/server/http/handlers/connect.go
+++ b/server/http/handlers/connect.go
@@ -21,10 +21,11 @@ import (
 // isSafeConnectError reports whether err is one of the small set of
 // deliberately-crafted, safe sentinel errors core.ReadFederatedSecret /
 // CreateConnectRefGrant / DeleteConnectRefGrant themselves produce (an
-// unknown/disabled connector, a missing role, or a per-reference policy
-// denial). This checks err's type via errors.Is against the core package's
-// sentinels rather than substring-matching err.Error(): connectorName and ref
-// are caller-controlled and, if an upstream connector (e.g. Vault) happened to
+// unknown/disabled connector, a missing role, a platform-scoped connector
+// rejected at grant creation (#1479), or a per-reference policy denial). This
+// checks err's type via errors.Is against the core package's sentinels rather
+// than substring-matching err.Error(): connectorName and ref are
+// caller-controlled and, if an upstream connector (e.g. Vault) happened to
 // echo either back in its own raw error text, a substring match against the
 // message could be spoofed into passing as "safe" and leaking that raw text
 // to the client (backlog #116). Anything that doesn't match one of these
@@ -35,6 +36,7 @@ func isSafeConnectError(err error) bool {
 	return errors.Is(err, core.ErrConnectDisabled) ||
 		errors.Is(err, core.ErrConnectUnknownConnector) ||
 		errors.Is(err, core.ErrConnectRoleRequired) ||
+		errors.Is(err, core.ErrConnectRefGrantAgainstPlatformConnector) ||
 		errors.Is(err, core.ErrConnectRefNotPermitted)
 }
 

--- a/server/http/handlers/connector_project_bindings_proxy.go
+++ b/server/http/handlers/connector_project_bindings_proxy.go
@@ -99,6 +99,18 @@ type connectorProjectBindingCreateBody struct {
 // /api/v1/system/connector-project-bindings. The caller (the downstream server's
 // own boot-time resolution) has already resolved the connector's project: name to
 // an ID; this is a raw persist, no re-resolution.
+//
+// #1477: validates project_id against this hub's own storage — a live project
+// row is exactly what the binding will reference, so a nonexistent ID is
+// rejected rather than silently persisted. Deliberately does NOT validate that
+// connector exists in any config: the connector belongs to the CALLING
+// (downstream) node's cfg.Connect.Connectors, not this hub's own — this hub has
+// no way to see that config, and threading its own config in here would
+// validate against the wrong deployment's connector list, worse than not
+// validating at all. The boot-time consistency warning next to
+// connectOwnershipKeySetMismatch (server/main.go) is the only place in the
+// system that sees both config and DB rows together, and closes the orphaned-
+// binding direction this handler structurally cannot.
 func (h *AuthHandler) CreateConnectorProjectBindingProxy(w http.ResponseWriter, r *http.Request) {
 	var body connectorProjectBindingCreateBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -107,6 +119,15 @@ func (h *AuthHandler) CreateConnectorProjectBindingProxy(w http.ResponseWriter, 
 	}
 	if body.Connector == "" || body.ProjectID == 0 || body.ProjectName == "" {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "connector, project_id, and project_name are required")
+		return
+	}
+	if _, err := h.coreService.Storage().GetProject(r.Context(), body.ProjectID); err != nil {
+		if isProjectNotFound(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errProjectNotFound)
+			return
+		}
+		log.Printf("connector-project-bindings proxy: project lookup failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
 	}
 	created, err := h.coreService.Storage().CreateConnectorProjectBinding(r.Context(), &models.ConnectorProjectBinding{

--- a/server/http/handlers/connector_project_bindings_proxy_test.go
+++ b/server/http/handlers/connector_project_bindings_proxy_test.go
@@ -25,7 +25,7 @@ func newConnectorProjectBindingProxyHandler(t *testing.T) (*AuthHandler, *gorm.D
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.ConnectorProjectBinding{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.ConnectorProjectBinding{}, &models.AuditEvent{}, &models.Project{}))
 	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
 	return NewAuthHandler(cs, false), db
 }
@@ -39,6 +39,7 @@ func newConnectorProjectBindingProxyHandler(t *testing.T) (*AuthHandler, *gorm.D
 // system.write caller, never a human session.
 func TestCreateConnectorProjectBindingProxy_Audited(t *testing.T) {
 	h, db := newConnectorProjectBindingProxyHandler(t)
+	require.NoError(t, db.Create(&models.Project{ID: 7, Name: "payments"}).Error)
 
 	body, err := json.Marshal(map[string]any{
 		"connector":    "aws",
@@ -70,6 +71,7 @@ func TestCreateConnectorProjectBindingProxy_Audited(t *testing.T) {
 // actually persisted.
 func TestCreateConnectorProjectBindingProxy_StorageFailureStillReturnsError(t *testing.T) {
 	h, db := newConnectorProjectBindingProxyHandler(t)
+	require.NoError(t, db.Create(&models.Project{ID: 7, Name: "payments"}).Error)
 
 	body, err := json.Marshal(map[string]any{
 		"connector":    "aws",
@@ -93,4 +95,34 @@ func TestCreateConnectorProjectBindingProxy_StorageFailureStillReturnsError(t *t
 	var count int64
 	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", core.EventConnectorProjectBindingCreate).Count(&count).Error)
 	assert.EqualValues(t, 1, count, "only the successful create should be audited, not the failed duplicate attempt")
+}
+
+// TestCreateConnectorProjectBindingProxy_RejectsNonexistentProject is #1477's
+// fix: project_id must resolve to a live project row in THIS hub's own
+// storage — a binding referencing a project that doesn't exist here would
+// persist as silently-broken configuration. Deliberately does not test
+// connector-name validation (see the handler's own doc comment for why that's
+// not meaningfully possible at this layer).
+func TestCreateConnectorProjectBindingProxy_RejectsNonexistentProject(t *testing.T) {
+	h, db := newConnectorProjectBindingProxyHandler(t)
+	// No project 7 created — the binding's project_id must not resolve.
+
+	body, err := json.Marshal(map[string]any{
+		"connector":    "aws",
+		"project_id":   7,
+		"project_name": "payments",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/connector-project-bindings", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.CreateConnectorProjectBindingProxy(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+
+	var count int64
+	require.NoError(t, db.Model(&models.ConnectorProjectBinding{}).Count(&count).Error)
+	assert.EqualValues(t, 0, count, "no binding should be persisted for a project that doesn't exist")
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", core.EventConnectorProjectBindingCreate).Count(&count).Error)
+	assert.EqualValues(t, 0, count, "a rejected create must not be audited as a successful binding write")
 }

--- a/server/main.go
+++ b/server/main.go
@@ -658,6 +658,17 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			coreService.SetConnectManager(mgr)
 			coreService.SetConnectOwnership(ownership)
 			log.Printf("Keyorix Connect enabled (%d connector(s))", len(connectors))
+
+			// #1477/#1479: warn-only consistency check, run here because this is the
+			// only place in the system that sees both config (ownership, resolved
+			// just above) and DB rows (ConnectRefGrant, ConnectorProjectBinding)
+			// together — the create-time checks (CreateConnectRefGrant,
+			// CreateConnectorProjectBindingProxy) each structurally cannot see this:
+			// a grant/binding valid when created can still drift out of sync with a
+			// LATER config edit. Neither condition this checks is a security risk —
+			// a dead ref-grant or an orphaned binding both already fail closed/are
+			// simply unused, no over-permission — so this warns, never fails boot.
+			warnConnectConfigDrift(context.Background(), coreService.Storage(), ownership)
 		}
 	}
 
@@ -1093,6 +1104,55 @@ func connectOwnershipKeySetMismatch(builtNames []string, ownership map[string]co
 		}
 	}
 	return mismatch
+}
+
+// warnConnectConfigDrift performs two READ-ONLY, warn-only consistency checks
+// after Connect's boot-time wiring (ownership) is resolved — #1477/#1479's
+// boot-time drift detection. This is the only place in the system that sees
+// both config (ownership, resolved from cfg.Connect.Connectors just before
+// this is called) and DB rows (ConnectRefGrant, ConnectorProjectBinding)
+// together, which is why it closes what the create-time checks
+// (CreateConnectRefGrant, CreateConnectorProjectBindingProxy) structurally
+// cannot: a config edit AFTER a grant/binding already exists. Neither
+// condition here is a security risk — a dead ref-grant already denies
+// nothing extra (ReadFederatedSecret's platform branch is a terminal deny
+// regardless of any grant), and an orphaned binding is simply unused, not
+// over-permissive — so this warns, aggregated in ADR-082's own established
+// style (one summary line naming every offender), and never fails boot.
+// Scoped to when Connect's boot-wiring actually runs (cc.Enabled with at
+// least one recognized connector) — a fully-disabled Connect config with
+// leftover rows from a PRIOR enabled state is not covered; that is a
+// narrower, separate case than the config-edit drift this targets.
+func warnConnectConfigDrift(ctx context.Context, st corestorage.Storage, ownership map[string]core.ConnectOwnership) {
+	if grants, err := st.ListConnectRefGrants(ctx); err != nil {
+		log.Printf("Keyorix Connect: boot-time drift check: failed to list ref-grants: %v", err)
+	} else {
+		var dead []string
+		for _, g := range grants {
+			if ownership[g.Connector].Scope == "platform" {
+				dead = append(dead, fmt.Sprintf("grant %d (connector %q)", g.ID, g.Connector))
+			}
+		}
+		if len(dead) > 0 {
+			log.Printf("Keyorix Connect: WARNING: %d ConnectRefGrant(s) are dead configuration — bound to a connector that now resolves to scope: platform, a terminal deny that never consults ref-grant delegation (ADR-082): %s",
+				len(dead), strings.Join(dead, ", "))
+		}
+	}
+
+	if bindings, err := st.ListConnectorProjectBindings(ctx); err != nil {
+		log.Printf("Keyorix Connect: boot-time drift check: failed to list connector project bindings: %v", err)
+	} else {
+		var orphaned []string
+		for _, b := range bindings {
+			if _, ok := ownership[b.Connector]; !ok {
+				orphaned = append(orphaned, fmt.Sprintf("%s (bound to project %q)", b.Connector, b.ProjectName))
+			}
+		}
+		if len(orphaned) > 0 {
+			log.Printf("Keyorix Connect: WARNING: %d connector project binding(s) reference a connector no longer in cfg.Connect.Connectors — orphaned by a removed or renamed connector: %s",
+				len(orphaned), strings.Join(orphaned, ", "))
+		}
+	}
 }
 
 // cmpOr returns a if non-empty, else b (a tiny local helper to avoid a new import).


### PR DESCRIPTION
## Summary

Closes #1477
Closes #1479

Both are ADR-082 follow-ups closing "configuration that looks like it works but doesn't." Three commits.

### Commit 1 — validate `project_id` in `CreateConnectorProjectBindingProxy` (#1477)

`POST /api/v1/system/connector-project-bindings` accepted any `project_id` with no existence check, silently persisting a binding row that referenced a nonexistent project. Now validates `project_id` against this hub's own storage before persisting.

**Deliberately does not validate the connector name against any config**, and the handler's own doc comment now records why: the connector belongs to the *calling* (downstream) node's `cfg.Connect.Connectors`, not this hub's own — this hub structurally cannot see that config, and threading its own config into the handler would validate against the wrong deployment's connector list, worse than not validating at all.

**This endpoint currently has no reachable caller.** Its only documented caller is a downstream server booted with `storage.type: remote` + `server.http`/`grpc` enabled, and ADR-083 (already merged) established that combination can no longer boot at all. Confirmed no other caller exists anywhere in the codebase (CLI included). ADR-083's own "Deferred work" section explicitly *deferred*, not decided, removal of this route, so hardening it here is defensive pending that decision, not validation of a currently-live path.

### Commit 2 — refuse `ConnectRefGrant` creation against a platform connector (#1479)

`CreateConnectRefGrant` validated that a connector was configured but never its scope. A grant against a platform-scoped connector was accepted, listed, and persisted, but never consulted: `connectOwnershipSatisfied`'s platform branch is a terminal deny in `ReadFederatedSecret` — a caller who lacks `connect.platform.use` never falls through to ref-grant delegation. Dead configuration that looks live. Now refused at creation with a new sentinel error, wired into both transports' safe-error classifiers so it surfaces as a clean 400/`InvalidArgument`.

Confirmed before pushing that this doesn't open a new information-disclosure surface: the sibling "connector must be configured" check one line above already reveals connector existence to the same caller, and both checks require the identical `roles.write` permission on both transports (HTTP: `RequirePermission(permRolesWrite)` on `POST /connect/ref-grants`; gRPC: `authorizeGlobal(ctx, s.core, actor, "roles.write")` in `CreateRefGrant`) — same authorization tier, no change needed.

### Commit 3 — boot-time warning for config/DB drift (#1477, #1479)

Neither create-time check can catch drift: a grant or binding valid when created can go stale if the config is edited afterward (a connector's scope changed after a grant exists; a connector removed or renamed after a binding exists). Both create-time checks are structurally the wrong layer to see this.

`server/main.go`'s Connect-wiring block — right after `SetConnectOwnership` resolves ownership from config — is **the only place in the system that sees both the current config-derived ownership map and every existing DB row together**. Added a warn-only pass there covering both drift directions: every `ConnectRefGrant` whose connector now resolves to `Scope: "platform"`, and every `ConnectorProjectBinding` whose connector name is absent from config (the orphan direction neither side of the existing `connectOwnershipKeySetMismatch` check enumerates, since both its inputs are entirely config-derived). Warns, never fails boot — neither condition over-permits anything, both are visibility problems.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean on all three commits
- `gosec -severity medium -exclude-generated` — 0 issues
- Full `internal/core` and `server/...` suites pass (including `server` itself, which contains commit 3's new code)
- `server/http`'s 18 failures are byte-for-byte the established pre-existing baseline (zero new, zero resolved)