### PR TITLE
test(grpc): give gRPC metrics tests per-test isolation instead of a shared global

### DIFF
--- a/server/grpc/interceptors/metrics.go
+++ b/server/grpc/interceptors/metrics.go
@@ -16,42 +16,63 @@ type Metrics struct {
 	TotalDuration   int64 // in nanoseconds
 }
 
+// grpcMetrics is the process-wide metrics singleton: exactly one gRPC server
+// runs per process, so one shared counter set is correct in production.
+// MetricsInterceptor and GetGRPCMetrics always operate on this global.
 var grpcMetrics = &Metrics{}
 
 // MetricsInterceptor returns a unary server interceptor for collecting metrics
+// into the shared, process-wide grpcMetrics singleton.
 func MetricsInterceptor() grpc.UnaryServerInterceptor {
+	return metricsInterceptorFor(grpcMetrics)
+}
+
+// metricsInterceptorFor returns a unary server interceptor that records into
+// target instead of the package-level grpcMetrics singleton — the injection
+// seam #1504 added so tests can construct a fully isolated interceptor bound
+// to its own *Metrics instance, rather than three tests racing to reset/read/
+// assert on shared process-wide state with no isolation contract between
+// them. Production code always goes through MetricsInterceptor above, which
+// fixes target to grpcMetrics; this unexported variant exists for tests only
+// and changes no production behavior.
+func metricsInterceptorFor(target *Metrics) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		start := time.Now()
 
 		// Increment total requests
-		atomic.AddInt64(&grpcMetrics.TotalRequests, 1)
+		atomic.AddInt64(&target.TotalRequests, 1)
 
 		// Call the handler
 		resp, err := handler(ctx, req)
 
 		// Record duration
 		duration := time.Since(start)
-		atomic.AddInt64(&grpcMetrics.TotalDuration, duration.Nanoseconds())
+		atomic.AddInt64(&target.TotalDuration, duration.Nanoseconds())
 
 		// Record success/error
 		if err != nil {
-			atomic.AddInt64(&grpcMetrics.ErrorRequests, 1)
+			atomic.AddInt64(&target.ErrorRequests, 1)
 		} else {
-			atomic.AddInt64(&grpcMetrics.SuccessRequests, 1)
+			atomic.AddInt64(&target.SuccessRequests, 1)
 		}
 
 		return resp, err
 	}
 }
 
