### PR TITLE
fix(rbac): audit built-in role permission changes instead of blocking them

### DIFF
--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -747,6 +747,22 @@ the binding itself already persisted — but is logged loudly
 (`SECURITY`-prefixed), matching `emitAudit`'s own convention for a failed
 audit write.
 
+**Convention reused outside Connect (#1500):** `internal/core/audit.go`'s
+`permission.assigned`/`permission.removed` events (RBAC, unrelated to
+Connect) adopt this same closed-set `reason=<value>` token at the same
+Description position, via `reasonBuiltinRoleTarget = "builtin_role_target"`,
+to flag that the permission change landed on a built-in role
+(`IsBuiltinRole`) — ADR-044 permits this and it stays permitted; the token
+only makes it visible. Recorded here so both conventions stay in the same
+place and don't drift apart (e.g. a future call site using `reason:` with a
+colon, or a mid-string position, instead of matching this one). Unlike the
+events above, this one ALSO sets a structured boolean
+(`rbacAuditDetail.BuiltinRoleTarget`) alongside the free-text token, since
+`rbacAuditDetail` already existed as a structured Diff payload for RBAC
+events — the "parse-and-backfill" target this section anticipated already
+exists for this call site, so there was no reason to carry the signal in
+free text only.
+
 ### I. ADR-045 is explicitly amended, not silently superseded
 
 `docs/adr-045-connect-per-reference-rbac.md` gains an "Amended by ADR-082"

--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -42,15 +42,38 @@ var rbacAuditEventTypes = []string{
 	EventGroupMemberAdded, EventGroupMemberRemoved,
 }
 
+// reasonBuiltinRoleTarget is a fixed reason= token appended to a
+// permission.assigned/permission.removed event's Description when the target
+// role is a built-in (IsBuiltinRole) — #1500. Reuses ADR-082 §H's convention
+// (docs/adr-082-connect-connector-tenant-scoping.md): a closed-set free-text
+// token at a consistent position in Description, so an operator can learn
+// something the API response itself doesn't distinguish (here: whether the
+// permission change just landed on a built-in role's authorization
+// baseline). ADR-044 already establishes that this stays PERMITTED, not
+// refused — ONLY the visibility changes; see the call sites in
+// rbac_management.go for the full reasoning. Unlike §H's Connect events,
+// this event ALSO carries the same signal as a structured field
+// (rbacAuditDetail.BuiltinRoleTarget below) because rbacAuditDetail already
+// existed here — §H used free text only because no structured field was
+// available for Connect events at the time, and named the day a structured
+// column exists as the point this would become "parse-and-backfill, not a
+// rewrite"; rbacAuditDetail's JSON Diff is exactly that column already, so
+// there is no reason to wait.
+const reasonBuiltinRoleTarget = "builtin_role_target"
+
 // rbacAuditDetail is the structured payload stored in an RBAC event's Diff field,
 // carrying the target/role/scope that the generic AuditEvent row cannot.
 type rbacAuditDetail struct {
-	TargetUserID  uint `json:"target_user_id,omitempty"`
-	GroupID       uint `json:"group_id,omitempty"`
-	RoleID        uint `json:"role_id"`
-	PermissionID  uint `json:"permission_id,omitempty"`
-	ProjectID     uint `json:"project_id,omitempty"`
-	EnvironmentID uint `json:"environment_id,omitempty"`
+	TargetUserID uint `json:"target_user_id,omitempty"`
+	GroupID      uint `json:"group_id,omitempty"`
+	RoleID       uint `json:"role_id"`
+	PermissionID uint `json:"permission_id,omitempty"`
+	// BuiltinRoleTarget is true when RoleID identifies a built-in role
+	// (IsBuiltinRole) — #1500. Set only by logPermissionChange today; see
+	// reasonBuiltinRoleTarget above for the parallel Description token.
+	BuiltinRoleTarget bool `json:"builtin_role_target,omitempty"`
+	ProjectID         uint `json:"project_id,omitempty"`
+	EnvironmentID     uint `json:"environment_id,omitempty"`
 }
 
 // LogRoleAssigned / LogRoleRemoved record an RBAC change. actorID is the user who
@@ -115,20 +138,27 @@ func (c *KeyorixCore) logGroupMemberChange(ctx context.Context, eventType, verb 
 }
 
 // LogPermissionAssigned / LogPermissionRemoved record a permission granted to /
