### PR TITLE
fix(audit): UTC-normalize AuditEvent.EventTime write and read paths

### DIFF
--- a/internal/core/permission_change_audit.go
+++ b/internal/core/permission_change_audit.go
@@ -59,13 +59,24 @@ type PermissionChangeReport struct {
 }
 
 // normPermChangeWindow normalises the since/until/limit parameters, filling in defaults.
+//
+// since/until are also UTC-normalized here (G81, third recurrence, read side)
+// even though GetAuditLogs already normalizes its own filter bounds — a
+// caller-supplied non-zero value skips the defaulting branches below and
+// would otherwise reach GetAuditLogs un-normalized until it, too, is checked.
+// Redundant with GetAuditLogs' own normalization for the default-window case,
+// but correct by construction is cheap here.
 func normPermChangeWindow(since, until time.Time, limit int) (time.Time, time.Time, int) {
-	now := time.Now()
+	now := time.Now().UTC()
 	if since.IsZero() {
 		since = now.Add(-permChangeDefaultWindow)
+	} else {
+		since = since.UTC()
 	}
 	if until.IsZero() {
 		until = now
+	} else {
+		until = until.UTC()
 	}
 	if limit <= 0 {
 		limit = permChangeDefaultLimit

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -1139,6 +1139,48 @@ type AuditEvent struct {
 	EntryHash string `gorm:"index"`
 }
 
+// BeforeSave normalises EventTime to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 — this
+// is the third recurrence of the same bug class; the other members already
+// carrying this fix are MFAStepupToken, MFAStepUpGrant, UserRole, GroupRole,
+// and DynamicSecretLease, all above in this file). Without it, an EventTime
+// written under one local timezone and a filter bound parsed under another
+// (e.g. a client-supplied RFC3339 "...Z" window against a server process not
+// pinned to TZ=UTC) silently miss each other in GetAuditLogs' event_time >= /
+// <= range query on SQLite — reproduced and fixed by this change, not a
+// theoretical hazard (see g81_audit_event_timezone_test.go).
+//
+// Two facts make this hook safe here, neither obvious from the hook itself:
+//
+//  1. Hash-chain ordering: LogAuditEvent (local_audit_chain.go) computes
+//     EntryHash and assigns it to the event BEFORE calling tx.Create, and
+//     GORM only invokes BeforeSave during Create — so this hook's mutation
+//     happens strictly after the hash for THIS row's own write is already
+//     fixed. That is safe only because computeAuditEntryHash encodes
+//     EventTime as e.EventTime.UnixMicro() (local_audit_chain.go), which is
+//     an absolute instant and therefore location-independent: UTC-normalizing
+//     EventTime here changes its Location but not its UnixMicro() value, so
+//     it changes neither the hash LogAuditEvent already computed for this row
+//     nor the hash VerifyAuditChain recomputes later by re-reading the stored
+//     (already-normalized) EventTime. If EventTime's encoding in
+//     computeAuditEntryHash is ever changed to anything location-dependent
+//     (e.g. a formatted string that varies with Location), this hook would
+//     silently break tamper-evidence for every future write — the two must
+//     be changed together, if ever.
+//
+//  2. Write-funnel coverage: LogAuditEvent is the ONLY path that writes
+//     event_time — unlike MFAStepupToken, no ON CONFLICT/raw-map UPDATE
+//     path bypasses model hooks for audit_events (verified: no such path
+//     exists today). If a future upsert or bulk-write path is added to
+//     audit_events, it must be checked for the same hook-bypass hazard
+//     MFAStepupToken has (see local_mfa_stepup.go's explicit normalization
+//     at its ON CONFLICT call site) and normalize EventTime explicitly if it
+//     bypasses this hook.
+func (e *AuditEvent) BeforeSave(_ *gorm.DB) error {
+	e.EventTime = e.EventTime.UTC()
+	return nil
+}
+
 // AuditCheckpoint is a signed notarisation of the audit hash-chain head
 // (ADR-029). Signature is an HMAC over (ChainedEvents, HeadID, HeadHash,
 // KeyVersion) keyed by a DEK-derived key the database/DBA does not hold, so a

--- a/internal/storage/store/g81_audit_event_timezone_test.go
+++ b/internal/storage/store/g81_audit_event_timezone_test.go
@@ -1,0 +1,126 @@
+// g81_audit_event_timezone_test.go — regression coverage for G81's AuditEvent
+// member (#1492): this codebase previously fixed a GORM/SQLite timezone-
+// comparison bug (mixed UTC/local time.Time values break SQLite's
+// string-based time comparisons) by adding UTC-normalizing BeforeSave hooks
+// to the affected models (MFAStepupToken, MFAStepUpGrant, UserRole,
+// GroupRole, DynamicSecretLease), but AuditEvent was never given one — and
+// its EventTime is exactly the field GetAuditLogs' event_time >= / <= range
+// filter depends on comparing correctly. This is the third recurrence of the
+// same bug class.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// TestLogAuditEvent_NonUTCEventTimeStoredAsUTC pins the write half of G81 for
+// AuditEvent: an event logged with an EventTime constructed in a non-UTC
+// local timezone (e.g. a server running with TZ set) must be persisted and
+// read back as UTC, with the instant preserved. This also confirms the hook
+// actually fires on LogAuditEvent — the single write funnel for
+// audit_events (see BeforeSave's doc comment).
+func TestLogAuditEvent_NonUTCEventTimeStoredAsUTC(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	ctx := context.Background()
+	nonUTC := time.FixedZone("UTC-7", -7*60*60)
+	at := time.Date(2026, 8, 20, 12, 0, 0, 0, nonUTC)
+
+	tr := true
+	event := &models.AuditEvent{
+		EventType: "auth.login", Description: "g81-utc", Success: &tr,
+		EventTime: at, ActorType: "user",
+	}
+	require.NoError(t, ls.LogAuditEvent(ctx, event))
+	assert.Equal(t, time.UTC, event.EventTime.Location(), "event_time must be stored in UTC")
+	assert.True(t, event.EventTime.Equal(at), "the instant must be preserved even though the zone changed")
+
+	var reloaded models.AuditEvent
+	require.NoError(t, ls.db.First(&reloaded, event.ID).Error)
+	assert.Equal(t, time.UTC, reloaded.EventTime.Location())
+	assert.True(t, reloaded.EventTime.Equal(at))
+}
+
+// TestVerifyAuditChain_ValidatesRowWithNonUTCEventTime confirms the hook does
+// not break tamper-evidence: EntryHash is computed by LogAuditEvent before
+// BeforeSave mutates EventTime (see local_audit_chain.go:187), and
+// computeAuditEntryHash encodes EventTime as UnixMicro() — location-
+// independent — so a row written through the hook must still verify, both
+// alone and chained with a second row.
+func TestVerifyAuditChain_ValidatesRowWithNonUTCEventTime(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	ctx := context.Background()
+	nonUTC := time.FixedZone("UTC+9", 9*60*60)
+	at := time.Now().In(nonUTC)
+
+	tr := true
+	e1 := &models.AuditEvent{
+		EventType: "auth.login", Description: "g81-chain-1", Success: &tr,
+		EventTime: at, ActorType: "user",
+	}
+	require.NoError(t, ls.LogAuditEvent(ctx, e1))
+
+	v, err := ls.VerifyAuditChain(ctx, nil)
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "chain must verify for a row written through the UTC hook: %s", v.Reason)
+	assert.Equal(t, int64(1), v.ChainedEvents)
+
+	e2 := &models.AuditEvent{
+		EventType: "secret.read", Description: "g81-chain-2", Success: &tr,
+		EventTime: at.Add(time.Second), ActorType: "user",
+	}
+	require.NoError(t, ls.LogAuditEvent(ctx, e2))
+	assert.Equal(t, e1.EntryHash, e2.PrevHash, "chain linkage must hold across hook-normalized rows")
+
+	v2, err := ls.VerifyAuditChain(ctx, nil)
+	require.NoError(t, err)
+	assert.True(t, v2.Valid, "2-row chain must verify: %s", v2.Reason)
+	assert.Equal(t, int64(2), v2.ChainedEvents)
+}
+
+// TestGetAuditLogs_RangeQuery_FindsRowWithNonUTCEventTime is the regression
+// test for the live bug this change fixes (not a theoretical hazard): an
+// event is written with EventTime expressed in a non-UTC local zone (as
+// every real write site's bare time.Now() would produce on a server process
+// not pinned to TZ=UTC), then queried through GetAuditLogs with a UTC
+// RFC3339 window — the exact shape internal/core/audit_search.go produces
+// via time.Parse(time.RFC3339, "...Z") for a client-supplied filter. Without
+// the BeforeSave hook, SQLite's string-based time comparison misses the row
+// even though both sides denote the same instant (confirmed by temporarily
+// reverting the hook and re-running this test during development — it fails
+// with total=0 without the hook, and passes with it; the other two tests in
+// this file fail even harder without the hook, with a hard Scan error reading
+// the row back at all — "unsupported Scan, storing driver.Value type string
+// into type *time.Time" — since modernc.org/sqlite's driver can't parse every
+// offset representation it itself wrote back into a Go time.Time).
+func TestGetAuditLogs_RangeQuery_FindsRowWithNonUTCEventTime(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	ctx := context.Background()
+
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	instant := time.Date(2026, 8, 20, 14, 0, 0, 0, time.UTC)
+	localRepresentation := instant.In(loc)
+
+	tr := true
+	event := &models.AuditEvent{
+		EventType: "auth.login", Description: "g81-range", Success: &tr,
+		EventTime: localRepresentation, ActorType: "user",
+	}
+	require.NoError(t, ls.LogAuditEvent(ctx, event))
+
+	start := instant.Add(-time.Minute)
+	end := instant.Add(time.Minute)
+	events, total, err := ls.GetAuditLogs(ctx, &storage.AuditFilter{StartTime: &start, EndTime: &end})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total, "row bracketing the instant must be found by a same-instant UTC range filter")
+	require.Len(t, events, 1)
+	assert.Equal(t, event.ID, events[0].ID)
+}

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -421,10 +421,15 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 			query = query.Where("event_type IN ?", filter.Actions)
 		}
 		if filter.StartTime != nil {
-			query = query.Where("event_time >= ?", *filter.StartTime)
+			// G81 (third recurrence, read side): normalize here rather than trusting
+			// every caller to pass UTC, mirroring ListExpiredActiveLeases. event_time
+			// is now always stored in UTC (models.AuditEvent.BeforeSave); a bound in
+			// any other Location denotes the same instant but, on SQLite, compares as
+			// a different string, silently mismatching rows that are actually in range.
+			query = query.Where("event_time >= ?", filter.StartTime.UTC())
 		}
 		if filter.EndTime != nil {
-			query = query.Where("event_time <= ?", *filter.EndTime)
+			query = query.Where("event_time <= ?", filter.EndTime.UTC())
 		}
 		if filter.Success != nil {
 			query = query.Where("success = ?", *filter.Success)
@@ -498,6 +503,8 @@ func (ls *LocalStorage) GetRBACAuditLogs(_ context.Context, _ *storage.RBACAudit
 // Machine-identity reads (actor_type="machine_identity") have no user row — their
 // username column is empty in the result, consistent with the description column.
 func (ls *LocalStorage) GetSecretReadCounts(ctx context.Context, secretID uint, since, until time.Time, limit int) ([]storage.SecretReadEntry, error) {
+	// G81 (third recurrence, read side): normalize internally — see GetAuditLogs.
+	since, until = since.UTC(), until.UTC()
 	type row struct {
 		ActorID       string
 		ActorUsername string
@@ -537,9 +544,10 @@ func (ls *LocalStorage) GetSecretReadCounts(ctx context.Context, secretID uint, 
 // CountImpersonatedActions counts impersonated audit events for actingAs by
 // impersonator since `since`, excluding the impersonation.start/.end markers.
 func (ls *LocalStorage) CountImpersonatedActions(ctx context.Context, actingAs, impersonator uint, since time.Time) (int64, error) {
+	// G81 (third recurrence, read side): normalize internally — see GetAuditLogs.
 	var n int64
 	err := ls.db.WithContext(ctx).Model(&models.AuditEvent{}).
-		Where("impersonation = ? AND acting_as = ? AND impersonated_by = ? AND event_time >= ?", true, actingAs, impersonator, since).
+		Where("impersonation = ? AND acting_as = ? AND impersonated_by = ? AND event_time >= ?", true, actingAs, impersonator, since.UTC()).
 		Where("event_type NOT IN ?", []string{"impersonation.start", "impersonation.end"}).
 		Count(&n).Error
 	return n, err
@@ -627,10 +635,11 @@ func (ls *LocalStorage) MarkAnomalyAlertAlerted(ctx context.Context, id uint) er
 
 // GetDistinctActiveUserIDs returns the IDs of users who have logged in since the given time.
 func (ls *LocalStorage) GetDistinctActiveUserIDs(ctx context.Context, since time.Time) ([]uint, error) {
+	// G81 (third recurrence, read side): normalize internally — see GetAuditLogs.
 	var ids []uint
 	err := ls.db.WithContext(ctx).
 		Model(&models.AuditEvent{}).
-		Where("event_type = ? AND event_time >= ?", "auth.login", since).
+		Where("event_type = ? AND event_time >= ?", "auth.login", since.UTC()).
 		Distinct("user_id").
 		Pluck("user_id", &ids).Error
 	return ids, err

--- a/internal/storage/store/local_billing.go
+++ b/internal/storage/store/local_billing.go
@@ -165,6 +165,12 @@ func (ls *LocalStorage) distinctUsersByProject(ctx context.Context, projectIDs [
 // SecretWrites / SecretRotations / UniqueUsers / MachineReads aggregations
 // and merges them into one map keyed by project ID.
 func (ls *LocalStorage) billingCountsByProject(ctx context.Context, from, to time.Time, projectIDs []uint) (map[uint]*billingCounts, error) {
+	// G81 (third recurrence, read side): normalize internally rather than trusting
+	// the caller — see GetAuditLogs. GenerateBillingReport already normalizes
+	// today, but every event_time comparison below would otherwise silently
+	// depend on that staying true forever.
+	from, to = from.UTC(), to.UTC()
+
 	secretCounts, err := ls.countByProject(ctx, "secret_nodes",
 		"project_id IN ? AND is_secret = ? AND deleted_at IS NULL", projectIDs, true)
 	if err != nil {


### PR DESCRIPTION
This fixes both sides of one timezone bug on SQLite. `audit_events.event_time` was never normalized to UTC, and every range query comparing against it built its own bound the same unsafe way — so the write side and the read side either both matched (by accident, when consistently un-normalized) or both mismatched, depending on which timezone the writing process and the querying caller each happened to use. Reproduced directly: a row written with a non-UTC `EventTime`, queried with an equivalent-instant UTC RFC3339 window, returned 0 rows instead of 1. Some read paths fail even harder — a hard `sql: Scan error ... unsupported Scan, storing driver.Value type string into type *time.Time`, since `modernc.org/sqlite` can't always parse back every offset it wrote. Postgres is unaffected (timestamptz compares absolute instants); this is SQLite-only.

**Write side:** a `BeforeSave` hook on `models.AuditEvent` normalizes `EventTime` to UTC — the same fix already applied to `MFAStepupToken`, `MFAStepUpGrant`, `UserRole`, `GroupRole`, and `DynamicSecretLease` (G81, third recurrence). Safe against the tamper-evidence hash chain: `LogAuditEvent` computes `EntryHash` before `tx.Create` runs `BeforeSave`, and `computeAuditEntryHash` encodes `EventTime` as `UnixMicro()` — an absolute, location-independent instant — so normalizing `Location` changes neither the hash already computed for a write nor the hash `VerifyAuditChain` recomputes later. `LogAuditEvent` is also the only path that writes `event_time`; no `ON CONFLICT`/raw-map path bypasses hooks, so no call-site sweep was needed.

**Read side:** every function comparing a bound against `event_time` now normalizes internally, mirroring `ListExpiredActiveLeases`' existing precedent (normalize inside the function, don't trust every caller) — `GetAuditLogs` (the shared choke point behind audit search, dashboard, permission-change audit, RBAC audit, secret audit trail/ownership history, access-log export, the gRPC audit service, and the CSV/HTTP handlers), `GetDistinctActiveUserIDs`, `GetSecretReadCounts`, `CountImpersonatedActions`, `billingCountsByProject` (and everything it feeds), and `normPermChangeWindow`'s default window. `GetProjectUsageStats` and `DeleteAuditLogsBefore`'s cutoff were already correctly normalized and are untouched. None of these bounds are externally-sourced in a way normalization changes meaning — every one is either `time.Now()`-derived or client RFC3339, and `.UTC()` only changes representation, never the instant.

Out of scope, flagged not touched: `MostAccessedSecrets`/`UnusedSecrets`/`CountUnusedSecretsByProject` query `secret_access_logs.access_time`, a different model with no `BeforeSave` hook — structurally the same hazard, different table.

## Test plan
- [x] `go build ./...`
- [x] `internal/core`, `internal/storage`, `server/...` — full runs; `server/...` byte-identical to the established baseline (18 known pre-existing failures + local-environment `[setup failed]` noise, zero regressions)
- [x] All 12 tests that regressed when only the write side was fixed (10 `TestGetPermissionChangeAudit_*`, `TestGetAuditLogs_AllFilters`, `TestGetDistinctActiveUserIDs`) now pass
- [x] New tests in `g81_audit_event_timezone_test.go`: round-trip UTC storage, `VerifyAuditChain` validates a hook-normalized row (single + chained), range-query regression test — each confirmed to fail without the hook and pass with it

Closes #1492