-// GetGRPCMetrics returns current gRPC metrics
-func GetGRPCMetrics() *Metrics {
+// loadMetrics returns an atomic point-in-time snapshot of m's four counters.
+func loadMetrics(m *Metrics) *Metrics {
 	return &Metrics{
-		TotalRequests:   atomic.LoadInt64(&grpcMetrics.TotalRequests),
-		SuccessRequests: atomic.LoadInt64(&grpcMetrics.SuccessRequests),
-		ErrorRequests:   atomic.LoadInt64(&grpcMetrics.ErrorRequests),
-		TotalDuration:   atomic.LoadInt64(&grpcMetrics.TotalDuration),
+		TotalRequests:   atomic.LoadInt64(&m.TotalRequests),
+		SuccessRequests: atomic.LoadInt64(&m.SuccessRequests),
+		ErrorRequests:   atomic.LoadInt64(&m.ErrorRequests),
+		TotalDuration:   atomic.LoadInt64(&m.TotalDuration),
 	}
+}
+
+// GetGRPCMetrics returns a snapshot of the current process-wide gRPC metrics.
+func GetGRPCMetrics() *Metrics {
+	return loadMetrics(grpcMetrics)
 }
 
 // GetAverageResponseTime returns the average response time in milliseconds

--- a/server/grpc/interceptors/metrics_test.go
+++ b/server/grpc/interceptors/metrics_test.go
@@ -10,12 +10,17 @@ import (
 
 // TestMetricsInterceptor_CountsSuccessAndError verifies that the metrics interceptor
 // correctly increments success and error counters, and records total duration.
+//
+// #1504: bound to a fresh, test-local *Metrics via metricsInterceptorFor rather
+// than the shared package-level grpcMetrics singleton (MetricsInterceptor()) —
+// this test previously computed a before/after delta on that global with no
+// isolation contract against prometheus_test.go's two tests, which hard-reset
+// the same global. A per-test instance removes the shared state entirely
+// instead of coping with it, so no delta arithmetic is needed: every count
+// asserted below is this call's own, absolute total.
 func TestMetricsInterceptor_CountsSuccessAndError(t *testing.T) {
-	// Reset global metrics before the test to avoid interference from other tests.
-	// The global is a package-level var; we snapshot it and compare deltas.
-	before := GetGRPCMetrics()
-
-	interceptor := MetricsInterceptor()
+	target := &Metrics{}
+	interceptor := metricsInterceptorFor(target)
 	info := &grpc.UnaryServerInfo{FullMethod: "/keyorix.v1.SecretService/GetSecret"}
 
 	// A successful call.
@@ -36,22 +41,17 @@ func TestMetricsInterceptor_CountsSuccessAndError(t *testing.T) {
 		t.Fatal("expected an error from the interceptor, got nil")
 	}
 
-	after := GetGRPCMetrics()
-	deltaTotal := after.TotalRequests - before.TotalRequests
-	deltaSuccess := after.SuccessRequests - before.SuccessRequests
-	deltaError := after.ErrorRequests - before.ErrorRequests
-
-	if deltaTotal != 2 {
-		t.Errorf("TotalRequests delta = %d, want 2", deltaTotal)
+	if target.TotalRequests != 2 {
+		t.Errorf("TotalRequests = %d, want 2", target.TotalRequests)
 	}
-	if deltaSuccess != 1 {
-		t.Errorf("SuccessRequests delta = %d, want 1", deltaSuccess)
+	if target.SuccessRequests != 1 {
+		t.Errorf("SuccessRequests = %d, want 1", target.SuccessRequests)
 	}
-	if deltaError != 1 {
-		t.Errorf("ErrorRequests delta = %d, want 1", deltaError)
+	if target.ErrorRequests != 1 {
+		t.Errorf("ErrorRequests = %d, want 1", target.ErrorRequests)
 	}
-	if after.TotalDuration <= before.TotalDuration {
-		t.Errorf("TotalDuration should have increased: before=%d, after=%d", before.TotalDuration, after.TotalDuration)
+	if target.TotalDuration <= 0 {
+		t.Errorf("TotalDuration should be positive, got %d", target.TotalDuration)
 	}
 }
 

--- a/server/grpc/interceptors/prometheus.go
+++ b/server/grpc/interceptors/prometheus.go
@@ -17,9 +17,25 @@ import (
 type grpcCollector struct {
 	requests *prometheus.Desc
 	duration *prometheus.Desc
+	// target is the *Metrics this collector reports — grpcMetrics in
+	// production (see newGRPCCollector), an injected per-test instance in
+	// tests (see newGRPCCollectorFor). #1504.
+	target *Metrics
 }
 
+// newGRPCCollector returns a collector reporting the shared, process-wide
+// grpcMetrics singleton — the only variant production code (RegisterPrometheusMetrics)
+// uses.
 func newGRPCCollector() *grpcCollector {
+	return newGRPCCollectorFor(grpcMetrics)
+}
+
+// newGRPCCollectorFor returns a collector reporting target instead of the
+// package-level grpcMetrics singleton — the injection seam #1504 added so
+// tests can scrape a fully isolated *Metrics instance instead of racing
+// other tests to reset/read the shared global. Unexported: production always
+// goes through newGRPCCollector above.
+func newGRPCCollectorFor(target *Metrics) *grpcCollector {
 	return &grpcCollector{
 		requests: prometheus.NewDesc(
 			"keyorix_grpc_requests_total",
@@ -31,6 +47,7 @@ func newGRPCCollector() *grpcCollector {
 			"Cumulative gRPC unary handler time in seconds; divide its rate by the request rate for average latency.",
 			nil, nil,
 		),
+		target: target,
 	}
 }
 
@@ -40,7 +57,7 @@ func (c *grpcCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *grpcCollector) Collect(ch chan<- prometheus.Metric) {
-	m := GetGRPCMetrics()
+	m := loadMetrics(c.target)
 	ch <- prometheus.MustNewConstMetric(c.requests, prometheus.CounterValue, float64(m.SuccessRequests), "success")
 	ch <- prometheus.MustNewConstMetric(c.requests, prometheus.CounterValue, float64(m.ErrorRequests), "error")
 	ch <- prometheus.MustNewConstMetric(c.duration, prometheus.CounterValue, float64(m.TotalDuration)/1e9)

--- a/server/grpc/interceptors/prometheus_test.go
+++ b/server/grpc/interceptors/prometheus_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"sync/atomic"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,14 +14,15 @@ import (
 
 // The collector reports gRPC request outcomes as Prometheus counters, driven by the
 // same atomics the MetricsInterceptor increments.
+//
+// #1504: bound to a fresh, test-local *Metrics (metricsInterceptorFor +
+// newGRPCCollectorFor) instead of resetting and reading the shared
+// package-level grpcMetrics singleton — this test previously hard-reset that
+// global with no isolation contract against metrics_test.go's delta-based
+// test. A per-test instance removes the need to reset anything at all.
 func TestGRPCPrometheusCollector(t *testing.T) {
-	// Reset the package-global counters for a deterministic comparison.
-	atomic.StoreInt64(&grpcMetrics.TotalRequests, 0)
-	atomic.StoreInt64(&grpcMetrics.SuccessRequests, 0)
-	atomic.StoreInt64(&grpcMetrics.ErrorRequests, 0)
-	atomic.StoreInt64(&grpcMetrics.TotalDuration, 0)
-
-	intercept := MetricsInterceptor()
+	target := &Metrics{}
+	intercept := metricsInterceptorFor(target)
 	info := &grpc.UnaryServerInfo{FullMethod: "/keyorix.SecretService/Get"}
 	ok := func(context.Context, interface{}) (interface{}, error) { return "ok", nil }
 	fail := func(context.Context, interface{}) (interface{}, error) { return nil, errors.New("boom") }
@@ -32,7 +32,7 @@ func TestGRPCPrometheusCollector(t *testing.T) {
 	_, _ = intercept(context.Background(), nil, info, fail)
 
 	reg := prometheus.NewRegistry()
-	reg.MustRegister(newGRPCCollector())
+	reg.MustRegister(newGRPCCollectorFor(target))
 
 	expected := `
 # HELP keyorix_grpc_requests_total Total gRPC unary requests, by outcome (success or error).
@@ -53,13 +53,12 @@ keyorix_grpc_requests_total{status="success"} 2
 // *1e9 or +1e9 previously survived because no test asserted this counter's
 // value at all.
 func TestGRPCPrometheusCollector_DurationConvertsNanosecondsToSeconds(t *testing.T) {
-	atomic.StoreInt64(&grpcMetrics.TotalRequests, 0)
-	atomic.StoreInt64(&grpcMetrics.SuccessRequests, 0)
-	atomic.StoreInt64(&grpcMetrics.ErrorRequests, 0)
-	atomic.StoreInt64(&grpcMetrics.TotalDuration, 5_000_000_000) // exactly 5s in ns
+	// #1504: a fresh, test-local *Metrics instead of resetting the shared
+	// grpcMetrics global — see TestGRPCPrometheusCollector's doc comment.
+	target := &Metrics{TotalDuration: 5_000_000_000} // exactly 5s in ns
 
 	reg := prometheus.NewRegistry()
-	reg.MustRegister(newGRPCCollector())
+	reg.MustRegister(newGRPCCollectorFor(target))
 
 	expected := `
 # HELP keyorix_grpc_request_duration_seconds_total Cumulative gRPC unary handler time in seconds; divide its rate by the request rate for average latency.


### PR DESCRIPTION
TestMetricsInterceptor_CountsSuccessAndError computed a before/after delta on the package-level grpcMetrics global, while TestGRPCPrometheusCollector and TestGRPCPrometheusCollector_DurationConvertsNanosecondsToSeconds hard-reset that same global. No isolation contract existed between them — only incidental source-file ordering (and, empirically, the absence of any t.Parallel() in this package) kept them from colliding. Confirmed via go test -shuffle=on -count=3 that this specific hazard is not yet reproducible today (nothing in the package opts into parallel execution, so -shuffle=on only reorders sequential runs, never interrupts one test's before/after window with another's reset) — but the lack of a contract is the bug, independent of whether the current test suite happens to trigger it.

Structural fix, not a reset helper: MetricsInterceptor() and newGRPCCollector() (the two production entry points, one call site each — server/grpc/server.go:58 and RegisterPrometheusMetrics respectively) now delegate to unexported metricsInterceptorFor(target)/newGRPCCollectorFor(target) variants that operate on an injected *Metrics instead of unconditionally reaching for the grpcMetrics global. Production behavior and both exported signatures are completely unchanged — MetricsInterceptor() and GetGRPCMetrics() still operate on the same process-wide grpcMetrics singleton, correct for a single running server. This mirrors GRPCRateLimitInterceptor's existing pattern in the same package (rate_limit.go), which already constructs a fresh limiter per call rather than sharing a package global — the same seam, applied to metrics.

All three tests now construct their own local *Metrics and bind the interceptor/collector to it, removing the shared global from every test instead of coping with it (a reset helper would have left the global in place for the next test author to reintroduce this same problem). TestMetricsInterceptor_CountsSuccessAndError no longer needs delta arithmetic — every count it asserts is now that call's own absolute total. TestGRPCPrometheusCollector and its duration sibling no longer reset anything.

**Also investigated (report-only, not fixed here):** `globalGRPCTokenAuthFailureLimiter` (rate_limit.go) is the same hazard class with no reset mechanism at all, and is currently, empirically reproducible under `-shuffle=on` — confirmed **not** production-reachable (verified the gRPC server's actual TCP-listener topology, ruled out bufconn/gateway/in-process paths), so it's a test-only isolation bug, not a security issue, but a different risk tier from this fix since closing it needs a production signature change on `AuthInterceptor`/`StreamAuthInterceptor`. Filed as #1509 rather than folded into this commit.

## Test plan
- [x] `go test -shuffle=on -count=5`, run three times independently with fresh random seeds (both scoped to the three affected tests and across the full package) — all pass every time
- [x] The full-package shuffled runs' only failures are the pre-existing #1509 set, confirming this fix doesn't touch that hazard
- [x] `go build ./...` clean
- [x] Full `server/...` run matches the established 18-item `server/http` baseline exactly, zero new regressions

Closes #1504