-// removed from a role. See LogRoleAssigned for actorID semantics.
-func (c *KeyorixCore) LogPermissionAssigned(ctx context.Context, actorID, roleID, permissionID uint) {
-	c.logPermissionChange(ctx, EventPermissionAdded, "granted to role", actorID, roleID, permissionID)
+// removed from a role. See LogRoleAssigned for actorID semantics. builtinTarget
+// is true when roleID identifies a built-in role (IsBuiltinRole) — #1500; it
+// does not change whether the event is written, only what it carries (see
+// reasonBuiltinRoleTarget).
+func (c *KeyorixCore) LogPermissionAssigned(ctx context.Context, actorID, roleID, permissionID uint, builtinTarget bool) {
+	c.logPermissionChange(ctx, EventPermissionAdded, "granted to role", actorID, roleID, permissionID, builtinTarget)
 }
 
-func (c *KeyorixCore) LogPermissionRemoved(ctx context.Context, actorID, roleID, permissionID uint) {
-	c.logPermissionChange(ctx, EventPermissionRemoved, "removed from role", actorID, roleID, permissionID)
+func (c *KeyorixCore) LogPermissionRemoved(ctx context.Context, actorID, roleID, permissionID uint, builtinTarget bool) {
+	c.logPermissionChange(ctx, EventPermissionRemoved, "removed from role", actorID, roleID, permissionID, builtinTarget)
 }
 
-func (c *KeyorixCore) logPermissionChange(ctx context.Context, eventType, verb string, actorID, roleID, permissionID uint) {
+func (c *KeyorixCore) logPermissionChange(ctx context.Context, eventType, verb string, actorID, roleID, permissionID uint, builtinTarget bool) {
 	desc := fmt.Sprintf("permission %d %s %d", permissionID, verb, roleID)
+	if builtinTarget {
+		desc = fmt.Sprintf("%s reason=%s", desc, reasonBuiltinRoleTarget)
+	}
 	c.writeRBACAudit(ctx, eventType, desc, actorID, Scope{}, rbacAuditDetail{
-		RoleID:       roleID,
-		PermissionID: permissionID,
+		RoleID:            roleID,
+		PermissionID:      permissionID,
+		BuiltinRoleTarget: builtinTarget,
 	})
 }
 

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -60,8 +61,20 @@ func (c *KeyorixCore) GetRoleWithPermissions(ctx context.Context, roleID uint) (
 // — matching how roles.write itself is gated (RequirePermission always resolves to
 // ScopeGlobal). c.Authorize already includes the admin-role bypass, so a genuine
 // global admin is unaffected.
+//
+// #1500: mutating a built-in role's permission set stays PERMITTED here, on
+// purpose. ADR-044's "Alternatives considered" already rejected making RBAC
+// permission changes converge/refuse against operator intent — the same
+// reasoning applies to bundling a permission into a built-in role directly:
+// operators must retain authority to widen (or narrow, see
+// RemovePermissionFromRole below) a built-in role's grants. Do NOT add an
+// IsBuiltinRole guard here — that would be exactly the "fix" ADR-044 already
+// considered and declined. What changes is visibility: the audit event and
+// log warning below let an operator/reviewer SEE that a built-in role's
+// authorization baseline moved, without blocking the move.
 func (c *KeyorixCore) AssignPermissionToRole(ctx context.Context, actorID, roleID, permissionID uint) error {
-	if _, err := c.storage.GetRole(ctx, roleID); err != nil {
+	role, err := c.storage.GetRole(ctx, roleID)
+	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
 	perm, err := c.storage.GetPermission(ctx, permissionID)
@@ -84,20 +97,43 @@ func (c *KeyorixCore) AssignPermissionToRole(ctx context.Context, actorID, roleI
 	if err := c.storage.AssignPermissionToRole(ctx, roleID, permissionID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
-	c.LogPermissionAssigned(ctx, actorID, roleID, permissionID)
+	builtinTarget := IsBuiltinRole(role.Name)
+	if builtinTarget {
+		log.Printf("SECURITY: permission %q (id %d) added to built-in role %q (id %d) by actor %d — permitted by design (ADR-044); operator authority over a built-in role's permission set is deliberate, not a bug",
+			perm.Name, permissionID, role.Name, roleID, actorID)
+	}
+	c.LogPermissionAssigned(ctx, actorID, roleID, permissionID, builtinTarget)
 	return nil
 }
 
 // RemovePermissionFromRole verifies the role exists, removes the permission, and
 // records an RBAC audit event. actorID is the acting principal (0 = none).
+//
+// #1500: mutating a built-in role's permission set stays PERMITTED here, on
+// purpose — see the identical note on AssignPermissionToRole above. Removing a
+// permission from a built-in role must not be refused; only made visible.
 func (c *KeyorixCore) RemovePermissionFromRole(ctx context.Context, actorID, roleID, permissionID uint) error {
-	if _, err := c.storage.GetRole(ctx, roleID); err != nil {
+	role, err := c.storage.GetRole(ctx, roleID)
+	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
 	if err := c.storage.RemovePermissionFromRole(ctx, roleID, permissionID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
-	c.LogPermissionRemoved(ctx, actorID, roleID, permissionID)
+	builtinTarget := IsBuiltinRole(role.Name)
+	if builtinTarget {
+		// A best-effort name lookup purely for the log line's readability — unlike
+		// AssignPermissionToRole, the permission is never otherwise fetched on this
+		// path, so this query only runs in the (rare) built-in-target case rather
+		// than on every call.
+		permName := fmt.Sprintf("id %d", permissionID)
+		if perm, perr := c.storage.GetPermission(ctx, permissionID); perr == nil {
+			permName = fmt.Sprintf("%q (id %d)", perm.Name, permissionID)
+		}
+		log.Printf("SECURITY: permission %s removed from built-in role %q (id %d) by actor %d — permitted by design (ADR-044); operator authority over a built-in role's permission set is deliberate, not a bug",
+			permName, role.Name, roleID, actorID)
+	}
+	c.LogPermissionRemoved(ctx, actorID, roleID, permissionID, builtinTarget)
 	return nil
 }
 

--- a/internal/core/rbac_management_test.go
+++ b/internal/core/rbac_management_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
@@ -9,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
@@ -110,6 +113,112 @@ func TestRemovePermissionFromRole_NoSelfPermissionRequired(t *testing.T) {
 
 	const actor = uint(9) // holds nothing
 	require.NoError(t, c.RemovePermissionFromRole(ctx, actor, 1, 1))
+}
+
+// lastRBACEventDetail fetches the most recent audit event of the given type
+// and decodes its structured Diff, for asserting on rbacAuditDetail fields
+// (unexported, but this test file is in package core) that ListRBACAuditLogs
+// doesn't currently surface — #1500's BuiltinRoleTarget among them.
+func lastRBACEventDetail(t *testing.T, c *KeyorixCore, eventType string) (*models.AuditEvent, rbacAuditDetail) {
+	t.Helper()
+	events, _, err := c.storage.GetAuditLogs(context.Background(), &storage.AuditFilter{
+		Actions: []string{eventType}, Page: 1, PageSize: 50,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, events, "expected at least one %s event", eventType)
+	event := events[0]
+	var detail rbacAuditDetail
+	require.NoError(t, json.Unmarshal([]byte(event.Diff), &detail))
+	return event, detail
+}
+
+// #1500: removing a permission from a built-in role stays PERMITTED (ADR-044) —
+// this only asserts the operation succeeds and its audit event carries the
+// distinct built-in signal, not that it's refused.
+func TestRemovePermissionFromRole_BuiltinRoleTarget_SignalsInAudit(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error) // builtin
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "system.write", Resource: "system", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+
+	logOutput := captureLog(t, func() {
+		require.NoError(t, c.RemovePermissionFromRole(ctx, 9, 1, 1))
+	})
+
+	event, detail := lastRBACEventDetail(t, c, EventPermissionRemoved)
+	assert.Contains(t, event.Description, "reason=builtin_role_target")
+	assert.True(t, detail.BuiltinRoleTarget)
+	assert.Equal(t, uint(1), detail.RoleID)
+	assert.Equal(t, uint(1), detail.PermissionID)
+
+	assert.Contains(t, logOutput, "SECURITY", "expected a log warning naming the role and permission")
+	assert.Contains(t, logOutput, "admin", "log warning must name the built-in role")
+	assert.Contains(t, logOutput, "system.write", "log warning must name the permission")
+}
+
+// A non-built-in role produces the ordinary event: no reason= token, no
+// structured flag, no SECURITY log line.
+func TestRemovePermissionFromRole_NonBuiltinRole_NoSignal(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "custom"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "system.write", Resource: "system", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+
+	logOutput := captureLog(t, func() {
+		require.NoError(t, c.RemovePermissionFromRole(ctx, 9, 1, 1))
+	})
+
+	event, detail := lastRBACEventDetail(t, c, EventPermissionRemoved)
+	assert.NotContains(t, event.Description, "reason=")
+	assert.False(t, detail.BuiltinRoleTarget)
+	assert.Empty(t, strings.TrimSpace(logOutput), "no SECURITY warning expected for a non-built-in target")
+}
+
+// #1500: assigning a permission to a built-in role also stays PERMITTED and
+// must carry the same signal — the inverse of RemovePermissionFromRole above.
+func TestAssignPermissionToRole_BuiltinRoleTarget_SignalsInAudit(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin"}).Error) // builtin
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "system.write", Resource: "system", Action: "write"}).Error)
+	// Actor must already hold the permission (#169) — make them a global admin.
+	const actor = uint(9)
+	require.NoError(t, db.Create(&models.UserRole{UserID: actor, RoleID: 1}).Error)
+
+	logOutput := captureLog(t, func() {
+		require.NoError(t, c.AssignPermissionToRole(ctx, actor, 1, 1))
+	})
+
+	event, detail := lastRBACEventDetail(t, c, EventPermissionAdded)
+	assert.Contains(t, event.Description, "reason=builtin_role_target")
+	assert.True(t, detail.BuiltinRoleTarget)
+
+	assert.Contains(t, logOutput, "SECURITY")
+	assert.Contains(t, logOutput, "admin")
+	assert.Contains(t, logOutput, "system.write")
+}
+
+// A non-built-in role produces the ordinary event on assignment too.
+func TestAssignPermissionToRole_NonBuiltinRole_NoSignal(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "custom"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "holder"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
+	const holder = uint(9)
+	require.NoError(t, db.Create(&models.UserRole{UserID: holder, RoleID: 2}).Error)
+
+	logOutput := captureLog(t, func() {
+		require.NoError(t, c.AssignPermissionToRole(ctx, holder, 1, 1))
+	})
+
+	event, detail := lastRBACEventDetail(t, c, EventPermissionAdded)
+	assert.NotContains(t, event.Description, "reason=")
+	assert.False(t, detail.BuiltinRoleTarget)
+	assert.Empty(t, strings.TrimSpace(logOutput), "no SECURITY warning expected for a non-built-in target")
 }
 
 // RemoveUserRole must evict the target user's cached sessions from the HTTP auth


### PR DESCRIPTION
## Summary

`RemovePermissionFromRole` and `AssignPermissionToRole` have no `IsBuiltinRole` guard, unlike `UpdateRole`/`DeleteRole` which do. Per ADR-044's "Alternatives considered" (see `rbac_reconcile.go`), that's deliberate: operators must retain authority to widen or narrow a built-in role's permission set. Both directions stay permitted here — that reasoning is now in a code comment on each function so it isn't later "fixed" into a refusal. What changes is visibility, not permission.

Both now emit a distinct signal when the target role is built-in:

- `reason=builtin_role_target` appended to the audit event's `Description`, reusing ADR-082 §H's closed-set `reason=` token convention and position.
- A structured `BuiltinRoleTarget bool` on `rbacAuditDetail`, alongside the existing `RoleID`/`PermissionID` fields. §H used free text only because no structured field existed for Connect's events at the time, and named a future structured column as the point that becomes a parse-and-backfill rather than a rewrite — `rbacAuditDetail` already is that column here, so both signals are written now rather than deferring the structured one.
- A `SECURITY`-prefixed log warning naming the role and the permission.

`docs/adr-082-connect-connector-tenant-scoping.md` §H gets a cross-reference note documenting this reuse, so the two conventions (Connect's and RBAC's) stay in the same place and don't drift apart.

`RemovePermissionFromRole` already fetched the role and discarded it (`if _, err := ...`); this keeps the object for the `IsBuiltinRole` check instead of adding a new fetch. `AssignPermissionToRole` already fetched the permission for the `#169` self-hold check, reused here for the log line's permission name.

## Filed separately

- **#1503** — Stage-1 investigation also surfaced that `UpdateRole`/`DeleteRole` correctly refuse built-in-role targets on both HTTP and gRPC (four call sites), but none of those four refusals write an audit event. That's a distinct gap (auditing a refusal, not changing whether it refuses) and is out of scope here.
- **#1504** — pre-push regression testing surfaced an unrelated, pre-existing intermittent flake in `server/grpc/interceptors` (`TestMetricsInterceptor_CountsSuccessAndError` racing a shared package-level `grpcMetrics` global against two hard-reset tests in a sibling file). Confirmed not caused by this change; could not reproduce on demand across 9 attempts. Filed for separate triage.

Closes #1500

## Test plan

- `go build ./...` clean.
- New tests in `internal/core/rbac_management_test.go`: both directions × built-in vs non-built-in role, asserting the operation still succeeds, the `reason=` token and structured bool appear only for a built-in target, and the log warning names the role and permission.
- Full `internal/core` suite passes.
- Full `internal/core` + `server/...` regression: only the pre-existing 18-item `server/http` baseline fails (unrelated, confirmed pre-existing this session), plus the one-off #1504 flake described above (confirmed unrelated, non-reproducing).