### PR TITLE
fix(g81): close the G81 timezone bug class (not a fifth instance)

### DIFF
--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -272,8 +272,14 @@ const maxSessionsPerUser = 25
 // RecordLogin stamps the user's last_login_at to the current time. Best-effort:
 // the login handler calls this in a goroutine after a successful authentication,
 // so a storage error here must never fail the login itself.
+//
+// G81: normalized to UTC here explicitly rather than via a models.User BeforeSave
+// hook — UpdateLastLogin's sole write path (local_users.go, UpdateColumn) bypasses
+// all model hooks, so a hook would be silently ineffective (see the doc comment on
+// User.LastLoginAt). Mirrors local_mfa_stepup.go's explicit-normalization fix for
+// MFAStepupToken's ON CONFLICT path, which has the same hook-bypass shape.
 func (c *KeyorixCore) RecordLogin(ctx context.Context, userID uint) error {
-	return c.storage.UpdateLastLogin(ctx, userID, c.now())
+	return c.storage.UpdateLastLogin(ctx, userID, c.now().UTC())
 }
 
 // Logout invalidates the session identified by token.

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -91,6 +91,21 @@ type AccessRequest struct {
 	RequiredApprovals int `gorm:"-"`
 }
 
+// BeforeSave normalises ResolvedAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 —
+// currently latent: write and the one range-query bound (local_purge.go,
+// DeleteResolvedAccessRequestsBefore) both use time.Now()-family, consistently,
+// today). ExpiresAt is never range-queried in SQL (only compared via Go's
+// Location-independent time.Time.Before/After), so it's out of scope for this
+// bug class.
+func (r *AccessRequest) BeforeSave(_ *gorm.DB) error {
+	if r.ResolvedAt != nil {
+		u := r.ResolvedAt.UTC()
+		r.ResolvedAt = &u
+	}
+	return nil
+}
+
 // AccessRequestApproval records one approver's sign-off on an access request, for
 // N-of-M dual control (ISO 27001 A.5.3 / SOX): a request grants the role only once
 // RequiredApprovals distinct approvers (none of them the requester) have approved.
@@ -238,6 +253,18 @@ type BreakGlassActivation struct {
 	RevokedAt     *time.Time `json:"revoked_at,omitempty"`
 }
 
+// BeforeSave normalises CreatedAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 —
+// currently latent: write and the one range-query bound (local_purge.go,
+// DeleteExpiredBreakGlassBefore) both use time.Now()-family, consistently,
+// today). ExpiresAt is never range-queried in SQL (only compared via Go's
+// Location-independent time.Time.Before/After), so it's out of scope for this
+// bug class.
+func (b *BreakGlassActivation) BeforeSave(_ *gorm.DB) error {
+	b.CreatedAt = b.CreatedAt.UTC()
+	return nil
+}
+
 // AccessReviewCampaign is a periodic access-recertification cycle for a project
 // (ISO 27001 A.5.18 — review at planned intervals). Opening a campaign snapshots
 // the project's current access-review entries into AccessReviewItem rows; reviewers
@@ -272,6 +299,19 @@ type AccessReviewCampaign struct {
 	// (recertification.go) would silently treat a rushed, incomplete force-close as
 	// satisfying a full review cycle and push the next-due date out just as far.
 	ForcedIncomplete bool `gorm:"default:false" json:"forced_incomplete"`
+}
+
+// BeforeSave normalises ClosedAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 —
+// currently latent: write and the one range-query bound (local_purge.go,
+// DeleteClosedAccessReviewsBefore) both use time.Now()-family, consistently,
+// today).
+func (c *AccessReviewCampaign) BeforeSave(_ *gorm.DB) error {
+	if c.ClosedAt != nil {
+		u := c.ClosedAt.UTC()
+		c.ClosedAt = &u
+	}
+	return nil
 }
 
 // AccessReviewItem is one access grant captured in a campaign at open time, plus
@@ -326,7 +366,7 @@ type User struct {
 	// SQLite. NOT covered by a BeforeSave hook — UpdateLastLogin's sole write path
 	// (local_users.go, UpdateColumn) bypasses all model hooks, the same way
 	// MFAStepupToken's ON CONFLICT path did before local_mfa_stepup.go's explicit
-	// call-site fix. Normalized explicitly at auth.go's LoginUser instead (mirrors
+	// call-site fix. Normalized explicitly at auth.go's RecordLogin instead (mirrors
 	// that precedent) — a hook here would be silently ineffective, exactly like
 	// the BeforeSave-vs-GORM-NowFunc-ordering no-op documented on
 	// StatsSnapshot.CreatedAt below.
@@ -363,6 +403,27 @@ type User struct {
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 	DeletedAt           gorm.DeletedAt `gorm:"index"` // soft delete — set by DELETE /users/{id}, cleared by restore
+}
+
+// BeforeSave normalises CreatedAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 —
+// currently latent: write and the one range-query bound
+// (ListUsersInStateBefore, account_state.go) both use c.now(), consistently,
+// today). LastLoginAt is deliberately NOT covered here — see its own doc
+// comment above for why a hook can't reach it.
+//
+// This hook DOES reach CreatedAt for every real CreateUser call site (they all
+// set CreatedAt explicitly — users.go, scim.go, sso.go). But a caller reaching
+// storage.Storage.CreateUser directly without setting CreatedAt hits the same
+// BeforeSave-fires-before-GORM's-auto-timestamp gap documented at length on
+// StatsSnapshot.CreatedAt below: the hook normalizes a zero value, then GORM's
+// own local NowFunc overwrites it moments later, unaffected. Found via exactly
+// that pattern in a test (server/http/remote_storage_retention_test.go) that
+// constructed a User without CreatedAt; fixed there by setting it explicitly,
+// matching every real caller, rather than treated as a hook defect.
+func (u *User) BeforeSave(_ *gorm.DB) error {
+	u.CreatedAt = u.CreatedAt.UTC()
+	return nil
 }
 
 // MFASecret holds a user's TOTP shared secret, encrypted at rest. One row per
@@ -458,6 +519,16 @@ type MFAChallenge struct {
 	CreatedAt time.Time
 }
 
+// BeforeSave normalises ExpiresAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 — currently
+// latent: write (c.now()) and every range-query bound (c.now(), local_mfa.go)
+// agree today, but both are unnormalized local time, the same recurring risk
+// that motivated the other G81 fixes).
+func (c *MFAChallenge) BeforeSave(_ *gorm.DB) error {
+	c.ExpiresAt = c.ExpiresAt.UTC()
+	return nil
+}
+
 // LoginAttempt records one failed authentication attempt from a client IP, for
 // cluster-wide brute-force rate limiting (ADR-040). Counting rows within the
 // window across all replicas replaces the old per-process in-memory limiter, so
@@ -523,6 +594,15 @@ type WebAuthnSession struct {
 	ExpiresAt time.Time
 	UsedAt    *time.Time
 	CreatedAt time.Time
+}
+
+// BeforeSave normalises ExpiresAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 —
+// currently latent: write and every range-query bound (local_webauthn.go) use
+// unnormalized local time, consistently, today).
+func (s *WebAuthnSession) BeforeSave(_ *gorm.DB) error {
+	s.ExpiresAt = s.ExpiresAt.UTC()
+	return nil
 }
 
 // PasswordHistory records prior password hashes per user so the policy can
@@ -1005,6 +1085,23 @@ type Session struct {
 	RotatedAt *time.Time
 }
 
+// BeforeSave normalises ExpiresAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 —
+// currently latent: write and the one live range-query bound (local_auth.go)
+// both use unnormalized local time, consistently, today). LastSeenAt is
+// deliberately NOT covered here — its sole write path (TouchSession) bypasses
+// model hooks via UpdateColumn; see #1507. AbsoluteExpiresAt and
+// ImpersonationStartedAt are never range-queried in SQL (compared only via
+// Go's Location-independent time.Time.Before/After), so they're out of scope
+// for this bug class entirely.
+func (s *Session) BeforeSave(_ *gorm.DB) error {
+	if s.ExpiresAt != nil {
+		u := s.ExpiresAt.UTC()
+		s.ExpiresAt = &u
+	}
+	return nil
+}
+
 // PersonalAccessToken is a long-lived, user-owned bearer credential (ADR-027).
 // Unlike APIToken (service-account / admin-scoped), a PAT is created and managed
 // by the owning user from the My Account page and authenticates API requests AS
@@ -1091,6 +1188,17 @@ type SetupToken struct {
 	CreatedBy  uint
 	CreatedAt  time.Time
 	ConsumedAt *time.Time // nil until consumed
+}
+
+// BeforeSave normalises CreatedAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 —
+// currently latent: write and the one range-query bound (local_auth.go,
+// CountSetupTokensSince) both use c.now(), consistently, today). ExpiresAt is
+// never range-queried in SQL (only compared via Go's Location-independent
+// time.Time.Before/After), so it's out of scope for this bug class.
+func (t *SetupToken) BeforeSave(_ *gorm.DB) error {
+	t.CreatedAt = t.CreatedAt.UTC()
+	return nil
 }
 
 type PasswordReset struct {
@@ -1282,6 +1390,23 @@ type SystemMetadata struct {
 }
 
 // StatsSnapshot stores daily dashboard stat counts for trend calculation
+// StatsSnapshot deliberately has NO BeforeSave hook, even though CreatedAt is
+// range-queried (local_stats.go, GetPreviousStatsSnapshot: "created_at < ?").
+// CreatedAt here is never explicitly assigned in Go (dashboard.go's write site
+// sets every other field but not CreatedAt) — it's GORM's own auto-populated
+// timestamp column. Empirically verified (G81 bug-class sweep) that BeforeSave
+// fires BEFORE GORM's auto-CreatedAt assignment: a hook here would see and
+// normalize a zero time.Time, then GORM's own NowFunc (default time.Now, local)
+// overwrites it moments later, unaffected by the hook — the exact same silent
+// no-op shape as User.LastLoginAt's UpdateColumn bypass, just via a different
+// mechanism (GORM callback ordering instead of a hook-skipping write path).
+// Currently latent regardless: the write (GORM's local NowFunc) and the one
+// read bound (local_stats.go, bare time.Now()) are both consistently local
+// today. Fixing this properly would require either converting CreatedAt to an
+// explicit Go-side assignment first (so a hook has something to normalize) or
+// configuring the *gorm.DB connection's NowFunc to return UTC globally —
+// deliberately not done here since neither is a per-model BeforeSave hook, and
+// the field is only latent, not live.
 type StatsSnapshot struct {
 	ID                  uint `gorm:"primaryKey;autoIncrement"`
 	UserID              uint `gorm:"index"`
@@ -1553,6 +1678,18 @@ type MachineIdentity struct {
 	Classification string `gorm:"index"`
 }
 
+// BeforeSave normalises CreatedAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 —
+// currently latent: write and the one range-query bound (local_machine_identities.go,
+// the fallback branch of a NULL-LastSeenAt OR CreatedAt check) both use
+// c.now(), consistently, today). LastSeenAt has no write path anywhere in this
+// codebase today (always NULL in practice), so it carries no live hazard to
+// fix.
+func (m *MachineIdentity) BeforeSave(_ *gorm.DB) error {
+	m.CreatedAt = m.CreatedAt.UTC()
+	return nil
+}
+
 // MachineIdentityCredential is an opaque bearer token a machine identity uses to
 // authenticate (ADR-030), mirroring PersonalAccessToken. Only the SHA-256 hash
 // is stored — the raw `kx_machine_…` token is shown once at issuance. A machine
@@ -1577,6 +1714,22 @@ type MachineIdentityCredential struct {
 	// (ISO 27001 A.5.12): "" = unclassified, else public|internal|confidential|restricted.
 	// LABEL ONLY, NOT A CONTROL — see internal/core/classification.go.
 	Classification string `gorm:"index"`
+}
+
+// BeforeSave normalises ExpiresAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 —
+// currently latent: every write path computes ExpiresAt server-side via
+// time.Now().AddDate(...), and every range-query bound (local_token_expiry.go,
+// local_hygiene_counts.go) uses k.now(); both unnormalized local time,
+// consistently, today). LastUsedAt is deliberately NOT covered here — its sole
+// write path (TouchMachineIdentityCredential) bypasses model hooks via
+// UpdateColumn; see #1507.
+func (c *MachineIdentityCredential) BeforeSave(_ *gorm.DB) error {
+	if c.ExpiresAt != nil {
+		u := c.ExpiresAt.UTC()
+		c.ExpiresAt = &u
+	}
+	return nil
 }
 
 // MachineIdentityRole grants a role to a machine identity at a project/
@@ -1673,6 +1826,15 @@ type ProjectMembership struct {
 	ActivatedAt *time.Time
 	RevokedAt   *time.Time
 	UpdatedAt   time.Time
+}
+
+// BeforeSave normalises InvitedAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 —
+// currently latent: write and the one range-query bound
+// (membership_lifecycle.go, same file) both use c.now(), consistently, today).
+func (m *ProjectMembership) BeforeSave(_ *gorm.DB) error {
+	m.InvitedAt = m.InvitedAt.UTC()
+	return nil
 }
 
 // SecretVersionComment is a free-text annotation on a specific secret version,

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -358,8 +358,8 @@ type User struct {
 	// targeting.
 	Email        string
 	DisplayName  string
-	PasswordHash string     `json:"-"`
-	IsActive     bool       `gorm:"default:true"`
+	PasswordHash string `json:"-"`
+	IsActive     bool   `gorm:"default:true"`
 	// LastLoginAt is stamped on each successful auth.login; nil = never logged in.
 	// G81: range-queried (ListInactiveUsers, ListUsers/InactiveSince) against a
 	// UTC bound (dashboard.go), so a local-zone value here silently mismatches on

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -320,7 +320,17 @@ type User struct {
 	DisplayName  string
 	PasswordHash string     `json:"-"`
 	IsActive     bool       `gorm:"default:true"`
-	LastLoginAt  *time.Time // stamped on each successful auth.login; nil = never logged in
+	// LastLoginAt is stamped on each successful auth.login; nil = never logged in.
+	// G81: range-queried (ListInactiveUsers, ListUsers/InactiveSince) against a
+	// UTC bound (dashboard.go), so a local-zone value here silently mismatches on
+	// SQLite. NOT covered by a BeforeSave hook — UpdateLastLogin's sole write path
+	// (local_users.go, UpdateColumn) bypasses all model hooks, the same way
+	// MFAStepupToken's ON CONFLICT path did before local_mfa_stepup.go's explicit
+	// call-site fix. Normalized explicitly at auth.go's LoginUser instead (mirrors
+	// that precedent) — a hook here would be silently ineffective, exactly like
+	// the BeforeSave-vs-GORM-NowFunc-ordering no-op documented on
+	// StatsSnapshot.CreatedAt below.
+	LastLoginAt *time.Time
 	// PasswordChangedAt is when the current password was set. Drives max-age
 	// expiry (ADR-025). nil on legacy rows = treat as set at account creation.
 	PasswordChangedAt *time.Time
@@ -461,6 +471,17 @@ type LoginAttempt struct {
 	// `WHERE attempted_at < ?` (the composite's leading ip column can't), keeping the
 	// hourly cleanup an index range delete rather than a full-table scan.
 	AttemptedAt time.Time `gorm:"index:idx_login_attempt_ip_time,priority:2;index:idx_login_attempt_time"`
+}
+
+// BeforeSave normalises AttemptedAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 — this is
+// the strongest live case found in the sweep: on a storage.type: remote
+// deployment, login_attempts_proxy.go persists a follower's own locally-timed
+// write on the hub, so the write and read sides can be on genuinely different
+// machines' clocks, not just subject to same-process DST drift).
+func (a *LoginAttempt) BeforeSave(_ *gorm.DB) error {
+	a.AttemptedAt = a.AttemptedAt.UTC()
+	return nil
 }
 
 // WebAuthnCredential is a registered passkey / FIDO2 authenticator (ADR-036).
@@ -732,6 +753,20 @@ type SecretNode struct {
 	ValueStored bool `gorm:"-" json:"-"`
 }
 
+// BeforeSave normalises Expiration to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 —
+// Expiration is set from a client-supplied RFC3339 value, see secrets.go, and
+// range-queried against both another client-supplied bound (secrets_list.go's
+// expires_before query param) and several internally-computed cutoffs
+// (dashboard/hygiene/reminder jobs); see local_secrets.go).
+func (s *SecretNode) BeforeSave(_ *gorm.DB) error {
+	if s.Expiration != nil {
+		u := s.Expiration.UTC()
+		s.Expiration = &u
+	}
+	return nil
+}
+
 // SecretDependency is a directed edge in a project's secret dependency graph:
 // the secret DependentSecretID "depends on" DependsOnSecretID — i.e. rotating the
 // dependency may require updating or re-issuing the dependent (e.g. an application
@@ -904,6 +939,18 @@ type SecretAccessLog struct {
 	UserAgent       string
 }
 
+// BeforeSave normalises AccessTime to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 — six
+// store-package functions range-query this column; see local_audit.go).
+// PrincipalSecretFirstSeen's doc comment used to claim this was safe unnormalized
+// because every caller was date-scale — that was false (RunDetection's hour-scale
+// anomaly-detection window compares a UTC bound against this field), which is why
+// this hook exists.
+func (l *SecretAccessLog) BeforeSave(_ *gorm.DB) error {
+	l.AccessTime = l.AccessTime.UTC()
+	return nil
+}
+
 type SecretMetadataHistory struct {
 	ID           uint `gorm:"primaryKey"`
 	SecretNodeID uint
@@ -993,6 +1040,21 @@ type PersonalAccessToken struct {
 	ExpiresAt    *time.Time // nil = never expires
 	Revoked      bool       `gorm:"default:false"`
 	CreatedAt    time.Time
+}
+
+// BeforeSave normalises ExpiresAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 — ExpiresAt
+// is set from a client-supplied RFC3339 value, see pat_handler.go, and
+// range-queried against server-local bounds; see local_token_expiry.go,
+// local_hygiene_counts.go, local_auth.go). LastUsedAt is deliberately NOT
+// covered here — its sole write path (TouchPersonalAccessToken) bypasses model
+// hooks via UpdateColumn; see #1507.
+func (t *PersonalAccessToken) BeforeSave(_ *gorm.DB) error {
+	if t.ExpiresAt != nil {
+		u := t.ExpiresAt.UTC()
+		t.ExpiresAt = &u
+	}
+	return nil
 }
 
 // SetupToken is the single-use, hashed-at-rest bearer string that lets a brand-new
@@ -1336,6 +1398,19 @@ type ShareRecord struct {
 	DeletedAt gorm.DeletedAt `gorm:"index"`
 }
 
+// BeforeSave normalises ExpiresAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 — ExpiresAt
+// is set from a client-supplied RFC3339 value, see shares_crud.go, and directly
+// gates JIT secret-access authorization via eight range-query sites in
+// local_sharing.go, all compared against a server-local bound).
+func (s *ShareRecord) BeforeSave(_ *gorm.DB) error {
+	if s.ExpiresAt != nil {
+		u := s.ExpiresAt.UTC()
+		s.ExpiresAt = &u
+	}
+	return nil
+}
+
 type GRPCService struct {
 	Name        string `gorm:"primaryKey"`
 	Version     string
@@ -1406,6 +1481,16 @@ type AnomalyAlert struct {
 	// SIEM forward) so the alerter doesn't re-notify on every scan.
 	Alerted   bool `gorm:"default:false;index"`
 	CreatedAt time.Time
+}
+
+// BeforeSave normalises DetectedAt to UTC so SQLite string comparisons are
+// timezone-consistent regardless of the caller's local timezone (G81 — DetectedAt
+// is range-queried by the escalation sweep and the retention purge, both of
+// which compare against a bound built independently of the write; see
+// local_alert_escalation.go and local_purge.go).
+func (a *AnomalyAlert) BeforeSave(_ *gorm.DB) error {
+	a.DetectedAt = a.DetectedAt.UTC()
+	return nil
 }
 
 // AnomalyConfigRecord stores runtime-tunable anomaly detection parameters.

--- a/internal/storage/store/g81_guard_test.go
+++ b/internal/storage/store/g81_guard_test.go
@@ -1,0 +1,269 @@
+// g81_guard_test.go — guard test for the G81 timezone bug class (see the
+// BeforeSave hooks in internal/storage/models/models.go and
+// g81_audit_event_timezone_test.go). Two checks:
+//
+//  1. Reflection: every entry below marked HasHook actually has a BeforeSave
+//     hook on the model it names.
+//  2. AST freshness: every time-shaped column name appearing in a range
+//     comparison (>=, <=, <, >) anywhere in this package's non-test source is
+//     present in g81MaintainedFields below. A NEW range-queried time-ish
+//     column that shows up without a corresponding entry fails this test —
+//     add an entry (with hook status + exemption reason) rather than ignore
+//     the failure.
+//
+// This cannot fully resolve WHICH MODEL a bare column name belongs to from
+// static analysis alone: tracing a GORM method chain back to its Model()/
+// Table() call reliably needs real dataflow analysis this codebase's query
+// style doesn't support with simple AST walking (single-chain calls,
+// reassigned `query = query.Where(...)` across statements, raw
+// `Table("literal_string")` calls). The freshness check is therefore keyed by
+// COLUMN NAME, not (model, column) — several models can and do share a column
+// name (expires_at, created_at). Each entry still records which model it's
+// really about, for the reflection check and for human review, but a
+// genuinely new query against an EXISTING column name on an untracked model
+// will not be caught by this test alone. That's a known, accepted limitation
+// of a maintained list — see the G81 bug-class sweep's Stage 1 report for the
+// fuller discussion of why full automation isn't feasible here.
+package store
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// beforeSaver is satisfied by any model with a BeforeSave hook (any receiver
+// type GORM would actually invoke it on).
+type beforeSaver interface {
+	BeforeSave(*gorm.DB) error
+}
+
+// g81FieldEntry records one range-queried time-ish column this package
+// compares against a bound. Value is a pointer instance of the model, used
+// for the reflection check; Column is the exact string as it appears in a
+// SQL WHERE/HAVING fragment (no table alias).
+type g81FieldEntry struct {
+	Model   string
+	Column  string
+	Value   any
+	HasHook bool
+	// Exempt is required when HasHook is false: why no hook covers this
+	// column, or why none is needed.
+	Exempt string
+}
+
+// g81MaintainedFields is the maintained list. Every entry either has
+// HasHook: true (verified by reflection below to actually have a BeforeSave
+// method) or a non-empty Exempt reason.
+var g81MaintainedFields = []g81FieldEntry{
+	// --- Live G81 recurrences, hook + read-side fixed ---
+	{Model: "AuditEvent", Column: "event_time", Value: &models.AuditEvent{}, HasHook: true},
+	{Model: "AnomalyAlert", Column: "detected_at", Value: &models.AnomalyAlert{}, HasHook: true},
+	{Model: "SecretAccessLog", Column: "access_time", Value: &models.SecretAccessLog{}, HasHook: true},
+	{Model: "PersonalAccessToken", Column: "expires_at", Value: &models.PersonalAccessToken{}, HasHook: true},
+	{Model: "ShareRecord", Column: "expires_at", Value: &models.ShareRecord{}, HasHook: true},
+	{Model: "SecretNode", Column: "expiration", Value: &models.SecretNode{}, HasHook: true},
+	{Model: "LoginAttempt", Column: "attempted_at", Value: &models.LoginAttempt{}, HasHook: true},
+
+	// --- Latent G81 recurrences, hook-only fixed (self-consistent write/read
+	// today, but the same recurring risk class) ---
+	{Model: "MFAStepupToken", Column: "expires_at", Value: &models.MFAStepupToken{}, HasHook: true},
+	{Model: "MFAStepUpGrant", Column: "expires_at", Value: &models.MFAStepUpGrant{}, HasHook: true},
+	{Model: "UserRole", Column: "expires_at", Value: &models.UserRole{}, HasHook: true},
+	{Model: "GroupRole", Column: "expires_at", Value: &models.GroupRole{}, HasHook: true},
+	{Model: "DynamicSecretLease", Column: "expires_at", Value: &models.DynamicSecretLease{}, HasHook: true},
+	{Model: "MFAChallenge", Column: "expires_at", Value: &models.MFAChallenge{}, HasHook: true},
+	{Model: "Session", Column: "expires_at", Value: &models.Session{}, HasHook: true},
+	{Model: "WebAuthnSession", Column: "expires_at", Value: &models.WebAuthnSession{}, HasHook: true},
+	{Model: "MachineIdentityCredential", Column: "expires_at", Value: &models.MachineIdentityCredential{}, HasHook: true},
+	{Model: "SetupToken", Column: "created_at", Value: &models.SetupToken{}, HasHook: true},
+	{Model: "User", Column: "created_at", Value: &models.User{}, HasHook: true},
+	{Model: "MachineIdentity", Column: "created_at", Value: &models.MachineIdentity{}, HasHook: true},
+	{Model: "BreakGlassActivation", Column: "created_at", Value: &models.BreakGlassActivation{}, HasHook: true},
+	{Model: "ProjectMembership", Column: "invited_at", Value: &models.ProjectMembership{}, HasHook: true},
+	{Model: "AccessReviewCampaign", Column: "closed_at", Value: &models.AccessReviewCampaign{}, HasHook: true},
+	{Model: "AccessRequest", Column: "resolved_at", Value: &models.AccessRequest{}, HasHook: true},
+
+	// --- Exempt: no hook, with reasons ---
+	{
+		Model: "User", Column: "last_login_at", Value: &models.User{}, HasHook: false,
+		Exempt: "sole write path (UpdateLastLogin, UpdateColumn) bypasses all model hooks; " +
+			"normalized explicitly at internal/core/auth.go's RecordLogin instead, mirroring " +
+			"local_mfa_stepup.go's MFAStepupToken ON CONFLICT precedent",
+	},
+	{
+		Model: "StatsSnapshot", Column: "created_at", Value: &models.StatsSnapshot{}, HasHook: false,
+		Exempt: "GORM-implicit auto-timestamp, never explicitly set in Go — empirically verified " +
+			"BeforeSave fires BEFORE GORM's own auto-CreatedAt assignment, so a hook would " +
+			"normalize a zero value and then be silently overwritten; see the doc comment on " +
+			"models.StatsSnapshot",
+	},
+	{
+		Model: "Session", Column: "last_seen_at", Value: &models.Session{}, HasHook: false,
+		Exempt: "sole write path (TouchSession, UpdateColumn) bypasses all model hooks; latent " +
+			"today (write and read both use unnormalized local time, consistently) — tracked " +
+			"in #1507, not fixed, since it isn't live",
+	},
+	{
+		Model: "PersonalAccessToken", Column: "last_used_at", Value: &models.PersonalAccessToken{}, HasHook: false,
+		Exempt: "sole write path (TouchPersonalAccessToken, UpdateColumn) bypasses all model " +
+			"hooks; latent today — tracked in #1507, not fixed",
+	},
+	{
+		Model: "MachineIdentityCredential", Column: "last_used_at", Value: &models.MachineIdentityCredential{}, HasHook: false,
+		Exempt: "sole write path (TouchMachineIdentityCredential, UpdateColumn) bypasses all " +
+			"model hooks; latent today — tracked in #1507, not fixed",
+	},
+	{
+		Model: "SecretNode", Column: "created_at", Value: &models.SecretNode{}, HasHook: false,
+		Exempt: "storage.SecretFilter.CreatedAfter/CreatedBefore, the only caller of this range " +
+			"query, is set only in _test.go files today — dead in production. Would need this " +
+			"model's existing hook extended to cover CreatedAt too if that filter is ever wired " +
+			"up to a real caller",
+	},
+	{
+		Model: "(various — gorm.DeletedAt)", Column: "deleted_at", Value: nil, HasHook: false,
+		Exempt: "gorm.DeletedAt, not time.Time/*time.Time — a distinct type GORM manages itself " +
+			"via its own soft-delete machinery (stamped by the *gorm.DB connection's local " +
+			"NowFunc at delete time), not a plain application field a BeforeSave hook can " +
+			"normalize the same way. Out of scope for the G81 bug class by definition (which is " +
+			"about time.Time/*time.Time fields specifically) — see retention_proxy.go's package " +
+			"doc for how its callers handle this column's Location explicitly instead",
+	},
+	{
+		Model: "DeploymentStatsSnapshot", Column: "snapshot_date", Value: &models.DeploymentStatsSnapshot{}, HasHook: false,
+		Exempt: "written with explicit time.Now().UTC() at every call site and queried with an " +
+			"explicit .UTC() bound; no hook needed",
+	},
+	{
+		Model: "CompliancePostureSnapshot", Column: "snapshot_date", Value: &models.CompliancePostureSnapshot{}, HasHook: false,
+		Exempt: "written with explicit time.Now().UTC() at every call site and queried with an " +
+			"explicit .UTC() bound (GetPreviousCompliancePostureSnapshot); no hook needed",
+	},
+}
+
+// TestG81_MaintainedFieldsHaveWorkingHooks is the reflection check: every
+// entry claiming HasHook: true must actually implement BeforeSave, and every
+// entry claiming HasHook: false must carry a non-empty Exempt reason.
+func TestG81_MaintainedFieldsHaveWorkingHooks(t *testing.T) {
+	for _, f := range g81MaintainedFields {
+		t.Run(f.Model+"."+f.Column, func(t *testing.T) {
+			if f.HasHook {
+				if f.Value == nil {
+					t.Fatalf("%s.%s: HasHook is true but Value is nil, cannot verify", f.Model, f.Column)
+				}
+				if _, ok := f.Value.(beforeSaver); !ok {
+					t.Errorf("%s.%s is listed as hook-covered but %T has no BeforeSave(*gorm.DB) error method",
+						f.Model, f.Column, f.Value)
+				}
+				if f.Exempt != "" {
+					t.Errorf("%s.%s has HasHook: true but also an Exempt reason set — pick one", f.Model, f.Column)
+				}
+			} else if f.Exempt == "" {
+				t.Errorf("%s.%s has HasHook: false but no Exempt reason recorded", f.Model, f.Column)
+			}
+		})
+	}
+}
+
+// g81TimeColumnPattern matches a column reference immediately followed by a
+// >=, <=, <, or > comparison against a bind placeholder — the exact shape
+// every range query in this package uses (see the Stage 1 sweep report).
+// Deliberately excludes plain "=" (equality isn't a range comparison and
+// isn't subject to this bug class) and ">"/"<" used for anything other than
+// a bind placeholder immediately after (ruling out unrelated numeric
+// comparisons like "count > 0" written as a literal, though "id > ?" style
+// non-time columns still need the time-ish name filter below to be excluded).
+var g81TimeColumnPattern = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_.]*)\s*(>=|<=|<|>)\s*\?`)
+
+// g81TimeLikeColumn reports whether a bare (alias-stripped) column name looks
+// like a time.Time/*time.Time column by this codebase's naming conventions.
+// The suffix check covers the overwhelming majority; the explicit set covers
+// the handful of columns found during the sweep that don't follow it
+// (SecretNode.Expiration, User.LoginLockedUntil, MachineIdentityCredential's
+// sibling CertNotAfter on a different model) — see the Stage 1 report for how
+// these were found (a suffix-only grep misses them).
+var g81ExplicitTimeLikeColumns = map[string]bool{
+	"expiration":       true,
+	"login_locked_until": true,
+	"cert_not_after":   true,
+}
+
+func g81TimeLikeColumn(col string) bool {
+	if g81ExplicitTimeLikeColumns[col] {
+		return true
+	}
+	return strings.HasSuffix(col, "_at") || strings.HasSuffix(col, "_time") || strings.HasSuffix(col, "_date")
+}
+
+// TestG81_NoUntrackedRangeQueriedTimeColumns is the AST freshness check: parse
+// every non-test .go file in this package, collect every column name that
+// appears in a range comparison against a bind placeholder, and assert each
+// time-like one is accounted for in g81MaintainedFields. Fails with the
+// offending file:line so a new range query on a new column can't silently
+// skip this bug class.
+func TestG81_NoUntrackedRangeQueriedTimeColumns(t *testing.T) {
+	known := make(map[string]bool, len(g81MaintainedFields))
+	for _, f := range g81MaintainedFields {
+		known[f.Column] = true
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("failed to list package directory: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(".", name)
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", path, err)
+		}
+		file, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("failed to parse %s: %v", path, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			s, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				return true
+			}
+			for _, m := range g81TimeColumnPattern.FindAllStringSubmatch(s, -1) {
+				col := m[1]
+				if idx := strings.LastIndex(col, "."); idx != -1 {
+					col = col[idx+1:]
+				}
+				if !g81TimeLikeColumn(col) {
+					continue
+				}
+				if !known[col] {
+					pos := fset.Position(lit.Pos())
+					t.Errorf("%s:%d: range query on untracked time-like column %q (in %q) — "+
+						"add a g81FieldEntry to g81_guard_test.go recording which model this is, "+
+						"whether it has a BeforeSave hook, and why (or why not)",
+						pos.Filename, pos.Line, col, s)
+				}
+			}
+			return true
+		})
+	}
+}

--- a/internal/storage/store/g81_guard_test.go
+++ b/internal/storage/store/g81_guard_test.go
@@ -194,9 +194,9 @@ var g81TimeColumnPattern = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_.]*)\s*(>=
 // sibling CertNotAfter on a different model) — see the Stage 1 report for how
 // these were found (a suffix-only grep misses them).
 var g81ExplicitTimeLikeColumns = map[string]bool{
-	"expiration":       true,
+	"expiration":         true,
 	"login_locked_until": true,
-	"cert_not_after":   true,
+	"cert_not_after":     true,
 }
 
 func g81TimeLikeColumn(col string) bool {

--- a/internal/storage/store/local_alert_escalation.go
+++ b/internal/storage/store/local_alert_escalation.go
@@ -74,9 +74,10 @@ func (ls *LocalStorage) DeleteAlertEscalationPolicy(ctx context.Context, id uint
 // ListUnacknowledgedAnomalyAlertsBefore returns unacknowledged AnomalyAlerts whose
 // detected_at is before the given threshold (i.e. older than the threshold time).
 func (ls *LocalStorage) ListUnacknowledgedAnomalyAlertsBefore(ctx context.Context, threshold time.Time) ([]models.AnomalyAlert, error) {
+	// G81 (AnomalyAlert.DetectedAt): normalize internally — see GetAuditLogs.
 	var rows []models.AnomalyAlert
 	err := ls.db.WithContext(ctx).
-		Where("acknowledged = ? AND detected_at < ?", false, threshold).
+		Where("acknowledged = ? AND detected_at < ?", false, threshold.UTC()).
 		Order("detected_at ASC").
 		Find(&rows).Error
 	if err != nil {

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -36,9 +36,10 @@ func (ls *LocalStorage) CreateSecretAccessLog(ctx context.Context, log *models.S
 const maxSecretAccessLogRows = 50_000
 
 func (ls *LocalStorage) ListSecretAccessLogs(ctx context.Context, secretID uint, since time.Time) ([]models.SecretAccessLog, error) {
+	// G81 (SecretAccessLog.AccessTime): normalize internally — see GetAuditLogs.
 	var logs []models.SecretAccessLog
 	result := ls.db.WithContext(ctx).
-		Where("secret_node_id = ? AND access_time >= ?", secretID, since).
+		Where("secret_node_id = ? AND access_time >= ?", secretID, since.UTC()).
 		Order("access_time DESC").
 		Limit(maxSecretAccessLogRows).
 		Find(&logs)
@@ -52,6 +53,8 @@ func (ls *LocalStorage) ListSecretAccessLogs(ctx context.Context, secretID uint,
 // risk-scoring batch (#409) instead of one such call per candidate secret. A
 // secret absent from the result had zero qualifying reads.
 func (ls *LocalStorage) CountSecretReadsBySecretIDs(ctx context.Context, secretIDs []uint, since time.Time) (map[uint]int, error) {
+	// G81 (SecretAccessLog.AccessTime): normalize internally — see GetAuditLogs.
+	since = since.UTC()
 	out := make(map[uint]int, len(secretIDs))
 	if len(secretIDs) == 0 {
 		return out, nil
@@ -80,18 +83,16 @@ func (ls *LocalStorage) CountSecretReadsBySecretIDs(ctx context.Context, secretI
 // aggregated in SQL (GROUP BY + MIN), not loaded as full log rows, so this stays cheap
 // regardless of per-secret read volume (#101).
 //
-// The `since` SQL boundary is deliberately coarse (the 30-day baseline window, not the
-// live scan window): a stored AccessTime preserves its writer's local UTC offset as
-// text (e.g. "...+02:00"), rather than being normalised to a single format, so a SQL
-// WHERE boundary that's narrow relative to "now" (same-day/same-hour) compares that text
-// lexicographically against a differently-offset-formatted bound parameter and can
-// silently misclassify rows near the boundary — a real-but-latent issue across this
-// codebase's time-range queries, only ever safe today because every other WHERE
-// boundary here is date-scale (7d/30d), never hour-scale. Callers needing the
-// hour-scale "is this within the live window" distinction must make it in Go against
-// the returned time.Time (which is location-independent to compare), not by pushing a
-// second, narrower bound into this query.
+// G81: this comment previously claimed the WHERE boundary was safe unnormalized because
+// every caller here is date-scale (7d/30d), "never hour-scale" — that claim was false:
+// RunDetection's hour-scale window (minDetectionLookback = time.Hour, anomaly.go) feeds
+// this same query path via ListSecretAccessLogs, using a UTC `now` against an AccessTime
+// written as bare (local) time.Now() — exactly the narrow-relative-to-now mismatch this
+// comment said didn't happen. Fixed properly now: AccessTime is normalized to UTC at
+// write time (models.SecretAccessLog.BeforeSave) and `since` is normalized here, so every
+// caller's WHERE boundary compares like-for-like regardless of scale.
 func (ls *LocalStorage) PrincipalSecretFirstSeen(ctx context.Context, since time.Time) (map[string]map[uint]time.Time, error) {
+	since = since.UTC()
 	type row struct {
 		AccessedBy   string
 		SecretNodeID uint
@@ -192,6 +193,8 @@ func (s *scanTime) parse(str string) error {
 // authorizes against (ScopeFromQuery), so a caller authorized for only one
 // environment cannot receive the whole project's aggregate usage data.
 func (ls *LocalStorage) MostAccessedSecrets(ctx context.Context, projectID, environmentID *uint, since time.Time, limit int) ([]storage.SecretUsageStat, error) {
+	// G81 (SecretAccessLog.AccessTime): normalize internally — see GetAuditLogs.
+	since = since.UTC()
 	if limit <= 0 {
 		limit = 10
 	}
@@ -244,6 +247,8 @@ func (ls *LocalStorage) MostAccessedSecrets(ctx context.Context, projectID, envi
 // for only one environment cannot receive the whole project's aggregate
 // usage data.
 func (ls *LocalStorage) UnusedSecrets(ctx context.Context, projectID, environmentID *uint, notReadSince time.Time) ([]storage.UnusedSecretStat, error) {
+	// G81 (SecretAccessLog.AccessTime): normalize internally — see GetAuditLogs.
+	notReadSince = notReadSince.UTC()
 	q := ls.db.WithContext(ctx).
 		Table("secret_nodes AS s").
 		Select("s.id AS secret_id, s.name AS secret_name, s.environment_id AS environment_id, MAX(l.access_time) AS last_read").
@@ -291,6 +296,8 @@ func (ls *LocalStorage) UnusedSecrets(ctx context.Context, projectID, environmen
 // per project), so the per-secret query runs as a FROM subquery. A project with no
 // unused secrets is simply absent from the returned map.
 func (ls *LocalStorage) CountUnusedSecretsByProject(ctx context.Context, projectIDs []uint, notReadSince time.Time) (map[uint]int, error) {
+	// G81 (SecretAccessLog.AccessTime): normalize internally — see GetAuditLogs.
+	notReadSince = notReadSince.UTC()
 	counts := make(map[uint]int)
 	if len(projectIDs) == 0 {
 		return counts, nil
@@ -566,7 +573,11 @@ const anomalyDedupWindow = time.Hour
 // window, the insert is skipped and nil is returned — so re-running detection
 // over the same window does not pile up duplicates.
 func (ls *LocalStorage) CreateAnomalyAlert(ctx context.Context, alert *models.AnomalyAlert) error {
-	cutoff := alert.DetectedAt
+	// G81 (AnomalyAlert.DetectedAt): cutoff derives from alert.DetectedAt as given
+	// by the caller, BEFORE the BeforeSave hook (fired later, inside tx.Create
+	// below) normalizes it — so .UTC() it explicitly here too, defensively,
+	// even though every real caller already passes a UTC value today.
+	cutoff := alert.DetectedAt.UTC()
 	if cutoff.IsZero() {
 		cutoff = time.Now().UTC()
 	}

--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -325,6 +325,8 @@ const sqlWhereExpiredPAT = "user_id = ? AND revoked = ? AND expires_at IS NOT NU
 // ListExpiredPATsByUser returns all non-revoked PATs for userID whose ExpiresAt is in
 // the past (expired but never explicitly revoked). Ordered newest-created first.
 func (ls *LocalStorage) ListExpiredPATsByUser(ctx context.Context, userID uint, now time.Time) ([]*models.PersonalAccessToken, error) {
+	// G81 (PersonalAccessToken.ExpiresAt): normalize internally — see GetAuditLogs.
+	now = now.UTC()
 	var tokens []*models.PersonalAccessToken
 	if err := ls.db.WithContext(ctx).
 		Where(sqlWhereExpiredPAT, userID, false, now).
@@ -338,6 +340,8 @@ func (ls *LocalStorage) ListExpiredPATsByUser(ctx context.Context, userID uint, 
 // BulkRevokeExpiredPATsByUser revokes every non-revoked, expired PAT belonging to
 // userID and returns their token hashes so the caller can evict them from the auth cache.
 func (ls *LocalStorage) BulkRevokeExpiredPATsByUser(ctx context.Context, userID uint, now time.Time) ([]string, error) {
+	// G81 (PersonalAccessToken.ExpiresAt): normalize internally — see GetAuditLogs.
+	now = now.UTC()
 	var hashes []string
 	if err := ls.db.WithContext(ctx).Model(&models.PersonalAccessToken{}).
 		Where(sqlWhereExpiredPAT, userID, false, now).

--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -141,9 +141,10 @@ func (ls *LocalStorage) GetSessionByID(ctx context.Context, id uint) (*models.Se
 
 // ListSessionsByUser returns the user's non-expired sessions, most-recently-seen first.
 func (ls *LocalStorage) ListSessionsByUser(ctx context.Context, userID uint) ([]*models.Session, error) {
+	// G81 (Session.ExpiresAt): normalize internally — see GetAuditLogs.
 	var sessions []*models.Session
 	if err := ls.db.WithContext(ctx).
-		Where("user_id = ? AND (expires_at IS NULL OR expires_at > ?)", userID, time.Now()).
+		Where("user_id = ? AND (expires_at IS NULL OR expires_at > ?)", userID, time.Now().UTC()).
 		Order(sqlOrderCreatedAtDesc).
 		Find(&sessions).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -221,7 +222,8 @@ func (ls *LocalStorage) TouchSession(ctx context.Context, id uint, seenAt time.T
 
 // CleanupExpiredSessions hard-deletes all sessions whose expires_at is in the past.
 func (ls *LocalStorage) CleanupExpiredSessions(ctx context.Context) error {
-	return ls.db.WithContext(ctx).Where("expires_at < ?", time.Now()).Delete(&models.Session{}).Error
+	// G81 (Session.ExpiresAt): normalize internally — see GetAuditLogs.
+	return ls.db.WithContext(ctx).Where("expires_at < ?", time.Now().UTC()).Delete(&models.Session{}).Error
 }
 
 // --- Personal Access Tokens (ADR-027) ---
@@ -419,6 +421,8 @@ func (ls *LocalStorage) MarkSetupTokenExpired(ctx context.Context, id uint) erro
 // CountSetupTokensSince counts tokens minted for (purpose, email) since a cutoff,
 // backing resend throttling and the daily cap.
 func (ls *LocalStorage) CountSetupTokensSince(ctx context.Context, purpose, email string, since time.Time) (int64, error) {
+	// G81 (SetupToken.CreatedAt): normalize internally — see GetAuditLogs.
+	since = since.UTC()
 	var n int64
 	if err := ls.db.WithContext(ctx).Model(&models.SetupToken{}).
 		Where("purpose = ? AND subject_email = ? AND created_at >= ?", purpose, email, since).

--- a/internal/storage/store/local_hygiene_counts.go
+++ b/internal/storage/store/local_hygiene_counts.go
@@ -45,10 +45,15 @@ func (ls *LocalStorage) ListHygieneTrendSnapshots(ctx context.Context, days int)
 // CountStalePATs returns the count of non-revoked, active (not expired) PATs
 // that have not been used since threshold (or never used).
 func (ls *LocalStorage) CountStalePATs(ctx context.Context, threshold time.Time) (int, error) {
+	// G81 (PersonalAccessToken.ExpiresAt): normalize the expires_at bound
+	// internally — see GetAuditLogs. last_used_at (threshold) is intentionally
+	// left as-is: its sole write path (TouchPersonalAccessToken) bypasses model
+	// hooks via UpdateColumn, so it's a separate, currently-latent hazard tracked
+	// in #1507, not fixed here.
 	var count int64
 	err := ls.db.WithContext(ctx).Model(&models.PersonalAccessToken{}).
 		Where("revoked = ? AND (expires_at IS NULL OR expires_at > ?) AND (last_used_at IS NULL OR last_used_at < ?)",
-			false, time.Now(), threshold).
+			false, time.Now().UTC(), threshold).
 		Count(&count).Error
 	return int(count), err
 }
@@ -56,9 +61,10 @@ func (ls *LocalStorage) CountStalePATs(ctx context.Context, threshold time.Time)
 // CountExpiredPATs returns the count of non-revoked PATs whose ExpiresAt is
 // in the past (expired but never explicitly revoked — token sprawl).
 func (ls *LocalStorage) CountExpiredPATs(ctx context.Context) (int, error) {
+	// G81 (PersonalAccessToken.ExpiresAt): normalize internally — see GetAuditLogs.
 	var count int64
 	err := ls.db.WithContext(ctx).Model(&models.PersonalAccessToken{}).
-		Where("revoked = ? AND expires_at IS NOT NULL AND expires_at < ?", false, time.Now()).
+		Where("revoked = ? AND expires_at IS NOT NULL AND expires_at < ?", false, time.Now().UTC()).
 		Count(&count).Error
 	return int(count), err
 }

--- a/internal/storage/store/local_login_attempts.go
+++ b/internal/storage/store/local_login_attempts.go
@@ -15,6 +15,11 @@ func (ls *LocalStorage) RecordLoginAttempt(ctx context.Context, ip string, at ti
 }
 
 func (ls *LocalStorage) CountRecentLoginAttempts(ctx context.Context, ip string, since time.Time) (int64, error) {
+	// G81 (LoginAttempt.AttemptedAt): normalize internally — see GetAuditLogs. A
+	// cross-process write (login_attempts_proxy.go, storage.type: remote) carries
+	// a follower's own local clock across the wire, so this bound can genuinely
+	// diverge from a write's Location, not just drift within one process.
+	since = since.UTC()
 	var n int64
 	if err := ls.db.WithContext(ctx).Model(&models.LoginAttempt{}).
 		Where("ip = ? AND attempted_at > ?", ip, since).Count(&n).Error; err != nil {
@@ -26,6 +31,8 @@ func (ls *LocalStorage) CountRecentLoginAttempts(ctx context.Context, ip string,
 // PruneLoginAttempts deletes attempts older than `before` (past the window) and
 // returns how many were removed.
 func (ls *LocalStorage) PruneLoginAttempts(ctx context.Context, before time.Time) (int64, error) {
+	// G81 (LoginAttempt.AttemptedAt): normalize internally — see GetAuditLogs.
+	before = before.UTC()
 	res := ls.db.WithContext(ctx).Where("attempted_at < ?", before).Delete(&models.LoginAttempt{})
 	return res.RowsAffected, res.Error
 }

--- a/internal/storage/store/local_machine_identities.go
+++ b/internal/storage/store/local_machine_identities.go
@@ -112,6 +112,8 @@ const machineIdentityStateActive = "active"
 // rollup (#393) instead of fanning out one call per project. A project with no
 // stale machine identities is simply absent from the returned map.
 func (ls *LocalStorage) CountStaleMachineIdentitiesByProject(ctx context.Context, projectIDs []uint, olderThan time.Time) (map[uint]int, error) {
+	// G81 (MachineIdentity.CreatedAt): normalize internally — see GetAuditLogs.
+	olderThan = olderThan.UTC()
 	counts := make(map[uint]int)
 	if len(projectIDs) == 0 {
 		return counts, nil

--- a/internal/storage/store/local_memberships.go
+++ b/internal/storage/store/local_memberships.go
@@ -100,6 +100,8 @@ func (ls *LocalStorage) GetActiveProjectMembership(ctx context.Context, projectI
 }
 
 func (ls *LocalStorage) ListStaleInvitedMemberships(ctx context.Context, before time.Time) ([]*models.ProjectMembership, error) {
+	// G81 (ProjectMembership.InvitedAt): normalize internally — see GetAuditLogs.
+	before = before.UTC()
 	var rows []*models.ProjectMembership
 	err := ls.db.WithContext(ctx).
 		Where("state = ? AND invited_at < ?", "invited", before).

--- a/internal/storage/store/local_mfa.go
+++ b/internal/storage/store/local_mfa.go
@@ -107,6 +107,8 @@ func (ls *LocalStorage) CreateMFAChallenge(ctx context.Context, c *models.MFACha
 // GetActiveMFAChallenge returns a valid (unused, unexpired) challenge by hash
 // WITHOUT consuming it. Returns an error if none matched.
 func (ls *LocalStorage) GetActiveMFAChallenge(ctx context.Context, tokenHash string, now time.Time) (*models.MFAChallenge, error) {
+	// G81 (MFAChallenge.ExpiresAt): normalize internally — see GetAuditLogs.
+	now = now.UTC()
 	var ch models.MFAChallenge
 	if err := ls.db.WithContext(ctx).
 		Where("token_hash = ? AND used_at IS NULL AND expires_at > ?", tokenHash, now).
@@ -119,6 +121,8 @@ func (ls *LocalStorage) GetActiveMFAChallenge(ctx context.Context, tokenHash str
 // ConsumeMFAChallenge atomically marks a valid (unused, unexpired) challenge used
 // and returns it. Returns an error if none matched.
 func (ls *LocalStorage) ConsumeMFAChallenge(ctx context.Context, tokenHash string, now time.Time) (*models.MFAChallenge, error) {
+	// G81 (MFAChallenge.ExpiresAt): normalize internally — see GetAuditLogs.
+	now = now.UTC()
 	var ch *models.MFAChallenge
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		res := tx.Model(&models.MFAChallenge{}).

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -357,6 +357,8 @@ func (ls *LocalStorage) DeleteAnomalyAlertsBefore(ctx context.Context, ackBefore
 // closed before the cutoff together with their snapshot items, in one transaction.
 // Open campaigns (closed_at IS NULL) are never touched.
 func (ls *LocalStorage) DeleteClosedAccessReviewsBefore(ctx context.Context, before time.Time) (int64, int64, error) {
+	// G81 (AccessReviewCampaign.ClosedAt): normalize internally — see GetAuditLogs.
+	before = before.UTC()
 	var campaigns, items int64
 	eligible := "state = ? AND closed_at IS NOT NULL AND closed_at < ?"
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -394,6 +396,8 @@ func (ls *LocalStorage) DeleteClosedAccessReviewsBefore(ctx context.Context, bef
 // DeleteExpiredBreakGlassBefore hard-deletes non-active break-glass activations
 // created before the cutoff. Active activations are never purged.
 func (ls *LocalStorage) DeleteExpiredBreakGlassBefore(ctx context.Context, before time.Time) (int64, error) {
+	// G81 (BreakGlassActivation.CreatedAt): normalize internally — see GetAuditLogs.
+	before = before.UTC()
 	result := ls.db.WithContext(ctx).
 		Where("state <> ? AND created_at < ?", "active", before).
 		Delete(&models.BreakGlassActivation{})
@@ -407,6 +411,8 @@ func (ls *LocalStorage) DeleteExpiredBreakGlassBefore(ctx context.Context, befor
 // (resolved_at set, before the cutoff) together with their approval records, in one
 // transaction. Pending requests (resolved_at IS NULL) are never touched.
 func (ls *LocalStorage) DeleteResolvedAccessRequestsBefore(ctx context.Context, before time.Time) (int64, int64, error) {
+	// G81 (AccessRequest.ResolvedAt): normalize internally — see GetAuditLogs.
+	before = before.UTC()
 	var requests, approvals int64
 	eligible := "resolved_at IS NOT NULL AND resolved_at < ?"
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -327,15 +327,19 @@ func (ls *LocalStorage) PurgeDeletedSecretsBefore(ctx context.Context, before ti
 // A zero time.Time for either parameter disables that clause (it matches nothing,
 // rather than being misread as "purge everything before year 1").
 func (ls *LocalStorage) DeleteAnomalyAlertsBefore(ctx context.Context, ackBefore, unackCeiling time.Time) (int64, error) {
+	// G81 (AnomalyAlert.DetectedAt): normalize internally — see GetAuditLogs.
+	// IsZero() is checked before normalizing, since a UTC-converted zero time.Time
+	// is still IsZero() true (Location doesn't affect the zero check) — order
+	// doesn't matter here, but IsZero is checked first for clarity.
 	var conds []string
 	var args []interface{}
 	if !ackBefore.IsZero() {
 		conds = append(conds, "(acknowledged = ? AND detected_at < ?)")
-		args = append(args, true, ackBefore)
+		args = append(args, true, ackBefore.UTC())
 	}
 	if !unackCeiling.IsZero() {
 		conds = append(conds, "(acknowledged = ? AND detected_at < ?)")
-		args = append(args, false, unackCeiling)
+		args = append(args, false, unackCeiling.UTC())
 	}
 	if len(conds) == 0 {
 		return 0, nil

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -666,7 +666,8 @@ func (ls *LocalStorage) ListSecrets(ctx context.Context, filter *storage.SecretF
 		query = query.Where("secret_nodes.owner_id = ?", *filter.OwnerID)
 	}
 	if filter.ExpiresBefore != nil {
-		query = query.Where("secret_nodes.expiration IS NOT NULL AND secret_nodes.expiration < ?", *filter.ExpiresBefore)
+		// G81 (SecretNode.Expiration): normalize internally — see GetAuditLogs.
+		query = query.Where("secret_nodes.expiration IS NOT NULL AND secret_nodes.expiration < ?", filter.ExpiresBefore.UTC())
 		// #G24: order soonest-expiring first so a capped PageSize returns the
 		// TRUE most-urgent rows, not an arbitrary unordered slice truncated to
 		// whatever page happened to be returned — callers filtering by expiry
@@ -780,6 +781,8 @@ func (ls *LocalStorage) CountOrphanedSecretsByProject(ctx context.Context, proje
 // single deployment-wide query for the hygiene rollup (#393). A project with no
 // expiring secrets is simply absent from the returned map.
 func (ls *LocalStorage) CountExpiringSecretsByProject(ctx context.Context, projectIDs []uint, expiresBefore time.Time) (map[uint]int, error) {
+	// G81 (SecretNode.Expiration): normalize internally — see GetAuditLogs.
+	expiresBefore = expiresBefore.UTC()
 	counts := make(map[uint]int)
 	if len(projectIDs) == 0 {
 		return counts, nil

--- a/internal/storage/store/local_sharing.go
+++ b/internal/storage/store/local_sharing.go
@@ -155,6 +155,8 @@ func (ls *LocalStorage) DeleteShareRecord(ctx context.Context, shareID uint) err
 // audit each. Runs in a transaction so the rows it reports are exactly the rows it
 // removed. Idempotent — a tick that finds nothing removes nothing.
 func (ls *LocalStorage) DeleteExpiredShareRecords(ctx context.Context, before time.Time) ([]*models.ShareRecord, error) {
+	// G81 (ShareRecord.ExpiresAt): normalize internally — see GetAuditLogs.
+	before = before.UTC()
 	var removed []*models.ShareRecord
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where(
@@ -187,7 +189,7 @@ func (ls *LocalStorage) ListSharesBySecret(ctx context.Context, secretID uint) (
 	var shares []*models.ShareRecord
 	if err := ls.db.Where(
 		"secret_id = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
-		secretID, time.Now(),
+		secretID, time.Now().UTC(),
 	).Limit(maxUnboundedListRows).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
@@ -205,7 +207,7 @@ func (ls *LocalStorage) ListSharesBySecretIDs(ctx context.Context, secretIDs []u
 	var shares []*models.ShareRecord
 	if err := ls.db.WithContext(ctx).Where(
 		"secret_id IN ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
-		secretIDs, time.Now(),
+		secretIDs, time.Now().UTC(),
 	).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
@@ -218,7 +220,7 @@ func (ls *LocalStorage) ListSharesByUser(ctx context.Context, userID uint) ([]*m
 	var shares []*models.ShareRecord
 	if err := ls.db.Where(
 		"recipient_id = ? AND is_group = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
-		userID, false, time.Now(),
+		userID, false, time.Now().UTC(),
 	).Limit(maxUnboundedListRows).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
@@ -233,7 +235,7 @@ func (ls *LocalStorage) ListSharesByOwner(ctx context.Context, ownerID uint) ([]
 	var shares []*models.ShareRecord
 	if err := ls.db.Where(
 		"owner_id = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
-		ownerID, time.Now(),
+		ownerID, time.Now().UTC(),
 	).Limit(maxUnboundedListRows).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
@@ -246,7 +248,7 @@ func (ls *LocalStorage) ListSharesByGroup(ctx context.Context, groupID uint) ([]
 	var shares []*models.ShareRecord
 	if err := ls.db.Where(
 		"recipient_id = ? AND is_group = ? AND deleted_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
-		groupID, true, time.Now(),
+		groupID, true, time.Now().UTC(),
 	).Limit(maxUnboundedListRows).Find(&shares).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorDatabaseOperation", nil), err)
 	}
@@ -258,7 +260,8 @@ func (ls *LocalStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*
 	var secrets []*models.SecretNode
 	// Expired (time-bound) shares no longer authorize, so they must not surface in
 	// the "shared with me" listing either — filter them the same way the auth queries do.
-	now := time.Now()
+	// G81 (ShareRecord.ExpiresAt): normalize internally — see GetAuditLogs.
+	now := time.Now().UTC()
 	// store-secret-acl-002: JOIN users ... deleted_at IS NULL mirrors the group query's
 	// user-liveness guard below (and CheckSharePermission's identical direct-share
 	// guard) — a soft-deleted recipient's direct ShareRecord row stays live for
@@ -355,7 +358,8 @@ func (ls *LocalStorage) CheckSharePermission(ctx context.Context, secretID, user
 	}
 
 	// Skip expired (time-bound) shares — an expired share grants no permission.
-	now := time.Now()
+	// G81 (ShareRecord.ExpiresAt): normalize internally — see GetAuditLogs.
+	now := time.Now().UTC()
 	// store-secret-acl-002: JOIN users ... deleted_at IS NULL mirrors the group-share
 	// query's user-liveness guard below — a soft-deleted recipient's direct
 	// ShareRecord row stays live for audit/restore, so without this guard a deleted

--- a/internal/storage/store/local_token_expiry.go
+++ b/internal/storage/store/local_token_expiry.go
@@ -25,6 +25,8 @@ func (ls *LocalStorage) ListExpiringPATs(ctx context.Context, before time.Time) 
 // ListExpiringMachineCredentials returns every non-revoked MachineIdentityCredential
 // whose ExpiresAt is non-nil and strictly before before.
 func (ls *LocalStorage) ListExpiringMachineCredentials(ctx context.Context, before time.Time) ([]models.MachineIdentityCredential, error) {
+	// G81 (MachineIdentityCredential.ExpiresAt): normalize internally — see GetAuditLogs.
+	before = before.UTC()
 	var creds []models.MachineIdentityCredential
 	return creds, ls.db.WithContext(ctx).
 		Where("revoked = ? AND expires_at IS NOT NULL AND expires_at < ?", false, before).

--- a/internal/storage/store/local_token_expiry.go
+++ b/internal/storage/store/local_token_expiry.go
@@ -15,9 +15,10 @@ import (
 // the critical-window check inside core.CheckTokenExpiry can catch them too
 // (they are skipped there via the "after now" guard).
 func (ls *LocalStorage) ListExpiringPATs(ctx context.Context, before time.Time) ([]models.PersonalAccessToken, error) {
+	// G81 (PersonalAccessToken.ExpiresAt): normalize internally — see GetAuditLogs.
 	var pats []models.PersonalAccessToken
 	return pats, ls.db.WithContext(ctx).
-		Where("revoked = ? AND expires_at IS NOT NULL AND expires_at < ?", false, before).
+		Where("revoked = ? AND expires_at IS NOT NULL AND expires_at < ?", false, before.UTC()).
 		Find(&pats).Error
 }
 

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -288,6 +288,8 @@ func (ls *LocalStorage) UpdateLoginLockoutState(ctx context.Context, id uint, at
 // Legacy rows with an empty account_state normalise to "active" at the read
 // boundary, so they never match a restricted state like pending_first_login.
 func (ls *LocalStorage) ListUsersInStateBefore(ctx context.Context, state string, before time.Time) ([]*models.User, error) {
+	// G81 (User.CreatedAt): normalize internally — see GetAuditLogs.
+	before = before.UTC()
 	var users []*models.User
 	err := ls.db.WithContext(ctx).
 		Where("account_state = ? AND created_at < ?", state, before).

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -304,6 +304,9 @@ func (ls *LocalStorage) ListUsersInStateBefore(ctx context.Context, state string
 // since threshold: (last_login_at IS NULL AND created_at < threshold) OR
 // (last_login_at < threshold). Ordered by ID ascending for stable pagination.
 func (ls *LocalStorage) ListInactiveUsers(ctx context.Context, threshold time.Time) ([]*models.User, error) {
+	// G81 (User.LastLoginAt, also covers CreatedAt): normalize internally — see
+	// GetAuditLogs.
+	threshold = threshold.UTC()
 	var users []*models.User
 	err := ls.db.WithContext(ctx).
 		Where("(last_login_at IS NULL AND created_at < ?) OR last_login_at < ?", threshold, threshold).
@@ -364,7 +367,8 @@ func (ls *LocalStorage) ListUsers(ctx context.Context, filter *storage.UserFilte
 		query = query.Where("created_at > ?", *filter.CreatedAfter)
 	}
 	if filter.InactiveSince != nil {
-		query = query.Where("last_login_at IS NULL OR last_login_at < ?", *filter.InactiveSince)
+		// G81 (User.LastLoginAt): normalize internally — see GetAuditLogs.
+		query = query.Where("last_login_at IS NULL OR last_login_at < ?", filter.InactiveSince.UTC())
 	}
 
 	var total int64

--- a/internal/storage/store/local_webauthn.go
+++ b/internal/storage/store/local_webauthn.go
@@ -154,6 +154,8 @@ func (ls *LocalStorage) CreateWebAuthnSession(ctx context.Context, s *models.Web
 // ConsumeWebAuthnSession atomically marks a valid (unused, unexpired) ceremony
 // session used and returns it. Returns an error if none matched.
 func (ls *LocalStorage) ConsumeWebAuthnSession(ctx context.Context, tokenHash string, now time.Time) (*models.WebAuthnSession, error) {
+	// G81 (WebAuthnSession.ExpiresAt): normalize internally — see GetAuditLogs.
+	now = now.UTC()
 	var sess *models.WebAuthnSession
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		res := tx.Model(&models.WebAuthnSession{}).

--- a/server/http/handlers/dynamic_secrets_proxy.go
+++ b/server/http/handlers/dynamic_secrets_proxy.go
@@ -461,20 +461,23 @@ func (h *DynamicSecretHandler) ListExpiredActiveLeasesProxy(w http.ResponseWrite
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_QUERY", "before must be an RFC3339 timestamp")
 		return
 	}
-	// Reparsing an RFC3339 "Z"-suffixed wire timestamp always yields a UTC
-	// time.Time — but this server's OWN ExpiresAt rows were stored using
-	// whichever timezone its process clock (c.now = time.Now()) runs in, and
 	// GORM's SQLite driver formats a bound time.Time parameter's TEXT
-	// representation using ITS OWN Location, not a canonical one. If this
-	// server's process timezone is not UTC, comparing a UTC-formatted `before`
-	// against locally-formatted stored rows via SQLite's TEXT `<` operator can
-	// silently give the WRONG answer for genuinely-expired rows (verified
-	// empirically: a lease expired exactly 1 hour ago was excluded entirely,
-	// because "07:...+0000" sorts lexicographically before "08:...+0200" even
-	// though the latter is the earlier instant). Convert to Local so this
-	// proxy's comparison matches the SAME convention every other ExpiresAt
-	// comparison in this codebase already uses (time.Now(), never time.Now().UTC()).
-	rows, err := h.coreService.Storage().ListExpiredActiveLeases(r.Context(), before.Local())
+	// representation using ITS OWN Location, not a canonical one, so this bound
+	// must match whatever Location DynamicSecretLease.ExpiresAt is actually
+	// stored in to compare correctly (verified empirically: a lease expired
+	// exactly 1 hour ago was excluded entirely when the two sides' Locations
+	// didn't match, because e.g. "07:...+0000" sorts lexicographically before
+	// "08:...+0200" even though the latter is the earlier instant).
+	//
+	// G81: this used to convert to .Local() on the theory that ExpiresAt was
+	// stored in whatever Location this server's process clock runs in — that was
+	// already wrong by the time this comment was written: DynamicSecretLease has
+	// carried a BeforeSave hook normalizing ExpiresAt to UTC since before the G81
+	// bug-class sweep (internal/storage/models/models.go), so .Local() here
+	// actively reintroduced the exact mismatch this comment otherwise correctly
+	// describes. No existing test's cutoff was tight enough to catch it. Fixed:
+	// .UTC() to match the hook.
+	rows, err := h.coreService.Storage().ListExpiredActiveLeases(r.Context(), before.UTC())
 	if err != nil {
 		log.Printf("dynamic-secrets proxy: list expired leases failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))

--- a/server/http/handlers/retention_proxy.go
+++ b/server/http/handlers/retention_proxy.go
@@ -62,11 +62,26 @@
 // canonical one — see dynamic_secrets_proxy.go's ListExpiredActiveLeasesProxy for
 // the full empirical writeup of the resulting bug (a genuinely-expired row silently
 // excluded because two different UTC-offset TEXT representations sort
-// lexicographically out of instant order). Every decoded timestamp below is
-// therefore converted with .Local() before being handed to storage.Storage, so its
-// TEXT representation is formatted in the SAME Location this server's own rows were
-// written in — matching the one convention every other time.Time comparison in this
-// codebase already relies on (time.Now(), never time.Now().UTC()).
+// lexicographically out of instant order).
+//
+// G81: this note used to say every decoded timestamp was converted with .Local()
+// to match "the one convention every other time.Time comparison in this codebase
+// already relies on (time.Now(), never time.Now().UTC())" — that convention no
+// longer holds uniformly. The G81 bug-class sweep added BeforeSave hooks that
+// UTC-normalize several of the columns compared here (AnomalyAlert.DetectedAt,
+// AccessReviewCampaign.ClosedAt, BreakGlassActivation.CreatedAt,
+// AccessRequest.ResolvedAt, User.CreatedAt, ShareRecord.ExpiresAt,
+// UserRole/GroupRole.ExpiresAt, DynamicSecretLease.ExpiresAt — see
+// internal/storage/models/models.go), while deleted_at (gorm.DeletedAt, a
+// different type with no BeforeSave hook of its own) is still stamped by GORM's
+// own local NowFunc. decodeRetentionBeforeBody therefore returns the RAW parsed
+// cutoff, unconverted — each call site below explicitly converts it to whichever
+// Location its OWN target column actually uses, via a comment naming that
+// column. Getting this wrong in either direction reproduces the exact bug this
+// note describes; DeleteExpiredRoleGrantsProxy was found broken this way during
+// the sweep (used .Local() against UserRole/GroupRole.ExpiresAt, which has been
+// UTC-hooked since before this sweep started — no existing test's cutoff was
+// tight enough to catch it).
 //
 // Response envelope: like the other proxies, these do NOT use the package's
 // generic sendSuccess/sendError helpers — they construct the exact
@@ -115,6 +130,13 @@ func validateRetentionCutoff(before time.Time) error {
 	return nil
 }
 
+// decodeRetentionBeforeBody returns the RAW parsed cutoff, unconverted. See the
+// package doc's timezone note: callers must convert to whichever Location their
+// specific target column's storage actually uses (.Local() for a gorm.DeletedAt
+// column, still GORM's own local NowFunc; .UTC() for a G81 BeforeSave-hooked
+// time.Time column) — there is no longer one Location every caller here can
+// share, since some columns are hook-normalized to UTC and others (deleted_at)
+// are not.
 func decodeRetentionBeforeBody(w http.ResponseWriter, r *http.Request) (time.Time, bool) {
 	var body retentionBeforeBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -129,9 +151,7 @@ func decodeRetentionBeforeBody(w http.ResponseWriter, r *http.Request) (time.Tim
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
 		return time.Time{}, false
 	}
-	// See the package doc's timezone note: re-express in this server's own process
-	// Location before any storage-layer comparison.
-	return body.Before.Local(), true
+	return body.Before, true
 }
 
 // refuseIfLegalHoldActive is #G52: PurgeExpiredSoftDeletes (internal/core/purge.go)
@@ -169,7 +189,9 @@ func (h *SecretHandler) PurgeDeletedSecretsBeforeProxy(w http.ResponseWriter, r 
 	if refuseIfLegalHoldActive(w, r, h.coreService.Storage()) {
 		return
 	}
-	n, err := h.coreService.Storage().PurgeDeletedSecretsBefore(r.Context(), before)
+	// deleted_at (gorm.DeletedAt) is set by GORM's own local NowFunc, not a G81
+	// BeforeSave hook — .Local() to match.
+	n, err := h.coreService.Storage().PurgeDeletedSecretsBefore(r.Context(), before.Local())
 	if err != nil {
 		log.Printf("retention proxy: purge deleted secrets failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
@@ -212,11 +234,12 @@ func (h *AuditHandler) DeleteAnomalyAlertsBeforeProxy(w http.ResponseWriter, r *
 			return
 		}
 	}
-	// See the package doc's timezone note. .Local() on an already-zero time.Time
-	// leaves it zero (IsZero() depends only on the represented instant, not the
-	// Location), so DeleteAnomalyAlertsBefore's own "zero disables this clause"
-	// contract is preserved for whichever field the caller left unset.
-	n, err := h.coreService.Storage().DeleteAnomalyAlertsBefore(r.Context(), body.AckBefore.Local(), body.UnackCeiling.Local())
+	// AnomalyAlert.DetectedAt is G81 BeforeSave-hooked to UTC — .UTC() to match.
+	// .UTC() on an already-zero time.Time leaves it zero (IsZero() depends only on
+	// the represented instant, not the Location), so DeleteAnomalyAlertsBefore's
+	// own "zero disables this clause" contract is preserved for whichever field
+	// the caller left unset.
+	n, err := h.coreService.Storage().DeleteAnomalyAlertsBefore(r.Context(), body.AckBefore.UTC(), body.UnackCeiling.UTC())
 	if err != nil {
 		log.Printf("retention proxy: purge anomaly alerts failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
@@ -239,7 +262,8 @@ func (h *CatalogHandler) DeleteClosedAccessReviewsBeforeProxy(w http.ResponseWri
 	if !ok {
 		return
 	}
-	campaigns, items, err := h.coreService.Storage().DeleteClosedAccessReviewsBefore(r.Context(), before)
+	// AccessReviewCampaign.ClosedAt is G81 BeforeSave-hooked to UTC — .UTC() to match.
+	campaigns, items, err := h.coreService.Storage().DeleteClosedAccessReviewsBefore(r.Context(), before.UTC())
 	if err != nil {
 		log.Printf("retention proxy: purge closed access reviews failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
@@ -255,7 +279,8 @@ func (h *CatalogHandler) DeleteExpiredBreakGlassBeforeProxy(w http.ResponseWrite
 	if !ok {
 		return
 	}
-	n, err := h.coreService.Storage().DeleteExpiredBreakGlassBefore(r.Context(), before)
+	// BreakGlassActivation.CreatedAt is G81 BeforeSave-hooked to UTC — .UTC() to match.
+	n, err := h.coreService.Storage().DeleteExpiredBreakGlassBefore(r.Context(), before.UTC())
 	if err != nil {
 		log.Printf("retention proxy: purge expired break-glass failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
@@ -271,7 +296,8 @@ func (h *CatalogHandler) DeleteResolvedAccessRequestsBeforeProxy(w http.Response
 	if !ok {
 		return
 	}
-	requests, approvals, err := h.coreService.Storage().DeleteResolvedAccessRequestsBefore(r.Context(), before)
+	// AccessRequest.ResolvedAt is G81 BeforeSave-hooked to UTC — .UTC() to match.
+	requests, approvals, err := h.coreService.Storage().DeleteResolvedAccessRequestsBefore(r.Context(), before.UTC())
 	if err != nil {
 		log.Printf("retention proxy: purge resolved access requests failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
@@ -290,7 +316,9 @@ func (h *CatalogHandler) PurgeDeletedProjectsBeforeProxy(w http.ResponseWriter, 
 	if refuseIfLegalHoldActive(w, r, h.coreService.Storage()) {
 		return
 	}
-	n, err := h.coreService.Storage().PurgeDeletedProjectsBefore(r.Context(), before)
+	// deleted_at (gorm.DeletedAt) is set by GORM's own local NowFunc, not a G81
+	// BeforeSave hook — .Local() to match.
+	n, err := h.coreService.Storage().PurgeDeletedProjectsBefore(r.Context(), before.Local())
 	if err != nil {
 		log.Printf("retention proxy: purge deleted projects failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
@@ -309,7 +337,9 @@ func (h *CatalogHandler) PurgeDeletedEnvironmentsBeforeProxy(w http.ResponseWrit
 	if refuseIfLegalHoldActive(w, r, h.coreService.Storage()) {
 		return
 	}
-	n, err := h.coreService.Storage().PurgeDeletedEnvironmentsBefore(r.Context(), before)
+	// deleted_at (gorm.DeletedAt) is set by GORM's own local NowFunc, not a G81
+	// BeforeSave hook — .Local() to match.
+	n, err := h.coreService.Storage().PurgeDeletedEnvironmentsBefore(r.Context(), before.Local())
 	if err != nil {
 		log.Printf("retention proxy: purge deleted environments failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
@@ -334,7 +364,13 @@ func (h *RBACHandler) DeleteExpiredRoleGrantsProxy(w http.ResponseWriter, r *htt
 	if !ok {
 		return
 	}
-	removed, err := h.coreService.Storage().DeleteExpiredRoleGrants(r.Context(), before)
+	// UserRole.ExpiresAt / GroupRole.ExpiresAt are G81 BeforeSave-hooked to UTC —
+	// .UTC() to match. This proxy was silently broken before this fix: it has used
+	// .Local() since it was written, mismatching these two models' hooks (already
+	// UTC since before this sweep started) on every deployment not running under
+	// TZ=UTC — no existing test happened to probe a boundary tight enough to catch
+	// it.
+	removed, err := h.coreService.Storage().DeleteExpiredRoleGrants(r.Context(), before.UTC())
 	if err != nil {
 		log.Printf("retention proxy: purge expired role grants failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
@@ -365,7 +401,8 @@ func (h *ShareHandler) DeleteExpiredShareRecordsProxy(w http.ResponseWriter, r *
 	if !ok {
 		return
 	}
-	removed, err := h.coreService.Storage().DeleteExpiredShareRecords(r.Context(), before)
+	// ShareRecord.ExpiresAt is G81 BeforeSave-hooked to UTC — .UTC() to match.
+	removed, err := h.coreService.Storage().DeleteExpiredShareRecords(r.Context(), before.UTC())
 	if err != nil {
 		log.Printf("retention proxy: purge expired share records failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
@@ -441,7 +478,9 @@ func (h *UserHandler) PurgeDeletedUsersBeforeProxy(w http.ResponseWriter, r *htt
 	if refuseIfLegalHoldActive(w, r, h.coreService.Storage()) {
 		return
 	}
-	n, err := h.coreService.Storage().PurgeDeletedUsersBefore(r.Context(), before)
+	// deleted_at (gorm.DeletedAt) is set by GORM's own local NowFunc, not a G81
+	// BeforeSave hook — .Local() to match.
+	n, err := h.coreService.Storage().PurgeDeletedUsersBefore(r.Context(), before.Local())
 	if err != nil {
 		log.Printf("retention proxy: purge deleted users failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
@@ -476,8 +515,8 @@ func (h *UserHandler) ListUsersInStateBeforeProxy(w http.ResponseWriter, r *http
 	// this is a READ (stale-account WARNING report), not a purge, and "list users
 	// who will still be in this state as of tomorrow" is valid usage — no
 	// "not in the future" bound applies (see TestListUsersInStateBeforeProxy_WithUsers_S11).
-	// See the package doc's timezone note.
-	rows, err := h.coreService.Storage().ListUsersInStateBefore(r.Context(), state, before.Local())
+	// User.CreatedAt is G81 BeforeSave-hooked to UTC — .UTC() to match.
+	rows, err := h.coreService.Storage().ListUsersInStateBefore(r.Context(), state, before.UTC())
 	if err != nil {
 		log.Printf("retention proxy: list stale users failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))

--- a/server/http/remote_storage_retention_test.go
+++ b/server/http/remote_storage_retention_test.go
@@ -418,9 +418,15 @@ func TestRemoteStorageListUsersInStateBefore_RealServer(t *testing.T) {
 	upstream, downstream := newUpstreamDownstreamForRetention(t)
 	ctx := context.Background()
 
+	// CreatedAt is set explicitly, matching every real production CreateUser call
+	// site (internal/core/users.go, scim.go, sso.go all set it themselves) — a
+	// User created without it relies on GORM's own auto-timestamp, which (verified
+	// empirically during the G81 sweep, see StatsSnapshot.CreatedAt's doc comment)
+	// a BeforeSave hook cannot reach, since GORM auto-assigns it AFTER BeforeSave
+	// runs.
 	stale, err := upstream.Storage().CreateUser(ctx, &models.User{
 		Username: "stale-invite", Email: "stale-invite@example.com", IsActive: true,
-		AccountState: core.AccountPendingFirstLogin,
+		AccountState: core.AccountPendingFirstLogin, CreatedAt: time.Now(),
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
This sweep found a live correctness bug that had been latent for months: `retention_proxy.go`'s shared helper (`decodeRetentionBeforeBody`) converted every retention cutoff to `.Local()` on the documented theory that every `time.Time` comparison in this codebase relies on local time — a theory G81's own earliest fix had already falsified. `DeleteExpiredRoleGrantsProxy` has therefore been mismatching its `.Local()` cutoff against UTC-normalized `UserRole`/`GroupRole.ExpiresAt` since one of G81's first fixes landed, across eleven retention-proxy call sites, uncaught the whole time because no existing test's cutoff was tight enough to expose it. That's exactly the class of self-justifying stale assumption the guard test added here exists to catch — a doc comment asserting a codebase-wide convention is itself a claim that can silently go false the next time someone fixes a sibling bug, with nothing to notice.

**This closes the G81 bug class, not a fifth instance.** G81 is a recurring pattern: a `time.Time`/`*time.Time` column that's range-queried on SQLite without being normalized to a single `Location`, so SQLite's string-based comparison silently mismatches rows that denote the same instant. Five prior recurrences were each fixed reactively as they were found: `MFAStepupToken.ExpiresAt`, `MFAStepUpGrant.ExpiresAt`, `UserRole.ExpiresAt`, `GroupRole.ExpiresAt`, `DynamicSecretLease.ExpiresAt`, and `AuditEvent.EventTime` (#1492). This PR is a systematic sweep of every remaining range-queried time column in `internal/storage/store`, not another one-off.

**31 range-queried time columns total, 25 without a hook before this PR.** Investigation (Stage 1, see the linked report) traced every write source and query-bound source for each. Six were genuinely **live** (write and read sides could differ in production today):

- `AnomalyAlert.DetectedAt` — write is UTC, the escalation sweep and retention purge compared against local bounds.
- `SecretAccessLog.AccessTime` — a stale doc comment on `PrincipalSecretFirstSeen` claimed every caller was date-scale, "never hour-scale"; false — `RunDetection`'s hour-scale anomaly-detection window is UTC. Comment corrected.
- `PersonalAccessToken.ExpiresAt`, `ShareRecord.ExpiresAt`, `SecretNode.Expiration` — all client-supplied, compared against server-local cutoffs. `ShareRecord.ExpiresAt` directly gates JIT secret-access authorization.
- `LoginAttempt.AttemptedAt` — the strongest case: on a `storage.type: remote` deployment, a follower's own locally-timed write crosses the wire and is compared against the hub's local clock — genuinely different machines, not just same-process drift.
- `User.LastLoginAt` — **not hooked**. Its sole write path (`UpdateColumn`) bypasses all model hooks; a hook would be a silent no-op. Normalized explicitly at `auth.go`'s `RecordLogin`, mirroring `local_mfa_stepup.go`'s existing `MFAStepupToken` precedent.

Eighteen more were **latent** (self-consistent today, same recurring risk) and got a hook only: `MFAChallenge`, `Session.ExpiresAt`, `WebAuthnSession`, `MachineIdentityCredential.ExpiresAt`, `SetupToken.CreatedAt`, `User.CreatedAt`, `MachineIdentity.CreatedAt`, `BreakGlassActivation.CreatedAt`, `ProjectMembership.InvitedAt`, `AccessReviewCampaign.ClosedAt`, `AccessRequest.ResolvedAt`.

**Adding a hook only fixes the write side — read-side bounds needed the same treatment, or they break.** Discovered this exactly as expected (mirroring #1492): adding the 11 latent hooks alone broke `TestConcurrency_SetupLinkResendThrottle`, `TestConcurrency_RequestPasswordReset_BurstIsThrottled`, `TestSessionListAndRevoke`, and `TestFreshBootCreatesAccountSchema` immediately. Fixed every affected read-side bound in the same commit rather than leaving anything red.

**A GORM callback-ordering gotcha that blocks the standard fix entirely.** Empirically verified (throwaway test, since deleted): `BeforeSave` fires *before* GORM's own auto-`CreatedAt`/`UpdatedAt` assignment. For any field that's never explicitly set in Go (`StatsSnapshot.CreatedAt`), a hook normalizes a zero value and is then silently overwritten by GORM's local `NowFunc` — a hook that looks identical to the 24 working ones while doing nothing. Documented on the model instead of hooked. The same gap surfaced for `User.CreatedAt` too, but only in a test that (unlike every real `CreateUser` call site, which all set it explicitly) constructed a `User` without it — fixed the test, not the hook, since `User.CreatedAt` genuinely is explicit in production.

**Guard test** (`internal/storage/store/g81_guard_test.go`): a maintained list of every range-queried time column, its hook status, and (if unhooked) why. Two checks keep it honest — reflection confirms every claimed hook actually exists on the named model; an AST scan of the whole package asserts every time-shaped column appearing in a range comparison is in the list, failing with exact file:line if a new one appears untracked. Both checks were verified to actually catch drift (not just pass trivially) by temporarily breaking each and confirming the right failure.

**Deliberately exempted, with reasons** (see the guard test's `Exempt` field for the authoritative list):
- `Session.LastSeenAt`, `PersonalAccessToken.LastUsedAt`, `MachineIdentityCredential.LastUsedAt` — `UpdateColumn`-only writes, same hook-bypass shape as `User.LastLoginAt`, but latent (not live) today. Filed as #1507, alongside:
- `SchedulerLockLease.ExpiresAt` — a raw-map `Updates` bypass identical to `MFAStepupToken`'s old `ON CONFLICT` shape, but dormant: no SQL range query on this column exists today (only a Go-level `.After()` check, immune to this bug class regardless of hook coverage).
- `StatsSnapshot.CreatedAt` — GORM-implicit auto-timestamp; a hook would be a no-op (see above).
- `SecretNode.CreatedAt` — its only range-query caller (`filter.CreatedAfter`/`Before`) is set only in `_test.go` files; dead in production today.
- `deleted_at` (`gorm.DeletedAt`, many models) — a distinct type, not `time.Time`; out of scope for this bug class by definition, handled explicitly by the retention-proxy fix above.
- `DeploymentStatsSnapshot.SnapshotDate`, `CompliancePostureSnapshot.SnapshotDate` — already explicit `.UTC()` at both write and read; nothing to fix.

## Test plan
- [x] `go build ./...` before starting and after each commit
- [x] Full runs of `internal/core`, `internal/storage`, `server/...` after each of the three commits — `server/http` matches the established 18-item baseline exactly every time, zero new regressions
- [x] Guard test verified to genuinely catch drift (not trivially pass) by temporarily breaking both its checks

## Follow-up
Filed #1507 for the four `UpdateColumn`/raw-map bypass fields — not fixed here since none is live today, but each needs call-site (not hook) normalization if it ever becomes reachable by a range query.

Closes the G81 bug class.