### PR TITLE
test(go): raise coverage across 68 root-module packages

### DIFF
--- a/cmd/keyorix-mcp/main_test.go
+++ b/cmd/keyorix-mcp/main_test.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,4 +58,213 @@ func TestResolveAllowedRefs_ZeroPatternsIsFatal(t *testing.T) {
 		assert.Error(t, err, "raw=%q must be rejected, not silently allow everything", raw)
 		assert.Nil(t, patterns)
 	}
+}
+
+// KEYORIX_MCP_MAX_LIST_CALLS unset must apply defaultMaxListCalls (a bounded,
+// non-infinite ceiling) rather than "unlimited" — mirrors resolveMaxReads (#G44).
+func TestResolveMaxListCalls_UnsetAppliesDefault(t *testing.T) {
+	n, usedDefault, err := resolveMaxListCalls("")
+	require.NoError(t, err)
+	assert.True(t, usedDefault)
+	assert.Equal(t, defaultMaxListCalls, n)
+}
+
+func TestResolveMaxListCalls_ValidOverride(t *testing.T) {
+	n, usedDefault, err := resolveMaxListCalls("250")
+	require.NoError(t, err)
+	assert.False(t, usedDefault)
+	assert.Equal(t, 250, n)
+}
+
+func TestResolveMaxListCalls_InvalidIsFatal(t *testing.T) {
+	for _, raw := range []string{"not-a-number", "0", "-5", "3.5"} {
+		_, _, err := resolveMaxListCalls(raw)
+		assert.Error(t, err, "raw=%q must be rejected, not silently fall back to unlimited", raw)
+	}
+}
+
+// runMainSubprocess re-executes this test binary with -test.run scoped to a single
+// test, whose body detects KEYORIX_MCP_MAIN_SUBPROCESS=1 and calls main() directly
+// instead of running normal test assertions. This lets us exercise main()'s log.Fatal
+// (os.Exit(1)) and normal-return paths from the OUTSIDE, by inspecting the subprocess's
+// exit code and stderr, without terminating the actual test process. Mirrors the
+// existing subprocess pattern in internal/cli/system/system_s17_test.go
+// (TestRunAudit_ExitOnFailure).
+//
+// extraEnv are additional KEY=VALUE entries; any KEYORIX_-prefixed variable already in
+// this process's environment is stripped first so ambient developer config (e.g. a
+// local KEYORIX_TOKEN) can't leak into the subprocess and change its behavior.
+func runMainSubprocess(t *testing.T, testName string, extraEnv []string, stdin *bytes.Reader) (stderr string, exitCode int, runErr error) {
+	t.Helper()
+
+	var env []string
+	for _, kv := range os.Environ() {
+		if len(kv) >= 8 && kv[:8] == "KEYORIX_" {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env, extraEnv...)
+	env = append(env, "KEYORIX_MCP_MAIN_SUBPROCESS=1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^"+testName+"$")
+	cmd.Env = env
+	if stdin != nil {
+		cmd.Stdin = stdin
+	} else {
+		cmd.Stdin = bytes.NewReader(nil)
+	}
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	runErr = cmd.Run()
+	exitCode = 0
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		exitCode = exitErr.ExitCode()
+	}
+	return stderrBuf.String(), exitCode, runErr
+}
+
+// A missing KEYORIX_URL must be a fatal, immediate startup error.
+func TestMainSubprocess_MissingURL(t *testing.T) {
+	if os.Getenv("KEYORIX_MCP_MAIN_SUBPROCESS") == "1" {
+		main()
+		return
+	}
+	stderr, exitCode, runErr := runMainSubprocess(t, "TestMainSubprocess_MissingURL", nil, nil)
+	require.Error(t, runErr, "main() must exit non-zero when KEYORIX_URL is unset")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "KEYORIX_URL is required")
+}
+
+// A missing KEYORIX_TOKEN must be a fatal, immediate startup error (checked after URL).
+func TestMainSubprocess_MissingToken(t *testing.T) {
+	if os.Getenv("KEYORIX_MCP_MAIN_SUBPROCESS") == "1" {
+		main()
+		return
+	}
+	stderr, exitCode, runErr := runMainSubprocess(t, "TestMainSubprocess_MissingToken",
+		[]string{"KEYORIX_URL=http://127.0.0.1:1"}, nil)
+	require.Error(t, runErr, "main() must exit non-zero when KEYORIX_TOKEN is unset")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "KEYORIX_TOKEN is required")
+}
+
+// A KEYORIX_URL that fails NewKeyorixClient's own validation (non-https, non-loopback)
+// must abort startup via the client-construction error path, not silently proceed.
+func TestMainSubprocess_InvalidClientURL(t *testing.T) {
+	if os.Getenv("KEYORIX_MCP_MAIN_SUBPROCESS") == "1" {
+		main()
+		return
+	}
+	stderr, exitCode, runErr := runMainSubprocess(t, "TestMainSubprocess_InvalidClientURL",
+		[]string{"KEYORIX_URL=http://example.com", "KEYORIX_TOKEN=t"}, nil)
+	require.Error(t, runErr, "main() must exit non-zero when KEYORIX_URL fails client validation")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "must use https")
+}
+
+// A set-but-empty-after-parsing KEYORIX_MCP_ALLOWED_REFS must abort startup rather than
+// silently run unrestricted (#122).
+func TestMainSubprocess_InvalidAllowedRefs(t *testing.T) {
+	if os.Getenv("KEYORIX_MCP_MAIN_SUBPROCESS") == "1" {
+		main()
+		return
+	}
+	stderr, exitCode, runErr := runMainSubprocess(t, "TestMainSubprocess_InvalidAllowedRefs",
+		[]string{"KEYORIX_URL=http://127.0.0.1:1", "KEYORIX_TOKEN=t", "KEYORIX_MCP_ALLOWED_REFS=,"}, nil)
+	require.Error(t, runErr, "main() must exit non-zero on an unusable KEYORIX_MCP_ALLOWED_REFS")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "refusing to start unrestricted")
+}
+
+// A non-numeric KEYORIX_MCP_MAX_READS must abort startup, not silently fall back.
+func TestMainSubprocess_InvalidMaxReads(t *testing.T) {
+	if os.Getenv("KEYORIX_MCP_MAIN_SUBPROCESS") == "1" {
+		main()
+		return
+	}
+	stderr, exitCode, runErr := runMainSubprocess(t, "TestMainSubprocess_InvalidMaxReads",
+		[]string{"KEYORIX_URL=http://127.0.0.1:1", "KEYORIX_TOKEN=t", "KEYORIX_MCP_MAX_READS=abc"}, nil)
+	require.Error(t, runErr, "main() must exit non-zero on an invalid KEYORIX_MCP_MAX_READS")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "KEYORIX_MCP_MAX_READS must be a positive integer")
+}
+
+// A non-numeric KEYORIX_MCP_MAX_LIST_CALLS must abort startup, not silently fall back.
+func TestMainSubprocess_InvalidMaxListCalls(t *testing.T) {
+	if os.Getenv("KEYORIX_MCP_MAIN_SUBPROCESS") == "1" {
+		main()
+		return
+	}
+	stderr, exitCode, runErr := runMainSubprocess(t, "TestMainSubprocess_InvalidMaxListCalls",
+		[]string{"KEYORIX_URL=http://127.0.0.1:1", "KEYORIX_TOKEN=t", "KEYORIX_MCP_MAX_LIST_CALLS=abc"}, nil)
+	require.Error(t, runErr, "main() must exit non-zero on an invalid KEYORIX_MCP_MAX_LIST_CALLS")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "KEYORIX_MCP_MAX_LIST_CALLS must be a positive integer")
+}
+
+// With only the required KEYORIX_URL/KEYORIX_TOKEN set, main() must start up cleanly
+// using the documented defaults (defaultMaxReads/defaultMaxListCalls, no ref
+// allowlist) and, once stdin hits EOF, return normally (exit 0) rather than treating a
+// clean disconnect as fatal.
+func TestMainSubprocess_SuccessWithDefaults(t *testing.T) {
+	if os.Getenv("KEYORIX_MCP_MAIN_SUBPROCESS") == "1" {
+		main()
+		return
+	}
+	stderr, exitCode, runErr := runMainSubprocess(t, "TestMainSubprocess_SuccessWithDefaults",
+		[]string{"KEYORIX_URL=http://127.0.0.1:1", "KEYORIX_TOKEN=t"}, bytes.NewReader(nil))
+	require.NoError(t, runErr, "stderr: %s", stderr)
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr, "ready (server dev)")
+	assert.Contains(t, stderr, "applying default per-process read cap of 100")
+	assert.Contains(t, stderr, "applying default per-process list-call cap of 100")
+	assert.NotContains(t, stderr, "ref allowlist active")
+}
+
+// Explicit overrides for KEYORIX_MCP_MAX_READS, KEYORIX_MCP_MAX_LIST_CALLS, and
+// KEYORIX_MCP_ALLOWED_REFS must all take effect and be logged as active (not the
+// default-applied branch), and SetAllowedRefs must actually be invoked.
+func TestMainSubprocess_SuccessWithExplicitOverrides(t *testing.T) {
+	if os.Getenv("KEYORIX_MCP_MAIN_SUBPROCESS") == "1" {
+		main()
+		return
+	}
+	stderr, exitCode, runErr := runMainSubprocess(t, "TestMainSubprocess_SuccessWithExplicitOverrides",
+		[]string{
+			"KEYORIX_URL=http://127.0.0.1:1",
+			"KEYORIX_TOKEN=t",
+			"KEYORIX_MCP_MAX_READS=5",
+			"KEYORIX_MCP_MAX_LIST_CALLS=7",
+			"KEYORIX_MCP_ALLOWED_REFS=app/prod/*",
+		}, bytes.NewReader(nil))
+	require.NoError(t, runErr, "stderr: %s", stderr)
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr, "ready (server dev)")
+	assert.Contains(t, stderr, "per-process read cap active: 5")
+	assert.Contains(t, stderr, "per-process list-call cap active: 7")
+	assert.Contains(t, stderr, "ref allowlist active: 1 pattern(s)")
+	assert.NotContains(t, stderr, "applying default")
+}
+
+// A stdin stream that fails to parse as JSON-RPC (rather than cleanly hitting EOF) makes
+// Server.Serve return a non-nil error; main() must treat that as fatal
+// (log.Fatalf("serve: ...")) instead of exiting cleanly.
+func TestMainSubprocess_ServeErrorIsFatal(t *testing.T) {
+	if os.Getenv("KEYORIX_MCP_MAIN_SUBPROCESS") == "1" {
+		main()
+		return
+	}
+	stderr, exitCode, runErr := runMainSubprocess(t, "TestMainSubprocess_ServeErrorIsFatal",
+		[]string{"KEYORIX_URL=http://127.0.0.1:1", "KEYORIX_TOKEN=t"},
+		bytes.NewReader([]byte("this is not json-rpc\n")))
+	require.Error(t, runErr, "main() must exit non-zero when Serve reports a non-EOF error")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "serve:")
 }

--- a/cmd/system/fixfileperm_test.go
+++ b/cmd/system/fixfileperm_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -141,4 +142,115 @@ func TestRunFixFilePerm_MissingConfigFails(t *testing.T) {
 
 	assert.True(t, failed, "a missing config file must be reported as a failure, not a false pass")
 	assert.NotContains(t, out, "fixed successfully")
+}
+
+// writeFixFilePermConfigNoEncryption writes a valid config with no
+// storage.encryption section at all, so cfg.Storage.Encryption.SaltPath and
+// DEKPath are both the zero value (""). This exercises the
+// `spec.path == "" { continue }` skip in runFixFilePermNoExit's
+// file-collection loop — the same shape a real deployment with encryption
+// disabled would produce.
+func writeFixFilePermConfigNoEncryption(t *testing.T, dir, name string) string {
+	t.Helper()
+	cfgPath := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(cfgPath, []byte("storage:\n  type: local\n"), 0644))
+	return cfgPath
+}
+
+// When a config has no salt/DEK paths configured (encryption disabled), the
+// fix must skip those entries rather than treating the empty path as a real
+// file to touch, while still fixing the config file's own permissions.
+func TestRunFixFilePermNoExit_SkipsEmptySaltAndDEKPaths(t *testing.T) {
+	resetFixFilePermConfigFile(t)
+	dir := t.TempDir()
+	cfgPath := writeFixFilePermConfigNoEncryption(t, dir, "no-encryption.yaml")
+	fixFilePermConfigFile = cfgPath
+
+	var failed bool
+	out := captureFixFilePermStdout(t, func() { failed = runFixFilePermNoExit() })
+
+	assert.False(t, failed, "empty salt/dek paths must be skipped, not treated as a failure")
+	assert.Contains(t, out, "fixed successfully")
+
+	info, err := os.Stat(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "the config file's own perms must still be fixed")
+}
+
+// A salt_path that passes the "safe" (no "..") containment check but points
+// at a file that doesn't actually exist on disk must surface as a reported
+// failure from securefiles.FixFilePerms (open ENOENT), not a silent pass —
+// exercises the FixFilePerms error branch of runFixFilePermNoExit.
+func TestRunFixFilePermNoExit_FixFilePermsFailureReported(t *testing.T) {
+	resetFixFilePermConfigFile(t)
+	dir := t.TempDir()
+	missingSaltPath := filepath.Join(dir, "missing-salt.bin")
+	dekPath := filepath.Join(dir, "dek.bin")
+	require.NoError(t, os.WriteFile(dekPath, []byte("dek"), 0600))
+
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	yaml := fmt.Sprintf("storage:\n  encryption:\n    enabled: true\n    salt_path: %s\n    dek_path: %s\n", missingSaltPath, dekPath)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(yaml), 0600))
+
+	fixFilePermConfigFile = cfgPath
+
+	var failed bool
+	out := captureFixFilePermStdout(t, func() { failed = runFixFilePermNoExit() })
+
+	assert.True(t, failed, "a nonexistent salt file must be reported as a failure, not silently skipped")
+	assert.Contains(t, out, "Failed to fix file permissions")
+}
+
+// TestRunFixFilePerm_SuccessDoesNotCallExit exercises runFixFilePerm()'s
+// success path directly: when runFixFilePermNoExit() returns false,
+// runFixFilePerm must return normally without calling os.Exit. If it did
+// call os.Exit, this test process would die before reaching the assertion.
+func TestRunFixFilePerm_SuccessDoesNotCallExit(t *testing.T) {
+	resetFixFilePermConfigFile(t)
+	dir := t.TempDir()
+	cfgPath := writeFixFilePermConfig(t, dir, "run-fixfileperm-ok.yaml",
+		filepath.Join(dir, "salt.bin"), filepath.Join(dir, "dek.bin"))
+	fixFilePermConfigFile = cfgPath
+
+	out := captureFixFilePermStdout(t, func() { runFixFilePerm() })
+	assert.Contains(t, out, "fixed successfully")
+}
+
+// TestFixFilePermCmd_Run exercises the cobra command's Run closure, which
+// simply delegates to runFixFilePerm(). Uses a known-good config so the
+// underlying fix succeeds and does not os.Exit.
+func TestFixFilePermCmd_Run(t *testing.T) {
+	resetFixFilePermConfigFile(t)
+	dir := t.TempDir()
+	cfgPath := writeFixFilePermConfig(t, dir, "fixfileperm-cmd-run.yaml",
+		filepath.Join(dir, "salt.bin"), filepath.Join(dir, "dek.bin"))
+	fixFilePermConfigFile = cfgPath
+
+	out := captureFixFilePermStdout(t, func() { FixFilePermCmd.Run(FixFilePermCmd, nil) })
+	assert.Contains(t, out, "fixed successfully")
+}
+
+// TestRunFixFilePerm_ExitOnFailure verifies that runFixFilePerm() calls
+// os.Exit(1) when the fix fails. Run in a subprocess (mirroring the
+// TestRunAudit_ExitOnFailure pattern in internal/cli/system) so the os.Exit
+// does not kill the outer test binary.
+func TestRunFixFilePerm_ExitOnFailure(t *testing.T) {
+	if os.Getenv("FIXFILEPERM_EXIT_SUBPROCESS") == "1" {
+		// This is the subprocess. Point at a missing config so the fix fails
+		// and triggers os.Exit(1).
+		fixFilePermConfigFile = filepath.Join(t.TempDir(), "does-not-exist.yaml")
+		runFixFilePerm()
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunFixFilePerm_ExitOnFailure")
+	cmd.Env = append(os.Environ(), "FIXFILEPERM_EXIT_SUBPROCESS=1")
+	err := cmd.Run()
+
+	// exec.Command.Run returns a non-nil error when the subprocess exits with
+	// a non-zero status (os.Exit(1) produces exit status 1).
+	require.Error(t, err, "subprocess must exit non-zero when the fix fails")
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
 }

--- a/cmd/validate-translations/main_s23_test.go
+++ b/cmd/validate-translations/main_s23_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -641,4 +642,146 @@ func TestPrintValidationSummary_S23_InconsistentKeyDetail(t *testing.T) {
 		strings.Contains(out, "Present in:") || strings.Contains(out, "Missing in:"),
 		"expected language breakdown in inconsistent keys section",
 	)
+}
+
+// TestValidateTranslations_S23_ReadDirFailsOnRegularFile is a regression test
+// for the os.ReadDir error branch: os.Stat succeeds for a path that exists
+// but isn't a directory (so the "does not exist" check doesn't fire), and
+// os.ReadDir then fails with ENOTDIR. validateTranslations must surface that
+// as a wrapped "failed to read locales directory" error rather than panicking
+// or silently continuing.
+func TestValidateTranslations_S23_ReadDirFailsOnRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	notADir := filepath.Join(dir, "not-a-directory")
+	require.NoError(t, os.WriteFile(notADir, []byte("hi"), 0600))
+
+	_, err := validateTranslations(notADir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read locales directory")
+}
+
+// ---------------------------------------------------------------------------
+// main — exercised via a re-exec'd subprocess.
+//
+// main() calls os.Exit(1) on several error/invalid paths, which would kill
+// the entire `go test` process if invoked in-process. Following the standard
+// Go idiom for testing os.Exit-calling code (see e.g. os/exec_test.go's
+// TestHelperProcess pattern), we re-exec the test binary itself, restricted
+// via -test.run to a single helper test that actually calls main(), and
+// assert on the subprocess's exit code and captured output.
+// ---------------------------------------------------------------------------
+
+// TestHelperProcess_S23_Main is not a real test: it is invoked only by
+// runMainSubprocess as a subprocess entry point. When run directly by `go
+// test` (without the GO_WANT_HELPER_PROCESS_S23 env var set) it is a no-op.
+func TestHelperProcess_S23_Main(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS_S23") != "1" {
+		return
+	}
+
+	// os.Args at this point is the full test-binary invocation, e.g.
+	// [testbinary -test.run=TestHelperProcess_S23_Main -- arg1 arg2]. Find
+	// the "--" separator and treat everything after it as main()'s argv.
+	var mainArgs []string
+	for i, a := range os.Args {
+		if a == "--" {
+			mainArgs = os.Args[i+1:]
+			break
+		}
+	}
+	os.Args = append([]string{"validate-translations"}, mainArgs...)
+
+	main()
+}
+
+// runMainSubprocess re-execs the current test binary so that main() runs in
+// a genuine child process, then returns its combined stdout+stderr and exit
+// code. dir, if non-empty, sets the child's working directory.
+func runMainSubprocess(t *testing.T, args []string, dir string) (output string, exitCode int) {
+	t.Helper()
+
+	cmdArgs := []string{"-test.run=TestHelperProcess_S23_Main", "--"}
+	cmdArgs = append(cmdArgs, args...)
+
+	cmd := exec.Command(os.Args[0], cmdArgs...) // #nosec G204 -- re-execs the trusted test binary itself for os.Exit isolation
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS_S23=1")
+	if dir != "" {
+		cmd.Dir = dir
+	}
+
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return string(out), 0
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	require.True(t, ok, "expected subprocess to fail via exit code, got: %v (output: %s)", err, out)
+	return string(out), exitErr.ExitCode()
+}
+
+func TestMain_S23_HelpShortFlag(t *testing.T) {
+	out, exitCode := runMainSubprocess(t, []string{"-h"}, "")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, out, "Usage:")
+	assert.Contains(t, out, "Translation Validation Utility")
+	// Help output must not attempt any validation.
+	assert.NotContains(t, out, "Validating translations in")
+}
+
+func TestMain_S23_HelpLongFlag(t *testing.T) {
+	out, exitCode := runMainSubprocess(t, []string{"--help"}, "")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, out, "Usage:")
+}
+
+func TestMain_S23_DirNotFoundExitsNonZero(t *testing.T) {
+	out, exitCode := runMainSubprocess(t, []string{"/nonexistent/path/for/validate-translations-test"}, "")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, out, "❌ Error:")
+	assert.Contains(t, out, "does not exist")
+}
+
+func TestMain_S23_AllValidExitsZero(t *testing.T) {
+	dir := t.TempDir()
+	tf := TranslationFile{"hello": {One: "Hello", Other: "Hellos"}}
+	writeJSONFile(t, dir, "en.json", tf)
+
+	out, exitCode := runMainSubprocess(t, []string{dir}, "")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, out, "All translations are valid")
+	assert.Contains(t, out, "Validating translations in: "+dir)
+}
+
+func TestMain_S23_InvalidLanguagesExitsNonZero(t *testing.T) {
+	dir := t.TempDir()
+	enTF := TranslationFile{
+		"a": {One: "A", Other: "As"},
+		"b": {One: "B", Other: "Bs"},
+	}
+	esTF := TranslationFile{
+		"a": {One: "Ae", Other: "Aes"},
+		// "b" intentionally missing, forcing an invalid language.
+	}
+	writeJSONFile(t, dir, "en.json", enTF)
+	writeJSONFile(t, dir, "es.json", esTF)
+
+	out, exitCode := runMainSubprocess(t, []string{dir}, "")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, out, "language(s) have validation issues")
+}
+
+// TestMain_S23_DefaultLocalesDir exercises the no-argument path, where main()
+// falls back to the hardcoded default "internal/i18n/locales" relative
+// directory. The subprocess's working directory is set to the repo root so
+// that default path resolves against the real locale files, mirroring how
+// the tool is documented to be invoked.
+func TestMain_S23_DefaultLocalesDir(t *testing.T) {
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+
+	out, exitCode := runMainSubprocess(t, nil, repoRoot)
+	assert.Contains(t, out, "Validating translations in: internal/i18n/locales")
+	// Real locale files may or may not all be fully consistent; either
+	// outcome is a legitimate exit code for this branch, but the process
+	// must not crash or exit with anything else.
+	assert.Contains(t, []int{0, 1}, exitCode)
 }

--- a/internal/audit/siem/siem_g80_test.go
+++ b/internal/audit/siem/siem_g80_test.go
@@ -1,0 +1,104 @@
+package siem
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// buildRequest() — payload marshal error path
+// ---------------------------------------------------------------------------
+
+// TestBuildRequest_MarshalErrorOnInvalidDiff verifies that buildRequest surfaces
+// a wrapped error (rather than panicking or silently producing a malformed
+// request) when the event's Diff is not valid JSON. eventPayload.Diff is typed
+// json.RawMessage, and encoding/json validates a RawMessage field's bytes when
+// marshaling the containing struct — a malformed Diff (which should never occur
+// given callers write it via json.Marshal, but a corrupted/hand-edited DB row is
+// possible) must fail loudly here rather than shipping truncated/invalid JSON to
+// the SIEM.
+func TestBuildRequest_MarshalErrorOnInvalidDiff(t *testing.T) {
+	f, err := New(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: "http://example.invalid"})
+	require.NoError(t, err)
+	t.Cleanup(f.Close)
+
+	e := sampleEvent()
+	e.Diff = `{not valid json` // malformed — not parseable as JSON
+
+	_, err = f.buildRequest(context.Background(), e)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal payload")
+}
+
+// TestBuildRequest_MarshalErrorOnInvalidDiff_AllProviders verifies the same
+// marshal-error path is reached regardless of which provider's envelope wraps
+// the payload (Splunk/Datadog nest it under a field; webhook marshals it
+// directly) — all three code paths funnel into the same shared error check.
+func TestBuildRequest_MarshalErrorOnInvalidDiff_AllProviders(t *testing.T) {
+	for _, p := range []Provider{ProviderSplunk, ProviderDatadog, ProviderWebhook} {
+		t.Run(string(p), func(t *testing.T) {
+			f, err := New(Config{Enabled: true, Provider: p, Endpoint: "http://example.invalid", Token: "tok"})
+			require.NoError(t, err)
+			t.Cleanup(f.Close)
+
+			e := sampleEvent()
+			e.Diff = `[[[`
+
+			_, err = f.buildRequest(context.Background(), e)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "marshal payload")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// scanSpoolLines() — final line with no trailing newline
+// ---------------------------------------------------------------------------
+
+// TestScanSpoolLines_FinalLineWithoutTrailingNewline verifies that a spool
+// file's last line is still parsed even when it has no trailing '\n'. Every
+// line spool.add() writes ends in '\n' (it appends one unconditionally), but a
+// process killed mid-write, or a file hand-edited/truncated during recovery,
+// can leave a final line with no newline — that record must not be silently
+// dropped.
+func TestScanSpoolLines_FinalLineWithoutTrailingNewline(t *testing.T) {
+	data := []byte("{\"id\":1}\n{\"id\":2}") // second (last) line has NO trailing newline
+	lines := scanSpoolLines(data)
+	require.Len(t, lines, 2, "the final line without a trailing newline must still be captured")
+	assert.Equal(t, `{"id":1}`, string(lines[0]))
+	assert.Equal(t, `{"id":2}`, string(lines[1]))
+}
+
+// TestSpool_ReplayDeliversFinalLineWithoutTrailingNewline is the end-to-end
+// counterpart: a spool file on disk whose last line lacks a trailing newline
+// (as a crash mid-append could leave it) must still have that event replayed,
+// not silently lost.
+func TestSpool_ReplayDeliversFinalLineWithoutTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	d := &fakeDelivery{}
+	s, err := newSpool(dir, time.Hour, d.deliver)
+	require.NoError(t, err)
+	s.close() // drive replay() manually
+
+	tr := true
+	e1, err := json.Marshal(&models.AuditEvent{ID: 1, EventType: "secret.read", Success: &tr})
+	require.NoError(t, err)
+	e2, err := json.Marshal(&models.AuditEvent{ID: 2, EventType: "secret.updated", Success: &tr})
+	require.NoError(t, err)
+
+	// Write both lines directly, WITHOUT a trailing newline after the second —
+	// simulating a process killed mid-append.
+	content := append(append(e1, '\n'), e2...)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, spoolFileName), content, 0o600))
+
+	s.replay()
+	assert.ElementsMatch(t, []uint{1, 2}, d.delivered, "the event on the newline-less final line must still be delivered")
+}

--- a/internal/bundle/bundle_coverage_test.go
+++ b/internal/bundle/bundle_coverage_test.go
@@ -20,7 +20,10 @@ import (
 	"compress/gzip"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -405,4 +408,303 @@ func TestWriteBundle_Cov_ComponentFileDisappears(t *testing.T) {
 	var buf bytes.Buffer
 	err = WriteBundle(&buf, dir, m, sig)
 	assert.Error(t, err, "WriteBundle must fail when a component file is missing from srcDir")
+}
+
+// ---------------------------------------------------------------------------
+// WriteBundle — component tw.WriteHeader / io.Copy / tw.Close error branches
+// via a truncating writer over large, INCOMPRESSIBLE component data.
+//
+// gzip/flate buffer internally: for small or highly-compressible content
+// (as used by the other WriteBundle error-injection tests in this package),
+// essentially every byte the tar writer hands to gzip stays buffered until
+// gz.Close() flushes it all at once, so a truncating writer can only ever
+// surface an error from the final gz.Close() call — never from the
+// tw.WriteHeader/io.Copy/tw.Close call sites that logically preceded it.
+// Large, random (incompressible) component data forces flate to emit real
+// output continuously as it compresses, so a writer that stops accepting
+// bytes partway through can land the failure at any of those call sites.
+// Scanning many cut points over the real output range reliably exercises
+// all of them without depending on exact internal buffer thresholds.
+// ---------------------------------------------------------------------------
+
+func TestWriteBundle_Cov_ComponentWriteErrorsIncompressible(t *testing.T) {
+	randBytes := func(n int) string {
+		b := make([]byte, n)
+		_, err := rand.Read(b)
+		require.NoError(t, err)
+		return string(b)
+	}
+	dir := srcDirWith(t, map[string]string{
+		"images/a.tar": randBytes(160 * 1024),
+		"images/b.tar": randBytes(160 * 1024),
+	})
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	m, err := BuildManifest(dir, "v1.0.0", "k-incompressible", "", time.Unix(1_700_000_000, 0))
+	require.NoError(t, err)
+	sig, err := Sign(m, priv)
+	require.NoError(t, err)
+
+	var full bytes.Buffer
+	require.NoError(t, WriteBundle(&full, dir, m, sig))
+	total := full.Len()
+	require.Greater(t, total, 64*1024, "incompressible components must dominate the archive size")
+
+	var errCount int
+	for cut := 512; cut < total; cut += 512 {
+		w := &limitedWriter{limit: cut}
+		if err := WriteBundle(w, dir, m, sig); err != nil {
+			errCount++
+		}
+	}
+	assert.Greater(t, errCount, 0,
+		"at least one truncation point must cause WriteBundle to fail while writing component data")
+}
+
+// TestWriteBundle_Cov_SigWriteErrorViaLargeManifest targets the writeTarBytes(sigName)
+// error branch specifically: it must fail on manifest.json's own bytes for the "sig" write
+// to ever be attempted at all with something for the truncating writer to reject. A manifest
+// with many components produces a manifest.json large enough that flate emits real output
+// during the manifest write itself (rather than buffering it entirely until gz.Close, as
+// happens with the small manifests used elsewhere in this package) — so scanning cut points
+// across that region can land the failure between the manifest write succeeding and the sig
+// write being attempted.
+func TestWriteBundle_Cov_SigWriteErrorViaLargeManifest(t *testing.T) {
+	const numComponents = 600
+	files := make(map[string]string, numComponents)
+	for i := 0; i < numComponents; i++ {
+		b := make([]byte, 4)
+		_, err := rand.Read(b)
+		require.NoError(t, err)
+		files[fmt.Sprintf("c/%05d.bin", i)] = string(b)
+	}
+	dir := srcDirWith(t, files)
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	m, err := BuildManifest(dir, "v1.0.0", "k-big-manifest", "", time.Unix(1_700_000_000, 0))
+	require.NoError(t, err)
+	sig, err := Sign(m, priv)
+	require.NoError(t, err)
+	manifestBytes, err := m.MarshalCanonical()
+	require.NoError(t, err)
+	require.Greater(t, len(manifestBytes), 40*1024, "manifest with 600 components must be sizeable")
+
+	var errCount int
+	for cut := 512; cut < len(manifestBytes)+2048; cut += 512 {
+		w := &limitedWriter{limit: cut}
+		if err := WriteBundle(w, dir, m, sig); err != nil {
+			errCount++
+		}
+	}
+	assert.Greater(t, errCount, 0,
+		"at least one truncation point must cause WriteBundle to fail while writing the manifest/sig entries")
+}
+
+// ---------------------------------------------------------------------------
+// streamComponent — mkdirAllNoSymlink error path (line "bundle: mkdir for %s")
+// ---------------------------------------------------------------------------
+
+// TestExtract_Cov_ComponentDirBlockedByEarlierComponentFile verifies that Extract
+// fails when a later component's required parent directory was already staged as
+// a plain FILE by an earlier component in the same archive (processed in archive
+// order). This is distinct from the "pre-existing" collision case covered
+// elsewhere: destDir starts genuinely EMPTY (so the no-marker-but-non-empty
+// fail-closed gate in readInstalledVersion never fires), and the conflict is
+// created mid-extraction by the archive's own first component, exercising the
+// mkdirAllNoSymlink error branch inside streamComponent itself.
+func TestExtract_Cov_ComponentDirBlockedByEarlierComponentFile(t *testing.T) {
+	sumHex := func(s string) string {
+		h := sha256.Sum256([]byte(s))
+		return hex.EncodeToString(h[:])
+	}
+	m := &Manifest{
+		Version:    "v1.0.0",
+		ReleasedAt: time.Unix(1_700_000_000, 0).UTC(),
+		KeyID:      "k-conflict",
+		Components: []Component{
+			{Path: "conflict", SHA256: sumHex("A"), Size: 1},
+			{Path: "conflict/nested.bin", SHA256: sumHex("B"), Size: 1},
+		},
+	}
+	manifestBytes, err := m.MarshalCanonical()
+	require.NoError(t, err)
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	sig, err := Sign(m, priv)
+	require.NoError(t, err)
+
+	// Archive order matters: "conflict" (staged as a FILE) must be processed before
+	// "conflict/nested.bin" (which then needs "conflict" to be a directory).
+	raw := writeRawBundle(t, manifestBytes, sig, [][2]string{
+		{"conflict", "A"},
+		{"conflict/nested.bin", "B"},
+	})
+
+	reg := trust.NewRegistry()
+	pub := priv.Public().(ed25519.PublicKey)
+	require.NoError(t, reg.Add(trust.PurposeUpdate, "k-conflict", pub))
+
+	dest := t.TempDir()
+	_, err = Extract(bytes.NewReader(raw), reg, dest, "")
+	assert.Error(t, err, "Extract must fail when a component's own file blocks another component's required directory")
+}
+
+// ---------------------------------------------------------------------------
+// streamComponent — os.Rename error path ("bundle: stage %s")
+// ---------------------------------------------------------------------------
+
+// TestExtract_Cov_RenameFailsComponentPathIsDir verifies that Extract fails when
+// the final destination path for a component already exists as a DIRECTORY
+// (rather than being absent or a file), which makes the atomic os.Rename(tmp,
+// finalPath) fail — a scenario mkdirAllNoSymlink cannot catch up front because
+// the conflicting entry is the leaf component path itself, not one of its parent
+// directories.
+func TestExtract_Cov_RenameFailsComponentPathIsDir(t *testing.T) {
+	// A destDir with any pre-existing entry but no installed-version marker is
+	// refused up front by the no-marker-but-non-empty fail-closed gate (see
+	// readInstalledVersion), well before per-component processing — so we can't
+	// just pre-plant a conflicting directory in a fresh destDir. Instead: run a
+	// real first Extract to populate dest with a legitimate marker, THEN plant
+	// the conflicting directory for a second, newer-version Extract — which
+	// passes the marker/no-downgrade gate and reaches streamComponent for real.
+	reg := trust.NewRegistry()
+
+	pub1, priv1, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	require.NoError(t, reg.Add(trust.PurposeUpdate, "k-rename-1", pub1))
+	dir1 := srcDirWith(t, map[string]string{"other.bin": "y"})
+	m1, err := BuildManifest(dir1, "v1.0.0", "k-rename-1", "", time.Unix(1_700_000_000, 0))
+	require.NoError(t, err)
+	sig1, err := Sign(m1, priv1)
+	require.NoError(t, err)
+	var buf1 bytes.Buffer
+	require.NoError(t, WriteBundle(&buf1, dir1, m1, sig1))
+
+	dest := t.TempDir()
+	_, err = Extract(bytes.NewReader(buf1.Bytes()), reg, dest, "")
+	require.NoError(t, err, "first Extract must succeed and persist an installed-version marker")
+
+	pub2, priv2, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	require.NoError(t, reg.Add(trust.PurposeUpdate, "k-rename-2", pub2))
+	dir2 := srcDirWith(t, map[string]string{"img.bin": "data"})
+	m2, err := BuildManifest(dir2, "v2.0.0", "k-rename-2", "", time.Unix(1_700_000_001, 0))
+	require.NoError(t, err)
+	sig2, err := Sign(m2, priv2)
+	require.NoError(t, err)
+	var buf2 bytes.Buffer
+	require.NoError(t, WriteBundle(&buf2, dir2, m2, sig2))
+
+	// Pre-plant a DIRECTORY at the exact component leaf path so Rename(tmp file,
+	// that path) fails instead of succeeding.
+	require.NoError(t, os.Mkdir(filepath.Join(dest, "img.bin"), 0o755))
+
+	_, err = Extract(bytes.NewReader(buf2.Bytes()), reg, dest, "")
+	assert.Error(t, err, "Extract must fail when the component's destination path is already a directory")
+}
+
+// ---------------------------------------------------------------------------
+// mkdirAllNoSymlink — default branch: os.Lstat fails with a non-IsNotExist error
+// (permission denied walking through a no-execute directory)
+// ---------------------------------------------------------------------------
+
+func TestMkdirAllNoSymlink_Cov_LstatPermissionDenied(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permission checks; skip")
+	}
+	root := t.TempDir()
+	blocked := filepath.Join(root, "blocked")
+	require.NoError(t, os.Mkdir(blocked, 0o755))
+	// No execute bit at all: even Lstat-ing an entry underneath "blocked" fails
+	// with permission-denied (not "not exist"), unlike the sibling test that uses
+	// 0o555 (which still allows traversal, so Lstat of a nonexistent child there
+	// succeeds as IsNotExist and Mkdir itself is what fails).
+	require.NoError(t, os.Chmod(blocked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) })
+
+	err := mkdirAllNoSymlink(root, filepath.Join(blocked, "child"))
+	assert.Error(t, err, "mkdirAllNoSymlink must fail when Lstat itself is denied by a no-execute parent")
+}
+
+// ---------------------------------------------------------------------------
+// BuildManifest — hashFile error path (file becomes unreadable mid-walk)
+// ---------------------------------------------------------------------------
+
+func TestBuildManifest_Cov_HashFileUnreadable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permission checks; skip")
+	}
+	dir := srcDirWith(t, map[string]string{"secret.bin": "data"})
+	require.NoError(t, os.Chmod(filepath.Join(dir, "secret.bin"), 0o000))
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(dir, "secret.bin"), 0o644) })
+
+	_, err := BuildManifest(dir, "v1.0.0", "k", "", time.Unix(1_700_000_000, 0))
+	assert.Error(t, err, "BuildManifest must fail when a source file can't be read for hashing")
+}
+
+// ---------------------------------------------------------------------------
+// PersistedInstalledVersion — thin public wrapper around readInstalledVersion,
+// entirely untested prior to this file (0% coverage).
+// ---------------------------------------------------------------------------
+
+func TestPersistedInstalledVersion_Cov(t *testing.T) {
+	// No marker yet: a fresh, nonexistent destDir is a legitimate first install.
+	dest := filepath.Join(t.TempDir(), "does-not-exist-yet")
+	version, ok, err := PersistedInstalledVersion(dest)
+	require.NoError(t, err)
+	assert.False(t, ok, "no marker should mean ok=false")
+	assert.Empty(t, version)
+
+	// After a real Extract, the marker exists and PersistedInstalledVersion must
+	// surface the version that Extract just staged.
+	raw, reg, _ := signedBundle(t, map[string]string{"a.bin": "x"}, "v2.3.4", "k-persist", "")
+	dest2 := t.TempDir()
+	_, err = Extract(bytes.NewReader(raw), reg, dest2, "")
+	require.NoError(t, err)
+
+	version, ok, err = PersistedInstalledVersion(dest2)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "v2.3.4", version)
+}
+
+// ---------------------------------------------------------------------------
+// readInstalledVersion — os.ReadFile fails with a non-IsNotExist error (the
+// marker exists but is unreadable / is itself a blocked path).
+// ---------------------------------------------------------------------------
+
+func TestReadInstalledVersion_Cov_UnreadableMarker(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permission checks; skip")
+	}
+	dest := t.TempDir()
+	markerPath := filepath.Join(dest, installedVersionMarker)
+	require.NoError(t, os.WriteFile(markerPath, []byte("v1.0.0\n"), 0o644))
+	require.NoError(t, os.Chmod(markerPath, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(markerPath, 0o644) })
+
+	_, ok, err := PersistedInstalledVersion(dest)
+	assert.False(t, ok)
+	assert.Error(t, err, "a present-but-unreadable marker must fail closed, not be treated as absent")
+}
+
+// TestReadInstalledVersion_Cov_DestDirHasContentErrors covers the branch where the
+// marker is legitimately absent (a normal os.IsNotExist from os.ReadFile) but the
+// destDirHasContent fallback check itself errors for an unrelated reason — here,
+// destDir has execute-but-not-read permission: enough for os.ReadFile to look up
+// the (nonexistent) marker by name and get a clean ENOENT, but not enough for
+// os.ReadDir to list destDir's entries to decide whether it's "non-empty".
+func TestReadInstalledVersion_Cov_DestDirHasContentErrors(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permission checks; skip")
+	}
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "dest")
+	require.NoError(t, os.Mkdir(dest, 0o755))
+	require.NoError(t, os.Chmod(dest, 0o100)) // execute-only: lookup works, listing doesn't
+	t.Cleanup(func() { _ = os.Chmod(dest, 0o755) })
+
+	_, ok, err := PersistedInstalledVersion(dest)
+	assert.False(t, ok)
+	assert.Error(t, err, "a destDirHasContent failure must propagate as an error, not silently mean empty")
 }

--- a/internal/bundle/bundle_s27_test.go
+++ b/internal/bundle/bundle_s27_test.go
@@ -1,0 +1,273 @@
+// bundle_s27_test.go — additional coverage uplift targeting branches still uncovered after
+// s18/s24/s25/s26/extra/coverage/main test files (baseline 91.3% statements per the coverage
+// campaign; see bundle_s26_test.go's header for the branches it already closed).
+//
+// Gaps targeted here:
+//   - Sign / WriteBundle: MarshalCanonical error path (a manifest whose ReleasedAt year is
+//     outside time.Time's JSON-encodable range [0,9999] makes json.MarshalIndent fail)
+//   - process: writeInstalledVersion error AFTER a genuinely clean staging pass (a
+//     zero-component manifest, so the failure is isolated to the final marker write and
+//     not masked by an earlier component-staging failure on the same read-only dest)
+//   - streamBundleComponents: the blanket entries>maxComponentEntries cap, exercised via
+//     non-regular (directory) entries that never reach the duplicate-name check
+//   - streamComponent: n != comp.Size with NO copy error (a source that ends cleanly, via
+//     io.EOF, before satisfying the pinned size — distinct from the copyErr branch already
+//     covered by TestStreamComponent_S26_CopyError)
+//   - readNamedEntry: tr.Read() failing mid-entry for the manifest itself (declared size
+//     under the cap, but the archive's body bytes are absent)
+//   - hashFile: io.Copy error when the opened path is a directory (open succeeds, read
+//     fails) — distinct from the already-covered os.Open permission-denied branch
+//   - streamBundleComponents: tr.Next() returning a genuine non-EOF error (a corrupt,
+//     full-length-but-invalid tar header block after the manifest+sig entries — as opposed
+//     to a clean/EOF-terminated stream or a short trailing fragment, both of which the tar
+//     reader treats as ordinary EOF, not an error)
+//
+// Branches deliberately NOT targeted (documented here rather than left silently unexplained):
+//   - BuildManifest's filepath.Rel error and WriteBundle's f.Close() error: both require an
+//     OS-level failure mode (a differing filesystem "volume", a Close() syscall failure) with
+//     no portable way to force it from a normal Go test.
+//   - mkdirAllNoSymlink's / safeJoin's filepath.Abs error branches: only reachable if
+//     os.Getwd() fails, which requires a deleted cwd — confirmed NOT to error on macOS
+//     (getcwd is cached/resolved via fcntl(F_GETPATH) even after the directory is removed),
+//     so a test relying on it would be silently no-op on this platform and is not worth the
+//     portability risk.
+//   - mkdirAllNoSymlink's `part == ""` branch and safeJoin's escape-check branch: both sit
+//     downstream of cleanComponentPath, which already rejects the inputs (".", "..", leading
+//     "/") that would be needed to produce an empty path segment or an escaping join — see
+//     bundle_s26_test.go's TestSafeJoin_S26_ValidNestedPath comment, which reached the same
+//     conclusion for the safeJoin branch.
+package bundle
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/ed25519"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/trust"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Sign / WriteBundle — MarshalCanonical error path
+// ---------------------------------------------------------------------------
+
+// TestSign_S27_MarshalCanonicalError verifies Sign propagates a MarshalCanonical failure
+// instead of signing whatever partial bytes json.MarshalIndent managed to produce. A
+// ReleasedAt year outside [0,9999] is the one field on Manifest whose JSON encoding can
+// fail (time.Time.MarshalJSON explicitly rejects it), so this is a real, reachable failure
+// mode rather than a contrived one.
+func TestSign_S27_MarshalCanonicalError(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	m := &Manifest{
+		Version:    "v1.0.0",
+		KeyID:      "s27-badyear",
+		ReleasedAt: time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	_, err = Sign(m, priv)
+	assert.Error(t, err, "Sign must propagate a MarshalCanonical failure instead of signing garbage")
+}
+
+// TestWriteBundle_S27_MarshalCanonicalError verifies WriteBundle fails before writing any
+// tar entry when the manifest itself can't be canonically marshaled.
+func TestWriteBundle_S27_MarshalCanonicalError(t *testing.T) {
+	m := &Manifest{
+		Version:    "v1.0.0",
+		KeyID:      "s27-badyear2",
+		ReleasedAt: time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	var buf bytes.Buffer
+	err := WriteBundle(&buf, t.TempDir(), m, []byte("sig"))
+	assert.Error(t, err, "WriteBundle must propagate a MarshalCanonical failure before writing anything")
+	assert.Zero(t, buf.Len(), "nothing should be written to w once MarshalCanonical fails")
+}
+
+// ---------------------------------------------------------------------------
+// process — writeInstalledVersion error isolated from earlier staging failures
+// ---------------------------------------------------------------------------
+
+// TestExtract_S27_MarkerWriteFailsZeroComponents targets the writeInstalledVersion error
+// branch specifically — as opposed to the existing read-only-dest tests (e.g.
+// TestExtract_S25_MarkerWriteFailure, TestExtract_S26_MarkerWriteFailsAfterStaging), which
+// use a manifest with at least one component and so actually fail earlier, at component
+// staging (CreateTemp into the read-only dir), never reaching the marker write at all. A
+// zero-component manifest is a legitimate (if degenerate) bundle: it still needs a
+// signature and a key-id, and process() still runs staging + the final marker write, but
+// staging itself never touches the filesystem, so a read-only dest is guaranteed to fail
+// exactly at, and only at, the marker write.
+func TestExtract_S27_MarkerWriteFailsZeroComponents(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permission checks; skip")
+	}
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	m := &Manifest{Version: "v1.0.0", KeyID: "s27-marker", ReleasedAt: time.Unix(1_700_000_000, 0)}
+	sig, err := Sign(m, priv)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	// srcDir is irrelevant: m.Components is empty, so WriteBundle's component loop never
+	// runs and never touches srcDir.
+	require.NoError(t, WriteBundle(&buf, t.TempDir(), m, sig))
+
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeUpdate, "s27-marker", pub))
+
+	dest := t.TempDir()
+	require.NoError(t, os.Chmod(dest, 0o555)) // read+execute only: no write
+	t.Cleanup(func() { _ = os.Chmod(dest, 0o755) })
+
+	_, err = Extract(bytes.NewReader(buf.Bytes()), reg, dest, "")
+	require.Error(t, err, "writing the installed-version marker into a read-only, otherwise-untouched destination must fail")
+	assert.Contains(t, err.Error(), "installed-version marker", "error should identify the marker write as the failure point")
+}
+
+// ---------------------------------------------------------------------------
+// streamBundleComponents — the blanket entries>maxComponentEntries cap
+// ---------------------------------------------------------------------------
+
+// TestVerify_S27_TooManyNonRegularEntries verifies the general entries++ cap fires on its
+// own, independent of the (cheaper, more specific) duplicate-name check. The existing
+// TestVerify_RejectsThousandsOfRepeatedValidEntries repeats one regular-file component name,
+// which trips ErrDuplicateComponent on its second iteration — long before entries could ever
+// reach maxComponentEntries. Directory-type entries are never regular files, so they skip
+// the name/duplicate checks entirely (via the `continue` below the Typeflag check) and so
+// are the only way to actually drive the entries counter past the cap.
+func TestVerify_S27_TooManyNonRegularEntries(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	m := &Manifest{Version: "v1.0.0", KeyID: "s27-many", ReleasedAt: time.Unix(1_700_000_000, 0)}
+	sig, err := Sign(m, priv)
+	require.NoError(t, err)
+	manifestBytes, err := m.MarshalCanonical()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	putReg := func(name string, b []byte) {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(b)), Typeflag: tar.TypeReg}))
+		_, werr := tw.Write(b)
+		require.NoError(t, werr)
+	}
+	putReg(manifestName, manifestBytes)
+	putReg(sigName, sig)
+	for i := range maxComponentEntries + 1 {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name:     fmt.Sprintf("dir-%d/", i),
+			Mode:     0o755,
+			Typeflag: tar.TypeDir,
+		}))
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeUpdate, "s27-many", pub))
+
+	_, err = Verify(bytes.NewReader(buf.Bytes()), reg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTooManyEntries)
+}
+
+// ---------------------------------------------------------------------------
+// streamComponent — size mismatch with a clean EOF (no copy error)
+// ---------------------------------------------------------------------------
+
+// TestStreamComponent_S27_ShortReadCleanEOF covers the n != comp.Size branch when the
+// underlying reader simply runs out of bytes (io.Copy treats that as a normal end, not an
+// error) — distinct from TestStreamComponent_S26_CopyError, which forces an actual I/O
+// error. A source that legitimately ends early without erroring (e.g. a well-behaved
+// io.Reader wrapping fewer bytes than the pinned size) must still be rejected as a digest
+// mismatch, not silently accepted as a short write.
+func TestStreamComponent_S27_ShortReadCleanEOF(t *testing.T) {
+	comp := Component{Path: "x.bin", SHA256: strings.Repeat("0", 64), Size: 1000}
+	err := streamComponent(strings.NewReader("short content, well under the pinned size"), comp, "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDigestMismatch, "a source that ends cleanly before the pinned size must still be rejected")
+}
+
+// ---------------------------------------------------------------------------
+// readNamedEntry — tr.Read() failing mid-entry for the manifest itself
+// ---------------------------------------------------------------------------
+
+// TestVerify_S27_TruncatedManifestBody verifies readNamedEntry propagates a read failure
+// when a tar entry declares a size UNDER the size cap (so the early declared-size check
+// doesn't fire) but the archive's actual body bytes are absent — the archive ends before
+// satisfying the header's own declared size. writeRawBundleOversizedEntry writes exactly
+// this shape (a header with no following body, gz.Close() called directly); it is normally
+// used with a declaredSize ABOVE the cap to test the size-cap rejection, but reusing it with
+// a modest size below the cap instead exercises the read-error branch this test targets.
+func TestVerify_S27_TruncatedManifestBody(t *testing.T) {
+	raw := writeRawBundleOversizedEntry(t, nil, nil, manifestName, 1000)
+	reg := trust.NewRegistry()
+	_, err := Verify(bytes.NewReader(raw), reg)
+	require.Error(t, err, "a manifest entry shorter than its own declared header size must fail while reading, not silently truncate")
+}
+
+// ---------------------------------------------------------------------------
+// hashFile — io.Copy error (open succeeds, read fails)
+// ---------------------------------------------------------------------------
+
+// TestHashFile_S27_DirectoryReadError covers hashFile's io.Copy error return, distinct from
+// TestBuildManifest_Cov_HashFileUnreadable / TestHashFile_S25_FileNotFound which both fail at
+// os.Open. Opening a directory succeeds (os.Open works on directories), but reading its
+// contents as a byte stream fails at the first Read — this is the only portable, no-mocking
+// way to separate the "open failed" and "read failed" branches of hashFile.
+func TestHashFile_S27_DirectoryReadError(t *testing.T) {
+	dir := t.TempDir()
+	_, _, err := hashFile(dir)
+	assert.Error(t, err, "hashFile must fail when the read (not the open) of the target path fails")
+}
+
+// ---------------------------------------------------------------------------
+// streamBundleComponents — tr.Next() returning a genuine non-EOF error
+// ---------------------------------------------------------------------------
+
+// TestVerify_S27_CorruptTarHeaderAfterSig verifies streamBundleComponents propagates a
+// tr.Next() failure that is a real parse error, not end-of-archive. A full 512-byte block of
+// non-zero garbage right after a valid manifest+sig fails tar's header checksum validation —
+// unlike simply truncating the stream (which the tar reader treats as ordinary EOF, already
+// exercised by TestVerify_S26_CorruptTarAfterSig and friends), a complete-but-invalid block
+// is what actually drives tr.Next() down the err != nil (and NOT io.EOF) branch.
+func TestVerify_S27_CorruptTarHeaderAfterSig(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	m := &Manifest{Version: "v1.0.0", KeyID: "s27-corrupt", ReleasedAt: time.Unix(1_700_000_000, 0)}
+	sig, err := Sign(m, priv)
+	require.NoError(t, err)
+	manifestBytes, err := m.MarshalCanonical()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	putReg := func(name string, b []byte) {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(b)), Typeflag: tar.TypeReg}))
+		_, werr := tw.Write(b)
+		require.NoError(t, werr)
+	}
+	putReg(manifestName, manifestBytes)
+	putReg(sigName, sig)
+	// Deliberately skip tw.Close() (which would append the proper end-of-archive zero
+	// blocks) and instead write one full, non-zero, non-header-shaped block directly to the
+	// underlying gzip stream — a complete block the tar reader will attempt to parse as a
+	// header and reject on checksum, rather than a short/absent tail it would treat as EOF.
+	_, werr := gz.Write(bytes.Repeat([]byte{0x41}, 512))
+	require.NoError(t, werr)
+	require.NoError(t, gz.Close())
+
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeUpdate, "s27-corrupt", pub))
+
+	_, err = Verify(bytes.NewReader(buf.Bytes()), reg)
+	require.Error(t, err, "a corrupt (not merely truncated) tar header after the manifest+sig must fail Verify")
+	assert.Contains(t, err.Error(), "read archive", "error should identify the archive-read failure, not a signature or digest mismatch")
+}

--- a/internal/cli/accessreview/accessreview_gap_test.go
+++ b/internal/cli/accessreview/accessreview_gap_test.go
@@ -1,0 +1,160 @@
+// accessreview_gap_test.go — closes remaining coverage gaps identified by
+// reading accessreview.go/campaign.go against the existing test suite:
+//   - a "role" source entry with EnvironmentID==0 (the "project"-scope label,
+//     as opposed to the "env=N" label already covered elsewhere)
+//   - a "user" principal with no email (the plain-name branch, as opposed to
+//     the "name <email>" branch already covered elsewhere)
+//   - runDecision's own server-error path (c.Post returning an error), which
+//     is exercised for the campaign subcommands but not for revoke/attest
+//   - revokeCmd.RunE and attestCmd.RunE themselves: every existing test calls
+//     runDecision(...) directly, so the one-line closures that wire the two
+//     cobra commands to it (`return runDecision("revoke")` /
+//     `return runDecision("attest")`) were never actually executed
+package accessreview
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccessReview_RoleEntry_ProjectScope covers the EnvironmentID==0 branch
+// of the "role" detail formatting (scope stays "project" rather than
+// "env=N"), which TestAccessReview_WithRoleEntry does not exercise since it
+// always sets a nonzero environment_id.
+func TestAccessReview_RoleEntry_ProjectScope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"entries":[
+			{"principal_type":"user","principal_name":"carol","email":"carol@x.io","source":"role","role_name":"admin","access_level":"admin","environment_id":0}
+		],"count":1}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject := flagProject
+	defer func() { flagProject = origProject }()
+	flagProject = 9
+
+	out, err := captureStdout(t, func() error { return AccessReviewCmd.RunE(AccessReviewCmd, nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "role=admin (project)")
+	assert.NotContains(t, out, "env=")
+}
+
+// TestAccessReview_UserWithoutEmail covers the branch where a "user"
+// principal has no email — the principal column must stay the plain name,
+// not "name <>". Every existing user-principal fixture in this package sets
+// a nonempty email, so this line was previously uncovered.
+func TestAccessReview_UserWithoutEmail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"entries":[
+			{"principal_type":"user","principal_name":"dave","email":"","source":"owner","secret_name":"db-pass","access_level":"read"}
+		],"count":1}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject := flagProject
+	defer func() { flagProject = origProject }()
+	flagProject = 9
+
+	out, err := captureStdout(t, func() error { return AccessReviewCmd.RunE(AccessReviewCmd, nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "dave")
+	assert.NotContains(t, out, "dave <")
+}
+
+// TestRunDecision_ServerError covers runDecision's own c.Post error path
+// (revoke/attest hitting a failing server) — the analogous "ServerError"
+// case already exists for every campaign subcommand but not for
+// revoke/attest themselves.
+func TestRunDecision_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	origProject, origSource, origPrincipalID, origRoleID :=
+		dProject, dSource, dPrincipalID, dRoleID
+	defer func() {
+		dProject = origProject
+		dSource = origSource
+		dPrincipalID = origPrincipalID
+		dRoleID = origRoleID
+	}()
+	dProject = 4
+	dSource = "role"
+	dPrincipalID = 1
+	dRoleID = 2
+
+	err := runDecision("revoke")
+	require.Error(t, err)
+}
+
+// TestRevokeCmd_RunE covers revokeCmd's own RunE closure — every other
+// revoke-related test calls runDecision("revoke") directly, bypassing the
+// closure that cobra actually invokes when a user runs `access-review
+// revoke`.
+func TestRevokeCmd_RunE(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject, origSource, origPrincipalID, origRoleID :=
+		dProject, dSource, dPrincipalID, dRoleID
+	defer func() {
+		dProject = origProject
+		dSource = origSource
+		dPrincipalID = origPrincipalID
+		dRoleID = origRoleID
+	}()
+	dProject = 6
+	dSource = "role"
+	dPrincipalID = 2
+	dRoleID = 9
+
+	require.NoError(t, revokeCmd.RunE(revokeCmd, nil))
+	assert.Equal(t, "/api/v1/projects/6/access-review/revoke", gotPath)
+}
+
+// TestAttestCmd_RunE covers attestCmd's own RunE closure, the attest
+// counterpart of TestRevokeCmd_RunE above.
+func TestAttestCmd_RunE(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origProject, origSource, origPrincipalID, origRoleID :=
+		dProject, dSource, dPrincipalID, dRoleID
+	defer func() {
+		dProject = origProject
+		dSource = origSource
+		dPrincipalID = origPrincipalID
+		dRoleID = origRoleID
+	}()
+	dProject = 6
+	dSource = "role"
+	dPrincipalID = 2
+	dRoleID = 9
+
+	require.NoError(t, attestCmd.RunE(attestCmd, nil))
+	assert.Equal(t, "/api/v1/projects/6/access-review/attest", gotPath)
+}

--- a/internal/cli/anomalies/config_extra_test.go
+++ b/internal/cli/anomalies/config_extra_test.go
@@ -1,0 +1,224 @@
+package anomalies
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunConfigGet_NotConnected exercises the top-level runConfigGet's
+// not-connected branch, which runConfigGetRemote (tested elsewhere via the
+// *_test.go stubs) never reaches on its own.
+func TestRunConfigGet_NotConnected(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	err := runConfigGet(configGetCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+// TestRunConfigGet_Connected exercises the top-level runConfigGet's success
+// path, which requires NewRemoteClient to return ok=true.
+func TestRunConfigGet_Connected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"config":{"lookback_days":7,"quarantine_hours":24}}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	require.NoError(t, runConfigGet(configGetCmd, nil))
+}
+
+// TestRunConfigGetRemote_ServerError exercises the error-return branch of
+// runConfigGetRemote, left uncovered by the existing success-only test.
+func TestRunConfigGetRemote_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	err := runConfigGetRemote(rc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestRunConfigSet_NotConnected exercises the top-level runConfigSet's
+// not-connected branch.
+func TestRunConfigSet_NotConnected(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	err := runConfigSet(configSetCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+// TestRunConfigSet_Connected exercises the top-level runConfigSet's success
+// path (RunE -> NewRemoteClient ok -> runConfigSetRemote) using the real
+// configSetCmd and its registered flags, which the existing tests only drive
+// through runConfigSetRemote with hand-built cobra.Command instances.
+func TestRunConfigSet_Connected(t *testing.T) {
+	var putBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"data":{"config":{"lookback_days":7,"quarantine_hours":24,"ml_threshold":0.6,"ml_num_trees":100,"ml_sample_size":256}}}`))
+			return
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &putBody)
+		_, _ = w.Write([]byte(`{"data":{"config":{"lookback_days":30,"quarantine_hours":24,"ml_threshold":0.6,"ml_num_trees":100,"ml_sample_size":256}}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	lookbackFlag := configSetCmd.Flags().Lookup("lookback-days")
+	require.NotNil(t, lookbackFlag)
+	require.NoError(t, configSetCmd.Flags().Set("lookback-days", "30"))
+	defer func() { lookbackFlag.Changed = false }()
+
+	require.NoError(t, runConfigSet(configSetCmd, nil))
+	assert.EqualValues(t, 30, putBody["lookback_days"])
+}
+
+// TestRunConfigSetRemote_FetchError exercises the "fetch current config"
+// error-wrapping branch of runConfigSetRemote.
+func TestRunConfigSetRemote_FetchError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	cmd := newEmptyConfigSetCmd()
+
+	err := runConfigSetRemote(rc, cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch current config")
+}
+
+// TestRunConfigSetRemote_PutError exercises the PUT error-return branch of
+// runConfigSetRemote (the fetch succeeds, but the write fails).
+func TestRunConfigSetRemote_PutError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"data":{"config":{"lookback_days":7}}}`))
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	cmd := newEmptyConfigSetCmd()
+
+	err := runConfigSetRemote(rc, cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+}
+
+// TestPrintAnomalyConfig_WithUpdatedBy covers the branch of printAnomalyConfig
+// that prints the "Last updated by" line, which every other test in this
+// package leaves unset (empty UpdatedBy).
+func TestPrintAnomalyConfig_WithUpdatedBy(t *testing.T) {
+	cfg := anomalyConfigRecord{
+		LookbackDays: 7,
+		UpdatedBy:    "alice",
+		UpdatedAt:    "2026-08-01T00:00:00Z",
+	}
+
+	out := captureStdoutHelper(t, func() { printAnomalyConfig(cfg) })
+	assert.Contains(t, out, "Last updated by:   alice at 2026-08-01T00:00:00Z")
+}
+
+// TestRunConfigSetRemote_MarshalError exercises the "marshal config" error
+// branch of runConfigSetRemote. encoding/json refuses to marshal a NaN
+// float64 ("json: unsupported value: NaN"), and pflag's Float64Var accepts
+// the literal "NaN" without a parse error, so a caller passing
+// --ml-threshold=NaN reaches json.Marshal(current) with an unsupported
+// value and the call must surface that as a wrapped "marshal config" error
+// rather than panicking or silently dropping the field.
+func TestRunConfigSetRemote_MarshalError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"config":{"lookback_days":7}}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Float64Var(&cfgMLThreshold, "ml-threshold", 0, "")
+	require.NoError(t, cmd.Flags().Set("ml-threshold", "NaN"))
+	defer func() { cfgMLThreshold = 0 }()
+
+	err := runConfigSetRemote(rc, cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal config")
+}
+
+// newEmptyConfigSetCmd builds a fresh cobra.Command with all the "config set"
+// flags registered but none of them marked Changed, so runConfigSetRemote
+// applies no overrides on top of whatever the GET returns.
+func newEmptyConfigSetCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().IntVar(&cfgLookbackDays, "lookback-days", 0, "")
+	cmd.Flags().IntVar(&cfgQuarantineHours, "quarantine-hours", 0, "")
+	cmd.Flags().BoolVar(&cfgOffHoursEnabled, "off-hours-enabled", false, "")
+	cmd.Flags().StringVar(&cfgOffHoursTimezone, "off-hours-timezone", "", "")
+	cmd.Flags().IntVar(&cfgOffHoursStart, "off-hours-start", 0, "")
+	cmd.Flags().IntVar(&cfgOffHoursEnd, "off-hours-end", 0, "")
+	cmd.Flags().BoolVar(&cfgMLEnabled, "ml-enabled", false, "")
+	cmd.Flags().Float64Var(&cfgMLThreshold, "ml-threshold", 0, "")
+	cmd.Flags().IntVar(&cfgMLNumTrees, "ml-num-trees", 0, "")
+	cmd.Flags().IntVar(&cfgMLSampleSize, "ml-sample-size", 0, "")
+	return cmd
+}
+
+// captureStdoutHelper runs fn with os.Stdout redirected and returns what was
+// written, mirroring captureStdout in terminal_injection_test.go but for a
+// function with no error return.
+func captureStdoutHelper(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}

--- a/internal/cli/anomalies/escalation_extra_test.go
+++ b/internal/cli/anomalies/escalation_extra_test.go
@@ -1,0 +1,83 @@
+package anomalies
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunEscalationList_Connected exercises the top-level runEscalationList's
+// success branch (RunE -> NewRemoteClient ok -> runEscalationListRemote),
+// which the existing tests only reach indirectly through runEscalationListRemote.
+func TestRunEscalationList_Connected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"policies":[]}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	require.NoError(t, runEscalationList(escalationListCmd, nil))
+}
+
+// TestRunEscalationCreate_Connected exercises the top-level runEscalationCreate's
+// success branch, requiring both a non-empty --name and a connected server.
+func TestRunEscalationCreate_Connected(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"id":9,"name":"conn-pol","min_severity":"high","escalate_after_minutes":30,"channel_ids":"1","enabled":true}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	orig := flagEscalationName
+	defer func() { flagEscalationName = orig }()
+	flagEscalationName = "conn-pol"
+	flagEscalationMinSeverity = "high"
+	flagEscalationAfterMinutes = 30
+	flagEscalationChannels = "1"
+
+	require.NoError(t, runEscalationCreate(escalationCreateCmd, nil))
+	assert.Equal(t, "/api/v1/alert-escalation-policies", gotPath)
+}
+
+// TestRunEscalationDelete_Connected exercises the top-level runEscalationDelete's
+// success branch, requiring both a valid numeric ID and a connected server.
+func TestRunEscalationDelete_Connected(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	require.NoError(t, runEscalationDelete(escalationDeleteCmd, []string{"11"}))
+	assert.Equal(t, "/api/v1/alert-escalation-policies/11", gotPath)
+}
+
+// TestRunEscalationRun_Connected exercises the top-level runEscalationRun's
+// success branch.
+func TestRunEscalationRun_Connected(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"evaluated":1,"escalated":0,"skipped":1}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	require.NoError(t, runEscalationRun(escalationRunCmd, nil))
+	assert.Equal(t, "/api/v1/system/admin/jobs/run-alert-escalation", gotPath)
+}

--- a/internal/cli/audit/audit_coverage_test.go
+++ b/internal/cli/audit/audit_coverage_test.go
@@ -1,0 +1,133 @@
+// audit_coverage_test.go — additional coverage for branches the existing
+// suite doesn't reach:
+//
+//   - the client()-returns-error path as actually taken by each command's
+//     RunE/run* function (verify, export, checkpoint, migrate-chain-encoding,
+//     logs, search) — the existing "NoClient" tests in audit_s18_test.go and
+//     audit_search_test.go only clear KEYORIX_SERVER/KEYORIX_TOKEN, which on a
+//     machine with a leftover ~/.keyorix/cli.yaml (written by a previous
+//     `keyorix connect`) still resolves to a remote via the config-file
+//     fallback in common.ResolveRemote — so those tests spuriously dial that
+//     stale server instead of exercising the "not connected" branch. This file
+//     additionally redirects HOME (and clears XDG_CONFIG_HOME) to an empty
+//     temp directory so ResolveRemote's config-file fallback has nothing to
+//     find, making the "not connected" branch deterministically reachable
+//     regardless of the local machine's state.
+//   - exportCmd's CSV path when a page event fails to unmarshal into
+//     csvEventRow (the json.Unmarshal error → continue branch).
+package audit
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isolateFromLocalConfig clears every source common.ResolveRemote consults
+// (env vars, ~/.keyorix/cli.yaml via a redirected empty HOME) so client()
+// deterministically returns the "not connected" error, independent of
+// whatever remote config a previous `keyorix connect` may have left on this
+// machine.
+func isolateFromLocalConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+}
+
+func TestClient_ErrorWhenNotConnected_Isolated(t *testing.T) {
+	isolateFromLocalConfig(t)
+	c, err := client()
+	require.Error(t, err)
+	assert.Nil(t, c)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestVerifyCmd_ClientErrorSurfaces(t *testing.T) {
+	isolateFromLocalConfig(t)
+	err := verifyCmd.RunE(verifyCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestExportCmd_ClientErrorSurfaces(t *testing.T) {
+	isolateFromLocalConfig(t)
+	flagSince, flagAfterID, flagLimit, flagAll, flagCSV = "", 0, 100, false, false
+	err := exportCmd.RunE(exportCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestCheckpointCmd_ClientErrorSurfaces(t *testing.T) {
+	isolateFromLocalConfig(t)
+	err := checkpointCmd.RunE(checkpointCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestMigrateChainCmd_ClientErrorSurfaces(t *testing.T) {
+	isolateFromLocalConfig(t)
+	flagMigrateConfirm = false
+	err := migrateChainCmd.RunE(migrateChainCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestRunLogsQuery_ClientErrorSurfaces(t *testing.T) {
+	isolateFromLocalConfig(t)
+	logEventType, logUserID, logProjectID, logActorType = "", 0, 0, ""
+	flagSince, logUntil, logLimit = "", "", 50
+	err := runLogsQuery()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestRunAuditSearch_ClientErrorSurfaces(t *testing.T) {
+	isolateFromLocalConfig(t)
+	resetSearchFlags()
+	err := runAuditSearch()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+// TestExport_CSV_SkipsUnparsableEvent exercises the json.Unmarshal error →
+// continue branch in exportCmd's CSV path: a page event that is syntactically
+// valid JSON (so it survives being captured as a json.RawMessage in
+// exportPage.Events) but is not a JSON object (so it fails to decode into
+// csvEventRow) must be silently skipped, while well-formed rows around it
+// still make it into the CSV.
+func TestExport_CSV_SkipsUnparsableEvent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"events":[
+			{"id":1,"event_type":"secret.read","timestamp":"2026-06-19T10:00:00Z","actor":"alice","actor_type":"user","success":true,"description":"first"},
+			42,
+			{"id":2,"event_type":"secret.updated","timestamp":"2026-06-19T10:05:00Z","actor":"bob","actor_type":"user","success":true,"description":"second"}
+		],"count":3,"next_cursor":null}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	var out, errOut bytes.Buffer
+	exportCmd.SetOut(&out)
+	exportCmd.SetErr(&errOut)
+	flagSince, flagAfterID, flagLimit, flagAll, flagCSV = "", 0, 100, false, true
+	defer func() { flagCSV = false }()
+	require.NoError(t, exportCmd.RunE(exportCmd, nil))
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 3, "header + 2 valid rows; the unparsable middle event is skipped, not emitted as a blank/malformed row")
+	assert.Contains(t, lines[1], "alice")
+	assert.Contains(t, lines[1], "first")
+	assert.Contains(t, lines[2], "bob")
+	assert.Contains(t, lines[2], "second")
+	// The unparsable event still counts toward the reported total (it was a
+	// real event on the page, just not CSV-representable) — total is 3 events
+	// even though only 2 CSV rows were written.
+	assert.Contains(t, errOut.String(), "exported 3 event(s)")
+}

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -12,6 +12,14 @@ const (
 	configFilename = "keyorix.yaml"
 )
 
+// resolveAPIKey is a test seam over common.ResolveAPIKey: production code
+// always uses the real implementation, but tests can stub it to exercise the
+// "API key is required" branch in runLogin without needing a real TTY (the
+// real implementation's interactive prompt uses term.ReadPassword, which
+// requires an actual terminal fd and errors — rather than returning "" — on
+// a pipe or other non-terminal stdin).
+var resolveAPIKey = common.ResolveAPIKey
+
 // AuthCmd represents the auth command
 var AuthCmd = &cobra.Command{
 	Use:   "auth",
@@ -88,7 +96,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	// Resolve the API key without ever requiring it on the command line: the
 	// (insecure, warned) --api-key flag if set, else KEYORIX_API_KEY, else an
 	// interactive no-echo prompt.
-	apiKey, err := common.ResolveAPIKey(cmd, true)
+	apiKey, err := resolveAPIKey(cmd, true)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/auth/auth_apikey_seam_test.go
+++ b/internal/cli/auth/auth_apikey_seam_test.go
@@ -1,0 +1,62 @@
+// auth_apikey_seam_test.go — exercises the "API key is required" branch in
+// runLogin (auth.go), which fires when resolveAPIKey returns an empty key
+// with no error. The real common.ResolveAPIKey only returns "" via its
+// interactive term.ReadPassword prompt, which itself requires a real
+// terminal fd and errors (rather than returning "") on a pipe or other
+// non-terminal stdin — so this branch is unreachable in a normal test
+// process without a real PTY. resolveAPIKey is stubbed via its package-level
+// var seam to drive this specific, otherwise-untestable branch directly.
+package auth
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunLogin_EmptyAPIKeyFromResolver(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	require.NoError(t, loginCmd.Flags().Set("server", "https://keyorix.example.com"))
+	t.Cleanup(func() {
+		_ = loginCmd.Flags().Set("server", "")
+		loginCmd.Flags().Lookup("server").Changed = false
+	})
+
+	orig := resolveAPIKey
+	resolveAPIKey = func(*cobra.Command, bool) (string, error) { return "", nil }
+	t.Cleanup(func() { resolveAPIKey = orig })
+
+	err := runLogin(loginCmd, nil)
+	require.Error(t, err)
+	assert.Equal(t, "API key is required", err.Error())
+}
+
+// TestRunLogin_ResolveAPIKeyError verifies runLogin propagates a resolver
+// error (e.g. the interactive prompt failing) rather than swallowing it.
+func TestRunLogin_ResolveAPIKeyError(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	require.NoError(t, loginCmd.Flags().Set("server", "https://keyorix.example.com"))
+	t.Cleanup(func() {
+		_ = loginCmd.Flags().Set("server", "")
+		loginCmd.Flags().Lookup("server").Changed = false
+	})
+
+	orig := resolveAPIKey
+	sentinel := &keyResolveErr{"boom"}
+	resolveAPIKey = func(*cobra.Command, bool) (string, error) { return "", sentinel }
+	t.Cleanup(func() { resolveAPIKey = orig })
+
+	err := runLogin(loginCmd, nil)
+	require.Error(t, err)
+	assert.Equal(t, sentinel, err)
+}
+
+type keyResolveErr struct{ msg string }
+
+func (e *keyResolveErr) Error() string { return e.msg }

--- a/internal/cli/auth/mfa_stepup_remote_test.go
+++ b/internal/cli/auth/mfa_stepup_remote_test.go
@@ -1,0 +1,117 @@
+// mfa_stepup_remote_test.go — exercises the remaining branches of runMFAStepUp
+// that mfa_stepup_flag_warning_test.go doesn't reach: the "no remote session"
+// early-return, the interactive-prompt path when --code is omitted (both the
+// empty/EOF failure and, via a stubbed remote server, the full success path).
+package auth
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetMFACodeFlag(t *testing.T) {
+	t.Helper()
+	_ = mfaStepUpCmd.Flags().Set("code", "")
+	mfaStepUpCmd.Flags().Lookup("code").Changed = false
+	t.Cleanup(func() {
+		_ = mfaStepUpCmd.Flags().Set("code", "")
+		mfaStepUpCmd.Flags().Lookup("code").Changed = false
+	})
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}
+
+// TestRunMFAStepUp_NoRemoteSession exercises the "!ok" early return: with no
+// KEYORIX_SERVER/KEYORIX_TOKEN, no ~/.keyorix/cli.yaml (HOME redirected to an
+// empty temp dir), and no CWD-relative keyorix.yaml, NewRemoteClient must
+// report no remote configuration.
+func TestRunMFAStepUp_NoRemoteSession(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	resetMFACodeFlag(t)
+
+	err := runMFAStepUp(mfaStepUpCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MFA step-up requires remote mode")
+}
+
+// TestRunMFAStepUp_Success drives the full happy path: a stubbed remote
+// server accepts the POST and runMFAStepUp reports success. --code is set
+// explicitly so the interactive prompt is skipped.
+func TestRunMFAStepUp_Success(t *testing.T) {
+	var gotPath, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	resetMFACodeFlag(t)
+	require.NoError(t, mfaStepUpCmd.Flags().Set("code", "123456"))
+
+	out := captureStdout(t, func() {
+		require.NoError(t, runMFAStepUp(mfaStepUpCmd, nil))
+	})
+
+	assert.Equal(t, "/api/v1/auth/mfa/stepup", gotPath)
+	assert.Contains(t, gotBody, "123456")
+	assert.Contains(t, out, "MFA step-up verified")
+}
+
+// TestRunMFAStepUp_EmptyCodeFromPrompt drives the --code-omitted branch: with
+// a working remote session but no --code flag, runMFAStepUp falls through to
+// the interactive prompt. Redirecting stdin to an already-closed pipe makes
+// fmt.Scanln fail immediately (EOF), which must surface as "code is required"
+// without ever reaching the remote server.
+func TestRunMFAStepUp_EmptyCodeFromPrompt(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	resetMFACodeFlag(t)
+
+	origStdin := os.Stdin
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	require.NoError(t, w.Close()) // no writer, so the reader sees immediate EOF
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+
+	err = runMFAStepUp(mfaStepUpCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "code is required")
+	assert.False(t, called, "remote server should not be contacted when the code prompt fails")
+}

--- a/internal/cli/billing/billing_test.go
+++ b/internal/cli/billing/billing_test.go
@@ -1,0 +1,327 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetFlags restores the package-level flag vars to their zero values so
+// tests that mutate them (mirroring what cobra flag parsing would do) don't
+// leak state into other tests.
+func resetFlags(t *testing.T) {
+	t.Helper()
+	origFrom, origTo, origProjectID, origFormat := flagFrom, flagTo, flagProjectID, flagFormat
+	t.Cleanup(func() {
+		flagFrom, flagTo, flagProjectID, flagFormat = origFrom, origTo, origProjectID, origFormat
+	})
+}
+
+func TestNewBillingCmd(t *testing.T) {
+	cmd := NewBillingCmd()
+	assert.Equal(t, "billing", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+
+	sub, _, err := cmd.Find([]string{"report"})
+	require.NoError(t, err)
+	assert.Equal(t, "report", sub.Name())
+}
+
+func TestNewReportCmd_Flags(t *testing.T) {
+	cmd := newReportCmd()
+	assert.Equal(t, "report", cmd.Use)
+	assert.NotNil(t, cmd.RunE)
+
+	fromFlag := cmd.Flags().Lookup("from")
+	require.NotNil(t, fromFlag)
+	toFlag := cmd.Flags().Lookup("to")
+	require.NotNil(t, toFlag)
+	projectFlag := cmd.Flags().Lookup("project-id")
+	require.NotNil(t, projectFlag)
+	assert.Equal(t, "", projectFlag.DefValue)
+	formatFlag := cmd.Flags().Lookup("format")
+	require.NotNil(t, formatFlag)
+	assert.Equal(t, "table", formatFlag.DefValue)
+
+	// "from" and "to" are required — Cobra records this via an annotation.
+	assert.Contains(t, fromFlag.Annotations, cobraRequiredAnnotation)
+	assert.Contains(t, toFlag.Annotations, cobraRequiredAnnotation)
+}
+
+// cobraRequiredAnnotation mirrors cobra's internal BashCompOneRequiredFlag
+// annotation key used by MarkFlagRequired, so the test above doesn't need to
+// import cobra just for this one constant string.
+const cobraRequiredAnnotation = "cobra_annotation_bash_completion_one_required_flag"
+
+func TestRunReport_InvalidFrom(t *testing.T) {
+	resetFlags(t)
+	flagFrom = "not-a-date"
+	flagTo = "2026-02-01T00:00:00Z"
+
+	err := runReport(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --from value")
+}
+
+func TestRunReport_InvalidTo(t *testing.T) {
+	resetFlags(t)
+	flagFrom = "2026-01-01T00:00:00Z"
+	flagTo = "also-not-a-date"
+
+	err := runReport(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --to value")
+}
+
+func TestParseProjectIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []uint
+		wantErr bool
+	}{
+		{name: "empty returns nil", input: "", want: nil},
+		{name: "single id", input: "42", want: []uint{42}},
+		{name: "multiple ids", input: "1,2,3", want: []uint{1, 2, 3}},
+		{name: "trims whitespace", input: " 1 , 2 ", want: []uint{1, 2}},
+		{name: "skips empty segments", input: "1,,2", want: []uint{1, 2}},
+		{name: "invalid id errors", input: "1,abc", wantErr: true},
+		{name: "negative id errors", input: "-1", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseProjectIDs(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func sampleReport() *storage.BillingReport {
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	gen := time.Date(2026, 2, 1, 12, 30, 0, 0, time.UTC)
+	return &storage.BillingReport{
+		From:        from,
+		To:          to,
+		GeneratedAt: gen,
+		Projects: []storage.BillingProjectStat{
+			{ProjectID: 2, ProjectName: "zeta", SecretCount: 1, SecretReads: 2, SecretWrites: 3, SecretRotations: 1, UniqueUsers: 1, MachineReads: 0},
+			{ProjectID: 1, ProjectName: "alpha", SecretCount: 5, SecretReads: 10, SecretWrites: 2, SecretRotations: 0, UniqueUsers: 3, MachineReads: 4},
+			{ProjectID: 3, ProjectName: "", SecretCount: 0, SecretReads: 0, SecretWrites: 0, SecretRotations: 0, UniqueUsers: 0, MachineReads: 0},
+		},
+		Totals: storage.BillingTotals{
+			Projects: 3, SecretCount: 6, SecretReads: 12, SecretWrites: 5, SecretRotations: 1, UniqueUsers: 4, MachineReads: 4,
+		},
+	}
+}
+
+func TestPrintBillingReport_TableSortsAndFormats(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "table"
+
+	out, err := captureStdout(t, func() error { return printBillingReport(sampleReport()) })
+	require.NoError(t, err)
+
+	// "alpha" (project 1) must be printed before "zeta" (project 2) — stable
+	// sort by ProjectName.
+	alphaIdx := indexOf(t, out, "alpha")
+	zetaIdx := indexOf(t, out, "zeta")
+	assert.Less(t, alphaIdx, zetaIdx, "expected alpha row before zeta row, got:\n%s", out)
+
+	// Blank ProjectName falls back to "(project <id>)".
+	assert.Contains(t, out, "(project 3)")
+
+	// Header and totals line are present.
+	assert.Contains(t, out, "PROJECT")
+	assert.Contains(t, out, "SECRETS")
+	assert.Contains(t, out, "Totals (3 project(s))")
+	assert.Contains(t, out, "2026-01-01")
+	assert.Contains(t, out, "2026-02-01")
+}
+
+func TestPrintBillingReport_TableSortsByProjectIDOnNameTie(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "table"
+
+	report := &storage.BillingReport{
+		From: time.Now(), To: time.Now(), GeneratedAt: time.Now(),
+		Projects: []storage.BillingProjectStat{
+			{ProjectID: 9, ProjectName: "same", SecretCount: 1},
+			{ProjectID: 2, ProjectName: "same", SecretCount: 2},
+		},
+		Totals: storage.BillingTotals{Projects: 2},
+	}
+	out, err := captureStdout(t, func() error { return printBillingReport(report) })
+	require.NoError(t, err)
+
+	// Both rows share ProjectName "same"; the tie-break on ProjectID must put
+	// project 2 (SECRETS=2) before project 9 (SECRETS=1). Match the whole
+	// "same"-prefixed row (tabwriter pads with spaces, not literal tabs) to
+	// pull out each row's SECRETS column in printed order.
+	rowPattern := regexp.MustCompile(`(?m)^same\s+(\d+)`)
+	matches := rowPattern.FindAllStringSubmatch(out, -1)
+	require.Len(t, matches, 2, "expected exactly 2 'same' rows, got:\n%s", out)
+	assert.Equal(t, "2", matches[0][1], "expected project 2's row (SECRETS=2) first, got:\n%s", out)
+	assert.Equal(t, "1", matches[1][1], "expected project 9's row (SECRETS=1) second, got:\n%s", out)
+}
+
+// TestPrintBillingReport_Table_FlushWriteError forces the tabwriter's
+// underlying os.Stdout write to fail (by closing the read end of a pipe
+// before flushing) so printBillingReport's w.Flush() error branch — which
+// none of the happy-path table tests exercise, since tabwriter defers all
+// actual writes until Flush — propagates the write error instead of
+// silently succeeding.
+func TestPrintBillingReport_Table_FlushWriteError(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "table"
+
+	orig := os.Stdout
+	r, w, perr := os.Pipe()
+	require.NoError(t, perr)
+	require.NoError(t, r.Close()) // closed read end -> write to w fails with EPIPE
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	err := printBillingReport(sampleReport())
+	_ = w.Close()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pipe")
+}
+
+func TestPrintBillingReport_TableNoData(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "table"
+
+	report := &storage.BillingReport{
+		From: time.Now(), To: time.Now(), GeneratedAt: time.Now(),
+	}
+	out, err := captureStdout(t, func() error { return printBillingReport(report) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "(no data)")
+	assert.Contains(t, out, "Totals (0 project(s))")
+}
+
+func TestPrintBillingReport_JSON(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "json"
+
+	report := sampleReport()
+	out, err := captureStdout(t, func() error { return printBillingReport(report) })
+	require.NoError(t, err)
+
+	var decoded storage.BillingReport
+	require.NoError(t, json.Unmarshal([]byte(out), &decoded))
+	assert.Equal(t, report.Totals, decoded.Totals)
+	require.Len(t, decoded.Projects, 3)
+}
+
+func indexOf(t *testing.T, haystack, needle string) int {
+	t.Helper()
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	t.Fatalf("expected %q to contain %q", haystack, needle)
+	return -1
+}
+
+func TestRunReportRemote_Success(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "table"
+	flagProjectID = "1,2"
+
+	var gotPath string
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		env := map[string]interface{}{"data": sampleReport()}
+		require.NoError(t, json.NewEncoder(w).Encode(env))
+	}))
+	defer srv.Close()
+
+	rc, ok := common.NewRemoteClientWithCredentials(srv.URL, "test-token")
+	require.True(t, ok)
+
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	out, err := captureStdout(t, func() error {
+		return runReportRemote(context.Background(), rc, from, to)
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/v1/admin/billing/report", gotPath)
+	assert.Contains(t, gotQuery, "from=2026-01-01T00%3A00%3A00Z")
+	assert.Contains(t, gotQuery, "to=2026-02-01T00%3A00%3A00Z")
+	assert.Contains(t, gotQuery, "project_id=1%2C2")
+	assert.Contains(t, out, "alpha")
+	assert.Contains(t, out, "Totals (3 project(s))")
+}
+
+func TestRunReportRemote_NoProjectIDFilter(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "json"
+	flagProjectID = ""
+
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		env := map[string]interface{}{"data": sampleReport()}
+		require.NoError(t, json.NewEncoder(w).Encode(env))
+	}))
+	defer srv.Close()
+
+	rc, ok := common.NewRemoteClientWithCredentials(srv.URL, "test-token")
+	require.True(t, ok)
+
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	_, err := captureStdout(t, func() error {
+		return runReportRemote(context.Background(), rc, from, to)
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, gotQuery, "project_id")
+}
+
+func TestRunReportRemote_ServerError(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "table"
+	flagProjectID = ""
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	rc, ok := common.NewRemoteClientWithCredentials(srv.URL, "test-token")
+	require.True(t, ok)
+
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	_, err := captureStdout(t, func() error {
+		return runReportRemote(context.Background(), rc, from, to)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch billing report")
+}

--- a/internal/cli/billing/embedded_test.go
+++ b/internal/cli/billing/embedded_test.go
@@ -1,0 +1,119 @@
+// embedded_test.go exercises runReport's dispatch branches — remote-mode
+// selection via env, and the local/embedded storage path (storage-init
+// failure, parseProjectIDs failure, and the unlicensed-feature error from
+// core.GenerateBillingReport) — none of which billing_test.go's existing
+// cases (which call runReportRemote/printBillingReport directly) drive.
+package billing
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupEmbedded points KEYORIX_CONFIG_PATH at an isolated temp config in
+// local (embedded SQLite) mode and clears remote env vars/XDG_CONFIG_HOME so
+// common.NewRemoteClient() returns false and runReport takes the embedded
+// path against a throwaway database, mirroring internal/cli/project's
+// setupEmbedded helper.
+func setupEmbedded(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "test.db")}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_SERVER", "")
+}
+
+func TestRunReport_Embedded_StorageInitError(t *testing.T) {
+	resetFlags(t)
+	dir := t.TempDir()
+	// Points at a config file that does not exist, so config.Load (and thus
+	// common.InitializeStorage) fails before any core/storage object is built.
+	t.Setenv("KEYORIX_CONFIG_PATH", filepath.Join(dir, "nonexistent.yaml"))
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_SERVER", "")
+
+	flagFrom = "2026-01-01T00:00:00Z"
+	flagTo = "2026-02-01T00:00:00Z"
+	flagProjectID = ""
+
+	err := runReport(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+func TestRunReport_Embedded_ParseProjectIDsError(t *testing.T) {
+	resetFlags(t)
+	setupEmbedded(t)
+
+	flagFrom = "2026-01-01T00:00:00Z"
+	flagTo = "2026-02-01T00:00:00Z"
+	flagProjectID = "not-a-number"
+
+	err := runReport(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid project ID")
+}
+
+// TestRunReport_Embedded_Unlicensed drives runReport all the way through
+// storage init, core construction, and parseProjectIDs success into
+// core.GenerateBillingReport itself. The billing feature has no license gate
+// wired for a bare CLI-constructed core, so it fails closed with a
+// commercial-license error — this is the real, current behavior of running
+// `keyorix billing report` embedded without a license, not a stand-in.
+func TestRunReport_Embedded_Unlicensed(t *testing.T) {
+	resetFlags(t)
+	setupEmbedded(t)
+
+	flagFrom = "2026-01-01T00:00:00Z"
+	flagTo = "2026-02-01T00:00:00Z"
+	flagProjectID = ""
+
+	err := runReport(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to generate billing report")
+	assert.Contains(t, err.Error(), "commercial license")
+}
+
+// TestRunReport_Remote_ViaEnv drives runReport's own remote-vs-embedded
+// dispatch (the `if rc, ok := common.NewRemoteClient(); ok` branch), as
+// opposed to the existing TestRunReportRemote_* cases which call
+// runReportRemote directly and never exercise that selection.
+func TestRunReport_Remote_ViaEnv(t *testing.T) {
+	resetFlags(t)
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		env := map[string]interface{}{"data": sampleReport()}
+		require.NoError(t, json.NewEncoder(w).Encode(env))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	flagFormat = "json"
+	flagFrom = "2026-01-01T00:00:00Z"
+	flagTo = "2026-02-01T00:00:00Z"
+	flagProjectID = ""
+
+	out, err := captureStdout(t, func() error { return runReport(nil, nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "\"totals\"")
+	assert.Equal(t, "/api/v1/admin/billing/report", gotPath)
+}

--- a/internal/cli/breakglass/breakglass_notconnected_test.go
+++ b/internal/cli/breakglass/breakglass_notconnected_test.go
@@ -1,0 +1,52 @@
+package breakglass
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// isolateFromLocalConfig points HOME/XDG_CONFIG_HOME at an empty scratch
+// directory so ResolveRemote can't pick up a real ~/.keyorix/cli.yaml or
+// ./keyorix.yaml left on the developer's machine (see
+// breakglass_s24_test.go's TestActivate_NotConnected/TestList_NotConnected/
+// TestRevoke_NotConnected, which are pre-existing and fail locally for
+// exactly this reason). With no config file to find, ResolveRemote is
+// guaranteed to return ok=false whenever KEYORIX_SERVER/KEYORIX_TOKEN are
+// also unset, which is what these tests need to reliably exercise the
+// "not connected to a server" branch in each RunE.
+func isolateFromLocalConfig(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+}
+
+func TestActivate_NotConnected_Isolated(t *testing.T) {
+	isolateFromLocalConfig(t)
+	bgProject, bgJustify = 5, "reason"
+	t.Cleanup(func() { bgProject, bgJustify = 0, "" })
+
+	err := activateCmd.RunE(nil, nil)
+	require.ErrorContains(t, err, "not connected to a server — run: keyorix connect <server>")
+}
+
+func TestList_NotConnected_Isolated(t *testing.T) {
+	isolateFromLocalConfig(t)
+	bgProject = 5
+	t.Cleanup(func() { bgProject = 0 })
+
+	err := listCmd.RunE(nil, nil)
+	require.ErrorContains(t, err, "not connected to a server — run: keyorix connect <server>")
+}
+
+func TestRevoke_NotConnected_Isolated(t *testing.T) {
+	isolateFromLocalConfig(t)
+	bgProject, bgActivation = 5, 9
+	t.Cleanup(func() { bgProject, bgActivation = 0, 0 })
+
+	err := revokeCmd.RunE(nil, nil)
+	require.ErrorContains(t, err, "not connected to a server — run: keyorix connect <server>")
+}

--- a/internal/cli/breakglass/breakglass_test.go
+++ b/internal/cli/breakglass/breakglass_test.go
@@ -68,6 +68,17 @@ func TestActivate_Remote(t *testing.T) {
 	assert.Contains(t, out, `role "break-glass-editor"`)
 }
 
+func TestActivate_RemoteError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	bgProject, bgJustify, bgTTL = 3, "prod outage #42", "2h"
+	t.Cleanup(func() { bgProject, bgJustify, bgTTL = 0, "", "" })
+
+	err := activateCmd.RunE(nil, nil)
+	require.ErrorContains(t, err, "server returned HTTP 500")
+}
+
 func TestList_Remote(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
@@ -92,6 +103,17 @@ func TestList_Remote(t *testing.T) {
 	})
 }
 
+func TestList_RemoteError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	bgProject = 3
+	t.Cleanup(func() { bgProject = 0 })
+
+	err := listCmd.RunE(nil, nil)
+	require.ErrorContains(t, err, "server returned HTTP 500")
+}
+
 func TestRevoke_RequiredFlagsAndRemote(t *testing.T) {
 	bgProject, bgActivation = 0, 0
 	require.ErrorContains(t, revokeCmd.RunE(nil, nil), "required")
@@ -104,4 +126,15 @@ func TestRevoke_RequiredFlagsAndRemote(t *testing.T) {
 	t.Cleanup(func() { bgProject, bgActivation = 0, 0 })
 	out := captureStdout(t, func() { require.NoError(t, revokeCmd.RunE(nil, nil)) })
 	assert.Contains(t, out, "Revoked break-glass activation 9 in project 3.")
+}
+
+func TestRevoke_RemoteError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	bgProject, bgActivation = 3, 9
+	t.Cleanup(func() { bgProject, bgActivation = 0, 0 })
+
+	err := revokeCmd.RunE(nil, nil)
+	require.ErrorContains(t, err, "server returned HTTP 500")
 }

--- a/internal/cli/bundle/bundle_s3_test.go
+++ b/internal/cli/bundle/bundle_s3_test.go
@@ -246,6 +246,36 @@ func TestBuildCmd_UnwritableOut(t *testing.T) {
 	assert.Contains(t, err.Error(), "create bundle")
 }
 
+// TestBuildCmd_WriteBundleFails exercises the ibundle.WriteBundle error path: --out is
+// pointed at the very component file living under --src. BuildManifest hashes the file's
+// original (non-empty) content and pins its size in the manifest; os.Create(buildOut) then
+// truncates that same file to zero bytes (same path, O_TRUNC) before WriteBundle re-opens it
+// to copy component bytes into the tar stream. The tar writer detects, at Close, that fewer
+// bytes were written than the header's declared size and returns an error, which WriteBundle
+// propagates — a real (if unusual) operator mistake: naming --out the same as a source file.
+func TestBuildCmd_WriteBundleFails(t *testing.T) {
+	resetBuildVars(t)
+
+	pemBytes, _, _ := ed25519KeyPEM(t)
+	keyPath := writeKeyFile(t, pemBytes)
+
+	src := srcDirWithFiles(t, map[string]string{
+		"bin/keyorix": "non-empty original content that will be truncated away",
+	})
+	selfPath := filepath.Join(src, "bin", "keyorix")
+
+	buildSrc = src
+	buildOut = selfPath // same path as the only component file
+	buildVersion = "v0.99.0"
+	buildKeyID = "test-key-2026"
+	buildSignKey = keyPath
+	buildReleased = ""
+
+	err := buildCmd.RunE(buildCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write bundle")
+}
+
 // TestVerifyCmd_VerifyFailsEmptyRegistry exercises verifyCmd.RunE past the
 // os.Open call: a real bundle is opened but the injected registry has no trusted
 // keys, so ibundle.Verify returns a "no trusted keys" error. This covers the

--- a/internal/cli/common/common_s5_test.go
+++ b/internal/cli/common/common_s5_test.go
@@ -1,0 +1,225 @@
+// common_s5_test.go — coverage push for cli/common (batch s5).
+// Targets:
+//   - ValidateRemoteEndpointURL: parse-error, non-http(s)-scheme, missing-host,
+//     and valid branches (directly, not just indirectly via NewRemoteClient).
+//   - NewRemoteClientWithCredentials: success and validation-failure paths.
+//   - newHardenedRemoteClient: the ValidateRemoteEndpointURL failure branch.
+//   - refuseRemoteClientRedirect: the CheckRedirect callback, both as a direct
+//     unit test and wired end-to-end through an http.Client via Get().
+//   - ResolveAPIKey: the prompt=true / interactive-read branch.
+//   - wireSecretEncryption: the AcquireSharedKeyLock failure branch (a live
+//     "server" already holds the exclusive key lock on the same key directory).
+package common
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cliconfig "github.com/keyorixhq/keyorix/internal/cli/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── ValidateRemoteEndpointURL ─────────────────────────────────────────────────
+
+func TestValidateRemoteEndpointURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr string // substring expected in the error, "" means no error
+	}{
+		{"parse error", "://\x00bad", "invalid remote endpoint"},
+		{"non-http(s) scheme", "ftp://example.com", "must use http or https"},
+		{"missing host", "http://", "missing a host"},
+		{"valid http", "http://keyorix.example.com", ""},
+		{"valid https", "https://keyorix.example.com:8443", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateRemoteEndpointURL(c.raw)
+			if c.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), c.wantErr)
+			if c.name != "parse error" {
+				// The parse-error case re-quotes the raw string via url.Parse's own
+				// %q-wrapped error, which double-escapes the NUL byte — skip the
+				// literal substring check there and rely on wantErr instead.
+				assert.Contains(t, err.Error(), c.raw)
+			}
+		})
+	}
+}
+
+// ── NewRemoteClientWithCredentials ────────────────────────────────────────────
+
+func TestNewRemoteClientWithCredentials_Success(t *testing.T) {
+	rc, ok := NewRemoteClientWithCredentials("https://keyorix.example.com", "explicit-token")
+	require.True(t, ok)
+	require.NotNil(t, rc)
+	assert.Equal(t, "https://keyorix.example.com", rc.Endpoint)
+	assert.Equal(t, "explicit-token", rc.Token)
+}
+
+// TestNewRemoteClientWithCredentials_InvalidEndpoint covers both
+// NewRemoteClientWithCredentials's failure return and, underneath it,
+// newHardenedRemoteClient's ValidateRemoteEndpointURL rejection branch.
+func TestNewRemoteClientWithCredentials_InvalidEndpoint(t *testing.T) {
+	rc, ok := NewRemoteClientWithCredentials("ftp://example.com", "tok")
+	assert.False(t, ok)
+	assert.Nil(t, rc)
+}
+
+// ── refuseRemoteClientRedirect ────────────────────────────────────────────────
+
+func TestRefuseRemoteClientRedirect(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://internal.example.com/secret", nil)
+	require.NoError(t, err)
+
+	err = refuseRemoteClientRedirect(req, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to follow redirect")
+	assert.Contains(t, err.Error(), "internal.example.com/secret")
+}
+
+// TestRemoteClient_RefusesToFollowRedirect proves the hardening is actually wired
+// into the http.Client used by RemoteClient.Get (CWE-918): a server response that
+// tries to 302 the request elsewhere (e.g. to an internal host) must not be
+// followed transparently with the bearer token attached.
+func TestRemoteClient_RefusesToFollowRedirect(t *testing.T) {
+	var redirectTargetHit bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectTargetHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/internal", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	rc, ok := newHardenedRemoteClient(srv.URL, "tok")
+	require.True(t, ok)
+
+	var out struct{}
+	err := rc.Get(context.Background(), "/v1/x", &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request failed")
+	assert.False(t, redirectTargetHit, "the client must never actually reach the redirect target")
+}
+
+// ── ResolveRemote: invalid-stored-endpoint warning branches ──────────────────
+
+// TestResolveRemote_CLIConfig_InvalidEndpointIsIgnored covers the
+// ValidateRemoteEndpointURL failure branch inside the ~/.keyorix/cli.yaml
+// resolution: a malformed endpoint persisted by a prior 'keyorix connect' (or
+// hand-edited) must be ignored (not returned to the caller) rather than handed
+// to an HTTP client, and a warning naming the source file must be printed.
+func TestResolveRemote_CLIConfig_InvalidEndpointIsIgnored(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_API_KEY", "")
+
+	cfg := cliconfig.DefaultCLIConfig()
+	cfg.SetClientMode("ftp://not-http-or-https.example.com", "cli-cfg-token")
+	xdg := writeCLIConfig(t, cfg)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("KEYORIX_CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.yaml"))
+
+	stderr := captureStderr(t, func() {
+		endpoint, _, ok := ResolveRemote()
+		assert.False(t, ok, "an invalid persisted endpoint must not be surfaced as usable")
+		assert.Empty(t, endpoint)
+	})
+	assert.Contains(t, stderr, "Ignoring remote endpoint from ~/.keyorix/cli.yaml")
+	assert.Contains(t, stderr, "must use http or https")
+}
+
+// TestResolveRemote_MainConfig_InvalidEndpointIsIgnored is the ./keyorix.yaml
+// counterpart: an invalid storage.remote.base_url must be ignored with a
+// warning, not silently handed to an HTTP client.
+func TestResolveRemote_MainConfig_InvalidEndpointIsIgnored(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`storage:
+  type: remote
+  remote:
+    base_url: "ftp://not-http-or-https.example.com"
+    api_key: "main-cfg-token"
+`), 0600))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+
+	stderr := captureStderr(t, func() {
+		endpoint, token, ok := ResolveRemote()
+		assert.False(t, ok, "an invalid persisted endpoint must not be surfaced as usable")
+		assert.Empty(t, endpoint)
+		// Token still comes through independently of the endpoint validity.
+		assert.Equal(t, "main-cfg-token", token)
+	})
+	assert.Contains(t, stderr, "Ignoring remote endpoint from ./keyorix.yaml")
+	assert.Contains(t, stderr, "must use http or https")
+}
+
+// ── ResolveAPIKey: interactive prompt path ────────────────────────────────────
+
+// TestResolveAPIKey_PromptWithNeitherFlagNorEnv exercises the prompt=true branch
+// (--api-key unset, KEYORIX_API_KEY unset). In the non-tty environment `go test`
+// runs under, term.ReadPassword always fails immediately (the same established
+// pattern as internal/cli/dynamic's TestReadAdminDSN_S23_ErrorMentionsEnvVar), so
+// this deterministically exercises the "failed to read API key" wrapping without
+// blocking on real terminal input.
+func TestResolveAPIKey_PromptWithNeitherFlagNorEnv(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("api-key", "", "")
+	t.Setenv(APIKeyEnvVar, "")
+
+	got, err := ResolveAPIKey(cmd, true)
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.Contains(t, err.Error(), "failed to read API key")
+}
+
+// ── wireSecretEncryption: AcquireSharedKeyLock failure ────────────────────────
+
+// TestWireSecretEncryption_RefusedWhileServerHoldsExclusiveLock exercises the
+// AcquireSharedKeyLock error branch: a "live server" (simulated exactly as
+// internal/encryption's own exclusive_lock_test.go does, by a Service that has
+// taken the exclusive key lock) holds the same key directory, so a CLI command's
+// wireSecretEncryption must be refused rather than reading/writing secret values
+// against a DEK that might be mid-rotation.
+func TestWireSecretEncryption_RefusedWhileServerHoldsExclusiveLock(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	const passphrase = "shared-dir-passphrase"
+	t.Setenv("KEYORIX_MASTER_PASSWORD", passphrase)
+
+	cfg := encEnabledCfg("local")
+
+	// Simulate a live server that already holds the exclusive key lock on this
+	// same key directory (same DEKPath/SaltPath, same passphrase so Initialize
+	// can derive the same KEK).
+	serverSvc := encryption.NewService(&cfg.Storage.Encryption, dir)
+	require.NoError(t, serverSvc.Initialize(passphrase))
+	require.NoError(t, serverSvc.AcquireExclusiveKeyLock())
+	defer serverSvc.Shutdown()
+
+	svc := core.NewKeyorixCore(nil)
+	err := wireSecretEncryption(svc, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exclusively")
+	assert.False(t, svc.SecretValueEncryptionActive())
+}

--- a/internal/cli/compliance/g80_error_paths_test.go
+++ b/internal/cli/compliance/g80_error_paths_test.go
@@ -1,0 +1,172 @@
+package compliance
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// This file rounds out the compliance package's remaining uncovered error
+// branches: the server-error path through common.RemoteClient.Get/Post/GetRaw
+// for each command, and the os.WriteFile failure path for the JSON-format
+// permission-baseline export. Follows the existing convention of returning
+// http.StatusInternalServerError from the mock server (see
+// rotation_backend_test.go, permission_changes_test.go).
+// ---------------------------------------------------------------------------
+
+func TestReport_ServerError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"boom"}`))
+	})
+	err := reportCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestExport_ServerError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"boom"}`))
+	})
+	exportOutput = ""
+	err := exportCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestExport_WriteError covers the os.WriteFile error branch in exportCmd
+// when --output points at a non-writable directory.
+func TestExport_WriteError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":{"posture":{"ok":true}}}`))
+	})
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	exportOutput = filepath.Join(dir, "pack.json")
+	t.Cleanup(func() { exportOutput = "" })
+
+	err := exportCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write")
+}
+
+func TestControls_ServerError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"boom"}`))
+	})
+	controlsCSV = false
+	controlsOutput = ""
+	t.Cleanup(func() { controlsCSV, controlsOutput = false, "" })
+
+	err := controlsCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestInventory_ServerError covers the rc.GetRaw error branch inside emitCSV,
+// shared by inventoryCmd, baselineCmd (csv format) and controlsCmd (--csv).
+func TestInventory_ServerError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"success":false,"error":"forbidden"}`))
+	})
+	inventoryProject = 0
+	inventoryOutput = ""
+	t.Cleanup(func() { inventoryProject, inventoryOutput = 0, "" })
+
+	err := inventoryCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+func TestVerify_ServerError(t *testing.T) {
+	dir := t.TempDir()
+	packPath := filepath.Join(dir, "pack.json")
+	require.NoError(t, os.WriteFile(packPath, []byte(`{"pack":true}`), 0o600))
+	require.NoError(t, os.WriteFile(packPath+".sig", []byte("deadbeef"), 0o600))
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"boom"}`))
+	})
+	verifyFile = packPath
+	verifySig = ""
+	t.Cleanup(func() { verifyFile, verifySig = "", "" })
+
+	err := verifyCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestDigest_ServerError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"boom"}`))
+	})
+	digestSend = false
+	t.Cleanup(func() { digestSend = false })
+
+	err := digestCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestDigest_Send_ServerError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"boom"}`))
+	})
+	digestSend = true
+	t.Cleanup(func() { digestSend = false })
+
+	err := digestCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestBaselineCmd_JSON_ServerError covers the c.Get error branch of the
+// json-format path in baselineCmd.
+func TestBaselineCmd_JSON_ServerError(t *testing.T) {
+	t.Cleanup(func() { baselineFormat = "csv"; baselineOutput = "" })
+	baselineFormat = "json"
+	baselineOutput = ""
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"boom"}`))
+	})
+
+	err := baselineCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestBaselineCmd_JSONWriteError covers the os.WriteFile error branch of the
+// json-format path in baselineCmd, when --output points at a non-writable
+// directory.
+func TestBaselineCmd_JSONWriteError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	t.Cleanup(func() { baselineFormat = "csv"; baselineOutput = "" })
+	baselineFormat = "json"
+	baselineOutput = filepath.Join(dir, "baseline.json")
+
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":{"rows":[]}}`))
+	})
+
+	err := baselineCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write")
+}

--- a/internal/cli/config/config_g80_test.go
+++ b/internal/cli/config/config_g80_test.go
@@ -1,0 +1,220 @@
+// config_g80_test.go — closes remaining coverage gaps in internal/cli/config
+// after prior sprints (s2/s26/extra/remote/conn/api_key/cleartext_warning).
+//
+// Gaps targeted:
+//   - warnIfInsecureRemoteURL: empty raw, loopback-hostname short-circuits
+//     (localhost/127.x/::1), and the net.ParseIP loopback fallback for an
+//     IPv6 loopback literal not caught by the string checks.
+//   - refuseConfigRedirect: never invoked by any existing test.
+//   - runSetRemote / runUseLocal: config.Save failure branch, and reusing
+//     an already-loaded config (existing Remote block / existing DB path).
+//   - runTestConnection: config.Load failure branch.
+//   - SetClientMode: apiKey == "" branch (Auth.Type == "none").
+//   - SaveCLIConfig: empty configPath (uses default) and MkdirAll failure.
+//   - LoadCLIConfig: os.ReadFile failure (path is a directory).
+//   - getDefaultCLIConfigPath: last-resort branch when both XDG_CONFIG_HOME
+//     and os.UserHomeDir() are unavailable.
+package config
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ──────────────────────────── warnIfInsecureRemoteURL ────────────────────────
+
+func TestWarnIfInsecureRemoteURL_EmptyRaw_NoOutput(t *testing.T) {
+	out := captureStderr(t, func() {
+		warnIfInsecureRemoteURL("")
+	})
+	assert.Empty(t, out, "empty URL must not produce a warning")
+}
+
+func TestWarnIfInsecureRemoteURL_LoopbackHostnames_NoOutput(t *testing.T) {
+	for _, raw := range []string{
+		"http://localhost/",
+		"http://127.0.0.1:8080/",
+		"http://[::1]/",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			out := captureStderr(t, func() {
+				warnIfInsecureRemoteURL(raw)
+			})
+			assert.Empty(t, out, "loopback host %q must not warn", raw)
+		})
+	}
+}
+
+// TestWarnIfInsecureRemoteURL_LoopbackIPLiteral_NoOutput exercises the
+// net.ParseIP(...).IsLoopback() fallback specifically: an IPv6 loopback
+// literal spelled out in full does not match any of the string-prefix
+// short-circuits (localhost / "127." / "::1") but must still be recognized
+// as loopback and suppress the warning.
+func TestWarnIfInsecureRemoteURL_LoopbackIPLiteral_NoOutput(t *testing.T) {
+	raw := "http://[0:0:0:0:0:0:0:1]/"
+	out := captureStderr(t, func() {
+		warnIfInsecureRemoteURL(raw)
+	})
+	assert.Empty(t, out, "full-form IPv6 loopback literal must not warn")
+}
+
+// ──────────────────────────── refuseConfigRedirect ────────────────────────────
+
+func TestRefuseConfigRedirect_ReturnsErrorNamingTarget(t *testing.T) {
+	req := &http.Request{URL: &url.URL{Scheme: "https", Host: "evil.example.com", Path: "/redirected"}}
+	err := refuseConfigRedirect(req, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "evil.example.com")
+	assert.Contains(t, err.Error(), "refusing to follow redirect")
+}
+
+// ──────────────────────────── runSetRemote / runUseLocal gaps ────────────────
+
+// TestRunSetRemote_SaveConfigError exercises the config.Save error branch: a
+// directory already occupies the "keyorix.yaml" path in the CWD, so the
+// write fails instead of silently succeeding.
+func TestRunSetRemote_SaveConfigError(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "keyorix.yaml"), 0750))
+
+	cmd := newSetRemoteCmd("https://keyorix.example.com", "")
+	err := runSetRemote(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save configuration")
+}
+
+func TestRunUseLocal_SaveConfigError(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "keyorix.yaml"), 0750))
+
+	cmd := &cobra.Command{}
+	err := runUseLocal(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save configuration")
+}
+
+// TestRunSetRemote_ReusesExistingRemoteConfig covers the case where
+// config.Load succeeds AND the loaded config already has a non-nil
+// Storage.Remote block, so runSetRemote must reuse (not replace) it while
+// still overwriting the fields it owns.
+func TestRunSetRemote_ReusesExistingRemoteConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	yaml := "storage:\n  type: remote\n  remote:\n    base_url: https://old.example.com\n    timeout_seconds: 5\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keyorix.yaml"), []byte(yaml), 0600))
+
+	cmd := newSetRemoteCmd("https://new.example.com", "")
+	t.Setenv("KEYORIX_API_KEY", "")
+	require.NoError(t, runSetRemote(cmd, nil))
+
+	data, err := os.ReadFile(filepath.Join(dir, "keyorix.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "https://new.example.com")
+	assert.NotContains(t, string(data), "old.example.com")
+}
+
+// TestRunUseLocal_PreservesExistingDBPath covers the branch where a config
+// already on disk has a non-empty Storage.Database.Path: runUseLocal must
+// leave that path alone rather than overwriting it with the "./secrets.db"
+// default.
+func TestRunUseLocal_PreservesExistingDBPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	yaml := "storage:\n  type: remote\n  database:\n    path: /custom/my.db\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keyorix.yaml"), []byte(yaml), 0600))
+
+	cmd := &cobra.Command{}
+	require.NoError(t, runUseLocal(cmd, nil))
+
+	data, err := os.ReadFile(filepath.Join(dir, "keyorix.yaml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "/custom/my.db", "existing DB path must be preserved, not reset to the default")
+}
+
+// ──────────────────────────── runTestConnection gap ───────────────────────────
+
+func TestRunTestConnection_LoadConfigError(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	// No keyorix.yaml present — config.Load fails.
+	cmd := &cobra.Command{}
+	err := runTestConnection(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load configuration")
+}
+
+// ──────────────────────────── SetClientMode gap ───────────────────────────────
+
+func TestSetClientMode_EmptyAPIKey_TypeNone(t *testing.T) {
+	c := DefaultCLIConfig()
+	c.SetClientMode("https://keyorix.example.com", "")
+	assert.Equal(t, "none", c.Client.Auth.Type)
+	assert.Empty(t, c.Client.Auth.APIKey)
+}
+
+// ──────────────────────────── SaveCLIConfig gaps ──────────────────────────────
+
+func TestSaveCLIConfig_EmptyPath_UsesDefault(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	cfg := DefaultCLIConfig()
+	require.NoError(t, SaveCLIConfig(cfg, ""))
+
+	expected := filepath.Join(dir, "keyorix", "cli.yaml")
+	_, err := os.Stat(expected)
+	assert.NoError(t, err, "SaveCLIConfig with an empty path should write to the default location")
+}
+
+// TestSaveCLIConfig_MkdirAllError exercises the os.MkdirAll error branch: a
+// regular file occupies a path component that needs to become a directory.
+func TestSaveCLIConfig_MkdirAllError(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0600))
+
+	path := filepath.Join(blocker, "sub", "cli.yaml")
+	cfg := DefaultCLIConfig()
+	err := SaveCLIConfig(cfg, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create config directory")
+}
+
+// ──────────────────────────── LoadCLIConfig gap ───────────────────────────────
+
+// TestLoadCLIConfig_ReadFileError exercises the os.ReadFile error branch: the
+// config path exists (so the os.IsNotExist short-circuit is skipped) but is a
+// directory, so the read itself fails.
+func TestLoadCLIConfig_ReadFileError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cli.yaml")
+	require.NoError(t, os.Mkdir(path, 0750))
+
+	_, err := LoadCLIConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read config file")
+}
+
+// ──────────────────────────── getDefaultCLIConfigPath gap ────────────────────
+
+// TestGetDefaultCLIConfigPath_LastResort exercises the final fallback branch:
+// neither XDG_CONFIG_HOME nor a resolvable home directory is available.
+func TestGetDefaultCLIConfigPath_LastResort(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+	if _, err := os.UserHomeDir(); err == nil {
+		t.Skip("os.UserHomeDir() still resolves on this platform even with HOME unset; last-resort branch not reachable here")
+	}
+	assert.Equal(t, "./keyorix-cli.yaml", getDefaultCLIConfigPath())
+}

--- a/internal/cli/connect/connect_s3_test.go
+++ b/internal/cli/connect/connect_s3_test.go
@@ -1,0 +1,209 @@
+// connect_s3_test.go — sprint-3 coverage: connectHTTPClient's redirect refusal,
+// the "no API key" tip branch in runConnect, LoadCLIConfig/SaveCLIConfig failure
+// paths across runConnect/runDisconnect/runStatus, and the "failed to create
+// request" branches in loginWithCredentials/testServerConnection.
+package connect
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cliconfig "github.com/keyorixhq/keyorix/internal/cli/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRefuseConnectRedirect verifies the CheckRedirect callback itself rejects
+// any redirect with a descriptive error naming the target URL.
+func TestRefuseConnectRedirect(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://internal.example.com/evil", nil)
+	require.NoError(t, err)
+
+	err = refuseConnectRedirect(req, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to follow redirect")
+	assert.Contains(t, err.Error(), "internal.example.com/evil")
+}
+
+// TestConnectHTTPClient_RefusesRedirect is the end-to-end regression test for
+// CWE-918: a server that responds with a 3xx pointing somewhere else (e.g. an
+// internal metadata endpoint) must not be silently followed by the shared
+// connectHTTPClient used by testServerConnection/loginWithCredentials.
+func TestConnectHTTPClient_RefusesRedirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	err := testServerConnection(srv.URL, "key", 5*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to follow redirect")
+}
+
+// TestRunConnect_NoAPIKeyPrintsTip exercises the branch where runConnect
+// finishes with an empty resolved API key (no --api-key, no KEYORIX_API_KEY,
+// no --username login): the saved config must persist "no auth" rather than a
+// stray empty-string key mistaken for a real one.
+func TestRunConnect_NoAPIKeyPrintsTip(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	t.Setenv("KEYORIX_API_KEY", "")
+
+	require.NoError(t, ConnectCmd.Flags().Set("username", ""))
+	require.NoError(t, ConnectCmd.Flags().Set("api-key", ""))
+	require.NoError(t, ConnectCmd.Flags().Set("insecure", "false"))
+	require.NoError(t, ConnectCmd.Flags().Set("test", "false"))
+	t.Cleanup(func() {
+		_ = ConnectCmd.Flags().Set("insecure", "false")
+		_ = ConnectCmd.Flags().Set("test", "false")
+	})
+
+	require.NoError(t, runConnect(ConnectCmd, []string{"https://keyorix.example.com"}))
+
+	cfg, err := cliconfig.LoadCLIConfig("")
+	require.NoError(t, err)
+	assert.Equal(t, "client", cfg.Mode)
+	assert.Equal(t, "none", cfg.Client.Auth.Type)
+	assert.Equal(t, "", cfg.Client.Auth.APIKey)
+}
+
+// TestRunConnect_UnreadableConfigFallsBackToDefault verifies that when the
+// existing cli.yaml can't be read (here: the path is a directory, not a file),
+// runConnect swallows that LoadCLIConfig error and proceeds with a fresh
+// default config rather than failing the whole command.
+func TestRunConnect_UnreadableConfigFallsBackToDefault(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	configDir := filepath.Join(dir, "config", "keyorix")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	require.NoError(t, os.MkdirAll(configDir, 0750))
+	// A directory where cli.yaml is expected makes os.ReadFile fail.
+	require.NoError(t, os.MkdirAll(filepath.Join(configDir, "cli.yaml"), 0750))
+
+	require.NoError(t, ConnectCmd.Flags().Set("insecure", "false"))
+	require.NoError(t, ConnectCmd.Flags().Set("test", "false"))
+	t.Cleanup(func() {
+		_ = ConnectCmd.Flags().Set("insecure", "false")
+		_ = ConnectCmd.Flags().Set("test", "false")
+	})
+
+	err := runConnect(ConnectCmd, []string{"https://keyorix.example.com"})
+	// SaveCLIConfig will also fail to write through the cli.yaml directory
+	// (can't create a regular file where a directory already exists), so the
+	// overall command surfaces that later failure — but it must be the SAVE
+	// error, not a load/config-parsing failure, proving the load error was
+	// swallowed and a default config was used instead.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save configuration")
+}
+
+// TestRunConnect_SaveConfigFails verifies that a directory-creation failure in
+// SaveCLIConfig (a regular file sits where the config directory must go) is
+// propagated as "failed to save configuration".
+func TestRunConnect_SaveConfigFails(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	xdg := filepath.Join(dir, "config")
+	require.NoError(t, os.MkdirAll(xdg, 0750))
+	// Block the "keyorix" config subdirectory with a plain file, so
+	// os.MkdirAll(dir) inside SaveCLIConfig fails with "not a directory".
+	require.NoError(t, os.WriteFile(filepath.Join(xdg, "keyorix"), []byte("blocker"), 0600))
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("KEYORIX_API_KEY", "test-key")
+
+	require.NoError(t, ConnectCmd.Flags().Set("insecure", "false"))
+	require.NoError(t, ConnectCmd.Flags().Set("test", "false"))
+	t.Cleanup(func() {
+		_ = ConnectCmd.Flags().Set("insecure", "false")
+		_ = ConnectCmd.Flags().Set("test", "false")
+	})
+
+	err := runConnect(ConnectCmd, []string{"https://keyorix.example.com"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save configuration")
+}
+
+// TestRunDisconnect_LoadConfigFails verifies that a cli.yaml that can't be
+// read (here: it's a directory) makes runDisconnect return "failed to load
+// configuration" rather than silently defaulting (unlike runConnect, which
+// intentionally falls back).
+func TestRunDisconnect_LoadConfigFails(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	configDir := filepath.Join(dir, "config", "keyorix")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	require.NoError(t, os.MkdirAll(configDir, 0750))
+	require.NoError(t, os.MkdirAll(filepath.Join(configDir, "cli.yaml"), 0750))
+
+	err := runDisconnect(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load configuration")
+}
+
+// TestRunDisconnect_SaveConfigFails verifies that a save failure after a
+// successful load (client mode, so SetEmbeddedMode+Save is reached) is
+// propagated as "failed to save configuration". The existing cli.yaml file is
+// made read-only so the open-for-write in SaveCLIConfig fails with EACCES.
+func TestRunDisconnect_SaveConfigFails(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	configDir := filepath.Join(dir, "config", "keyorix")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	require.NoError(t, os.MkdirAll(configDir, 0750))
+
+	cliYAML := "mode: client\nclient:\n  endpoint: https://keyorix.example.com\n"
+	cliPath := filepath.Join(configDir, "cli.yaml")
+	require.NoError(t, os.WriteFile(cliPath, []byte(cliYAML), 0600))
+	require.NoError(t, os.Chmod(cliPath, 0400))
+	t.Cleanup(func() { _ = os.Chmod(cliPath, 0600) })
+
+	err := runDisconnect(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save configuration")
+}
+
+// TestRunStatus_LoadConfigFails verifies that an unreadable cli.yaml (a
+// directory in place of the file) surfaces as "failed to load configuration"
+// from runStatus.
+func TestRunStatus_LoadConfigFails(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	configDir := filepath.Join(dir, "config", "keyorix")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	require.NoError(t, os.MkdirAll(configDir, 0750))
+	require.NoError(t, os.MkdirAll(filepath.Join(configDir, "cli.yaml"), 0750))
+
+	err := runStatus(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load configuration")
+}
+
+// TestLoginWithCredentials_Unreachable verifies the connectHTTPClient.Do
+// failure branch: a refused TCP connection is wrapped as "request failed".
+func TestLoginWithCredentials_Unreachable(t *testing.T) {
+	_, err := loginWithCredentials("http://127.0.0.1:1", "alice", "pw", 2*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request failed")
+}
+
+// TestLoginWithCredentials_InvalidURL verifies the http.NewRequestWithContext
+// failure branch: an endpoint containing a raw control byte is rejected by
+// net/url before any network I/O, wrapped as "failed to create request".
+func TestLoginWithCredentials_InvalidURL(t *testing.T) {
+	_, err := loginWithCredentials("http://example.com/\x7f\x01", "alice", "pw", 2*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create request")
+}
+
+// TestTestServerConnection_InvalidURL is the same http.NewRequestWithContext
+// failure branch, exercised via testServerConnection instead.
+func TestTestServerConnection_InvalidURL(t *testing.T) {
+	err := testServerConnection("http://example.com/\x7f\x01", "key", 2*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create request")
+}

--- a/internal/cli/dynamic/dynamic_g80_test.go
+++ b/internal/cli/dynamic/dynamic_g80_test.go
@@ -1,0 +1,199 @@
+package dynamic
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// G80: exact-output-format regression coverage
+//
+// The existing suite mostly asserts individual substrings (assert.Contains),
+// which verifies a value made it into the output but not that it landed in
+// the right column/position, kept its exact punctuation, or that adjacent
+// fields didn't collide. These tests assert full-string equality against the
+// production format strings applied to known inputs, so a field swap (e.g.
+// ProjectID/EnvironmentID), a dropped separator, or a padding-width change
+// would fail loudly instead of silently passing a Contains check.
+// ---------------------------------------------------------------------------
+
+// TestPrintConfig_G80_ExactOutput verifies every line and field position of
+// printConfig's output, not just that individual values appear somewhere in
+// it. This would catch e.g. ProjectID and EnvironmentID being swapped.
+func TestPrintConfig_G80_ExactOutput(t *testing.T) {
+	cfg := configView{
+		ID:                7,
+		Name:              "demo-db",
+		ProjectID:         3,
+		EnvironmentID:     2,
+		BackendType:       "postgres",
+		DefaultTTLSeconds: 60,
+		MaxTTLSeconds:     120,
+		Classification:    "restricted",
+	}
+	out := captureStdout(t, func() {
+		printConfig(cfg)
+	})
+
+	want := fmt.Sprintf("ID:             %d\n", cfg.ID) +
+		fmt.Sprintf("Name:           %s\n", cfg.Name) +
+		fmt.Sprintf("Project ID:     %d\n", cfg.ProjectID) +
+		fmt.Sprintf("Environment ID: %d\n", cfg.EnvironmentID) +
+		fmt.Sprintf("Backend:        %s\n", cfg.BackendType) +
+		fmt.Sprintf("Default TTL:    %ds\n", cfg.DefaultTTLSeconds) +
+		fmt.Sprintf("Max TTL:        %ds\n", cfg.MaxTTLSeconds) +
+		fmt.Sprintf("Classification: %s\n", cfg.Classification)
+
+	assert.Equal(t, want, out)
+}
+
+// TestList_G80_ExactOutputFormat verifies the header line and a data row are
+// rendered with the exact column widths and separators the format strings
+// specify, using fresh field values distinct from other tests so a
+// misattributed column can't accidentally still read as correct.
+func TestList_G80_ExactOutputFormat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"id":42,"name":"app-db","backend_type":"postgres","default_ttl_seconds":3600,"max_ttl_seconds":7200}]}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	flagProjectID, flagEnvID = 0, 0
+
+	out := captureStdout(t, func() {
+		require.NoError(t, listCmd.RunE(listCmd, nil))
+	})
+
+	want := fmt.Sprintf("%-5s %-24s %-10s %-8s %-8s\n", "ID", "NAME", "BACKEND", "TTL", "MAXTTL") +
+		fmt.Sprintf("%-5d %-24s %-10s %-8d %-8d\n", 42, "app-db", "postgres", 3600, 7200)
+
+	assert.Equal(t, want, out)
+}
+
+// TestList_G80_LongNameNotTruncated verifies that a config name longer than
+// the %-24s padding width is printed in full, not cut off. Left-padding
+// verbs in Go never truncate a wider value, but that's a non-obvious
+// behavior worth pinning: a naive re-implementation using a fixed-width
+// buffer could silently start truncating names.
+func TestList_G80_LongNameNotTruncated(t *testing.T) {
+	longName := "this-config-name-is-longer-than-24-characters-wide"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"data":[{"id":1,"name":%q,"backend_type":"mysql","default_ttl_seconds":30,"max_ttl_seconds":60}]}`, longName)))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	flagProjectID, flagEnvID = 0, 0
+
+	out := captureStdout(t, func() {
+		require.NoError(t, listCmd.RunE(listCmd, nil))
+	})
+	assert.Contains(t, out, longName, "a name wider than the padding column must not be truncated")
+}
+
+// TestLeases_G80_ExactOutputFormat mirrors TestList_G80_ExactOutputFormat for
+// the leases table.
+func TestLeases_G80_ExactOutputFormat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"lease_id":"lease-1","role_name":"readwrite","status":"active","issued_at":"2026-07-01T10:00:00Z","expires_at":"2026-07-01T11:00:00Z"}]}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	out := captureStdout(t, func() {
+		require.NoError(t, leasesCmd.RunE(leasesCmd, []string{"5"}))
+	})
+
+	want := fmt.Sprintf("%-34s %-16s %-14s %s\n", "LEASE", "ROLE", "STATUS", "EXPIRES") +
+		fmt.Sprintf("%-34s %-16s %-14s %s\n", "lease-1", "readwrite", "active", "2026-07-01T11:00:00Z")
+
+	assert.Equal(t, want, out)
+}
+
+// TestGetConfig_G80_NegativeConfigID documents that strconv.Atoi accepts a
+// leading "-" and get-config forwards it verbatim into the request path
+// (there is no positive-ID validation). If someone later adds bounds
+// checking, this pins the current, intentional behavior so the change is
+// visible in a test diff rather than discovered in production.
+func TestGetConfig_G80_NegativeConfigID(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"id":1,"name":"x","backend_type":"postgres"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	require.NoError(t, getConfigCmd.RunE(getConfigCmd, []string{"-5"}))
+	assert.Equal(t, "/api/v1/dynamic-secrets/configs/-5", gotPath)
+}
+
+// TestClassify_G80_ExactSuccessMessage verifies the full success line,
+// including the %q-quoted level and the checkmark prefix, rather than just
+// checking that the level and ID appear somewhere in the output.
+func TestClassify_G80_ExactSuccessMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"id":9,"name":"db","classification":"top-secret"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	flagLevel = "top-secret"
+	t.Cleanup(func() { flagLevel = "" })
+
+	out := captureStdout(t, func() {
+		require.NoError(t, classifyCmd.RunE(classifyCmd, []string{"9"}))
+	})
+	want := fmt.Sprintf("✅ Classification set to %q for config %d.\n", "top-secret", 9)
+	assert.Equal(t, want, out)
+}
+
+// TestRevoke_G80_ExactOutputFormat verifies the full "Lease <id> <status>."
+// success line, including the trailing period, rather than a substring
+// match that would also pass if the punctuation were dropped or duplicated.
+func TestRevoke_G80_ExactOutputFormat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"lease_id":"lease-42","status":"revoked"}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	out := captureStdout(t, func() {
+		require.NoError(t, revokeCmd.RunE(revokeCmd, []string{"lease-42"}))
+	})
+	assert.Equal(t, "Lease lease-42 revoked.\n", out)
+}
+
+// TestSortedKeys_G80_UnicodeAndNumericKeys verifies sortedKeys uses plain
+// byte-wise string ordering (not locale-aware collation), which matters
+// because issueCmd relies on this order to print cloud-IAM fields
+// deterministically regardless of the host's locale.
+func TestSortedKeys_G80_UnicodeAndNumericKeys(t *testing.T) {
+	m := map[string]string{
+		"Zebra": "1",
+		"apple": "2",
+		"10":    "3",
+		"2":     "4",
+	}
+	got := sortedKeys(m)
+	// Byte-wise ordering: digits < uppercase < lowercase, and "10" < "2"
+	// lexicographically even though 10 > 2 numerically.
+	want := []string{"10", "2", "Zebra", "apple"}
+	require.Equal(t, want, got)
+	assert.True(t, sort.StringsAreSorted(got))
+}

--- a/internal/cli/dynamic/dynamic_g80_test.go
+++ b/internal/cli/dynamic/dynamic_g80_test.go
@@ -85,7 +85,7 @@ func TestList_G80_ExactOutputFormat(t *testing.T) {
 func TestList_G80_LongNameNotTruncated(t *testing.T) {
 	longName := "this-config-name-is-longer-than-24-characters-wide"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"data":[{"id":1,"name":%q,"backend_type":"mysql","default_ttl_seconds":30,"max_ttl_seconds":60}]}`, longName)))
+		_, _ = fmt.Fprintf(w, `{"data":[{"id":1,"name":%q,"backend_type":"mysql","default_ttl_seconds":30,"max_ttl_seconds":60}]}`, longName)
 	}))
 	defer srv.Close()
 

--- a/internal/cli/encryption/auth_encryption_coverage_test.go
+++ b/internal/cli/encryption/auth_encryption_coverage_test.go
@@ -1,0 +1,267 @@
+// auth_encryption_coverage_test.go — coverage uplift for narrow error
+// branches in auth_encryption.go / auth_encryption_migrate.go /
+// auth_encryption_validate.go that the existing test suite (encryption_s2/
+// s22/s23/s27_test.go, g62_auth_encryption_lock_test.go) doesn't reach:
+//
+//   - openDatabase failures (unsupported storage type), reached through
+//     authStatusWithConfig and enableAuthEncryptionWithConfig directly.
+//   - config.Load failure through the runEnableAuthEncryption cobra shim.
+//   - authEnc.Initialize failures caused by a wrong master passphrase against
+//     already-provisioned key material, reached through runRotateAuthEncryption,
+//     migrateAuthDataWithConfig, and validateAuthEncryptionWithConfig.
+//   - the openDatabase failure through runRotateAuthEncryption's cobra shim.
+package encryption
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// badStorageCfg returns a *config.Config with an unsupported storage type, so
+// openDatabase(cfg) (storage.OpenGormDB under the hood) fails deterministically
+// without needing any real database or key material.
+func badStorageCfg() *config.Config {
+	return &config.Config{
+		Storage: config.StorageConfig{
+			Type:       "badtype",
+			Encryption: config.EncryptionConfig{Enabled: true},
+		},
+	}
+}
+
+// ── authStatusWithConfig: openDatabase error ─────────────────────────────────
+
+func TestAuthStatusWithConfig_DBOpenError(t *testing.T) {
+	err := authStatusWithConfig(badStorageCfg())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open database")
+}
+
+// ── runEnableAuthEncryption: config.Load error ───────────────────────────────
+
+func TestRunEnableAuthEncryption_ConfigLoadError(t *testing.T) {
+	t.Chdir(t.TempDir()) // no keyorix.yaml → config.Load("") fails
+	t.Setenv("KEYORIX_CONFIG_PATH", "")
+
+	err := enableCmd.RunE(enableCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+// ── enableAuthEncryptionWithConfig: openDatabase error ───────────────────────
+
+func TestEnableAuthEncryptionWithConfig_DBOpenError(t *testing.T) {
+	err := enableAuthEncryptionWithConfig(badStorageCfg(), false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open database")
+}
+
+// TestEnableAuthEncryptionWithConfig_WrongPassphrase covers the
+// "authEnc.Initialize(passphrase); err != nil" branch: status is checked on a
+// freshly constructed AuthEncryption handle (always initialized=false at that
+// point, so the "already enabled" early return never fires here), then
+// Initialize fails against already-provisioned key material with the wrong
+// passphrase.
+func TestEnableAuthEncryptionWithConfig_WrongPassphrase(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	cfg := newAuthLockTestConfig(t, workDir)
+	provisionAuthLockTestDB(t, cfg)
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "definitely-the-wrong-passphrase")
+
+	err := enableAuthEncryptionWithConfig(cfg, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize auth encryption")
+}
+
+// ── runRotateAuthEncryption: openDatabase error, reached via the real ────────
+// ── cobra shim (config.Load must succeed first). ─────────────────────────────
+
+func TestRunRotateAuthEncryption_DBOpenError(t *testing.T) {
+	cfgPath := writeConfig(t, badStorageConfigYAML) // storage.type: badtype
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+
+	require.NoError(t, authRotateCmd.Flags().Set("confirm", "true"))
+	t.Cleanup(func() { _ = authRotateCmd.Flags().Set("confirm", "false") })
+
+	err := authRotateCmd.RunE(authRotateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open database")
+}
+
+// ── runRotateAuthEncryption: authEnc.Initialize error (wrong passphrase), ────
+// ── reached via the real cobra shim with a real db + real key material. ──────
+
+func TestRunRotateAuthEncryption_WrongPassphrase(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	cfg := newAuthLockTestConfig(t, workDir) // provisions the correct passphrase via KEYORIX_MASTER_PASSWORD
+	provisionAuthLockTestDB(t, cfg)
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	cfgYAML := writeConfig(t, `
+storage:
+  type: local
+  database:
+    path: `+cfg.Storage.Database.Path+`
+  encryption:
+    enabled: true
+    dek_path: `+cfg.Storage.Encryption.DEKPath+`
+    salt_path: `+cfg.Storage.Encryption.SaltPath+`
+`)
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgYAML)
+
+	// Break the passphrase AFTER provisioning — runRotateAuthEncryption reads
+	// it fresh via masterPassphrase(cfg) inside the shim.
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "definitely-the-wrong-passphrase")
+
+	require.NoError(t, authRotateCmd.Flags().Set("confirm", "true"))
+	t.Cleanup(func() { _ = authRotateCmd.Flags().Set("confirm", "false") })
+
+	err := authRotateCmd.RunE(authRotateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize auth encryption")
+}
+
+// ── runRotateAuthEncryption: success path (real db + real key material, ─────
+// ── correct passphrase) — covers the two success-print statements after ─────
+// ── authEnc.RotateAuthEncryption succeeds, which no existing test reaches: ───
+// ── TestRunRotateAuthEncryption_S27_ConfirmMissingWithRealConfig stops at the ─
+// ── --confirm gate, TestRunRotateAuthEncryption_ConfirmTrue_LocalDB (s3) uses ─
+// ── an empty passphrase against a config with no key material provisioned ────
+// ── (outcome unasserted), and TestRunRotateAuthEncryption_WrongPassphrase ────
+// ── (above) deliberately breaks the passphrase. ───────────────────────────────
+
+func TestRunRotateAuthEncryption_Success(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	cfg := newAuthLockTestConfig(t, workDir) // sets KEYORIX_MASTER_PASSWORD to the correct passphrase
+
+	// RotateDEKWithSweep re-encrypts every encrypted table it knows about, not
+	// just the auth ones — provisionAuthLockTestDB only migrates the auth four,
+	// which leaves "no such table: secret_nodes" etc. Migrate the full set (all
+	// empty — the sweep just needs to see and pass over zero rows in each).
+	db, dbErr := storage.OpenGormDB(cfg)
+	if dbErr != nil {
+		t.Fatalf("failed to open test db: %v", dbErr)
+	}
+	if err := db.AutoMigrate(
+		&models.SecretNode{}, &models.SecretVersion{}, &models.Session{},
+		&models.APIToken{}, &models.APIClient{}, &models.PasswordReset{},
+		&models.MFASecret{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
+	); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	if sqlDB, err := db.DB(); err == nil {
+		_ = sqlDB.Close()
+	}
+
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	cfgYAML := writeConfig(t, `
+storage:
+  type: local
+  database:
+    path: `+cfg.Storage.Database.Path+`
+  encryption:
+    enabled: true
+    dek_path: `+cfg.Storage.Encryption.DEKPath+`
+    salt_path: `+cfg.Storage.Encryption.SaltPath+`
+`)
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgYAML)
+
+	require.NoError(t, authRotateCmd.Flags().Set("confirm", "true"))
+	t.Cleanup(func() { _ = authRotateCmd.Flags().Set("confirm", "false") })
+
+	err := authRotateCmd.RunE(authRotateCmd, nil)
+	require.NoError(t, err, "rotation against freshly-provisioned key material with the correct passphrase should succeed")
+}
+
+// ── validatePasswordResetTokens: unmigrated-rows query error ─────────────────
+
+// TestValidatePasswordResetTokens_UnmigratedQueryError covers the SECOND query
+// in validatePasswordResetTokens (the "token != ” AND ... encrypted_token IS
+// NULL" lookup for still-unmigrated rows) — distinct from the already-covered
+// first-query and per-row-decrypt error branches elsewhere in the suite. The
+// table is created by hand WITHOUT the legacy "token" column (AutoMigrate would
+// add a unique index on it that blocks a later ALTER TABLE ... DROP COLUMN, so
+// this sidesteps that rather than fighting it): the first query (which only
+// touches encrypted_token, over zero rows) still succeeds, but the second
+// query fails with "no such column: token".
+func TestValidatePasswordResetTokens_UnmigratedQueryError(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "test.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE password_resets (
+		id INTEGER PRIMARY KEY,
+		user_id INTEGER,
+		encrypted_token BLOB,
+		token_metadata TEXT,
+		expires_at DATETIME,
+		created_at DATETIME
+	)`).Error)
+
+	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
+	authEnc := encryption.NewAuthEncryption(cfg, tempDir, db)
+	require.NoError(t, authEnc.Initialize("unmigrated-query-error-test-passphrase"))
+	t.Cleanup(func() {
+		if sqlDB, derr := db.DB(); derr == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	_, verr := validatePasswordResetTokens(db, authEnc, false)
+	require.Error(t, verr)
+	assert.Contains(t, verr.Error(), "no such column")
+}
+
+// ── migrateAuthDataWithConfig: authEnc.Initialize error (wrong passphrase) ───
+
+func TestMigrateAuthDataWithConfig_WrongPassphrase(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	cfg := newAuthLockTestConfig(t, workDir)
+	provisionAuthLockTestDB(t, cfg)
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	// Break the passphrase after provisioning.
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "definitely-the-wrong-passphrase")
+
+	err := migrateAuthDataWithConfig(cfg, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize auth encryption")
+}
+
+// ── validateAuthEncryptionWithConfig: authEnc.Initialize error ───────────────
+// ── (wrong passphrase) ────────────────────────────────────────────────────────
+
+func TestValidateAuthEncryptionWithConfig_WrongPassphrase(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	cfg := newAuthLockTestConfig(t, workDir)
+	provisionAuthLockTestDB(t, cfg)
+	provisionAuthLockTestKeys(t, cfg, workDir)
+
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "definitely-the-wrong-passphrase")
+
+	err := validateAuthEncryptionWithConfig(cfg, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize auth encryption")
+}

--- a/internal/cli/encryption/cli_wrappers_coverage_test.go
+++ b/internal/cli/encryption/cli_wrappers_coverage_test.go
@@ -1,0 +1,143 @@
+// cli_wrappers_coverage_test.go — coverage uplift for the thin cobra RunE
+// wrappers in encryption.go that were previously only exercised through their
+// config.Load/loadConfig ERROR branch:
+//
+//   - runInit / runStatus: the initLocalKeyOpService failure branch (a live
+//     server or in-progress rotation holds the exclusive key lock), reached
+//     via the real cobra command with a real config file.
+//   - runRotate / runUpgradeAAD / runValidate / runFixPerms: the "delegate to
+//     the *WithConfig testable core" line itself, reached by giving loadConfig
+//     a real, loadable config (via KEYORIX_CONFIG_PATH) instead of letting it
+//     fail first.
+package encryption
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	enc "github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeEncEnabledConfigYAML writes a keyorix.yaml with local storage and
+// encryption enabled at the given key paths, and returns its absolute path
+// for KEYORIX_CONFIG_PATH.
+func writeEncEnabledConfigYAML(t *testing.T, dekPath, saltPath string) string {
+	t.Helper()
+	yaml := fmt.Sprintf(`
+storage:
+  type: local
+  encryption:
+    enabled: true
+    dek_path: %s
+    salt_path: %s
+`, dekPath, saltPath)
+	return writeConfig(t, yaml)
+}
+
+// ── runInit / runStatus: initLocalKeyOpService refusal while a live server ──
+// ── (or in-progress rotation/migrate-provider) holds the exclusive lock ─────
+
+func TestRunInit_RefusedWhileServerHoldsLock(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	const pass = "cli-wrapper-lock-init-passphrase"
+	t.Setenv("KEYORIX_MASTER_PASSWORD", pass)
+
+	cfgPath := writeEncEnabledConfigYAML(t, "dek.key", "kek.salt")
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+
+	encCfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
+
+	// Provision key material up front (mirrors a prior `keyorix encryption init`).
+	setup := enc.NewService(encCfg, workDir)
+	require.NoError(t, setup.Initialize(pass))
+	setup.Shutdown()
+
+	// Simulate a live server (or an in-progress rotation/migrate-provider)
+	// holding the key directory exclusively.
+	serverSvc := enc.NewService(encCfg, workDir)
+	require.NoError(t, serverSvc.Initialize(pass))
+	require.NoError(t, serverSvc.AcquireExclusiveKeyLock())
+	defer serverSvc.Shutdown()
+
+	err := initCmd.RunE(initCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "a live server or an in-progress rotation")
+}
+
+func TestRunStatus_PrintsErrorWhileServerHoldsLock(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	const pass = "cli-wrapper-lock-status-passphrase"
+	t.Setenv("KEYORIX_MASTER_PASSWORD", pass)
+
+	cfgPath := writeEncEnabledConfigYAML(t, "dek.key", "kek.salt")
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+
+	encCfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
+
+	setup := enc.NewService(encCfg, workDir)
+	require.NoError(t, setup.Initialize(pass))
+	setup.Shutdown()
+
+	serverSvc := enc.NewService(encCfg, workDir)
+	require.NoError(t, serverSvc.Initialize(pass))
+	require.NoError(t, serverSvc.AcquireExclusiveKeyLock())
+	defer serverSvc.Shutdown()
+
+	// runStatus does NOT return the initLocalKeyOpService error — it prints
+	// "❌ <err>" and returns nil, so assert on the printed message instead.
+	out := captureProviderStatusOutput(t, func() {
+		err := statusCmd.RunE(statusCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "a live server or an in-progress rotation")
+}
+
+// ── runRotate / runUpgradeAAD / runValidate / runFixPerms: reach the ────────
+// ── delegate-to-*WithConfig line by giving loadConfig a real, loadable ──────
+// ── config instead of letting config.Load fail first. ───────────────────────
+
+func TestRunRotate_DelegatesToRotateWithConfig_DisabledEncryption(t *testing.T) {
+	cfgPath := writeMinimalConfig(t) // local storage, encryption disabled
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+
+	err := rotateCmd.RunE(rotateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encryption is disabled")
+}
+
+func TestRunUpgradeAAD_DelegatesToUpgradeAADWithConfig_DisabledEncryption(t *testing.T) {
+	cfgPath := writeMinimalConfig(t)
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+
+	err := upgradeAADCmd.RunE(upgradeAADCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encryption is disabled")
+}
+
+func TestRunValidate_DelegatesToValidateWithConfig_DisabledEncryption(t *testing.T) {
+	cfgPath := writeMinimalConfig(t)
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+
+	// validateWithConfig treats disabled encryption as "nothing to validate"
+	// and returns nil — assert on the printed message to confirm the delegate
+	// call (and its early-return branch) actually ran.
+	out := captureProviderStatusOutput(t, func() {
+		err := validateCmd.RunE(validateCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "nothing to validate")
+}
+
+func TestRunFixPerms_DelegatesToFixPermsWithConfig_DisabledEncryption(t *testing.T) {
+	cfgPath := writeMinimalConfig(t)
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+
+	err := fixPermsCmd.RunE(fixPermsCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encryption is disabled")
+}

--- a/internal/cli/encryption/migrate_provider_test.go
+++ b/internal/cli/encryption/migrate_provider_test.go
@@ -3,6 +3,7 @@ package encryption
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -280,6 +281,191 @@ func TestMigrateProviderCleanup_RejectsDisabledEncryption(t *testing.T) {
 	err := migrateProviderCleanupWithConfig(cfg, t.TempDir(), false, true)
 	if err == nil || !strings.Contains(err.Error(), "disabled") {
 		t.Fatalf("expected disabled-encryption rejection, got: %v", err)
+	}
+}
+
+// TestMigrateProviderCleanup_SecureDeleteError_SymlinkBackup covers the
+// securefiles.SecureDeleteFile error branch inside migrateProviderCleanupWithConfig:
+// a migrate-backup path that's actually a symlink fails at SecureDeleteFile's
+// O_NOFOLLOW open (ELOOP) rather than being silently "deleted". The symlink's
+// target must exist, or SecureDeleteFile's own initial os.Stat would treat the
+// (broken-link) path as already-gone and return nil instead of an error.
+func TestMigrateProviderCleanup_SecureDeleteError_SymlinkBackup(t *testing.T) {
+	dir := t.TempDir()
+	cfg := enabledLocalCfg()
+	cfg.Storage.Encryption.DEKPath = "dek.key"
+
+	target := filepath.Join(dir, "real-target.txt")
+	if err := os.WriteFile(target, []byte("hi"), 0600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	backupPath := filepath.Join(dir, "dek.key.migrate-backup.1")
+	if err := os.Symlink(target, backupPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	err := migrateProviderCleanupWithConfig(cfg, dir, false, true)
+	if err == nil || !strings.Contains(err.Error(), "failed to securely delete") {
+		t.Fatalf("expected a secure-delete failure for the symlinked backup, got: %v", err)
+	}
+}
+
+// TestMigrateProvider_TargetConfigError covers migrateProviderWithConfig's
+// "tgtEnc, err := targetEncryptionConfig(...); if err != nil { return err }"
+// branch: --to-type is set (passing the earlier required-flag gate) but the
+// type-specific fields targetEncryptionConfig itself validates are missing.
+func TestMigrateProvider_TargetConfigError(t *testing.T) {
+	cfg := enabledLocalCfg()
+	err := migrateProviderWithConfig(cfg, migrateOpts{toType: "file"}, true)
+	if err == nil || !strings.Contains(err.Error(), "--to-file-path") {
+		t.Fatalf("expected --to-file-path requirement to propagate, got: %v", err)
+	}
+}
+
+// TestMigrateProvider_RewrapFailsMissingTargetFile drives migrateProviderWithConfig
+// far enough to reach oldSvc.RewrapDEKWithProvider — covering the "re-wrap
+// failed" error-wrap branch — by pointing --to-file-path at a KEK file that
+// doesn't exist. Also confirms the pre-rewrap backup is cleaned up on failure,
+// matching the comment on that branch ("RewrapDEK leaves the active DEK
+// untouched on failure — drop the backup").
+func TestMigrateProvider_RewrapFailsMissingTargetFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "Sup3r-Secret-Passphrase!")
+
+	cfg := enabledLocalCfg()
+	cfg.Storage.Encryption.DEKPath = "dek.key"
+	cfg.Storage.Encryption.SaltPath = "kek.salt"
+
+	missingKEKPath := filepath.Join(dir, "does-not-exist.kek")
+	opts := migrateOpts{toType: "file", toFilePath: missingKEKPath}
+
+	err := migrateProviderWithConfig(cfg, opts, true)
+	if err == nil || !strings.Contains(err.Error(), "re-wrap failed") {
+		t.Fatalf("expected a re-wrap failure, got: %v", err)
+	}
+
+	matches, _ := filepath.Glob(filepath.Join(dir, "dek.key.migrate-backup.*"))
+	if len(matches) != 0 {
+		t.Errorf("expected the pre-rewrap backup to be cleaned up on failure, found: %v", matches)
+	}
+}
+
+// TestMigrateProvider_BackupCopyFails_ReadOnlyDir covers migrateProviderWithConfig's
+// "failed to back up current wrapped DEK" branch: copyFile's OpenFile(dst, O_CREATE)
+// fails because the key directory itself has been made read-only. The DEK/salt are
+// pre-provisioned (so oldSvc.Initialize below only needs to READ them, which a
+// read-only-but-executable directory still permits) before the directory is
+// chmod'd, matching TestRotateKEKCommand_RotateFailsOnReadOnlyKeyDir's pattern in
+// rotate_kek_test.go.
+func TestMigrateProvider_BackupCopyFails_ReadOnlyDir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: a read-only directory doesn't block writes")
+	}
+
+	const passphrase = "Sup3r-Secret-Passphrase!"
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cfg := enabledLocalCfg()
+	cfg.Storage.Encryption.DEKPath = "dek.key"
+	cfg.Storage.Encryption.SaltPath = "kek.salt"
+
+	setup := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := setup.Initialize(passphrase); err != nil {
+		t.Fatalf("provision key material: %v", err)
+	}
+	setup.Shutdown()
+
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	t.Setenv("KEYORIX_MASTER_PASSWORD", passphrase)
+
+	opts := migrateOpts{toType: "env", toEnvVar: "KEYORIX_TARGET_KEK"}
+	err := migrateProviderWithConfig(cfg, opts, true)
+	if err == nil || !strings.Contains(err.Error(), "failed to back up current wrapped DEK") {
+		t.Fatalf("expected a backup-copy failure, got: %v", err)
+	}
+
+	// No migrate-backup file should have been left behind — the copy never
+	// succeeded, so nothing exists to clean up.
+	matches, _ := filepath.Glob(filepath.Join(dir, "dek.key.migrate-backup.*"))
+	if len(matches) != 0 {
+		t.Errorf("expected no migrate-backup file after a failed backup copy, found: %v", matches)
+	}
+}
+
+// TestMigrateProvider_VerifyFailsOnProviderReInitError covers migrateProviderWithConfig's
+// "verification failed (target provider could not open)" branch. The target is an
+// "exec" provider backed by a helper script that succeeds on its first invocation
+// (consumed by RewrapDEKWithProvider re-wrapping the DEK) but fails on its second
+// (consumed by the fresh verifySvc.Initialize call afterward) — deterministic via a
+// counter file, no network/credentials involved. Also confirms the previous wrapped
+// DEK is restored (the backup round-trips back onto the active DEK path) rather than
+// left in the new, re-wrapped state.
+func TestMigrateProvider_VerifyFailsOnProviderReInitError(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	const passphrase = "Sup3r-Secret-Passphrase!"
+	t.Setenv("KEYORIX_MASTER_PASSWORD", passphrase)
+
+	cfg := enabledLocalCfg()
+	cfg.Storage.Encryption.DEKPath = "dek.key"
+	cfg.Storage.Encryption.SaltPath = "kek.salt"
+
+	// Snapshot the active DEK before migration so we can confirm restoreBackup put
+	// it back unchanged after the verify failure below.
+	setup := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := setup.Initialize(passphrase); err != nil {
+		t.Fatalf("provision key material: %v", err)
+	}
+	setup.Shutdown()
+	origDEK, err := os.ReadFile(filepath.Join(dir, "dek.key"))
+	if err != nil {
+		t.Fatalf("read original dek.key: %v", err)
+	}
+
+	counterPath := filepath.Join(dir, "counter")
+	scriptPath := filepath.Join(dir, "kek-helper.sh")
+	key := strings.Repeat("ab", 32) // 64 hex chars = 32 raw bytes (KEKSize)
+	script := fmt.Sprintf("#!/bin/sh\n"+
+		"n=$(cat %q 2>/dev/null || echo 0)\n"+
+		"n=$((n+1))\n"+
+		"echo \"$n\" > %q\n"+
+		"if [ \"$n\" -ge 2 ]; then\n"+
+		"  echo \"helper unavailable on second call\" >&2\n"+
+		"  exit 1\n"+
+		"fi\n"+
+		"printf '%%s' %q\n",
+		counterPath, counterPath, key)
+	if err := os.WriteFile(scriptPath, []byte(script), 0o700); err != nil {
+		t.Fatalf("write helper script: %v", err)
+	}
+
+	opts := migrateOpts{toType: "exec", toExecCommand: []string{scriptPath}}
+	err = migrateProviderWithConfig(cfg, opts, true)
+	if err == nil || !strings.Contains(err.Error(), "verification failed (target provider could not open)") {
+		t.Fatalf("expected a verify-open failure, got: %v", err)
+	}
+
+	// The helper must actually have run twice — once for the re-wrap, once for the
+	// failed verify — confirming this test reaches the branch it claims to.
+	counterBytes, cerr := os.ReadFile(counterPath)
+	if cerr != nil || strings.TrimSpace(string(counterBytes)) != "2" {
+		t.Fatalf("expected the helper to have been invoked exactly twice, counter file: %q (err=%v)", counterBytes, cerr)
+	}
+
+	gotDEK, rerr := os.ReadFile(filepath.Join(dir, "dek.key"))
+	if rerr != nil {
+		t.Fatalf("read restored dek.key: %v", rerr)
+	}
+	if string(gotDEK) != string(origDEK) {
+		t.Fatalf("expected the previous wrapped DEK to be restored after a failed verify, but it changed")
 	}
 }
 

--- a/internal/cli/encryption/provider_status_test.go
+++ b/internal/cli/encryption/provider_status_test.go
@@ -86,4 +86,76 @@ func TestPrintProviderStatus_AWSKMS(t *testing.T) {
 	})
 	assert.Contains(t, out, "Key Provider: aws-kms")
 	assert.Contains(t, out, "arn:aws:kms")
+	// No WrappedKeyPath configured — the "Wrapped key:" line must be omitted.
+	assert.NotContains(t, out, "Wrapped key:")
+}
+
+func TestPrintProviderStatus_AWSKMS_WithWrappedKeyPath(t *testing.T) {
+	out := captureProviderStatusOutput(t, func() {
+		printProviderStatus(config.KeyProviderConfig{
+			Type:           "aws-kms",
+			KMSKeyID:       "arn:aws:kms:eu-west-1:123:key/abc",
+			WrappedKeyPath: "/var/lib/keyorix/wrapped.key",
+		})
+	})
+	assert.Contains(t, out, "Key Provider: aws-kms")
+	assert.Contains(t, out, "Wrapped key: /var/lib/keyorix/wrapped.key")
+	assert.Contains(t, out, "connectivity not checked")
+}
+
+func TestPrintProviderStatus_GCPKMS(t *testing.T) {
+	out := captureProviderStatusOutput(t, func() {
+		printProviderStatus(config.KeyProviderConfig{
+			Type:     "gcp-kms",
+			KMSKeyID: "projects/p/locations/l/keyRings/r/cryptoKeys/k",
+		})
+	})
+	assert.Contains(t, out, "Key Provider: gcp-kms")
+	assert.Contains(t, out, "projects/p/locations")
+}
+
+func TestPrintProviderStatus_AzureKMS(t *testing.T) {
+	out := captureProviderStatusOutput(t, func() {
+		printProviderStatus(config.KeyProviderConfig{
+			Type:     "azure-kms",
+			KMSKeyID: "https://vault.vault.azure.net/keys/kek/abc",
+		})
+	})
+	assert.Contains(t, out, "Key Provider: azure-kms")
+	assert.Contains(t, out, "vault.azure.net")
+}
+
+func TestPrintProviderStatus_Exec(t *testing.T) {
+	out := captureProviderStatusOutput(t, func() {
+		printProviderStatus(config.KeyProviderConfig{
+			Type:        "exec",
+			ExecCommand: []string{"/usr/local/bin/get-kek", "--format", "hex"},
+		})
+	})
+	assert.Contains(t, out, "Key Provider: exec")
+	assert.Contains(t, out, "get-kek")
+}
+
+func TestPrintProviderStatus_Shamir(t *testing.T) {
+	out := captureProviderStatusOutput(t, func() {
+		printProviderStatus(config.KeyProviderConfig{
+			Type:             "shamir",
+			ShamirShareFiles: []string{"share1.key", "share2.key", "share3.key"},
+		})
+	})
+	assert.Contains(t, out, "Key Provider: shamir")
+	assert.Contains(t, out, "3 configured")
+}
+
+func TestPrintProviderStatus_TPM(t *testing.T) {
+	out := captureProviderStatusOutput(t, func() {
+		printProviderStatus(config.KeyProviderConfig{
+			Type:           "tpm",
+			TPMDevice:      "/dev/tpmrm0",
+			WrappedKeyPath: "wrapped-kek.tpm",
+		})
+	})
+	assert.Contains(t, out, "Key Provider: tpm")
+	assert.Contains(t, out, "TPM device: /dev/tpmrm0")
+	assert.Contains(t, out, "Wrapped key: wrapped-kek.tpm")
 }

--- a/internal/cli/encryption/rotate_dryrun_upgrade_gaps_test.go
+++ b/internal/cli/encryption/rotate_dryrun_upgrade_gaps_test.go
@@ -1,0 +1,216 @@
+// rotate_dryrun_upgrade_gaps_test.go — coverage uplift for narrow error
+// branches in rotateWithConfig, dryRunRotation, and upgradeAADWithConfig
+// (encryption.go) that the existing suites (encryption_s2/s3/s22/s23/s24/s27,
+// local_key_lock_test.go) don't reach:
+//
+//   - storage.OpenGormDB error (invalid storage.type), reached via
+//     rotateWithConfig and dryRunRotation directly.
+//   - the RotateDEKWithSweep / PreviewRotationSweep error branch, reached by
+//     pointing a "local" storage config at a fresh, unmigrated sqlite file (no
+//     schema for the sweep to query).
+//   - initLocalKeyOpService's exclusive-lock refusal, reached via
+//     dryRunRotation and upgradeAADWithConfig directly (mirrors
+//     local_key_lock_test.go's pattern for validateWithConfig).
+package encryption
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	enc "github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const rotateGapsPassphrase = "rotate-dryrun-upgrade-gaps-passphrase-123"
+
+// rotateGapsCfg returns an encryption-enabled config for the given storage
+// type/db path, pointing key files at workDir-relative paths.
+func rotateGapsCfg(storageType, dbPath string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Storage.Type = storageType
+	cfg.Storage.Database.Path = dbPath
+	cfg.Storage.Encryption = config.EncryptionConfig{
+		Enabled:  true,
+		DEKPath:  "dek.key",
+		SaltPath: "kek.salt",
+	}
+	return cfg
+}
+
+// ── rotateWithConfig: storage.OpenGormDB error (invalid storage.type) ────────
+
+func TestRotateWithConfig_DBOpenError(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	t.Setenv("KEYORIX_MASTER_PASSWORD", rotateGapsPassphrase)
+
+	cfg := rotateGapsCfg("badtype", "")
+	err := rotateWithConfig(cfg, true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open database for rotation")
+}
+
+// ── rotateWithConfig: RotateDEKWithSweep error (no DB schema to sweep) ───────
+
+func TestRotateWithConfig_SweepError_NoSchema(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	t.Setenv("KEYORIX_MASTER_PASSWORD", rotateGapsPassphrase)
+
+	cfg := rotateGapsCfg("local", filepath.Join(workDir, "empty.db"))
+	err := rotateWithConfig(cfg, true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DEK rotation failed")
+}
+
+// ── dryRunRotation: initLocalKeyOpService refusal while a live server ────────
+// ── holds the exclusive lock ──────────────────────────────────────────────────
+
+func TestDryRunRotation_RefusedWhileServerHoldsLock(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	t.Setenv("KEYORIX_MASTER_PASSWORD", rotateGapsPassphrase)
+
+	cfg := rotateGapsCfg("local", filepath.Join(workDir, "dryrun.db"))
+
+	setup := enc.NewService(&cfg.Storage.Encryption, workDir)
+	require.NoError(t, setup.Initialize(rotateGapsPassphrase))
+	setup.Shutdown()
+
+	serverSvc := enc.NewService(&cfg.Storage.Encryption, workDir)
+	require.NoError(t, serverSvc.Initialize(rotateGapsPassphrase))
+	require.NoError(t, serverSvc.AcquireExclusiveKeyLock())
+	defer serverSvc.Shutdown()
+
+	err := dryRunRotation(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "a live server or an in-progress rotation")
+}
+
+// ── dryRunRotation: storage.OpenGormDB error (invalid storage.type) ──────────
+
+func TestDryRunRotation_DBOpenError(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	t.Setenv("KEYORIX_MASTER_PASSWORD", rotateGapsPassphrase)
+
+	cfg := rotateGapsCfg("badtype", "")
+	err := dryRunRotation(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open database for dry-run rotation preview")
+}
+
+// ── dryRunRotation: PreviewRotationSweep error (no DB schema to preview) ─────
+
+func TestDryRunRotation_PreviewError_NoSchema(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	t.Setenv("KEYORIX_MASTER_PASSWORD", rotateGapsPassphrase)
+
+	cfg := rotateGapsCfg("local", filepath.Join(workDir, "empty.db"))
+	err := dryRunRotation(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dry-run rotation preview failed")
+}
+
+// ── upgradeAADWithConfig: initLocalKeyOpService refusal while a live server ──
+// ── holds the exclusive lock ──────────────────────────────────────────────────
+
+func TestUpgradeAADWithConfig_RefusedWhileServerHoldsLock(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	t.Setenv("KEYORIX_MASTER_PASSWORD", rotateGapsPassphrase)
+
+	cfg := rotateGapsCfg("local", filepath.Join(workDir, "upgrade.db"))
+
+	setup := enc.NewService(&cfg.Storage.Encryption, workDir)
+	require.NoError(t, setup.Initialize(rotateGapsPassphrase))
+	setup.Shutdown()
+
+	serverSvc := enc.NewService(&cfg.Storage.Encryption, workDir)
+	require.NoError(t, serverSvc.Initialize(rotateGapsPassphrase))
+	require.NoError(t, serverSvc.AcquireExclusiveKeyLock())
+	defer serverSvc.Shutdown()
+
+	err := upgradeAADWithConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "a live server or an in-progress rotation")
+}
+
+// ── upgradeAADWithConfig: success path (real db + schema, no live server) ────
+
+// TestUpgradeAADWithConfig_Success drives upgradeAADWithConfig all the way
+// through service.UpgradeAuthAAD succeeding, covering the "AAD upgrade
+// complete" summary print that every other upgradeAADWithConfig test stops
+// short of (they all exercise an earlier guard/error branch instead).
+func TestUpgradeAADWithConfig_Success(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+	t.Setenv("KEYORIX_MASTER_PASSWORD", rotateGapsPassphrase)
+
+	cfg := rotateGapsCfg("local", filepath.Join(workDir, "upgrade-success.db"))
+
+	setup := enc.NewService(&cfg.Storage.Encryption, workDir)
+	require.NoError(t, setup.Initialize(rotateGapsPassphrase))
+	setup.Shutdown()
+
+	// UpgradeAuthAAD sweeps mfa_secrets/dynamic_secret_configs/dynamic_secret_leases —
+	// migrate the (empty) schema so the sweep has tables to query successfully.
+	db, dbErr := storage.OpenGormDB(cfg)
+	require.NoError(t, dbErr)
+	require.NoError(t, db.AutoMigrate(&models.MFASecret{}, &models.DynamicSecretConfig{}, &models.DynamicSecretLease{}))
+	if sqlDB, derr := db.DB(); derr == nil {
+		_ = sqlDB.Close()
+	}
+
+	err := upgradeAADWithConfig(cfg)
+	require.NoError(t, err)
+}
+
+// ── fixPermsWithConfig: FixKeyFilePermissions error (missing salt file) ──────
+
+// TestFixPermsWithConfig_FixKeyFilePermissionsFails covers fixPermsWithConfig's
+// "failed to fix permissions" branch. FixKeyFilePermissions unconditionally
+// tries to fix BOTH the DEK and salt file, regardless of key-provider type —
+// using a "file" key provider (which never touches SaltPath at all) means
+// Initialize succeeds without ever creating kek.salt, but FixKeyFilePermissions
+// then fails to even open the (nonexistent) salt file, so the overall call
+// returns an error.
+func TestFixPermsWithConfig_FixKeyFilePermissionsFails(t *testing.T) {
+	workDir := t.TempDir()
+	t.Chdir(workDir)
+
+	kekPath := filepath.Join(workDir, "external-kek.hex")
+	kekHex := strings.Repeat("cd", 32) // 64 hex chars = 32 raw bytes (KEKSize)
+	require.NoError(t, os.WriteFile(kekPath, []byte(kekHex), 0600))
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "local"
+	cfg.Storage.Encryption = config.EncryptionConfig{
+		Enabled: true,
+		DEKPath: "dek.key",
+		// SaltPath deliberately left pointing at a path that never gets created —
+		// the "file" provider below never calls ensureSaltExists.
+		SaltPath: "kek.salt",
+		KeyProvider: config.KeyProviderConfig{
+			Type:     "file",
+			FilePath: kekPath,
+		},
+	}
+
+	err := fixPermsWithConfig(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fix permissions")
+
+	// Confirm kek.salt genuinely was never created — the failure is because
+	// FixKeyFilePermissions can't open a file that doesn't exist, not some
+	// other unrelated error.
+	_, statErr := os.Stat(filepath.Join(workDir, "kek.salt"))
+	assert.True(t, os.IsNotExist(statErr), "expected kek.salt to never be created by the file key provider")
+}

--- a/internal/cli/encryption/rotate_kek_test.go
+++ b/internal/cli/encryption/rotate_kek_test.go
@@ -8,6 +8,7 @@ package encryption
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -174,5 +175,194 @@ func TestRotateKEKCommand_Success_OldPassphraseNoLongerWorks(t *testing.T) {
 	}
 	if _, err := os.Stat("kek.salt.pending"); !os.IsNotExist(err) {
 		t.Errorf("kek.salt.pending still exists after successful rotation")
+	}
+}
+
+// ── runRotateKEK: the thin cobra shim (config.Load + delegate) ──────────────
+//
+// The tests above all exercise rotateKEKWithConfig directly. runRotateKEK
+// itself — config.Load("") via loadConfig(), then delegate to
+// rotateKEKWithConfig — was entirely untested (0% coverage), so these two
+// tests drive it via rotateKEKCmd.RunE, following the same
+// KEYORIX_CONFIG_PATH-driven convention TestRunValidateAuthEncryption_
+// ConfigLoadError (cli_encryption_s17_test.go) already established for the
+// sibling *Cmd.RunE shims.
+
+// TestRunRotateKEKCommand_ConfigLoadError verifies runRotateKEK's first error
+// branch: loadConfig() fails when there is no keyorix.yaml discoverable, and
+// the error is wrapped with "failed to load configuration".
+func TestRunRotateKEKCommand_ConfigLoadError(t *testing.T) {
+	t.Chdir(t.TempDir()) // no keyorix.yaml → config.Load("") returns an error
+	t.Setenv("KEYORIX_CONFIG_PATH", "")
+
+	err := rotateKEKCmd.RunE(rotateKEKCmd, nil)
+	if err == nil {
+		t.Fatal("expected config-load error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to load configuration") {
+		t.Errorf("expected 'failed to load configuration' in error, got: %v", err)
+	}
+}
+
+// TestRunRotateKEKCommand_DelegatesToWithConfig verifies runRotateKEK's
+// success branch: once loadConfig() succeeds, it must delegate straight to
+// rotateKEKWithConfig(cfg, rotateKEKConfirm) rather than swallowing the
+// config or silently no-op'ing. A config with encryption disabled makes
+// rotateKEKWithConfig return a specific, recognizable error, proving the
+// delegation actually happened (not just "config loaded, function returned
+// nil for an unrelated reason").
+func TestRunRotateKEKCommand_DelegatesToWithConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	const yaml = `
+storage:
+  type: local
+  encryption:
+    enabled: false
+`
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+
+	old := rotateKEKConfirm
+	rotateKEKConfirm = false
+	t.Cleanup(func() { rotateKEKConfirm = old })
+
+	err := rotateKEKCmd.RunE(rotateKEKCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Fatalf("expected rotateKEKWithConfig's disabled-encryption error to surface through runRotateKEK, got: %v", err)
+	}
+}
+
+// ── rotateKEKWithConfig: remaining error branches ────────────────────────────
+
+// TestRotateKEKCommand_RequiresMasterPassphraseEnv verifies that a missing
+// KEYORIX_MASTER_PASSWORD (old passphrase) causes an error before any key
+// file is touched, distinct from the already-covered missing-NEW-passphrase
+// case.
+func TestRotateKEKCommand_RequiresMasterPassphraseEnv(t *testing.T) {
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "")
+	t.Setenv("KEYORIX_NEW_MASTER_PASSWORD", "irrelevant-new-pass")
+
+	cfg := enabledLocalCfgKEK()
+	err := rotateKEKWithConfig(cfg, true)
+	if err == nil || !strings.Contains(err.Error(), "KEYORIX_MASTER_PASSWORD") {
+		t.Fatalf("expected missing-old-passphrase rejection, got: %v", err)
+	}
+}
+
+// TestRotateKEKCommand_WrongOldPassphraseRejected verifies that Initialize
+// fails (and rotateKEKWithConfig surfaces a clear error) when
+// KEYORIX_MASTER_PASSWORD does not match the passphrase the key material was
+// actually provisioned with.
+func TestRotateKEKCommand_WrongOldPassphraseRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cfg := enabledLocalCfgKEK()
+	svc := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := svc.Initialize("the-real-old-passphrase"); err != nil {
+		t.Fatalf("provision key material: %v", err)
+	}
+	svc.Shutdown()
+
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "not-the-real-passphrase")
+	t.Setenv("KEYORIX_NEW_MASTER_PASSWORD", "some-new-passphrase")
+
+	err := rotateKEKWithConfig(cfg, true)
+	if err == nil || !strings.Contains(err.Error(), "failed to initialize encryption") {
+		t.Fatalf("expected wrong-old-passphrase initialization failure, got: %v", err)
+	}
+}
+
+// TestRotateKEKCommand_RefusedWhileLockHeld proves rotateKEKWithConfig fails
+// fast, via AcquireExclusiveKeyLock, when another process (simulated here by
+// a second Service instance) already holds the key directory — mirroring
+// TestValidateWithConfig_RefusedWhileServerHoldsLock in local_key_lock_test.go.
+func TestRotateKEKCommand_RefusedWhileLockHeld(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	const oldPass = "kek-lock-held-old-passphrase"
+	cfg := enabledLocalCfgKEK()
+
+	setup := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := setup.Initialize(oldPass); err != nil {
+		t.Fatalf("provision key material: %v", err)
+	}
+	setup.Shutdown()
+
+	// Simulate a live server (or an in-progress rotation) holding the key
+	// directory exclusively.
+	serverSvc := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := serverSvc.Initialize(oldPass); err != nil {
+		t.Fatalf("simulated server init: %v", err)
+	}
+	if err := serverSvc.AcquireExclusiveKeyLock(); err != nil {
+		t.Fatalf("simulated server failed to acquire the exclusive key lock: %v", err)
+	}
+	defer serverSvc.Shutdown()
+
+	t.Setenv("KEYORIX_MASTER_PASSWORD", oldPass)
+	t.Setenv("KEYORIX_NEW_MASTER_PASSWORD", "kek-lock-held-new-passphrase")
+
+	err := rotateKEKWithConfig(cfg, true)
+	if err == nil {
+		t.Fatal("expected rotate-kek to be refused while a live server holds the exclusive key lock")
+	}
+	if !strings.Contains(err.Error(), "refusing to rotate KEK") {
+		t.Errorf("expected a clear, actionable error mentioning the refusal, got: %v", err)
+	}
+}
+
+// TestRotateKEKCommand_RotateFailsOnReadOnlyKeyDir drives service.
+// RotateKEKPassphrase itself into an error, covering rotateKEKWithConfig's
+// "KEK rotation failed: %w" wrap — the only branch of rotateKEKWithConfig none
+// of the tests above reach. Once the key directory is made read-only,
+// commitNewKEKFiles can't create kek.salt.pending (a brand-new directory
+// entry, unlike dek.lock/dek.key/kek.salt which already exist and so only need
+// read/write on the file itself, not the directory).
+func TestRotateKEKCommand_RotateFailsOnReadOnlyKeyDir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: a read-only directory doesn't block writes")
+	}
+
+	const (
+		oldPass = "kek-readonly-dir-old-passphrase"
+		newPass = "kek-readonly-dir-new-passphrase"
+	)
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	cfg := enabledLocalCfgKEK()
+
+	setup := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := setup.Initialize(oldPass); err != nil {
+		t.Fatalf("provision key material: %v", err)
+	}
+	// Pre-create dek.lock (acquire + release) so rotateKEKWithConfig's own
+	// AcquireExclusiveKeyLock call — which opens it with O_CREATE — still
+	// succeeds once the directory below is made read-only: opening an EXISTING
+	// file only needs directory *search* (execute) permission, not write.
+	if err := setup.AcquireExclusiveKeyLock(); err != nil {
+		t.Fatalf("pre-provision dek.lock: %v", err)
+	}
+	setup.Shutdown()
+
+	if err := os.Chmod(dir, 0555); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0755) })
+
+	t.Setenv("KEYORIX_MASTER_PASSWORD", oldPass)
+	t.Setenv("KEYORIX_NEW_MASTER_PASSWORD", newPass)
+
+	err := rotateKEKWithConfig(cfg, true)
+	if err == nil {
+		t.Fatal("expected rotation to fail when the key directory is read-only")
+	}
+	if !strings.Contains(err.Error(), "KEK rotation failed") {
+		t.Errorf("expected the RotateKEKPassphrase error to be wrapped as 'KEK rotation failed', got: %v", err)
 	}
 }

--- a/internal/cli/group/group_errorpath_test.go
+++ b/internal/cli/group/group_errorpath_test.go
@@ -1,0 +1,136 @@
+// group_errorpath_test.go — deterministic coverage for the wrapped
+// service-error branches (`fmt.Errorf("failed to ... group: %w", err)`) that
+// the existing test files leave to chance ("may or may not error"). Each test
+// here drives a service call that is *guaranteed* to fail against a fresh,
+// empty local DB (operating on a group ID that cannot exist yet), so the
+// error branch is exercised deterministically rather than incidentally.
+package group
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunGet_CLI_NotFound_Deterministic drives runGet against a fresh local DB
+// with a group ID that is guaranteed not to exist, covering get.go's
+// "failed to get group" wrapped-error branch deterministically.
+func TestRunGet_CLI_NotFound_Deterministic(t *testing.T) {
+	setupLocalDB(t)
+
+	orig := getGroupID
+	defer func() { getGroupID = orig }()
+	getGroupID = 99999
+
+	err := runGet(nil, nil)
+	require.Error(t, err, "getting a nonexistent group must fail, not silently succeed")
+	assert.Contains(t, err.Error(), "failed to get group")
+}
+
+// TestRunUpdate_CLI_NotFound_Deterministic drives runUpdate against a fresh
+// local DB with a group ID that is guaranteed not to exist, covering
+// update.go's "failed to update group" wrapped-error branch deterministically.
+func TestRunUpdate_CLI_NotFound_Deterministic(t *testing.T) {
+	setupLocalDB(t)
+
+	origID, origName := updateGroupID, updateGroupName
+	defer func() { updateGroupID = origID; updateGroupName = origName }()
+	updateGroupID = 99999
+	updateGroupName = "does-not-matter"
+
+	err := runUpdate(nil, nil)
+	require.Error(t, err, "updating a nonexistent group must fail, not silently succeed")
+	assert.Contains(t, err.Error(), "failed to update group")
+}
+
+// TestRunDelete_CLI_Force_NotFound_Deterministic drives runDelete with --force
+// (skipping the confirmation prompt) against a fresh local DB with a group ID
+// that is guaranteed not to exist, covering delete.go's "failed to delete
+// group" wrapped-error branch deterministically.
+func TestRunDelete_CLI_Force_NotFound_Deterministic(t *testing.T) {
+	setupLocalDB(t)
+
+	origID, origForce := deleteGroupID, deleteForce
+	defer func() { deleteGroupID = origID; deleteForce = origForce }()
+	deleteGroupID = 99999
+	deleteForce = true
+
+	err := runDelete(nil, nil)
+	require.Error(t, err, "force-deleting a nonexistent group must fail, not silently succeed")
+	assert.Contains(t, err.Error(), "failed to delete group")
+}
+
+// TestRunCreate_CLI_DuplicateName_Deterministic drives runCreate twice with the
+// same name against a fresh local DB. Group names are enforced unique by a
+// partial unique index (name WHERE deleted_at IS NULL) applied during the real
+// migration path that common.InitializeCoreService uses (see
+// internal/storage/models.Group's doc comment), so the second create is
+// guaranteed to fail — covering create.go's "failed to create group" wrapped-
+// error branch deterministically.
+func TestRunCreate_CLI_DuplicateName_Deterministic(t *testing.T) {
+	setupLocalDB(t)
+
+	origName, origDesc := createName, createDescription
+	defer func() { createName = origName; createDescription = origDesc }()
+	createName = "duplicate-name-target"
+	createDescription = ""
+
+	require.NoError(t, runCreate(nil, nil), "first create with a fresh name must succeed")
+
+	err := runCreate(nil, nil)
+	require.Error(t, err, "creating a second group with the same name must fail, not silently succeed")
+	assert.Contains(t, err.Error(), "failed to create group")
+}
+
+// TestRunDelete_CLI_NoForce_ConfirmedYes_NotFound_Deterministic covers the
+// branch where the (non-force) confirmation prompt is answered "yes" for a
+// group that does not exist: the GetGroup label lookup fails (fallback label
+// used — already covered by TestRunDelete_CancelledByPrompt's "no" case), the
+// prompt is confirmed, and the subsequent service.DeleteGroup call then
+// surfaces the "failed to delete group" error. This exercises the "yes at the
+// prompt but service call still fails" path, which is distinct from both the
+// force-mode error test above and the "no" cancellation test.
+func TestRunDelete_CLI_NoForce_ConfirmedYes_NotFound_Deterministic(t *testing.T) {
+	setupLocalDB(t)
+
+	origID, origForce := deleteGroupID, deleteForce
+	defer func() { deleteGroupID = origID; deleteForce = origForce }()
+	deleteGroupID = 88888
+	deleteForce = false
+
+	var err error
+	withStdin(t, "yes\n", func() {
+		err = runDelete(nil, nil)
+	})
+	require.Error(t, err, "confirming deletion of a nonexistent group must still surface the service error")
+	assert.Contains(t, err.Error(), "failed to delete group")
+}
+
+// TestRunList_CLI_Deterministic_MultipleGroups exercises the list.go for-loop
+// body over more than one row via the real CLI RunE path, and asserts on the
+// count returned by the underlying service to confirm runList is reading the
+// same store it just wrote to (not merely "no panic").
+func TestRunList_CLI_Deterministic_MultipleGroups(t *testing.T) {
+	setupLocalDB(t)
+
+	origName, origDesc := createName, createDescription
+	defer func() { createName = origName; createDescription = origDesc }()
+
+	createName = "list-det-a"
+	createDescription = "first"
+	require.NoError(t, runCreate(nil, nil))
+	createName = "list-det-b"
+	createDescription = "second"
+	require.NoError(t, runCreate(nil, nil))
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	groups, err := svc.ListGroups(context.Background())
+	require.NoError(t, err)
+	require.Len(t, groups, 2, "both created groups must be visible to the same store runList reads from")
+
+	assert.NoError(t, runList(nil, nil))
+}

--- a/internal/cli/group/group_g80_test.go
+++ b/internal/cli/group/group_g80_test.go
@@ -1,0 +1,386 @@
+// group_g80_test.go — closes the remaining coverage gap on top of
+// group_s2_test.go/group_s24_test.go: the local-mode (non-remote) execution
+// paths of add-member/remove-member, the "failed to initialize service"
+// branch shared by every subcommand, and the remote Post/Delete error
+// branches of add-member/remove-member.
+//
+// A note on isolateFromStaleGlobalConfig: on a developer machine that has
+// ever run `keyorix connect`, ~/.keyorix/cli.yaml (or
+// $XDG_CONFIG_HOME/keyorix/cli.yaml) can point at a real remote server.
+// common.NewRemoteClient() consults that file even when the test only sets
+// KEYORIX_SERVER="" — so without isolating $HOME, a test that intends to
+// exercise the LOCAL (embedded core) branch can silently flip to the remote
+// HTTP branch instead depending on what's installed on the machine running
+// it (see internal/cli group_remote_test.go's long comment on this same
+// class of issue, and the "Local-only test failures" memory entry). Pointing
+// $HOME at a fresh empty temp dir makes these tests deterministic regardless
+// of the host machine's state.
+package group
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+)
+
+// isolateFromStaleGlobalConfig points $HOME (and clears $XDG_CONFIG_HOME) at a
+// fresh, empty temp dir so common.ResolveRemote()/NewRemoteClient() cannot pick
+// up a real operator's leftover ~/.keyorix/cli.yaml. See file header comment.
+func isolateFromStaleGlobalConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+}
+
+// setupInvalidStorageConfig writes a keyorix.yaml with an unrecognized
+// storage.type so common.InitializeCoreService's factory.CreateStorage call
+// fails deterministically and fast (no DB I/O, no filesystem-permission
+// tricks), letting us drive every subcommand's "failed to initialize
+// service" branch reliably.
+func setupInvalidStorageConfig(t *testing.T) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, config.Save("keyorix.yaml", &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "not-a-real-backend"},
+	}))
+}
+
+// ── service-init-error branch: every subcommand ────────────────────────────
+
+func TestRunCreate_ServiceInitError_InvalidStorageType(t *testing.T) {
+	setupInvalidStorageConfig(t)
+
+	origName, origDesc := createName, createDescription
+	defer func() { createName = origName; createDescription = origDesc }()
+	createName = "whatever"
+	createDescription = ""
+
+	err := runCreate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunGet_ServiceInitError_InvalidStorageType(t *testing.T) {
+	setupInvalidStorageConfig(t)
+
+	orig := getGroupID
+	defer func() { getGroupID = orig }()
+	getGroupID = 1
+
+	err := runGet(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunList_ServiceInitError_InvalidStorageType(t *testing.T) {
+	setupInvalidStorageConfig(t)
+
+	err := runList(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunUpdate_ServiceInitError_InvalidStorageType(t *testing.T) {
+	setupInvalidStorageConfig(t)
+
+	origID, origName := updateGroupID, updateGroupName
+	defer func() { updateGroupID = origID; updateGroupName = origName }()
+	updateGroupID = 1
+	updateGroupName = "new-name"
+
+	err := runUpdate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunDelete_ServiceInitError_InvalidStorageType(t *testing.T) {
+	setupInvalidStorageConfig(t)
+
+	origID, origForce := deleteGroupID, deleteForce
+	defer func() { deleteGroupID = origID; deleteForce = origForce }()
+	deleteGroupID = 1
+	// service init happens before the confirmation prompt in runDelete, but set
+	// --force anyway so this test can never block on stdin.
+	deleteForce = true
+
+	err := runDelete(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunMembers_ServiceInitError_InvalidStorageType(t *testing.T) {
+	setupInvalidStorageConfig(t)
+
+	orig := membersGroupID
+	defer func() { membersGroupID = orig }()
+	membersGroupID = 1
+
+	err := runMembers(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunAddMember_Local_ServiceInitError_InvalidStorageType(t *testing.T) {
+	isolateFromStaleGlobalConfig(t)
+	setupInvalidStorageConfig(t)
+
+	origG, origU := addMemberGroupID, addMemberUserID
+	defer func() { addMemberGroupID = origG; addMemberUserID = origU }()
+	addMemberGroupID = 1
+	addMemberUserID = 1
+
+	err := runAddMember(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunRemoveMember_Local_ServiceInitError_InvalidStorageType(t *testing.T) {
+	isolateFromStaleGlobalConfig(t)
+	setupInvalidStorageConfig(t)
+
+	origG, origU := removeMemberGroupID, removeMemberUserID
+	defer func() { removeMemberGroupID = origG; removeMemberUserID = origU }()
+	removeMemberGroupID = 1
+	removeMemberUserID = 1
+
+	err := runRemoveMember(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+// ── add-member / remove-member: local (embedded core) success + error ──────
+
+// TestRunAddMember_Local_Success_Isolated drives the local-mode success branch
+// of runAddMember end to end (real seeded user+group, real membership write)
+// with $HOME isolated so the test is not at the mercy of the running
+// machine's global CLI config.
+func TestRunAddMember_Local_Success_Isolated(t *testing.T) {
+	isolateFromStaleGlobalConfig(t)
+	setupLocalDB(t)
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	u, err := svc.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "kara", Email: "kara@example.com", DisplayName: "Kara",
+		Password: "P@ssword1234567!",
+	})
+	require.NoError(t, err)
+	g, err := svc.CreateGroup(ctx, 0, &core.CreateGroupRequest{Name: "isolated-add-group"})
+	require.NoError(t, err)
+
+	origG, origU, origP := addMemberGroupID, addMemberUserID, addMemberProjectID
+	defer func() {
+		addMemberGroupID = origG
+		addMemberUserID = origU
+		addMemberProjectID = origP
+	}()
+	addMemberGroupID = g.ID
+	addMemberUserID = u.ID
+	addMemberProjectID = 0
+
+	err = runAddMember(nil, nil)
+	require.NoError(t, err, "local-mode add-member must succeed against a real seeded user+group")
+
+	members, err := svc.GetGroupMembers(ctx, g.ID)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, u.ID, members[0].ID)
+}
+
+// TestRunAddMember_Local_ErrorFromService_Isolated drives the local-mode error
+// branch deterministically: AddUserToGroup looks the group up before writing
+// the membership row, so a nonexistent group ID always errors.
+func TestRunAddMember_Local_ErrorFromService_Isolated(t *testing.T) {
+	isolateFromStaleGlobalConfig(t)
+	setupLocalDB(t)
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	u, err := svc.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "liam", Email: "liam@example.com", DisplayName: "Liam",
+		Password: "P@ssword1234567!",
+	})
+	require.NoError(t, err)
+
+	origG, origU := addMemberGroupID, addMemberUserID
+	defer func() { addMemberGroupID = origG; addMemberUserID = origU }()
+	addMemberGroupID = 999999 // does not exist
+	addMemberUserID = u.ID
+
+	err = runAddMember(nil, nil)
+	require.Error(t, err, "adding a member to a nonexistent group must fail, not silently succeed")
+	assert.Contains(t, err.Error(), "failed to add member")
+}
+
+// TestRunRemoveMember_Local_Success_Isolated drives the local-mode success
+// branch of runRemoveMember end to end.
+func TestRunRemoveMember_Local_Success_Isolated(t *testing.T) {
+	isolateFromStaleGlobalConfig(t)
+	setupLocalDB(t)
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	u, err := svc.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "mia", Email: "mia@example.com", DisplayName: "Mia",
+		Password: "P@ssword1234567!",
+	})
+	require.NoError(t, err)
+	g, err := svc.CreateGroup(ctx, 0, &core.CreateGroupRequest{Name: "isolated-remove-group"})
+	require.NoError(t, err)
+	require.NoError(t, svc.AddUserToGroup(ctx, 0, u.ID, g.ID, 0))
+
+	origG, origU := removeMemberGroupID, removeMemberUserID
+	defer func() { removeMemberGroupID = origG; removeMemberUserID = origU }()
+	removeMemberGroupID = g.ID
+	removeMemberUserID = u.ID
+
+	err = runRemoveMember(nil, nil)
+	require.NoError(t, err)
+
+	members, err := svc.GetGroupMembers(ctx, g.ID)
+	require.NoError(t, err)
+	assert.Empty(t, members)
+}
+
+// TestRunRemoveMember_Local_RefusesLastGlobalAdmin_Isolated drives the
+// local-mode error branch of runRemoveMember deterministically via the same
+// last-global-admin guard internal/core/group_admin_guard_test.go exercises
+// directly: a group that carries the install's only global "admin" role
+// grant, with the target user as its sole member. There is no CLI surface to
+// assign a role to a group, so the grant is seeded directly at the storage
+// layer against the same sqlite file runRemoveMember will open.
+func TestRunRemoveMember_Local_RefusesLastGlobalAdmin_Isolated(t *testing.T) {
+	isolateFromStaleGlobalConfig(t)
+	dir := setupLocalDB(t)
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	u, err := svc.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "nora", Email: "nora@example.com", DisplayName: "Nora",
+		Password: "P@ssword1234567!",
+	})
+	require.NoError(t, err)
+	g, err := svc.CreateGroup(ctx, 0, &core.CreateGroupRequest{Name: "sole-admin-group"})
+	require.NoError(t, err)
+	require.NoError(t, svc.AddUserToGroup(ctx, 0, u.ID, g.ID, 0))
+
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{Logger: logger.Discard})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.Role{Name: "admin"}).Error)
+	var role models.Role
+	require.NoError(t, db.Where("name = ?", "admin").First(&role).Error)
+	require.NoError(t, db.Create(&models.GroupRole{GroupID: g.ID, RoleID: role.ID}).Error)
+
+	origG, origU := removeMemberGroupID, removeMemberUserID
+	defer func() { removeMemberGroupID = origG; removeMemberUserID = origU }()
+	removeMemberGroupID = g.ID
+	removeMemberUserID = u.ID
+
+	err = runRemoveMember(nil, nil)
+	require.Error(t, err, "removing the sole member of the install's only admin-conferring group must be refused")
+	assert.Contains(t, err.Error(), "failed to remove member")
+
+	// The membership must survive the refused removal.
+	members, merr := svc.GetGroupMembers(ctx, g.ID)
+	require.NoError(t, merr)
+	require.Len(t, members, 1)
+}
+
+// ── add-member / remove-member: remote HTTP error branch ───────────────────
+
+func TestRunAddMember_Remote_PostError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origG, origU := addMemberGroupID, addMemberUserID
+	defer func() { addMemberGroupID = origG; addMemberUserID = origU }()
+	addMemberGroupID = 7
+	addMemberUserID = 3
+
+	err := runAddMember(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to add member")
+}
+
+func TestRunRemoveMember_Remote_DeleteError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origG, origU := removeMemberGroupID, removeMemberUserID
+	defer func() { removeMemberGroupID = origG; removeMemberUserID = origU }()
+	removeMemberGroupID = 7
+	removeMemberUserID = 3
+
+	err := runRemoveMember(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to remove member")
+}
+
+// TestRunAddMember_Remote_PostError_RequestReachesServer verifies that the
+// POST error branch is reached only after the request is actually issued
+// (not e.g. a client-construction failure) by decoding the captured body.
+func TestRunAddMember_Remote_PostError_RequestReachesServer(t *testing.T) {
+	reached := false
+	var body map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origG, origU := addMemberGroupID, addMemberUserID
+	defer func() { addMemberGroupID = origG; addMemberUserID = origU }()
+	addMemberGroupID = 11
+	addMemberUserID = 22
+
+	err := runAddMember(nil, nil)
+	require.Error(t, err)
+	assert.True(t, reached, "runAddMember must actually issue the POST before surfacing the error")
+	require.NotNil(t, body)
+	assert.Equal(t, float64(22), body["user_id"])
+}

--- a/internal/cli/invite/invite_s26_test.go
+++ b/internal/cli/invite/invite_s26_test.go
@@ -1,0 +1,149 @@
+// invite_s26_test.go — coverage sprint 26 for internal/cli/invite.
+// Targets the two remaining uncovered branches after sprint 25:
+//   - runRevoke: requireInviteAuthority fails (no roles.assign) → revoke.go:50-52
+//   - runList:   ListProjectInvitations/StaleInvitations fails → list.go:52-54
+package invite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ──────────────────────────── runRevoke — authority failure ──────────────────
+
+// TestRunRevoke_RequireAuthorityFails exercises revoke.go:50-52: when
+// requireInviteAuthority rejects the --by actor (resolves to a real user, but
+// one holding only project_viewer — no roles.assign at the invitation's
+// project), runRevoke must propagate that error and must NOT proceed to call
+// RevokeInvitation. Mirrors TestRunSend_RequireAuthorityFails (invite_s25_test.go)
+// for the revoke path.
+func TestRunRevoke_RequireAuthorityFails(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, invID := seedInviteDB(t)
+	require.NotZero(t, invID, "seedInviteDB must return a valid invitation ID")
+
+	ctx := context.Background()
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+
+	viewerEmail := "revoke_viewer_no_assign_s26@example.com"
+	newUser, err := svc.Storage().CreateUser(ctx, &models.User{
+		Username: "revokeviewernoassigns26",
+		Email:    viewerEmail,
+		IsActive: true,
+	})
+	require.NoError(t, err)
+
+	// The invitation seeded by seedInviteDB belongs to the "default" project,
+	// which is project ID 1 (the first project created by BootstrapSystem).
+	viewerRole, err := svc.Storage().GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	require.NoError(t, svc.Storage().AssignRole(ctx, newUser.ID, viewerRole.ID, core.Scope{ProjectID: 1}))
+
+	origID, origBy := revokeID, revokeBy
+	defer func() { revokeID = origID; revokeBy = origBy }()
+	revokeID = invID
+	revokeBy = viewerEmail
+
+	revokeErr := runRevoke(nil, nil)
+	require.Error(t, revokeErr)
+	assert.Contains(t, revokeErr.Error(), "roles.assign")
+
+	// Confirm the invitation was NOT revoked — the authority check must have
+	// short-circuited before RevokeInvitation ran.
+	inv, getErr := svc.Storage().GetProjectInvitation(ctx, invID)
+	require.NoError(t, getErr)
+	assert.Equal(t, "pending", inv.State, "invitation must remain pending after a rejected revoke attempt")
+}
+
+// ──────────────────────────── runList — list query failure ───────────────────
+
+// TestRunList_ListInvitationsFails exercises list.go:52-54: when the storage
+// query underlying ListProjectInvitations fails, runList must wrap and return
+// that error rather than panicking or silently reporting an empty list.
+//
+// The project_invitations table itself is left in place (dropping it outright
+// would just have factory.go's migrateDatabase recreate it as empty on the next
+// InitializeCoreService call inside runList, since it only re-creates tables
+// that are MISSING — see the `if !invitationsExists` branch). GORM's Find
+// issues a bare `SELECT *`, so dropping a column that is merely part of the
+// model (e.g. email) does not break the query. ListProjectInvitations'
+// `Where("project_id = ?", projectID)` clause, however, references project_id
+// directly in the generated SQL, so dropping THAT column guarantees the
+// underlying SELECT genuinely fails with "no such column: project_id".
+func TestRunList_ListInvitationsFails(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_PROJECT", "default")
+
+	_, invID := seedInviteDB(t)
+	require.NotZero(t, invID, "need a seeded invitation so the table pre-exists before corrupting it")
+
+	db, err := gorm.Open(sqlite.Open("./secrets.db"), &gorm.Config{})
+	require.NoError(t, err)
+	// The project_id column carries a GORM-generated index
+	// (idx_project_invitations_project_id); SQLite refuses to drop a column
+	// that an index still references, so the index must go first.
+	require.NoError(t, db.Exec("DROP INDEX IF EXISTS idx_project_invitations_project_id").Error)
+	require.NoError(t, db.Exec("ALTER TABLE project_invitations DROP COLUMN project_id").Error)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	origProject, origStale := listProject, listStaleDays
+	defer func() { listProject = origProject; listStaleDays = origStale }()
+	listProject = ""
+	listStaleDays = 0
+
+	err = runList(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list invitations")
+}
+
+// TestRunList_StaleInvitationsFails is the --stale-days sibling of
+// TestRunList_ListInvitationsFails: StaleInvitations calls the same broken
+// storage query internally.
+func TestRunList_StaleInvitationsFails(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_PROJECT", "default")
+
+	_, invID := seedInviteDB(t)
+	require.NotZero(t, invID, "need a seeded invitation so the table pre-exists before corrupting it")
+
+	db, err := gorm.Open(sqlite.Open("./secrets.db"), &gorm.Config{})
+	require.NoError(t, err)
+	// See TestRunList_ListInvitationsFails: the index on project_id must be
+	// dropped before the column itself can be.
+	require.NoError(t, db.Exec("DROP INDEX IF EXISTS idx_project_invitations_project_id").Error)
+	require.NoError(t, db.Exec("ALTER TABLE project_invitations DROP COLUMN project_id").Error)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	origProject, origStale := listProject, listStaleDays
+	defer func() { listProject = origProject; listStaleDays = origStale }()
+	listProject = ""
+	listStaleDays = 7
+
+	err = runList(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list invitations")
+}

--- a/internal/cli/invite/invite_s27_test.go
+++ b/internal/cli/invite/invite_s27_test.go
@@ -1,0 +1,136 @@
+// invite_s27_test.go — coverage sprint 27 for internal/cli/invite.
+//
+// `go tool cover -func` does not attribute statements inside a closure that is
+// assigned directly as a cobra.Command field literal (resendCmd's RunE is
+// `RunE: func(cmd *cobra.Command, args []string) error { ... }` inside the var
+// block), so it silently omits those blocks from its per-function summary even
+// though the underlying coverage profile still records them as 0-count. Both
+// branches below were confirmed uncovered by inspecting the raw -coverprofile
+// output directly (resend.go:45-47 and resend.go:52-54), not by trusting the
+// -func report.
+//
+// Targets:
+//   - resendCmd.RunE: requireInviteAuthority fails (no roles.assign) → resend.go:45-47
+//   - resendCmd.RunE: ResendInvitationLink fails (non-pending invitation) → resend.go:49-51
+//   - resendCmd.RunE: full success path (prints + returns nil) → resend.go:52-54
+package invite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResendCmd_RequireAuthorityFails exercises resend.go:45-47: the actor
+// resolves to a real user, but one holding only project_viewer (no
+// roles.assign at the invitation's project), so requireInviteAuthority must
+// reject the resend before ResendInvitationLink is ever called. Mirrors
+// TestRunSend_RequireAuthorityFails/TestRunRevoke_RequireAuthorityFails
+// (invite_s25_test.go / invite_s26_test.go) for the resend path.
+func TestResendCmd_RequireAuthorityFails(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, invID := seedInviteDB(t)
+	require.NotZero(t, invID, "seedInviteDB must return a valid invitation ID")
+
+	ctx := context.Background()
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+
+	viewerEmail := "resend_viewer_no_assign_s27@example.com"
+	newUser, err := svc.Storage().CreateUser(ctx, &models.User{
+		Username: "resendviewernoassigns27",
+		Email:    viewerEmail,
+		IsActive: true,
+	})
+	require.NoError(t, err)
+
+	// The invitation seeded by seedInviteDB belongs to the "default" project,
+	// which is project ID 1 (the first project created by BootstrapSystem).
+	viewerRole, err := svc.Storage().GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	require.NoError(t, svc.Storage().AssignRole(ctx, newUser.ID, viewerRole.ID, core.Scope{ProjectID: 1}))
+
+	origID, origBy := resendID, resendBy
+	defer func() { resendID = origID; resendBy = origBy }()
+	resendID = invID
+	resendBy = viewerEmail
+
+	err = resendCmd.RunE(resendCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "roles.assign")
+
+	// Confirm the invitation was NOT touched — the authority check must have
+	// short-circuited before ResendInvitationLink ran.
+	inv, getErr := svc.Storage().GetProjectInvitation(ctx, invID)
+	require.NoError(t, getErr)
+	assert.Equal(t, "pending", inv.State, "invitation must remain pending after a rejected resend attempt")
+}
+
+// TestResendCmd_ResendInvitationLinkFails exercises resend.go:52-54: the actor
+// is authorized and the invitation exists, but it is no longer pending (it was
+// revoked first), so the core ResendInvitationLink call itself fails and
+// resendCmd.RunE must wrap that error with "failed to resend invitation link".
+func TestResendCmd_ResendInvitationLinkFails(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	projectID, invID := seedInviteDB(t)
+	require.NotZero(t, invID, "seedInviteDB must return a valid invitation ID")
+
+	ctx := context.Background()
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+
+	admin, err := svc.GetUserByEmail(ctx, "admin@example.com")
+	require.NoError(t, err)
+	require.NoError(t, svc.RevokeInvitation(ctx, projectID, invID, admin.ID))
+
+	origID, origBy := resendID, resendBy
+	defer func() { resendID = origID; resendBy = origBy }()
+	resendID = invID
+	resendBy = "admin@example.com"
+
+	err = resendCmd.RunE(resendCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resend invitation link")
+}
+
+// TestResendCmd_SuccessPath exercises resend.go:52-54: when ResendInvitationLink
+// succeeds, resendCmd.RunE must print the reissue confirmation and return nil.
+// This requires credential_delivery.base_url to be configured so
+// provisionSetupLinkThrottled can build the link without SMTP (out-of-band
+// mode), mirroring TestRunSend_SuccessPath (invite_s25_test.go) for the resend
+// path.
+func TestResendCmd_SuccessPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	// Bootstrap the DB first using the plain default config (no base_url yet).
+	_, invID := seedInviteDB(t)
+	require.NotZero(t, invID, "seedInviteDB must return a valid invitation ID")
+
+	// Write keyorix.yaml with base_url so that the next InitializeCoreService
+	// call (inside resendCmd.RunE) sets setupBaseURL and enables the link build.
+	writeYAML(t, baseURLYAML)
+
+	origID, origBy := resendID, resendBy
+	defer func() { resendID = origID; resendBy = origBy }()
+	resendID = invID
+	resendBy = "admin@example.com"
+
+	err := resendCmd.RunE(resendCmd, nil)
+	require.NoError(t, err)
+}

--- a/internal/cli/legalhold/legalhold_remote_test.go
+++ b/internal/cli/legalhold/legalhold_remote_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -94,6 +95,31 @@ func TestPlaceCmd_ServerError(t *testing.T) {
 	placeReason = "test reason"
 
 	err := placeCmd.RunE(placeCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+// TestLiftCmd_ServerError verifies liftCmd surfaces HTTP errors from the
+// DeleteWithBody call (e.g. the server rejecting the lift), rather than
+// reporting success.
+func TestLiftCmd_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/legal-hold", r.URL.Path)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origR, origY := liftReason, liftYes
+	defer func() { liftReason = origR; liftYes = origY }()
+	liftReason = "test lift reason"
+	liftYes = true
+
+	cmd := &cobra.Command{}
+	err := liftCmd.RunE(cmd, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "403")
 }

--- a/internal/cli/license/license.go
+++ b/internal/cli/license/license.go
@@ -22,6 +22,11 @@ const (
 	flagDeploymentID = "deployment-id"
 )
 
+// defaultRegistryFn is the function used to load the trusted key registry for verifying
+// license tokens. It's a var (not a direct call) so tests can inject a failing registry to
+// exercise the "load trusted keys" error path, mirroring internal/cli/bundle's same pattern.
+var defaultRegistryFn = trust.DefaultRegistry
+
 // LicenseCmd is the `keyorix license` command group.
 var LicenseCmd = &cobra.Command{
 	Use:   "license",
@@ -107,7 +112,7 @@ var installCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		reg, err := trust.DefaultRegistry()
+		reg, err := defaultRegistryFn()
 		if err != nil {
 			return fmt.Errorf("load trusted keys: %w", err)
 		}
@@ -143,7 +148,7 @@ var statusCmd = &cobra.Command{
 			}
 			token = t
 		}
-		reg, err := trust.DefaultRegistry()
+		reg, err := defaultRegistryFn()
 		if err != nil {
 			return fmt.Errorf("load trusted keys: %w", err)
 		}

--- a/internal/cli/license/license_registry_test.go
+++ b/internal/cli/license/license_registry_test.go
@@ -1,0 +1,65 @@
+package license
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/trust"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetDefaultRegistryFn saves and restores defaultRegistryFn, mirroring the same helper
+// in internal/cli/bundle — defaultRegistryFn is package-global state shared across tests.
+func resetDefaultRegistryFn(t *testing.T) {
+	t.Helper()
+	orig := defaultRegistryFn
+	t.Cleanup(func() { defaultRegistryFn = orig })
+}
+
+// TestInstall_RegistryLoadError covers the "load trusted keys" error branch in
+// installCmd.RunE: when defaultRegistryFn itself fails (e.g. a malformed embedded key
+// spec — a build/release misconfiguration), install must surface that error verbatim and
+// must not attempt to evaluate or write the token.
+func TestInstall_RegistryLoadError(t *testing.T) {
+	resetDefaultRegistryFn(t)
+	defaultRegistryFn = func() (*trust.KeyRegistry, error) {
+		return nil, fmt.Errorf("simulated registry failure")
+	}
+
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "empty.token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte(""), 0o600))
+
+	installDest = filepath.Join(dir, "installed.token")
+	installDeployment = ""
+	installGraceHours = 0
+	t.Cleanup(func() { installDest, installDeployment, installGraceHours = "", "", 0 })
+
+	err := installCmd.RunE(nil, []string{tokenFile})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load trusted keys")
+	assert.Contains(t, err.Error(), "simulated registry failure")
+	_, statErr := os.Stat(installDest)
+	assert.True(t, os.IsNotExist(statErr), "a registry-load failure must not write the token")
+}
+
+// TestStatus_RegistryLoadError covers the same branch in statusCmd.RunE.
+func TestStatus_RegistryLoadError(t *testing.T) {
+	resetDefaultRegistryFn(t)
+	defaultRegistryFn = func() (*trust.KeyRegistry, error) {
+		return nil, fmt.Errorf("simulated registry failure")
+	}
+
+	statusFile = ""
+	statusDeployment = ""
+	statusGraceHours = 0
+	t.Cleanup(func() { statusFile, statusDeployment, statusGraceHours = "", "", 0 })
+
+	err := statusCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load trusted keys")
+	assert.Contains(t, err.Error(), "simulated registry failure")
+}

--- a/internal/cli/license/license_s25_test.go
+++ b/internal/cli/license/license_s25_test.go
@@ -74,6 +74,23 @@ func TestIssue_NoPEMBlock(t *testing.T) {
 	assert.Contains(t, err.Error(), "no PEM block")
 }
 
+// TestIssue_IssueCallFails covers the branch where ilicense.Issue itself returns an
+// error (as opposed to the earlier PEM-parsing failures already covered above) — here
+// by leaving --key-id empty, which Issue rejects even though issueCmd.RunE never
+// validates it itself (that's normally cobra's MarkFlagRequired, bypassed when calling
+// RunE directly in tests).
+func TestIssue_IssueCallFails(t *testing.T) {
+	issueLicensee = "acme"
+	issueNotAfter = time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	issueKeyID = ""
+	issueSignKey = writeSigningKey(t)
+	t.Cleanup(func() { issueLicensee, issueNotAfter, issueKeyID, issueSignKey = "", "", "", "" })
+
+	err := issueCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "key-id is required")
+}
+
 // --- installCmd error paths ---
 
 func TestInstall_MissingTokenFile(t *testing.T) {
@@ -84,6 +101,27 @@ func TestInstall_MissingTokenFile(t *testing.T) {
 	err := installCmd.RunE(nil, []string{filepath.Join(dir, "no-such-file.token")})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "read license token")
+}
+
+// TestInstall_WriteFailure covers the branch where the license validates fine (an
+// empty token, same as TestInstall_EmptyTokenBaselineWritesFile) but
+// securefiles.SecureWriteFileSync itself fails — here because --dest's parent
+// directory doesn't exist, so the underlying open(2) of the base directory fails.
+func TestInstall_WriteFailure(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "empty.token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte(""), 0o600))
+
+	installDest = filepath.Join(dir, "no-such-subdir", "installed.token")
+	installDeployment = ""
+	installGraceHours = 0
+	t.Cleanup(func() { installDest, installDeployment, installGraceHours = "", "", 0 })
+
+	err := installCmd.RunE(nil, []string{tokenFile})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write license")
+	_, statErr := os.Stat(installDest)
+	assert.True(t, os.IsNotExist(statErr), "a failed write must not leave a file behind")
 }
 
 // --- statusCmd error paths ---

--- a/internal/cli/main_s25_test.go
+++ b/internal/cli/main_s25_test.go
@@ -1,0 +1,57 @@
+// main_s25_test.go — coverage sprint s25 for internal/cli/main.go.
+//
+// Targets the one remaining branch in Execute() that main_test.go and
+// modes_s24_test.go don't reach: the rootCmd.Execute() error path, which
+// prints the error to stderr and calls os.Exit(1). That os.Exit(1) would
+// kill the test binary if invoked in-process, so this uses the standard Go
+// "re-exec the test binary as a subprocess" pattern (the same technique
+// os/exec's own tests use for TestHelperProcess) to observe the exit code
+// and stderr output from outside the process.
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecute_UnknownCommand_ExitsNonZero_Helper is not a real test on its
+// own — when run directly (KEYORIX_TEST_EXECUTE_HELPER=1) it drives Execute()
+// with an unknown subcommand so rootCmd.Execute() returns an error, which
+// exercises the fmt.Fprintln(os.Stderr, err) + os.Exit(1) branch in Execute.
+// TestExecute_UnknownCommand_ExitsNonZero (below) re-invokes this test as a
+// subprocess and asserts on the resulting exit code / stderr.
+func TestExecute_UnknownCommand_ExitsNonZero_Helper(t *testing.T) {
+	if os.Getenv("KEYORIX_TEST_EXECUTE_HELPER") != "1" {
+		t.Skip("only runs as a subprocess helper; see TestExecute_UnknownCommand_ExitsNonZero")
+	}
+	rootCmd.SetArgs([]string{"this-command-does-not-exist-s25"})
+	Execute()
+	// Execute() must call os.Exit(1) before reaching here when the command is
+	// unknown; if it doesn't, the parent test will see exit code 0 and fail.
+}
+
+// TestExecute_UnknownCommand_ExitsNonZero drives Execute()'s error path (the
+// branch main_test.go and modes_s24_test.go leave uncovered): an unknown
+// subcommand makes rootCmd.Execute() return a non-nil error, which Execute
+// must print to stderr and turn into a process exit code of 1 (not a panic,
+// not exit 0). Runs the test binary as a subprocess because os.Exit(1)
+// cannot be observed from within the same process that calls it.
+func TestExecute_UnknownCommand_ExitsNonZero(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestExecute_UnknownCommand_ExitsNonZero_Helper$", "-test.v")
+	cmd.Env = append(os.Environ(), "KEYORIX_TEST_EXECUTE_HELPER=1")
+	var stderr bytes.Buffer
+	cmd.Stdout = &bytes.Buffer{}
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, "Execute() must exit non-zero on an unknown command, not exit 0 or panic")
+	assert.Equal(t, 1, exitErr.ExitCode(), "Execute() must exit with code 1 on rootCmd.Execute() error")
+	assert.Contains(t, stderr.String(), "this-command-does-not-exist-s25",
+		"Execute() must print the rootCmd.Execute() error (which names the unknown command) to stderr")
+}

--- a/internal/cli/migrate/migrate_authorize_error_test.go
+++ b/internal/cli/migrate/migrate_authorize_error_test.go
@@ -1,0 +1,99 @@
+// migrate_authorize_error_test.go — closes the two remaining branches inside
+// requireMigrationAuthority (user_to_machine.go) where svc.Authorize itself
+// returns a genuine storage-layer error (not merely "not authorized") for the
+// roles.assign check and, separately, the users.write check.
+//
+// Neither branch is reachable by manipulating account state or permission
+// grants alone: a canceled context fails the earlier AccountStillUsable check
+// first (see TestRequireMigrationAuthority_AuthorizeErrorFirstCall in
+// migrate_s3_test.go), and Authorize's only error surface is a genuine
+// storage-layer failure inside scopedRoleIDs/roleSetContainsAdmin — see the
+// extensive commentary on TestRequireMigrationAuthority_AuthorizeErrorSecondCall
+// in migrate_s3_test.go, which concludes this needs "internal access" to
+// trigger cleanly. This file supplies that access from outside core/storage by
+// wrapping the storage.Storage interface core.NewKeyorixCore already accepts,
+// injecting a targeted failure into GetUserRoleIDsAt (the first call
+// scopedRoleIDs makes) on a chosen invocation, while every other storage call —
+// including the ones AccountStillUsable and the untouched Authorize calls
+// need — passes through to the real, fully-functional underlying storage.
+package migrate
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+)
+
+// roleIDsFailingStorage wraps a real storage.Storage and forces
+// GetUserRoleIDsAt to fail starting from the failFromCall'th invocation
+// (1-indexed) onward; every call before that, and every other method, is
+// delegated unmodified to the embedded real implementation.
+type roleIDsFailingStorage struct {
+	corestorage.Storage
+	calls        atomic.Int32
+	failFromCall int32
+}
+
+func (s *roleIDsFailingStorage) GetUserRoleIDsAt(ctx context.Context, userID uint, scope corestorage.Scope) ([]uint, error) {
+	n := s.calls.Add(1)
+	if n >= s.failFromCall {
+		return nil, errors.New("injected storage failure")
+	}
+	return s.Storage.GetUserRoleIDsAt(ctx, userID, scope)
+}
+
+// TestRequireMigrationAuthority_RolesAssignAuthorizeErrors exercises the
+// error return of the FIRST svc.Authorize call (roles.assign,
+// user_to_machine.go:119-122): AccountStillUsable succeeds (it only calls
+// GetUser, untouched by the wrapper), but the very first GetUserRoleIDsAt call
+// — made by scopedRoleIDs inside Authorize's roles.assign check — fails, so
+// Authorize itself returns a genuine error rather than (false, nil).
+func TestRequireMigrationAuthority_RolesAssignAuthorizeErrors(t *testing.T) {
+	_, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	bareUser := seedUserWithRole(t, st, "wrap-roles-assign-actor", "project_viewer", core.Scope{ProjectID: 1})
+
+	wrapped := &roleIDsFailingStorage{Storage: st, failFromCall: 1}
+	wrappedCore := core.NewKeyorixCore(wrapped)
+
+	err := requireMigrationAuthority(ctx, wrappedCore, bareUser, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to verify --by authority")
+	assert.Contains(t, err.Error(), "injected storage failure")
+	// Exactly one GetUserRoleIDsAt call happened before the error propagated —
+	// proving this is the FIRST Authorize call's error surface, not the second.
+	assert.Equal(t, int32(1), wrapped.calls.Load())
+}
+
+// TestRequireMigrationAuthority_UsersWriteAuthorizeErrors exercises the error
+// return of the SECOND svc.Authorize call (users.write,
+// user_to_machine.go:126-129). The actor holds the global admin role, so the
+// first Authorize call (roles.assign at the project scope) succeeds using one
+// real, unwrapped GetUserRoleIDsAt call; only the SECOND invocation — made for
+// the users.write check at global scope — is forced to fail.
+func TestRequireMigrationAuthority_UsersWriteAuthorizeErrors(t *testing.T) {
+	_, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	admin := seedUserWithRole(t, st, "wrap-users-write-actor", "admin", core.Scope{})
+
+	wrapped := &roleIDsFailingStorage{Storage: st, failFromCall: 2}
+	wrappedCore := core.NewKeyorixCore(wrapped)
+
+	err := requireMigrationAuthority(ctx, wrappedCore, admin, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to verify --by authority")
+	assert.Contains(t, err.Error(), "injected storage failure")
+	// Two GetUserRoleIDsAt calls happened: the first (roles.assign) succeeded
+	// via the real storage, the second (users.write) is the one that errored —
+	// proving this is genuinely the SECOND Authorize call's error surface.
+	assert.Equal(t, int32(2), wrapped.calls.Load())
+}

--- a/internal/cli/migrate/migrate_g80_coverage_test.go
+++ b/internal/cli/migrate/migrate_g80_coverage_test.go
@@ -1,0 +1,128 @@
+// migrate_g80_coverage_test.go — closes the remaining reasonably-reachable gaps
+// left after the s3/s24 waves: the runUserToMachine branch that PROPAGATES a
+// requireMigrationAuthority failure through the full command (rather than
+// calling requireMigrationAuthority directly), and the default (--keep-user
+// unset) success path that prints the "Source user suspended" notice.
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// bootstrapFileDBWithProjectAndUnprivilegedActor is like
+// bootstrapFileDBWithProjectAndUser (migrate_s24_test.go) but the extra user it
+// creates holds no roles at all, so it is unfit to be credited as the acting
+// admin for a migration. Returns that user's email for use as --by.
+func bootstrapFileDBWithProjectAndUnprivilegedActor(t *testing.T, dbPath, projectName, actorUsername string) (actorEmail string) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}, &models.SystemMetadata{},
+		&models.MachineIdentity{}, &models.MachineIdentityRole{},
+		&models.PersonalAccessToken{}, &models.Session{}, &models.AuditEvent{},
+		&models.PasswordHistory{},
+	))
+
+	st := store.NewLocalStorage(db)
+	c := core.NewKeyorixCore(st)
+	c.SetBootstrapToken("test-g80-bootstrap-token")
+	_, err = c.BootstrapSystem(context.Background(), &core.BootstrapRequest{
+		Username: "admin", Email: "admin@g80.example.com",
+		Password: "BootstrapPass123!", DisplayName: "Admin",
+		Token: "test-g80-bootstrap-token",
+	})
+	require.NoError(t, err)
+
+	_, err = st.CreateProject(context.Background(), &models.Project{Name: projectName})
+	require.NoError(t, err)
+
+	// The actor has an active account but zero role assignments, so it holds
+	// neither roles.assign nor users.write.
+	actorEmail = fmt.Sprintf("%s@example.com", actorUsername)
+	_, err = st.CreateUser(context.Background(), &models.User{
+		Username: actorUsername,
+		Email:    actorEmail,
+		IsActive: true,
+	})
+	require.NoError(t, err)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	return actorEmail
+}
+
+// TestRunUserToMachine_AuthorityCheckFails_FullPipeline exercises the
+// requireMigrationAuthority failure branch AS REACHED THROUGH runUserToMachine
+// (user_to_machine.go:70-72), rather than by calling requireMigrationAuthority
+// directly. --by resolves to a real, active user who nonetheless holds no
+// roles at all, so the authority check fails and runUserToMachine must
+// propagate that error verbatim without ever calling MigrateUserToMachine.
+func TestRunUserToMachine_AuthorityCheckFails_FullPipeline(t *testing.T) {
+	resetU2MVars(t)
+
+	dbPath := filepath.Join(t.TempDir(), "g80-authfail.db")
+	actorEmail := bootstrapFileDBWithProjectAndUnprivilegedActor(t, dbPath, "g80-proj-authfail", "g80-unpriv-actor")
+
+	writeConfigYAML(t, "storage:\n  type: local\n  database:\n    path: "+dbPath+"\n")
+
+	u2mBy = actorEmail
+	u2mProject = "g80-proj-authfail"
+
+	err := runUserToMachine(userToMachineCmd, []string{"some-target-user"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "roles.assign")
+	// The error must be the authority error, not a wrapped "migration failed"
+	// error — proving requireMigrationAuthority's failure short-circuits before
+	// MigrateUserToMachine is ever invoked (the target user was never created).
+	assert.NotContains(t, err.Error(), "migration failed")
+}
+
+// TestRunUserToMachine_SuccessDefaultSuspendsUser exercises the full happy path
+// of runUserToMachine with the default --keep-user=false, hitting the
+// "Source user suspended" notice branch (user_to_machine.go:81-83) that the
+// existing --keep-user=true success test (migrate_s24_test.go) deliberately
+// does NOT reach.
+func TestRunUserToMachine_SuccessDefaultSuspendsUser(t *testing.T) {
+	resetU2MVars(t)
+
+	dbPath := filepath.Join(t.TempDir(), "g80-suspend.db")
+	adminEmail := bootstrapFileDBWithProjectAndUser(t, dbPath, "g80-proj-suspend", "svc-account-suspend")
+
+	writeConfigYAML(t, "storage:\n  type: local\n  database:\n    path: "+dbPath+"\n")
+
+	u2mBy = adminEmail
+	u2mProject = "g80-proj-suspend"
+	u2mKeepUser = false
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runUserToMachine(userToMachineCmd, []string{"svc-account-suspend"})
+	})
+	require.NoError(t, runErr)
+
+	assert.Contains(t, out, "svc-account-suspend")
+	assert.Contains(t, out, "Source user suspended (login blocked). Use `keyorix user reactivate` to restore.")
+}

--- a/internal/cli/notification/channels_test.go
+++ b/internal/cli/notification/channels_test.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -285,6 +286,76 @@ func TestRunChannelDelete_NoServer(t *testing.T) {
 	assert.Contains(t, err.Error(), "not connected to a server")
 }
 
+// ── cobra entry-point coverage (no-server, config-isolated) ───────────────────
+//
+// The *_NoServer tests above rely on the ambient environment having no
+// ~/.keyorix/cli.yaml / ./keyorix.yaml lying around; on a machine that has one
+// (e.g. from a prior 'keyorix connect'), common.ResolveRemote finds it despite
+// KEYORIX_SERVER/KEYORIX_TOKEN being cleared, and the test instead exercises a
+// real (slow, network-dependent) connection attempt to that stale server. This
+// is a known local-only condition — see internal/cli/config/cli_config.go's
+// getDefaultCLIConfigPath, which honors XDG_CONFIG_HOME first. Pointing
+// XDG_CONFIG_HOME at an empty per-test temp dir (the pattern already used
+// elsewhere in this repo, e.g. internal/cli/anomalies) makes LoadCLIConfig see
+// no config file regardless of the host machine's state, so these variants
+// deterministically exercise the "not connected" branch every time.
+
+func TestRunChannelList_NoServer_ConfigIsolated(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	err := runChannelList(listCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestRunChannelAdd_NoServer_ConfigIsolated(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	origType := flagChannelType
+	t.Cleanup(func() { flagChannelType = origType })
+	flagChannelType = "webhook"
+
+	err := runChannelAdd(addCmd, []string{"my-channel"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestRunChannelGet_NoServer_ConfigIsolated(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	err := runChannelGet(getCmd, []string{"my-channel"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestRunChannelUpdate_NoServer_ConfigIsolated(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	err := runChannelUpdate(updateCmd, []string{"my-channel"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+func TestRunChannelDelete_NoServer_ConfigIsolated(t *testing.T) {
+	origConfirm := flagConfirm
+	t.Cleanup(func() { flagConfirm = origConfirm })
+	flagConfirm = true
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	err := runChannelDelete(deleteCmd, []string{"my-channel"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
 // ── additional coverage: empty list, error paths ──────────────────────────────
 
 // TestNotificationChannelList_Remote_Empty verifies that when the server returns
@@ -401,4 +472,99 @@ func TestNotificationChannelList_Remote_WithEnabledFalse(t *testing.T) {
 
 	err := runChannelListRemote(rc)
 	require.NoError(t, err)
+}
+
+// ── cobra entry-point coverage (connected-server success paths) ───────────────
+//
+// The tests above exercise the *Remote helpers directly and the "not
+// connected to a server" branch of each cobra entry point. None of them drive
+// the entry point's own "connected" branch — the call from e.g. runChannelList
+// into runChannelListRemote. These tests close that gap by pointing the
+// package-level env-resolved client at a live httptest server and invoking
+// the cobra RunE function itself.
+
+func TestRunChannelList_ConnectedServer(t *testing.T) {
+	buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(channelListBody))
+	})
+
+	err := runChannelList(listCmd, nil)
+	require.NoError(t, err)
+}
+
+func TestRunChannelAdd_ConnectedServer(t *testing.T) {
+	origType, origURL, origEmail, origEvents := flagChannelType, flagChannelURL, flagChannelEmail, flagChannelEvents
+	t.Cleanup(func() {
+		flagChannelType, flagChannelURL, flagChannelEmail, flagChannelEvents = origType, origURL, origEmail, origEvents
+	})
+	flagChannelType = "webhook"
+	flagChannelURL = "https://hook.example.com"
+	flagChannelEmail = ""
+	flagChannelEvents = ""
+
+	var gotBody map[string]interface{}
+	buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(channelSingleBody))
+	})
+
+	err := runChannelAdd(addCmd, []string{"slack-ops"})
+	require.NoError(t, err)
+	assert.Equal(t, "webhook", gotBody["type"])
+	assert.Equal(t, "https://hook.example.com", gotBody["url"])
+}
+
+func TestRunChannelGet_ConnectedServer_Found(t *testing.T) {
+	buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(channelListBody))
+	})
+
+	err := runChannelGet(getCmd, []string{"slack-ops"})
+	require.NoError(t, err)
+}
+
+func TestRunChannelUpdate_ConnectedServer(t *testing.T) {
+	require.NoError(t, updateCmd.Flags().Set("events", "secret.rotated"))
+	t.Cleanup(func() {
+		updateCmd.Flags().Lookup("events").Changed = false
+		flagChannelEvents = ""
+	})
+
+	callCount := 0
+	var gotBody map[string]interface{}
+	buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(channelListBody))
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(channelSingleBody))
+	})
+
+	err := runChannelUpdate(updateCmd, []string{"slack-ops"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount, "expected exactly GET+PUT calls")
+	assert.Equal(t, "secret.rotated", gotBody["events"])
+}
+
+func TestRunChannelDelete_ConnectedServer(t *testing.T) {
+	origConfirm := flagConfirm
+	t.Cleanup(func() { flagConfirm = origConfirm })
+	flagConfirm = true
+
+	callCount := 0
+	buildTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(channelListBody))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"id":1,"deleted":true}}`))
+	})
+
+	err := runChannelDelete(deleteCmd, []string{"slack-ops"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount, "expected exactly GET+DELETE calls")
 }

--- a/internal/cli/pat/pat_s3_test.go
+++ b/internal/cli/pat/pat_s3_test.go
@@ -1,0 +1,114 @@
+// pat_s3_test.go — sprint-3 coverage: the server-error branches of
+// createCmd/listCmd/revokeCmd.RunE (the c.Post/c.Get/c.Delete err != nil path),
+// which were previously only exercised indirectly for hygiene/list-expired but
+// never for create/list/revoke.
+package pat
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateCmd_ServerError verifies that a server-side error from the POST
+// /api/v1/auth/tokens call propagates out of createCmd.RunE (the err != nil
+// branch right after c.Post, distinct from the pre-flight validation errors
+// already covered by TestCreate_Validation and TestCreateWithBadExpiry).
+func TestCreateCmd_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	flagName, flagScopes, flagProject, flagEnv, flagExpires, flagCIDRs = "ci", nil, 0, 0, "", nil
+
+	err := createCmd.RunE(createCmd, nil)
+	require.Error(t, err)
+}
+
+// TestListCmd_ServerError verifies that a server-side error from the GET
+// /api/v1/auth/tokens call propagates out of listCmd.RunE (the err != nil
+// branch right after c.Get, distinct from TestListCmd_NotConnected which
+// never reaches the network call).
+func TestListCmd_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	err := listCmd.RunE(listCmd, nil)
+	require.Error(t, err)
+}
+
+// TestRevokeCmd_ServerError verifies that a server-side error from the DELETE
+// /api/v1/auth/tokens/{id} call propagates out of revokeCmd.RunE (the err !=
+// nil branch right after c.Delete, distinct from TestRevokeInvalidID which
+// never reaches the network call and TestRevokeCmd_NotConnected which never
+// has a server to talk to).
+func TestRevokeCmd_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	err := revokeCmd.RunE(revokeCmd, []string{"7"})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "invalid token id", "must fail at the network call, not id parsing")
+}
+
+// The three tests below exercise the client()-error ("not connected") branch
+// of listExpiredCmd/cleanupExpiredCmd/hygieneCmd.RunE. They set
+// XDG_CONFIG_HOME to an empty temp dir (mirroring TestCreateCmd_NotConnected
+// et al. in pat_s25_test.go) so the assertion is isolated from any real
+// ~/.keyorix/cli.yaml on the machine running the test — without this
+// isolation a stale local connect config makes client() succeed instead of
+// erroring, and the test would try (and time out) reaching a real host.
+
+// TestListExpiredCmd_NotConnected_Isolated verifies listExpiredCmd.RunE's
+// client() error branch (expired.go's `if err != nil { return err }` right
+// after `client()`) in an environment with no server configured at all.
+func TestListExpiredCmd_NotConnected_Isolated(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	err := listExpiredCmd.RunE(listExpiredCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+// TestCleanupExpiredCmd_NotConnected_Isolated verifies cleanupExpiredCmd.RunE's
+// client() error branch in an environment with no server configured at all.
+func TestCleanupExpiredCmd_NotConnected_Isolated(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	err := cleanupExpiredCmd.RunE(cleanupExpiredCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+// TestHygieneCmd_NotConnected_Isolated verifies hygieneCmd.RunE's client()
+// error branch in an environment with no server configured at all.
+func TestHygieneCmd_NotConnected_Isolated(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	hygieneDays = 0
+
+	err := hygieneCmd.RunE(hygieneCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}

--- a/internal/cli/project/env_clone_test.go
+++ b/internal/cli/project/env_clone_test.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -111,4 +112,177 @@ func TestEnvClone_Remote_NotFound(t *testing.T) {
 	err := runEnvClone(nil, []string{"staging", "production"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `destination environment "production" not found`)
+}
+
+// TestRunEnvClone_Remote_ResolveProjectContextError verifies that a failure
+// resolving the --project flag (server error on GET /api/v1/projects) is
+// surfaced from runEnvClone before any environment lookups happen.
+func TestRunEnvClone_Remote_ResolveProjectContextError(t *testing.T) {
+	setupCloneRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	envCloneProjectFlag = "web"
+
+	err := runEnvClone(nil, []string{"staging", "production"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list projects")
+}
+
+// TestRunEnvClone_Remote_ListEnvsError verifies that a server error listing
+// the project's environments is surfaced from runEnvCloneRemote.
+func TestRunEnvClone_Remote_ListEnvsError(t *testing.T) {
+	setupCloneRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+	envCloneProjectFlag = "web"
+
+	err := runEnvClone(nil, []string{"staging", "production"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list environments")
+}
+
+// TestEnvClone_Remote_SourceNotFound verifies the source-not-found branch
+// (previously only the destination-not-found branch was exercised).
+func TestEnvClone_Remote_SourceNotFound(t *testing.T) {
+	setupCloneRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		case "/api/v1/projects/1/environments":
+			// Only returns production, no staging.
+			_, _ = w.Write([]byte(`{"success":true,"data":{"environments":[{"id":11,"name":"production"}]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	envCloneProjectFlag = "web"
+
+	err := runEnvClone(nil, []string{"staging", "production"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `source environment "staging" not found`)
+}
+
+// TestEnvClone_Remote_CloneAPIError verifies that a server error from the
+// clone POST endpoint itself is surfaced.
+func TestEnvClone_Remote_CloneAPIError(t *testing.T) {
+	setupCloneRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		case r.URL.Path == "/api/v1/projects/1/environments":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"environments":[{"id":10,"name":"staging"},{"id":11,"name":"production"}]}}`))
+		case r.URL.Path == "/api/v1/projects/1/environments/10/clone" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	envCloneProjectFlag = "web"
+
+	err := runEnvClone(nil, []string{"staging", "production"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to clone environment")
+}
+
+// ── Embedded mode ───────────────────────────────────────────────────────────
+
+// TestRunEnvClone_Embedded_Success drives runEnvClone (not just
+// runEnvCloneEmbedded directly) end to end in embedded mode: it creates a
+// project with two environments and a secret in the source environment, then
+// exercises the full success path (both environments resolve, CloneEnvironment
+// runs, and the result is printed without error).
+//
+// NB: runEnvCloneEmbedded calls svc.CloneEnvironment with a hardcoded actorID
+// of 0 ("cli", 0), and the underlying CopySecret requires a nonzero actor ID
+// for its permission check — so every secret is reported skipped rather than
+// cloned in embedded mode today. This test asserts that actual (if surprising)
+// behavior rather than the value we might have expected, since fixing the
+// underlying actor-ID plumbing is out of scope here (internal/core is off
+// limits for this change).
+func TestRunEnvClone_Embedded_Success(t *testing.T) {
+	setupEmbedded(t)
+	ctx := context.Background()
+	svc := embeddedCore(t)
+
+	project, err := svc.CreateProjectWithEnvs(ctx, "web", "", []string{"staging", "production"})
+	require.NoError(t, err)
+
+	envs, err := svc.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	var stagingID uint
+	for _, e := range envs {
+		if e.Name == "staging" {
+			stagingID = e.ID
+		}
+	}
+	require.NotZero(t, stagingID)
+
+	_, err = svc.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name:          "db-password",
+		Value:         []byte("s3cret"),
+		ProjectID:     project.ID,
+		EnvironmentID: stagingID,
+		Type:          "password",
+		CreatedBy:     "test",
+	})
+	require.NoError(t, err)
+
+	envCloneProjectFlag = "web"
+	t.Cleanup(func() { envCloneProjectFlag = "" })
+
+	out := captureStdout(t, func() {
+		require.NoError(t, runEnvClone(nil, []string{"staging", "production"}))
+	})
+	assert.Contains(t, out, `Cloned environment "staging" → "production"`)
+	assert.Contains(t, out, "Secrets skipped: 1  (already exist in destination)")
+}
+
+// TestRunEnvClone_Embedded_SourceNotFound verifies the embedded
+// source-not-found branch of runEnvCloneEmbedded.
+func TestRunEnvClone_Embedded_SourceNotFound(t *testing.T) {
+	setupEmbedded(t)
+	ctx := context.Background()
+	svc := embeddedCore(t)
+	_, err := svc.CreateProjectWithEnvs(ctx, "web", "", []string{"production"})
+	require.NoError(t, err)
+
+	envCloneProjectFlag = "web"
+	t.Cleanup(func() { envCloneProjectFlag = "" })
+
+	err = runEnvClone(nil, []string{"staging", "production"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `source environment "staging" not found`)
+}
+
+// TestRunEnvClone_Embedded_DestNotFound verifies the embedded
+// destination-not-found branch of runEnvCloneEmbedded.
+func TestRunEnvClone_Embedded_DestNotFound(t *testing.T) {
+	setupEmbedded(t)
+	ctx := context.Background()
+	svc := embeddedCore(t)
+	_, err := svc.CreateProjectWithEnvs(ctx, "web", "", []string{"staging"})
+	require.NoError(t, err)
+
+	envCloneProjectFlag = "web"
+	t.Cleanup(func() { envCloneProjectFlag = "" })
+
+	err = runEnvClone(nil, []string{"staging", "production"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `destination environment "production" not found`)
+}
+
+// TestRunEnvCloneEmbedded_ServiceInitError verifies that a broken storage
+// config surfaces as an initialization error from runEnvCloneEmbedded itself
+// (called directly since resolveProjectContext would otherwise fail first).
+func TestRunEnvCloneEmbedded_ServiceInitError(t *testing.T) {
+	setupBrokenService(t)
+
+	err := runEnvCloneEmbedded(context.Background(), 1, "staging", "production")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
 }

--- a/internal/cli/project/project_s26_test.go
+++ b/internal/cli/project/project_s26_test.go
@@ -1,0 +1,255 @@
+// project_s26_test.go — s26 coverage blitz: remaining error/edge branches in
+// env create/delete, verifyEnvironmentBelongsToProject, resolveProjectContext,
+// runCreate (dup name with --envs), and runUse (LoadCLIConfig / SaveCLIConfig
+// fallback paths).
+package project
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── runEnvCreate — embedded CreateEnvironment failure ────────────────────────
+
+// TestRunEnvCreate_Embedded_CreateFails verifies that an invalid environment
+// name (fails core validation) is surfaced as a "failed to create environment"
+// error from the embedded path of runEnvCreate.
+func TestRunEnvCreate_Embedded_CreateFails(t *testing.T) {
+	setupEmbedded(t)
+	svc := embeddedCore(t)
+	_, err := svc.CreateProject(context.Background(), "web", "")
+	require.NoError(t, err)
+
+	envProjectFlag = "web"
+	envCreateName = "" // fails validateEnvironmentName ("name is required")
+
+	err = runEnvCreate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create environment")
+}
+
+// ── runEnvDelete — embedded resolveProjectContext / init / delete errors ─────
+
+// TestRunEnvDelete_Embedded_ProjectFlagNotFound verifies that a --project flag
+// naming a nonexistent project is refused before any delete is attempted.
+func TestRunEnvDelete_Embedded_ProjectFlagNotFound(t *testing.T) {
+	setupEmbedded(t)
+	origConfirm := envDeleteConfirm
+	origProject := envProjectFlag
+	t.Cleanup(func() { envDeleteConfirm = origConfirm; envProjectFlag = origProject })
+	envDeleteConfirm = true
+	envProjectFlag = "no-such-project"
+
+	err := runEnvDelete(nil, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestRunEnvDelete_Embedded_BrokenService_Confirmed verifies the embedded
+// InitializeCoreService failure branch inside runEnvDelete itself (distinct
+// from resolveProjectContext's own InitializeCoreService call, which is
+// skipped here by leaving --project unset).
+func TestRunEnvDelete_Embedded_BrokenService_Confirmed(t *testing.T) {
+	setupBrokenService(t)
+	origConfirm := envDeleteConfirm
+	origProject := envProjectFlag
+	t.Cleanup(func() { envDeleteConfirm = origConfirm; envProjectFlag = origProject })
+	envDeleteConfirm = true
+	envProjectFlag = "" // skip the --project cross-check branch entirely
+
+	err := runEnvDelete(nil, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+// TestRunEnvDelete_Embedded_DeleteFails verifies that deleting a nonexistent
+// environment ID surfaces svc.DeleteEnvironment's "not found" error wrapped as
+// "failed to delete environment".
+func TestRunEnvDelete_Embedded_DeleteFails(t *testing.T) {
+	setupEmbedded(t)
+	origConfirm := envDeleteConfirm
+	origProject := envProjectFlag
+	t.Cleanup(func() { envDeleteConfirm = origConfirm; envProjectFlag = origProject })
+	envDeleteConfirm = true
+	envProjectFlag = ""
+
+	err := runEnvDelete(nil, []string{"999999"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete environment")
+}
+
+// ── verifyEnvironmentBelongsToProject — embedded ─────────────────────────────
+
+// TestVerifyEnvironmentBelongsToProject_Embedded_Mismatch verifies the
+// embedded cross-check refuses an environment id that belongs to a different
+// project than the one named.
+func TestVerifyEnvironmentBelongsToProject_Embedded_Mismatch(t *testing.T) {
+	setupEmbedded(t)
+	ctx := context.Background()
+	svc := embeddedCore(t)
+
+	projA, err := svc.CreateProjectWithEnvs(ctx, "proj-a", "", []string{"prod"})
+	require.NoError(t, err)
+	projB, err := svc.CreateProjectWithEnvs(ctx, "proj-b", "", []string{"prod"})
+	require.NoError(t, err)
+
+	envsA, err := svc.ListEnvironmentsByProject(ctx, projA.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envsA)
+
+	err = verifyEnvironmentBelongsToProject(ctx, projB.ID, envsA[0].ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not belong to project")
+}
+
+// TestVerifyEnvironmentBelongsToProject_Embedded_Match verifies the positive
+// counterpart: an environment id that does belong to the named project passes.
+func TestVerifyEnvironmentBelongsToProject_Embedded_Match(t *testing.T) {
+	setupEmbedded(t)
+	ctx := context.Background()
+	svc := embeddedCore(t)
+
+	proj, err := svc.CreateProjectWithEnvs(ctx, "proj-a", "", []string{"prod"})
+	require.NoError(t, err)
+	envs, err := svc.ListEnvironmentsByProject(ctx, proj.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+
+	err = verifyEnvironmentBelongsToProject(ctx, proj.ID, envs[0].ID)
+	require.NoError(t, err)
+}
+
+// TestRunEnvDelete_Remote_VerifyGetEnvironmentsError verifies that a server
+// error on GET /api/v1/projects/{id}/environments during the --project
+// cross-check (verifyEnvironmentBelongsToProject) is surfaced distinctly from
+// a resolveProjectContext failure: the project list call succeeds, but the
+// subsequent environments call used to verify env ownership fails.
+func TestRunEnvDelete_Remote_VerifyGetEnvironmentsError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		default:
+			// /api/v1/projects/1/environments (verify step) → 500
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+	origConfirm := envDeleteConfirm
+	origProject := envProjectFlag
+	t.Cleanup(func() { envDeleteConfirm = origConfirm; envProjectFlag = origProject })
+	envDeleteConfirm = true
+	envProjectFlag = "web"
+
+	err := runEnvDelete(nil, []string{"10"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to verify environment")
+}
+
+// ── runStatsEmbedded — InitializeCoreService failure ─────────────────────────
+
+// TestProjectStats_Embedded_ServiceInitError forces InitializeCoreService to
+// fail by pointing the DB path at a directory (SQLite cannot open a directory),
+// mirroring TestProjectHealth_Embedded_ServiceInitError.
+func TestProjectStats_Embedded_ServiceInitError(t *testing.T) {
+	dir := t.TempDir()
+	dbDirPath := filepath.Join(dir, "isadirectory")
+	require.NoError(t, os.MkdirAll(dbDirPath, 0o700))
+
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: dbDirPath}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_SERVER", "")
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() { statsFormat = "table" })
+
+	err := runStatsEmbedded(context.Background(), "any-project")
+	require.Error(t, err, "expected error when storage cannot be opened")
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+// ── resolveProjectContext — remote not-found ─────────────────────────────────
+
+// TestResolveProjectContext_Remote_NotFound verifies that a remote project
+// list not containing the named project is reported as "not found".
+func TestResolveProjectContext_Remote_NotFound(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"other"}]}}`))
+	})
+
+	_, _, err := resolveProjectContext("ghost")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// ── runCreate — embedded duplicate name with --envs ──────────────────────────
+
+// TestRunCreate_Embedded_DupName_WithEnvs verifies that the
+// CreateProjectWithEnvs error branch (used when --envs is set) surfaces a
+// duplicate-name failure, distinct from the no-envs CreateProject branch
+// already covered by TestRunCreate_Embedded_DupName.
+func TestRunCreate_Embedded_DupName_WithEnvs(t *testing.T) {
+	setupEmbedded(t)
+	svc := embeddedCore(t)
+	_, err := svc.CreateProject(context.Background(), "dupe2", "")
+	require.NoError(t, err)
+
+	createName = "dupe2"
+	createEnvs = "dev,prod"
+	err = runCreate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create project")
+}
+
+// ── runUse — LoadCLIConfig / SaveCLIConfig branches ──────────────────────────
+
+// TestRunUse_Embedded_LoadConfigFallback verifies that a malformed existing
+// cli.yaml causes LoadCLIConfig to error, and runUse falls back to
+// cliconfig.DefaultCLIConfig() rather than failing outright.
+func TestRunUse_Embedded_LoadConfigFallback(t *testing.T) {
+	setupEmbedded(t)
+	svc := embeddedCore(t)
+	_, err := svc.CreateProject(context.Background(), "web", "")
+	require.NoError(t, err)
+
+	// Write a malformed cli.yaml at the exact path getDefaultCLIConfigPath()
+	// resolves to ($XDG_CONFIG_HOME/keyorix/cli.yaml) so LoadCLIConfig("")
+	// hits its YAML-parse error branch instead of the file-not-exist branch.
+	cliDir := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "keyorix")
+	require.NoError(t, os.MkdirAll(cliDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(cliDir, "cli.yaml"), []byte("not: valid: yaml: [["), 0o600))
+
+	out := captureStdout(t, func() { require.NoError(t, runUse(nil, []string{"web"})) })
+	assert.Contains(t, out, `Active project set to "web"`)
+}
+
+// TestRunUse_Embedded_SaveConfigError verifies that a SaveCLIConfig failure
+// (config directory cannot be created because a file already occupies that
+// path) is surfaced as "failed to save config".
+func TestRunUse_Embedded_SaveConfigError(t *testing.T) {
+	setupEmbedded(t)
+	svc := embeddedCore(t)
+	_, err := svc.CreateProject(context.Background(), "web", "")
+	require.NoError(t, err)
+
+	// Occupy the "keyorix" path (which SaveCLIConfig's MkdirAll needs to be a
+	// directory) with a regular file, so os.MkdirAll fails.
+	xdg := os.Getenv("XDG_CONFIG_HOME")
+	require.NoError(t, os.WriteFile(filepath.Join(xdg, "keyorix"), []byte("blocker"), 0o600))
+
+	err = runUse(nil, []string{"web"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to save config")
+}

--- a/internal/cli/project/project_s27_test.go
+++ b/internal/cli/project/project_s27_test.go
@@ -1,0 +1,53 @@
+// project_s27_test.go — s27 coverage blitz: hygieneCmd.RunE's not-connected and
+// fetchHygiene-error branches, the embedded env-clone source==destination
+// validation error, and verifyEnvironmentBelongsToProject's own
+// InitializeCoreService failure branch (called directly, since
+// resolveProjectContext would otherwise fail first with the same broken
+// config).
+package project
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHygieneCmd_NotConnected verifies that hygieneCmd.RunE refuses to run in
+// embedded (non-remote) mode with the documented "not connected" error,
+// rather than silently doing nothing or panicking on a nil RemoteClient.
+func TestHygieneCmd_NotConnected(t *testing.T) {
+	setupEmbedded(t)
+
+	err := hygieneCmd.RunE(hygieneCmd, []string{"5"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected to a server")
+}
+
+// TestHygieneCmd_FetchError verifies that a server error from the hygiene
+// endpoint is propagated (unwrapped) from hygieneCmd.RunE via fetchHygiene,
+// rather than being swallowed or replaced with a generic message.
+func TestHygieneCmd_FetchError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := hygieneCmd.RunE(hygieneCmd, []string{"5"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server returned HTTP 500")
+}
+
+// TestVerifyEnvironmentBelongsToProject_Embedded_ServiceInitError verifies the
+// embedded InitializeCoreService failure branch inside
+// verifyEnvironmentBelongsToProject itself (called directly, since going
+// through runEnvDelete would fail earlier at resolveProjectContext's own
+// InitializeCoreService call against the same broken config).
+func TestVerifyEnvironmentBelongsToProject_Embedded_ServiceInitError(t *testing.T) {
+	setupBrokenService(t)
+
+	err := verifyEnvironmentBelongsToProject(context.Background(), 1, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}

--- a/internal/cli/project/stats_test.go
+++ b/internal/cli/project/stats_test.go
@@ -1,13 +1,16 @@
 package project
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,4 +145,140 @@ func TestProjectStats_Remote_NotFound(t *testing.T) {
 	err := runStatsRemote(t.Context(), rc, "nonexistent-project")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestProjectStats_Remote_UnsupportedFormat verifies the printStats default
+// branch (format neither "table" nor "json") is rejected.
+func TestProjectStats_Remote_UnsupportedFormat(t *testing.T) {
+	rc, done := setupStatsRemote(t, projectsAndStatsHandler)
+	defer done()
+
+	statsFormat = "xml"
+	err := runStatsRemote(t.Context(), rc, "acme")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+}
+
+// TestProjectStats_Remote_ListProjectsError verifies that a server error on
+// GET /api/v1/projects is surfaced from runStatsRemote.
+func TestProjectStats_Remote_ListProjectsError(t *testing.T) {
+	rc, done := setupStatsRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer done()
+
+	err := runStatsRemote(t.Context(), rc, "acme")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list projects")
+}
+
+// TestProjectStats_Remote_StatsEndpointError verifies that a server error on
+// GET /api/v1/projects/{id}/stats is surfaced from runStatsRemote.
+func TestProjectStats_Remote_StatsEndpointError(t *testing.T) {
+	rc, done := setupStatsRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"acme"}]}}`))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+	defer done()
+
+	err := runStatsRemote(t.Context(), rc, "acme")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get project stats")
+}
+
+// ── Embedded mode ────────────────────────────────────────────────────────
+
+// setupStatsEmbedded configures an isolated on-disk SQLite database for the
+// stats command in embedded mode (no KEYORIX_SERVER/TOKEN set).
+func setupStatsEmbedded(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "test.db")}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_PROJECT", "")
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(func() { statsFormat = "table" })
+}
+
+// TestProjectStats_Embedded_NotFound verifies runStatsEmbedded propagates the
+// project-not-found error from common.LookupProjectIDByName.
+func TestProjectStats_Embedded_NotFound(t *testing.T) {
+	setupStatsEmbedded(t)
+
+	err := runStatsEmbedded(context.Background(), "no-such-project")
+	require.Error(t, err)
+}
+
+// TestProjectStats_Embedded_Table exercises the full embedded success path
+// (InitializeCoreService, LookupProjectIDByName, GetProjectStats, table print).
+func TestProjectStats_Embedded_Table(t *testing.T) {
+	setupStatsEmbedded(t)
+
+	createName = "alpha"
+	createDescription = ""
+	createEnvs = "dev"
+	require.NoError(t, runCreate(nil, nil))
+	t.Cleanup(func() { createName, createDescription, createEnvs = "", "", "" })
+
+	statsFormat = "table"
+	out := captureStatsStdout(t, func() {
+		require.NoError(t, runStatsEmbedded(context.Background(), "alpha"))
+	})
+	assert.Contains(t, out, "Project: alpha")
+	assert.Contains(t, out, "Secrets")
+	assert.Contains(t, out, "Rotation")
+	assert.Contains(t, out, "Access")
+}
+
+// TestProjectStats_Embedded_JSON exercises the embedded JSON-format branch.
+func TestProjectStats_Embedded_JSON(t *testing.T) {
+	setupStatsEmbedded(t)
+
+	createName = "beta"
+	createDescription = ""
+	createEnvs = "prod"
+	require.NoError(t, runCreate(nil, nil))
+	t.Cleanup(func() { createName, createDescription, createEnvs = "", "", "" })
+
+	statsFormat = "json"
+	out := captureStatsStdout(t, func() {
+		require.NoError(t, runStatsEmbedded(context.Background(), "beta"))
+	})
+	assert.Contains(t, out, `"project_name":"beta"`)
+	assert.Contains(t, out, `"total_secrets"`)
+}
+
+// ── runStats dispatcher ─────────────────────────────────────────────────────
+
+// TestProjectStats_RunE_Remote verifies statsCmd.RunE dispatches to the
+// remote path when KEYORIX_SERVER + KEYORIX_TOKEN are set.
+func TestProjectStats_RunE_Remote(t *testing.T) {
+	_, done := setupStatsRemote(t, projectsAndStatsHandler)
+	defer done()
+
+	statsFormat = "table"
+	out := captureStatsStdout(t, func() {
+		require.NoError(t, statsCmd.RunE(statsCmd, []string{"acme"}))
+	})
+	assert.Contains(t, out, "acme")
+}
+
+// TestProjectStats_RunE_Embedded verifies statsCmd.RunE dispatches to the
+// embedded path when no server env vars are set.
+func TestProjectStats_RunE_Embedded(t *testing.T) {
+	setupStatsEmbedded(t)
+
+	err := statsCmd.RunE(statsCmd, []string{"no-such-project"})
+	require.Error(t, err)
 }

--- a/internal/cli/request/request_coverage_gaps_test.go
+++ b/internal/cli/request/request_coverage_gaps_test.go
@@ -1,0 +1,300 @@
+// request_coverage_gaps_test.go — targeted coverage for branches the existing
+// suites leave unexercised: the "service init failed" early-return in every
+// top-level command that has no injectable service factory (unlike
+// bulk.go's bulkInitService), and the genuine storage-error branch of
+// Authorize() inside requireListAuthority/requireReviewAuthority/
+// requireTemplateAuthority (as opposed to the far more common "resolves but
+// isn't authorized" branch, already covered by list_template_authority_test.go
+// and review_authority_test.go).
+package request
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// ── shared fixtures ─────────────────────────────────────────────────────────
+
+// withInvalidStorageConfig points KEYORIX_CONFIG_PATH at a config file with an
+// unrecognised storage.type, so common.InitializeCoreService's real
+// factory.CreateStorage call fails. This is the only way to exercise the
+// "failed to initialize service" branch of access/list/review/secret-access/
+// withdraw: unlike bulk.go's bulkInitService, none of those commands have an
+// injectable service factory, so the real function must actually fail.
+// Mirrors common.TestInitializeCoreService_InvalidStorageTypeFails.
+func withInvalidStorageConfig(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`storage:
+  type: "invalid-storage-type"
+locale:
+  language: "en"
+  fallback_language: "en"
+`), 0600))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+}
+
+// usersOnlyCounter avoids DSN collisions across parallel package runs.
+var usersOnlyCounter int
+
+// newUsersOnlyCore returns a KeyorixCore backed by an in-memory SQLite DB that
+// has ONLY the users table migrated (no role/permission tables at all), with
+// one user seeded. Calling Authorize (directly, or via any requireXAuthority
+// helper) against this service returns a genuine storage error — not merely
+// "no roles held" — because GetUserRoleIDsAt queries a table that doesn't
+// exist. This exercises the err!=nil branch of Authorize() that a
+// fully-seeded RBAC fixture (newTestRequestCore) can never reach, since every
+// role query there just returns an empty/negative result, not an error.
+func newUsersOnlyCore(t *testing.T, email string) (*core.KeyorixCore, uint) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	usersOnlyCounter++
+	dsn := fmt.Sprintf("file:users_only_%d?mode=memory&cache=shared", usersOnlyCounter)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}))
+	u := &models.User{Username: "partial-user", Email: email, IsActive: true}
+	require.NoError(t, db.Create(u).Error)
+	svc := core.NewKeyorixCore(store.NewLocalStorage(db))
+	t.Cleanup(func() {
+		sqlDB, _ := db.DB()
+		_ = sqlDB.Close()
+	})
+	return svc, u.ID
+}
+
+// ── InitializeCoreService failure paths (no injectable factory) ─────────────
+
+func TestRunAccess_InitServiceError_RealFailure(t *testing.T) {
+	withInvalidStorageConfig(t)
+	origUser := accessUser
+	defer func() { accessUser = origUser }()
+	accessUser = "user@example.com"
+
+	err := runAccess(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+	assert.Contains(t, err.Error(), "failed to create storage")
+}
+
+func TestRunList_InitServiceError_RealFailure(t *testing.T) {
+	withInvalidStorageConfig(t)
+
+	err := runList(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+	assert.Contains(t, err.Error(), "failed to create storage")
+}
+
+func TestRunReview_InitServiceError_RealFailure(t *testing.T) {
+	withInvalidStorageConfig(t)
+	origID, origAction := reviewID, reviewAction
+	defer func() { reviewID = origID; reviewAction = origAction }()
+	reviewID = 1
+	reviewAction = "approve"
+
+	err := runReview(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+	assert.Contains(t, err.Error(), "failed to create storage")
+}
+
+func TestRunSecretAccess_InitServiceError_RealFailure(t *testing.T) {
+	withInvalidStorageConfig(t)
+	origUser, origID := secretAccessUser, secretAccessSecretID
+	defer func() { secretAccessUser = origUser; secretAccessSecretID = origID }()
+	secretAccessUser = "user@example.com"
+	secretAccessSecretID = 1
+
+	err := runSecretAccess(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+	assert.Contains(t, err.Error(), "failed to create storage")
+}
+
+func TestRunWithdraw_InitServiceError_RealFailure(t *testing.T) {
+	withInvalidStorageConfig(t)
+	origID := withdrawID
+	defer func() { withdrawID = origID }()
+	withdrawID = 1
+
+	err := runWithdraw(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+	assert.Contains(t, err.Error(), "failed to create storage")
+}
+
+// ── runList: remaining branches ──────────────────────────────────────────────
+
+// TestRunList_ResolveProjectError exercises the common.ResolveProject error
+// branch: no --project flag, no KEYORIX_PROJECT, and no active project on
+// disk leaves nothing for runList to resolve.
+func TestRunList_ResolveProjectError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_PROJECT", "")
+
+	origProject := listProject
+	defer func() { listProject = origProject }()
+	listProject = ""
+
+	err := runList(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no project specified")
+}
+
+// TestRunList_ResolveUserIDError exercises the resolveUserID error branch:
+// --by names an email with no matching user record.
+func TestRunList_ResolveUserIDError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, _, _ = seedRequestDB(t)
+
+	origProject, origBy := listProject, listBy
+	defer func() { listProject = origProject; listBy = origBy }()
+	listProject = "testproj"
+	listBy = "nobody-at-all@example.com"
+
+	err := runList(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no user found")
+}
+
+// TestRunList_RequireListAuthorityError exercises the
+// "requireListAuthority returns an error" branch via the real runList
+// entrypoint: --by resolves to a real user who simply doesn't hold
+// roles.assign at the project.
+func TestRunList_RequireListAuthorityError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, projectID, svc := seedRequestDB(t)
+	ctx := context.Background()
+	unprivileged, err := svc.Storage().CreateUser(ctx, &models.User{
+		Username: "list-unpriv", Email: "list-unpriv@example.com", IsActive: true,
+	})
+	require.NoError(t, err)
+	_ = projectID
+
+	origProject, origBy := listProject, listBy
+	defer func() { listProject = origProject; listBy = origBy }()
+	listProject = "testproj"
+	listBy = unprivileged.Email
+
+	runErr := runList(nil, nil)
+	require.Error(t, runErr)
+	assert.Contains(t, runErr.Error(), "roles.assign")
+}
+
+// ── Authorize() genuine storage-error branch (direct helper calls) ──────────
+
+// TestRequireListAuthority_AuthorizeStorageError exercises the err!=nil
+// branch inside requireListAuthority's call to svc.Authorize — distinct from
+// the far more common "resolves but isn't authorized" (ok=false) branch
+// already covered by TestRequireListAuthority_UnprivilegedActorRejected.
+func TestRequireListAuthority_AuthorizeStorageError(t *testing.T) {
+	svc, uid := newUsersOnlyCore(t, "partial-list@example.com")
+	err := requireListAuthority(context.Background(), svc, uid, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to verify --by authority")
+}
+
+// TestRequireReviewAuthority_AuthorizeStorageError is the review.go sibling
+// of the above.
+func TestRequireReviewAuthority_AuthorizeStorageError(t *testing.T) {
+	svc, uid := newUsersOnlyCore(t, "partial-review@example.com")
+	err := requireReviewAuthority(context.Background(), svc, uid, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to verify --by authority")
+}
+
+// TestRequireTemplateAuthority_AuthorizeStorageError is the bulk.go sibling.
+func TestRequireTemplateAuthority_AuthorizeStorageError(t *testing.T) {
+	svc, uid := newUsersOnlyCore(t, "partial-tmpl@example.com")
+	err := requireTemplateAuthority(context.Background(), svc, uid)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to verify --by authority")
+}
+
+// ── bulk.go: requireTemplateAuthority error propagation from each caller ────
+
+// TestRunTmplList_RequireTemplateAuthorityError exercises runTmplList's own
+// "if err := requireTemplateAuthority(...); err != nil" branch (as opposed to
+// the "not ok" case already covered indirectly): the --by user resolves, but
+// the underlying Authorize call itself fails closed on missing role tables.
+func TestRunTmplList_RequireTemplateAuthorityError(t *testing.T) {
+	origBy := tmplListBy
+	defer func() { tmplListBy = origBy }()
+	tmplListBy = "partial-list-cmd@example.com"
+	withUserSeededPartialService(t, "partial-list-cmd@example.com")
+
+	err := runTmplList(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to verify --by authority")
+}
+
+// TestRunTmplAdd_RequireTemplateAuthorityError is runTmplAdd's sibling.
+func TestRunTmplAdd_RequireTemplateAuthorityError(t *testing.T) {
+	origName, origReason, origBy := tmplName, tmplReason, tmplBy
+	defer func() { tmplName = origName; tmplReason = origReason; tmplBy = origBy }()
+	tmplName = "x"
+	tmplReason = "y"
+	tmplBy = "partial-add-cmd@example.com"
+	withUserSeededPartialService(t, "partial-add-cmd@example.com")
+
+	err := runTmplAdd(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to verify --by authority")
+}
+
+// TestRunTmplDelete_RequireTemplateAuthorityError is runTmplDelete's sibling.
+func TestRunTmplDelete_RequireTemplateAuthorityError(t *testing.T) {
+	origBy := tmplDeleteBy
+	defer func() { tmplDeleteBy = origBy }()
+	tmplDeleteBy = "partial-delete-cmd@example.com"
+	withUserSeededPartialService(t, "partial-delete-cmd@example.com")
+
+	err := runTmplDelete(nil, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to verify --by authority")
+}
+
+// TestRunTmplDelete_DeleteTemplateNotFoundError exercises runTmplDelete's
+// DeleteRejectionReasonTemplate error branch specifically — an authorized
+// admin (so requireTemplateAuthority passes) deleting an ID that was never
+// created.
+func TestRunTmplDelete_DeleteTemplateNotFoundError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, _, _ = seedBulkApproveDB(t)
+
+	origBy := tmplDeleteBy
+	defer func() { tmplDeleteBy = origBy }()
+	tmplDeleteBy = "admin@example.com"
+
+	err := runTmplDelete(nil, []string{"99999"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete template")
+}

--- a/internal/cli/request/request_final_gaps_test.go
+++ b/internal/cli/request/request_final_gaps_test.go
@@ -1,0 +1,75 @@
+// request_final_gaps_test.go — closes a statement-coverage gap left in the
+// package: runList's "ListAccessRequests returned an error" branch.
+//
+// runReview's sibling "dual control still pending" branch (req.State !=
+// "approved" after an approve) is NOT covered here: it can only be reached
+// when the core service's in-process dualControlRequiredApprovals field is
+// >1, and that field is set exclusively via KeyorixCore.SetDualControlPolicy,
+// which only server/main.go calls (from config) — common.InitializeCoreService,
+// the CLI's own service constructor that runReview calls internally, never
+// calls it. review.go has no injectable service factory (unlike bulk.go's
+// bulkInitService), so a test cannot swap in a pre-configured *core.KeyorixCore
+// for runReview's internal call either. Reaching that branch from this
+// package's tests as written is not possible without changing production
+// code, which is out of scope for a test-only change.
+package request
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	sqlite "github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// ──────────────────────────── runList — storage error ──────────────────────
+
+// TestRunList_ListAccessRequestsFails exercises the
+// "failed to list access requests" branch. Dropping the access_requests table
+// doesn't work here — every InitializeCoreService() call (including runList's
+// own) re-runs the storage factory's AutoMigrate, which silently recreates
+// any missing table. Instead this poisons a single ROW's data: user_id is
+// stored as non-numeric text (SQLite's dynamic typing allows writing a TEXT
+// value into an INTEGER-affinity column when it can't be coerced to a
+// number), so the SELECT that maps rows back into models.AccessRequest fails
+// to scan that column into its uint field — a real storage-layer failure, not
+// a fabricated mock error.
+func TestRunList_ListAccessRequestsFails(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, projectID, svc := seedRequestDB(t)
+	ctx := context.Background()
+
+	requester, err := svc.Storage().CreateUser(ctx, &models.User{
+		Username: "listfailreq", Email: "listfailreq@example.com", IsActive: true,
+	})
+	require.NoError(t, err)
+	req, err := svc.RequestProjectAccess(ctx, projectID, requester.ID, "viewer", "need")
+	require.NoError(t, err)
+
+	db, err := gorm.Open(sqlite.Open("secrets.db"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(
+		"UPDATE access_requests SET user_id = 'not-a-number' WHERE id = ?", req.ID,
+	).Error)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	origProject, origBy := listProject, listBy
+	defer func() {
+		listProject = origProject
+		listBy = origBy
+	}()
+	listProject = "testproj"
+	listBy = "admin@example.com"
+
+	err = runList(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list access requests")
+}

--- a/internal/cli/risk/risk_test.go
+++ b/internal/cli/risk/risk_test.go
@@ -96,6 +96,105 @@ func TestApprove_RequiredIDAndRemote(t *testing.T) {
 	assert.Contains(t, out, "Risk exception 4 approved.")
 }
 
+// TestList_RemoteError covers the listCmd.RunE path where c.Get itself
+// returns an error (e.g. a non-2xx response), distinct from the "not
+// connected" and successful-decode paths already covered above.
+func TestList_RemoteError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	listAll = false
+	err := listCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestAdd_RemoteError covers the addCmd.RunE path where validation passes,
+// a server is configured, but c.Post returns an error.
+func TestAdd_RemoteError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	addTitle, addJustification = "gap", "accepted for Q3"
+	addExpires = time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	t.Cleanup(func() { addTitle, addJustification, addExpires = "", "", "" })
+	err := addCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestApprove_RemoteError covers the approveCmd.RunE path where the ID is
+// set, a server is configured, but c.Post returns an error.
+func TestApprove_RemoteError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	approveID = 4
+	t.Cleanup(func() { approveID = 0 })
+	err := approveCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestRevoke_RemoteError covers the revokeCmd.RunE path where the ID is
+// set, a server is configured, but c.Delete returns an error.
+func TestRevoke_RemoteError(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	revokeID = 4
+	t.Cleanup(func() { revokeID = 0 })
+	err := revokeCmd.RunE(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+// TestNotConnected_IsolatedFromLocalConfig re-covers the "not connected"
+// branch in all four RunE funcs (the counterpart to the RemoteError tests
+// above) with the CLI config lookup isolated to an empty temp dir. Without
+// this isolation, a real ~/.keyorix/cli.yaml (or $XDG_CONFIG_HOME/keyorix/
+// cli.yaml) written by a prior `keyorix connect` on the machine running the
+// tests can make common.NewRemoteClient() report "connected" even with
+// KEYORIX_SERVER/KEYORIX_TOKEN unset, which starves this branch of coverage
+// on such a machine. Isolating HOME/XDG_CONFIG_HOME (the pattern already
+// used throughout internal/cli, e.g. internal/cli/breakglass and
+// internal/cli/group) makes the branch deterministically reachable.
+func TestNotConnected_IsolatedFromLocalConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	t.Run("list", func(t *testing.T) {
+		listAll = false
+		err := listCmd.RunE(nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not connected")
+	})
+	t.Run("add", func(t *testing.T) {
+		addTitle, addJustification, addExpires = "gap", "j", "2026-12-31T00:00:00Z"
+		t.Cleanup(func() { addTitle, addJustification, addExpires = "", "", "" })
+		err := addCmd.RunE(nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not connected")
+	})
+	t.Run("approve", func(t *testing.T) {
+		approveID = 5
+		t.Cleanup(func() { approveID = 0 })
+		err := approveCmd.RunE(nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not connected")
+	})
+	t.Run("revoke", func(t *testing.T) {
+		revokeID = 5
+		t.Cleanup(func() { revokeID = 0 })
+		err := revokeCmd.RunE(nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not connected")
+	})
+}
+
 func TestRevoke_RequiredIDAndRemote(t *testing.T) {
 	revokeID = 0
 	require.ErrorContains(t, revokeCmd.RunE(nil, nil), "--id is required")

--- a/internal/cli/rotation/rotation_g80_test.go
+++ b/internal/cli/rotation/rotation_g80_test.go
@@ -1,0 +1,228 @@
+// rotation_g80_test.go — coverage sweep for the remaining branches in rotation.go,
+// order.go and plan.go: per-command "not connected" and server-error paths for
+// list/create/show/delete/status, orderCmd/planCmd not-connected and fetch-error
+// paths driven through RunE (not just the split-out fetch* helpers), and the
+// create body's optional-field branches (description, environment-id).
+package rotation
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// notConnected points KEYORIX_SERVER/TOKEN at nothing and isolates config
+// discovery so common.NewRemoteClient() (and client()) reliably reports "not
+// connected", mirroring TestClientHelper_NotConnected in rotation_extra_test.go.
+func notConnected(t *testing.T) {
+	t.Helper()
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+}
+
+func TestListCmd_NotConnected(t *testing.T) {
+	notConnected(t)
+	err := listCmd.RunE(listCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestListCmd_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	lProject, lEnv = 0, 0
+	err := listCmd.RunE(listCmd, nil)
+	require.Error(t, err)
+}
+
+func TestCreateCmd_NotConnected(t *testing.T) {
+	notConnected(t)
+	cName, cScope, cInterval, cProject, cEnv, cDesc = "x", "project", 30, 5, 0, ""
+	err := createCmd.RunE(createCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestCreateCmd_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	cName, cScope, cInterval, cProject, cEnv, cDesc = "x", "project", 30, 5, 0, ""
+	err := createCmd.RunE(createCmd, nil)
+	require.Error(t, err)
+}
+
+// TestCreateCmd_DescriptionAndEnvironmentInBody verifies the create body carries
+// "description" only when --description is set, and carries "environment_id"
+// (not "project_id") for environment-scoped policies.
+func TestCreateCmd_DescriptionAndEnvironmentInBody(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{"data":{"ID":9,"Name":"env-policy","Scope":"environment","EnvironmentID":4,"IntervalDays":14,"AlertDaysBefore":3}}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	cName, cScope, cProject, cEnv, cInterval, cAlert, cNotify, cDesc =
+		"env-policy", "environment", 0, 4, 14, 3, false, "rotate the env creds"
+	require.NoError(t, createCmd.RunE(createCmd, nil))
+
+	assert.Equal(t, "rotate the env creds", gotBody["description"])
+	assert.Equal(t, float64(4), gotBody["environment_id"])
+	assert.NotContains(t, gotBody, "project_id")
+}
+
+func TestShowCmd_NotConnected(t *testing.T) {
+	notConnected(t)
+	err := showCmd.RunE(showCmd, []string{"3"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestShowCmd_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	err := showCmd.RunE(showCmd, []string{"3"})
+	require.Error(t, err)
+}
+
+func TestDeleteCmd_NotConnected(t *testing.T) {
+	notConnected(t)
+	err := deleteCmd.RunE(deleteCmd, []string{"3"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestDeleteCmd_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	err := deleteCmd.RunE(deleteCmd, []string{"3"})
+	require.Error(t, err)
+}
+
+func TestStatusCmd_NotConnected(t *testing.T) {
+	notConnected(t)
+	sProject = 0
+	err := statusCmd.RunE(statusCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestStatusCmd_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	sProject = 0
+	err := statusCmd.RunE(statusCmd, nil)
+	require.Error(t, err)
+}
+
+// TestOrderCmd_InvalidProjectID verifies orderCmd's own id-parsing branch
+// (distinct from planCmd's, and from the direct fetchRotationOrder tests which
+// never exercise argument parsing).
+func TestOrderCmd_InvalidProjectID(t *testing.T) {
+	err := orderCmd.RunE(orderCmd, []string{"abc"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid project id")
+
+	err = orderCmd.RunE(orderCmd, []string{"0"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid project id")
+}
+
+func TestOrderCmd_NotConnected(t *testing.T) {
+	notConnected(t)
+	err := orderCmd.RunE(orderCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+// TestOrderCmd_FetchError verifies the RunE-level error branch after
+// fetchRotationOrder fails (distinct from calling fetchRotationOrder directly).
+func TestOrderCmd_FetchError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	err := orderCmd.RunE(orderCmd, []string{"1"})
+	require.Error(t, err)
+}
+
+func TestPlanCmd_NotConnected(t *testing.T) {
+	notConnected(t)
+	origAllProjects := planAllProjects
+	defer func() { planAllProjects = origAllProjects }()
+	planAllProjects = false
+
+	err := planCmd.RunE(planCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+// TestPlanCmd_FetchError verifies the RunE-level error branch after
+// fetchRotationPlan fails for a single project.
+func TestPlanCmd_FetchError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	origAllProjects := planAllProjects
+	defer func() { planAllProjects = origAllProjects }()
+	planAllProjects = false
+
+	err := planCmd.RunE(planCmd, []string{"1"})
+	require.Error(t, err)
+}
+
+// TestPlanCmd_AllProjectsFetchError verifies the RunE-level error branch after
+// fetchDeploymentRotationPlan fails.
+func TestPlanCmd_AllProjectsFetchError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+	setRemote(t, srv.URL)
+
+	origAllProjects := planAllProjects
+	defer func() { planAllProjects = origAllProjects }()
+	planAllProjects = true
+
+	err := planCmd.RunE(planCmd, []string{})
+	require.Error(t, err)
+}

--- a/internal/cli/run/run_g80_test.go
+++ b/internal/cli/run/run_g80_test.go
@@ -1,0 +1,222 @@
+// run_g80_test.go — additional coverage for branches not exercised by the
+// existing run_test.go / run_extra_test.go / run_fetch_test.go / run_s2_test.go /
+// run_s25_test.go / run_dangerous_env_test.go suites:
+//   - fetchSecretsEmbedded's common.InitializeCoreService error branch
+//   - fetchSecretsEmbedded's ListProjects error branch (via a canceled context)
+//   - fetchSecretsEmbedded skipping a secret whose value fetch fails (expired secret)
+//   - fetchSecretsRemote's invalid-endpoint branch
+//   - fetchSecretsRemote's maxRunInjectedSecrets cap
+//   - execChild's os.Exit(exitErr.ExitCode()) branch, tested via the repo's
+//     established re-exec-the-test-binary pattern (see
+//     cmd/validate-translations/main_s23_test.go's TestHelperProcess_S23_Main)
+//     since calling os.Exit in-process would kill the whole `go test` run.
+package run
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFetchSecretsEmbedded_InitializeServiceError verifies that when the
+// underlying storage cannot be created (an unrecognized storage.type in the
+// resolved config), fetchSecretsEmbedded surfaces it as a wrapped
+// "failed to initialize service" error instead of panicking or returning a
+// nil service that the rest of the function would then dereference.
+func TestFetchSecretsEmbedded_InitializeServiceError(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		// An unrecognized storage type makes the storage factory fail fast,
+		// with no network I/O or migration involved (mirrors
+		// internal/storage's own TestCreateStorage_RejectsUnknownStorageType).
+		Storage: config.StorageConfig{Type: "postgres_typo"},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	got, err := fetchSecretsEmbedded(context.Background(), "web", "dev")
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+// TestFetchSecretsEmbedded_ListProjectsError_ContextCanceled verifies that a
+// canceled context propagates through the core service's storage layer and is
+// surfaced as a wrapped "failed to list projects" error rather than the
+// function hanging or panicking on a nil projects slice.
+func TestFetchSecretsEmbedded_ListProjectsError_ContextCanceled(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "s.db")}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled before fetchSecretsEmbedded's first ctx-consuming call
+
+	got, err := fetchSecretsEmbedded(ctx, "web", "dev")
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "failed to list projects")
+}
+
+// TestFetchSecretsEmbedded_SkipsExpiredSecret verifies the embedded-mode
+// counterpart of TestFetchSecretsRemote_SkipsFailedSecretValue: a secret whose
+// GetSecretValue call fails (here, because it is already expired) is skipped
+// with a warning, and the fetch still succeeds with the other, valid secret's
+// value present.
+func TestFetchSecretsEmbedded_SkipsExpiredSecret(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, config.Save(cfgPath, &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "s.db")}},
+	}))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	ctx := context.Background()
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	project, err := svc.CreateProjectWithEnvs(ctx, "web", "", []string{"dev"})
+	require.NoError(t, err)
+	envs, err := svc.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, envs)
+
+	// A secret that is already expired: GetSecretValue's enforceSecretReadGuards
+	// rejects it, which fetchSecretsEmbedded must treat as a skip-with-warning,
+	// not a fatal error for the whole run.
+	pastExpiration := time.Now().Add(-1 * time.Hour)
+	_, err = svc.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "expired-secret", Value: []byte("should-not-be-injected"), ProjectID: project.ID,
+		EnvironmentID: envs[0].ID, Type: "password", CreatedBy: "test", Expiration: &pastExpiration,
+	})
+	require.NoError(t, err)
+	_, err = svc.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "live-secret", Value: []byte("should-be-injected"), ProjectID: project.ID,
+		EnvironmentID: envs[0].ID, Type: "password", CreatedBy: "test",
+	})
+	require.NoError(t, err)
+
+	got, err := fetchSecretsEmbedded(ctx, "web", "dev")
+	require.NoError(t, err, "an expired secret must be skipped, not fail the whole fetch")
+	assert.Equal(t, "should-be-injected", got["LIVE_SECRET"])
+	assert.NotContains(t, got, "EXPIRED_SECRET", "an expired secret's value must never be injected into the child process")
+}
+
+// TestFetchSecretsRemote_InvalidEndpoint verifies that an endpoint which fails
+// common.ValidateRemoteEndpointURL (e.g. no scheme) is rejected up front with a
+// clear "invalid remote endpoint" error, before any HTTP request is attempted.
+func TestFetchSecretsRemote_InvalidEndpoint(t *testing.T) {
+	got, err := fetchSecretsRemote(context.Background(), "not-a-valid-endpoint", "tok", "web", "dev")
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "invalid remote endpoint")
+}
+
+// TestFetchSecretsRemote_ExceedsMaxInjectedSecrets verifies the #G44 cap:
+// fetchSecretsRemote refuses to continue, rather than silently truncating or
+// exhausting memory/ARG_MAX, once the number of secrets seen crosses
+// maxRunInjectedSecrets.
+func TestFetchSecretsRemote_ExceedsMaxInjectedSecrets(t *testing.T) {
+	const tooMany = 2001 // maxRunInjectedSecrets is 2000
+	var secretsJSON strings.Builder
+	secretsJSON.WriteString(`{"data":{"secrets":[`)
+	for i := 0; i < tooMany; i++ {
+		if i > 0 {
+			secretsJSON.WriteByte(',')
+		}
+		fmt.Fprintf(&secretsJSON, `{"id":%d,"name":"s%d"}`, i+1, i+1)
+	}
+	secretsJSON.WriteString(`]}}`)
+	body := secretsJSON.String()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(`{"data":{"projects":[{"id":1,"name":"web"}]}}`))
+		case "/api/v1/projects/1/environments":
+			_, _ = w.Write([]byte(`{"data":{"environments":[{"id":2,"name":"dev"}]}}`))
+		case "/api/v1/secrets":
+			_, _ = w.Write([]byte(body))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	got, err := fetchSecretsRemote(context.Background(), srv.URL, "tok", "web", "dev")
+	require.Error(t, err, "a project/environment with more than maxRunInjectedSecrets must abort the run")
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "more than 2000 secrets")
+	assert.Contains(t, err.Error(), "web")
+	assert.Contains(t, err.Error(), "dev")
+}
+
+// ---------------------------------------------------------------------------
+// execChild — os.Exit(exitErr.ExitCode()) branch, exercised via a re-exec'd
+// subprocess (calling os.Exit in-process would kill the whole `go test` run).
+// Mirrors cmd/validate-translations/main_s23_test.go's TestHelperProcess
+// pattern, scoped to this package with its own env var name.
+// ---------------------------------------------------------------------------
+
+// TestHelperProcess_G80_ExecChild is not a real test: it is invoked only by
+// TestExecChild_NonZeroExitPropagatesAsProcessExitCode as a subprocess entry
+// point. When run directly by `go test` (without GO_WANT_HELPER_PROCESS_RUN_G80
+// set) it is a no-op.
+func TestHelperProcess_G80_ExecChild(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS_RUN_G80") != "1" {
+		return
+	}
+	// The child command itself exits 7; execChild must translate that into an
+	// *exec.ExitError, hit the errors.As branch, and os.Exit(7) — never
+	// reaching this test's own return/pass/fail machinery.
+	err := execChild([]string{"sh", "-c", "exit 7"}, nil, false)
+	// Only reachable if execChild did NOT os.Exit, which is itself a bug this
+	// subprocess is designed to catch.
+	fmt.Fprintf(os.Stderr, "execChild returned instead of os.Exit-ing: %v\n", err)
+	os.Exit(9)
+}
+
+// TestExecChild_NonZeroExitPropagatesAsProcessExitCode verifies that when the
+// launched child command exits non-zero, execChild's *exec.ExitError branch
+// terminates the CURRENT process with that same exit code (os.Exit), rather
+// than returning a Go error the caller could otherwise recover from.
+func TestExecChild_NonZeroExitPropagatesAsProcessExitCode(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelperProcess_G80_ExecChild") // #nosec G204 -- re-execs the trusted test binary itself for os.Exit isolation
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS_RUN_G80=1")
+
+	out, err := cmd.CombinedOutput()
+	exitErr, ok := err.(*exec.ExitError)
+	require.True(t, ok, "expected the subprocess to terminate via os.Exit with a non-zero code, got err=%v output=%s", err, out)
+	assert.Equal(t, 7, exitErr.ExitCode(), "execChild must os.Exit with the child command's own exit code")
+}

--- a/internal/cli/sod/sod_test.go
+++ b/internal/cli/sod/sod_test.go
@@ -89,6 +89,54 @@ func TestPolicyDelete_RequiredIDAndRemote(t *testing.T) {
 	assert.Contains(t, out, "Deleted SoD policy 5.")
 }
 
+// TestNotConnected_IsolatedConfig exercises the same "not connected" branches
+// as sod_s25_test.go's *_NotConnected tests, but hermetically: it redirects
+// XDG_CONFIG_HOME to an empty temp dir so ResolveRemote can't fall back to a
+// developer's real ~/.keyorix/cli.yaml (see internal/cli/common/common_test.go
+// for the same isolation convention). Without this, a machine with a stale
+// client-mode cli.yaml makes these commands dial a real (possibly dead)
+// endpoint instead of hitting the "not connected" guard — which is exactly
+// the pre-existing, local-only failure mode of the sibling tests in
+// sod_s25_test.go.
+func TestNotConnected_IsolatedConfig(t *testing.T) {
+	t.Run("policy list", func(t *testing.T) {
+		t.Setenv("KEYORIX_SERVER", "")
+		t.Setenv("KEYORIX_TOKEN", "")
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		err := policyListCmd.RunE(nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not connected")
+	})
+	t.Run("policy create", func(t *testing.T) {
+		t.Setenv("KEYORIX_SERVER", "")
+		t.Setenv("KEYORIX_TOKEN", "")
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		sName, sPermA, sPermB = "p", "roles.assign", "secrets.delete"
+		t.Cleanup(func() { sName, sPermA, sPermB = "", "", "" })
+		err := policyCreateCmd.RunE(nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not connected")
+	})
+	t.Run("policy delete", func(t *testing.T) {
+		t.Setenv("KEYORIX_SERVER", "")
+		t.Setenv("KEYORIX_TOKEN", "")
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		sID = 7
+		t.Cleanup(func() { sID = 0 })
+		err := policyDeleteCmd.RunE(nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not connected")
+	})
+	t.Run("violations", func(t *testing.T) {
+		t.Setenv("KEYORIX_SERVER", "")
+		t.Setenv("KEYORIX_TOKEN", "")
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		err := violationsCmd.RunE(nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not connected")
+	})
+}
+
 func TestViolations_Remote(t *testing.T) {
 	t.Run("none", func(t *testing.T) {
 		setupRemote(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cli/status/status_s3_test.go
+++ b/internal/cli/status/status_s3_test.go
@@ -1,0 +1,100 @@
+// status_s3_test.go — sprint-3 coverage additions for the status package.
+// Targets: runStatus's "Unhealthy" branch (service initializes but HealthCheck
+// fails) and runPing's per-iteration "Failed" branch + "Partial connectivity"
+// summary branch (some pings succeed, some fail against the same backend).
+package status
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunStatus_RemoteUnhealthy exercises the branch in runStatus where
+// common.InitializeCoreService succeeds (a well-formed remote config with a
+// reachable server) but service.HealthCheck returns an error because the
+// server's /health endpoint reports success:false. This is the "err != nil"
+// arm of the health-check if/else that the other remote tests (which fail at
+// InitializeCoreService itself, before ever reaching HealthCheck) don't reach.
+func TestRunStatus_RemoteUnhealthy(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintln(w, `{"success":false,"error":{"code":"UNHEALTHY","message":"backend degraded"}}`)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_REMOTE_API_KEY", "test-api-key")
+
+	writePingConfig(t, dir, srv.URL, 2)
+
+	out := captureStdout(t, func() { require.NoError(t, runStatus(nil, nil)) })
+
+	assert.Contains(t, out, "Storage Type: 🌐 Remote")
+	assert.Contains(t, out, "❌ Unhealthy (health check failed: UNHEALTHY: backend degraded)")
+	assert.Contains(t, out, "Response Time:")
+}
+
+// TestRunPing_PartialConnectivity exercises runPing's per-iteration "Failed"
+// branch (HealthCheck errors after a successful InitializeCoreService) and the
+// "Partial connectivity" summary branch (0 < successCount < pingCount) by
+// pointing at a real server that succeeds on the first health check and fails
+// on the rest.
+//
+// Note: runPing sleeps 1s between iterations so this test takes ~2s.
+func TestRunPing_PartialConnectivity(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if calls.Add(1) == 1 {
+			_, _ = fmt.Fprintln(w, `{"success":true}`)
+			return
+		}
+		_, _ = fmt.Fprintln(w, `{"success":false,"error":{"code":"UNHEALTHY","message":"degraded"}}`)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_REMOTE_API_KEY", "test-api-key")
+
+	writePingConfig(t, dir, srv.URL, 2)
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	require.NoError(t, runPing(nil, nil))
+	_ = w.Close()
+	outBytes, _ := io.ReadAll(r)
+	out := string(outBytes)
+
+	assert.Contains(t, out, "Ping 1: ✅ Success")
+	assert.Contains(t, out, "Ping 2: ❌ Failed (health check failed: UNHEALTHY: degraded)")
+	assert.Contains(t, out, "Ping 3: ❌ Failed (health check failed: UNHEALTHY: degraded)")
+	assert.Contains(t, out, "Successful:     1")
+	assert.Contains(t, out, "Failed:         2")
+	assert.Contains(t, out, "Status:         ⚠️  Partial connectivity")
+	assert.Equal(t, int32(3), calls.Load())
+}

--- a/internal/cli/system/system_s26_test.go
+++ b/internal/cli/system/system_s26_test.go
@@ -1,0 +1,317 @@
+// system_s26_test.go — coverage sprint 26 for internal/cli/system.
+// Targets the wrapped-error branches in runInit that weren't reachable through
+// the existing "selective component" tests (which use a template config that
+// makes every downstream step succeed), plus a couple of always-0%
+// helper/branch spots:
+//   - runInit: generateConfigFile() error branch (init.go:101-103)
+//   - runInit: config.Load() error branch (init.go:106-108)
+//   - runInit: initializeEncryption() error branch (init.go:111-113), and
+//     initializeEncryption's own DEK-dir/salt-dir MkdirAll failure branches
+//   - runInit: initializeDatabase() error branch (init.go:117-119), and
+//     initializeDatabase's own MkdirAll failure branch (distinct from the
+//     already-covered ".." rejection)
+//   - runInit: initializeLogging() error branch (init.go:123-125), and
+//     initializeLogging's own OpenFile failure branch
+//   - generateConfigFile: MkdirAll failure and SecureWriteFileSync failure
+//     branches (init.go:150-152, 154-156)
+//   - refuseInitRedirect (init.go, 0% covered): the http.Client CheckRedirect
+//     guard is never invoked in-process (no test server issues a 3xx), so it
+//     needs a direct unit test
+//   - runAuditNoExit: the spec.path == "" skip branch (audit.go:66-67) — hit
+//     when a config has no encryption paths configured at all
+package system
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ──────────────────────────── refuseInitRedirect ───────────────────────────
+
+// TestRefuseInitRedirect exercises the CheckRedirect guard directly: it must
+// always return a non-nil error naming the redirect target, since runRemoteInit
+// relies on it never letting the credential-carrying POST follow a 3xx.
+func TestRefuseInitRedirect(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://internal.example.invalid/imds", nil)
+	require.NoError(t, err)
+
+	rerr := refuseInitRedirect(req, nil)
+	require.Error(t, rerr)
+	assert.Contains(t, rerr.Error(), "refusing to follow redirect")
+	assert.Contains(t, rerr.Error(), "internal.example.invalid")
+}
+
+// ──────────────────────────── runInit wrapped-error branches ───────────────
+
+// TestRunInit_GenerateConfigFileErrorPropagates exercises init.go:101-103: when
+// generateConfigFile fails (no template file present, and the config doesn't
+// already exist so the "already exists" skip can't short-circuit first),
+// runInit must wrap and return that error rather than continuing.
+func TestRunInit_GenerateConfigFileErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir) // deliberately no keyorix_template.yaml here
+
+	restore := saveInitFlags(t)
+	defer restore()
+	configPath = "keyorix.yaml"
+	force = true
+	initAll = true
+	initServer = ""
+
+	err := runInit(InitCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to generate config file")
+}
+
+// TestRunInit_ConfigLoadErrorPropagates exercises init.go:106-108: the
+// template is written successfully but contains a field config.Load's
+// KnownFields(true) decoder rejects, so config.Load fails on the freshly
+// generated file and runInit must wrap that error.
+func TestRunInit_ConfigLoadErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	badTemplate := "storage:\n  type: local\n  totally_unrecognized_field: true\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keyorix_template.yaml"), []byte(badTemplate), 0600))
+	t.Chdir(dir)
+
+	restore := saveInitFlags(t)
+	defer restore()
+	configPath = "keyorix.yaml"
+	force = false
+	initAll = true
+	initServer = ""
+
+	err := runInit(InitCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+// TestRunInit_InitializeEncryptionErrorPropagates exercises init.go:111-113
+// (and, inside initializeEncryption itself, the DEK-dir MkdirAll failure
+// branch): the generated config's dek_path/salt_path sit under a path
+// component that's already an existing regular file, so MkdirAll fails with
+// ENOTDIR and runInit must wrap that error.
+func TestRunInit_InitializeEncryptionErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("not a directory"), 0600))
+
+	template := fmt.Sprintf("storage:\n  type: local\n  encryption:\n    dek_path: %s/dek.bin\n    salt_path: %s/salt.bin\n", blocker, blocker)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keyorix_template.yaml"), []byte(template), 0600))
+	t.Chdir(dir)
+
+	restore := saveInitFlags(t)
+	defer restore()
+	configPath = "keyorix.yaml"
+	force = false
+	initAll = true
+	initEncryption = true
+	initDatabase = false
+	initLogging = false
+	initServer = ""
+
+	err := runInit(InitCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize encryption")
+}
+
+// TestRunInit_InitializeDatabaseErrorPropagates exercises init.go:117-119: the
+// generated config's database path contains "..", which initializeDatabase
+// rejects, and runInit must wrap that error.
+func TestRunInit_InitializeDatabaseErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	template := "storage:\n  type: local\n  database:\n    path: ../escapes.db\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keyorix_template.yaml"), []byte(template), 0600))
+	t.Chdir(dir)
+
+	restore := saveInitFlags(t)
+	defer restore()
+	configPath = "keyorix.yaml"
+	force = false
+	initAll = true
+	initEncryption = false
+	initDatabase = true
+	initLogging = false
+	initServer = ""
+
+	err := runInit(InitCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize database")
+}
+
+// TestRunInit_InitializeLoggingErrorPropagates exercises init.go:123-125 (and,
+// inside initializeLogging itself, the OpenFile non-IsExist failure branch):
+// the config already exists (so generateConfigFile takes the no-write skip
+// path) and the working directory is read-only, so initializeLogging's
+// os.OpenFile(O_CREATE) for keyorix.log fails with permission denied — a
+// non-IsExist error — and runInit must wrap it.
+func TestRunInit_InitializeLoggingErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "keyorix.yaml"), []byte(minimalTemplate), 0600))
+	t.Chdir(dir)
+
+	restore := saveInitFlags(t)
+	defer restore()
+	configPath = "keyorix.yaml" // already exists: generateConfigFile takes the no-write branch
+	force = false
+	initAll = true
+	initEncryption = false
+	initDatabase = false
+	initLogging = true
+	initServer = ""
+
+	require.NoError(t, os.Chmod(dir, 0500)) // read+execute only: blocks creating keyorix.log
+	t.Cleanup(func() { _ = os.Chmod(dir, 0750) })
+
+	err := runInit(InitCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize logging")
+}
+
+// ──────────────────────────── generateConfigFile own error branches ────────
+
+// TestGenerateConfigFile_MkdirAllFails exercises init.go:150-152: configPath's
+// parent directory can't be created because a path component ("blocker") is
+// already an existing regular file, not a directory.
+func TestGenerateConfigFile_MkdirAllFails(t *testing.T) {
+	dir := setupInitDir(t) // template present, cwd = dir
+
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0600))
+
+	restore := saveInitFlags(t)
+	defer restore()
+	configPath = filepath.Join("blocker", "sub", "keyorix.yaml")
+	force = true
+
+	out := captureStdout(t, func() {
+		err := generateConfigFile()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create config directory")
+	})
+	assert.Contains(t, out, "Generating config file")
+}
+
+// TestGenerateConfigFile_WriteFails exercises init.go:154-156:
+// SecureWriteFileSync fails because configPath names an existing directory,
+// not a writable regular-file target.
+func TestGenerateConfigFile_WriteFails(t *testing.T) {
+	dir := setupInitDir(t) // template present, cwd = dir
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "existing-dir"), 0750))
+
+	restore := saveInitFlags(t)
+	defer restore()
+	configPath = "existing-dir"
+	force = true
+
+	out := captureStdout(t, func() {
+		err := generateConfigFile()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to write config file")
+	})
+	assert.Contains(t, out, "Generating config file")
+}
+
+// ──────────────────────────── initializeDatabase own error branch ──────────
+
+// TestInitializeDatabase_MkdirAllFails exercises init.go:167-169: the database
+// directory can't be created because a path component is an existing regular
+// file — distinct from the already-covered ".." rejection branch.
+func TestInitializeDatabase_MkdirAllFails(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0600))
+	dbPath := filepath.Join(blocker, "sub", "secrets.db")
+
+	cfg := &config.Config{
+		Storage: config.StorageConfig{
+			Database: config.DatabaseConfig{Path: dbPath},
+		},
+	}
+	err := initializeDatabase(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create database directory")
+}
+
+// TestInitializeDatabase_OpenFileFailsNotExist exercises init.go:177-179: the
+// database directory already exists but is read-only, so os.OpenFile's
+// O_CREATE fails with permission-denied — a non-IsExist error distinct from
+// the "file already exists" ok-path.
+func TestInitializeDatabase_OpenFileFailsNotExist(t *testing.T) {
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "dbdir")
+	require.NoError(t, os.Mkdir(subDir, 0750))
+	dbPath := filepath.Join(subDir, "secrets.db")
+
+	require.NoError(t, os.Chmod(subDir, 0500)) // read+execute only, no write
+	t.Cleanup(func() { _ = os.Chmod(subDir, 0750) })
+
+	cfg := &config.Config{
+		Storage: config.StorageConfig{
+			Database: config.DatabaseConfig{Path: dbPath},
+		},
+	}
+	err := initializeDatabase(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create database file")
+}
+
+// ──────────────────────────── initializeEncryption own error branches ──────
+
+// TestInitializeEncryption_SaltDirMkdirAllFails exercises init.go:191-193 (the
+// salt-dir MkdirAll failure), distinct from the DEK-dir failure already
+// covered via TestRunInit_InitializeEncryptionErrorPropagates: the DEK
+// directory can be created fine, but the salt directory's parent is an
+// existing regular file.
+func TestInitializeEncryption_SaltDirMkdirAllFails(t *testing.T) {
+	dir := t.TempDir()
+	dekPath := filepath.Join(dir, "dek-dir", "dek.bin")
+
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0600))
+	saltPath := filepath.Join(blocker, "sub", "salt.bin")
+
+	cfg := &config.Config{
+		Storage: config.StorageConfig{
+			Encryption: config.EncryptionConfig{DEKPath: dekPath, SaltPath: saltPath},
+		},
+	}
+	err := initializeEncryption(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create salt directory")
+
+	// The DEK directory must have been created successfully before the salt
+	// failure was hit, confirming this test exercises the SECOND MkdirAll,
+	// not a repeat of the DEK-dir failure branch.
+	_, statErr := os.Stat(filepath.Dir(dekPath))
+	require.NoError(t, statErr, "DEK directory should have been created before the salt MkdirAll failed")
+}
+
+// ──────────────────────────── runAuditNoExit: empty key-path skip ──────────
+
+// TestRunAuditNoExit_SkipsUnconfiguredKeyPaths exercises audit.go:66-67: when
+// a config has no storage.encryption.salt_path/dek_path configured (both are
+// the empty string), the per-spec loop must `continue` rather than trying to
+// stat an empty path — the audit should still pass, checking only the config
+// file's own permissions.
+func TestRunAuditNoExit_SkipsUnconfiguredKeyPaths(t *testing.T) {
+	resetAuditConfigFile(t)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "no-encryption-paths.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("storage:\n  type: local\n"), 0600))
+	auditConfigFile = cfgPath
+
+	var failed bool
+	out := captureStdout(t, func() {
+		failed = runAuditNoExit()
+	})
+
+	assert.False(t, failed, "audit must pass when no salt/DEK paths are configured at all")
+	assert.Contains(t, out, "Audit passed")
+}

--- a/internal/cli/trust/trust_s25_test.go
+++ b/internal/cli/trust/trust_s25_test.go
@@ -177,3 +177,34 @@ func TestKeygen_DirDoesNotExist(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "write private key")
 }
+
+// TestKeygen_PublicKeyWriteFails_AfterPrivateKeySucceeds covers the branch
+// where the private key write succeeds but the public key write fails: a
+// dangling symlink planted only at the public-key path makes
+// SecureWriteFileSync refuse to write through it (O_NOFOLLOW), while the
+// private-key path is untouched and writes normally. The error must be
+// wrapped as "write public key: …", and the already-written private key
+// file must be left in place (the command does not roll it back).
+func TestKeygen_PublicKeyWriteFails_AfterPrivateKeySucceeds(t *testing.T) {
+	resetKeygenVars(t)
+	dir := t.TempDir()
+	outsideTarget := filepath.Join(t.TempDir(), "exfiltrated.public.pem")
+	require.NoError(t, os.Symlink(outsideTarget, filepath.Join(dir, "pub-sym-key.public.pem")))
+
+	keygenPurpose = "update"
+	keygenKeyID = "pub-sym-key"
+	keygenDir = dir
+	keygenForce = false
+
+	err := keygenCmd.RunE(keygenCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write public key")
+
+	_, statErr := os.Stat(outsideTarget)
+	assert.True(t, os.IsNotExist(statErr), "the symlink target must NOT have been created")
+
+	privPath := filepath.Join(dir, "pub-sym-key.private.pem")
+	fi, err := os.Stat(privPath)
+	require.NoError(t, err, "the private key write happens first and must have succeeded")
+	assert.Equal(t, os.FileMode(0o600), fi.Mode().Perm())
+}

--- a/internal/cli/usage/usage_test.go
+++ b/internal/cli/usage/usage_test.go
@@ -1,0 +1,261 @@
+// usage_test.go exercises runShow, runShowRemote, and the printReport
+// branches (table/json format, sorting, empty-state) that
+// terminal_injection_test.go's single G69 regression test doesn't cover.
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetFlags restores the package-level flag vars to their zero/default
+// values after a test mutates them, so tests don't leak state into each
+// other (these are cobra flag-backed globals, not per-test locals).
+func resetFlags(t *testing.T) {
+	t.Helper()
+	origDays, origProjectID, origFormat := flagDays, flagProjectID, flagFormat
+	t.Cleanup(func() {
+		flagDays, flagProjectID, flagFormat = origDays, origProjectID, origFormat
+	})
+}
+
+func TestRunShowRemote_Success(t *testing.T) {
+	resetFlags(t)
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.RequestURI()
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer tok")
+		}
+		report := storage.UsageReport{
+			WindowDays:  7,
+			GeneratedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+			Projects: []storage.ProjectUsageStat{
+				{ProjectID: 1, ProjectName: "alpha", SecretCount: 2, ReadsInWindow: 5, UniqueReaders: 1},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		body, err := json.Marshal(map[string]interface{}{"data": report})
+		require.NoError(t, err)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	rc, ok := common.NewRemoteClientWithCredentials(srv.URL, "tok")
+	require.True(t, ok)
+
+	flagDays = 7
+	flagProjectID = 42
+	flagFormat = "table"
+
+	out, err := captureStdout(t, func() error { return runShowRemote(context.Background(), rc) })
+	require.NoError(t, err)
+	assert.Equal(t, "/api/v1/admin/usage?days=7&project_id=42", gotPath)
+	assert.Contains(t, out, "alpha")
+	assert.Contains(t, out, "last 7 days")
+}
+
+func TestRunShowRemote_OmitsProjectIDWhenZero(t *testing.T) {
+	resetFlags(t)
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.RequestURI()
+		body, err := json.Marshal(map[string]interface{}{"data": storage.UsageReport{WindowDays: 30}})
+		require.NoError(t, err)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	rc, ok := common.NewRemoteClientWithCredentials(srv.URL, "tok")
+	require.True(t, ok)
+
+	flagDays = 30
+	flagProjectID = 0
+	flagFormat = "table"
+
+	_, err := captureStdout(t, func() error { return runShowRemote(context.Background(), rc) })
+	require.NoError(t, err)
+	assert.Equal(t, "/api/v1/admin/usage?days=30", gotPath)
+}
+
+func TestRunShowRemote_ServerError(t *testing.T) {
+	resetFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	rc, ok := common.NewRemoteClientWithCredentials(srv.URL, "tok")
+	require.True(t, ok)
+
+	flagDays = 30
+	flagFormat = "table"
+
+	err := runShowRemote(context.Background(), rc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch usage report")
+}
+
+// TestRunShow_RemoteMode drives runShow's cobra RunE entry point end to end
+// via env-var-resolved remote mode (KEYORIX_SERVER/KEYORIX_TOKEN), verifying
+// it dispatches to runShowRemote rather than the embedded-storage path.
+func TestRunShow_RemoteMode(t *testing.T) {
+	resetFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/admin/usage?days=15", r.URL.RequestURI())
+		body, err := json.Marshal(map[string]interface{}{
+			"data": storage.UsageReport{WindowDays: 15, GeneratedAt: time.Now()},
+		})
+		require.NoError(t, err)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	origServer, hadServer := os.LookupEnv("KEYORIX_SERVER")
+	origToken, hadToken := os.LookupEnv("KEYORIX_TOKEN")
+	t.Cleanup(func() {
+		if hadServer {
+			os.Setenv("KEYORIX_SERVER", origServer)
+		} else {
+			os.Unsetenv("KEYORIX_SERVER")
+		}
+		if hadToken {
+			os.Setenv("KEYORIX_TOKEN", origToken)
+		} else {
+			os.Unsetenv("KEYORIX_TOKEN")
+		}
+	})
+	require.NoError(t, os.Setenv("KEYORIX_SERVER", srv.URL))
+	require.NoError(t, os.Setenv("KEYORIX_TOKEN", "tok"))
+
+	flagDays = 15
+	flagProjectID = 0
+	flagFormat = "table"
+
+	out, err := captureStdout(t, func() error { return runShow(nil, nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "last 15 days")
+}
+
+// TestRunShow_LocalModeStorageInitFailure drives runShow's embedded/local-mode
+// branch (no remote config resolved) through common.InitializeStorage's own
+// config.Load failure. HOME is redirected to an empty temp dir so this does
+// not depend on (or get derailed by) a real ~/.keyorix/cli.yaml that might be
+// present on the machine running the test — see the "Local ~/.keyorix/cli.yaml
+// breaks CLI tests" pitfall: without this, a real connect config on the
+// developer's machine could route this at a live remote server instead of
+// exercising the local branch this test targets.
+func TestRunShow_LocalModeStorageInitFailure(t *testing.T) {
+	resetFlags(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_SERVER", "")
+
+	flagDays = 30
+	flagProjectID = 0
+	flagFormat = "table"
+
+	err := runShow(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+func TestPrintReport_JSONFormat(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "json"
+	report := &storage.UsageReport{
+		WindowDays:  9,
+		GeneratedAt: time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC),
+		Projects: []storage.ProjectUsageStat{
+			{ProjectID: 3, ProjectName: "gamma", SecretCount: 1, ReadsInWindow: 2, UniqueReaders: 1},
+		},
+	}
+	out, err := captureStdout(t, func() error { return printReport(report) })
+	require.NoError(t, err)
+
+	var decoded storage.UsageReport
+	require.NoError(t, json.Unmarshal([]byte(out), &decoded))
+	assert.Equal(t, 9, decoded.WindowDays)
+	require.Len(t, decoded.Projects, 1)
+	assert.Equal(t, "gamma", decoded.Projects[0].ProjectName)
+}
+
+func TestPrintReport_EmptyProjectsShowsNoData(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "table"
+	report := &storage.UsageReport{WindowDays: 30, GeneratedAt: time.Now()}
+	out, err := captureStdout(t, func() error { return printReport(report) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "(no data)")
+}
+
+// TestPrintReport_SortsByNameThenProjectID exercises both branches of the
+// sort.Slice comparator: names differ (primary key), and names are equal so
+// it must fall back to comparing ProjectID.
+func TestPrintReport_SortsByNameThenProjectID(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "table"
+	report := &storage.UsageReport{
+		WindowDays:  30,
+		GeneratedAt: time.Now(),
+		Projects: []storage.ProjectUsageStat{
+			// SecretCount differs between the two same-named projects so
+			// their printed rows are distinguishable, letting the test
+			// confirm the ProjectID tie-break actually reordered them
+			// (rather than just preserving input order coincidentally).
+			{ProjectID: 20, ProjectName: "dup", SecretCount: 99},
+			{ProjectID: 2, ProjectName: "zeta", SecretCount: 1},
+			{ProjectID: 10, ProjectName: "dup", SecretCount: 1},
+			{ProjectID: 1, ProjectName: "alpha", SecretCount: 1},
+		},
+	}
+	out, err := captureStdout(t, func() error { return printReport(report) })
+	require.NoError(t, err)
+
+	var dataLines []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "alpha") || strings.HasPrefix(line, "dup") || strings.HasPrefix(line, "zeta") {
+			dataLines = append(dataLines, line)
+		}
+	}
+	require.Len(t, dataLines, 4)
+	// Primary key (name) orders alpha < dup < dup < zeta; secondary key
+	// (ProjectID) breaks the "dup"/"dup" tie so ID 10 (SecretCount 1)
+	// precedes ID 20 (SecretCount 99).
+	assert.True(t, strings.HasPrefix(dataLines[0], "alpha"))
+	// tabwriter renders tabs as column-aligned spaces, not literal '\t', so
+	// match on the distinguishing SecretCount field with flexible spacing.
+	dupRow10 := regexp.MustCompile(`^dup\s+1\s+0\s+0$`)
+	dupRow20 := regexp.MustCompile(`^dup\s+99\s+0\s+0$`)
+	assert.Truef(t, dupRow10.MatchString(dataLines[1]), "want ID-10 row (count 1) first, got %q", dataLines[1])
+	assert.Truef(t, dupRow20.MatchString(dataLines[2]), "want ID-20 row (count 99) second, got %q", dataLines[2])
+	assert.True(t, strings.HasPrefix(dataLines[3], "zeta"))
+}
+
+// TestPrintReport_EmptyProjectNameFallsBackToProjectID covers the
+// SanitizeForTerminal-emptied name branch, where printReport substitutes a
+// "(project N)" placeholder rather than printing a blank cell.
+func TestPrintReport_EmptyProjectNameFallsBackToProjectID(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "table"
+	report := &storage.UsageReport{
+		WindowDays:  30,
+		GeneratedAt: time.Now(),
+		Projects:    []storage.ProjectUsageStat{{ProjectID: 7, ProjectName: "\x1b"}},
+	}
+	out, err := captureStdout(t, func() error { return printReport(report) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "(project 7)")
+}

--- a/internal/cli/usage/usage_test.go
+++ b/internal/cli/usage/usage_test.go
@@ -127,14 +127,14 @@ func TestRunShow_RemoteMode(t *testing.T) {
 	origToken, hadToken := os.LookupEnv("KEYORIX_TOKEN")
 	t.Cleanup(func() {
 		if hadServer {
-			os.Setenv("KEYORIX_SERVER", origServer)
+			_ = os.Setenv("KEYORIX_SERVER", origServer)
 		} else {
-			os.Unsetenv("KEYORIX_SERVER")
+			_ = os.Unsetenv("KEYORIX_SERVER")
 		}
 		if hadToken {
-			os.Setenv("KEYORIX_TOKEN", origToken)
+			_ = os.Setenv("KEYORIX_TOKEN", origToken)
 		} else {
-			os.Unsetenv("KEYORIX_TOKEN")
+			_ = os.Unsetenv("KEYORIX_TOKEN")
 		}
 	})
 	require.NoError(t, os.Setenv("KEYORIX_SERVER", srv.URL))

--- a/internal/cli/user/user_s27_test.go
+++ b/internal/cli/user/user_s27_test.go
@@ -1,0 +1,429 @@
+// user_s27_test.go — coverage sprint 27 for internal/cli/user.
+// Targets the remaining gaps left by sprint 26 (measured via go tool cover -func
+// with XDG_CONFIG_HOME isolated from any local ~/.keyorix/cli.yaml):
+//   - requireUserAuthority: the Authorize() storage-error branch (not just the
+//     "unauthorized" boolean branch already covered by by_authority_test.go)
+//   - suspendCmd / reactivateCmd: their own embedded RunE apply closures had
+//     never actually been invoked (existing tests exercised equivalent
+//     closures written directly in the test file, not these specific ones)
+//   - revokeSessionsCmd: InitializeCoreService failure, requireUserAuthority
+//     rejection, and RevokeUserSessions failure branches
+//   - runLifecycle: the InitializeCoreService failure branch
+//   - runCreate: requireUserAuthority rejection on both the --setup-link and
+//     --one-time-password createBy paths
+//   - runDelete / runGet / runUpdate: InitializeCoreService failure branches,
+//     plus DeleteUser failure for a nonexistent target
+//   - resendSetupLinkCmd: InitializeCoreService failure, requireUserAuthority
+//     rejection, and the full success path (fmt.Printf + PrintProvisionResult)
+package user
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+// setupInitFailureConfig writes a keyorix.yaml that enables storage encryption
+// without a master password available, so common.InitializeCoreService fails
+// deterministically — mirroring TestSuspendInactiveCmd_LocalInitError's
+// established pattern. Returns nothing; sets env vars for the duration of the
+// test via t.Setenv (auto-restored).
+func setupInitFailureConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	cfgContent := "storage:\n  encryption:\n    enabled: true\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o600))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+}
+
+// createUnprivilegedUser creates a plain user (no role assigned) against the
+// service backing the current working directory's file DB, for use as an
+// unprivileged --by actor. Mirrors the pattern in by_authority_test.go's
+// TestRunLifecycle_UnprivilegedByRejected / TestRunDelete_UnprivilegedByRejected.
+func createUnprivilegedUser(t *testing.T, username, email string) {
+	t.Helper()
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	ctx := context.Background()
+	_, err = svc.CreateUser(ctx, &core.CreateUserRequest{
+		Username: username, Email: email,
+		DisplayName: username, Password: "Unpr1v!P@ssw0rd#2026",
+	})
+	require.NoError(t, err)
+}
+
+// ──────────────────────── requireUserAuthority: Authorize() storage error ────
+
+// TestRequireUserAuthority_AuthorizeStorageError covers the "failed to verify
+// --by authority" branch (distinct from the "does not hold <perm>" branch
+// already covered): Authorize itself must return an error, not just false.
+// Closing the underlying DB connection forces scopedRoleIDs to fail.
+func TestRequireUserAuthority_AuthorizeStorageError(t *testing.T) {
+	svc, st := newUserTestCore(t)
+	ctx := context.Background()
+	admin, err := svc.GetUserByEmail(ctx, "admin@example.com")
+	require.NoError(t, err)
+
+	sqlDB, err := st.DB().DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	err = requireUserAuthority(ctx, svc, admin.ID, permUsersWrite)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to verify --by authority")
+}
+
+// ──────────────────────── suspendCmd / reactivateCmd: own RunE closures ──────
+
+// TestSuspendCmd_RunE_SeededDB_InvokesOwnClosure exercises suspendCmd's own
+// embedded RunE (and the apply closure literal inside it) end to end against a
+// seeded DB, rather than a structurally-similar closure written directly in a
+// test. This is the only way to cover that specific closure's body.
+func TestSuspendCmd_RunE_SeededDB_InvokesOwnClosure(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, targetID := seedUserDB(t)
+
+	origID, origBy := suspendUserID, suspendBy
+	defer func() { suspendUserID = origID; suspendBy = origBy }()
+	suspendUserID = targetID
+	suspendBy = "admin@example.com"
+
+	require.NoError(t, suspendCmd.RunE(suspendCmd, nil))
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	u, err := svc.GetUser(context.Background(), targetID)
+	require.NoError(t, err)
+	assert.Equal(t, core.AccountSuspended, u.AccountState, "target must actually be suspended by suspendCmd's own closure")
+}
+
+// TestReactivateCmd_RunE_SeededDB_InvokesOwnClosure is the reactivate sibling:
+// suspend first (via runLifecycle, already covered), then reactivate through
+// reactivateCmd's own embedded RunE/apply closure.
+func TestReactivateCmd_RunE_SeededDB_InvokesOwnClosure(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, targetID := seedUserDB(t)
+
+	suspendErr := runLifecycle(targetID, "admin@example.com", "suspended",
+		func(s *core.KeyorixCore, c context.Context, adminID, userID uint) error {
+			return s.SuspendUser(c, adminID, userID)
+		})
+	require.NoError(t, suspendErr)
+
+	origID, origBy := reactivateUserID, reactivateBy
+	defer func() { reactivateUserID = origID; reactivateBy = origBy }()
+	reactivateUserID = targetID
+	reactivateBy = "admin@example.com"
+
+	require.NoError(t, reactivateCmd.RunE(reactivateCmd, nil))
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	u, err := svc.GetUser(context.Background(), targetID)
+	require.NoError(t, err)
+	assert.Equal(t, core.AccountActive, u.AccountState, "target must actually be reactivated by reactivateCmd's own closure")
+}
+
+// ──────────────────────── revokeSessionsCmd: remaining branches ──────────────
+
+// TestRevokeSessionsCmd_RunE_ServiceInitFailure covers the InitializeCoreService
+// error branch inside revokeSessionsCmd's RunE.
+func TestRevokeSessionsCmd_RunE_ServiceInitFailure(t *testing.T) {
+	setupInitFailureConfig(t)
+
+	origID, origBy := revokeSessionsUserID, revokeSessionsBy
+	defer func() { revokeSessionsUserID = origID; revokeSessionsBy = origBy }()
+	revokeSessionsUserID = 1
+	revokeSessionsBy = "admin@example.com"
+
+	err := revokeSessionsCmd.RunE(revokeSessionsCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+// TestRevokeSessionsCmd_RunE_UnprivilegedByRejected covers the
+// requireUserAuthority rejection branch inside revokeSessionsCmd's RunE.
+func TestRevokeSessionsCmd_RunE_UnprivilegedByRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, targetID := seedUserDB(t)
+	createUnprivilegedUser(t, "revoke-victim", "revoke-victim@example.com")
+
+	origID, origBy := revokeSessionsUserID, revokeSessionsBy
+	defer func() { revokeSessionsUserID = origID; revokeSessionsBy = origBy }()
+	revokeSessionsUserID = targetID
+	revokeSessionsBy = "revoke-victim@example.com"
+
+	err := revokeSessionsCmd.RunE(revokeSessionsCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "users.write")
+	assert.Contains(t, err.Error(), "refusing to attribute")
+}
+
+// TestRevokeSessionsCmd_RunE_RevokeSessionsError covers the
+// service.RevokeUserSessions failure branch (target user does not exist).
+func TestRevokeSessionsCmd_RunE_RevokeSessionsError(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, _ = seedUserDB(t)
+
+	origID, origBy := revokeSessionsUserID, revokeSessionsBy
+	defer func() { revokeSessionsUserID = origID; revokeSessionsBy = origBy }()
+	revokeSessionsUserID = 99999
+	revokeSessionsBy = "admin@example.com"
+
+	err := revokeSessionsCmd.RunE(revokeSessionsCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed:")
+}
+
+// ──────────────────────── runLifecycle: service init failure ─────────────────
+
+// TestRunLifecycle_ServiceInitFailure covers the InitializeCoreService failure
+// branch inside runLifecycle (distinct from the resolveAdminID / requireUserAuthority
+// / apply error branches already covered).
+func TestRunLifecycle_ServiceInitFailure(t *testing.T) {
+	setupInitFailureConfig(t)
+
+	err := runLifecycle(1, "admin@example.com", "suspended",
+		func(s *core.KeyorixCore, c context.Context, adminID, userID uint) error {
+			return s.SuspendUser(c, adminID, userID)
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+// ──────────────────────── runCreate: requireUserAuthority rejection ──────────
+
+// TestRunCreate_SetupLink_UnprivilegedByRejected covers the requireUserAuthority
+// rejection branch on the --setup-link createBy path (distinct from the
+// resolveAdminID "unknown email" branch already covered).
+func TestRunCreate_SetupLink_UnprivilegedByRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, _ = seedUserDB(t)
+	createUnprivilegedUser(t, "sl-victim", "sl-victim@example.com")
+
+	origU, origE, origSL, origOTP, origPW, origBy := createUsername, createEmail, createSetupLink, createOneTimePassword, createPassword, createBy
+	defer func() {
+		createUsername = origU
+		createEmail = origE
+		createSetupLink = origSL
+		createOneTimePassword = origOTP
+		createPassword = origPW
+		createBy = origBy
+	}()
+	createUsername = "slrejected"
+	createEmail = "slrejected@example.com"
+	createSetupLink = true
+	createOneTimePassword = false
+	createPassword = ""
+	createBy = "sl-victim@example.com"
+
+	err := runCreate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "users.write")
+	assert.Contains(t, err.Error(), "refusing to attribute")
+}
+
+// TestRunCreate_OTP_UnprivilegedByRejected is the one-time-password sibling.
+func TestRunCreate_OTP_UnprivilegedByRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, _ = seedUserDB(t)
+	createUnprivilegedUser(t, "otp-victim", "otp-victim@example.com")
+
+	origU, origE, origSL, origOTP, origPW, origBy := createUsername, createEmail, createSetupLink, createOneTimePassword, createPassword, createBy
+	defer func() {
+		createUsername = origU
+		createEmail = origE
+		createSetupLink = origSL
+		createOneTimePassword = origOTP
+		createPassword = origPW
+		createBy = origBy
+	}()
+	createUsername = "otprejected"
+	createEmail = "otprejected@example.com"
+	createSetupLink = false
+	createOneTimePassword = true
+	createPassword = ""
+	createBy = "otp-victim@example.com"
+
+	err := runCreate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "users.write")
+	assert.Contains(t, err.Error(), "refusing to attribute")
+}
+
+// ──────────────────────── runDelete / runGet / runUpdate: init failure ───────
+
+func TestRunDelete_ServiceInitFailure(t *testing.T) {
+	setupInitFailureConfig(t)
+
+	origID, origBy, origForce := deleteUserID, deleteBy, deleteForce
+	defer func() { deleteUserID = origID; deleteBy = origBy; deleteForce = origForce }()
+	deleteUserID = 1
+	deleteBy = "admin@example.com"
+	deleteForce = true
+
+	err := runDelete(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunGet_ServiceInitFailure(t *testing.T) {
+	setupInitFailureConfig(t)
+
+	origID, origEmail := getUserID, getUserEmail
+	defer func() { getUserID = origID; getUserEmail = origEmail }()
+	getUserID = 1
+	getUserEmail = ""
+
+	err := runGet(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunUpdate_ServiceInitFailure(t *testing.T) {
+	setupInitFailureConfig(t)
+
+	origID, origU := updateUserID, updateUsername
+	defer func() { updateUserID = origID; updateUsername = origU }()
+	updateUserID = 1
+	updateUsername = "whatever"
+
+	err := runUpdate(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunList_ServiceInitFailure(t *testing.T) {
+	setupInitFailureConfig(t)
+
+	origPage, origSize := listPage, listPageSize
+	defer func() { listPage = origPage; listPageSize = origSize }()
+	listPage = 1
+	listPageSize = 20
+
+	err := runList(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+// TestRunDelete_DeleteUserError_NonexistentTarget covers the service.DeleteUser
+// failure branch: a valid, authorized admin deleting a user ID that does not
+// exist.
+func TestRunDelete_DeleteUserError_NonexistentTarget(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, _ = seedUserDB(t)
+
+	origID, origBy, origForce := deleteUserID, deleteBy, deleteForce
+	defer func() { deleteUserID = origID; deleteBy = origBy; deleteForce = origForce }()
+	deleteUserID = 99999
+	deleteBy = "admin@example.com"
+	deleteForce = true
+
+	err := runDelete(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete user")
+}
+
+// ──────────────────────── resendSetupLinkCmd: remaining branches ─────────────
+
+func TestResendSetupLinkCmd_RunE_ServiceInitFailure(t *testing.T) {
+	setupInitFailureConfig(t)
+
+	origID, origBy := resendSetupLinkUserID, resendSetupLinkBy
+	defer func() { resendSetupLinkUserID = origID; resendSetupLinkBy = origBy }()
+	resendSetupLinkUserID = 1
+	resendSetupLinkBy = "admin@example.com"
+
+	err := resendSetupLinkCmd.RunE(resendSetupLinkCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestResendSetupLinkCmd_RunE_UnprivilegedByRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, targetID := seedUserDB(t)
+	createUnprivilegedUser(t, "resend-victim", "resend-victim@example.com")
+
+	origID, origBy := resendSetupLinkUserID, resendSetupLinkBy
+	defer func() { resendSetupLinkUserID = origID; resendSetupLinkBy = origBy }()
+	resendSetupLinkUserID = targetID
+	resendSetupLinkBy = "resend-victim@example.com"
+
+	err := resendSetupLinkCmd.RunE(resendSetupLinkCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "users.write")
+	assert.Contains(t, err.Error(), "refusing to attribute")
+}
+
+// TestResendSetupLinkCmd_RunE_Success_WithBaseURL covers the full success path
+// (fmt.Printf + common.PrintProvisionResult + return nil): with a configured
+// credential_delivery.base_url, ResendAccountSetupLink can mint an out-of-band
+// link instead of failing on ErrSetupBaseURLRequired.
+func TestResendSetupLinkCmd_RunE_Success_WithBaseURL(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	configYAML := "credential_delivery:\n  base_url: \"https://test.example.com\"\n  mode: out_of_band\n"
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(configYAML), 0o600))
+
+	_, targetID := seedUserDB(t)
+
+	origID, origBy := resendSetupLinkUserID, resendSetupLinkBy
+	defer func() { resendSetupLinkUserID = origID; resendSetupLinkBy = origBy }()
+	resendSetupLinkUserID = targetID
+	resendSetupLinkBy = "admin@example.com"
+
+	out := captureOutput(t, func() {
+		err := resendSetupLinkCmd.RunE(resendSetupLinkCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "Setup link reissued")
+	assert.Contains(t, out, "target@example.com")
+}

--- a/internal/config/config_env_expand_test.go
+++ b/internal/config/config_env_expand_test.go
@@ -78,6 +78,23 @@ func TestLoadLeavesUnresolvedEnvVarWithNoDefaultIntact(t *testing.T) {
 	assert.Equal(t, "${KEYORIX_REQUIRED_DOMAIN}", cfg.Server.HTTP.Domain)
 }
 
+// bash ${VAR} semantics (no default form): a variable explicitly set to the empty
+// string, with no ":-default" fallback in the reference, resolves to that explicit
+// empty value rather than being left unresolved — distinct from the fully-unset case
+// in TestLoadLeavesUnresolvedEnvVarWithNoDefaultIntact, which must stay literal.
+func TestLoadExpandsEnvVarNoDefaultExplicitlyEmpty(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(
+		"server:\n  http:\n    domain: \"prefix-${KEYORIX_EMPTY_NO_DEFAULT}-suffix\"\n",
+	), 0600))
+
+	t.Setenv("KEYORIX_EMPTY_NO_DEFAULT", "")
+	cfg, err := Load(p)
+	require.NoError(t, err)
+	assert.Equal(t, "prefix--suffix", cfg.Server.HTTP.Domain)
+}
+
 // production.yaml itself must still load cleanly and resolve its documented
 // KEYORIX_DOMAIN interpolation end to end.
 func TestLoadProductionYAMLExpandsDomain(t *testing.T) {

--- a/internal/config/config_extra_test.go
+++ b/internal/config/config_extra_test.go
@@ -586,6 +586,77 @@ func TestValidateAllowedOrigins_TrailingSlash(t *testing.T) {
 	assert.Contains(t, err.Error(), "allowed_origins")
 }
 
+// TestPasswordPolicyConfig_Resolve_AllFieldsSetOverrideDefaults exercises the
+// true branch of every *pointer field's nil-check in Resolve — the existing
+// partial-block tests each set only one or two of MinLength/RequireUppercase/
+// RequireLowercase/RequireDigit/RejectPersonalInfo/HistoryCount, leaving those
+// individual "explicitly set" branches uncovered. Set every field explicitly to
+// a value that DIFFERS from the defaults so each branch is both taken and
+// verified to actually take effect.
+func TestPasswordPolicyConfig_Resolve_AllFieldsSetOverrideDefaults(t *testing.T) {
+	defaults := PasswordPolicyValues{
+		MinLength: 16, RequireUppercase: true, RequireLowercase: true, RequireDigit: true,
+		RequireSpecial: true, RejectPersonalInfo: true, RejectCommonPasswords: true, HistoryCount: 5,
+		MaxAgeDays: 90,
+	}
+	full := PasswordPolicyConfig{
+		MinLength:             IntPtr(24),
+		RequireUppercase:      BoolPtr(false),
+		RequireLowercase:      BoolPtr(false),
+		RequireDigit:          BoolPtr(false),
+		RequireSpecial:        BoolPtr(false),
+		RejectPersonalInfo:    BoolPtr(false),
+		RejectCommonPasswords: BoolPtr(false),
+		HistoryCount:          IntPtr(10),
+		MaxAgeDays:            30,
+	}
+	resolved := full.Resolve(defaults)
+
+	assert.Equal(t, 24, resolved.MinLength)
+	assert.False(t, resolved.RequireUppercase)
+	assert.False(t, resolved.RequireLowercase)
+	assert.False(t, resolved.RequireDigit)
+	assert.False(t, resolved.RequireSpecial)
+	assert.False(t, resolved.RejectPersonalInfo)
+	assert.False(t, resolved.RejectCommonPasswords)
+	assert.Equal(t, 10, resolved.HistoryCount)
+	// MaxAgeDays is unconditional in Resolve (not gated on a pointer nil-check),
+	// so it always takes the config's value, even 0 — verify that's still true here.
+	assert.Equal(t, 30, resolved.MaxAgeDays)
+}
+
+// TestIntPtr validates that IntPtr returns a pointer to the given value.
+func TestIntPtr(t *testing.T) {
+	p := IntPtr(42)
+	require.NotNil(t, p)
+	assert.Equal(t, 42, *p)
+
+	pZero := IntPtr(0)
+	require.NotNil(t, pZero)
+	assert.Equal(t, 0, *pZero)
+}
+
+// TestClassificationConfig_GetMFAStepUpGrantRetentionDays_Default validates
+// that an unset (zero) retention defaults to 30 days.
+func TestClassificationConfig_GetMFAStepUpGrantRetentionDays_Default(t *testing.T) {
+	c := ClassificationConfig{}
+	assert.Equal(t, 30, c.GetMFAStepUpGrantRetentionDays())
+}
+
+// TestClassificationConfig_GetMFAStepUpGrantRetentionDays_Negative validates
+// that a negative retention also falls back to the 30 day default.
+func TestClassificationConfig_GetMFAStepUpGrantRetentionDays_Negative(t *testing.T) {
+	c := ClassificationConfig{MFAStepUpGrantRetentionDays: -5}
+	assert.Equal(t, 30, c.GetMFAStepUpGrantRetentionDays())
+}
+
+// TestClassificationConfig_GetMFAStepUpGrantRetentionDays_Positive validates
+// that a positive retention is used as-is.
+func TestClassificationConfig_GetMFAStepUpGrantRetentionDays_Positive(t *testing.T) {
+	c := ClassificationConfig{MFAStepUpGrantRetentionDays: 90}
+	assert.Equal(t, 90, c.GetMFAStepUpGrantRetentionDays())
+}
+
 // TestValidateAllowedOrigins_Empty validates that an empty list is accepted.
 func TestValidateAllowedOrigins_Empty(t *testing.T) {
 	require.NoError(t, validateAllowedOrigins(nil))

--- a/internal/config/config_save_test.go
+++ b/internal/config/config_save_test.go
@@ -27,6 +27,36 @@ func TestSaveEnforcesPermsOnExistingFile(t *testing.T) {
 	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
 }
 
+// TestSaveDefaultsPathWhenEmpty validates that Save("", cfg) writes to
+// appRootDir/keyorix.yaml (mirroring Load's own empty-path default) rather than
+// erroring or requiring the caller to always name a path.
+func TestSaveDefaultsPathWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	require.NoError(t, Save("", &Config{Environment: "default-path-test"}))
+
+	loaded, err := Load("")
+	require.NoError(t, err)
+	assert.Equal(t, "default-path-test", loaded.Environment)
+}
+
+// TestSaveRejectsPathEscapingBaseDir validates that Save surfaces (wraps) the
+// traversal-guard error from the underlying secure writer instead of silently
+// writing outside appRootDir when given a relative path that escapes it.
+func TestSaveRejectsPathEscapingBaseDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	err := Save("../escape.yaml", &Config{Environment: "should-not-be-written"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write config file")
+
+	// Confirm nothing was actually written outside dir.
+	_, statErr := os.Stat(filepath.Join(filepath.Dir(dir), "escape.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "Save must not write outside its base directory")
+}
+
 // TestSaveHonorsAbsolutePath is the regression test for Save's absolute-path
 // handling: unlike Load (which already special-cases filepath.IsAbs by
 // rooting at the path's own directory), Save used to always join its path arg

--- a/internal/config/grpc_keepalive_config_test.go
+++ b/internal/config/grpc_keepalive_config_test.go
@@ -27,3 +27,17 @@ func TestGRPCKeepaliveConfig_GetMinTime(t *testing.T) {
 	assert.Equal(t, 5*time.Minute, GRPCKeepaliveConfig{MinTime: "garbage"}.GetMinTime(), "unparseable falls back")
 	assert.Equal(t, 30*time.Second, GRPCKeepaliveConfig{MinTime: "30s"}.GetMinTime())
 }
+
+// GRPC-008: MaxConnectionAge/MaxConnectionAgeGrace force periodic reconnection so a
+// stream-slot-holding attacker can't pin audit-stream slots indefinitely.
+func TestGRPCKeepaliveConfig_GetMaxConnectionAge(t *testing.T) {
+	assert.Equal(t, time.Hour, GRPCKeepaliveConfig{}.GetMaxConnectionAge(), "default when unset")
+	assert.Equal(t, time.Hour, GRPCKeepaliveConfig{MaxConnectionAge: "garbage"}.GetMaxConnectionAge(), "unparseable falls back")
+	assert.Equal(t, 15*time.Minute, GRPCKeepaliveConfig{MaxConnectionAge: "15m"}.GetMaxConnectionAge())
+}
+
+func TestGRPCKeepaliveConfig_GetMaxConnectionAgeGrace(t *testing.T) {
+	assert.Equal(t, 30*time.Second, GRPCKeepaliveConfig{}.GetMaxConnectionAgeGrace(), "default when unset")
+	assert.Equal(t, 30*time.Second, GRPCKeepaliveConfig{MaxConnectionAgeGrace: "garbage"}.GetMaxConnectionAgeGrace(), "unparseable falls back")
+	assert.Equal(t, 5*time.Second, GRPCKeepaliveConfig{MaxConnectionAgeGrace: "5s"}.GetMaxConnectionAgeGrace())
+}

--- a/internal/connect/connect_s25_test.go
+++ b/internal/connect/connect_s25_test.go
@@ -1,0 +1,253 @@
+package connect
+
+// connect_s25_test.go — coverage blitz targeting the remaining fully- or
+// mostly-uncovered functions after the s21-s24 rounds:
+//
+//   - connect.go RefWithinPrefix (the exported wrapper) was 0% — every existing
+//     test calls the unexported refWithinPrefix directly.
+//   - vault.go CheckTokenTTL was 0% — no test exercised the token self-lookup at
+//     all.
+//   - vault.go validateConnectorURL was missing its "bad scheme" and "missing
+//     host" branches (only the url.Parse-error branch was covered).
+//   - azurekv.go client()'s NewDefaultAzureCredential-error branch was
+//     environment-dependent (coverage_test.go accepts "either outcome" because
+//     the SDK's lazy credential chain does not fail by default). Setting the
+//     SDK's own AZURE_TOKEN_CREDENTIALS selector to an invalid value makes
+//     NewDefaultAzureCredential return a deterministic, hermetic error with no
+//     network access — reliably covering that branch.
+//   - gcpsm.go client()'s success return (`return cl, nil`) was uncovered
+//     because secretmanager.NewClient fails without ADC in this sandbox
+//     (coverage_test.go's TestGCPSM_ClientRealPath already covers the error
+//     branch). Pointing GOOGLE_APPLICATION_CREDENTIALS at a syntactically valid
+//     but freshly-generated (never real) service-account key lets the client
+//     construct successfully — the gRPC channel dials lazily, so no network
+//     call or real credential is required to reach the success path.
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── connect.go: RefWithinPrefix (exported wrapper) ──────────────────────────
+
+// TestRefWithinPrefix_S25_ExportedWrapper proves the exported RefWithinPrefix
+// delegates to the same logic as the unexported refWithinPrefix that every
+// other test exercises directly — the wrapper itself was never called.
+func TestRefWithinPrefix_S25_ExportedWrapper(t *testing.T) {
+	assert.True(t, RefWithinPrefix("db/prod", "db/prod"), "exact match")
+	assert.True(t, RefWithinPrefix("db/prod", "db/prod/config"), "segment-boundary extension")
+	assert.False(t, RefWithinPrefix("db/prod", "db/production-other-team"),
+		"must not match on a bare substring across the segment boundary")
+	assert.False(t, RefWithinPrefix("db/prod", "db/other"), "unrelated sibling")
+}
+
+// ── vault.go: CheckTokenTTL ──────────────────────────────────────────────────
+
+// fakeVaultTokenLookup stands up an in-process Vault endpoint that only serves
+// the token self-lookup path, keyed on the expected token.
+func fakeVaultTokenLookup(t *testing.T, expectedToken, body string, status int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/auth/token/lookup-self" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Header.Get("X-Vault-Token") != expectedToken {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestVault_S25_CheckTokenTTL_Success proves a normal, renewable token returns
+// its TTL and renewable flag from the Data envelope.
+func TestVault_S25_CheckTokenTTL_Success(t *testing.T) {
+	srv := fakeVaultTokenLookup(t, "tok", `{"data":{"ttl":3600,"renewable":true}}`, http.StatusOK)
+	c := NewVaultConnector("v", srv.URL, "tok", nil)
+
+	ttl, renewable, err := c.CheckTokenTTL(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 3600, ttl)
+	assert.True(t, renewable)
+}
+
+// TestVault_S25_CheckTokenTTL_RootToken proves a root token (TTL 0, not
+// renewable) is reported back verbatim rather than treated as an error.
+func TestVault_S25_CheckTokenTTL_RootToken(t *testing.T) {
+	srv := fakeVaultTokenLookup(t, "root-tok", `{"data":{"ttl":0,"renewable":false}}`, http.StatusOK)
+	c := NewVaultConnector("v", srv.URL, "root-tok", nil)
+
+	ttl, renewable, err := c.CheckTokenTTL(context.Background())
+	require.NoError(t, err)
+	assert.Zero(t, ttl)
+	assert.False(t, renewable)
+}
+
+// TestVault_S25_CheckTokenTTL_NonOKStatus proves a non-200 response (e.g. an
+// invalid/expired token) surfaces as an error carrying the status code.
+func TestVault_S25_CheckTokenTTL_NonOKStatus(t *testing.T) {
+	srv := fakeVaultTokenLookup(t, "tok", `{"errors":["permission denied"]}`, http.StatusForbidden)
+	c := NewVaultConnector("v", srv.URL, "wrong-tok", nil)
+
+	_, _, err := c.CheckTokenTTL(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "returned 403")
+}
+
+// TestVault_S25_CheckTokenTTL_InvalidJSON proves a malformed response body is
+// reported as a parse error rather than panicking or silently zeroing the TTL.
+func TestVault_S25_CheckTokenTTL_InvalidJSON(t *testing.T) {
+	srv := fakeVaultTokenLookup(t, "tok", `not json`, http.StatusOK)
+	c := NewVaultConnector("v", srv.URL, "tok", nil)
+
+	_, _, err := c.CheckTokenTTL(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse error")
+}
+
+// TestVault_S25_CheckTokenTTL_NetworkError proves a connector pointed at an
+// address nothing is listening on surfaces the transport failure wrapped with
+// the "token TTL lookup failed" prefix, rather than the request-construction
+// error.
+func TestVault_S25_CheckTokenTTL_NetworkError(t *testing.T) {
+	// Bind an ephemeral port, note its address, then close it immediately — the
+	// port is guaranteed to have nothing listening on it, so a connection
+	// attempt fails fast with "connection refused" without depending on any
+	// real network access.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	c := NewVaultConnector("v", "http://"+addr, "tok", nil)
+	_, _, err = c.CheckTokenTTL(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token TTL lookup failed")
+}
+
+// TestVault_S25_CheckTokenTTL_RequestConstructionError proves the branch where
+// http.NewRequestWithContext itself fails (a malformed connector address)
+// surfaces the raw construction error rather than attempting a request.
+func TestVault_S25_CheckTokenTTL_RequestConstructionError(t *testing.T) {
+	// A control character in the URL makes url.Parse (used internally by
+	// http.NewRequestWithContext) fail before any network I/O is attempted.
+	c := NewVaultConnector("v", "http://exa\x7fmple.com", "tok", nil)
+	_, _, err := c.CheckTokenTTL(context.Background())
+	require.Error(t, err)
+}
+
+// ── vault.go: validateConnectorURL ───────────────────────────────────────────
+
+func TestValidateConnectorURL_S25(t *testing.T) {
+	t.Run("valid https", func(t *testing.T) {
+		require.NoError(t, validateConnectorURL("https://vault.example.com:8200"))
+	})
+	t.Run("valid http", func(t *testing.T) {
+		require.NoError(t, validateConnectorURL("http://127.0.0.1:8200"))
+	})
+	t.Run("unparseable", func(t *testing.T) {
+		err := validateConnectorURL("://")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid connector address")
+	})
+	t.Run("non-http(s) scheme is rejected", func(t *testing.T) {
+		err := validateConnectorURL("ftp://vault.example.com")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must use http or https")
+	})
+	t.Run("file scheme is rejected", func(t *testing.T) {
+		err := validateConnectorURL("file:///etc/passwd")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must use http or https")
+	})
+	t.Run("missing host is rejected", func(t *testing.T) {
+		err := validateConnectorURL("http:///v1/secret")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing a host")
+	})
+}
+
+// ── azurekv.go: client() real path, deterministic credential error ─────────
+
+// TestAzureKV_S25_ClientRealPath_CredentialErrorIsDeterministic covers the
+// NewDefaultAzureCredential-error branch of client() hermetically. The SDK's
+// own AZURE_TOKEN_CREDENTIALS selector env var, when set to a value it does
+// not recognize, makes NewDefaultAzureCredential return a synchronous error
+// with no network access at all — unlike leaving the ambient chain to its
+// default (lazy) behavior, which coverage_test.go's TestAzureKV_ClientRealPath
+// must treat as "either outcome" because it doesn't fail predictably.
+func TestAzureKV_S25_ClientRealPath_CredentialErrorIsDeterministic(t *testing.T) {
+	t.Setenv("AZURE_TOKEN_CREDENTIALS", "not-a-real-credential-type")
+
+	c := NewAzureKeyVaultConnector("az-real-s25", "https://myvault.vault.azure.net/", nil)
+	cl, err := c.client(context.Background())
+	require.Error(t, err, "an unrecognized AZURE_TOKEN_CREDENTIALS value must make credential construction fail")
+	assert.Nil(t, cl)
+	assert.Contains(t, err.Error(), "azure-key-vault: default credential")
+}
+
+// ── gcpsm.go: client() real path, deterministic success ────────────────────
+
+// fakeGCPServiceAccountKeyFile writes a syntactically valid, freshly generated
+// (never real) service-account JSON key to a temp file and returns its path.
+// google.golang.org/api's credential loader parses and holds the key without
+// making any network call — the underlying gRPC channel dials lazily — so
+// client construction succeeds deterministically without any real GCP
+// credential or network access, letting the test hit gcpsm.go's `return cl,
+// nil` success branch that coverage_test.go's TestGCPSM_ClientRealPath cannot
+// reach in a sandbox with no ADC available.
+func fakeGCPServiceAccountKeyFile(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	keyBytes := x509.MarshalPKCS1PrivateKey(key)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: keyBytes})
+
+	sa := map[string]string{
+		"type":                        "service_account",
+		"project_id":                  "s25-fake-project",
+		"private_key_id":              "s25fakekeyid",
+		"private_key":                 string(keyPEM),
+		"client_email":                "s25-fake@s25-fake-project.iam.gserviceaccount.com",
+		"client_id":                   "100000000000000000000",
+		"auth_uri":                    "https://accounts.google.com/o/oauth2/auth",
+		"token_uri":                   "https://oauth2.googleapis.com/token",
+		"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+		"client_x509_cert_url":        "https://www.googleapis.com/robot/v1/metadata/x509/s25-fake%40s25-fake-project.iam.gserviceaccount.com",
+	}
+	blob, err := json.Marshal(sa)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "fake-sa.json")
+	require.NoError(t, os.WriteFile(p, blob, 0o600))
+	return p
+}
+
+func TestGCPSM_S25_ClientRealPath_SucceedsWithSyntacticallyValidKey(t *testing.T) {
+	keyPath := fakeGCPServiceAccountKeyFile(t)
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", keyPath)
+
+	c := NewGCPSecretManagerConnector("gcp-real-s25", "", nil)
+	cl, err := c.client(context.Background())
+	require.NoError(t, err, "a syntactically valid key file must let the client construct without any network call")
+	require.NotNil(t, cl)
+	_ = cl.Close()
+}

--- a/internal/crypto/azurekms/azurekms_extra_test.go
+++ b/internal/crypto/azurekms/azurekms_extra_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestEncodeDecodeEnvelope_RoundTrip verifies the envelope encodes and decodes symmetrically.
@@ -144,6 +147,75 @@ func TestAzureKMS_DecryptCorruptEnvelope(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error when the envelope is corrupt")
 	}
+}
+
+// TestValidateKeyVaultHost_UnparsableURL covers the url.Parse error branch
+// inside validateKeyVaultHost, distinct from the "parses fine but wrong
+// scheme/host" cases already covered by TestValidateKeyVaultHost. An invalid
+// percent-encoding is a reliable, deterministic way to make net/url itself
+// fail to parse, independent of anything this package validates.
+func TestValidateKeyVaultHost_UnparsableURL(t *testing.T) {
+	err := validateKeyVaultHost("https://myvault.vault.azure.net/%zz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid vault URL")
+}
+
+// TestParseKeyID_UnparsableURL covers the url.Parse error branch inside
+// parseKeyID, distinct from the "parses fine but the wrong shape" cases
+// already covered by TestParseKeyID. Same invalid-percent-encoding trick as
+// TestValidateKeyVaultHost_UnparsableURL.
+func TestParseKeyID_UnparsableURL(t *testing.T) {
+	_, _, _, err := parseKeyID("https://myvault.vault.azure.net/keys/kek/%zz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid kms_key_id")
+}
+
+// TestNew_DefaultCredentialError covers the azidentity.NewDefaultAzureCredential
+// error branch inside New. AZURE_TOKEN_CREDENTIALS is a documented azidentity
+// env var that, when set to anything other than a recognized credential name
+// (or "dev"/"prod"), makes construction fail deterministically — a reliable
+// way to exercise this branch without needing real/broken Azure credentials.
+func TestNew_DefaultCredentialError(t *testing.T) {
+	const envVar = "AZURE_TOKEN_CREDENTIALS"
+	orig, hadOrig := os.LookupEnv(envVar)
+	require.NoError(t, os.Setenv(envVar, "not-a-real-credential-type"))
+	defer func() {
+		if hadOrig {
+			os.Setenv(envVar, orig)
+		} else {
+			os.Unsetenv(envVar)
+		}
+	}()
+
+	_, err := New(context.Background(), "https://myvault.vault.azure.net/keys/kek")
+	require.Error(t, err, "New must surface a NewDefaultAzureCredential construction error rather than swallow it")
+	assert.Contains(t, err.Error(), "azure-kms: default credential:")
+}
+
+// fakeKeysUnparsableKID returns a WrapKey response whose KID is not a valid
+// key identifier at all (wrong path shape) — modeling an SDK bug or a rogue
+// component in front of Key Vault, distinct from fakeKeysWrongKID (which
+// returns a syntactically valid KID naming a different key).
+type fakeKeysUnparsableKID struct{}
+
+func (f fakeKeysUnparsableKID) WrapKey(_ context.Context, _ string, _ string, params azkeys.KeyOperationParameters, _ *azkeys.WrapKeyOptions) (azkeys.WrapKeyResponse, error) {
+	kid := azkeys.ID("https://vault.vault.azure.net/secrets/not-a-key-path")
+	return azkeys.WrapKeyResponse{KeyOperationResult: azkeys.KeyOperationResult{KID: &kid, Result: params.Value}}, nil
+}
+
+func (f fakeKeysUnparsableKID) UnwrapKey(_ context.Context, _ string, _ string, _ azkeys.KeyOperationParameters, _ *azkeys.UnwrapKeyOptions) (azkeys.UnwrapKeyResponse, error) {
+	return azkeys.UnwrapKeyResponse{}, fmt.Errorf("fakeKeysUnparsableKID: UnwrapKey not implemented")
+}
+
+// TestAzureKMS_EncryptRefusesUnparsableKID covers the parseKeyID-error branch
+// inside Encrypt when the wrap response's KID isn't a valid key identifier at
+// all — distinct from TestAzureKMS_EncryptRefusesMismatchedKID, which covers
+// a KID that parses fine but names a different key.
+func TestAzureKMS_EncryptRefusesUnparsableKID(t *testing.T) {
+	c := &client{keys: fakeKeysUnparsableKID{}, keyName: "kek", keyVersion: ""}
+	_, err := c.Encrypt(context.Background(), []byte("kek-material"))
+	require.Error(t, err, "Encrypt must refuse a wrap response whose KID cannot be parsed as a key identifier")
+	assert.Contains(t, err.Error(), "not a valid key identifier")
 }
 
 // TestParseKeyID_AdditionalCases covers path forms not already tested.

--- a/internal/crypto/azurekms/azurekms_extra_test.go
+++ b/internal/crypto/azurekms/azurekms_extra_test.go
@@ -181,9 +181,9 @@ func TestNew_DefaultCredentialError(t *testing.T) {
 	require.NoError(t, os.Setenv(envVar, "not-a-real-credential-type"))
 	defer func() {
 		if hadOrig {
-			os.Setenv(envVar, orig)
+			_ = os.Setenv(envVar, orig)
 		} else {
-			os.Unsetenv(envVar)
+			_ = os.Unsetenv(envVar)
 		}
 	}()
 

--- a/internal/crypto/coverage_test.go
+++ b/internal/crypto/coverage_test.go
@@ -1,6 +1,8 @@
 package crypto
 
 import (
+	cryptorand "crypto/rand"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -10,6 +12,26 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// failingReader is an io.Reader that always fails — used to deterministically
+// exercise the crypto/rand failure branches in generateAndWrap/ensureSalt/Split
+// without any real entropy exhaustion. crypto/rand.Reader is a package-level
+// var, so swapping it for the duration of a test (single-goroutine, no
+// t.Parallel anywhere in this package) is a legitimate way to reach an
+// otherwise-untriggerable error path.
+type failingReader struct{}
+
+func (failingReader) Read(_ []byte) (int, error) { return 0, errors.New("injected rand failure") }
+
+// withFailingRand swaps crypto/rand.Reader for the duration of fn and restores
+// the original afterward, even if fn fails.
+func withFailingRand(t *testing.T, fn func()) {
+	t.Helper()
+	old := cryptorand.Reader
+	cryptorand.Reader = failingReader{}
+	defer func() { cryptorand.Reader = old }()
+	fn()
+}
 
 // ---- TPMKeyProvider: error-path coverage for generateAndSeal and seal ----
 
@@ -108,6 +130,315 @@ func TestKMSProvider_GenerateAndWrap_PersistFailure(t *testing.T) {
 	_, err := p.KEK()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "persist wrapped KEK")
+}
+
+// TestKMSKeyProvider_Client_ReturnsConfiguredClient covers the Client() getter,
+// which lets a caller (encryption.Service.wireKMSAuditSink) type-assert the
+// underlying KMSClient to a concrete backend for backend-specific wiring.
+func TestKMSKeyProvider_Client_ReturnsConfiguredClient(t *testing.T) {
+	kms := &fakeKMS{tag: "cmk-A"}
+	p := NewKMSKeyProvider(kms, "aws-kms", t.TempDir(), "kek.kms")
+	assert.Same(t, kms, p.Client(), "Client() must return the exact KMSClient the provider was built with")
+}
+
+// TestKMSKeyProvider_ReadWrappedKEK_PathEscapeFails covers the "read wrapped
+// KEK" error branch in KEK(): the wrapped-key file exists (so KEK() takes the
+// read path, not generateAndWrap) but is a symlink escaping baseDir, so
+// SafeReadFile's containment check rejects it.
+func TestKMSKeyProvider_ReadWrappedKEK_PathEscapeFails(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "secret.bin")
+	require.NoError(t, os.WriteFile(target, []byte("not a real wrapped kek"), 0600))
+	require.NoError(t, os.Symlink(target, filepath.Join(dir, "kek.kms")))
+
+	_, err := NewKMSKeyProvider(&fakeKMS{tag: "x"}, "aws-kms", dir, "kek.kms").KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read wrapped KEK")
+}
+
+// TestKMSKeyProvider_GenerateAndWrap_RandFailure covers generateAndWrap's
+// io.ReadFull(rand.Reader, ...) error branch on first run.
+func TestKMSKeyProvider_GenerateAndWrap_RandFailure(t *testing.T) {
+	dir := t.TempDir()
+	withFailingRand(t, func() {
+		_, err := NewKMSKeyProvider(&fakeKMS{tag: "x"}, "aws-kms", dir, "kek.kms").KEK()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "generate KEK")
+	})
+	assert.NoFileExists(t, filepath.Join(dir, "kek.kms"), "no wrapped blob persisted when KEK generation itself fails")
+}
+
+// ---- PasswordKeyProvider: ensureSalt error paths ----
+
+// TestPasswordKeyProvider_EnsureSalt_RandFailure covers the salt-generation
+// io.ReadFull(rand.Reader, ...) error branch on first run.
+func TestPasswordKeyProvider_EnsureSalt_RandFailure(t *testing.T) {
+	dir := t.TempDir()
+	withFailingRand(t, func() {
+		_, err := NewPasswordKeyProvider("passphrase", dir, "kek.salt").KEK()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to generate salt")
+	})
+}
+
+// TestPasswordKeyProvider_EnsureSalt_WriteFailure covers the
+// SecureWriteFileSync error branch when persisting a freshly generated salt:
+// the directory is read-only so the write cannot happen.
+func TestPasswordKeyProvider_EnsureSalt_WriteFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; read-only dir test cannot be enforced")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	_, err := NewPasswordKeyProvider("passphrase", dir, "kek.salt").KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write salt")
+}
+
+// TestPasswordKeyProvider_EnsureSalt_ReadFailure covers the SafeReadFile error
+// branch when an existing salt file is actually a symlink escaping baseDir.
+func TestPasswordKeyProvider_EnsureSalt_ReadFailure(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "salt.bin")
+	require.NoError(t, os.WriteFile(target, make([]byte, saltSize), 0600))
+	require.NoError(t, os.Symlink(target, filepath.Join(dir, "kek.salt")))
+
+	_, err := NewPasswordKeyProvider("passphrase", dir, "kek.salt").KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read salt")
+}
+
+// ---- FileKeyProvider: read failure ----
+
+// TestFileKeyProvider_KEK_ReadFailure covers the os.ReadFile error branch: the
+// configured path passes the Stat + permission-bits check (it's a directory
+// with owner-only mode) but cannot be read as file content.
+func TestFileKeyProvider_KEK_ReadFailure(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "kek-is-a-dir")
+	require.NoError(t, os.Mkdir(sub, 0700))
+
+	_, err := NewFileKeyProvider(sub).KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read")
+}
+
+// NOTE: Split's `if _, err := rand.Read(coeffs[1:]); err != nil` branch
+// (shamir.go) is NOT covered by a test. Since Go 1.24, crypto/rand.Read (the
+// package-level function, as opposed to io.ReadFull(rand.Reader, ...)) is
+// documented to "never return an error" and instead calls runtime.fatal
+// (crashing the process irrecoverably) if the underlying Reader fails — see
+// crypto/rand.Read's doc comment and https://go.dev/issue/66821. Swapping
+// rand.Reader to a failing implementation to exercise this branch therefore
+// crashes the test binary instead of returning an error, so this defensive
+// branch is dead code under the current Go runtime and cannot be reached from
+// a unit test without patching the standard library. Left uncovered
+// deliberately rather than done via a test that kills the test process.
+
+// ---- combineKEK: below-embedded-threshold with otherwise-valid reconstruction ----
+
+// TestCombineKEK_BelowEmbeddedThreshold covers the "insufficient shares
+// supplied vs. the threshold embedded in the payload" branch directly. This
+// branch is unreachable via the normal SplitKEK/ShamirKeyProvider path because
+// combining fewer shares than the ACTUAL polynomial degree used at split time
+// almost always fails the magic check first (garbage reconstruction). To
+// isolate the embedded-threshold check, this crafts a payload whose declared
+// threshold byte (5) is higher than the REAL Shamir threshold used to split it
+// (2), so 2 shares reconstruct correctly (magic + KEK intact) while still
+// being fewer than the byte the payload claims is required.
+func TestCombineKEK_BelowEmbeddedThreshold(t *testing.T) {
+	kek := testKEK()
+	payload := append([]byte{}, kekShareMagic...)
+	payload = append(payload, byte(5)) // claims threshold=5
+	payload = append(payload, kek...)
+
+	shares, err := Split(payload, 5, 2) // actually only needs 2 shares to reconstruct
+	require.NoError(t, err)
+
+	_, err = combineKEK(shares[:2], nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shares supplied but the split requires")
+}
+
+// ---- TPMKeyProvider: remaining error/wiring branches ----
+
+// TestNewTPMKeyProvider_DefaultOpen_AttemptsRealDevice covers the default
+// `open` closure built by NewTPMKeyProvider (only ever overridden with a
+// simulator in every other test in this package). There is no real TPM device
+// in this test environment, so the call is expected to fail — the point is to
+// prove the closure is wired to the configured device path at all, not that a
+// real TPM is present.
+func TestNewTPMKeyProvider_DefaultOpen_AttemptsRealDevice(t *testing.T) {
+	p := NewTPMKeyProvider("/dev/nonexistent-tpm-for-test", "", "x.tpm")
+	require.NotNil(t, p.open)
+	_, err := p.open()
+	assert.Error(t, err, "opening a nonexistent TPM device must fail, proving open() actually targets p.devicePath")
+}
+
+// TestTPMKeyProvider_ReadSealedBlob_PathEscapeFails covers the "read sealed
+// blob" SafeReadFile error branch: the blob path exists but is a symlink
+// escaping baseDir.
+func TestTPMKeyProvider_ReadSealedBlob_PathEscapeFails(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "blob.bin")
+	require.NoError(t, os.WriteFile(target, []byte("{}"), 0600))
+	require.NoError(t, os.Symlink(target, filepath.Join(dir, "kek.tpm")))
+
+	p := newTPMProvider(t, dir, 11)
+	_, err := p.KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read sealed blob")
+}
+
+// NOTE: generateAndSeal's `if _, err := rand.Read(kek); err != nil` branch
+// (tpm_provider.go) is likewise not covered — it calls the crypto/rand.Read
+// package function directly, which (see the Split note above, same Go 1.24+
+// behavior) crashes the process instead of returning an error when the
+// underlying Reader fails, so it cannot be exercised from a unit test.
+
+// TestTPMKeyProvider_Unseal_DecodePublicFailure covers unseal()'s
+// tpm2.Unmarshal[TPM2BPublic] error branch: the stored blob is valid JSON with
+// the right shape, but the "public" bytes don't decode as a TPM2B public
+// structure.
+func TestTPMKeyProvider_Unseal_DecodePublicFailure(t *testing.T) {
+	dir := t.TempDir()
+	writeSealedBlobFile(t, dir, "kek.tpm", tpmSealedBlob{
+		Public:  []byte("not a valid TPM2B public structure"),
+		Private: []byte{0x00, 0x02, 0xAB, 0xCD},
+	})
+
+	p := newTPMProvider(t, dir, 13)
+	_, err := p.KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode sealed public")
+}
+
+// TestTPMKeyProvider_Unseal_DecodePrivateFailure covers unseal()'s
+// tpm2.Unmarshal[TPM2BPrivate] error branch: a genuinely-sealed public blob
+// (from a real seal) paired with corrupt private bytes.
+func TestTPMKeyProvider_Unseal_DecodePrivateFailure(t *testing.T) {
+	dir := t.TempDir()
+	sealer := newTPMProvider(t, dir, 14)
+	blob, err := sealer.seal(testKEK())
+	require.NoError(t, err)
+
+	writeSealedBlobFile(t, dir, "kek.tpm", tpmSealedBlob{
+		Public:  blob.Public,
+		Private: []byte("not a valid TPM2B private structure"),
+	})
+
+	p := newTPMProvider(t, dir, 14)
+	_, err = p.KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode sealed private")
+}
+
+// countingFailAfter wraps a real transport.TPMCloser (backed by the in-process
+// simulator) and fails every Send call after the first n succeed. Each tpm2
+// command used by seal()/unseal() here issues exactly one Send (no HMAC/policy
+// sessions), so this lets a test target one SPECIFIC command in a
+// seal/unseal sequence — e.g. let CreatePrimary succeed but fail the following
+// Create/Load/Unseal command — against a real simulator backend, rather than
+// failing the whole TPM connection outright (which errorOpener already covers).
+type countingFailAfter struct {
+	transport.TPMCloser
+	n     int
+	calls int
+}
+
+func (f *countingFailAfter) Send(input []byte) ([]byte, error) {
+	f.calls++
+	if f.calls > f.n {
+		return nil, errors.New("injected TPM command failure")
+	}
+	return f.TPMCloser.Send(input)
+}
+
+// failAfterOpener returns an opener over the fixed-seed simulator whose TPM
+// connection fails every command after the first n succeed.
+func failAfterOpener(t *testing.T, seed int64, n int) func() (transport.TPMCloser, error) {
+	t.Helper()
+	inner := simOpener(t, seed)
+	return func() (transport.TPMCloser, error) {
+		tp, err := inner()
+		if err != nil {
+			return nil, err
+		}
+		return &countingFailAfter{TPMCloser: tp, n: n}, nil
+	}
+}
+
+// TestTPMKeyProvider_Seal_CreatePrimaryFailure covers seal()'s createPrimary
+// error branch: the TPM connection opens fine, but the very first command
+// (CreatePrimary) fails.
+func TestTPMKeyProvider_Seal_CreatePrimaryFailure(t *testing.T) {
+	dir := t.TempDir()
+	p := NewTPMKeyProvider("", dir, "kek.tpm")
+	p.open = failAfterOpener(t, 101, 0)
+
+	_, err := p.KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create primary")
+}
+
+// TestTPMKeyProvider_Seal_CreateSealedObjectFailure covers seal()'s
+// tpm2.Create error branch: CreatePrimary succeeds, but the following Create
+// (the actual seal command) fails.
+func TestTPMKeyProvider_Seal_CreateSealedObjectFailure(t *testing.T) {
+	dir := t.TempDir()
+	p := NewTPMKeyProvider("", dir, "kek.tpm")
+	p.open = failAfterOpener(t, 102, 1)
+
+	_, err := p.KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create sealed object")
+}
+
+// TestTPMKeyProvider_Unseal_CreatePrimaryFailure covers unseal()'s
+// createPrimary error branch, using a genuinely-sealed blob from a prior
+// successful seal so KEK() reaches the unseal path at all.
+func TestTPMKeyProvider_Unseal_CreatePrimaryFailure(t *testing.T) {
+	dir := t.TempDir()
+	_, err := newTPMProvider(t, dir, 103).KEK()
+	require.NoError(t, err)
+
+	p := NewTPMKeyProvider("", dir, "kek.tpm")
+	p.open = failAfterOpener(t, 103, 0)
+
+	_, err = p.KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create primary")
+}
+
+// TestTPMKeyProvider_Unseal_UnsealCommandFailure covers unseal()'s final
+// tpm2.Unseal error branch: createPrimary and Load both succeed (same TPM,
+// same seed as the original seal, so the blob loads fine) but the Unseal
+// command itself fails.
+func TestTPMKeyProvider_Unseal_UnsealCommandFailure(t *testing.T) {
+	dir := t.TempDir()
+	_, err := newTPMProvider(t, dir, 104).KEK()
+	require.NoError(t, err)
+
+	p := NewTPMKeyProvider("", dir, "kek.tpm")
+	p.open = failAfterOpener(t, 104, 2)
+
+	_, err = p.KEK()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unseal:")
+}
+
+// writeSealedBlobFile persists a tpmSealedBlob as the JSON file KEK() expects
+// to find at baseDir/name, mirroring generateAndSeal's on-disk format.
+func writeSealedBlobFile(t *testing.T, baseDir, name string, blob tpmSealedBlob) {
+	t.Helper()
+	out, err := json.Marshal(blob)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, name), out, 0600))
 }
 
 // helper: reports whether s contains any of the given substrings.

--- a/internal/crypto/gcpkms/gcpkms_test.go
+++ b/internal/crypto/gcpkms/gcpkms_test.go
@@ -53,9 +53,10 @@ func (fakeKMS) Decrypt(_ context.Context, req *kmspb.DecryptRequest, _ ...gax.Ca
 // does not match its payload, modelling transport corruption between the client
 // and the KMS service.
 type corruptChecksumKMS struct {
-	corruptEncryptResp bool
-	corruptDecryptResp bool
-	dropVerifiedFlags  bool
+	corruptEncryptResp   bool
+	corruptDecryptResp   bool
+	dropVerifiedFlags    bool
+	dropAADVerifiedFlags bool
 }
 
 func (c corruptChecksumKMS) Encrypt(ctx context.Context, req *kmspb.EncryptRequest, opts ...gax.CallOption) (*kmspb.EncryptResponse, error) {
@@ -68,6 +69,9 @@ func (c corruptChecksumKMS) Encrypt(ctx context.Context, req *kmspb.EncryptReque
 	}
 	if c.dropVerifiedFlags {
 		resp.VerifiedPlaintextCrc32C = false
+	}
+	if c.dropAADVerifiedFlags {
+		resp.VerifiedAdditionalAuthenticatedDataCrc32C = false
 	}
 	return resp, nil
 }
@@ -274,6 +278,24 @@ func TestGCPKMS_Encrypt_RejectsUnverifiedPlaintextChecksum(t *testing.T) {
 	}
 }
 
+// crypto-gcpkms-02: an EncryptResponse that carries AAD but never reports the AAD
+// checksum as verified (the server received/echoed the AAD but did not confirm the
+// checksum against it) must be rejected on the same grounds as an unverified
+// plaintext checksum — an unverified AAD checksum is exactly what undetected
+// request-side corruption of the AAD looks like, and this bug would silently
+// upgrade to an unbound wrapped KEK.
+func TestGCPKMS_Encrypt_RejectsUnverifiedAADChecksum(t *testing.T) {
+	c := &client{
+		kms:     corruptChecksumKMS{dropAADVerifiedFlags: true},
+		keyName: "k",
+		aad:     []byte("env=prod\n"),
+	}
+	_, err := c.Encrypt(context.Background(), []byte("payload"))
+	if err == nil {
+		t.Fatal("Encrypt must reject a response that does not report the AAD checksum as verified when AAD is set")
+	}
+}
+
 // crypto-gcpkms-02: a corrupted DecryptResponse.plaintext_crc32c must be detected
 // and rejected rather than silently trusted.
 func TestGCPKMS_Decrypt_RejectsCorruptedResponseChecksum(t *testing.T) {
@@ -335,6 +357,36 @@ func TestGCPKMS_Decrypt_NoFallback_NoAuditEvent(t *testing.T) {
 	}
 	if fired {
 		t.Fatal("audit sink must not fire when the decrypt succeeds without falling back")
+	}
+}
+
+// emitFallbackAudit is best-effort: a wired sink that itself fails to write must
+// be swallowed (logged, not propagated) since by the time it runs the fallback
+// decrypt it's reporting on has already succeeded and must not be undone by an
+// audit-logging failure.
+func TestGCPKMS_Decrypt_FallbackAuditSinkErrorStillSucceeds(t *testing.T) {
+	legacy := newTestClient(nil, false)
+	ct, err := legacy.Encrypt(context.Background(), []byte("kek"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	bound := newTestClient(map[string]string{"keyorix-install": "inst-1"}, true)
+
+	sinkCalled := false
+	bound.SetAuditSink(func(_ context.Context, _ *models.AuditEvent) error {
+		sinkCalled = true
+		return errors.New("audit backend unavailable")
+	})
+
+	pt, err := bound.Decrypt(context.Background(), ct)
+	if err != nil {
+		t.Fatalf("decrypt via fallback must succeed even though the audit sink errors: %v", err)
+	}
+	if string(pt) != "kek" {
+		t.Fatalf("got %q", pt)
+	}
+	if !sinkCalled {
+		t.Fatal("audit sink was not invoked on a fallback decrypt")
 	}
 }
 

--- a/internal/crypto/multi_provider_test.go
+++ b/internal/crypto/multi_provider_test.go
@@ -178,6 +178,54 @@ func TestMultiKeyProvider_KEK_NoDowngradeHookWhenPrimarySucceeds(t *testing.T) {
 	assert.False(t, called, "the hook must not fire when the primary itself succeeds — no fallback happened")
 }
 
+// TestMultiKeyProvider_KEK_FailureTierTracking_AffectsDowngradeFromTier covers
+// KEK()'s "if t := ProviderTierOf(p.Name()); t > maxTier { maxTier = t }"
+// branch, which updates the running tier ceiling after a FAILED provider —
+// not just from the primary before the loop starts. It is only observable
+// through its effect on a later downgrade's reported FromTier: the chain is
+// [password (fails), tpm (fails, HIGHER tier than the running ceiling),
+// password (succeeds)]. If the failed tpm step did not raise maxTier, the
+// final downgrade would incorrectly report FromTier=software instead of
+// hardware.
+func TestMultiKeyProvider_KEK_FailureTierTracking_AffectsDowngradeFromTier(t *testing.T) {
+	m, err := crypto.NewMultiKeyProvider([]crypto.KeyProvider{
+		badProvider("password"),  // TierSoftware, fails
+		badProvider("tpm"),       // TierHardware, fails — must raise the tracked ceiling
+		goodProvider("password"), // TierSoftware, succeeds — now a real downgrade
+	})
+	require.NoError(t, err)
+
+	var got *crypto.FallbackDowngrade
+	m.SetDowngradeHook(func(d crypto.FallbackDowngrade) { got = &d })
+
+	key, err := m.KEK()
+	require.NoError(t, err)
+	assert.NotEmpty(t, key)
+	require.NotNil(t, got, "a failed higher-tier provider earlier in the chain must still raise the tracked ceiling")
+	assert.Equal(t, crypto.TierHardware, got.FromTier, "FromTier must reflect the failed tpm provider's tier, not just the primary's")
+	assert.Equal(t, crypto.TierSoftware, got.ToTier)
+}
+
+// TestMultiKeyProvider_KEK_SingleProviderSucceeds_NoMultiLogNoise covers the
+// len(m.providers) > 1 == false branch: with exactly one configured provider,
+// KEK() must still succeed and return its key (the branch only gates a log
+// line, so the meaningful assertion is that a single-provider chain works at
+// all, not just multi-provider chains).
+func TestMultiKeyProvider_KEK_SingleProviderSucceeds_NoMultiLogNoise(t *testing.T) {
+	good := goodProvider("password")
+	m, err := crypto.NewMultiKeyProvider([]crypto.KeyProvider{good})
+	require.NoError(t, err)
+
+	key, err := m.KEK()
+	require.NoError(t, err)
+	assert.Equal(t, good.key, key)
+}
+
+func TestProviderTier_String_UnrecognizedRendersAsUnknown(t *testing.T) {
+	assert.Equal(t, "unknown", crypto.TierUnknown.String())
+	assert.Equal(t, "unknown", crypto.ProviderTier(99).String(), "a tier value with no known case must render as unknown, not zero-value/panic")
+}
+
 func TestMultiKeyProvider_KEK_NoDowngradeHookOnSameTierFallback(t *testing.T) {
 	m, err := crypto.NewMultiKeyProvider([]crypto.KeyProvider{
 		badProvider("aws-kms"), goodProvider("gcp-kms"),

--- a/internal/delivery/smtp_test.go
+++ b/internal/delivery/smtp_test.go
@@ -1,7 +1,9 @@
 package delivery
 
 import (
+	"bufio"
 	"context"
+	"net"
 	"strings"
 	"testing"
 
@@ -113,6 +115,108 @@ func TestSMTPDeliverDegradesOnSendFailure(t *testing.T) {
 	assert.Equal(t, ChannelSMTP, res.Channel)
 	assert.False(t, res.Delivered)
 	assert.Equal(t, "https://keyorix.acme.internal/auth/setup/kx_setup_abc", res.LinkForAdmin)
+}
+
+// startFakeSMTPServer starts a minimal SMTP relay on an ephemeral localhost port
+// that speaks just enough of the protocol (EHLO/MAIL FROM/RCPT TO/DATA/QUIT) to
+// let go-mail complete a real send, letting us exercise DeliverSetupLink's
+// success path (Delivered=true) without a live external relay. It serves exactly
+// one connection and stops on its own once that connection closes or the test ends.
+func startFakeSMTPServer(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		writeLine := func(s string) { _, _ = conn.Write([]byte(s + "\r\n")) }
+		writeLine("220 fake.smtp ESMTP ready")
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				return
+			}
+			cmd := strings.TrimSpace(line)
+			switch {
+			case strings.HasPrefix(cmd, "EHLO"), strings.HasPrefix(cmd, "HELO"):
+				writeLine("250 fake.smtp")
+			case strings.HasPrefix(cmd, "MAIL FROM"):
+				writeLine("250 2.1.0 OK")
+			case strings.HasPrefix(cmd, "RCPT TO"):
+				writeLine("250 2.1.5 OK")
+			case strings.EqualFold(cmd, "NOOP"):
+				// go-mail's checkConn sends NOOP before every send to verify the
+				// connection is still alive; it must succeed or the client reports
+				// "not connected to SMTP server" and never attempts the real send.
+				writeLine("250 2.0.0 OK")
+			case strings.EqualFold(cmd, "DATA"):
+				writeLine("354 End data with <CR><LF>.<CR><LF>")
+				for {
+					dline, derr := reader.ReadString('\n')
+					if derr != nil {
+						return
+					}
+					if strings.TrimSpace(dline) == "." {
+						writeLine("250 2.0.0 OK: queued as fake-id")
+						break
+					}
+				}
+			case strings.EqualFold(cmd, "RSET"):
+				// sendSingleMsg RSETs the session between messages; must succeed.
+				writeLine("250 2.0.0 OK")
+			case strings.EqualFold(cmd, "QUIT"):
+				writeLine("221 2.0.0 Bye")
+				return
+			default:
+				writeLine("500 5.5.2 unrecognized command")
+			}
+		}
+	}()
+
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func TestSMTPDeliverSucceeds(t *testing.T) {
+	// End-to-end against the fake relay above: a real send that succeeds must
+	// report Delivered=true with no LinkForAdmin fallback (the link only needs
+	// manual relay when sending fails).
+	t.Setenv(EnvAllowInsecureSMTP, "true")
+	port := startFakeSMTPServer(t)
+	d, err := newSMTPDelivery(SMTPSettings{Host: "127.0.0.1", Port: port, From: "k@acme.io", TLS: "none"})
+	require.NoError(t, err)
+
+	res, err := d.DeliverSetupLink(context.Background(), SetupLinkRequest{
+		RecipientEmail: "new@acme.io",
+		Link:           "https://keyorix.acme.internal/auth/setup/kx_setup_ok",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ChannelSMTP, res.Channel)
+	assert.True(t, res.Delivered, "a successful send must report Delivered=true")
+	assert.Empty(t, res.LinkForAdmin, "no manual-relay fallback is needed on a successful send")
+}
+
+func TestSMTPDeliverDegradesOnClientInitFailure(t *testing.T) {
+	// Bypass newSMTPDelivery's validation (which requires Host != "") to construct
+	// an SMTPDelivery whose buildMessage succeeds (From/To don't touch Host) but
+	// whose newClient fails (go-mail's NewClient rejects an empty host with
+	// ErrNoHostname). DeliverSetupLink must still degrade to manual relay rather
+	// than surfacing an error.
+	d := &SMTPDelivery{cfg: SMTPSettings{From: "k@acme.io"}}
+	res, err := d.DeliverSetupLink(context.Background(), SetupLinkRequest{
+		RecipientEmail: "new@acme.io",
+		Link:           "https://keyorix.acme.internal/auth/setup/kx_setup_noclient",
+	})
+	require.NoError(t, err, "client-init failure degrades gracefully, never errors")
+	assert.Equal(t, ChannelSMTP, res.Channel)
+	assert.False(t, res.Delivered)
+	assert.Equal(t, "https://keyorix.acme.internal/auth/setup/kx_setup_noclient", res.LinkForAdmin)
 }
 
 func TestSMTPDeliverRejectsEmptyInput(t *testing.T) {

--- a/internal/delivery/smtp_test.go
+++ b/internal/delivery/smtp_test.go
@@ -133,7 +133,7 @@ func startFakeSMTPServer(t *testing.T) int {
 		if err != nil {
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		reader := bufio.NewReader(conn)
 		writeLine := func(s string) { _, _ = conn.Write([]byte(s + "\r\n")) }

--- a/internal/dynamic/dynamic_s26_test.go
+++ b/internal/dynamic/dynamic_s26_test.go
@@ -1,0 +1,473 @@
+package dynamic
+
+// dynamic_s26_test.go – G80 coverage push for internal/dynamic (93.3% → as close to
+// 100% as reasonably achievable).
+//
+// Strategy: fill the specific branches the existing sN test files left uncovered
+// (verified via `go tool cover -func`), reusing the same fake-server / fake-driver
+// conventions those files already established:
+//   - kubernetes.go: validateAPIServerHost's own branches (never unit-tested
+//     directly before) and refuseRedirect (0% — never called directly).
+//   - awssts.go: arnAccountID's malformed-ARN branch.
+//   - mongodb.go: parseMongoRoles' blocked-role rejection (a real security
+//     invariant that had NO test at all), plus createUser/dropUser failure
+//     branches via a fake MongoDB wire-protocol server that can be told to return
+//     a command error for a specific command name.
+//   - mysql.go: killUserConnections' QueryContext-error branch.
+//   - postgres.go: dialPostgres' pgx.ParseConfig error branch.
+//   - azure.go / gcp.go: the "build real credential/client" branches, using
+//     environment-variable / local-file tricks that make credential construction
+//     itself succeed or fail deterministically WITHOUT any live network call —
+//     see each test's comment for why it's hermetic.
+//
+// Branches deliberately left uncovered (documented, not silently dropped):
+//   - Every `if _, err := randString(N); err != nil` defensive branch across all
+//     six Issue implementations: randString's only failure mode is crypto/rand.Read
+//     erroring, which isn't feasible to force from a black-box test without
+//     modifying non-test source (out of scope for this pass).
+//   - mysql.go openMySQL's `mysql.NewConnector(cfg)` error branch: verified
+//     empirically that go-sql-driver/mysql's ParseDSN already runs the same
+//     cfg.normalize() validation NewConnector performs, so by the time
+//     ParseDSN succeeds, NewConnector cannot fail on the same cfg — the branch is
+//     dead code from an external caller's perspective.
+//   - gcp.go/azure.go's realGCPMinter.mintAccessToken / realAzureMinter.mintToken
+//     SUCCESS paths reachable only through Issue's nil-minter path with real
+//     ADC/workload-identity credentials — not obtainable in this environment
+//     (realGCPMinter's success path IS covered directly via
+//     TestRealGCPMinter_MintAccessToken_Success in dynamic_s3_test.go, which
+//     bypasses newRealGCPMinter entirely).
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/binary"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─────────────────────────── kubernetes.go: validateAPIServerHost ─────────────
+//
+// Never unit-tested directly before (only exercised transitively through
+// newRealK8sMinter's always-https/well-formed test inputs).
+
+func TestValidateAPIServerHost_InvalidURL(t *testing.T) {
+	// Malformed percent-encoding is one of the few inputs net/url.Parse itself
+	// rejects.
+	err := validateAPIServerHost("https://host/%zz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid api_server")
+}
+
+func TestValidateAPIServerHost_NonHTTPSScheme(t *testing.T) {
+	err := validateAPIServerHost("http://10.0.0.1:443")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must use https")
+}
+
+func TestValidateAPIServerHost_MissingHost(t *testing.T) {
+	err := validateAPIServerHost("https://")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing a host")
+}
+
+func TestValidateAPIServerHost_Valid(t *testing.T) {
+	require.NoError(t, validateAPIServerHost("https://10.0.0.1:443"))
+}
+
+// ─────────────────────────── kubernetes.go: refuseRedirect ────────────────────
+//
+// 0% coverage: refuseRedirect is wired in as http.Client.CheckRedirect but never
+// actually invoked by any existing test (none of the fake servers issue a 3xx).
+
+func TestRefuseRedirect(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://10.0.0.1/api/v1/secrets", nil)
+	require.NoError(t, err)
+	err = refuseRedirect(req, nil)
+	require.Error(t, err, "the TokenRequest/Secret client must never follow a redirect (CWE-918)")
+	assert.Contains(t, err.Error(), "refusing to follow redirect")
+	assert.Contains(t, err.Error(), req.URL.String())
+}
+
+// ─────────────────────────── kubernetes.go: newRealK8sMinter host validation ──
+//
+// newRealK8sMinter's own validateAPIServerHost(m.host) call (after the CA pool
+// is built) was never exercised with a value that fails it: every existing
+// test's api_server is already a well-formed https URL. An operator-configured
+// non-https api_server reaches this check unvalidated up to this point.
+
+func TestNewRealK8sMinter_APIServerNonHTTPS_Rejected(t *testing.T) {
+	// Any httptest.TLS server's cert works as a syntactically-valid CA PEM here;
+	// the request never actually reaches the network — validateAPIServerHost
+	// rejects the host before any client is used.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	caPEM := buildK8sCACertPEM(t, srv)
+
+	cfg := k8sConfig{APIServer: "http://insecure-k8s-api:6443", Token: "tok", CACert: caPEM}
+	_, err := newRealK8sMinter(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must use https")
+}
+
+// ─────────────────────────── awssts.go: client() LoadDefaultConfig failure ────
+//
+// e.client's error branch (LoadDefaultConfig failing) was never exercised —
+// dynamic_s3_test.go's client() tests only prove the call doesn't panic. Forcing
+// a genuine failure needs a shared AWS config profile whose assume-role chain
+// references a source_profile that doesn't exist: LoadDefaultConfig resolves
+// (not just parses) profiles eagerly, so this fails deterministically without
+// any real AWS credentials or network access.
+
+func TestAWSSTSEngine_ClientDefault_LoadConfigError(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "aws-config")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(
+		"[profile broken]\nsource_profile = does-not-exist\nrole_arn = arn:aws:iam::123456789012:role/x\n",
+	), 0o600))
+	t.Setenv("AWS_CONFIG_FILE", cfgPath)
+	t.Setenv("AWS_PROFILE", "broken")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(dir, "does-not-exist-creds"))
+
+	e := &AWSSTSEngine{} // no injected newClient — exercises the real LoadDefaultConfig path
+	_, err := e.client(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load AWS config")
+}
+
+// ─────────────────────────── awssts.go: arnAccountID ──────────────────────────
+
+func TestArnAccountID_MalformedARN(t *testing.T) {
+	// Fewer than 5 colon-separated segments — not a well-formed ARN.
+	for _, bad := range []string{"", "arn", "arn:aws", "arn:aws:iam", "arn:aws:iam:"} {
+		assert.Equal(t, "", arnAccountID(bad), "malformed ARN %q must yield no account ID", bad)
+	}
+}
+
+// ─────────────────────────── mongodb.go: parseMongoRoles blocked roles ────────
+//
+// mongoBlockedRoles rejection had NO test coverage at all despite being the
+// backend's core privilege-escalation guard (a dynamic-secret credential must
+// never receive a cluster-wide/superuser role).
+
+func TestParseMongoRoles_BlockedRole_StringForm(t *testing.T) {
+	_, err := parseMongoRoles(`{"roles": ["readWrite", "clusterAdmin"]}`)
+	require.Error(t, err, "clusterAdmin must be rejected even alongside a safe role")
+	assert.Contains(t, err.Error(), `"clusterAdmin"`)
+	assert.Contains(t, err.Error(), "cluster-wide or superuser privilege")
+}
+
+func TestParseMongoRoles_BlockedRole_ObjectForm(t *testing.T) {
+	_, err := parseMongoRoles(`{"roles": [{"role": "root", "db": "admin"}]}`)
+	require.Error(t, err, "root must be rejected in {role,db} object form too, not just as a bare string")
+	assert.Contains(t, err.Error(), `"root"`)
+}
+
+func TestParseMongoRoles_ObjectFormWithoutRoleKey_NotBlocked(t *testing.T) {
+	// An object entry with no "role" key resolves to an empty roleName, which is
+	// not in mongoBlockedRoles — parseMongoRoles must not reject it (the entry is
+	// passed through as-is for MongoDB itself to validate).
+	roles, err := parseMongoRoles(`{"roles": [{"db": "admin"}]}`)
+	require.NoError(t, err)
+	assert.Len(t, roles, 1)
+}
+
+func TestParseMongoRoles_AllBuiltinSuperuserRolesBlocked(t *testing.T) {
+	for role := range mongoBlockedRoles {
+		t.Run(role, func(t *testing.T) {
+			_, err := parseMongoRoles(fmt.Sprintf(`{"roles": [%q]}`, role))
+			require.Error(t, err, "every mongoBlockedRoles entry must be rejected")
+		})
+	}
+}
+
+// ─────────────────────────── mongodb.go: fake server with command errors ──────
+//
+// Extends the fake MongoDB OP_MSG server from dynamic_s25_test.go (which always
+// answers {ok:1}) with the ability to answer a specific command name with a
+// {ok:0, code, codeName, errmsg} CommandError — needed to cover Issue's
+// createUser failure branch and Revoke's two dropUser branches (idempotent
+// UserNotFound vs. a real failure), none of which any existing test reaches.
+
+// bsonDocMongoErr encodes a MongoDB command-error response document.
+func bsonDocMongoErr(code int32, codeName, errmsg string) []byte {
+	return bsonDoc(
+		bsonDouble("ok", 0.0),
+		bsonInt32("code", code),
+		bsonString("codeName", codeName),
+		bsonString("errmsg", errmsg),
+	)
+}
+
+// handleFakeMongoConnCmdErr is handleFakeMongoConn's sibling: it answers
+// hello/isMaster with the normal handshake response, answers any command whose
+// wire body contains cmdKey with the given command error, and answers
+// everything else with {ok:1} — exactly like handleFakeMongoConn.
+func handleFakeMongoConnCmdErr(conn net.Conn, cmdKey string, code int32, codeName, errmsg string) {
+	defer conn.Close() //nolint:errcheck
+	_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
+
+	for {
+		hdr := make([]byte, 16)
+		if _, err := io.ReadFull(conn, hdr); err != nil {
+			return
+		}
+		totalLen := int(binary.LittleEndian.Uint32(hdr[0:4]))
+		requestID := int32(binary.LittleEndian.Uint32(hdr[4:8]))
+		bodyLen := totalLen - 16
+		if bodyLen < 0 {
+			return
+		}
+		var body []byte
+		if bodyLen > 0 {
+			body = make([]byte, bodyLen)
+			if _, err := io.ReadFull(conn, body); err != nil {
+				return
+			}
+		}
+		var respBody []byte
+		switch {
+		case isHelloCommand(body):
+			respBody = bsonDocHello()
+		case containsAny(string(body), cmdKey):
+			respBody = bsonDocMongoErr(code, codeName, errmsg)
+		default:
+			respBody = bsonDocOK()
+		}
+		if err := writeOPMsgWithBody(conn, requestID, respBody); err != nil {
+			return
+		}
+	}
+}
+
+// startFakeMongoServerCmdErr starts a fake MongoDB server that fails any
+// command whose body contains cmdKey with the given command error, and returns
+// its connection URI.
+func startFakeMongoServerCmdErr(t *testing.T, cmdKey string, code int32, codeName, errmsg string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handleFakeMongoConnCmdErr(conn, cmdKey, code, codeName, errmsg)
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+	return fmt.Sprintf(
+		"mongodb://127.0.0.1:%s/admin?directConnection=true&serverSelectionTimeoutMS=5000",
+		port,
+	)
+}
+
+func TestMongoEngine_Issue_CreateUserFails(t *testing.T) {
+	uri := startFakeMongoServerCmdErr(t, "createUser", 13, "Unauthorized", "not authorized on admin")
+	e := &MongoEngine{}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	_, _, err := e.Issue(ctx, uri, `{"roles": ["readWrite"]}`, time.Minute)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create user")
+}
+
+func TestMongoEngine_Revoke_DropUserFails_NotIdempotent(t *testing.T) {
+	uri := startFakeMongoServerCmdErr(t, "dropUser", 13, "Unauthorized", "not authorized on admin")
+	e := &MongoEngine{}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	err := e.Revoke(ctx, uri, "kx_dyn_validname123")
+	require.Error(t, err, "a real (non-UserNotFound) dropUser failure must be reported, not swallowed")
+	assert.Contains(t, err.Error(), "drop user")
+}
+
+func TestMongoEngine_Revoke_DropUserNotFound_IsIdempotent(t *testing.T) {
+	uri := startFakeMongoServerCmdErr(t, "dropUser", 11, "UserNotFound", "user not found")
+	e := &MongoEngine{}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	err := e.Revoke(ctx, uri, "kx_dyn_validname123")
+	require.NoError(t, err, "UserNotFound (already gone) must be treated as a successful, idempotent revoke")
+}
+
+// ─────────────────────────── mysql.go: killUserConnections QueryContext error ─
+//
+// The rows.Scan error branch already has a test (TestKillUserConnections_ScanError
+// in dynamic_s23_test.go); the earlier `if err != nil { return }` guarding the
+// QueryContext call itself does not — that requires the SELECT against
+// information_schema.processlist to fail outright, not just return a bad row.
+
+type fakeQueryErrDriver struct{}
+
+func (d *fakeQueryErrDriver) Open(_ string) (driver.Conn, error) {
+	return &fakeQueryErrConn{}, nil
+}
+
+type fakeQueryErrConn struct{ execCalled *bool }
+
+func (c *fakeQueryErrConn) Prepare(_ string) (driver.Stmt, error) {
+	return &fakeQueryErrStmt{execCalled: c.execCalled}, nil
+}
+func (c *fakeQueryErrConn) Close() error              { return nil }
+func (c *fakeQueryErrConn) Begin() (driver.Tx, error) { return nil, fmt.Errorf("not supported") }
+
+type fakeQueryErrStmt struct{ execCalled *bool }
+
+func (s *fakeQueryErrStmt) Close() error  { return nil }
+func (s *fakeQueryErrStmt) NumInput() int { return -1 }
+func (s *fakeQueryErrStmt) Exec(_ []driver.Value) (driver.Result, error) {
+	if s.execCalled != nil {
+		*s.execCalled = true
+	}
+	return driver.RowsAffected(0), nil
+}
+func (s *fakeQueryErrStmt) Query(_ []driver.Value) (driver.Rows, error) {
+	// Simulates the processlist SELECT itself failing (e.g. missing privilege).
+	return nil, fmt.Errorf("simulated processlist query failure")
+}
+
+func TestKillUserConnections_QueryContextError(t *testing.T) {
+	var killExecuted bool
+	db := sql.OpenDB(&fakeQueryErrConnector{execCalled: &killExecuted})
+	defer db.Close() //nolint:errcheck
+
+	// killUserConnections is best-effort: when the processlist query itself
+	// fails, it must return immediately without ever attempting a KILL.
+	killUserConnections(context.Background(), db, "kx_dyn_test")
+	assert.False(t, killExecuted, "no KILL statement must run when the processlist query failed")
+}
+
+// fakeQueryErrConnector lets each test get its own execCalled flag (sql.Open
+// with a registered driver name shares no per-call state, so we use a
+// driver.Connector instead — it's part of database/sql, no new dependency).
+type fakeQueryErrConnector struct{ execCalled *bool }
+
+func (c *fakeQueryErrConnector) Connect(_ context.Context) (driver.Conn, error) {
+	return &fakeQueryErrConn{execCalled: c.execCalled}, nil
+}
+func (c *fakeQueryErrConnector) Driver() driver.Driver { return &fakeQueryErrDriver{} }
+
+// ─────────────────────────── postgres.go: dialPostgres ParseConfig error ──────
+
+func TestDialPostgres_InvalidDSN(t *testing.T) {
+	_, err := dialPostgres(context.Background(), "not a valid dsn at all ::: %zz", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connect to target")
+}
+
+// ─────────────────────────── azure.go: credential-construction failure ────────
+//
+// azidentity.NewDefaultAzureCredential checks AZURE_TOKEN_CREDENTIALS up front
+// and fails synchronously (no network) if it's set to an unrecognized value —
+// this is the one deterministic, hermetic way to force newRealAzureMinter's own
+// error branch (previously unreachable: in this environment
+// NewDefaultAzureCredential(nil) otherwise always succeeds, deferring any
+// failure to the later GetToken call).
+
+func TestNewRealAzureMinter_InvalidTokenCredentialsEnv(t *testing.T) {
+	t.Setenv("AZURE_TOKEN_CREDENTIALS", "not-a-real-credential-type")
+	_, err := newRealAzureMinter()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build default credential")
+}
+
+func TestAzureEngine_Issue_NilMinter_CredentialBuildFails(t *testing.T) {
+	t.Setenv("AZURE_TOKEN_CREDENTIALS", "not-a-real-credential-type")
+	eng := &AzureEngine{} // nil minter → Issue must call newRealAzureMinter itself
+	_, _, err := eng.Issue(context.Background(),
+		`{"scopes":["https://management.azure.com/.default"]}`, "", time.Hour)
+	require.Error(t, err)
+	// Must surface the credential-construction failure, not a downstream
+	// "acquire token" error — proves Issue's own nil-minter error-propagation
+	// branch (not just newRealAzureMinter in isolation) was exercised.
+	assert.Contains(t, err.Error(), "build default credential")
+}
+
+// ─────────────────────────── gcp.go: real client construction succeeds ────────
+//
+// iamcredentials.NewService only parses local Application Default Credentials —
+// it makes no network call at construction time. Pointing
+// GOOGLE_APPLICATION_CREDENTIALS at a syntactically-valid (but fake) service
+// account key file lets newRealGCPMinter succeed without any real GCP access.
+// Then, to cover Issue's own "minter = m" assignment (not just
+// newRealGCPMinter in isolation) without depending on live network
+// reachability, the request is made with an already-expired context: the
+// actual GenerateAccessToken HTTP call fails immediately on the expired
+// deadline before attempting to dial anything, so the test is fast and fully
+// hermetic in an air-gapped CI runner too.
+
+// writeFakeGCPServiceAccountKey writes a syntactically-valid (self-signed, not
+// registered with Google) service-account JSON key so google.FindDefaultCredentials
+// can parse it successfully; it is never used to make a real authenticated call.
+func writeFakeGCPServiceAccountKey(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der := x509.MarshalPKCS1PrivateKey(key)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der})
+	sa := map[string]string{
+		"type":                        "service_account",
+		"project_id":                  "fake-project",
+		"private_key_id":              "fakekeyid",
+		"private_key":                 string(pemBytes),
+		"client_email":                "fake@fake-project.iam.gserviceaccount.com",
+		"client_id":                   "123456789",
+		"auth_uri":                    "https://accounts.google.com/o/oauth2/auth",
+		"token_uri":                   "https://oauth2.googleapis.com/token",
+		"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+		"client_x509_cert_url":        "https://www.googleapis.com/robot/v1/metadata/x509/fake",
+	}
+	b, err := json.Marshal(sa)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "fake-sa.json")
+	require.NoError(t, os.WriteFile(path, b, 0o600))
+	return path
+}
+
+func TestNewRealGCPMinter_Success(t *testing.T) {
+	path := writeFakeGCPServiceAccountKey(t)
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	m, err := newRealGCPMinter(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.NotNil(t, m.svc)
+}
+
+func TestGCPEngine_Issue_NilMinter_BuildsRealMinter(t *testing.T) {
+	path := writeFakeGCPServiceAccountKey(t)
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
+
+	// Already-expired: newRealGCPMinter succeeds (local-only), the subsequent
+	// GenerateAccessToken call fails instantly on the expired deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(2 * time.Millisecond)
+
+	eng := &GCPEngine{} // nil minter → Issue must call newRealGCPMinter itself
+	_, _, err := eng.Issue(ctx,
+		`{"service_account":"fake@fake-project.iam.gserviceaccount.com"}`, "", time.Hour)
+	require.Error(t, err, "an already-expired context must fail the token request, but newRealGCPMinter itself must have succeeded first")
+}

--- a/internal/encryption/g80_coverage_test.go
+++ b/internal/encryption/g80_coverage_test.go
@@ -1,0 +1,1198 @@
+// g80_coverage_test.go — targeted gap-fill tests for internal/encryption (g80
+// coverage-uplift round, baseline 89.1% statement coverage).
+//
+// Each section below names the specific function/branch it exercises, matching
+// the convention already established in coverage_test.go.
+package encryption
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// skipIfRootOrWindows skips permission-based tests that don't work as root
+// (bypasses permission checks) or on Windows (chmod not enforced the same way).
+func skipIfRootOrWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("permission enforcement differs on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("running as root bypasses permission checks")
+	}
+}
+
+// ─── AuthEncryption.AcquireSharedKeyLock / Shutdown (auth_encryption.go) ──────
+
+// TestAuthEncryption_AcquireSharedKeyLock_Disabled verifies the disabled-service
+// no-op branch: with encryption disabled there is no DEK to guard, so the call
+// must succeed without touching the filesystem.
+func TestAuthEncryption_AcquireSharedKeyLock_Disabled(t *testing.T) {
+	dir := t.TempDir()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(dir, "test.db")), &gorm.Config{})
+	require.NoError(t, err)
+	cfg := &config.EncryptionConfig{Enabled: false}
+	ae := NewAuthEncryption(cfg, dir, db)
+	require.NoError(t, ae.Initialize("unused"))
+
+	require.NoError(t, ae.AcquireSharedKeyLock())
+}
+
+// TestAuthEncryption_AcquireSharedKeyLock_Enabled verifies the enabled branch
+// delegates to the underlying Service and actually takes the OS lock — a second,
+// independent AuthEncryption sharing the same key directory can still take a
+// shared lock alongside it (shared locks don't exclude each other).
+func TestAuthEncryption_AcquireSharedKeyLock_Enabled(t *testing.T) {
+	dir := t.TempDir()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(dir, "test.db")), &gorm.Config{})
+	require.NoError(t, err)
+	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
+	ae := NewAuthEncryption(cfg, dir, db)
+	require.NoError(t, ae.Initialize("g80-passphrase"))
+	defer ae.Shutdown()
+
+	require.NoError(t, ae.AcquireSharedKeyLock())
+
+	// A concurrent exclusive lock attempt from a second Service sharing the same
+	// key directory must now be refused — proving the shared lock was really taken
+	// at the OS level, not just a no-op.
+	other := NewService(cfg, dir)
+	require.NoError(t, other.Initialize("g80-passphrase"))
+	defer other.Shutdown()
+	err = other.AcquireExclusiveKeyLock()
+	assert.Error(t, err, "exclusive lock must be refused while AuthEncryption holds the shared lock")
+}
+
+// TestAuthEncryption_Shutdown_Disabled verifies Shutdown is safe to call on a
+// disabled/never-really-initialized AuthEncryption (no underlying key material).
+func TestAuthEncryption_Shutdown_Disabled(t *testing.T) {
+	dir := t.TempDir()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(dir, "test.db")), &gorm.Config{})
+	require.NoError(t, err)
+	cfg := &config.EncryptionConfig{Enabled: false}
+	ae := NewAuthEncryption(cfg, dir, db)
+	require.NoError(t, ae.Initialize("unused"))
+
+	ae.Shutdown() // must not panic
+}
+
+// TestAuthEncryption_Shutdown_ReleasesLock verifies Shutdown on an enabled,
+// initialized AuthEncryption releases a previously-acquired shared lock: a
+// second Service can then take the lock exclusively.
+func TestAuthEncryption_Shutdown_ReleasesLock(t *testing.T) {
+	dir := t.TempDir()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(dir, "test.db")), &gorm.Config{})
+	require.NoError(t, err)
+	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
+	ae := NewAuthEncryption(cfg, dir, db)
+	require.NoError(t, ae.Initialize("g80-passphrase-2"))
+	require.NoError(t, ae.AcquireSharedKeyLock())
+
+	ae.Shutdown()
+
+	other := NewService(cfg, dir)
+	require.NoError(t, other.Initialize("g80-passphrase-2"))
+	defer other.Shutdown()
+	assert.NoError(t, other.AcquireExclusiveKeyLock(), "exclusive lock must succeed after AuthEncryption.Shutdown released the shared lock")
+}
+
+// ─── auth_encryption_store.go: token.UserID != nil branch ────────────────────
+//
+// Every existing test for StoreEncryptedAPIToken/RetrieveAPIToken leaves
+// APIToken.UserID nil, so the `if token.UserID != nil { tokenUserID = *token.UserID }`
+// branch (both in StoreEncryptedAPIToken and RetrieveAPIToken) was never exercised.
+
+func TestAuthEncryption_StoreAndRetrieveAPIToken_WithUserID(t *testing.T) {
+	tempDir := t.TempDir()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(tempDir, "test.db")), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.APIToken{}))
+
+	cfg := &config.EncryptionConfig{Enabled: false}
+	ae := NewAuthEncryption(cfg, tempDir, db)
+	require.NoError(t, ae.Initialize("unused"))
+
+	uid := uint(42)
+	apiToken := &models.APIToken{
+		ClientID:  1,
+		UserID:    &uid,
+		Scope:     "read",
+		CreatedAt: time.Now(),
+	}
+	plain := "api-token-with-real-owner"
+
+	require.NoError(t, ae.StoreEncryptedAPIToken(apiToken, plain))
+	assert.NotZero(t, apiToken.ID)
+
+	retrieved, err := ae.RetrieveAPIToken(apiToken.ID)
+	require.NoError(t, err)
+	assert.Equal(t, plain, retrieved)
+}
+
+// TestAuthEncryption_StoreAndRetrieveAPIToken_WithUserID_Enabled exercises the
+// same UserID != nil branch with encryption actually enabled — the AAD binds to
+// the real owning user, so a wrong-user decrypt (see AUTH-CRYPTO-002) fails.
+func TestAuthEncryption_StoreAndRetrieveAPIToken_WithUserID_Enabled(t *testing.T) {
+	dir := t.TempDir()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(dir, "test.db")), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.APIToken{}))
+
+	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
+	ae := NewAuthEncryption(cfg, dir, db)
+	require.NoError(t, ae.Initialize("g80-apitoken-userid-pass"))
+	defer ae.Shutdown()
+
+	uid := uint(7)
+	apiToken := &models.APIToken{ClientID: 1, UserID: &uid, Scope: "write", CreatedAt: time.Now()}
+	plain := "api-token-plain-owned"
+	require.NoError(t, ae.StoreEncryptedAPIToken(apiToken, plain))
+
+	retrieved, err := ae.RetrieveAPIToken(apiToken.ID)
+	require.NoError(t, err)
+	assert.Equal(t, plain, retrieved)
+
+	// Sanity: the encrypted bytes are bound to userID=7's AAD, not userID=0's —
+	// decrypting directly with the wrong AAD must fail.
+	var stored models.APIToken
+	require.NoError(t, db.First(&stored, apiToken.ID).Error)
+	_, err = ae.DecryptAPIToken(stored.EncryptedToken, []byte(stored.TokenMetadata), 0)
+	assert.Error(t, err, "decrypting with the wrong (zero) userID AAD must fail once the row was encrypted with a real, non-nil UserID")
+}
+
+// ─── encryption.go: Decrypt — invalid base64 nonce (no rand mocking needed) ───
+
+func TestDecrypt_InvalidBase64Nonce_Error(t *testing.T) {
+	es, err := NewEncryptionService(make([]byte, 32))
+	require.NoError(t, err)
+
+	enc, err := es.Encrypt([]byte("payload"), "v1")
+	require.NoError(t, err)
+	enc.Metadata.Nonce = "not-valid-base64!!!"
+
+	_, err = es.Decrypt(enc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decode nonce")
+}
+
+// TestDecryptWithAAD_InvalidBase64Nonce_Error mirrors the above for the AAD path
+// (DecryptWithAAD has its own, separately-covered, base64-decode branch).
+func TestDecryptWithAAD_InvalidBase64Nonce_Error(t *testing.T) {
+	es, err := NewEncryptionService(make([]byte, 32))
+	require.NoError(t, err)
+
+	aad := []byte("aad")
+	enc, err := es.EncryptWithAAD([]byte("payload"), "v1", aad)
+	require.NoError(t, err)
+	enc.Metadata.Nonce = "%%%not-base64%%%"
+
+	_, err = es.DecryptWithAAD(enc, aad)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decode nonce")
+}
+
+// ─── encryption.go: rand.Reader failure branches ──────────────────────────────
+//
+// NOTE: GenerateRandomKey's own error branch (encryption.go:128-130) is NOT
+// covered here. It calls the crypto/rand.Read package function directly, and as
+// of Go 1.24 (https://go.dev/issue/66821) that function is documented to never
+// return an error — any failure crashes the process via runtime.fatal instead,
+// even when crypto/rand.Reader has been swapped for a failing io.Reader. That
+// makes the branch genuinely unreachable from a test in this Go toolchain, not
+// merely hard to set up; forcing it would crash the whole test binary.
+
+// TestEncryptionService_Encrypt_RandFailure_Error covers Encrypt's nonce-generation
+// io.ReadFull(rand.Reader, ...) error branch (encryption.go:139).
+func TestEncryptionService_Encrypt_RandFailure_Error(t *testing.T) {
+	es, err := NewEncryptionService(make([]byte, 32))
+	require.NoError(t, err)
+	withFailingRand(t, func() {
+		_, err := es.Encrypt([]byte("data"), "v1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to generate nonce")
+	})
+}
+
+// TestEncryptionService_EncryptWithAAD_RandFailure_Error covers EncryptWithAAD's
+// nonce-generation error branch (encryption.go:247).
+func TestEncryptionService_EncryptWithAAD_RandFailure_Error(t *testing.T) {
+	es, err := NewEncryptionService(make([]byte, 32))
+	require.NoError(t, err)
+	withFailingRand(t, func() {
+		_, err := es.EncryptWithAAD([]byte("data"), "v1", []byte("aad"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to generate nonce")
+	})
+}
+
+// TestEncryptionService_EncryptChunked_StreamIDRandFailure_Error covers
+// EncryptChunked's stream-ID generation error branch (encryption.go:302).
+func TestEncryptionService_EncryptChunked_StreamIDRandFailure_Error(t *testing.T) {
+	es, err := NewEncryptionService(make([]byte, 32))
+	require.NoError(t, err)
+	withFailingRand(t, func() {
+		_, err := es.EncryptChunked([]byte("some data to chunk"), 4, "v1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to generate chunk stream id")
+	})
+}
+
+// TestEncryptionService_EncryptChunked_PerChunkEncryptFailure_Error covers the
+// inner EncryptWithAAD-call error branch inside EncryptChunked's loop
+// (encryption.go:318) — the 16-byte stream ID read succeeds, but the first
+// chunk's nonce read (12 bytes, immediately after) fails.
+func TestEncryptionService_EncryptChunked_PerChunkEncryptFailure_Error(t *testing.T) {
+	es, err := NewEncryptionService(make([]byte, 32))
+	require.NoError(t, err)
+	withRandFailingAfter(t, 16, func() {
+		_, err := es.EncryptChunked([]byte("some data to chunk into pieces"), 4, "v1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to encrypt chunk 0")
+	})
+}
+
+// ─── exclusive_lock.go: OpenFile failure branches ─────────────────────────────
+
+// TestAcquireExclusiveKeyLock_OpenFileFailure_Error covers the os.OpenFile error
+// branch (exclusive_lock.go:45) — a baseDir whose parent doesn't exist can't have
+// the lock file created inside it.
+func TestAcquireExclusiveKeyLock_OpenFileFailure_Error(t *testing.T) {
+	badDir := filepath.Join(t.TempDir(), "does", "not", "exist")
+	_, err := acquireExclusiveKeyLock(badDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open DEK lock file")
+}
+
+// TestAcquireSharedKeyLock_OpenFileFailure_Error mirrors the above for
+// acquireSharedKeyLock (exclusive_lock.go:67).
+func TestAcquireSharedKeyLock_OpenFileFailure_Error(t *testing.T) {
+	badDir := filepath.Join(t.TempDir(), "does", "not", "exist")
+	_, err := acquireSharedKeyLock(badDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open DEK lock file")
+}
+
+// ─── key_provider_downgrade.go: auditKeyProviderDowngrade ─────────────────────
+
+// TestAuditKeyProviderDowngrade_NilSink_NoOp covers the sink==nil early-return
+// branch (key_provider_downgrade.go:62): calling it before SetAuditSink must not
+// panic and must simply do nothing.
+func TestAuditKeyProviderDowngrade_NilSink_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{Enabled: false}
+	svc := NewService(cfg, dir)
+
+	// No SetAuditSink call — s.auditSink is nil.
+	svc.auditKeyProviderDowngrade(crypto.FallbackDowngrade{
+		Index:    1,
+		Provider: "password",
+	})
+	// No panic == pass. Nothing else to assert since the branch is a pure no-op.
+}
+
+// TestAuditKeyProviderDowngrade_SinkError_Swallowed covers the sink-returns-error
+// branch (key_provider_downgrade.go:75): the sink is still called (best-effort),
+// but its error is only logged, never propagated or panicked on.
+func TestAuditKeyProviderDowngrade_SinkError_Swallowed(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{Enabled: false}
+	svc := NewService(cfg, dir)
+
+	called := false
+	svc.SetAuditSink(func(_ context.Context, event *models.AuditEvent) error {
+		called = true
+		return fmt.Errorf("injected sink write failure")
+	})
+
+	svc.auditKeyProviderDowngrade(crypto.FallbackDowngrade{
+		Index:    2,
+		Provider: "env",
+	})
+	assert.True(t, called, "sink must still be called even though it will return an error")
+}
+
+// ─── service.go: wireKMSAuditSink — non-sinkable client branch ────────────────
+
+// TestWireKMSAuditSink_NonKMSProvider_NoOp covers the type-assertion-fails branch
+// (service.go:77): wireKMSAuditSink is called with any crypto.KeyProvider that is
+// NOT a *crypto.KMSKeyProvider (e.g. the plain password provider every enabled
+// test in this package already constructs) and must return without panicking.
+func TestWireKMSAuditSink_NonKMSProvider_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
+	svc := NewService(cfg, dir)
+	provider := crypto.NewPasswordKeyProvider("pw", dir, "kek.salt")
+
+	svc.wireKMSAuditSink(provider) // must not panic; provider is not *crypto.KMSKeyProvider
+}
+
+// ─── unwrapKey/wrapKey: bad-length KEK branches (no mocking needed) ───────────
+
+func TestWrapKey_BadKEKLength_Error(t *testing.T) {
+	_, err := wrapKey(make([]byte, 32), make([]byte, 15)) // AES needs 16/24/32
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create AES cipher")
+}
+
+func TestUnwrapKey_BadKEKLength_Error(t *testing.T) {
+	_, err := unwrapKey(make([]byte, 40), make([]byte, 15))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create AES cipher")
+}
+
+// TestWrapKey_RandFailure_Error covers wrapKey's nonce-generation error branch
+// (keymanager_lifecycle.go — the wrapKey helper's rand.Reader call).
+func TestWrapKey_RandFailure_Error(t *testing.T) {
+	withFailingRand(t, func() {
+		_, err := wrapKey(make([]byte, 32), make([]byte, 32))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to generate nonce")
+	})
+}
+
+// sanity: confirm AES block size assumption used above still holds (documents
+// intent rather than testing stdlib, keeps the "why 15 bytes" self-evident).
+func TestAESBlockSizeAssumption(t *testing.T) {
+	assert.Equal(t, 16, aes.BlockSize)
+}
+
+// ─── keymanager_lifecycle.go: ensureSaltExists rand-failure branch ────────────
+
+func TestEnsureSaltExists_RandFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	withFailingRand(t, func() {
+		_, err := km.ensureSaltExists()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to generate salt")
+	})
+}
+
+// TestEnsureSaltExists_WriteFailure_Error covers the salt-write failure branch:
+// the salt directory is read-only, so persisting a freshly generated salt fails.
+func TestEnsureSaltExists_WriteFailure_Error(t *testing.T) {
+	skipIfRootOrWindows(t)
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, os.Chmod(dir, 0555))
+	defer func() { _ = os.Chmod(dir, 0755) }()
+
+	_, err := km.ensureSaltExists()
+	require.Error(t, err)
+}
+
+// ─── keymanager_lifecycle.go: ensureWrappedDEKExists — wrapKey failure ────────
+
+// TestEnsureWrappedDEKExists_WrapKeyFailure_Error covers the wrapKey-error
+// branch by supplying a bad-length KEK directly (aes.NewCipher fails, no rand
+// mocking needed).
+func TestEnsureWrappedDEKExists_WrapKeyFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	err := km.ensureWrappedDEKExists(make([]byte, 10)) // invalid AES key size
+	require.Error(t, err)
+}
+
+// ─── keymanager_lifecycle.go: unwrapDEK — SafeReadFile failure ────────────────
+
+func TestUnwrapDEK_ReadFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	// dek.key does not exist.
+	_, err := km.unwrapDEK(make([]byte, 32))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read wrapped DEK")
+}
+
+// ─── keymanager_filelock.go / keymanager_rotation.go / keymanager_rewrap.go: ──
+// ─── shared lock-file setup helper                                          ───
+
+// createLockFileThenReadOnly pre-creates <baseDir>/<dekPath>.lock (so the
+// exclusive flock acquisition, which only needs to open an EXISTING file, still
+// succeeds) and then makes baseDir read-only, so any subsequent NEW file the
+// caller tries to create there (a .pending write) fails. Returns a cleanup func
+// that restores directory permissions.
+func createLockFileThenReadOnly(t *testing.T, baseDir, dekPath string) func() {
+	t.Helper()
+	lockPath := filepath.Join(baseDir, dekPath+".lock")
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	require.NoError(t, os.Chmod(baseDir, 0555))
+	return func() { _ = os.Chmod(baseDir, 0755) }
+}
+
+// ─── keymanager_rotation.go: RotateDEKWithSweep remaining branches ────────────
+//
+// NOTE: the GenerateRandomKey error branch (keymanager_rotation.go:61-63) is not
+// covered here for the same reason noted above: GenerateRandomKey calls
+// crypto/rand.Read, which cannot return an error in this Go toolchain (Go 1.24+,
+// https://go.dev/issue/66821) — it crashes the process on failure instead.
+
+// TestRotateDEKWithSweep_WrapKeyFailure_Error covers the wrapKey error branch
+// (keymanager_rotation.go:67) by installing a key provider that returns a
+// bad-length KEK — deriveKEK for the provider path does not itself validate
+// length, so wrapKey's aes.NewCipher call is what actually fails.
+func TestRotateDEKWithSweep_WrapKeyFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+	km.SetKeyProvider(&mockKeyProvider{kek: make([]byte, 10)})
+
+	err := km.RotateDEKWithSweep("unused-with-provider-set", func(_, _ *EncryptionService, _ string) error {
+		t.Fatal("sweepFn must not be called when wrapKey fails")
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to wrap new DEK")
+}
+
+// TestRotateDEKWithSweep_WritePendingFailure_ExactBranch covers the
+// SecureWriteFileSync failure branch (keymanager_rotation.go:71) precisely: the
+// lock file is pre-created (so lock acquisition itself succeeds) and only THEN
+// is baseDir made read-only, so the failure is specifically the pending-DEK
+// write, not the lock acquisition (unlike the pre-existing, similarly-named test
+// in coverage_test.go, which — per its own on-disk behavior — actually hits the
+// lock-acquisition branch instead, since it never pre-creates the lock file).
+func TestRotateDEKWithSweep_WritePendingFailure_ExactBranch(t *testing.T) {
+	skipIfRootOrWindows(t)
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+	dekBefore := km.GetDEK()
+
+	restore := createLockFileThenReadOnly(t, dir, "dek.key")
+	defer restore()
+
+	err := km.RotateDEKWithSweep("passphrase", func(_, _ *EncryptionService, _ string) error {
+		t.Fatal("sweepFn must not be called when the pending DEK write fails")
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write pending DEK")
+	assert.True(t, bytes.Equal(dekBefore, km.GetDEK()), "DEK must be unchanged on write failure")
+}
+
+// TestRotateDEKWithSweep_OldEncSvcCreationFailure_Error covers the
+// NewEncryptionService(km.currentDEK) failure branch for the OLD DEK
+// (keymanager_rotation.go:77) by directly corrupting the in-memory DEK to an
+// invalid AES key length (accessible since this test lives in-package).
+func TestRotateDEKWithSweep_OldEncSvcCreationFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+	km.currentDEK = make([]byte, 10) // corrupt: not a valid AES key size
+
+	err := km.RotateDEKWithSweep("passphrase", func(_, _ *EncryptionService, _ string) error {
+		t.Fatal("sweepFn must not be called when the old encryption service can't be created")
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create old encryption service")
+}
+
+// TestRotateDEKWithSweep_RenameFailure_Error covers the os.Rename failure branch
+// (keymanager_rotation.go:98) by replacing the active DEK path with a directory —
+// RotateDEKWithSweep never reads dek.key's own content before promoting the
+// pending file (unlike RewrapDEK/RotateKEKPassphrase, which do a staleness
+// check), so this is reachable without corrupting any earlier step.
+func TestRotateDEKWithSweep_RenameFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+
+	require.NoError(t, os.Remove(filepath.Join(dir, "dek.key")))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "dek.key"), 0755))
+
+	err := km.RotateDEKWithSweep("passphrase", func(_, _ *EncryptionService, _ string) error {
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to promote pending DEK to active")
+}
+
+// TestDeleteBackupFiles_BadGlobPattern_Error covers the filepath.Glob error
+// branch (keymanager_rotation.go:124): an unterminated "[" character in the glob
+// pattern makes filepath.Glob return ErrBadPattern.
+func TestDeleteBackupFiles_BadGlobPattern_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key[", "kek.salt")
+	km.deleteBackupFiles() // must not panic; the error is logged and swallowed
+}
+
+// ─── keymanager_kek_rotation.go: RotateKEKPassphrase remaining branches ───────
+
+// TestRotateKEKPassphrase_LockFailure_Error covers the acquireExclusiveKeyLock
+// failure branch (keymanager_kek_rotation.go:53): baseDir is read-only and the
+// lock file does not exist yet, so it can't be created.
+func TestRotateKEKPassphrase_LockFailure_Error(t *testing.T) {
+	skipIfRootOrWindows(t)
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+
+	require.NoError(t, os.Chmod(dir, 0555))
+	defer func() { _ = os.Chmod(dir, 0755) }()
+
+	err := km.RotateKEKPassphrase("passphrase", "new-passphrase")
+	require.Error(t, err)
+}
+
+// TestRotateKEKPassphrase_ReadDEKFailure_Error covers the SafeReadFile(dekPath)
+// failure branch (keymanager_kek_rotation.go:64): the lock file is pre-created
+// so locking succeeds, then dek.key is removed entirely.
+func TestRotateKEKPassphrase_ReadDEKFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+	require.NoError(t, os.Remove(filepath.Join(dir, "dek.key")))
+
+	err := km.RotateKEKPassphrase("passphrase", "new-passphrase")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "re-read active DEK under lock")
+}
+
+// TestRotateKEKPassphrase_StaleDEKSnapshot_Error covers the on-disk-DEK-changed
+// staleness branch (keymanager_kek_rotation.go:67): dek.key is overwritten with
+// different (but still valid-length) bytes after Initialize, simulating a
+// concurrent rotation from another process.
+func TestRotateKEKPassphrase_StaleDEKSnapshot_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+
+	stale := bytes.Repeat([]byte{0xAB}, 60)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dek.key"), stale, 0600))
+
+	err := km.RotateKEKPassphrase("passphrase", "new-passphrase")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "on-disk DEK changed since this process started")
+}
+
+// TestRotateKEKPassphrase_ReadSaltFailure_Error covers the salt-read failure
+// branch (keymanager_kek_rotation.go:74).
+func TestRotateKEKPassphrase_ReadSaltFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+	require.NoError(t, os.Remove(filepath.Join(dir, "kek.salt")))
+
+	err := km.RotateKEKPassphrase("passphrase", "new-passphrase")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read current salt")
+}
+
+// TestRotateKEKPassphrase_InvalidSaltSize_Error covers the salt-size-validation
+// branch (keymanager_kek_rotation.go:77).
+func TestRotateKEKPassphrase_InvalidSaltSize_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "kek.salt"), []byte("too-short"), 0600))
+
+	err := km.RotateKEKPassphrase("passphrase", "new-passphrase")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid current salt size")
+}
+
+// TestRotateKEKPassphrase_NewSaltRandFailure_Error covers the new-salt
+// generation error branch (keymanager_kek_rotation.go:93).
+func TestRotateKEKPassphrase_NewSaltRandFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+
+	withFailingRand(t, func() {
+		err := km.RotateKEKPassphrase("passphrase", "new-passphrase")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "generate new salt")
+	})
+}
+
+// TestRotateKEKPassphrase_WrapNewDEKFailure_Error covers the
+// wrapKey(km.currentDEK, newKEK) error branch (keymanager_kek_rotation.go:103):
+// the first 32 bytes of rand output (the new salt) succeed, but wrapKey's own
+// 12-byte nonce read (which happens after) fails.
+func TestRotateKEKPassphrase_WrapNewDEKFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+
+	withRandFailingAfter(t, 32, func() {
+		err := km.RotateKEKPassphrase("passphrase", "new-passphrase")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "wrap DEK with new KEK")
+	})
+}
+
+// TestRotateKEKPassphrase_CommitFailure_Error covers the commitNewKEKFiles error
+// propagation branch (keymanager_kek_rotation.go:107) by pre-creating
+// "kek.salt.pending" as a directory, so commitNewKEKFiles's first write fails.
+func TestRotateKEKPassphrase_CommitFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "kek.salt.pending"), 0755))
+
+	err := km.RotateKEKPassphrase("passphrase", "new-passphrase")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write pending salt")
+}
+
+// ─── keymanager_kek_rotation.go: commitNewKEKFiles direct branch coverage ─────
+//
+// Called directly (unexported method, in-package) to reach branches that are
+// impractical to set up through the full RotateKEKPassphrase flow, mirroring
+// coverage_test.go's existing direct-call pattern for deleteBackupFiles.
+
+func TestCommitNewKEKFiles_WriteSaltFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "kek.salt.pending"), 0755))
+
+	err := km.commitNewKEKFiles(make([]byte, 32), make([]byte, 48))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write pending salt")
+}
+
+func TestCommitNewKEKFiles_WriteDEKFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "dek.key.pending"), 0755))
+
+	err := km.commitNewKEKFiles(make([]byte, 32), make([]byte, 48))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write pending DEK")
+	// The pending salt file written just before the DEK write failed must be
+	// cleaned up, not left behind.
+	_, statErr := os.Stat(filepath.Join(dir, "kek.salt.pending"))
+	assert.True(t, os.IsNotExist(statErr), "pending salt file must be removed after a later write failure")
+}
+
+func TestCommitNewKEKFiles_RenameDEKFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	// dek.key exists as a directory, so renaming the pending file onto it fails.
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "dek.key"), 0755))
+
+	err := km.commitNewKEKFiles(make([]byte, 32), make([]byte, 48))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "promote pending DEK to active")
+	_, statErr := os.Stat(filepath.Join(dir, "dek.key.pending"))
+	assert.True(t, os.IsNotExist(statErr), "pending DEK file must be removed after a rename failure")
+	_, statErr = os.Stat(filepath.Join(dir, "kek.salt.pending"))
+	assert.True(t, os.IsNotExist(statErr), "pending salt file must also be removed after a DEK-rename failure")
+}
+
+func TestCommitNewKEKFiles_RenameSaltFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	// kek.salt exists as a directory, so the DEK rename succeeds but the salt
+	// rename fails.
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "kek.salt"), 0755))
+
+	err := km.commitNewKEKFiles(make([]byte, 32), make([]byte, 48))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "promote pending salt to active")
+	// The DEK rename already succeeded and must NOT have been rolled back.
+	_, statErr := os.Stat(filepath.Join(dir, "dek.key"))
+	assert.NoError(t, statErr, "the DEK rename must remain committed even though the salt rename failed")
+}
+
+func TestCommitNewKEKFiles_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	salt := bytes.Repeat([]byte{0x11}, 32)
+	wrapped := bytes.Repeat([]byte{0x22}, 48)
+
+	require.NoError(t, km.commitNewKEKFiles(salt, wrapped))
+
+	gotSalt, err := os.ReadFile(filepath.Join(dir, "kek.salt"))
+	require.NoError(t, err)
+	assert.Equal(t, salt, gotSalt)
+	gotDEK, err := os.ReadFile(filepath.Join(dir, "dek.key"))
+	require.NoError(t, err)
+	assert.Equal(t, wrapped, gotDEK)
+}
+
+// ─── keymanager_rewrap.go: RewrapDEK remaining branches ───────────────────────
+
+func TestRewrapDEK_LockFailure_Error(t *testing.T) {
+	skipIfRootOrWindows(t)
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+
+	require.NoError(t, os.Chmod(dir, 0555))
+	defer func() { _ = os.Chmod(dir, 0755) }()
+
+	err := km.RewrapDEK(&mockKeyProvider{kek: make([]byte, 32)})
+	require.Error(t, err)
+}
+
+// TestRewrapDEK_WrapKeyFailure_Error covers wrapKey's error branch inside
+// RewrapDEK (keymanager_rewrap.go:80) via a rand.Reader failure — the new
+// provider's KEK is a valid 32 bytes (passes the length check), so wrapKey
+// itself must be what's reached and what fails.
+func TestRewrapDEK_WrapKeyFailure_Error(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+
+	withFailingRand(t, func() {
+		err := km.RewrapDEK(&mockKeyProvider{kek: make([]byte, 32)})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "wrap DEK with new KEK")
+	})
+}
+
+// TestRewrapDEK_WritePendingFailure_Error covers the SecureWriteFileSync failure
+// branch (keymanager_rewrap.go:90), using the same pre-create-lock-then-readonly
+// technique as the RotateDEKWithSweep equivalent above.
+func TestRewrapDEK_WritePendingFailure_Error(t *testing.T) {
+	skipIfRootOrWindows(t)
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.Initialize("passphrase"))
+
+	restore := createLockFileThenReadOnly(t, dir, "dek.key")
+	defer restore()
+
+	err := km.RewrapDEK(&mockKeyProvider{kek: make([]byte, 32)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write pending DEK")
+}
+
+// ─── keymanager_kek_rotation_test.go coverage note ─────────────────────────────
+// (RotateKEKPassphrase's happy path, wrong-passphrase, empty-passphrase, and
+// same-passphrase cases are already covered by keymanager_kek_rotation_test.go;
+// deriveEvidenceSignKey/deriveAuditCheckpointKey re-derivation failure branches
+// inside RotateKEKPassphrase are not exercised here — HKDF-SHA256 does not fail
+// for any 32-byte KEK input, making those branches practically unreachable
+// without modifying the golang.org/x/crypto/hkdf package itself.)
+
+// ─── g80SvcInit: shared helper for an initialized Service (service.go /       ──
+// ─── service_rotation.go sections below)                                     ──
+
+func g80SvcInit(t *testing.T, passphrase string) (*Service, string) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
+	svc := NewService(cfg, dir)
+	require.NoError(t, svc.Initialize(passphrase))
+	return svc, dir
+}
+
+// ─── service.go: EncryptSecret / EncryptSecretWithAAD / EncryptLargeSecret ────
+// ─── rand.Reader failure branches                                            ──
+
+func TestService_EncryptSecret_RandFailure_Error(t *testing.T) {
+	svc, _ := g80SvcInit(t, "g80-svc-encrypt-rand")
+	defer svc.Shutdown()
+
+	withFailingRand(t, func() {
+		_, _, err := svc.EncryptSecret([]byte("plaintext"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to encrypt secret")
+	})
+}
+
+func TestService_EncryptSecretWithAAD_RandFailure_Error(t *testing.T) {
+	svc, _ := g80SvcInit(t, "g80-svc-encrypt-aad-rand")
+	defer svc.Shutdown()
+
+	withFailingRand(t, func() {
+		_, _, err := svc.EncryptSecretWithAAD([]byte("plaintext"), []byte("aad"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to encrypt secret with AAD")
+	})
+}
+
+func TestService_EncryptLargeSecret_RandFailure_Error(t *testing.T) {
+	svc, _ := g80SvcInit(t, "g80-svc-encrypt-large-rand")
+	defer svc.Shutdown()
+
+	withFailingRand(t, func() {
+		_, _, err := svc.EncryptLargeSecret([]byte("a large secret payload to chunk"), 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to encrypt chunked secret")
+	})
+}
+
+// ─── service_rotation.go: RotateKEKPassphrase (Service level) ─────────────────
+
+func TestServiceRotateKEKPassphrase_NotInitialized_Error(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{Enabled: false}
+	svc := NewService(cfg, dir)
+
+	err := svc.RotateKEKPassphrase("old", "new")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not initialized")
+}
+
+// TestServiceRotateKEKPassphrase_LockFailure_Error covers the
+// AcquireExclusiveKeyLock failure branch (service_rotation.go:229): baseDir is
+// read-only and the Service-level lock file ("dek.lock", distinct from the
+// KeyManager-level "dek.key.lock") does not exist yet, so it can't be created.
+func TestServiceRotateKEKPassphrase_LockFailure_Error(t *testing.T) {
+	skipIfRootOrWindows(t)
+	svc, dir := g80SvcInit(t, "g80-svc-rotate-kek-lock")
+	defer svc.Shutdown()
+
+	require.NoError(t, os.Chmod(dir, 0555))
+	defer func() { _ = os.Chmod(dir, 0755) }()
+
+	err := svc.RotateKEKPassphrase("g80-svc-rotate-kek-lock", "new-passphrase")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stop the running server before rotating")
+}
+
+// ─── service_rotation.go: PreviewRotationSweep / UpgradeAuthAAD — tx.Begin ────
+// ─── error branches                                                          ──
+
+// g80ClosedDB returns a *gorm.DB whose underlying *sql.DB has already been
+// closed, so db.Begin() fails immediately — used to reach the tx.Begin()-error
+// branches that a merely-empty database can't reach.
+func g80ClosedDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "closed.db")), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+	return db
+}
+
+func TestPreviewRotationSweep_TxBeginFailure_Error(t *testing.T) {
+	svc, _ := g80SvcInit(t, "g80-preview-begin-fail")
+	defer svc.Shutdown()
+
+	_, err := svc.PreviewRotationSweep(g80ClosedDB(t))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to begin transaction")
+}
+
+func TestUpgradeAuthAAD_TxBeginFailure_Error(t *testing.T) {
+	svc, _ := g80SvcInit(t, "g80-upgradeaad-begin-fail")
+	defer svc.Shutdown()
+
+	_, err := svc.UpgradeAuthAAD(g80ClosedDB(t))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to begin transaction")
+}
+
+// TestServiceRotateDEKWithSweep_TxBeginFailure_Error covers the tx.Begin()
+// error branch inside RotateDEKWithSweep's own sweepFn (service_rotation.go:46)
+// — reached only once a full, real key rotation gets underway (KeyManager-level
+// RotateDEKWithSweep must succeed in generating and wrapping a new DEK before
+// sweepFn ever runs), so this exercises the real rotation path up to the point
+// where the caller-supplied *gorm.DB can't even start a transaction. The DEK
+// must remain the OLD one since the sweep never got a chance to run.
+func TestServiceRotateDEKWithSweep_TxBeginFailure_Error(t *testing.T) {
+	svc, _ := g80SvcInit(t, "g80-svc-rotate-begin-fail")
+	defer svc.Shutdown()
+	keyVersionBefore := svc.GetKeyVersion()
+
+	_, err := svc.RotateDEKWithSweep("g80-svc-rotate-begin-fail", g80ClosedDB(t))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DEK rotation with sweep failed")
+	assert.Equal(t, keyVersionBefore, svc.GetKeyVersion(), "key version must be unchanged when the sweep transaction can't even begin")
+}
+
+// ─── sweep.go: sweepSecretVersions — empty-value skip + re-encrypt failure ────
+// ─── + Updates() DB error                                                    ──
+
+func g80SweepDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "sweep.db")), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}))
+	return db
+}
+
+// TestSweepSecretVersions_SkipsEmptyEncryptedValue covers the
+// `if len(version.EncryptedValue) == 0 { continue }` branch (sweep.go:161): a
+// row with no ciphertext yet (e.g. a placeholder/reserved version) must be
+// skipped, not treated as a decrypt failure, and must not count toward swept.
+func TestSweepSecretVersions_SkipsEmptyEncryptedValue(t *testing.T) {
+	db := g80SweepDB(t)
+	es, err := NewEncryptionService(make([]byte, 32))
+	require.NoError(t, err)
+
+	node := &models.SecretNode{Name: "n-empty", ProjectID: 1, Type: "generic"}
+	require.NoError(t, db.Create(node).Error)
+	ver := &models.SecretVersion{SecretNodeID: node.ID, VersionNumber: 1, EncryptedValue: nil}
+	require.NoError(t, db.Create(ver).Error)
+
+	swept, legacy, err := sweepSecretVersions(db, es, es, "v2", false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, swept, "a row with no encrypted value must be skipped, not swept")
+	assert.Equal(t, 0, legacy)
+}
+
+// TestSweepSecretVersions_ReEncryptFailure covers the newSvc.EncryptWithAAD
+// error branch (sweep.go:188): decrypt with oldSvc succeeds, but the
+// re-encryption under newSvc fails.
+func TestSweepSecretVersions_ReEncryptFailure(t *testing.T) {
+	db := g80SweepDB(t)
+	oldSvc, err := NewEncryptionService(make([]byte, 32))
+	require.NoError(t, err)
+	newSvc, err := NewEncryptionService(bytes.Repeat([]byte{0x9}, 32))
+	require.NoError(t, err)
+
+	node := &models.SecretNode{Name: "n-reenc", ProjectID: 2, Type: "generic"}
+	require.NoError(t, db.Create(node).Error)
+	aad := SecretAAD(node.ID, 2, 1)
+	enc, err := oldSvc.EncryptWithAAD([]byte("secret-value"), "v1", aad)
+	require.NoError(t, err)
+	encBytes, err := SerializeEncryptedData(enc)
+	require.NoError(t, err)
+	ver := &models.SecretVersion{SecretNodeID: node.ID, VersionNumber: 1, EncryptedValue: encBytes}
+	require.NoError(t, db.Create(ver).Error)
+
+	withFailingRand(t, func() {
+		_, _, err := sweepSecretVersions(db, oldSvc, newSvc, "v2", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to re-encrypt secret_version")
+	})
+}
+
+// TestSweepSecretVersions_UpdatesError covers the Updates() DB-error branch
+// (sweep.go:207) via a read-only SQLite connection to a file that already
+// contains the row (same technique as TestSweepAPITokens_UpdatesError_ReadOnly
+// in encryption_s25_test.go).
+func TestSweepSecretVersions_UpdatesError(t *testing.T) {
+	es, err := NewEncryptionService(make([]byte, 32))
+	require.NoError(t, err)
+
+	dbFile := filepath.Join(t.TempDir(), "secretversion_ro.db")
+	rwDB, err := gorm.Open(sqlite.Open(dbFile), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, rwDB.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}))
+
+	node := &models.SecretNode{Name: "n-ro", ProjectID: 3, Type: "generic"}
+	require.NoError(t, rwDB.Create(node).Error)
+	aad := SecretAAD(node.ID, 3, 1)
+	enc, err := es.EncryptWithAAD([]byte("secret-value"), "v1", aad)
+	require.NoError(t, err)
+	encBytes, err := SerializeEncryptedData(enc)
+	require.NoError(t, err)
+	ver := &models.SecretVersion{SecretNodeID: node.ID, VersionNumber: 1, EncryptedValue: encBytes}
+	require.NoError(t, rwDB.Create(ver).Error)
+
+	roDB, err := gorm.Open(sqlite.Open("file:"+dbFile+"?mode=ro"), &gorm.Config{})
+	require.NoError(t, err)
+
+	_, _, err = sweepSecretVersions(roDB, es, es, "v2", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update re-encrypted secret_version")
+}
+
+// ─── sweep_auth.go: sweepAPITokens — token.UserID != nil branch ───────────────
+
+func TestSweepAPITokens_WithNonNilUserID(t *testing.T) {
+	db := g80SweepDB(t)
+	require.NoError(t, db.AutoMigrate(&models.APIToken{}))
+	es, err := NewEncryptionService(make([]byte, 32))
+	require.NoError(t, err)
+
+	uid := uint(55)
+	// APITokenAAD(55), matching the live write path (auth_encryption.go), so
+	// this is the AAD-bound (non-legacy) case with a real owning user.
+	enc, err := es.EncryptWithAAD([]byte("tok-val"), "v1", APITokenAAD(uid))
+	require.NoError(t, err)
+	encBytes, err := SerializeEncryptedData(enc)
+	require.NoError(t, err)
+	metaBytes, err := json.Marshal(enc.Metadata)
+	require.NoError(t, err)
+	row := &models.APIToken{
+		UserID:         &uid,
+		Token:          "h-userid-tok",
+		EncryptedToken: encBytes,
+		TokenMetadata:  models.JSON(metaBytes),
+	}
+	require.NoError(t, db.Create(row).Error)
+
+	swept, legacy, err := sweepAPITokens(db, es, es, "v2", false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, swept)
+	assert.Equal(t, 0, legacy)
+
+	// Confirm the re-encrypted row still round-trips under the real owning
+	// user's AAD (proves tokenUserID was actually derived from *token.UserID,
+	// not silently left at 0).
+	var reloaded models.APIToken
+	require.NoError(t, db.First(&reloaded, row.ID).Error)
+	reEnc, err := DeserializeEncryptedData(reloaded.EncryptedToken)
+	require.NoError(t, err)
+	plain, err := es.DecryptWithAAD(reEnc, APITokenAAD(uid))
+	require.NoError(t, err)
+	assert.Equal(t, "tok-val", string(plain))
+}
+
+// ─── sweep_auth.go: re-encrypt failure branches (one per sweep function) ──────
+
+func TestSweepSessions_ReEncryptFailure(t *testing.T) {
+	db := g80SweepDB(t)
+	require.NoError(t, db.AutoMigrate(&models.Session{}))
+	oldSvc, newSvc := g80OldNewSvc(t)
+
+	enc, err := oldSvc.EncryptWithAAD([]byte("sess-val"), "v1", SessionTokenAAD(1))
+	require.NoError(t, err)
+	encBytes, err := SerializeEncryptedData(enc)
+	require.NoError(t, err)
+	expiresAt := time.Now().Add(time.Hour)
+	row := &models.Session{UserID: 1, ExpiresAt: &expiresAt, EncryptedSessionToken: encBytes}
+	require.NoError(t, db.Create(row).Error)
+
+	withFailingRand(t, func() {
+		_, _, err := sweepSessions(db, oldSvc, newSvc, "v2", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to re-encrypt session")
+	})
+}
+
+func TestSweepAPITokens_ReEncryptFailure(t *testing.T) {
+	db := g80SweepDB(t)
+	require.NoError(t, db.AutoMigrate(&models.APIToken{}))
+	oldSvc, newSvc := g80OldNewSvc(t)
+
+	enc, err := oldSvc.EncryptWithAAD([]byte("tok-val"), "v1", APITokenAAD(0))
+	require.NoError(t, err)
+	encBytes, err := SerializeEncryptedData(enc)
+	require.NoError(t, err)
+	row := &models.APIToken{Token: "h-reenc-fail", EncryptedToken: encBytes}
+	require.NoError(t, db.Create(row).Error)
+
+	withFailingRand(t, func() {
+		_, _, err := sweepAPITokens(db, oldSvc, newSvc, "v2", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to re-encrypt api_token")
+	})
+}
+
+func TestSweepAPIClients_ReEncryptFailure(t *testing.T) {
+	db := g80SweepDB(t)
+	require.NoError(t, db.AutoMigrate(&models.APIClient{}))
+	oldSvc, newSvc := g80OldNewSvc(t)
+
+	enc, err := oldSvc.Encrypt([]byte("client-secret-val"), "v1")
+	require.NoError(t, err)
+	encBytes, err := SerializeEncryptedData(enc)
+	require.NoError(t, err)
+	row := &models.APIClient{ClientID: "cl-reenc-fail", EncryptedClientSecret: encBytes}
+	require.NoError(t, db.Create(row).Error)
+
+	withFailingRand(t, func() {
+		_, err := sweepAPIClients(db, oldSvc, newSvc, "v2", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to re-encrypt api_client")
+	})
+}
+
+func TestSweepMFASecrets_ReEncryptFailure(t *testing.T) {
+	db := g80SweepDB(t)
+	require.NoError(t, db.AutoMigrate(&models.MFASecret{}))
+	oldSvc, newSvc := g80OldNewSvc(t)
+
+	enc, err := oldSvc.EncryptWithAAD([]byte("totp-seed"), "v1", MFASecretAAD(9))
+	require.NoError(t, err)
+	encBytes, err := SerializeEncryptedData(enc)
+	require.NoError(t, err)
+	row := &models.MFASecret{UserID: 9, SecretEnc: encBytes}
+	require.NoError(t, db.Create(row).Error)
+
+	withFailingRand(t, func() {
+		_, _, err := sweepMFASecrets(db, oldSvc, newSvc, "v2", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to re-encrypt mfa_secret")
+	})
+}
+
+func TestSweepDynamicSecretConfigs_ReEncryptFailure(t *testing.T) {
+	db := g80SweepDB(t)
+	require.NoError(t, db.AutoMigrate(&models.DynamicSecretConfig{}))
+	oldSvc, newSvc := g80OldNewSvc(t)
+
+	enc, err := oldSvc.EncryptWithAAD([]byte("admin-dsn"), "v1", DynamicSecretConfigAAD(1, 2, 3))
+	require.NoError(t, err)
+	encBytes, err := SerializeEncryptedData(enc)
+	require.NoError(t, err)
+	row := &models.DynamicSecretConfig{ProjectID: 2, EnvironmentID: 3, AdminDSNEnc: encBytes}
+	require.NoError(t, db.Create(row).Error)
+
+	withFailingRand(t, func() {
+		_, _, err := sweepDynamicSecretConfigs(db, oldSvc, newSvc, "v2", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to re-encrypt dynamic_secret_config")
+	})
+}
+
+func TestSweepDynamicSecretLeases_ReEncryptFailure(t *testing.T) {
+	db := g80SweepDB(t)
+	require.NoError(t, db.AutoMigrate(&models.DynamicSecretLease{}))
+	oldSvc, newSvc := g80OldNewSvc(t)
+
+	enc, err := oldSvc.EncryptWithAAD([]byte("lease-cred"), "v1", DynamicSecretLeaseAAD("lease-1", 4))
+	require.NoError(t, err)
+	encBytes, err := SerializeEncryptedData(enc)
+	require.NoError(t, err)
+	row := &models.DynamicSecretLease{LeaseID: "lease-1", ConfigID: 4, CredentialEnc: encBytes}
+	require.NoError(t, db.Create(row).Error)
+
+	withFailingRand(t, func() {
+		_, _, err := sweepDynamicSecretLeases(db, oldSvc, newSvc, "v2", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to re-encrypt dynamic_secret_lease")
+	})
+}
+
+func TestSweepPasswordResets_ReEncryptFailure(t *testing.T) {
+	db := g80SweepDB(t)
+	require.NoError(t, db.AutoMigrate(&models.PasswordReset{}))
+	oldSvc, newSvc := g80OldNewSvc(t)
+
+	enc, err := oldSvc.EncryptWithAAD([]byte("reset-token"), "v1", PasswordResetTokenAAD(11))
+	require.NoError(t, err)
+	encBytes, err := SerializeEncryptedData(enc)
+	require.NoError(t, err)
+	row := &models.PasswordReset{UserID: 11, EncryptedToken: encBytes}
+	require.NoError(t, db.Create(row).Error)
+
+	withFailingRand(t, func() {
+		_, _, err := sweepPasswordResets(db, oldSvc, newSvc, "v2", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to re-encrypt password_reset")
+	})
+}
+
+// g80OldNewSvc returns two distinct, valid EncryptionServices to use as
+// oldSvc/newSvc in a sweep — separate keys so a round-trip decrypt-then-
+// re-encrypt is meaningful (not required for the re-encrypt-failure tests
+// above, but keeps the helper generally reusable).
+func g80OldNewSvc(t *testing.T) (*EncryptionService, *EncryptionService) {
+	t.Helper()
+	oldSvc, err := NewEncryptionService(make([]byte, 32))
+	require.NoError(t, err)
+	newSvc, err := NewEncryptionService(bytes.Repeat([]byte{0x5}, 32))
+	require.NoError(t, err)
+	return oldSvc, newSvc
+}

--- a/internal/encryption/g80_helpers_test.go
+++ b/internal/encryption/g80_helpers_test.go
@@ -1,0 +1,67 @@
+// g80_helpers_test.go — shared test helpers for the g80 coverage-uplift round
+// (internal/encryption statement coverage 89.1% baseline).
+//
+// withFailingRand / withLimitedThenFailingRand swap crypto/rand.Reader for the
+// duration of a callback, following the same pattern already established in
+// internal/crypto/coverage_test.go ("crypto/rand.Reader is a package-level var,
+// so swapping it for the duration of a test ... is a legitimate way to reach an
+// otherwise-untriggerable error path"). This package has no t.Parallel anywhere
+// (verified: every test in this package runs sequentially), so the swap is safe.
+package encryption
+
+import (
+	"crypto/rand"
+	"errors"
+	"io"
+	"testing"
+)
+
+// g80FailingReader is an io.Reader that always fails.
+type g80FailingReader struct{}
+
+func (g80FailingReader) Read(_ []byte) (int, error) {
+	return 0, errors.New("g80: injected rand failure")
+}
+
+// withFailingRand swaps crypto/rand.Reader for the duration of fn so that any
+// io.ReadFull(rand.Reader, ...)/rand.Read call made by fn fails deterministically,
+// then restores the original reader — even if fn panics.
+func withFailingRand(t *testing.T, fn func()) {
+	t.Helper()
+	old := rand.Reader
+	rand.Reader = g80FailingReader{}
+	defer func() { rand.Reader = old }()
+	fn()
+}
+
+// g80LimitedThenFailingReader lets the first n bytes read successfully (from the
+// real crypto/rand reader) and fails every read after that. Used to let an EARLIER
+// rand.Read call in the same code path (e.g. a salt/newSalt generation) succeed
+// while forcing a LATER one (e.g. a nonce generation inside a nested call) to fail
+// — reaching an inner error branch without also tripping an outer one.
+type g80LimitedThenFailingReader struct {
+	real      io.Reader
+	remaining int
+}
+
+func (r *g80LimitedThenFailingReader) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, errors.New("g80: injected rand failure after budget exhausted")
+	}
+	if len(p) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, err := r.real.Read(p)
+	r.remaining -= n
+	return n, err
+}
+
+// withRandFailingAfter swaps crypto/rand.Reader so the first n bytes read succeed
+// normally and every byte after that fails, then restores the original reader.
+func withRandFailingAfter(t *testing.T, n int, fn func()) {
+	t.Helper()
+	old := rand.Reader
+	rand.Reader = &g80LimitedThenFailingReader{real: old, remaining: n}
+	defer func() { rand.Reader = old }()
+	fn()
+}

--- a/internal/evidencesink/evidencesink_extra_test.go
+++ b/internal/evidencesink/evidencesink_extra_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -268,4 +269,67 @@ func TestMulti_AllFailing(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "a")
 	assert.Contains(t, err.Error(), "b")
+}
+
+// TestValidateEndpoint_MalformedURL covers the url.Parse error branch of
+// validateEndpoint (previously unreached — every existing test used a
+// syntactically valid URL, so only the well-formed path was exercised).
+func TestValidateEndpoint_MalformedURL(t *testing.T) {
+	err := validateEndpoint("http://[::1", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid endpoint")
+}
+
+// TestPinnedDialContext_NoAddressesResolved covers the branch where the
+// resolver succeeds but returns zero addresses — distinct from a resolution
+// error, and previously unreached.
+func TestPinnedDialContext_NoAddressesResolved(t *testing.T) {
+	orig := lookupIPAddr
+	t.Cleanup(func() { lookupIPAddr = orig })
+	lookupIPAddr = func(host string) ([]net.IPAddr, error) {
+		return nil, nil // resolves successfully but to nothing
+	}
+
+	dial, err := pinnedDialContext("empty-answer.evidence.example")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not resolve to any address")
+	assert.Nil(t, dial)
+}
+
+// TestPinnedDialContext_InvalidDialAddress covers the returned dialer's
+// net.SplitHostPort error branch: a dial address without a port must be
+// refused with a clear error rather than panicking or dialing garbage.
+func TestPinnedDialContext_InvalidDialAddress(t *testing.T) {
+	orig := lookupIPAddr
+	t.Cleanup(func() { lookupIPAddr = orig })
+	lookupIPAddr = func(host string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("203.0.113.20")}}, nil
+	}
+
+	dial, err := pinnedDialContext("split-host-port.evidence.example")
+	require.NoError(t, err)
+
+	_, dialErr := dial(context.Background(), "tcp", "no-port-here")
+	require.Error(t, dialErr, "a dial address with no port must be refused")
+	assert.Contains(t, dialErr.Error(), "invalid dial address")
+}
+
+// TestNewObjectStore_AWSConfigLoadFailurePropagates covers the
+// awsconfig.LoadDefaultConfig error branch of NewObjectStore (fail-closed):
+// a misconfigured AWS environment (here, an unreadable CA bundle path) must
+// surface as a constructor error rather than deferring the failure to the
+// first upload.
+func TestNewObjectStore_AWSConfigLoadFailurePropagates(t *testing.T) {
+	origCABundle, hadCABundle := os.LookupEnv("AWS_CA_BUNDLE")
+	require.NoError(t, os.Setenv("AWS_CA_BUNDLE", "/nonexistent/evidencesink-test/ca-bundle.pem"))
+	t.Cleanup(func() {
+		if hadCABundle {
+			_ = os.Setenv("AWS_CA_BUNDLE", origCABundle)
+		} else {
+			_ = os.Unsetenv("AWS_CA_BUNDLE")
+		}
+	})
+
+	_, err := NewObjectStore(context.Background(), ObjectStoreConfig{Bucket: "b"})
+	require.ErrorContains(t, err, "load AWS config")
 }

--- a/internal/k8ssync/k8ssync_s17_test.go
+++ b/internal/k8ssync/k8ssync_s17_test.go
@@ -135,6 +135,21 @@ func TestValidateMapping_EmptyFields(t *testing.T) {
 	}
 }
 
+// TestValidateMapping_InvalidKey exercises the !isK8sSecretKey branch: a key
+// containing a character outside [-._a-zA-Z0-9] (here a slash) must be rejected,
+// even when every other field is valid.
+func TestValidateMapping_InvalidKey(t *testing.T) {
+	m := SecretMapping{
+		Ref:       "prod/db",
+		Namespace: "default",
+		Name:      "my-secret",
+		Key:       "not/a/valid/key",
+	}
+	err := validateMapping(m)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid Kubernetes Secret data key")
+}
+
 // TestValidateMapping_InvalidNamespace exercises the !isDNS1123Label branch.
 func TestValidateMapping_InvalidNamespace(t *testing.T) {
 	m := SecretMapping{

--- a/internal/k8ssync/k8ssync_s24_test.go
+++ b/internal/k8ssync/k8ssync_s24_test.go
@@ -1,0 +1,99 @@
+package k8ssync
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// RESTSink — remaining request-build error branches. These call the sink's
+// (mostly unexported) methods directly with a deliberately invalid host or
+// an unmarshalable payload, since the exported entry points (Apply/Delete)
+// always route through a prior getOwnedMeta call on the same host+path, so a
+// bad host fails there first and never reaches these methods' own build step.
+// ---------------------------------------------------------------------------
+
+// invalidHostSink returns a RESTSink whose host makes http.NewRequestWithContext
+// fail deterministically (a control character in the URL), mirroring
+// TestRESTSink_newRequest_InvalidURL in k8ssync_s23_test.go.
+func invalidHostSink() *RESTSink {
+	return &RESTSink{host: "http://\x00invalid", token: "tok", fieldManager: "keyorix-sync", hc: &http.Client{}}
+}
+
+func TestRESTSink_Get_InvalidURL(t *testing.T) {
+	_, err := invalidHostSink().Get(context.Background(), "ns", "name")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build request")
+}
+
+func TestRESTSink_createSecret_InvalidURL(t *testing.T) {
+	err := invalidHostSink().createSecret(context.Background(), "ns", "name", map[string]interface{}{"kind": "Secret"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build request")
+}
+
+// TestRESTSink_createSecret_MarshalError exercises the json.Marshal error branch
+// directly: a channel value can never be marshaled to JSON, and this is otherwise
+// unreachable via Apply since the payloads Apply builds are always plain
+// strings/maps.
+func TestRESTSink_createSecret_MarshalError(t *testing.T) {
+	sink := testSinkHost("http://example.invalid")
+	err := sink.createSecret(context.Background(), "ns", "name", map[string]interface{}{"bad": make(chan int)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal secret")
+}
+
+func TestRESTSink_applyOwnedSecret_InvalidURL(t *testing.T) {
+	err := invalidHostSink().applyOwnedSecret(context.Background(), "ns", "name", map[string]interface{}{"kind": "Secret"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build request")
+}
+
+// TestRESTSink_applyOwnedSecret_MarshalError mirrors
+// TestRESTSink_createSecret_MarshalError for the update path.
+func TestRESTSink_applyOwnedSecret_MarshalError(t *testing.T) {
+	sink := testSinkHost("http://example.invalid")
+	err := sink.applyOwnedSecret(context.Background(), "ns", "name", map[string]interface{}{"bad": make(chan int)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal secret")
+}
+
+func TestRESTSink_List_InvalidURL(t *testing.T) {
+	_, err := invalidHostSink().List(context.Background(), "ns")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build request")
+}
+
+func TestRESTSink_getOwnedMeta_InvalidURL(t *testing.T) {
+	_, _, exists, owned, err := invalidHostSink().getOwnedMeta(context.Background(), "ns", "name")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build request")
+	assert.False(t, exists)
+	assert.False(t, owned)
+}
+
+// testSinkHost builds a RESTSink pointed at host without a live server — used only
+// for the marshal-error tests above, where the request is never actually sent.
+func testSinkHost(host string) *RESTSink {
+	return &RESTSink{host: host, token: "tok", fieldManager: "keyorix-sync", hc: &http.Client{}}
+}
+
+// ---------------------------------------------------------------------------
+// KeyorixFetcher.getJSON — request-build error branch.
+// ---------------------------------------------------------------------------
+
+// TestKeyorixFetcher_getJSON_InvalidURL exercises getJSON's http.NewRequestWithContext
+// error branch: baseURL itself passes validateFetcherBaseURL (a loopback http URL),
+// but the request path carries a control character that makes the concatenated URL
+// unparseable.
+func TestKeyorixFetcher_getJSON_InvalidURL(t *testing.T) {
+	f := NewKeyorixFetcher("http://127.0.0.1:9", "tok", 1)
+	var out struct{}
+	err := f.getJSON(context.Background(), "/\x00bad", &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build request")
+}

--- a/internal/k8ssync/keyorix_fetcher_test.go
+++ b/internal/k8ssync/keyorix_fetcher_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,6 +36,95 @@ func TestParseRef(t *testing.T) {
 		assert.Equal(t, c.env, env)
 		assert.Equal(t, c.name, name)
 	}
+}
+
+// TestRefuseRedirect verifies that the http.Client CheckRedirect hook always errors,
+// so a 3xx from a compromised/misconfigured Keyorix server can never bounce the
+// bearer-token-bearing request onward (CWE-918) — see refuseRedirect's doc comment.
+func TestRefuseRedirect(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/next", nil)
+	require.NoError(t, err)
+
+	err = refuseRedirect(req, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to follow redirect")
+	assert.Contains(t, err.Error(), "http://example.com/next")
+}
+
+// TestValidateFetcherBaseURL covers every branch: a well-formed https URL (always
+// allowed), a loopback http URL (allowed as a redundant runtime re-check for this
+// package's own httptest-backed tests), a non-loopback http URL (rejected), and two
+// distinct ways a raw string fails to be a well-formed absolute URL at all.
+func TestValidateFetcherBaseURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr string // "" means no error expected
+	}{
+		{"https always allowed", "https://example.com", ""},
+		{"http loopback IP allowed", "http://127.0.0.1:8080", ""},
+		{"http localhost allowed", "http://localhost:8080", ""},
+		{"http non-loopback host rejected", "http://example.com", "must use https"},
+		{"unparseable url rejected", "http://[::1", "invalid keyorix_url"},
+		{"no host rejected", "not-a-url", "invalid keyorix_url"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateFetcherBaseURL(c.raw)
+			if c.wantErr == "" {
+				assert.NoError(t, err, "raw %q", c.raw)
+				return
+			}
+			require.Error(t, err, "raw %q", c.raw)
+			assert.Contains(t, err.Error(), c.wantErr)
+		})
+	}
+}
+
+// TestIsLoopbackHostname covers all three ways a host can be recognized (or not) as
+// loopback: the literal "localhost", a loopback IP literal, and a non-loopback host
+// (by name or by IP) which must return false.
+func TestIsLoopbackHostname(t *testing.T) {
+	assert.True(t, isLoopbackHostname("localhost"))
+	assert.True(t, isLoopbackHostname("127.0.0.1"))
+	assert.True(t, isLoopbackHostname("::1"))
+	assert.False(t, isLoopbackHostname("example.com"))
+	assert.False(t, isLoopbackHostname("8.8.8.8"))
+}
+
+// TestKeyorixFetcher_InvalidBaseURLRejectedAtRequestTime exercises getJSON's runtime
+// re-validation of f.baseURL: a fetcher built (NewKeyorixFetcher never itself
+// validates baseURL) with an http URL to a non-loopback host must have every request
+// refused at request time, before any network call is attempted.
+func TestKeyorixFetcher_InvalidBaseURLRejectedAtRequestTime(t *testing.T) {
+	f := NewKeyorixFetcher("http://example.com", "tok", 1)
+	_, err := f.Fetch(context.Background(), "production/db-password")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must use https")
+}
+
+// TestKeyorixFetcher_ResolveID_ListSecretsError exercises resolveID's error path when
+// the environment resolves fine but the subsequent, environment-scoped secrets-list
+// call itself fails (a transient 5xx here, distinct from the "not found" case already
+// covered by TestKeyorixFetcher_NotFound).
+func TestKeyorixFetcher_ResolveID_ListSecretsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/environments"):
+			_, _ = w.Write([]byte(`{"data":{"environments":[{"ID":5,"Name":"production"}]}}`))
+		case r.URL.Path == "/api/v1/secrets":
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	f := NewKeyorixFetcher(srv.URL, "tok", 1)
+
+	_, err := f.Fetch(context.Background(), "production/db-password")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list secrets in project")
+	assert.Contains(t, err.Error(), "HTTP 500")
 }
 
 // stubSecret is one entry the fake secrets-list endpoint serves.

--- a/internal/k8ssync/rest_sink_test.go
+++ b/internal/k8ssync/rest_sink_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -261,6 +262,43 @@ func TestRESTSink_ApplyPatchRejectsResourceVersionConflict_Bug4(t *testing.T) {
 	err := testSink(srv).Apply(context.Background(), "app", "creds", map[string][]byte{"DB": []byte("v2")})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HTTP 409")
+}
+
+// failOnMethodTransport is an http.RoundTripper that simulates a network failure
+// for one specific HTTP method (letting every other method through to base), so a
+// test can force applyOwnedSecret's/createSecret's hc.Do error branch on exactly the
+// request it targets without disturbing the preceding ownership-check GET.
+type failOnMethodTransport struct {
+	base       http.RoundTripper
+	failMethod string
+}
+
+func (t *failOnMethodTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method == t.failMethod {
+		return nil, fmt.Errorf("simulated network failure")
+	}
+	return t.base.RoundTrip(req)
+}
+
+// TestRESTSink_ApplyPatchNetworkError exercises applyOwnedSecret's hc.Do error
+// branch: the ownership-check GET succeeds (the Secret is owned, so Apply proceeds
+// to the Server-Side-Apply PATCH), but the PATCH itself fails at the transport level
+// (e.g. a connection drop) rather than getting an HTTP response at all.
+func TestRESTSink_ApplyPatchNetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only the ownership-check GET should ever reach the server; the PATCH is
+		// intercepted by the failing transport before it leaves the client.
+		require.Equal(t, http.MethodGet, r.Method)
+		_, _ = w.Write([]byte(`{"metadata":{"uid":"u-1","resourceVersion":"rv-1","labels":{"app.kubernetes.io/managed-by":"keyorix-sync"}}}`))
+	}))
+	defer srv.Close()
+
+	sink := testSink(srv)
+	sink.hc = &http.Client{Transport: &failOnMethodTransport{base: http.DefaultTransport, failMethod: http.MethodPatch}}
+
+	err := sink.Apply(context.Background(), "app", "creds", map[string][]byte{"DB": []byte("v2")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request failed")
 }
 
 func TestRESTSink_ApplyError(t *testing.T) {

--- a/internal/license/license_s25_test.go
+++ b/internal/license/license_s25_test.go
@@ -116,6 +116,23 @@ func TestEvaluate_EmptyKeyID(t *testing.T) {
 	assert.False(t, st.Grants())
 }
 
+// TestIssue_MarshalError covers the json.Marshal error branch in Issue. time.Time's
+// MarshalJSON rejects years outside [0,9999], so a NotAfter far in the future makes
+// json.Marshal(&lic) fail even though all of Issue's own field validations pass.
+func TestIssue_MarshalError(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	lic := License{
+		Licensee: "ACME",
+		KeyID:    "k",
+		NotAfter: time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC), // year out of range for MarshalJSON
+	}
+	token, err := Issue(lic, priv)
+	assert.Error(t, err, "an unmarshalable NotAfter must surface the json.Marshal error")
+	assert.Empty(t, token, "no token should be produced on marshal failure")
+}
+
 // TestStatus_HasFeature_DegradedStates checks HasFeature returns false for every
 // non-granting state, covering the short-circuit in HasFeature.
 func TestStatus_HasFeature_DegradedStates(t *testing.T) {

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -306,6 +306,49 @@ func TestListSecrets_NotTruncated(t *testing.T) {
 	assert.NotContains(t, text, "incomplete")
 }
 
+// -- getJSON: request-build failure -------------------------------------------
+
+// TestGetJSON_BuildRequestError covers the http.NewRequestWithContext error
+// branch in getJSON. Every public constructor path (NewKeyorixClient) percent-
+// encodes user input via url.Values.Encode() before it ever reaches getJSON, so
+// this branch is unreachable through the exported API — it's exercised here by
+// constructing the client directly (same package) with a path whose invalid
+// percent-encoding survives to the request-build call.
+func TestGetJSON_BuildRequestError(t *testing.T) {
+	c := &KeyorixClient{baseURL: "http://example.com", token: "tok", hc: http.DefaultClient}
+	var out struct{}
+	err := c.getJSON(context.Background(), "/bad%zz", &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build request")
+}
+
+// -- toolListSecrets: maxListCalls cap branch --------------------------------
+
+// TestToolListSecrets_MaxListCallsCapReached covers the maxListCalls>0 &&
+// listCallCount>=maxListCalls branch in toolListSecrets (tools.go). As the
+// TestServe_SetMaxListCalls doc comment in server_test.go explains, nothing in
+// tools.go ever increments s.listCallCount, so this branch is unreachable
+// through the public tools/call JSON-RPC surface today (a pre-existing bug,
+// out of scope for a test-coverage task to fix). It IS reachable, and worth
+// covering, as a white-box call directly against the unexported method with
+// listCallCount pre-set to simulate the cap already being exhausted — this
+// asserts the real behavior the cap is supposed to have (refuse the call with
+// the generic error, and never touch the reader) once/if that increment bug
+// is fixed, without touching production code.
+func TestToolListSecrets_MaxListCallsCapReached(t *testing.T) {
+	fr := &fakeReader{list: []SecretInfo{{Ref: "app/prod/db"}}}
+	s := NewServer(fr, "")
+	s.SetMaxListCalls(1)
+	s.listCallCount.Store(1) // simulate the cap already reached
+
+	res := s.toolListSecrets(context.Background(), json.RawMessage(`{}`))
+
+	assert.Equal(t, true, res["isError"], "the call must be refused once the cap is reached")
+	content := res["content"].([]map[string]interface{})
+	assert.Equal(t, genericListError, content[0]["text"], "must return the generic list error, not leak detail")
+	assert.False(t, fr.listCalled, "the reader must never be consulted once the cap has refused the call")
+}
+
 // TestKeyorixClient_ListSecretsTruncated verifies that the KeyorixClient sets
 // the truncated flag when the server returns exactly 100 secrets.
 func TestKeyorixClient_ListSecretsTruncated(t *testing.T) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -23,6 +23,8 @@ type fakeReader struct {
 
 	gotRef string
 	gotEnv string
+
+	listCalled bool
 }
 
 func (f *fakeReader) GetSecret(_ context.Context, ref string) (string, error) {
@@ -34,6 +36,7 @@ func (f *fakeReader) GetSecret(_ context.Context, ref string) (string, error) {
 }
 
 func (f *fakeReader) ListSecrets(_ context.Context, env string) ([]SecretInfo, bool, error) {
+	f.listCalled = true
 	f.gotEnv = env
 	if f.listErr != nil {
 		return nil, false, f.listErr
@@ -205,6 +208,26 @@ func TestServe_MaxReadsCapsGetSecret(t *testing.T) {
 	third := resultMap(t, resps[2])
 	assert.Equal(t, true, third["isError"], "read 3 must be refused — the cap is exhausted")
 	assert.Equal(t, genericReadError, third["content"].([]interface{})[0].(map[string]interface{})["text"].(string))
+}
+
+// #G44: SetMaxListCalls sets s.maxListCalls for a positive argument and is a
+// no-op for a non-positive one (0 or negative), mirroring SetMaxReads's own
+// documented non-positive-is-ignored behavior (see SetMaxReads/SetMaxListCalls
+// doc comments in server.go). This is a white-box field assertion, deliberate:
+// toolListSecrets never increments s.listCallCount (no Add(1) call anywhere in
+// tools.go), so the maxListCalls>0 branch's body can never actually execute
+// through the public tools/call surface — that appears to be a real bug making
+// the #G44 per-process list-call cap non-functional today, but fixing
+// production code is outside a test-coverage task's scope. This test covers
+// what IS reachable and correct: the setter itself.
+func TestServe_SetMaxListCalls(t *testing.T) {
+	s := NewServer(&fakeReader{}, "")
+	s.SetMaxListCalls(3)
+	assert.EqualValues(t, 3, s.maxListCalls, "a positive value sets the cap")
+	s.SetMaxListCalls(0)
+	assert.EqualValues(t, 3, s.maxListCalls, "zero must not clear an existing cap")
+	s.SetMaxListCalls(-5)
+	assert.EqualValues(t, 3, s.maxListCalls, "a negative value must not clear an existing cap")
 }
 
 // A zero/unset max-reads cap means unlimited — the default, unchanged behavior.

--- a/internal/netutil/dialer_test.go
+++ b/internal/netutil/dialer_test.go
@@ -157,6 +157,79 @@ func TestDialer_DialContextTCP_DelegatesToDialContext(t *testing.T) {
 	assert.Equal(t, "tcp", network)
 }
 
+func TestDialer_DialContext_InvalidAddressReturnsError(t *testing.T) {
+	d := Dialer{Disallow: IsPrivateOrLinkLocal}
+	_, err := d.DialContext(context.Background(), "tcp", "not-a-valid-host-port")
+	require.Error(t, err, "an addr with no port must fail SplitHostPort")
+	assert.Contains(t, err.Error(), "invalid dial address")
+}
+
+func TestDialer_DialContext_EmptyResolvedAddressesReturnsError(t *testing.T) {
+	d := Dialer{
+		Disallow: IsPrivateOrLinkLocal,
+		Resolve: func(_ context.Context, _ string) ([]net.IPAddr, error) {
+			return nil, nil
+		},
+		Dial: func(_ context.Context, _, addr string) (net.Conn, error) {
+			t.Fatalf("dial must not be reached, got addr %q", addr)
+			return nil, nil
+		},
+	}
+	_, err := d.DialContext(context.Background(), "tcp", "no-addrs.example:443")
+	require.Error(t, err, "a hostname that resolves to zero addresses must be refused, not silently pass through")
+	assert.Contains(t, err.Error(), "did not resolve to any address")
+}
+
+func TestDialer_DialContext_NilDialDefaultsToNetDialer(t *testing.T) {
+	// No Dial field set: DialContext must fall back to (&net.Dialer{}).DialContext
+	// rather than panicking on a nil func. Dialing a closed local listener lets
+	// us observe the real dialer actually attempted a connection (and failed,
+	// as expected) without depending on outbound network access.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close(), "close immediately so the port is refusing connections")
+
+	d := Dialer{} // Disallow nil too: exercises the zero-value Dialer end to end.
+	_, dialErr := d.DialContext(context.Background(), "tcp", addr)
+	require.Error(t, dialErr, "connecting to a closed local port via the real net.Dialer must fail")
+}
+
+func TestDialer_DialContext_NilResolveDefaultsToDefaultResolver(t *testing.T) {
+	// No Resolve field set: DialContext must fall back to DefaultResolver
+	// (real DNS/hosts-file resolution) rather than a nil-func panic. Disallow
+	// is nil too, so any address localhost resolves to is permitted, and we
+	// only assert the dial was actually reached with a pinned IP:port.
+	var dialed string
+	d := Dialer{
+		Dial: func(_ context.Context, _, addr string) (net.Conn, error) {
+			dialed = addr
+			return &fakeConn{}, nil
+		},
+	}
+	_, err := d.DialContext(context.Background(), "tcp", "localhost:443")
+	require.NoError(t, err)
+	assert.NotEmpty(t, dialed)
+	dialedHost, dialedPort, splitErr := net.SplitHostPort(dialed)
+	require.NoError(t, splitErr)
+	assert.Equal(t, "443", dialedPort)
+	assert.NotNil(t, net.ParseIP(dialedHost), "dialed host must be a resolved IP literal, not the original hostname")
+}
+
+func TestDefaultResolver_ResolvesLoopback(t *testing.T) {
+	addrs, err := DefaultResolver(context.Background(), "localhost")
+	require.NoError(t, err)
+	require.NotEmpty(t, addrs, "localhost must resolve to at least one address")
+	found := false
+	for _, a := range addrs {
+		if a.IP.IsLoopback() {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "localhost must resolve to a loopback address, got %v", addrs)
+}
+
 func TestIsPrivateOrLinkLocal(t *testing.T) {
 	disallowed := []string{
 		"10.1.2.3", "172.16.0.1", "192.168.1.1", "127.0.0.1",

--- a/internal/notary/notary_s17_test.go
+++ b/internal/notary/notary_s17_test.go
@@ -275,3 +275,133 @@ func TestVerifyReceipt_AcceptsSHA256HashAlgorithm(t *testing.T) {
 	require.NoError(t, err)
 	assert.WithinDuration(t, fixedTime, at, time.Second)
 }
+
+// ---------------------------------------------------------------------------
+// Anchor — refuseRedirect, defense-in-depth URL re-validation, and the
+// recover() path around timestamp.ParseResponse
+// ---------------------------------------------------------------------------
+
+// TestRFC3161_Anchor_RefusesRedirect confirms the client never follows a 3xx
+// from the TSA endpoint: refuseRedirect must reject it (CWE-918 — a
+// compromised/misconfigured TSA could otherwise bounce the request to an
+// internal host such as cloud IMDS even though the configured URL itself was
+// fine at setup time).
+func TestRFC3161_Anchor_RefusesRedirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://127.0.0.1:1/elsewhere", http.StatusFound)
+	}))
+	t.Cleanup(srv.Close)
+	tsa, err := NewRFC3161(srv.URL, 5*time.Second)
+	require.NoError(t, err)
+	_, err = tsa.Anchor(context.Background(), []byte("m"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to follow redirect")
+}
+
+// TestRFC3161_Anchor_RevalidatesURLAtCallTime constructs an RFC3161 value
+// directly (bypassing NewRFC3161's constructor validation) to exercise
+// Anchor's own defense-in-depth validateTSAURL call. This matters because the
+// url field could in principle be reached via a path that skips the
+// constructor; Anchor must not trust a stale/bypassed value.
+func TestRFC3161_Anchor_RevalidatesURLAtCallTime(t *testing.T) {
+	r := &RFC3161{url: "http://not-loopback.example.com/tsr", client: &http.Client{Timeout: 5 * time.Second}}
+	_, err := r.Anchor(context.Background(), []byte("m"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "https")
+}
+
+// rfc3161TestPKIStatusInfo/rfc3161TestResponse mirror digitorus/timestamp's
+// unexported `pkiStatusInfo`/`response` ASN.1 shapes closely enough to build a
+// well-formed TSA response envelope by hand (see rfc3161_struct.go in that
+// module): a SEQUENCE of a status INTEGER-bearing structure followed by an
+// (optional) raw TimeStampToken.
+type rfc3161TestPKIStatusInfo struct {
+	Status int
+}
+
+type rfc3161TestResponse struct {
+	Status         rfc3161TestPKIStatusInfo
+	TimeStampToken asn1.RawValue `asn1:"optional"`
+}
+
+// TestRFC3161_Anchor_NestedMalformedResponse_RecoversFromPanic is #G61's
+// sibling for a panic that TestRFC3161_Anchor_MalformedTSAResponseNoPanic's
+// flat byte sequences cannot reach: those are all rejected by Go's
+// standard-library asn1 decoder (used for the OUTER response envelope) before
+// the bytes ever reach digitorus/pkcs7's own hand-rolled BER reader, so the
+// recover() in Anchor never actually fires for them.
+//
+// Here the outer envelope is well-formed DER (so encoding/asn1 accepts it and
+// hands the embedded TimeStampToken bytes through untouched), but those
+// embedded bytes are a high-tag-number form whose length byte sits exactly one
+// byte past the end of the buffer — digitorus/pkcs7's readObject indexes that
+// byte without a bounds check first (ber.go), panicking with "index out of
+// range" instead of returning a parse error. Anchor's recover() must convert
+// that into an error, never crash the process anchoring an audit checkpoint.
+func TestRFC3161_Anchor_NestedMalformedResponse_RecoversFromPanic(t *testing.T) {
+	respBytes, err := asn1.Marshal(rfc3161TestResponse{
+		Status: rfc3161TestPKIStatusInfo{Status: 0},
+		TimeStampToken: asn1.RawValue{
+			FullBytes: []byte{0x30, 0x02, 0xff, 0x30},
+		},
+	})
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(respBytes)
+	}))
+	t.Cleanup(srv.Close)
+	client, err := NewRFC3161(srv.URL, 5*time.Second)
+	require.NoError(t, err)
+
+	var anchorErr error
+	require.NotPanics(t, func() {
+		_, anchorErr = client.Anchor(context.Background(), []byte("anchor message"))
+	})
+	require.Error(t, anchorErr)
+	assert.Contains(t, anchorErr.Error(), "parser panic")
+}
+
+// TestRFC3161_Anchor_NilContext confirms Anchor surfaces
+// http.NewRequestWithContext's own defensive nil-Context error as a wrapped
+// "new request" error rather than panicking or silently proceeding with a
+// background context.
+func TestRFC3161_Anchor_NilContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	tsa, err := NewRFC3161(srv.URL, 5*time.Second)
+	require.NoError(t, err)
+
+	//lint:ignore SA1012 deliberately nil to exercise the nil-Context guard inside http.NewRequestWithContext
+	_, err = tsa.Anchor(nil, []byte("m"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "new request")
+}
+
+// TestRFC3161_Anchor_ResponseBodyReadError confirms a TSA response whose
+// declared Content-Length is never fully delivered (connection closed mid-body)
+// surfaces as a wrapped "read response" error from io.ReadAll, not a panic or
+// a response treated as complete.
+func TestRFC3161_Anchor_ResponseBodyReadError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		require.True(t, ok)
+		conn, buf, err := hj.Hijack()
+		require.NoError(t, err)
+		defer func() { _ = conn.Close() }()
+		// Claim far more body bytes than are actually sent, then close the
+		// connection — the client's io.ReadAll(resp.Body) hits an
+		// unexpected-EOF read error instead of a clean 200 with a full body.
+		_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 1000\r\nContent-Type: application/timestamp-reply\r\n\r\nshort")
+		_ = buf.Flush()
+	}))
+	t.Cleanup(srv.Close)
+	tsa, err := NewRFC3161(srv.URL, 5*time.Second)
+	require.NoError(t, err)
+	_, err = tsa.Anchor(context.Background(), []byte("m"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read response")
+}

--- a/internal/notary/notary_s17_test.go
+++ b/internal/notary/notary_s17_test.go
@@ -375,8 +375,7 @@ func TestRFC3161_Anchor_NilContext(t *testing.T) {
 	tsa, err := NewRFC3161(srv.URL, 5*time.Second)
 	require.NoError(t, err)
 
-	//lint:ignore SA1012 deliberately nil to exercise the nil-Context guard inside http.NewRequestWithContext
-	_, err = tsa.Anchor(nil, []byte("m"))
+	_, err = tsa.Anchor(nil, []byte("m")) //nolint:staticcheck // SA1012: deliberately nil to exercise the nil-Context guard inside http.NewRequestWithContext
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "new request")
 }

--- a/internal/notary/notary_test.go
+++ b/internal/notary/notary_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -146,4 +147,97 @@ func TestRFC3161_Anchor_GarbageResponse(t *testing.T) {
 	require.NoError(t, err)
 	_, err = tsa.Anchor(context.Background(), []byte("m"))
 	require.Error(t, err)
+}
+
+// buildTestCert issues a certificate for tmpl, signed by (parentTmpl, parentKey),
+// or self-signed when parentTmpl/parentKey are nil.
+func buildTestCert(t *testing.T, tmpl *x509.Certificate, parentTmpl *x509.Certificate, parentKey crypto.Signer) (*x509.Certificate, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	signParentTmpl, signKey := tmpl, crypto.Signer(key)
+	if parentTmpl != nil {
+		signParentTmpl, signKey = parentTmpl, parentKey
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, signParentTmpl, &key.PublicKey, signKey)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key
+}
+
+// TestVerifyReceipt_TrustsChainThroughIntermediateCA exercises the intermediates
+// pool notary.go's VerifyReceipt builds from p7.Certificates (the
+// `for _, c := range p7.Certificates { intermediates.AddCert(c) }` loop): a token
+// whose embedded chain is leaf -> intermediate -> root, where only the ROOT sits
+// in the configured trust anchor, must still verify. TestRFC3161_AnchorAndVerifyRoundTrip
+// only ever exercises a leaf that IS the root (self-signed, directly trusted), so
+// it never actually requires that intermediates pool to do anything; this pins
+// the genuine multi-hop chain-building behavior.
+func TestVerifyReceipt_TrustsChainThroughIntermediateCA(t *testing.T) {
+	fixedTime := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	validity := func(tmpl *x509.Certificate) {
+		tmpl.NotBefore = fixedTime.Add(-365 * 24 * time.Hour)
+		tmpl.NotAfter = fixedTime.Add(3650 * 24 * time.Hour)
+		tmpl.BasicConstraintsValid = true
+	}
+
+	rootTmpl := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "Test Root CA"}, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign, IsCA: true}
+	validity(rootTmpl)
+	rootCert, rootKey := buildTestCert(t, rootTmpl, nil, nil)
+
+	intTmpl := &x509.Certificate{SerialNumber: big.NewInt(2), Subject: pkix.Name{CommonName: "Test Intermediate CA"}, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageCRLSign, IsCA: true}
+	validity(intTmpl)
+	intCert, intKey := buildTestCert(t, intTmpl, rootTmpl, rootKey)
+
+	leafTmpl := &x509.Certificate{SerialNumber: big.NewInt(3), Subject: pkix.Name{CommonName: "Test TSA Leaf"}, KeyUsage: x509.KeyUsageDigitalSignature, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping}}
+	validity(leafTmpl)
+	leafCert, leafKey := buildTestCert(t, leafTmpl, intTmpl, intKey)
+
+	msg := []byte("chain verification message")
+	want := sha256.Sum256(msg)
+
+	// The token embeds the leaf AND the intermediate (Certificates: parents),
+	// mirroring what a real TSA operating behind an intermediate CA would send.
+	ts := &timestamp.Timestamp{
+		HashAlgorithm:     crypto.SHA256,
+		HashedMessage:     want[:],
+		Time:              fixedTime,
+		Policy:            asn1.ObjectIdentifier{1, 2, 3, 4, 1},
+		SerialNumber:      big.NewInt(42),
+		Certificates:      []*x509.Certificate{intCert},
+		AddTSACertificate: true,
+	}
+	resp, err := ts.CreateResponseWithOpts(leafCert, leafKey, crypto.SHA256)
+	require.NoError(t, err)
+	parsed, err := timestamp.ParseResponse(resp)
+	require.NoError(t, err)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(rootCert) // only the ROOT is trusted — leaf+intermediate arrive via the token
+
+	at, err := VerifyReceipt(roots, msg, parsed.RawToken)
+	require.NoError(t, err)
+	assert.WithinDuration(t, fixedTime, at, time.Second)
+
+	// Sanity: a token from the SAME leaf but with the intermediate withheld (so no
+	// path from leaf to the trusted root can be built) must fail — confirming the
+	// pass above genuinely depended on the intermediate being embedded, not on
+	// some unrelated path.
+	tsNoChain := &timestamp.Timestamp{
+		HashAlgorithm:     crypto.SHA256,
+		HashedMessage:     want[:],
+		Time:              fixedTime,
+		Policy:            asn1.ObjectIdentifier{1, 2, 3, 4, 1},
+		SerialNumber:      big.NewInt(43),
+		AddTSACertificate: true, // embeds ONLY the leaf, no parents
+	}
+	respNoChain, err := tsNoChain.CreateResponseWithOpts(leafCert, leafKey, crypto.SHA256)
+	require.NoError(t, err)
+	parsedNoChain, err := timestamp.ParseResponse(respNoChain)
+	require.NoError(t, err)
+
+	_, err = VerifyReceipt(roots, msg, parsedNoChain.RawToken)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not trusted")
 }

--- a/internal/notifychan/chat_test.go
+++ b/internal/notifychan/chat_test.go
@@ -2,6 +2,7 @@ package notifychan
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"log"
@@ -128,6 +129,22 @@ func TestChatSink_EscapesMrkdwnInjectionInTitle(t *testing.T) {
 	require.NoError(t, json.Unmarshal(get(), &payload))
 	assert.NotContains(t, payload["text"], "<!here>")
 	assert.Contains(t, payload["text"], "&lt;!here&gt;")
+}
+
+// TestChatSink_SendRequestBuildErrorIsPermanent covers send's http.NewRequestWithContext
+// error path. The webhook URL is validated once at construction (newChat), so the only
+// way to exercise a request-build failure at send time is to bypass the constructor and
+// hand send() a URL that url.Parse itself rejects (a raw control character) — proving
+// the documented contract (a request-construction failure is a permanent, non-retryable
+// error, same as a marshalling failure) actually holds, not just that some error occurs.
+func TestChatSink_SendRequestBuildErrorIsPermanent(t *testing.T) {
+	s := &ChatSink{
+		cfg:    ChatConfig{Kind: ChatSlack, WebhookURL: "https://example.com/\x7fbad"},
+		client: &http.Client{},
+	}
+	retryable, err := s.send(context.Background(), core.NotificationEvent{Title: "x"})
+	require.Error(t, err)
+	assert.False(t, retryable, "a malformed request must be treated as permanent, not retried")
 }
 
 func TestNewChat_Validation(t *testing.T) {

--- a/internal/notifychan/delivery_test.go
+++ b/internal/notifychan/delivery_test.go
@@ -2,9 +2,11 @@ package notifychan
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -67,4 +69,22 @@ func TestChatSink_DeliveryFailureLogDoesNotLeakWebhookToken(t *testing.T) {
 	assert.Contains(t, logged, "notifychan:", "sanity: the failure path should still log something")
 	assert.NotContains(t, logged, token, "the webhook's embedded bearer token must never reach the log stream")
 	assert.NotContains(t, logged, "services/T000/B000", "the webhook's path (which carries the token) must never reach the log stream")
+}
+
+// TestDeliverer_EnqueueAfterCloseIsANoOp is the #G63 regression at the deliverer
+// level: close() closes the queue channel, so an enqueue() that raced past the
+// closed check would panic sending on a closed channel. Once close() has
+// returned, every subsequent enqueue() must observe closed==true under the same
+// mutex and return immediately without ever touching the (closed) queue channel
+// or invoking send — not merely "not panic", but genuinely deliver nothing.
+func TestDeliverer_EnqueueAfterCloseIsANoOp(t *testing.T) {
+	var sent atomic.Int32
+	d := newDeliverer("post-close", 4, time.Millisecond, func(_ context.Context, _ core.NotificationEvent) (bool, error) {
+		sent.Add(1)
+		return false, nil
+	})
+	d.close()
+
+	assert.NotPanics(t, func() { d.enqueue(core.NotificationEvent{Type: "after-close"}) })
+	assert.Equal(t, int32(0), sent.Load(), "an event enqueued after close must never reach send")
 }

--- a/internal/notifychan/email_test.go
+++ b/internal/notifychan/email_test.go
@@ -1,8 +1,13 @@
 package notifychan
 
 import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -88,6 +93,170 @@ func TestEmailSink_BroadcastWithNoDestinationConfiguredIsDroppedAndCounted(t *te
 // pattern) so the send fails fast and deterministically; the point of this test is
 // that delivery was ATTEMPTED (and the resulting failure counted), not that it
 // succeeded.
+// TestEmailSink_Send_InvalidFromAddressIsPermanentFailure proves an unparsable
+// From address (email.go doesn't validate the format at construction, only that
+// it's non-empty) fails send() immediately, before ever dialing SMTP, and is
+// reported as a permanent (non-retryable) failure rather than a transient one —
+// retrying a malformed address would never succeed.
+func TestEmailSink_Send_InvalidFromAddressIsPermanentFailure(t *testing.T) {
+	s := &EmailSink{cfg: EmailConfig{Host: "smtp.example.com", From: "not-an-email", TLS: "starttls"}}
+	retryable, err := s.send(context.Background(), core.NotificationEvent{Email: "ada@x.io"})
+	require.Error(t, err)
+	assert.False(t, retryable, "a malformed from address is a permanent misconfiguration, not worth retrying")
+	assert.Contains(t, err.Error(), "not-an-email")
+}
+
+// TestEmailSink_Send_InvalidRecipientIsPermanentFailure is the mirror of the
+// above for the recipient address (ev.Email, which callers resolve — never
+// validated up front).
+func TestEmailSink_Send_InvalidRecipientIsPermanentFailure(t *testing.T) {
+	s := &EmailSink{cfg: EmailConfig{Host: "smtp.example.com", From: "ops@x.io", TLS: "starttls"}}
+	retryable, err := s.send(context.Background(), core.NotificationEvent{Email: "not-an-email"})
+	require.Error(t, err)
+	assert.False(t, retryable, "a malformed recipient address is a permanent misconfiguration, not worth retrying")
+	assert.Contains(t, err.Error(), "not-an-email")
+}
+
+// TestEmailSink_Send_NewClientErrorIsPermanentFailure proves that a client-
+// construction error (here, an out-of-range port passed straight through to
+// go-mail's WithPort option) surfaces from send() as a permanent failure — it's
+// a fixed misconfiguration, not a network blip retrying would fix.
+func TestEmailSink_Send_NewClientErrorIsPermanentFailure(t *testing.T) {
+	s := &EmailSink{cfg: EmailConfig{Host: "smtp.example.com", Port: 99999, From: "ops@x.io", TLS: "starttls"}}
+	retryable, err := s.send(context.Background(), core.NotificationEvent{Email: "ada@x.io"})
+	require.Error(t, err)
+	assert.False(t, retryable)
+}
+
+// TestEmailSink_NewClient_InvalidPort proves newClient itself surfaces go-mail's
+// port validation error rather than swallowing it.
+func TestEmailSink_NewClient_InvalidPort(t *testing.T) {
+	s := &EmailSink{cfg: EmailConfig{Host: "smtp.example.com", Port: -5, TLS: "starttls"}}
+	// Port <= 0 is never forwarded to WithPort (see newClient), so an
+	// out-of-range NEGATIVE port is silently ignored — client construction
+	// still succeeds with the default port. This documents that behavior.
+	c, err := s.newClient()
+	require.NoError(t, err)
+	assert.Equal(t, "smtp.example.com:25", c.ServerAddr(), "a non-positive configured port falls back to go-mail's default")
+
+	s2 := &EmailSink{cfg: EmailConfig{Host: "smtp.example.com", Port: 99999, TLS: "starttls"}}
+	_, err = s2.newClient()
+	require.Error(t, err, "an out-of-range positive port must be rejected, not silently clamped")
+}
+
+// TestEmailSink_NewClient_TLSModes proves each documented tls setting selects
+// the TLS policy go-mail will actually enforce when it dials — asserted via
+// go-mail's own TLSPolicy() getter, not by re-implementing the switch.
+func TestEmailSink_NewClient_TLSModes(t *testing.T) {
+	cases := []struct {
+		tls        string
+		wantPolicy string
+	}{
+		{"", "TLSMandatory"},
+		{"starttls", "TLSMandatory"},
+		{"STARTTLS", "TLSMandatory"}, // case-insensitive
+		{"implicit", "TLSMandatory"}, // WithSSL doesn't touch the STARTTLS policy field
+		{"none", "NoTLS"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tls, func(t *testing.T) {
+			s := &EmailSink{cfg: EmailConfig{Host: "smtp.example.com", Port: 2525, TLS: tc.tls}}
+			c, err := s.newClient()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPolicy, c.TLSPolicy())
+			assert.Equal(t, "smtp.example.com:2525", c.ServerAddr())
+		})
+	}
+}
+
+// TestEmailSink_NewClient_UsernameConfiguresAuth proves a configured Username
+// takes the SMTP-auth branch of newClient without erroring — it's a completely
+// separate code path from the no-auth default (internal relays that authenticate
+// by network, no Username set) exercised by every other test in this file.
+func TestEmailSink_NewClient_UsernameConfiguresAuth(t *testing.T) {
+	s := &EmailSink{cfg: EmailConfig{Host: "smtp.example.com", Username: "relay-user", Password: "relay-pass", TLS: "none"}}
+	c, err := s.newClient()
+	require.NoError(t, err)
+	assert.Equal(t, "smtp.example.com:25", c.ServerAddr())
+}
+
+// fakeSMTPServer starts a minimal SMTP server on a loopback port that accepts
+// exactly one message end-to-end (EHLO → MAIL FROM → RCPT TO → DATA → QUIT,
+// "250 OK" at every step), so a test can drive email.go's send() all the way
+// through a genuine successful DialAndSendWithContext — the one outcome no
+// other test in this file reaches, since every other test points at a
+// closed/refusing port to exercise the failure path instead.
+func fakeSMTPServer(t *testing.T) (host string, port int) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			return // listener closed by t.Cleanup
+		}
+		defer conn.Close()
+		r := bufio.NewReader(conn)
+		fmt.Fprint(conn, "220 fake.smtp ESMTP ready\r\n")
+		for {
+			line, readErr := r.ReadString('\n')
+			if readErr != nil {
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			switch {
+			case strings.HasPrefix(line, "EHLO"), strings.HasPrefix(line, "HELO"):
+				fmt.Fprint(conn, "250 fake.smtp Hello\r\n")
+			case strings.HasPrefix(line, "MAIL FROM"), strings.HasPrefix(line, "RCPT TO"):
+				fmt.Fprint(conn, "250 OK\r\n")
+			case strings.HasPrefix(line, "DATA"):
+				fmt.Fprint(conn, "354 Send data\r\n")
+				for {
+					dl, dataErr := r.ReadString('\n')
+					if dataErr != nil {
+						return
+					}
+					if strings.TrimRight(dl, "\r\n") == "." {
+						break
+					}
+				}
+				fmt.Fprint(conn, "250 OK: queued\r\n")
+			case strings.HasPrefix(line, "QUIT"):
+				fmt.Fprint(conn, "221 Bye\r\n")
+				return
+			default:
+				fmt.Fprint(conn, "250 OK\r\n")
+			}
+		}
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr)
+	return "127.0.0.1", addr.Port
+}
+
+// TestEmailSink_Send_DeliversAgainstFakeSMTPServer proves send() reports success
+// (no error) when the SMTP relay actually accepts the message end-to-end —
+// email.go:153's `return false, nil`, the terminal-success statement every other
+// test in this file leaves uncovered because they all point send() at a
+// refusing/closed port to exercise the failure path.
+func TestEmailSink_Send_DeliversAgainstFakeSMTPServer(t *testing.T) {
+	t.Setenv(envAllowInsecureSMTP, "true")
+	host, port := fakeSMTPServer(t)
+
+	delivBefore := testutil.ToFloat64(notifyDeliveries.WithLabelValues("email", outcomeDelivered))
+
+	sink, err := newEmail(EmailConfig{Host: host, Port: port, From: "ops@x.io", TLS: "none"}, time.Millisecond)
+	require.NoError(t, err)
+	attempted := sink.Deliver(core.NotificationEvent{Email: "ada@x.io", Title: "hi", Message: "body"})
+	require.True(t, attempted)
+	sink.Close()
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(notifyDeliveries.WithLabelValues("email", outcomeDelivered))-delivBefore,
+		"a genuine SMTP round-trip the server accepts must be counted as delivered, not failed")
+}
+
 func TestEmailSink_BroadcastRoutesToConfiguredDestination(t *testing.T) {
 	t.Setenv(envAllowInsecureSMTP, "true")
 	before := emailOutcomeTotal(t)

--- a/internal/notifychan/email_test.go
+++ b/internal/notifychan/email_test.go
@@ -197,9 +197,9 @@ func fakeSMTPServer(t *testing.T) (host string, port int) {
 		if acceptErr != nil {
 			return // listener closed by t.Cleanup
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		r := bufio.NewReader(conn)
-		fmt.Fprint(conn, "220 fake.smtp ESMTP ready\r\n")
+		_, _ = fmt.Fprint(conn, "220 fake.smtp ESMTP ready\r\n")
 		for {
 			line, readErr := r.ReadString('\n')
 			if readErr != nil {
@@ -208,11 +208,11 @@ func fakeSMTPServer(t *testing.T) (host string, port int) {
 			line = strings.TrimRight(line, "\r\n")
 			switch {
 			case strings.HasPrefix(line, "EHLO"), strings.HasPrefix(line, "HELO"):
-				fmt.Fprint(conn, "250 fake.smtp Hello\r\n")
+				_, _ = fmt.Fprint(conn, "250 fake.smtp Hello\r\n")
 			case strings.HasPrefix(line, "MAIL FROM"), strings.HasPrefix(line, "RCPT TO"):
-				fmt.Fprint(conn, "250 OK\r\n")
+				_, _ = fmt.Fprint(conn, "250 OK\r\n")
 			case strings.HasPrefix(line, "DATA"):
-				fmt.Fprint(conn, "354 Send data\r\n")
+				_, _ = fmt.Fprint(conn, "354 Send data\r\n")
 				for {
 					dl, dataErr := r.ReadString('\n')
 					if dataErr != nil {
@@ -222,12 +222,12 @@ func fakeSMTPServer(t *testing.T) (host string, port int) {
 						break
 					}
 				}
-				fmt.Fprint(conn, "250 OK: queued\r\n")
+				_, _ = fmt.Fprint(conn, "250 OK: queued\r\n")
 			case strings.HasPrefix(line, "QUIT"):
-				fmt.Fprint(conn, "221 Bye\r\n")
+				_, _ = fmt.Fprint(conn, "221 Bye\r\n")
 				return
 			default:
-				fmt.Fprint(conn, "250 OK\r\n")
+				_, _ = fmt.Fprint(conn, "250 OK\r\n")
 			}
 		}
 	}()

--- a/internal/notifychan/webhook_test.go
+++ b/internal/notifychan/webhook_test.go
@@ -2,6 +2,7 @@ package notifychan
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -85,6 +86,23 @@ func TestWebhookSink_NoTokenOmitsAuthHeader(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Empty(t, auth)
+}
+
+// TestWebhookSink_SendRequestBuildErrorIsPermanent covers send's
+// http.NewRequestWithContext error path. The endpoint is validated once at
+// construction (newWebhook), so the only way to exercise a request-build failure at
+// send time is to bypass the constructor and hand send() a URL that url.Parse itself
+// rejects (a raw control character) — proving the documented contract ("a marshalling
+// error is permanent" extends to any request-construction failure) actually holds,
+// not merely that some error occurs.
+func TestWebhookSink_SendRequestBuildErrorIsPermanent(t *testing.T) {
+	s := &WebhookSink{
+		cfg:    WebhookConfig{Endpoint: "https://example.com/\x7fbad"},
+		client: &http.Client{},
+	}
+	retryable, err := s.send(context.Background(), core.NotificationEvent{UserID: 1, Type: "x"})
+	require.Error(t, err)
+	assert.False(t, retryable, "a malformed request must be treated as permanent, not retried")
 }
 
 func TestNewWebhook_RequiresEndpoint(t *testing.T) {

--- a/internal/rotation/awsiam_test.go
+++ b/internal/rotation/awsiam_test.go
@@ -59,6 +59,22 @@ func iamWith(fake *fakeIAM, allowed ...string) *AWSIAMExecutor {
 	return e
 }
 
+// TestAWSIAM_Client_LoadDefaultConfigError exercises the awsconfig.LoadDefaultConfig
+// error branch inside AWSIAMExecutor.client() when newClient is nil. Pointing
+// AWS_CONFIG_FILE at a directory (rather than a file) makes the SDK's shared-config
+// read fail deterministically, without any network I/O or real AWS credentials.
+func TestAWSIAM_Client_LoadDefaultConfigError(t *testing.T) {
+	t.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	t.Setenv("AWS_CONFIG_FILE", t.TempDir())
+
+	e := NewAWSIAMExecutor("aws-test", "us-east-1", nil)
+	// e.newClient is left nil so the real awsconfig.LoadDefaultConfig path runs.
+	cl, err := e.client(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, cl)
+	assert.Contains(t, err.Error(), "aws-iam: load config")
+}
+
 func TestAWSIAM_TypeAndName(t *testing.T) {
 	e := NewAWSIAMExecutor("prod-aws", "", nil)
 	assert.Equal(t, "prod-aws", e.Name())
@@ -120,6 +136,29 @@ func TestAWSIAM_GenerateUpstream_PriorDeleteFailureIsSurfaced(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(partial.Value), &cred))
 	assert.Equal(t, "AKIANEW", cred["access_key_id"])
 	assert.Equal(t, "s3cr3t", cred["secret_access_key"])
+}
+
+// TestAWSIAM_GenerateUpstream_EvictionFallbackToFirstPrior exercises the defensive
+// `if victim == "" { victim = prior[0] }` fallback in GenerateUpstream: when
+// evictableAccessKey returns "" (all its candidate IDs happen to be the empty
+// string — a degenerate value AWS should never actually hand back, but one the
+// code must not crash on), the caller must still pick a concrete victim to evict
+// rather than leaving `victim` empty and calling DeleteAccessKey with a blank id
+// silently succeeding against the wrong "nothing".
+func TestAWSIAM_GenerateUpstream_EvictionFallbackToFirstPrior(t *testing.T) {
+	// Two prior keys, both reporting an empty-string AccessKeyId: evictableAccessKey
+	// still treats a non-nil *string as a candidate (only a nil pointer is skipped),
+	// so with no Inactive key and no CreateDate ordering it settles on "" as the
+	// victim. That drives the fallback: GenerateUpstream must fall back to prior[0]
+	// (also "") rather than leaving victim empty and skipping the eviction call.
+	fake := &fakeIAM{existing: []string{"", ""}, newID: "AKIANEW", newSecret: "x"}
+	v, err := iamWith(fake, "svc-").GenerateUpstream(context.Background(), "svc-app")
+	require.NoError(t, err)
+	assert.Contains(t, fake.deleted, "", "the fallback victim (prior[0], the empty id) must actually be deleted, not silently skipped")
+
+	var cred map[string]string
+	require.NoError(t, json.Unmarshal([]byte(v), &cred))
+	assert.Equal(t, "AKIANEW", cred["access_key_id"])
 }
 
 func TestAWSIAM_GenerateUpstream_Errors(t *testing.T) {

--- a/internal/rotation/azure_test.go
+++ b/internal/rotation/azure_test.go
@@ -70,6 +70,21 @@ func TestAzure_GenerateUpstream_RemovesPriorSecrets(t *testing.T) {
 	assert.ElementsMatch(t, []string{"kid1", "kid2"}, fake.removed, "all prior secrets removed")
 }
 
+// TestAzureExecutor_ClientRealPath_CredentialError exercises the
+// azidentity.NewDefaultAzureCredential error branch inside
+// AzureAppSecretExecutor.client() when newClient is nil. Setting
+// AZURE_TOKEN_CREDENTIALS to an unrecognized value makes credential construction
+// fail deterministically, without any network I/O.
+func TestAzureExecutor_ClientRealPath_CredentialError(t *testing.T) {
+	t.Setenv("AZURE_TOKEN_CREDENTIALS", "not-a-real-credential-type")
+
+	e := NewAzureAppSecretExecutor("azure-test", nil)
+	cl, err := e.client(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, cl)
+	assert.Contains(t, err.Error(), "azure-app: default credential")
+}
+
 func TestAzure_GenerateUpstream_Errors(t *testing.T) {
 	t.Run("empty ref", func(t *testing.T) {
 		_, err := azureWith(&fakeAzure{}, "app-").GenerateUpstream(context.Background(), "")

--- a/internal/rotation/gcpsa_test.go
+++ b/internal/rotation/gcpsa_test.go
@@ -100,6 +100,29 @@ func TestEvictableServiceAccountKey_PrefersDisabledOverEnabled(t *testing.T) {
 	assert.Equal(t, "k/disabled", evictableServiceAccountKey(keys))
 }
 
+// TestEvictableServiceAccountKey_SkipsNamelessKeys proves a key with no Name is
+// skipped entirely as an eviction candidate — it can never be returned (there'd be
+// nothing to pass to DeleteKey), and it must not shadow a later, real candidate by
+// being treated as "the oldest seen so far".
+func TestEvictableServiceAccountKey_SkipsNamelessKeys(t *testing.T) {
+	keys := []gcpServiceAccountKeyInfo{
+		{Name: "", Disabled: false, ValidAfterTime: "2000-01-01T00:00:00Z"}, // nameless: would look "oldest" if not skipped
+		{Name: "k/real-oldest", Disabled: false, ValidAfterTime: "2020-01-01T00:00:00Z"},
+		{Name: "k/newer", Disabled: false, ValidAfterTime: "2024-01-01T00:00:00Z"},
+	}
+	assert.Equal(t, "k/real-oldest", evictableServiceAccountKey(keys), "the nameless entry must never be selected, even though its timestamp is the oldest")
+}
+
+// TestEvictableServiceAccountKey_AllNameless proves the function returns "" (no
+// candidate) when every key lacks a name, per its documented contract.
+func TestEvictableServiceAccountKey_AllNameless(t *testing.T) {
+	keys := []gcpServiceAccountKeyInfo{
+		{Name: "", Disabled: false, ValidAfterTime: "2020-01-01T00:00:00Z"},
+		{Name: "", Disabled: true, ValidAfterTime: "2021-01-01T00:00:00Z"},
+	}
+	assert.Empty(t, evictableServiceAccountKey(keys))
+}
+
 func TestEvictableServiceAccountKey_PrefersOldestWhenAllEnabled(t *testing.T) {
 	keys := []gcpServiceAccountKeyInfo{
 		{Name: "k/newest", Disabled: false, ValidAfterTime: "2026-01-01T00:00:00Z"},

--- a/internal/rotation/mysql_test.go
+++ b/internal/rotation/mysql_test.go
@@ -70,6 +70,22 @@ func TestMySQL_RotateFailsClosedWithoutAllowedRefs(t *testing.T) {
 	assert.False(t, fake.called)
 }
 
+// TestMySQL_ConnRealPath_OpenError exercises the sql.Open error branch in
+// MySQLExecutor.conn() when newConn is nil. A structurally malformed DSN (missing
+// the mandatory slash before the database name) is rejected by the mysql driver's
+// DSN parser at Open time, deterministically and without any network I/O.
+func TestMySQL_ConnRealPath_OpenError(t *testing.T) {
+	e := &MySQLExecutor{
+		name:        "mysql-test",
+		dsn:         "not a valid dsn",
+		allowedRefs: []string{"svc-"},
+	}
+	c, err := e.conn(context.Background())
+	require.Error(t, err)
+	assert.Nil(t, c)
+	assert.Contains(t, err.Error(), "mysql: open")
+}
+
 func TestMySQL_RotateErrors(t *testing.T) {
 	t.Run("empty ref", func(t *testing.T) {
 		fake := &fakeMySQL{}

--- a/internal/rotation/rotation_s2_test.go
+++ b/internal/rotation/rotation_s2_test.go
@@ -113,6 +113,29 @@ func TestAzureGraphClient_Do_WithOutput(t *testing.T) {
 	assert.Equal(t, "myapp", out.Name)
 }
 
+// erroringRoundTripper always fails a request, simulating a transport-level failure
+// (e.g. DNS/connection refused) distinct from a Graph API error response.
+type erroringRoundTripper struct{ err error }
+
+func (rt *erroringRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, rt.err
+}
+
+// TestAzureGraphClient_Do_HTTPDoError exercises the c.http.Do error branch in
+// azureGraphClient.do() — distinct from TestAzureGraphClient_Do_HTTPError, which
+// covers a successfully-received non-2xx response. Here the request never gets a
+// response at all (the RoundTripper fails outright), the transport-error path do()
+// must also propagate.
+func TestAzureGraphClient_Do_HTTPDoError(t *testing.T) {
+	c := &azureGraphClient{
+		cred: &fakeTokenCredential{token: "tok"},
+		http: &http.Client{Transport: &erroringRoundTripper{err: fmt.Errorf("connection refused")}},
+	}
+	err := c.do(context.Background(), http.MethodGet, "http://127.0.0.1/unreachable", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
 func TestAzureGraphClient_Do_TokenError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/saml/coverage_test.go
+++ b/internal/saml/coverage_test.go
@@ -19,11 +19,16 @@ package saml
 //     Redirect error branch requires an SSO URL that is syntactically valid (passes
 //     url.Parse and the XML round-trip validator) but triggers an error inside
 //     req.Redirect. Tests below document what has been tried and what is reachable.
-//   - parseIDPMetadata EntitiesDescriptor unmarshal error: the round-trip validator
-//     already guarantees well-formed XML, and crewjam's EntitiesDescriptor struct
-//     uses loose string fields, so Unmarshal never returns an error for unexpected
-//     content. The branch is structurally unreachable in the same way as the
-//     Metadata marshal error. Documented below.
+//   - parseIDPMetadata EntitiesDescriptor unmarshal error: reachable — see
+//     TestParseIDPMetadata_EntitiesDescriptorUnmarshalError below. The outer
+//     xml.Unmarshal(data, entity) fails first because the root element name
+//     ("EntitiesDescriptor") doesn't match EntityDescriptor's XMLName, and that
+//     failure message names the actual root element, satisfying the
+//     strings.Contains(err.Error(), "EntitiesDescriptor") check. The retry into
+//     EntitiesDescriptor then fails independently when an attribute doesn't
+//     satisfy its Go type (e.g. an unparsable validUntil timestamp, since
+//     EntitiesDescriptor.ValidUntil is *time.Time and time.Time implements
+//     encoding.TextUnmarshaler).
 
 import (
 	"net/http"
@@ -173,6 +178,25 @@ func TestParseIDPMetadata_WhitespaceOnly(t *testing.T) {
 func TestParseIDPMetadata_MalformedXML(t *testing.T) {
 	_, err := parseIDPMetadata([]byte("<unclosed"))
 	require.Error(t, err)
+}
+
+// TestParseIDPMetadata_EntitiesDescriptorUnmarshalError covers the inner
+// `xml.Unmarshal(data, entities)` error branch inside parseIDPMetadata's
+// EntitiesDescriptor fallback: the outer unmarshal into EntityDescriptor fails
+// because the root element is <EntitiesDescriptor> (naming it in the error, so
+// the strings.Contains check routes here), and the retry into EntitiesDescriptor
+// itself fails because validUntil is not a parsable timestamp.
+func TestParseIDPMetadata_EntitiesDescriptorUnmarshalError(t *testing.T) {
+	xml := []byte(`<EntitiesDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" validUntil="not-a-valid-timestamp">
+  <EntityDescriptor entityID="https://sp.example">
+    <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"></SPSSODescriptor>
+  </EntityDescriptor>
+</EntitiesDescriptor>`)
+	entity, err := parseIDPMetadata(xml)
+	require.Error(t, err)
+	assert.Nil(t, entity)
+	assert.Contains(t, err.Error(), "not-a-valid-timestamp",
+		"the retry's own unmarshal error (not the outer root-mismatch error) must be returned")
 }
 
 // TestParseIDPMetadata_ValidEntityDescriptorWithIDP is a direct call to the

--- a/internal/saml/parse_response_success_test.go
+++ b/internal/saml/parse_response_success_test.go
@@ -1,0 +1,179 @@
+package saml
+
+// parse_response_success_test.go exercises the one remaining meaningfully-testable gap
+// in ParseResponse: the success path (the final `return extractAssertion(assertion, ...),
+// nil` line). Doing that for real — not with a stub — requires a genuinely valid, signed
+// SAML Response: crewjam/saml validates the XML-DSig signature against the pinned IdP
+// certificate, so nothing short of a real signature will do.
+//
+// crewjam/saml ships a full SAML Identity Provider implementation (identity_provider.go)
+// used by its own test suite to produce exactly this kind of fixture. This file drives
+// that IDP-side machinery directly (bypassing the HTTP handlers, which need a
+// SessionProvider/ServiceProviderProvider) to build one signed, IDP-initiated Response —
+// signed with the SAME private key embedded as the signing certificate in the IdP
+// metadata handed to our Provider — then feeds it through the public Provider.ParseResponse
+// exactly as a real ACS handler would (after calling r.ParseForm(), which crewjam's
+// ParseResponse relies on the caller having done: it reads req.PostForm, not
+// req.PostFormValue, and never parses the form itself).
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	csaml "github.com/crewjam/saml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// signedIDPFixture builds a self-signed RSA cert/key pair and the IdP metadata XML that
+// embeds it as the signing certificate — the same shape as idpMetadata(t) in
+// provider_test.go, except it also returns the private key and certificate so a caller
+// can sign a Response with the exact key the SP will trust.
+func signedIDPFixture(t *testing.T, entityID string) (metadataXML []byte, key *rsa.PrivateKey, cert *x509.Certificate) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		Subject:      pkix.Name{CommonName: "test-idp-signing"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	parsedCert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	certB64 := base64.StdEncoding.EncodeToString(der)
+
+	md := []byte(fmt.Sprintf(`<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="%s">
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data><X509Certificate>%s</X509Certificate></X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example/sso"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>`, entityID, certB64))
+
+	return md, priv, parsedCert
+}
+
+// TestParseResponse_Success builds a real, signed, IDP-initiated SAML Response using
+// crewjam/saml's own IdP-side assertion/response construction (the same code path its
+// own test suite uses to produce fixtures), submits it to Provider.ParseResponse exactly
+// as a real ACS handler would, and asserts the returned AssertionInfo reflects the
+// session attributes — exercising the success return line that every other ParseResponse
+// test necessarily leaves uncovered.
+func TestParseResponse_Success(t *testing.T) {
+	const idpEntityID = "https://idp.example/entity"
+	const spEntityID = "https://keyorix.internal/saml/corp/metadata"
+	const acsURL = "https://keyorix.internal/auth/saml/corp/acs"
+
+	idpMD, idpKey, idpCert := signedIDPFixture(t, idpEntityID)
+
+	p, err := NewProvider(Config{
+		Name:              "corp",
+		IDPMetadataXML:    idpMD,
+		SPEntityID:        spEntityID,
+		ACSURL:            acsURL,
+		AllowIDPInitiated: true,
+		// Match crewjam's DefaultAssertionMaker attribute FriendlyNames so the mapped
+		// AssertionInfo below reflects real session data, not just an empty struct.
+		EmailAttr:  "mail",
+		NameAttr:   "cn",
+		GroupsAttr: "eduPersonAffiliation",
+	})
+	require.NoError(t, err)
+
+	// Build the IdP side: an IdentityProvider whose signing key/cert are exactly the
+	// ones embedded in idpMD above, so the SP's signature check succeeds.
+	idpMetadataURL, err := url.Parse(idpEntityID)
+	require.NoError(t, err)
+	idp := &csaml.IdentityProvider{
+		Key:         idpKey,
+		Certificate: idpCert,
+		MetadataURL: *idpMetadataURL,
+	}
+
+	// req.ServiceProviderMetadata is exactly what our own SP would publish — pull it
+	// straight from the Provider under test rather than re-deriving it, so the fixture
+	// can't silently drift from what NewProvider actually built.
+	spMetadata := p.sp.Metadata()
+
+	var acsEndpoint *csaml.IndexedEndpoint
+	var spssoDescriptor *csaml.SPSSODescriptor
+	for i := range spMetadata.SPSSODescriptors {
+		d := spMetadata.SPSSODescriptors[i]
+		for j := range d.AssertionConsumerServices {
+			ep := d.AssertionConsumerServices[j]
+			if ep.Binding == csaml.HTTPPostBinding {
+				acsEndpoint = &ep
+				spssoDescriptor = &d
+				break
+			}
+		}
+		if acsEndpoint != nil {
+			break
+		}
+	}
+	require.NotNil(t, acsEndpoint, "SP metadata must advertise an HTTP-POST ACS endpoint")
+
+	httpReq := httptest.NewRequest(http.MethodGet, "https://idp.example/sso", nil)
+
+	idpReq := &csaml.IdpAuthnRequest{
+		IDP:                     idp,
+		HTTPRequest:             httpReq,
+		RelayState:              "return-here",
+		ServiceProviderMetadata: spMetadata,
+		SPSSODescriptor:         spssoDescriptor,
+		ACSEndpoint:             acsEndpoint,
+		Now:                     time.Now(),
+	}
+
+	session := &csaml.Session{
+		ID:             "sess-1",
+		CreateTime:     time.Now(),
+		ExpireTime:     time.Now().Add(time.Hour),
+		NameID:         "user@corp.example",
+		UserEmail:      "user@corp.example",
+		UserCommonName: "User Corp",
+		Groups:         []string{"admins", "devs"},
+	}
+
+	require.NoError(t, csaml.DefaultAssertionMaker{}.MakeAssertion(idpReq, session),
+		"building the IdP-side assertion must succeed")
+
+	form, err := idpReq.PostBinding()
+	require.NoError(t, err, "signing and serializing the Response must succeed")
+	require.NotEmpty(t, form.SAMLResponse)
+
+	// Submit exactly as a real ACS handler would: POST the base64 Response as
+	// application/x-www-form-urlencoded, and call ParseForm() first — crewjam's
+	// ParseResponse reads req.PostForm (not req.PostFormValue), so an un-parsed form
+	// would read back empty regardless of the body, which is not what we're testing here.
+	body := url.Values{"SAMLResponse": {form.SAMLResponse}}.Encode()
+	acsReq := httptest.NewRequest(http.MethodPost, acsURL, strings.NewReader(body))
+	acsReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	require.NoError(t, acsReq.ParseForm())
+
+	info, err := p.ParseResponse(acsReq, nil)
+	require.NoError(t, err, "a validly signed, IDP-initiated response must be accepted")
+	require.NotNil(t, info)
+
+	assert.Equal(t, "user@corp.example", info.Subject)
+	assert.Equal(t, "user@corp.example", info.Email)
+	assert.Equal(t, "User Corp", info.Name)
+	assert.ElementsMatch(t, []string{"admins", "devs"}, info.Groups)
+}

--- a/internal/secrettemplate/render_test.go
+++ b/internal/secrettemplate/render_test.go
@@ -448,3 +448,85 @@ func TestRenderJSON_PlainValueUnaffectedByEscaping(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
 }
+
+// EscapeYAMLString must fall back to its defensive replacer when yaml.v3 doesn't
+// encode the value as a plain double-quoted scalar: a value containing invalid
+// UTF-8 makes yaml.Marshal emit a `!!binary "...."` tagged scalar instead (since a
+// double-quoted style can't represent arbitrary binary), so the function's
+// quote-stripping fast path (which assumes the marshaled form starts and ends with
+// a bare `"`) doesn't apply. The fallback must still escape the *original* value's
+// quotes/backslashes rather than leak yaml.Marshal's `!!binary` tag or base64 body
+// into the caller's output.
+func TestEscapeYAMLString_FallsBackOnInvalidUTF8(t *testing.T) {
+	// Invalid UTF-8 byte combined with a quote and a backslash in the same value,
+	// so the assertion exercises the replacer's actual escaping behavior rather
+	// than merely "value passed through unchanged".
+	val := "\xc3(\"back\\slash"
+
+	got := EscapeYAMLString(val)
+
+	want := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(val)
+	assert.Equal(t, want, got, "fallback must escape the original value's quotes/backslashes")
+	assert.NotContains(t, got, "!!binary", "must not leak yaml.Marshal's !!binary tag into the escaped output")
+}
+
+// RenderWithOptions must cap total rendered output at MaxOutputBytes: a resolved
+// value large enough on its own to push the cumulative output past the cap must
+// abort the render with an error naming the byte limit, rather than allow Render
+// to be used as a memory-exhaustion amplifier (see MaxOutputBytes doc comment).
+func TestRender_RejectsOutputExceedingMaxBytes(t *testing.T) {
+	huge := strings.Repeat("a", MaxOutputBytes+1)
+	resolve := func(ref string) (string, error) { return huge, nil }
+
+	out, err := Render("${secret:prod/db}", resolve)
+	require.Error(t, err)
+	assert.Empty(t, out, "no partial output on a size-limit abort")
+	assert.Contains(t, err.Error(), fmt.Sprintf("%d", MaxOutputBytes))
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+// A rendered output of exactly MaxOutputBytes (the boundary, not over it) must
+// still succeed — the cap rejects output that exceeds the limit, not output that
+// merely reaches it.
+func TestRender_AllowsOutputAtExactlyMaxBytes(t *testing.T) {
+	exact := strings.Repeat("a", MaxOutputBytes)
+	resolve := func(ref string) (string, error) { return exact, nil }
+
+	out, err := Render("${secret:prod/db}", resolve)
+	require.NoError(t, err)
+	assert.Equal(t, exact, out)
+}
+
+// The MaxOutputBytes cap must also fire when no single resolved value is oversized
+// on its own, but several distinct references' values (plus literal text) sum past
+// the cap across multiple segments — the check runs after every segment write, not
+// just once at the end, so a template with many moderate-sized references can't
+// evade the cap by never naming one giant value.
+func TestRender_RejectsOutputExceedingMaxBytes_AccumulatedAcrossSegments(t *testing.T) {
+	const chunk = MaxOutputBytes / 4
+	value := strings.Repeat("a", chunk+1) // 4 refs * (chunk+1) > MaxOutputBytes
+	resolve := func(ref string) (string, error) { return value, nil }
+
+	tmpl := "${secret:a}${secret:b}${secret:c}${secret:d}"
+	out, err := Render(tmpl, resolve)
+	require.Error(t, err)
+	assert.Empty(t, out, "no partial output on a size-limit abort")
+	assert.Contains(t, err.Error(), fmt.Sprintf("%d", MaxOutputBytes))
+	assert.Contains(t, err.Error(), "exceeds")
+}
+
+// The accumulation check must not misfire early: a template whose several segments
+// sum to exactly MaxOutputBytes (never exceeding it at any intermediate step) must
+// still succeed, mirroring TestRender_AllowsOutputAtExactlyMaxBytes for the
+// multi-segment case.
+func TestRender_AllowsOutputAtExactlyMaxBytes_AccumulatedAcrossSegments(t *testing.T) {
+	const chunk = MaxOutputBytes / 4
+	value := strings.Repeat("a", chunk)
+	resolve := func(ref string) (string, error) { return value, nil }
+
+	tmpl := "${secret:a}${secret:b}${secret:c}${secret:d}"
+	out, err := Render(tmpl, resolve)
+	require.NoError(t, err)
+	assert.Equal(t, strings.Repeat(value, 4), out)
+	assert.Len(t, out, MaxOutputBytes)
+}

--- a/internal/storage/factory_g80_error_paths_test.go
+++ b/internal/storage/factory_g80_error_paths_test.go
@@ -1,0 +1,182 @@
+// factory_g80_error_paths_test.go — targeted coverage for genuinely-reachable
+// error branches left uncovered by the earlier s2x coverage sweeps:
+//
+//   - every ensure*Index helper's CREATE UNIQUE INDEX failure path (as opposed
+//     to the pre-flight warnIfDuplicatesExist failure path the s25 sweep's
+//     "NoTableError" tests actually exercise — see the doc comment on
+//     seedIndexNameOnDummyTable below for why those are different branches);
+//   - applyPoolSettings' db.DB() failure branch;
+//   - acquireSQLiteMigrationLock's os.OpenFile failure branch;
+//   - migrateDatabase's shared `exec` closure error-wrapping branch, and the
+//     first ALTER TABLE call site that uses it.
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+// ---------------------------------------------------------------------------
+// ensure*Index — CREATE INDEX failure path (distinct from the pre-flight
+// warnIfDuplicatesExist failure path)
+// ---------------------------------------------------------------------------
+
+// seedIndexNameOnDummyTable creates an unrelated table and an index named
+// idxName on it. Every ensure*Index helper in factory.go first checks
+// indexExists(db, idxName) and, only when that's false, runs the
+// warnIfDuplicatesExist pre-flight scan before its own CREATE UNIQUE INDEX
+// statement. Seeding an index of the same name on a throwaway table makes
+// indexExists report true, which skips the pre-flight scan entirely and
+// drives straight into the helper's own `db.Exec(sqlCreateUniqueIdx + ...)`
+// call — which then genuinely fails, because the target table the statement
+// actually names was never created. Confirmed against SQLite directly: a
+// `CREATE UNIQUE INDEX IF NOT EXISTS <existing-name> ON <missing-table> (...)`
+// still parses and validates the referenced table (raising "no such table")
+// even though the "IF NOT EXISTS" name check would otherwise short-circuit —
+// SQLite resolves the table reference before deciding whether to skip.
+func seedIndexNameOnDummyTable(t *testing.T, db *gorm.DB, idxName string) {
+	t.Helper()
+	dummyTable := idxName + "_dummy"
+	require.NoError(t, db.Exec("CREATE TABLE "+dummyTable+" (id INTEGER PRIMARY KEY)").Error)
+	require.NoError(t, db.Exec("CREATE INDEX "+idxName+" ON "+dummyTable+" (id)").Error)
+}
+
+func TestEnsureIndexHelpers_CreateIndexFailsWhenTargetTableMissing(t *testing.T) {
+	cases := []struct {
+		name        string
+		idxName     string
+		fn          func(*gorm.DB) error
+		errContains string
+	}{
+		{"ShareRecordUniqueIndex", "uniq_share_records_active", ensureShareRecordUniqueIndex, "failed to create partial share_records unique index"},
+		{"SecretNodeNameIndex", "uniq_secret_nodes_project_env_name_active", ensureSecretNodeNameIndex, "failed to create secret_nodes unique-name index"},
+		{"SecretVersionIndex", "uniq_secret_versions_node_version", ensureSecretVersionIndex, "failed to create secret_versions unique index"},
+		{"DynamicSecretConfigNameIndex", "uniq_dynamic_secret_configs_project_env_name", ensureDynamicSecretConfigNameIndex, "failed to create dynamic_secret_configs unique index"},
+		{"GroupNameIndex", "uniq_groups_name_active", ensureGroupNameIndex, "failed to create partial groups name index"},
+		{"ProjectMembershipIndex", "uniq_project_memberships_active", ensureProjectMembershipIndex, "failed to create partial project_memberships index"},
+		{"BreakGlassActiveIndex", "uniq_break_glass_active_project_user", ensureBreakGlassActiveIndex, "failed to create partial break_glass_activations active index"},
+		{"UserNameIndex", "uniq_users_username_active", ensureUserNameIndex, "failed to create partial users username index"},
+		{"UserEmailIndex", "uniq_users_email_active", ensureUserEmailIndex, "failed to create partial users email index"},
+		{"UserExternalIDIndex", "uniq_users_external_id_active", ensureUserExternalIDIndex, "failed to create partial users external_id index"},
+		{"ProjectNameIndex", "uniq_projects_name_active", ensureProjectNameIndex, "failed to create partial projects name index"},
+		{"LegalHoldActiveIndex", "uniq_legal_holds_active", ensureLegalHoldActiveIndex, "failed to create partial legal_holds active index"},
+		{"ReminderNotificationDedupIndex", "uniq_notifications_unread_reminder", ensureReminderNotificationDedupIndex, "failed to create partial notifications reminder-dedup index"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), tc.name+"-collision.db"))
+			require.NoError(t, err)
+			seedIndexNameOnDummyTable(t, db, tc.idxName)
+
+			err = tc.fn(db)
+			require.Error(t, err, "%s must return an error when its CREATE INDEX statement itself fails (target table missing)", tc.name)
+			assert.Contains(t, err.Error(), tc.errContains)
+			// Must be the CREATE INDEX wrapper message, not the pre-flight
+			// warnIfDuplicatesExist error (which is skipped here since the
+			// index name already "exists") — confirms the right branch fired.
+			assert.NotContains(t, err.Error(), "pre-existing group(s) of rows already share a value")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyPoolSettings — db.DB() failure branch
+// ---------------------------------------------------------------------------
+
+// TestApplyPoolSettings_ReturnsError_WhenConnPoolInvalid verifies that
+// applyPoolSettings propagates db.DB()'s error instead of panicking when
+// handed a *gorm.DB with a non-nil Config but no ConnPool set (as would occur
+// if a future refactor ever passed a *gorm.DB through before a real Open —
+// this pins the current fail-loud contract). gorm.DB embeds *Config, and
+// ConnPool itself lives on Config, not DB — a fully zero-value &gorm.DB{}
+// (nil embedded *Config) panics on field promotion before ever reaching
+// db.DB()'s own nil-handling, so Config must be non-nil here to exercise
+// db.DB()'s actual ErrInvalidDB fallback rather than an unrelated crash.
+func TestApplyPoolSettings_ReturnsError_WhenConnPoolInvalid(t *testing.T) {
+	db := &gorm.DB{Config: &gorm.Config{}}
+	err := applyPoolSettings(db, &config.DatabaseConfig{})
+	require.Error(t, err, "applyPoolSettings must surface a db.DB() failure rather than panic")
+	assert.Contains(t, err.Error(), "failed to get underlying sql.DB")
+}
+
+// ---------------------------------------------------------------------------
+// acquireSQLiteMigrationLock — os.OpenFile failure branch
+// ---------------------------------------------------------------------------
+
+// TestAcquireSQLiteMigrationLock_OpenFileFails_WhenParentDirMissing verifies
+// that acquireSQLiteMigrationLock surfaces an actionable error (rather than a
+// bare os.PathError or a panic) when the lock sidecar file cannot even be
+// opened — here because its parent directory does not exist.
+func TestAcquireSQLiteMigrationLock_OpenFileFails_WhenParentDirMissing(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "no-such-subdir", "secrets.db")
+
+	lock, err := acquireSQLiteMigrationLock(dbPath)
+	require.Error(t, err, "acquireSQLiteMigrationLock must surface the OpenFile error")
+	assert.Nil(t, lock)
+	assert.Contains(t, err.Error(), "open SQLite migration lock file")
+}
+
+// ---------------------------------------------------------------------------
+// migrateDatabase — shared `exec` closure error-wrapping branch
+// ---------------------------------------------------------------------------
+
+// TestMigrateDatabase_WrapsRawExecFailure exercises migrateDatabase's shared
+// `exec` closure error path via its very first call site (the secret_nodes
+// last_rotated_at ALTER). columnExists's pragma_table_info lookup is a
+// case-SENSITIVE string comparison, but SQLite itself treats column names as
+// case-INSENSITIVE for duplicate detection — so pre-creating the column under
+// a different case defeats the `!columnExists(...)` guard (it reports the
+// column absent) while the ALTER TABLE this triggers still genuinely fails
+// with "duplicate column name". This is a real (if narrow) gap in
+// columnExists's case-sensitivity, exercised here as a legitimate way to
+// reach the exec closure's error-wrapping branch and confirm migrateDatabase
+// propagates the failure instead of silently continuing.
+func TestMigrateDatabase_WrapsRawExecFailure(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "migrate-exec-fail.db"))
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE secret_nodes (id INTEGER PRIMARY KEY, Last_Rotated_At TIMESTAMP)`).Error)
+	require.False(t, columnExists(db, "secret_nodes", "last_rotated_at"),
+		"columnExists must miss the case-variant column (case-sensitive lookup) so the ALTER is attempted")
+
+	err = (&DefaultStorageFactory{}).migrateDatabase(db)
+	require.Error(t, err, "migrateDatabase must propagate the wrapped ALTER TABLE failure")
+	assert.Contains(t, err.Error(), "migration failed")
+	assert.Contains(t, err.Error(), "duplicate column name")
+}
+
+// ---------------------------------------------------------------------------
+// rebuildRolePKSQLite — CREATE TABLE failure branch
+// ---------------------------------------------------------------------------
+
+// TestRebuildRolePKSQLite_CreateTableFails_WhenScratchTableAlreadyExists
+// verifies that rebuildRolePKSQLite propagates a wrapped error when its own
+// `CREATE TABLE <table>_new` statement fails, by pre-creating that exact
+// scratch table out of band so the name collides.
+func TestRebuildRolePKSQLite_CreateTableFails_WhenScratchTableAlreadyExists(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "pk-rebuild-collision.db"))
+	require.NoError(t, err)
+
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id INTEGER NOT NULL,
+		role_id INTEGER NOT NULL,
+		PRIMARY KEY (user_id, role_id)
+	)`).Error)
+	// Collides with the scratch table rebuildRolePKSQLite itself tries to create.
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles_new (id INTEGER)`).Error)
+
+	err = rebuildRolePKSQLite(db, "user_roles", "user_id", "user_id, role_id, project_id, environment_id")
+	require.Error(t, err, "rebuildRolePKSQLite must propagate a CREATE TABLE failure on the scratch table")
+	assert.Contains(t, err.Error(), "create user_roles_new")
+}

--- a/internal/storage/models/models_beforesave_test.go
+++ b/internal/storage/models/models_beforesave_test.go
@@ -1,0 +1,336 @@
+// models_beforesave_test.go — coverage for the G81 BeforeSave UTC-normalization
+// hooks on models.go, none of which were previously exercised by any test in
+// this package. Each hook is a GORM callback invoked with a *gorm.DB that it
+// never touches (its receiver is `_ *gorm.DB`), so every test below calls it
+// directly with a nil *gorm.DB — real behavior, without needing a live DB.
+//
+// For hooks that normalize a *time.Time (pointer field), both branches are
+// covered: the nil-guard (field left nil, no panic) and the normalization
+// itself (a non-UTC Location is converted to UTC while the absolute instant
+// is preserved). For hooks that normalize a plain time.Time field, only the
+// normalization branch exists (there's no nil-guard to hit), so a single test
+// covers the function's one branch.
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nonUTCTime returns a fixed instant expressed in a fixed-offset, non-UTC
+// Location, so a BeforeSave hook's UTC-conversion is actually observable
+// (time.Now() alone might already happen to report a UTC-Location value in
+// some environments, which would make the assertion vacuous).
+func nonUTCTime() time.Time {
+	loc := time.FixedZone("UTC-5", -5*60*60)
+	return time.Date(2026, 3, 15, 10, 30, 0, 0, loc)
+}
+
+// --- AccessRequest.BeforeSave (ResolvedAt *time.Time, nil-guarded) ---
+
+func TestAccessRequest_BeforeSave_NilResolvedAt(t *testing.T) {
+	r := &AccessRequest{}
+	require.NoError(t, r.BeforeSave(nil))
+	assert.Nil(t, r.ResolvedAt)
+}
+
+func TestAccessRequest_BeforeSave_NormalizesResolvedAt(t *testing.T) {
+	src := nonUTCTime()
+	r := &AccessRequest{ResolvedAt: &src}
+	require.NoError(t, r.BeforeSave(nil))
+	require.NotNil(t, r.ResolvedAt)
+	assert.Equal(t, time.UTC, r.ResolvedAt.Location())
+	assert.True(t, src.Equal(*r.ResolvedAt), "instant must be preserved across the Location conversion")
+}
+
+// --- BreakGlassActivation.BeforeSave (CreatedAt time.Time, unconditional) ---
+
+func TestBreakGlassActivation_BeforeSave_NormalizesCreatedAt(t *testing.T) {
+	src := nonUTCTime()
+	b := &BreakGlassActivation{CreatedAt: src}
+	require.NoError(t, b.BeforeSave(nil))
+	assert.Equal(t, time.UTC, b.CreatedAt.Location())
+	assert.True(t, src.Equal(b.CreatedAt))
+}
+
+// --- AccessReviewCampaign.BeforeSave (ClosedAt *time.Time, nil-guarded) ---
+
+func TestAccessReviewCampaign_BeforeSave_NilClosedAt(t *testing.T) {
+	c := &AccessReviewCampaign{}
+	require.NoError(t, c.BeforeSave(nil))
+	assert.Nil(t, c.ClosedAt)
+}
+
+func TestAccessReviewCampaign_BeforeSave_NormalizesClosedAt(t *testing.T) {
+	src := nonUTCTime()
+	c := &AccessReviewCampaign{ClosedAt: &src}
+	require.NoError(t, c.BeforeSave(nil))
+	require.NotNil(t, c.ClosedAt)
+	assert.Equal(t, time.UTC, c.ClosedAt.Location())
+	assert.True(t, src.Equal(*c.ClosedAt))
+}
+
+// --- User.BeforeSave (CreatedAt time.Time, unconditional) ---
+
+func TestUser_BeforeSave_NormalizesCreatedAt(t *testing.T) {
+	src := nonUTCTime()
+	u := &User{CreatedAt: src}
+	require.NoError(t, u.BeforeSave(nil))
+	assert.Equal(t, time.UTC, u.CreatedAt.Location())
+	assert.True(t, src.Equal(u.CreatedAt))
+}
+
+// --- MFAStepupToken.BeforeSave (ExpiresAt time.Time, unconditional) ---
+
+func TestMFAStepupToken_BeforeSave_NormalizesExpiresAt(t *testing.T) {
+	src := nonUTCTime()
+	tok := &MFAStepupToken{ExpiresAt: src}
+	require.NoError(t, tok.BeforeSave(nil))
+	assert.Equal(t, time.UTC, tok.ExpiresAt.Location())
+	assert.True(t, src.Equal(tok.ExpiresAt))
+}
+
+// --- MFAStepUpGrant.BeforeSave (ExpiresAt time.Time, unconditional) ---
+
+func TestMFAStepUpGrant_BeforeSave_NormalizesExpiresAt(t *testing.T) {
+	src := nonUTCTime()
+	g := &MFAStepUpGrant{ExpiresAt: src}
+	require.NoError(t, g.BeforeSave(nil))
+	assert.Equal(t, time.UTC, g.ExpiresAt.Location())
+	assert.True(t, src.Equal(g.ExpiresAt))
+}
+
+// --- MFAChallenge.BeforeSave (ExpiresAt time.Time, unconditional) ---
+
+func TestMFAChallenge_BeforeSave_NormalizesExpiresAt(t *testing.T) {
+	src := nonUTCTime()
+	c := &MFAChallenge{ExpiresAt: src}
+	require.NoError(t, c.BeforeSave(nil))
+	assert.Equal(t, time.UTC, c.ExpiresAt.Location())
+	assert.True(t, src.Equal(c.ExpiresAt))
+}
+
+// --- LoginAttempt.BeforeSave (AttemptedAt time.Time, unconditional) ---
+
+func TestLoginAttempt_BeforeSave_NormalizesAttemptedAt(t *testing.T) {
+	src := nonUTCTime()
+	a := &LoginAttempt{AttemptedAt: src}
+	require.NoError(t, a.BeforeSave(nil))
+	assert.Equal(t, time.UTC, a.AttemptedAt.Location())
+	assert.True(t, src.Equal(a.AttemptedAt))
+}
+
+// --- WebAuthnSession.BeforeSave (ExpiresAt time.Time, unconditional) ---
+
+func TestWebAuthnSession_BeforeSave_NormalizesExpiresAt(t *testing.T) {
+	src := nonUTCTime()
+	s := &WebAuthnSession{ExpiresAt: src}
+	require.NoError(t, s.BeforeSave(nil))
+	assert.Equal(t, time.UTC, s.ExpiresAt.Location())
+	assert.True(t, src.Equal(s.ExpiresAt))
+}
+
+// --- UserRole.BeforeSave (ExpiresAt *time.Time, nil-guarded) ---
+
+func TestUserRole_BeforeSave_NilExpiresAt(t *testing.T) {
+	ur := &UserRole{}
+	require.NoError(t, ur.BeforeSave(nil))
+	assert.Nil(t, ur.ExpiresAt)
+}
+
+func TestUserRole_BeforeSave_NormalizesExpiresAt(t *testing.T) {
+	src := nonUTCTime()
+	ur := &UserRole{ExpiresAt: &src}
+	require.NoError(t, ur.BeforeSave(nil))
+	require.NotNil(t, ur.ExpiresAt)
+	assert.Equal(t, time.UTC, ur.ExpiresAt.Location())
+	assert.True(t, src.Equal(*ur.ExpiresAt))
+}
+
+// --- GroupRole.BeforeSave (ExpiresAt *time.Time, nil-guarded) ---
+
+func TestGroupRole_BeforeSave_NilExpiresAt(t *testing.T) {
+	gr := &GroupRole{}
+	require.NoError(t, gr.BeforeSave(nil))
+	assert.Nil(t, gr.ExpiresAt)
+}
+
+func TestGroupRole_BeforeSave_NormalizesExpiresAt(t *testing.T) {
+	src := nonUTCTime()
+	gr := &GroupRole{ExpiresAt: &src}
+	require.NoError(t, gr.BeforeSave(nil))
+	require.NotNil(t, gr.ExpiresAt)
+	assert.Equal(t, time.UTC, gr.ExpiresAt.Location())
+	assert.True(t, src.Equal(*gr.ExpiresAt))
+}
+
+// --- SecretNode.BeforeSave (Expiration *time.Time, nil-guarded) ---
+
+func TestSecretNode_BeforeSave_NilExpiration(t *testing.T) {
+	s := &SecretNode{}
+	require.NoError(t, s.BeforeSave(nil))
+	assert.Nil(t, s.Expiration)
+}
+
+func TestSecretNode_BeforeSave_NormalizesExpiration(t *testing.T) {
+	src := nonUTCTime()
+	s := &SecretNode{Expiration: &src}
+	require.NoError(t, s.BeforeSave(nil))
+	require.NotNil(t, s.Expiration)
+	assert.Equal(t, time.UTC, s.Expiration.Location())
+	assert.True(t, src.Equal(*s.Expiration))
+}
+
+// --- DynamicSecretLease.BeforeSave (ExpiresAt time.Time, unconditional) ---
+
+func TestDynamicSecretLease_BeforeSave_NormalizesExpiresAt(t *testing.T) {
+	src := nonUTCTime()
+	l := &DynamicSecretLease{ExpiresAt: src}
+	require.NoError(t, l.BeforeSave(nil))
+	assert.Equal(t, time.UTC, l.ExpiresAt.Location())
+	assert.True(t, src.Equal(l.ExpiresAt))
+}
+
+// --- SecretAccessLog.BeforeSave (AccessTime time.Time, unconditional) ---
+
+func TestSecretAccessLog_BeforeSave_NormalizesAccessTime(t *testing.T) {
+	src := nonUTCTime()
+	l := &SecretAccessLog{AccessTime: src}
+	require.NoError(t, l.BeforeSave(nil))
+	assert.Equal(t, time.UTC, l.AccessTime.Location())
+	assert.True(t, src.Equal(l.AccessTime))
+}
+
+// --- Session.BeforeSave (ExpiresAt *time.Time, nil-guarded) ---
+
+func TestSession_BeforeSave_NilExpiresAt(t *testing.T) {
+	s := &Session{}
+	require.NoError(t, s.BeforeSave(nil))
+	assert.Nil(t, s.ExpiresAt)
+}
+
+func TestSession_BeforeSave_NormalizesExpiresAt(t *testing.T) {
+	src := nonUTCTime()
+	s := &Session{ExpiresAt: &src}
+	require.NoError(t, s.BeforeSave(nil))
+	require.NotNil(t, s.ExpiresAt)
+	assert.Equal(t, time.UTC, s.ExpiresAt.Location())
+	assert.True(t, src.Equal(*s.ExpiresAt))
+}
+
+// --- PersonalAccessToken.BeforeSave (ExpiresAt *time.Time, nil-guarded) ---
+
+func TestPersonalAccessToken_BeforeSave_NilExpiresAt(t *testing.T) {
+	tok := &PersonalAccessToken{}
+	require.NoError(t, tok.BeforeSave(nil))
+	assert.Nil(t, tok.ExpiresAt)
+}
+
+func TestPersonalAccessToken_BeforeSave_NormalizesExpiresAt(t *testing.T) {
+	src := nonUTCTime()
+	tok := &PersonalAccessToken{ExpiresAt: &src}
+	require.NoError(t, tok.BeforeSave(nil))
+	require.NotNil(t, tok.ExpiresAt)
+	assert.Equal(t, time.UTC, tok.ExpiresAt.Location())
+	assert.True(t, src.Equal(*tok.ExpiresAt))
+}
+
+// --- SetupToken.BeforeSave (CreatedAt time.Time, unconditional) ---
+
+func TestSetupToken_BeforeSave_NormalizesCreatedAt(t *testing.T) {
+	src := nonUTCTime()
+	tok := &SetupToken{CreatedAt: src}
+	require.NoError(t, tok.BeforeSave(nil))
+	assert.Equal(t, time.UTC, tok.CreatedAt.Location())
+	assert.True(t, src.Equal(tok.CreatedAt))
+}
+
+// --- AuditEvent.BeforeSave (EventTime time.Time, unconditional) ---
+
+func TestAuditEvent_BeforeSave_NormalizesEventTime(t *testing.T) {
+	src := nonUTCTime()
+	e := &AuditEvent{EventTime: src}
+	require.NoError(t, e.BeforeSave(nil))
+	assert.Equal(t, time.UTC, e.EventTime.Location())
+	assert.True(t, src.Equal(e.EventTime))
+}
+
+// TestAuditEvent_BeforeSave_PreservesUnixMicro guards the specific invariant
+// the hook's doc comment calls out: normalizing EventTime's Location must not
+// change its UnixMicro() value, because the audit hash chain
+// (computeAuditEntryHash) is computed from UnixMicro() and must stay stable
+// whether the hook ran before or after that computation.
+func TestAuditEvent_BeforeSave_PreservesUnixMicro(t *testing.T) {
+	src := nonUTCTime()
+	before := src.UnixMicro()
+	e := &AuditEvent{EventTime: src}
+	require.NoError(t, e.BeforeSave(nil))
+	assert.Equal(t, before, e.EventTime.UnixMicro())
+}
+
+// --- ShareRecord.BeforeSave (ExpiresAt *time.Time, nil-guarded) ---
+
+func TestShareRecord_BeforeSave_NilExpiresAt(t *testing.T) {
+	s := &ShareRecord{}
+	require.NoError(t, s.BeforeSave(nil))
+	assert.Nil(t, s.ExpiresAt)
+}
+
+func TestShareRecord_BeforeSave_NormalizesExpiresAt(t *testing.T) {
+	src := nonUTCTime()
+	s := &ShareRecord{ExpiresAt: &src}
+	require.NoError(t, s.BeforeSave(nil))
+	require.NotNil(t, s.ExpiresAt)
+	assert.Equal(t, time.UTC, s.ExpiresAt.Location())
+	assert.True(t, src.Equal(*s.ExpiresAt))
+}
+
+// --- AnomalyAlert.BeforeSave (DetectedAt time.Time, unconditional) ---
+
+func TestAnomalyAlert_BeforeSave_NormalizesDetectedAt(t *testing.T) {
+	src := nonUTCTime()
+	a := &AnomalyAlert{DetectedAt: src}
+	require.NoError(t, a.BeforeSave(nil))
+	assert.Equal(t, time.UTC, a.DetectedAt.Location())
+	assert.True(t, src.Equal(a.DetectedAt))
+}
+
+// --- MachineIdentity.BeforeSave (CreatedAt time.Time, unconditional) ---
+
+func TestMachineIdentity_BeforeSave_NormalizesCreatedAt(t *testing.T) {
+	src := nonUTCTime()
+	m := &MachineIdentity{CreatedAt: src}
+	require.NoError(t, m.BeforeSave(nil))
+	assert.Equal(t, time.UTC, m.CreatedAt.Location())
+	assert.True(t, src.Equal(m.CreatedAt))
+}
+
+// --- MachineIdentityCredential.BeforeSave (ExpiresAt *time.Time, nil-guarded) ---
+
+func TestMachineIdentityCredential_BeforeSave_NilExpiresAt(t *testing.T) {
+	c := &MachineIdentityCredential{}
+	require.NoError(t, c.BeforeSave(nil))
+	assert.Nil(t, c.ExpiresAt)
+}
+
+func TestMachineIdentityCredential_BeforeSave_NormalizesExpiresAt(t *testing.T) {
+	src := nonUTCTime()
+	c := &MachineIdentityCredential{ExpiresAt: &src}
+	require.NoError(t, c.BeforeSave(nil))
+	require.NotNil(t, c.ExpiresAt)
+	assert.Equal(t, time.UTC, c.ExpiresAt.Location())
+	assert.True(t, src.Equal(*c.ExpiresAt))
+}
+
+// --- ProjectMembership.BeforeSave (InvitedAt time.Time, unconditional) ---
+
+func TestProjectMembership_BeforeSave_NormalizesInvitedAt(t *testing.T) {
+	src := nonUTCTime()
+	m := &ProjectMembership{InvitedAt: src}
+	require.NoError(t, m.BeforeSave(nil))
+	assert.Equal(t, time.UTC, m.InvitedAt.Location())
+	assert.True(t, src.Equal(m.InvitedAt))
+}

--- a/internal/storage/remote/config_s28_test.go
+++ b/internal/storage/remote/config_s28_test.go
@@ -1,0 +1,257 @@
+// config_s28_test.go — s28 coverage sweep for internal/storage/remote.
+//
+// Targets remaining gaps left after the s24/s27 sweeps:
+//
+//	config.go Validate
+//	  — empty APIKey is rejected before BaseURL is even inspected
+//	config.go validateBaseURL
+//	  — a genuinely unparseable base_url (url.Parse itself errors) is rejected
+//	    with the parse error, distinct from the "wrong scheme" rejection
+//
+//	client.go APIError.Error
+//	  — Details-populated branch renders "code: message (details)"
+//	client.go HTTPError.Error
+//	  — Message-only branch (no ErrorType) renders "HTTP <code>: <message>"
+//	client.go rawJSONToString
+//	  — a RawMessage that isn't a JSON string literal falls back to the raw text
+//	client.go circuitBreakerOpen
+//	  — the 30s-cooldown-elapsed branch actually closes the breaker and resets
+//	    the failure count, not just reports "not open"
+//	client.go Request
+//	  — a context that's canceled/expires during the inter-attempt backoff sleep
+//	    returns ctx.Err() instead of continuing to retry
+//	client.go makeRequest
+//	  — a request body that can't be JSON-marshaled surfaces a wrapped error
+//	  — an invalid HTTP method passed to Request surfaces the NewRequestWithContext
+//	    construction error
+//	  — a response body that is shorter than its own Content-Length header
+//	    surfaces a body-read error rather than silently returning a partial body
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Config.Validate
+// ---------------------------------------------------------------------------
+
+// TestValidate_S28_EmptyAPIKeyRejected verifies that a missing API key is
+// rejected with a clear message, independent of BaseURL validity.
+func TestValidate_S28_EmptyAPIKeyRejected(t *testing.T) {
+	c := &Config{BaseURL: "https://api.example.com", APIKey: ""}
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api_key is required")
+}
+
+// ---------------------------------------------------------------------------
+// validateBaseURL
+// ---------------------------------------------------------------------------
+
+// TestValidateBaseURL_S28_UnparseableURLRejected verifies that a base_url
+// which url.Parse itself rejects (not merely "wrong scheme") is surfaced as
+// an "invalid base_url" error carrying the underlying parse failure, distinct
+// from the https-scheme rejection message.
+func TestValidateBaseURL_S28_UnparseableURLRejected(t *testing.T) {
+	c := &Config{BaseURL: "http://exa mple.com", APIKey: "k"}
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid base_url")
+}
+
+// ---------------------------------------------------------------------------
+// APIError.Error
+// ---------------------------------------------------------------------------
+
+// TestAPIError_S28_ErrorWithDetails verifies the Details-populated rendering
+// branch of APIError.Error, distinct from the nil-receiver and no-details cases
+// already pinned elsewhere.
+func TestAPIError_S28_ErrorWithDetails(t *testing.T) {
+	e := &APIError{Code: "VALIDATION", Message: "bad input", Details: "field 'name' is required"}
+	got := e.Error()
+	assert.Equal(t, "VALIDATION: bad input (field 'name' is required)", got)
+}
+
+// ---------------------------------------------------------------------------
+// HTTPError.Error
+// ---------------------------------------------------------------------------
+
+// TestHTTPError_S28_MessageOnlyNoErrorType verifies the branch where a
+// Message is present but ErrorType is empty (e.g. a body that only had a
+// "message" field, no "error" type string) — falls back to "HTTP <code>: <message>"
+// rather than the ErrorType-driven format.
+func TestHTTPError_S28_MessageOnlyNoErrorType(t *testing.T) {
+	e := &HTTPError{StatusCode: http.StatusInternalServerError, Status: "500 Internal Server Error", Message: "database unavailable"}
+	got := e.Error()
+	assert.Equal(t, "HTTP 500: database unavailable", got)
+}
+
+// ---------------------------------------------------------------------------
+// rawJSONToString
+// ---------------------------------------------------------------------------
+
+// TestRawJSONToString_S28_NonStringFallsBackToRawText verifies that a
+// RawMessage which is valid JSON but not a JSON string literal (e.g. an
+// object, as a "details" field might legitimately carry) falls back to
+// returning the raw JSON text verbatim rather than an empty/failed unmarshal.
+func TestRawJSONToString_S28_NonStringFallsBackToRawText(t *testing.T) {
+	raw := json.RawMessage(`{"field":"name","reason":"required"}`)
+	got := rawJSONToString(raw)
+	assert.Equal(t, `{"field":"name","reason":"required"}`, got)
+}
+
+// TestRawJSONToString_S28_EmptyReturnsEmpty pins the len(raw)==0 short-circuit.
+func TestRawJSONToString_S28_EmptyReturnsEmpty(t *testing.T) {
+	assert.Equal(t, "", rawJSONToString(nil))
+	assert.Equal(t, "", rawJSONToString(json.RawMessage{}))
+}
+
+// ---------------------------------------------------------------------------
+// circuitBreakerOpen
+// ---------------------------------------------------------------------------
+
+// TestCircuitBreakerOpen_S28_ClosesAfterCooldown verifies that once the 30s
+// cooldown has elapsed since the last recorded failure, circuitBreakerOpen
+// both reports the breaker as closed AND actually resets circuitOpen/
+// failureCount as a side effect (not just a read-only "would be closed"
+// check) — a stuck-open breaker would permanently reject all requests.
+func TestCircuitBreakerOpen_S28_ClosesAfterCooldown(t *testing.T) {
+	client, err := NewHTTPClient(&Config{
+		BaseURL: "https://api.example.com", APIKey: "k", TimeoutSeconds: 5, RetryAttempts: 1, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	// Force the breaker into an open state as if 5 failures had just
+	// accumulated, but backdate lastFailureTime past the 30s cooldown.
+	client.cbMux.Lock()
+	client.circuitOpen = true
+	client.failureCount = 5
+	client.lastFailureTime = time.Now().Add(-31 * time.Second)
+	client.cbMux.Unlock()
+
+	open := client.circuitBreakerOpen()
+	assert.False(t, open, "cooldown elapsed: breaker must report closed")
+
+	client.cbMux.Lock()
+	stillOpen := client.circuitOpen
+	failures := client.failureCount
+	client.cbMux.Unlock()
+	assert.False(t, stillOpen, "cooldown elapsed: circuitOpen must be reset to false")
+	assert.Equal(t, 0, failures, "cooldown elapsed: failureCount must be reset to 0")
+}
+
+// ---------------------------------------------------------------------------
+// Request — context canceled during inter-attempt backoff
+// ---------------------------------------------------------------------------
+
+// TestRequest_S28_ContextExpiresDuringBackoff verifies that when the caller's
+// context is canceled/expires while Request is sleeping between retry
+// attempts, it returns ctx.Err() immediately instead of continuing to sleep
+// out the full exponential backoff and retry budget.
+func TestRequest_S28_ContextExpiresDuringBackoff(t *testing.T) {
+	// A server that always resets the connection: a retryable network error on
+	// every attempt, so Request always reaches the backoff-sleep between
+	// attempts (attempt=1 backs off for 1*1=1s).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if ok {
+			conn, _, _ := hj.Hijack()
+			_ = conn.Close()
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(&Config{
+		BaseURL: server.URL, APIKey: "k", TimeoutSeconds: 5, RetryAttempts: 3, TLSVerify: false,
+	})
+	require.NoError(t, err)
+
+	// Deadline shorter than the 1s backoff before the second attempt, but long
+	// enough for the first (immediately-failing) attempt to complete.
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err = client.Request(ctx, http.MethodGet, "/test", nil)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, elapsed, 900*time.Millisecond, "must return as soon as the context expires, not after the full 1s backoff")
+}
+
+// ---------------------------------------------------------------------------
+// makeRequest — construction/marshal/body-read failure branches
+// ---------------------------------------------------------------------------
+
+// TestMakeRequest_S28_UnmarshalableBodyErrors verifies that a request body
+// which json.Marshal cannot encode (a channel) surfaces a wrapped
+// "failed to marshal request body" error rather than panicking or silently
+// dropping the body.
+func TestMakeRequest_S28_UnmarshalableBodyErrors(t *testing.T) {
+	client, err := NewHTTPClient(&Config{
+		BaseURL: "https://api.example.com", APIKey: "k", TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	_, err = client.Post(context.Background(), "/test", make(chan int))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to marshal request body")
+}
+
+// TestMakeRequest_S28_InvalidMethodErrors verifies that an invalid HTTP
+// method (rejected by http.NewRequestWithContext itself) surfaces a wrapped
+// "failed to create request" error. isRetryableError treats this message as
+// non-retryable, so this also exercises the single-attempt, no-retry path.
+func TestMakeRequest_S28_InvalidMethodErrors(t *testing.T) {
+	client, err := NewHTTPClient(&Config{
+		BaseURL: "https://api.example.com", APIKey: "k", TimeoutSeconds: 5, RetryAttempts: 3, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	_, err = client.Request(context.Background(), "BAD METHOD", "/test", nil)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "failed to create request") || strings.Contains(err.Error(), "invalid method"),
+		"expected a request-construction error, got: %v", err)
+}
+
+// TestMakeRequest_S28_TruncatedBodyBelowContentLength verifies that a
+// response whose actual body is shorter than its own Content-Length header
+// (connection dropped mid-body) surfaces a body-read error from makeRequest
+// rather than silently returning a truncated/corrupt APIResponse.
+func TestMakeRequest_S28_TruncatedBodyBelowContentLength(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		require.True(t, ok)
+		conn, bufrw, err := hj.Hijack()
+		require.NoError(t, err)
+		// Promise 100 bytes of body but only send 5, then close the connection.
+		_, _ = bufrw.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\nshort")
+		_ = bufrw.Flush()
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	// RetryAttempts:0 would be defaulted up to 3 by Config.Validate (any
+	// value <=0 defaults to 3), turning this into a ~14s exponential-backoff
+	// run (1s+4s+9s across 3 retries) — use 1 explicitly so this stays fast
+	// (the read failure is retryable, so one retry attempt still happens).
+	client, err := NewHTTPClient(&Config{
+		BaseURL: server.URL, APIKey: "k", TimeoutSeconds: 5, RetryAttempts: 1, TLSVerify: false,
+	})
+	require.NoError(t, err)
+
+	_, err = client.Get(context.Background(), "/test")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read response body")
+}

--- a/internal/storage/sqlitedialect/ddlmod_parse_all_columns_test.go
+++ b/internal/storage/sqlitedialect/ddlmod_parse_all_columns_test.go
@@ -33,6 +33,48 @@ func TestParseAllColumns_UnexpectedToken(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParseAllColumns_BracketQuoted(t *testing.T) {
+	got, err := parseAllColumns("([id])")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id"}, got)
+}
+
+func TestParseAllColumns_EscapedQuoteInsideQuotedName(t *testing.T) {
+	got, err := parseAllColumns("(`na``me`)")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"na`me"}, got, "a doubled quote char inside a quoted name must be treated as an escaped literal, not the closing quote")
+}
+
+func TestParseAllColumns_SpacesAroundSeparator(t *testing.T) {
+	got, err := parseAllColumns("(id  , name)")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id", "name"}, got)
+}
+
+func TestParseAllColumns_TrailingWhitespaceAfterClose(t *testing.T) {
+	got, err := parseAllColumns("(id) ")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"id"}, got)
+}
+
+func TestParseAllColumns_UnquotedNameFollowedByQuoteErrors(t *testing.T) {
+	_, err := parseAllColumns(`(id"x)`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected token")
+}
+
+func TestParseAllColumns_UnexpectedTokenAfterName(t *testing.T) {
+	_, err := parseAllColumns("(id x)")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected token")
+}
+
+func TestParseAllColumns_UnterminatedInput(t *testing.T) {
+	_, err := parseAllColumns("(id")
+	require.Error(t, err)
+	assert.Equal(t, "unexpected end", err.Error())
+}
+
 func TestIsSpaceIsQuoteIsSeparator(t *testing.T) {
 	assert.True(t, isSpace(' '))
 	assert.True(t, isSpace('\t'))

--- a/internal/storage/sqlitedialect/ddlmod_test.go
+++ b/internal/storage/sqlitedialect/ddlmod_test.go
@@ -1,0 +1,160 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseDDL_EscapedQuoteInBody exercises the "skip escaped quote" branch in
+// parseDDL's bracket/comma scanner: a doubled quote character inside a quoted
+// identifier must not be treated as the identifier's closing quote, and the
+// comma that follows the quoted identifier must still be recognized as a
+// top-level field separator.
+func TestParseDDL_EscapedQuoteInBody(t *testing.T) {
+	d, err := parseDDL(`CREATE TABLE "foo" ("na""me" TEXT, "id" INTEGER)`)
+	require.NoError(t, err)
+	require.Len(t, d.fields, 2)
+	assert.Contains(t, d.fields[0], `"na""me"`, "the escaped quote must remain part of the same field, not split it")
+	assert.Contains(t, d.fields[1], `"id"`)
+}
+
+// TestParseDDL_UnbalancedExtraClosingParen exercises the bracketLevel<0 guard:
+// a stray ')' with no matching '(' inside the DDL body must be rejected as
+// invalid rather than silently accepted.
+func TestParseDDL_UnbalancedExtraClosingParen(t *testing.T) {
+	_, err := parseDDL("CREATE TABLE foo (id INTEGER))")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unbalanced brackets")
+}
+
+// TestParseDDL_UnbalancedUnclosedParen exercises the trailing bracketLevel!=0
+// guard: an open '(' inside the body (e.g. a truncated data-type length spec)
+// that never closes must be rejected.
+func TestParseDDL_UnbalancedUnclosedParen(t *testing.T) {
+	_, err := parseDDL("CREATE TABLE foo (id INTEGER(5)")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unbalanced brackets")
+}
+
+// TestParseDDL_ForeignKeyFieldSkipped exercises the FOREIGN KEY prefix branch:
+// a FOREIGN KEY table constraint field must not be turned into a bogus column.
+func TestParseDDL_ForeignKeyFieldSkipped(t *testing.T) {
+	d, err := parseDDL("CREATE TABLE foo (id INTEGER, FOREIGN KEY (id) REFERENCES bar(id))")
+	require.NoError(t, err)
+	require.Len(t, d.columns, 1)
+	assert.Equal(t, "id", d.columns[0].NameValue.String)
+}
+
+// TestParseDDL_CompositePrimaryKeyMarksColumns exercises the table-level
+// PRIMARY KEY(...) branch: every column named in the composite key must have
+// its PrimaryKeyValue flagged, not just the first.
+func TestParseDDL_CompositePrimaryKeyMarksColumns(t *testing.T) {
+	d, err := parseDDL("CREATE TABLE foo (id INTEGER, name TEXT, PRIMARY KEY (id, name))")
+	require.NoError(t, err)
+	require.Len(t, d.columns, 2)
+	for _, c := range d.columns {
+		assert.True(t, c.PrimaryKeyValue.Bool, "column %q should be marked primary key by the composite PRIMARY KEY clause", c.NameValue.String)
+	}
+}
+
+// TestParseDDL_InlineColumnModifiers exercises the inline NOT NULL / NULL /
+// UNIQUE / DEFAULT / sized-data-type branches of the per-column parser.
+func TestParseDDL_InlineColumnModifiers(t *testing.T) {
+	d, err := parseDDL("CREATE TABLE foo (id INTEGER NOT NULL, name TEXT NULL, email TEXT UNIQUE, age INTEGER DEFAULT 5, code VARCHAR(255))")
+	require.NoError(t, err)
+	require.Len(t, d.columns, 5)
+
+	byName := make(map[string]int)
+	for i, c := range d.columns {
+		byName[c.NameValue.String] = i
+	}
+
+	idCol := d.columns[byName["id"]]
+	assert.False(t, idCol.NullableValue.Bool, "id has NOT NULL")
+
+	nameCol := d.columns[byName["name"]]
+	assert.True(t, nameCol.NullableValue.Bool, "name has explicit NULL")
+
+	emailCol := d.columns[byName["email"]]
+	assert.True(t, emailCol.UniqueValue.Bool, "email has inline UNIQUE")
+
+	ageCol := d.columns[byName["age"]]
+	require.True(t, ageCol.DefaultValueValue.Valid)
+	assert.Equal(t, "5", ageCol.DefaultValueValue.String)
+
+	codeCol := d.columns[byName["code"]]
+	assert.Equal(t, "VARCHAR", codeCol.DataTypeValue.String)
+	require.True(t, codeCol.LengthValue.Valid)
+	assert.Equal(t, int64(255), codeCol.LengthValue.Int64)
+}
+
+// TestParseDDL_IndexStatementIgnored exercises the indexRegexp branch: a
+// CREATE INDEX statement passed alongside a CREATE TABLE statement must be
+// recognized and skipped, not reported as an invalid-DDL error.
+func TestParseDDL_IndexStatementIgnored(t *testing.T) {
+	d, err := parseDDL(
+		"CREATE TABLE foo (id INTEGER)",
+		"CREATE UNIQUE INDEX idx_foo_id ON foo (id)",
+	)
+	require.NoError(t, err)
+	require.Len(t, d.columns, 1)
+}
+
+// TestParseDDL_TotallyInvalidStatement exercises the final else branch: a
+// string that matches neither the CREATE TABLE nor CREATE INDEX pattern must
+// be rejected as invalid DDL.
+func TestParseDDL_TotallyInvalidStatement(t *testing.T) {
+	_, err := parseDDL("this is not sql")
+	require.Error(t, err)
+	assert.Equal(t, "invalid DDL", err.Error())
+}
+
+// TestDDLCompile_NoFields exercises the empty-fields branch of compile(): with
+// no fields at all, compile must fall back to head+suffix rather than
+// emitting an empty "()" field list.
+func TestDDLCompile_NoFields(t *testing.T) {
+	d := &ddl{head: "CREATE TABLE `foo`", suffix: " WITHOUT ROWID"}
+	assert.Equal(t, "CREATE TABLE `foo` WITHOUT ROWID", d.compile())
+}
+
+// TestDDLRenameTable_SourceNotFound exercises renameTable's error branch: if
+// the source table name can't be located in the DDL head, renaming must fail
+// loudly instead of silently leaving the head unchanged.
+func TestDDLRenameTable_SourceNotFound(t *testing.T) {
+	d := &ddl{head: "CREATE TABLE `foo`"}
+	err := d.renameTable("bar", "does_not_exist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to look up tablename")
+}
+
+// TestDDLAddConstraint_ReplacesExisting exercises addConstraint's match branch:
+// calling addConstraint twice with the same constraint name must replace the
+// existing field in place rather than appending a duplicate.
+func TestDDLAddConstraint_ReplacesExisting(t *testing.T) {
+	d := &ddl{fields: []string{"id INTEGER"}}
+
+	d.addConstraint("fk_1", "CONSTRAINT `fk_1` FOREIGN KEY (a) REFERENCES b(id)")
+	require.Len(t, d.fields, 2, "first call with a new name should append")
+
+	d.addConstraint("fk_1", "CONSTRAINT `fk_1` FOREIGN KEY (a) REFERENCES c(id)")
+	require.Len(t, d.fields, 2, "second call with the same name should replace, not append")
+	assert.Equal(t, "CONSTRAINT `fk_1` FOREIGN KEY (a) REFERENCES c(id)", d.fields[1])
+}
+
+// TestDDLRemoveConstraint_NotFound exercises removeConstraint's not-found
+// return path.
+func TestDDLRemoveConstraint_NotFound(t *testing.T) {
+	d := &ddl{fields: []string{"id INTEGER"}}
+	assert.False(t, d.removeConstraint("does_not_exist"))
+}
+
+// TestDDLGetColumns_SkipsTopLevelUnique exercises getColumns' uniqueRegexp
+// branch: a standalone table-level "UNIQUE (...)" field must not be reported
+// as a column.
+func TestDDLGetColumns_SkipsTopLevelUnique(t *testing.T) {
+	d := &ddl{fields: []string{"id INTEGER", "name TEXT", "UNIQUE (id, name)"}}
+	cols := d.getColumns()
+	assert.Equal(t, []string{"`id`", "`name`"}, cols)
+}

--- a/internal/storage/sqlitedialect/migrator_test.go
+++ b/internal/storage/sqlitedialect/migrator_test.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
 )
 
 type migratorTestModel struct {
@@ -201,6 +204,255 @@ func TestMigrator_DropColumn_NilSchemaReturnsErrorNotPanic(t *testing.T) {
 		require.Error(t, err, "DropColumn with a schema-less value must return an error, not panic")
 		assert.Contains(t, err.Error(), "schema")
 	})
+}
+
+// TestMigrator_RunWithoutForeignKey_TogglesPragma exercises the enabled==1
+// branch: when foreign_keys is already ON, RunWithoutForeignKey must turn it
+// OFF for the duration of fc and restore it afterward.
+func TestMigrator_RunWithoutForeignKey_TogglesPragma(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.Exec("PRAGMA foreign_keys = ON").Error)
+
+	var enabledDuring int
+	m, ok := db.Migrator().(Migrator)
+	require.True(t, ok)
+
+	called := false
+	err := m.RunWithoutForeignKey(func() error {
+		called = true
+		require.NoError(t, db.Raw("PRAGMA foreign_keys").Row().Scan(&enabledDuring))
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, 0, enabledDuring, "foreign_keys should be OFF while fc runs")
+
+	var enabledAfter int
+	require.NoError(t, db.Raw("PRAGMA foreign_keys").Row().Scan(&enabledAfter))
+	assert.Equal(t, 1, enabledAfter, "foreign_keys should be restored to ON afterward")
+}
+
+// TestMigrator_AlterColumn_UnknownFieldErrors exercises AlterColumn's final
+// "field not found in schema" branch.
+func TestMigrator_AlterColumn_UnknownFieldErrors(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	err := m.AlterColumn(&migratorTestModel{}, "NoSuchField")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to alter field")
+}
+
+// TestMigrator_AlterColumn_RebuildsInlineUniqueConstraint exercises
+// AlterColumn's "old-style inline UNIQUE column" branch: a table created by
+// hand with `... UNIQUE` inline (rather than a `CONSTRAINT ... UNIQUE`
+// clause, which is what this dialector's own CreateConstraint/AutoMigrate
+// generates) must still have its unique constraint carried forward as a
+// proper constraint when the column is altered, given a schema that declares
+// the field unique.
+func TestMigrator_AlterColumn_RebuildsInlineUniqueConstraint(t *testing.T) {
+	db := openTestDB(t)
+	type inlineUniqueModel struct {
+		ID   uint   `gorm:"primaryKey"`
+		Code string `gorm:"unique"`
+	}
+	require.NoError(t, db.Exec(
+		"CREATE TABLE inline_unique_models (id integer primary key autoincrement, code varchar(10) UNIQUE)",
+	).Error)
+	m := db.Migrator()
+
+	require.NoError(t, m.AlterColumn(&inlineUniqueModel{}, "Code"))
+
+	require.NoError(t, db.Create(&inlineUniqueModel{Code: "a"}).Error)
+	err := db.Create(&inlineUniqueModel{Code: "a"}).Error
+	require.Error(t, err, "the unique constraint must have survived AlterColumn's table rebuild")
+}
+
+// TestMigrator_ColumnTypes_NonexistentTableErrors exercises ColumnTypes' Rows()
+// error branch: querying column types for a model whose table was never
+// created must return an error, not a panic or an empty success.
+func TestMigrator_ColumnTypes_NonexistentTableErrors(t *testing.T) {
+	db := openTestDB(t)
+	type neverMigratedModel struct {
+		ID   uint `gorm:"primaryKey"`
+		Name string
+	}
+	m := db.Migrator()
+
+	_, err := m.ColumnTypes(&neverMigratedModel{})
+	require.Error(t, err)
+}
+
+// TestMigrator_ColumnTypes_CorruptDDLErrors exercises ColumnTypes'
+// parseDDL-error branch by corrupting the table's stored CREATE TABLE SQL
+// directly in sqlite_master (SQLite's writable_schema escape hatch), so
+// parseDDL is handed a string it cannot make sense of.
+func TestMigrator_ColumnTypes_CorruptDDLErrors(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	require.NoError(t, db.Exec("PRAGMA writable_schema = ON").Error)
+	require.NoError(t, db.Exec(
+		"UPDATE sqlite_master SET sql = 'not valid ddl' WHERE type = 'table' AND name = ?",
+		"migrator_test_models",
+	).Error)
+	t.Cleanup(func() {
+		_ = db.Exec("PRAGMA writable_schema = OFF").Error
+	})
+
+	m := db.Migrator()
+	_, err := m.ColumnTypes(&migratorTestModel{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid DDL")
+}
+
+// TestMigrator_CreateConstraint_UnknownNameIsNoOp exercises both
+// CreateConstraint's "constraint == nil" branch and recreateTable's
+// "createDDL == nil" early-return branch: asking to create a constraint by a
+// name GORM's schema doesn't recognize must be a harmless no-op, not an
+// error and not a table rebuild.
+func TestMigrator_CreateConstraint_UnknownNameIsNoOp(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	require.NoError(t, m.CreateConstraint(&migratorTestModel{}, "totally_unknown_constraint_name"))
+	assert.False(t, m.HasConstraint(&migratorTestModel{}, "totally_unknown_constraint_name"))
+}
+
+// TestMigrator_BuildIndexOptions_ExpressionCollateSort exercises all three
+// optional-suffix branches of BuildIndexOptions directly against manually
+// built IndexOptions, independent of whatever GORM's own tag parser produces
+// for this SQLite dialect.
+func TestMigrator_BuildIndexOptions_ExpressionCollateSort(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m, ok := db.Migrator().(Migrator)
+	require.True(t, ok)
+
+	var results []migratorTestModel
+	stmt := db.Session(&gorm.Session{DryRun: true}).Find(&results).Statement
+
+	opts := []schema.IndexOption{
+		{Field: &schema.Field{DBName: "name"}, Expression: "LOWER(name)"},
+		{Field: &schema.Field{DBName: "email"}, Collate: "NOCASE"},
+		{Field: &schema.Field{DBName: "score"}, Sort: "desc"},
+	}
+	built := m.BuildIndexOptions(opts, stmt)
+	require.Len(t, built, 3)
+
+	assert.Equal(t, clause.Expr{SQL: "LOWER(name)"}, built[0], "Expression must override the quoted column name")
+	assert.Equal(t, clause.Expr{SQL: "`email` COLLATE NOCASE"}, built[1])
+	assert.Equal(t, clause.Expr{SQL: "`score` desc"}, built[2])
+}
+
+// TestMigrator_CreateIndex_WithWhereClause exercises CreateIndex/
+// BuildIndexOptions' idx.Where branch via a real partial index, which SQLite
+// supports natively.
+func TestMigrator_CreateIndex_WithWhereClause(t *testing.T) {
+	db := openTestDB(t)
+	type whereIndexModel struct {
+		ID    uint `gorm:"primaryKey"`
+		Score int  `gorm:"index:idx_where_score,where:score > 0"`
+	}
+	require.NoError(t, db.AutoMigrate(&whereIndexModel{}))
+	m := db.Migrator()
+
+	assert.True(t, m.HasIndex(&whereIndexModel{}, "idx_where_score"))
+
+	var indexSQL string
+	require.NoError(t, db.Raw(
+		"SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?", "idx_where_score",
+	).Row().Scan(&indexSQL))
+	assert.Contains(t, indexSQL, "WHERE score > 0")
+}
+
+// TestMigrator_CreateIndex_TypeOptionIsUnsupportedBySQLite exercises
+// CreateIndex/BuildIndexOptions' idx.Type branch. SQLite has no "USING type"
+// index syntax, so building an index with a Type tag must surface as an
+// error from the underlying Exec, not succeed silently or panic.
+func TestMigrator_CreateIndex_TypeOptionIsUnsupportedBySQLite(t *testing.T) {
+	db := openTestDB(t)
+	type typedIndexModel struct {
+		ID    uint `gorm:"primaryKey"`
+		Score int  `gorm:"index:idx_typed_score,type:btree"`
+	}
+	require.NoError(t, db.Exec(
+		"CREATE TABLE typed_index_models (id integer primary key autoincrement, score integer)",
+	).Error)
+	m := db.Migrator()
+
+	err := m.CreateIndex(&typedIndexModel{}, "idx_typed_score")
+	require.Error(t, err, "SQLite doesn't support CREATE INDEX ... USING <type>")
+}
+
+// TestMigrator_CreateIndex_UnknownNameErrors exercises CreateIndex's final
+// "failed to create index" fallback branch.
+func TestMigrator_CreateIndex_UnknownNameErrors(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	err := m.CreateIndex(&migratorTestModel{}, "no_such_index")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create index")
+}
+
+// TestMigrator_RenameIndex_UnknownNameErrors exercises RenameIndex's
+// "failed to find index" fallback branch.
+func TestMigrator_RenameIndex_UnknownNameErrors(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+
+	err := m.RenameIndex(&migratorTestModel{}, "no_such_index", "new_name")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to find index")
+}
+
+// TestMigrator_GetIndexes_SkipsUniqueConstraintBackedIndex exercises
+// GetIndexes' "origin == u" skip branch: the automatic index SQLite creates
+// to back a UNIQUE constraint must not be reported by GetIndexes.
+func TestMigrator_GetIndexes_SkipsUniqueConstraintBackedIndex(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&constraintTestModel{}))
+	m := db.Migrator()
+
+	indexes, err := m.GetIndexes(&constraintTestModel{})
+	require.NoError(t, err)
+	for _, idx := range indexes {
+		assert.NotContains(t, strings.ToLower(idx.Name()), "sqlite_autoindex", "the UNIQUE-constraint-backed autoindex must be filtered out")
+	}
+}
+
+// TestMigrator_DropColumn_NeverMigratedTableErrors exercises recreateTable's
+// parseDDL-error branch reached through getRawDDL returning an empty string
+// for a table that was never created.
+func TestMigrator_DropColumn_NeverMigratedTableErrors(t *testing.T) {
+	db := openTestDB(t)
+	type neverMigratedModel struct {
+		ID   uint `gorm:"primaryKey"`
+		Name string
+	}
+	m := db.Migrator()
+
+	err := m.DropColumn(&neverMigratedModel{}, "Name")
+	require.Error(t, err)
+}
+
+// TestMigrator_DropColumn_SkipsIndexReferencingDroppedColumn exercises
+// recreateTable's aux-DDL-replay "no such column" skip branch: an index that
+// only covers the column being dropped can't be recreated on the rebuilt
+// table, and that must be silently tolerated rather than aborting the drop.
+func TestMigrator_DropColumn_SkipsIndexReferencingDroppedColumn(t *testing.T) {
+	db := openTestDB(t)
+	require.NoError(t, db.AutoMigrate(&migratorTestModel{}))
+	m := db.Migrator()
+	require.True(t, m.HasIndex(&migratorTestModel{}, "idx_migrator_name"))
+
+	require.NoError(t, m.DropColumn(&migratorTestModel{}, "Name"))
+	assert.False(t, m.HasIndex(&migratorTestModel{}, "idx_migrator_name"), "an index over the dropped column can't survive and must be silently skipped")
+	assert.False(t, m.HasColumn(&migratorTestModel{}, "Name"))
 }
 
 func TestMigrator_ColumnTypesAndTablesAndCurrentDatabase(t *testing.T) {

--- a/internal/storage/sqlitedialect/sqlite_test.go
+++ b/internal/storage/sqlitedialect/sqlite_test.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"database/sql"
 	"errors"
 	"strings"
 	"testing"
@@ -174,6 +175,50 @@ func TestTranslate_UnrelatedError(t *testing.T) {
 	assert.Equal(t, original, d.Translate(original))
 }
 
+// marshalFailError has an exported field of a type (func) that json.Marshal
+// cannot encode, forcing Translate's json.Marshal call to fail.
+type marshalFailError struct {
+	Fn func()
+}
+
+func (*marshalFailError) Error() string { return "marshal-fail" }
+
+func TestTranslate_MarshalFailureReturnsOriginalError(t *testing.T) {
+	d := Dialector{}
+	original := &marshalFailError{Fn: func() {}}
+	assert.Same(t, original, d.Translate(original), "when the error can't even be marshaled to JSON, Translate must return it unchanged")
+}
+
+// badCodeError has an exported "Code" field whose JSON representation
+// (a string) doesn't fit ErrMessage.Code (an int), forcing Translate's
+// json.Unmarshal call to fail.
+type badCodeError struct {
+	Code string
+}
+
+func (badCodeError) Error() string { return "bad-code" }
+
+func TestTranslate_UnmarshalFailureReturnsOriginalError(t *testing.T) {
+	d := Dialector{}
+	original := badCodeError{Code: "not-a-number"}
+	assert.Equal(t, original, d.Translate(original), "when the marshaled JSON can't be unmarshaled into ErrMessage, Translate must return the original error unchanged")
+}
+
+// extCodeError has an exported ExtendedCode field, matching ErrMessage's
+// json shape, so Translate can pattern-match it against errCodes purely via
+// the JSON fallback path (no Code() method).
+type extCodeError struct {
+	ExtendedCode int
+}
+
+func (extCodeError) Error() string { return "ext-code" }
+
+func TestTranslate_ExtendedCodeMatchViaJSONFallback(t *testing.T) {
+	d := Dialector{}
+	original := extCodeError{ExtendedCode: 1555}
+	assert.ErrorIs(t, d.Translate(original), gorm.ErrDuplicatedKey)
+}
+
 func TestMigrator_DropTable(t *testing.T) {
 	db := openTestDB(t)
 	type dropTableModel struct {
@@ -185,6 +230,88 @@ func TestMigrator_DropTable(t *testing.T) {
 	require.True(t, m.HasTable(&dropTableModel{}))
 	require.NoError(t, m.DropTable(&dropTableModel{}))
 	assert.False(t, m.HasTable(&dropTableModel{}))
+}
+
+// TestInitialize_UsesProvidedConnPool exercises Initialize's Conn-provided
+// branch: when Config.Conn is set, Initialize must use it directly instead of
+// opening a new connection via DriverName/DSN.
+func TestInitialize_UsesProvidedConnPool(t *testing.T) {
+	sqlDB, err := sql.Open(DriverName, ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	d := New(Config{Conn: sqlDB})
+	db, err := gorm.Open(d, &gorm.Config{})
+	require.NoError(t, err)
+
+	var version string
+	require.NoError(t, db.Raw("select sqlite_version()").Row().Scan(&version))
+	assert.NotEmpty(t, version)
+}
+
+// TestInitialize_SQLOpenErrorPropagates exercises Initialize's sql.Open error
+// branch: an unregistered driver name must surface as an error from
+// gorm.Open, not panic or silently succeed.
+func TestInitialize_SQLOpenErrorPropagates(t *testing.T) {
+	d := New(Config{DriverName: "not-a-real-driver", DSN: ":memory:"})
+	_, err := gorm.Open(d, &gorm.Config{})
+	require.Error(t, err)
+}
+
+// TestInitialize_VersionQueryErrorPropagates exercises Initialize's
+// version-query error branch: a closed connection pool must surface the
+// query error from gorm.Open rather than panicking.
+func TestInitialize_VersionQueryErrorPropagates(t *testing.T) {
+	sqlDB, err := sql.Open(DriverName, ":memory:")
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	d := New(Config{Conn: sqlDB})
+	_, err = gorm.Open(d, &gorm.Config{})
+	require.Error(t, err)
+}
+
+// TestClauseBuilders_InsertModifierAndTableOverride exercises the two
+// conditional branches of the INSERT clause builder: a non-empty Modifier
+// (e.g. "OR IGNORE") and an explicit Table override.
+func TestClauseBuilders_InsertModifierAndTableOverride(t *testing.T) {
+	db := openTestDB(t)
+	type insertOptsModel struct {
+		ID   uint `gorm:"primaryKey"`
+		Name string
+	}
+	require.NoError(t, db.AutoMigrate(&insertOptsModel{}))
+
+	modifierSQL := db.Session(&gorm.Session{DryRun: true}).
+		Clauses(clause.Insert{Modifier: "OR IGNORE"}).
+		Create(&insertOptsModel{Name: "x"}).Statement.SQL.String()
+	assert.Contains(t, modifierSQL, "INSERT OR IGNORE INTO")
+
+	tableOverrideSQL := db.Session(&gorm.Session{DryRun: true}).
+		Clauses(clause.Insert{Table: clause.Table{Name: "custom_table"}}).
+		Create(&insertOptsModel{Name: "x"}).Statement.SQL.String()
+	assert.Contains(t, tableOverrideSQL, "INSERT INTO `custom_table`")
+}
+
+func TestQuoteTo_BacktickEdgeCases(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"two consecutive backticks", "a``b", "`a``b`"},
+		{"leading backtick", "`a", "`a`"},
+		{"trailing backtick", "ab`", "`ab```"},
+	}
+
+	d := Dialector{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var w strings.Builder
+			d.QuoteTo(&w, tc.input)
+			assert.Equal(t, tc.want, w.String())
+		})
+	}
 }
 
 func TestCompareVersion(t *testing.T) {

--- a/internal/testhelper/testhelper_extra_test.go
+++ b/internal/testhelper/testhelper_extra_test.go
@@ -1,0 +1,73 @@
+// testhelper_extra_test.go — covers the remaining rbac_test_helper.go paths
+// left untested by testhelper_s36_test.go: HasPermission's true branch, and
+// the Cleanup/ExecuteRawSQL/QueryRawSQL helpers.
+package testhelper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHasPermission_TruePath verifies HasPermission returns true when the
+// user actually holds the permission via an assigned role, not just the
+// false/not-found branch already exercised elsewhere.
+func TestHasPermission_TruePath(t *testing.T) {
+	h := NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+
+	user := h.CreateTestUser(t, "bob", 101)
+	// role ID 4 ("viewer") is seeded with permSecretsRead and permUsersRead.
+	h.AssignUserRole(t, user.ID, 4, nil)
+
+	assert.True(t, h.HasPermission(t, user.ID, permSecretsRead),
+		"user assigned the viewer role should have secrets.read")
+	assert.False(t, h.HasPermission(t, user.ID, permSecretsDelete),
+		"viewer role does not grant secrets.delete")
+}
+
+// TestExecuteRawSQL_QueryRawSQL verifies ExecuteRawSQL actually mutates the
+// database and QueryRawSQL reads back real data (not just that no error is
+// returned).
+func TestExecuteRawSQL_QueryRawSQL(t *testing.T) {
+	h := NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+
+	h.ExecuteRawSQL(t, "INSERT INTO roles (id, name, description) VALUES (?, ?, ?)",
+		999, "raw_sql_role", "created via ExecuteRawSQL")
+
+	rows := h.QueryRawSQL(t, "SELECT name, description FROM roles WHERE id = ?", 999)
+	defer rows.Close() //nolint:errcheck
+
+	found := false
+	for rows.Next() {
+		var name, description string
+		require.NoError(t, rows.Scan(&name, &description))
+		assert.Equal(t, "raw_sql_role", name)
+		assert.Equal(t, "created via ExecuteRawSQL", description)
+		found = true
+	}
+	require.NoError(t, rows.Err())
+	assert.True(t, found, "row inserted by ExecuteRawSQL should be visible to QueryRawSQL")
+}
+
+// TestCleanup verifies Cleanup actually closes the underlying *sql.DB
+// (subsequent use of the connection fails), rather than being a no-op.
+func TestCleanup(t *testing.T) {
+	h := NewRBACTestHelper(t)
+
+	h.Cleanup()
+
+	err := h.SqlDB.Ping()
+	assert.Error(t, err, "SqlDB should be closed after Cleanup")
+}
+
+// TestCleanup_NilSqlDB verifies Cleanup tolerates a helper whose SqlDB was
+// never set (the nil-guard branch), rather than panicking.
+func TestCleanup_NilSqlDB(t *testing.T) {
+	h := &RBACTestHelper{}
+	assert.NotPanics(t, func() {
+		h.Cleanup()
+	})
+}

--- a/internal/trust/coverage_test.go
+++ b/internal/trust/coverage_test.go
@@ -77,6 +77,31 @@ func TestDefaultRegistry_MalformedKeySpec(t *testing.T) {
 	require.Error(t, err, "a malformed embedded key spec must surface as an error")
 }
 
+// TestDefaultRegistry_CrossPurposeKeyReuseErrors exercises the r.Add error path inside
+// DefaultRegistry's parse loop: if the update and license specs embed the SAME public key
+// (under different key-ids), the second Add call fails with ErrKeyReusedAcrossPurposes and
+// DefaultRegistry must propagate that error rather than silently building a registry that
+// violates the independent-blast-radii guarantee (see the Purpose doc comment).
+func TestDefaultRegistry_CrossPurposeKeyReuseErrors(t *testing.T) {
+	pub, _, err := GenerateKey()
+	require.NoError(t, err)
+	encoded := base64.StdEncoding.EncodeToString(pub)
+
+	origUpdate := updateKeysB64
+	origLicense := licenseKeysB64
+	updateKeysB64 = "upd-shared=" + encoded
+	licenseKeysB64 = "lic-shared=" + encoded
+	t.Cleanup(func() {
+		updateKeysB64 = origUpdate
+		licenseKeysB64 = origLicense
+	})
+
+	r, err := DefaultRegistry()
+	require.Error(t, err, "embedding the same public key for both purposes must be refused")
+	assert.ErrorIs(t, err, ErrKeyReusedAcrossPurposes)
+	assert.Nil(t, r, "DefaultRegistry must not return a partially-built registry on error")
+}
+
 // TestDefaultRegistry_MultipleKeys verifies that a comma-separated spec with
 // several keys is parsed and all keys are usable.
 func TestDefaultRegistry_MultipleKeys(t *testing.T) {

--- a/server/grpc/interceptors/metrics_test.go
+++ b/server/grpc/interceptors/metrics_test.go
@@ -55,6 +55,51 @@ func TestMetricsInterceptor_CountsSuccessAndError(t *testing.T) {
 	}
 }
 
+// TestMetricsInterceptor_UsesSharedGlobalSingleton verifies that the production
+// entrypoints — MetricsInterceptor() and GetGRPCMetrics() — are actually wired to
+// the same package-level grpcMetrics singleton, not merely that metricsInterceptorFor
+// and loadMetrics work in isolation (already covered by the test above and by
+// TestGRPCPrometheusCollector). Uses a before/after delta on the shared global
+// rather than resetting it (the global is process-wide and other tests never
+// write to it directly, only through this same pair of functions), so the
+// assertion holds regardless of test execution order.
+func TestMetricsInterceptor_UsesSharedGlobalSingleton(t *testing.T) {
+	before := GetGRPCMetrics()
+
+	interceptor := MetricsInterceptor()
+	info := &grpc.UnaryServerInfo{FullMethod: "/keyorix.v1.SecretService/GetSecret"}
+
+	_, err := interceptor(context.Background(), nil, info,
+		func(_ context.Context, _ interface{}) (interface{}, error) {
+			return "ok", nil
+		})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	_, err = interceptor(context.Background(), nil, info,
+		func(_ context.Context, _ interface{}) (interface{}, error) {
+			return nil, errors.New("fail")
+		})
+	if err == nil {
+		t.Fatal("expected an error from the interceptor, got nil")
+	}
+
+	after := GetGRPCMetrics()
+
+	if after.TotalRequests != before.TotalRequests+2 {
+		t.Errorf("TotalRequests delta = %d, want 2 (MetricsInterceptor must record into the same singleton GetGRPCMetrics reads)", after.TotalRequests-before.TotalRequests)
+	}
+	if after.SuccessRequests != before.SuccessRequests+1 {
+		t.Errorf("SuccessRequests delta = %d, want 1", after.SuccessRequests-before.SuccessRequests)
+	}
+	if after.ErrorRequests != before.ErrorRequests+1 {
+		t.Errorf("ErrorRequests delta = %d, want 1", after.ErrorRequests-before.ErrorRequests)
+	}
+	if after.TotalDuration <= before.TotalDuration {
+		t.Errorf("TotalDuration should have increased, before=%d after=%d", before.TotalDuration, after.TotalDuration)
+	}
+}
+
 // TestMetrics_AverageResponseTime verifies the helper returns 0 when no requests have
 // been recorded.
 func TestMetrics_AverageResponseTime(t *testing.T) {

--- a/server/grpc/interceptors/rate_limit_test.go
+++ b/server/grpc/interceptors/rate_limit_test.go
@@ -199,6 +199,27 @@ func TestGRPCRateLimiter_SweepsEveryNRequests(t *testing.T) {
 	assert.False(t, presentAfterSweep, "the sweep must run on exactly the Nth request and evict the stale entry")
 }
 
+// grpcIPFailureLimiter.sweepLocked (the per-IP token-auth-failure budget's own
+// sweep, distinct from grpcRateLimiter.sweepLocked above) evicts only entries
+// idle past the TTL, not everything and not nothing. allow() always sets
+// lastSeen to time.Now() for the entry it just touched before sweeping, so
+// driving this through the public recordGRPCTokenAuthFailure API can never
+// produce a stale entry for the sweep to evict; constructed directly against
+// the unexported type (white-box), same rationale as
+// TestGRPCRateLimiter_SweepEvictsOnlyIdleEntries.
+func TestGRPCIPFailureLimiter_SweepEvictsOnlyIdleEntries(t *testing.T) {
+	l := &grpcIPFailureLimiter{limiters: make(map[string]*grpcPrincipalBucket)}
+	l.limiters["stale"] = &grpcPrincipalBucket{lastSeen: time.Now().Add(-11 * time.Minute)}
+	l.limiters["fresh"] = &grpcPrincipalBucket{lastSeen: time.Now().Add(-9 * time.Minute)}
+
+	l.sweepLocked()
+
+	_, staleStillPresent := l.limiters["stale"]
+	_, freshStillPresent := l.limiters["fresh"]
+	assert.False(t, staleStillPresent, "an entry idle past the 10-minute TTL must be evicted")
+	assert.True(t, freshStillPresent, "an entry within the 10-minute TTL must survive")
+}
+
 // ---------------------------------------------------------------------------
 // StreamRateLimitInterceptor — G41: the streaming counterpart to
 // GRPCRateLimitInterceptor above. Before G41, StreamAuditLogs (the server's
@@ -258,6 +279,22 @@ func TestStreamRateLimitInterceptor_EnforcesPerPrincipalBudget(t *testing.T) {
 	other := &fakeStream{ctx: grpcCtxForUser(2, 0)}
 	err = interceptor(nil, other, nil, streamRLHandler())
 	assert.NoError(t, err, "a different principal opening a stream must have an independent budget")
+}
+
+// Mirrors TestGRPCRateLimitInterceptor_BurstDefaultsToRequestsPerSecond: Burst
+// defaults to RequestsPerSecond when unset (Burst <= 0) on the stream side too —
+// the token bucket accepts exactly RequestsPerSecond stream opens up front.
+func TestStreamRateLimitInterceptor_BurstDefaultsToRequestsPerSecond(t *testing.T) {
+	interceptor := StreamRateLimitInterceptor(config.RateLimitConfig{Enabled: true, RequestsPerSecond: 3})
+
+	for i := 0; i < 3; i++ {
+		stream := &fakeStream{ctx: grpcCtxForUser(1, 0)}
+		err := interceptor(nil, stream, nil, streamRLHandler())
+		require.NoError(t, err, "stream open %d within the defaulted burst of 3 must pass", i)
+	}
+	blocked := &fakeStream{ctx: grpcCtxForUser(1, 0)}
+	err := interceptor(nil, blocked, nil, streamRLHandler())
+	assert.Error(t, err, "the 4th stream open must be limited once the defaulted burst is exhausted")
 }
 
 // An unauthenticated stream open (no UserContext — StreamAuthInterceptor

--- a/server/grpc/services/coverage_g80_test.go
+++ b/server/grpc/services/coverage_g80_test.go
@@ -1,0 +1,802 @@
+// coverage_g80_test.go — additional coverage for branches the existing
+// per-service test files leave unexercised (G80 coverage sweep): proto
+// conversion field branches, error-classification switches, and a handful of
+// validation/not-found/storage-failure paths that existing tests never hit.
+// Follows the conventions of the file each addition targets (same rig
+// helpers, same testify style, same "not a raw error string" assertions).
+package services
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/dynamic"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
+	pb "github.com/keyorixhq/keyorix/server/proto/pb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"gorm.io/gorm"
+)
+
+// ---------------------------------------------------------------------------
+// break_glass_service.go
+// ---------------------------------------------------------------------------
+
+// breakGlassToProto's RevokedBy/RevokedAt branches: TestBreakGlass_ActivateListRevoke
+// (break_glass_service_test.go) revokes an activation but never re-lists it
+// afterward, so breakGlassToProto never saw a revoked row.
+func TestBreakGlass_RevokedActivation_ProtoCarriesRevocationFields(t *testing.T) {
+	svc := newBreakGlassService(t)
+
+	act, err := svc.ActivateBreakGlass(bgCtx(), &pb.ActivateBreakGlassRequest{
+		ProjectId: 1, Justification: "prod incident #77", Ttl: "1h",
+	})
+	require.NoError(t, err)
+
+	_, err = svc.RevokeBreakGlass(bgCtx(), &pb.RevokeBreakGlassRequest{ProjectId: 1, ActivationId: act.GetId()})
+	require.NoError(t, err)
+
+	list, err := svc.ListBreakGlassActivations(bgCtx(), &pb.ListBreakGlassActivationsRequest{ProjectId: 1})
+	require.NoError(t, err)
+	require.Len(t, list.GetActivations(), 1)
+	revoked := list.GetActivations()[0]
+	assert.Equal(t, "revoked", revoked.GetState())
+	require.NotNil(t, revoked.RevokedBy, "a revoked activation must carry who revoked it")
+	assert.Equal(t, uint32(1), revoked.GetRevokedBy())
+	require.NotNil(t, revoked.RevokedAt, "a revoked activation must carry when it was revoked")
+}
+
+// breakGlassError's classification switch — only the InvalidArgument branch is
+// exercised by the per-RPC tests; directly drive the rest as a table test.
+func TestBreakGlassError_Classification(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want codes.Code
+	}{
+		{"not found", "activation not found", codes.NotFound},
+		{"permission", "permission denied for this project", codes.PermissionDenied},
+		{"denied", "access denied", codes.PermissionDenied},
+		{"already revoked", "activation already revoked", codes.FailedPrecondition},
+		{"not active", "activation is not active", codes.FailedPrecondition},
+		{"expired", "activation expired", codes.FailedPrecondition},
+		{"default", "something went sideways", codes.Internal},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := breakGlassError(errors.New(c.msg))
+			assert.Equal(t, c.want, status.Code(got))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// audit_service.go
+// ---------------------------------------------------------------------------
+
+// auditEventToProto's ProjectID/SecretNodeID/ImpersonatedBy/ActingAs branches:
+// the seeded event in newAuditService only sets UserID, so those four
+// pointer-conditional fields were never exercised.
+func TestAuditService_GetAuditLogs_FullFieldEvent(t *testing.T) {
+	svc, db := newAuditServiceWithDB(t)
+	uid := uint(1)
+	pid := uint(1)
+	sid := uint(42)
+	impersonator := uint(1)
+	target := uint(1)
+	require.NoError(t, db.Create(&models.AuditEvent{
+		EventType: "secret.read", UserID: &uid, ProjectID: &pid, SecretNodeID: &sid,
+		ImpersonatedBy: &impersonator, ActingAs: &target, Impersonation: true,
+		Description: "impersonated read", EventTime: time.Now(), ActorType: "user",
+	}).Error)
+
+	resp, err := svc.GetAuditLogs(auditCtx(), &pb.GetAuditLogsRequest{})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.GetLogs())
+
+	var found *pb.AuditLog
+	for _, l := range resp.GetLogs() {
+		if l.GetDescription() == "impersonated read" {
+			found = l
+			break
+		}
+	}
+	require.NotNil(t, found, "the seeded full-field event must be in the response")
+	require.NotNil(t, found.ProjectId)
+	assert.Equal(t, uint32(1), found.GetProjectId())
+	require.NotNil(t, found.SecretId)
+	assert.Equal(t, uint32(42), found.GetSecretId())
+	assert.True(t, found.GetImpersonation())
+	require.NotNil(t, found.ImpersonatedBy)
+	assert.Equal(t, "alice", found.GetImpersonatedBy())
+	require.NotNil(t, found.ActingAs)
+	assert.Equal(t, "alice", found.GetActingAs())
+}
+
+// newAuditServiceWithDB mirrors newAuditService (audit_service_test.go) but
+// also returns the underlying db, for tests that insert extra fixture rows.
+func newAuditServiceWithDB(t *testing.T) (*AuditGRPCService, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(&models.AuditEvent{}, &models.User{},
+		&models.Role{}, &models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.Project{}, &models.Environment{}))
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "alice@example.com"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "super_admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 0}).Error)
+	return NewAuditService(core.NewKeyorixCore(store.NewLocalStorage(db))), db
+}
+
+// rbacEntryToProto's GroupID/PermissionID/EnvironmentID branches: the only
+// existing GetRBACAuditLogs fixture (audit_service_test.go) is a role.assigned
+// event carrying TargetUserID/RoleID/ProjectID, never Group/Permission/Environment.
+// Insert real role.group_assigned + permission.assigned events directly (the
+// shape core.LogGroupRoleAssigned/LogPermissionAssigned themselves write) via
+// the public core entry points, then read them back through GetRBACAuditLogs.
+func TestAuditService_GetRBACAuditLogs_GroupAndPermissionAndEnvironmentFields(t *testing.T) {
+	svc, db := newAuditServiceWithDB(t)
+	c := core.NewKeyorixCore(store.NewLocalStorage(db))
+	svc = NewAuditService(c)
+
+	// A group-role grant scoped to a project+environment carries GroupID,
+	// RoleID, ProjectID AND EnvironmentID — none of GetRBACAuditLogs_ReturnsRoleChanges'
+	// user-role fixture exercises GroupID/EnvironmentID.
+	c.LogGroupRoleAssigned(context.Background(), 1, 9, 2, core.Scope{ProjectID: 3, EnvironmentID: 7})
+	// A permission grant carries PermissionID (never set by a role-assignment event).
+	c.LogPermissionAssigned(context.Background(), 1, 2, 5, false)
+
+	resp, err := svc.GetRBACAuditLogs(auditCtx(), &pb.GetRBACAuditLogsRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.GetLogs(), 2)
+
+	var groupLog, permLog *pb.RBACAuditLog
+	for _, l := range resp.GetLogs() {
+		switch l.GetAction() {
+		case core.EventRoleGroupAssigned:
+			groupLog = l
+		case core.EventPermissionAdded:
+			permLog = l
+		}
+	}
+	require.NotNil(t, groupLog, "role.group_assigned event must be present")
+	require.NotNil(t, groupLog.GroupId)
+	assert.Equal(t, uint32(9), groupLog.GetGroupId())
+	require.NotNil(t, groupLog.EnvironmentId)
+	assert.Equal(t, uint32(7), groupLog.GetEnvironmentId())
+	require.NotNil(t, groupLog.ProjectId)
+	assert.Equal(t, uint32(3), groupLog.GetProjectId())
+
+	require.NotNil(t, permLog, "permission.assigned event must be present")
+	require.NotNil(t, permLog.PermissionId)
+	assert.Equal(t, uint32(5), permLog.GetPermissionId())
+}
+
+// reauthorizeAuditStream's machine-active-allowed success path (`return nil`
+// after the state check): the existing machine-branch tests
+// (coverage_s18_test.go/coverage_s21_test.go) either leave ActorType unset
+// (so ActorKind() silently defaults to "user", never entering the machine
+// branch at all) or exercise the machine-not-found error path — neither
+// reaches the success return. Build a machine actor with a REAL grant on a
+// dedicated role (not the admin-bypass "super_admin") so RoleSetHasPermission
+// resolves deterministically, matching AuthorizePrincipal's machine path (no
+// admin bypass — see authz.go's AuthorizePrincipal doc comment).
+func TestReauthorizeAuditStream_MachineActiveAndAuthorized_ReturnsNil(t *testing.T) {
+	svc, db := newAuditServiceWithDB(t)
+
+	require.NoError(t, db.AutoMigrate(&models.MachineIdentity{}, &models.MachineIdentityRole{}))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "default"}).Error)
+	machine := &models.MachineIdentity{ID: 30, ProjectID: 1, Name: "ci-runner", State: core.MachineActive}
+	require.NoError(t, db.Create(machine).Error)
+
+	// A dedicated non-admin role holding audit.read directly, granted globally —
+	// RoleSetHasPermission resolves this without any admin-bypass ambiguity.
+	require.NoError(t, db.Create(&models.Role{ID: 50, Name: "machine-auditor"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 60, Name: "audit.read", Resource: "audit", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 50, PermissionID: 60}).Error)
+	require.NoError(t, db.Create(&models.MachineIdentityRole{MachineIdentityID: 30, RoleID: 50, ProjectID: 0}).Error)
+
+	actor := &interceptors.UserContext{
+		MachineIdentityID: 30,
+		ActorType:         core.ActorTypeMachine,
+		Permissions:       []string{"audit.read"},
+	}
+	ctx := context.WithValue(context.Background(), interceptors.GetUserContextKey(), actor)
+	err := svc.reauthorizeAuditStream(ctx, actor)
+	assert.NoError(t, err, "an active machine identity holding audit.read directly must be reauthorized")
+}
+
+// ---------------------------------------------------------------------------
+// conversions.go
+// ---------------------------------------------------------------------------
+
+// goSafe's panic-recovery branch: fn panics inside the detached goroutine, and
+// the recover() must swallow it rather than crash the process. done is closed
+// from a defer INSIDE fn (so it fires during the panic unwind, before the
+// wrapping recover runs), proving fn actually ran; reaching the end of the
+// test without the whole binary aborting proves the panic was recovered.
+func TestGoSafe_RecoversPanic(t *testing.T) {
+	done := make(chan struct{})
+	goSafe(func() {
+		defer close(done)
+		panic("boom")
+	})
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goSafe's goroutine never ran fn")
+	}
+	// Give the wrapping recover() a moment to actually execute (it runs after
+	// fn's own deferred close(done)); if it didn't recover, the test binary
+	// itself would have already crashed by the time this line runs.
+	time.Sleep(20 * time.Millisecond)
+}
+
+// intPtrToInt32Ptr's overflow-clamp branch: a value beyond int32's range must
+// clamp to 0 rather than silently wrap or panic.
+func TestIntPtrToInt32Ptr_Overflow(t *testing.T) {
+	big := math.MaxInt32 + 1
+	got := intPtrToInt32Ptr(&big)
+	require.NotNil(t, got)
+	assert.Equal(t, int32(0), *got, "an out-of-range int must clamp to 0, not wrap")
+
+	// The in-range path still round-trips normally (sanity check alongside the
+	// overflow branch, not a separate coverage target).
+	small := 42
+	got = intPtrToInt32Ptr(&small)
+	require.NotNil(t, got)
+	assert.Equal(t, int32(42), *got)
+}
+
+// enforceProjectMFAForProjects' dedup/skip branch (id == 0 or already-seen):
+// no caller previously exercised it with a project-id list containing a zero
+// or a repeat. actor.SessionAuth is left false so enforceProjectMFA itself
+// no-ops for every id regardless — this test is specifically about the
+// wrapper tolerating 0/duplicate ids without erroring, not the MFA policy
+// itself (that's covered per-RPC in secret_service_test.go).
+func TestEnforceProjectMFAForProjects_SkipsZeroAndDuplicateIDs(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+	actor := &interceptors.UserContext{UserID: 1}
+	err := enforceProjectMFAForProjects(context.Background(), h.CoreService, actor, []uint{0, 1, 1, 0, 2})
+	assert.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// secret_service.go
+// ---------------------------------------------------------------------------
+
+// mapSecretACLError's classification switch — only the default/NotFound
+// branches are exercised by secret_acl_service_test.go; directly drive the
+// rest as a pure-function table test.
+func TestMapSecretACLError_Classification(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want codes.Code
+	}{
+		{"not found", "ACL entry not found", codes.NotFound},
+		{"invalid", "invalid permission set", codes.InvalidArgument},
+		{"required", "user_id is required", codes.InvalidArgument},
+		{"not authorized", "user not authorized to manage ACLs", codes.PermissionDenied},
+		{"default", "storage exploded", codes.Internal},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mapSecretACLError(errors.New(c.msg))
+			assert.Equal(t, c.want, status.Code(got))
+		})
+	}
+}
+
+// CreateSecret's ParentId branch: no existing CreateSecret test supplies a
+// parent folder id, so `if req.ParentId != nil && req.GetParentId() != 0`
+// never took its true branch. Create a folder node directly, then a secret
+// naming it as parent, and confirm the secret is actually filed under it.
+func TestSecretService_CreateSecret_WithParentFolder(t *testing.T) {
+	r := newSecretTestRig(t)
+	ctx := authCtx(1, "owner", "secrets.write", "secrets.read")
+
+	folder := &models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: "folder", Type: "folder",
+		IsSecret: false, Status: "active", OwnerID: 1, CreatedBy: "test",
+	}
+	require.NoError(t, r.db.Create(folder).Error)
+
+	sec, err := r.svc.CreateSecret(ctx, &pb.CreateSecretRequest{
+		Name: "child", Value: "v", ProjectId: 1, EnvironmentId: 1, Type: "password",
+		ParentId: ptrU32(folder.ID),
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, sec.GetId())
+
+	var stored models.SecretNode
+	require.NoError(t, r.db.First(&stored, sec.GetId()).Error)
+	require.NotNil(t, stored.ParentID)
+	assert.Equal(t, folder.ID, *stored.ParentID)
+}
+
+// ---------------------------------------------------------------------------
+// system_service.go
+// ---------------------------------------------------------------------------
+
+// dbLatencyMs' error branch: HealthCheck fails once the underlying connection
+// is closed, and the best-effort helper must report 0 rather than propagate.
+func TestSystemService_DbLatencyMs_ErrorReturnsZero(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+	svc := NewSystemService(h.CoreService, &config.Config{Environment: "test"})
+
+	require.NoError(t, h.SqlDB.Close())
+	got := svc.dbLatencyMs(context.Background())
+	assert.Equal(t, float64(0), got, "a failed health check must report 0ms, not propagate the error")
+}
+
+// ---------------------------------------------------------------------------
+// connect_service.go
+// ---------------------------------------------------------------------------
+
+// ListRefGrants / DeleteRefGrant's storage-error branches: both wrap a
+// storage call with no natural (validation) failure mode — drop the
+// underlying table (after authorization, which only touches
+// users/roles/permissions, succeeds) to force a genuine storage error.
+func TestConnectService_RefGrants_StorageErrorIsInternal(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+	h.AssignUserRole(t, 1, 1, nil)
+	svc := NewConnectService(h.CoreService)
+	ctx := authCtx(1, "admin", "roles.write")
+
+	require.NoError(t, h.DB.Exec("DROP TABLE connect_ref_grants").Error)
+
+	_, err := svc.ListRefGrants(ctx, &emptypb.Empty{})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+
+	_, err = svc.DeleteRefGrant(ctx, &pb.DeleteConnectRefGrantRequest{Id: 1})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+// ---------------------------------------------------------------------------
+// group_service.go
+// ---------------------------------------------------------------------------
+
+// GetGroupMembers/RemoveGroupMember's validation-error branches: a zero
+// group/user id fails core's own precondition check before any storage call,
+// classified by groupError's "required" branch — neither RPC's zero-id case
+// was previously exercised (only GetGroup/other RPCs' zero-id paths were).
+func TestGroupService_ZeroID_InvalidArgument(t *testing.T) {
+	svc, _ := newGroupService(t)
+
+	_, err := svc.GetGroupMembers(groupCtx(), &pb.GetGroupMembersRequest{Id: 0})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	_, err = svc.RemoveGroupMember(groupCtx(), &pb.GroupMemberRequest{GroupId: 1, UserId: 0})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// Note: ListGroups'/CreateGroup's storage-error branches (groupError's default
+// Internal case) are not covered here — the "groups" table participates in
+// EVERY global-scope authorization check (group_roles JOINs groups even for a
+// caller with no group membership), so dropping it to force a storage error
+// also breaks authorizeGlobal itself, which folds the resulting query error
+// into PermissionDenied before the RPC's own storage call is ever reached.
+// There is no way to isolate this failure from inside the RPC-level test
+// package without touching internal/core.
+
+// ---------------------------------------------------------------------------
+// machine_identity_service.go
+// ---------------------------------------------------------------------------
+
+// CreateMachineIdentity's mapMachineError branch via a real validation
+// failure core itself raises (an unrecognized identity_type) rather than a
+// storage-layer hack.
+func TestMachineIdentityService_CreateMachineIdentity_InvalidIdentityType(t *testing.T) {
+	svc := newMachineTestRig(t)
+	_, err := svc.CreateMachineIdentity(authCtx(1, "admin"), &pb.CreateMachineIdentityRequest{
+		ProjectId: 1, Name: "bot", IdentityType: "not-a-real-type",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TransitionMachineIdentity/ListMachineTokens's not-found branches: a valid
+// action/ids pair against a machine that does not exist in the project.
+func TestMachineIdentityService_UnknownMachine_NotFound(t *testing.T) {
+	svc := newMachineTestRig(t)
+	ctx := authCtx(1, "admin")
+
+	_, err := svc.TransitionMachineIdentity(ctx, &pb.TransitionMachineIdentityRequest{
+		ProjectId: 1, MachineId: 9999, Action: "suspend",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+
+	_, err = svc.ListMachineTokens(ctx, &pb.ListMachineTokensRequest{ProjectId: 1, MachineId: 9999})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// ListMachineIdentities' storage-error branch: it has no validation failure
+// of its own (it's a bare storage passthrough), so force a genuine error by
+// dropping the table.
+func TestMachineIdentityService_ListMachineIdentities_StorageErrorIsInternal(t *testing.T) {
+	svc, db := newMachineTestRigWithDB(t)
+	require.NoError(t, db.Exec("DROP TABLE machine_identities").Error)
+
+	_, err := svc.ListMachineIdentities(authCtx(1, "admin"), &pb.ListMachineIdentitiesRequest{ProjectId: 1})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+// ---------------------------------------------------------------------------
+// project_service.go
+// ---------------------------------------------------------------------------
+
+// Note: ListProjects' mapProjectError storage-error branch is not covered
+// here for the same structural reason as ListGroups/CreateGroup above — the
+// "projects" table is joined by authorizeGlobal's own role-scoping query
+// (LEFT JOIN projects, evaluated even at global scope), so dropping it breaks
+// authorization before ListProjects' own storage call is ever reached.
+
+// ---------------------------------------------------------------------------
+// role_service.go
+// ---------------------------------------------------------------------------
+
+// CreateRole's mapRoleError branch via a real storage failure: Role.Name
+// carries a `gorm:"unique"` tag (unlike Group.Name's partial index, this one
+// IS created by AutoMigrate), so creating two roles with the same name hits
+// a genuine UNIQUE constraint violation and mapRoleError's "unique" branch.
+func TestRoleService_CreateRole_DuplicateName(t *testing.T) {
+	svc, h := newRoleService(t)
+	perm := somePermission(t, h)
+	ctx := roleAdminCtx()
+
+	req := &pb.CreateRoleRequest{Name: "duplicate-role", Description: "a role", Permissions: []string{perm}}
+	_, err := svc.CreateRole(ctx, req)
+	require.NoError(t, err)
+
+	_, err = svc.CreateRole(ctx, req)
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err))
+}
+
+// ---------------------------------------------------------------------------
+// dynamic_secret_service.go
+// ---------------------------------------------------------------------------
+
+// dynTestRig mirrors newDynamicTestRig (dynamic_secret_service_test.go) but
+// also exposes the db and the fake engine, for tests that need to force a
+// backend-level failure or a storage-table failure.
+type dynTestRig struct {
+	svc  *DynamicSecretGRPCService
+	db   *gorm.DB
+	fake *dynamic.FakeEngine
+}
+
+func newDynTestRigWithFake(t *testing.T) *dynTestRig {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.Project{}, &models.Environment{}, &models.User{}, &models.Role{},
+		&models.Permission{}, &models.RolePermission{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.AuditEvent{},
+		&models.DynamicSecretConfig{}, &models.DynamicSecretLease{},
+	))
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "default"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "dev"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "owner"}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "writer"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 2, Name: "secrets.write", Resource: "secrets", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 2}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "admin"}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 2}).Error)
+
+	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())
+	require.NoError(t, enc.Initialize("test-passphrase"))
+
+	coreService := core.NewKeyorixCore(store.NewLocalStorage(db))
+	coreService.SetAuthEncryptor(enc)
+	coreService.SetDynamicAllowPrivateTargets(true)
+	fake := &dynamic.FakeEngine{NativeExpiry: true}
+	coreService.SetDynamicEngineFactory(func(string) (dynamic.CredentialEngine, error) { return fake, nil })
+	return &dynTestRig{svc: NewDynamicSecretService(coreService), db: db, fake: fake}
+}
+
+// CreateConfig's mapDynamicError branch via a real validation failure core
+// itself raises (default TTL exceeding max TTL).
+func TestDynamicSecretService_CreateConfig_TTLExceedsMax(t *testing.T) {
+	r := newDynTestRigWithFake(t)
+	_, err := r.svc.CreateConfig(authCtx(1, "owner"), &pb.CreateDynamicConfigRequest{
+		Name: "bad-ttl", ProjectId: 1, EnvironmentId: 1, BackendType: "postgres",
+		AdminDsn: "postgres://x", DefaultTtlSeconds: 7200, MaxTtlSeconds: 3600,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// ClassifyConfig's mapDynamicError branch via a real validation failure.
+func TestDynamicSecretService_ClassifyConfig_InvalidClassification(t *testing.T) {
+	r := newDynTestRigWithFake(t)
+	ctx := authCtx(1, "owner")
+	cfg, err := r.svc.CreateConfig(ctx, &pb.CreateDynamicConfigRequest{
+		Name: "cfg", ProjectId: 1, EnvironmentId: 1, BackendType: "postgres", AdminDsn: "postgres://x",
+	})
+	require.NoError(t, err)
+
+	_, err = r.svc.ClassifyConfig(ctx, &pb.ClassifyDynamicConfigRequest{Id: cfg.GetId(), Classification: "top-secret"})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// loadConfigScoped/loadLeaseScoped's found-but-unauthorized branch (#G14
+// uniform NotFound): a caller scoped to a different project than the
+// config/lease must get the same NotFound a nonexistent id would.
+func TestDynamicSecretService_CrossProjectAccess_NotFound(t *testing.T) {
+	r := newDynTestRigWithFake(t)
+	owner := authCtx(1, "owner")
+	cfg, err := r.svc.CreateConfig(owner, &pb.CreateDynamicConfigRequest{
+		Name: "cfg", ProjectId: 1, EnvironmentId: 1, BackendType: "postgres", AdminDsn: "postgres://x",
+	})
+	require.NoError(t, err)
+	lease, err := r.svc.IssueLease(owner, &pb.IssueLeaseRequest{ConfigId: cfg.GetId()})
+	require.NoError(t, err)
+
+	require.NoError(t, r.db.Create(&models.Project{ID: 2, Name: "other"}).Error)
+	require.NoError(t, r.db.Create(&models.User{ID: 3, Username: "scoped"}).Error)
+	require.NoError(t, r.db.Create(&models.UserRole{UserID: 3, RoleID: 1, ProjectID: 2}).Error)
+	scoped := authCtx(3, "scoped", "secrets.read", "secrets.write")
+
+	_, err = r.svc.GetConfig(scoped, &pb.GetDynamicConfigRequest{Id: cfg.GetId()})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err), "GetConfig cross-project")
+
+	_, err = r.svc.RenewLease(scoped, &pb.RenewLeaseRequest{LeaseId: lease.GetLeaseId()})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err), "RenewLease cross-project")
+}
+
+// ListConfigs/ListLeases' mapDynamicError branches: both are bare storage
+// passthroughs (no loadConfigScoped lookup involved), so force a genuine
+// storage error by dropping their tables.
+func TestDynamicSecretService_ListConfigsAndLeases_StorageErrorIsInternal(t *testing.T) {
+	r := newDynTestRigWithFake(t)
+	require.NoError(t, r.db.Exec("DROP TABLE dynamic_secret_configs").Error)
+	_, err := r.svc.ListConfigs(authCtx(1, "owner"), &pb.ListDynamicConfigsRequest{ProjectId: 1})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+func TestDynamicSecretService_ListLeases_StorageErrorIsInternal(t *testing.T) {
+	r := newDynTestRigWithFake(t)
+	owner := authCtx(1, "owner")
+	cfg, err := r.svc.CreateConfig(owner, &pb.CreateDynamicConfigRequest{
+		Name: "cfg", ProjectId: 1, EnvironmentId: 1, BackendType: "postgres", AdminDsn: "postgres://x",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, r.db.Exec("DROP TABLE dynamic_secret_leases").Error)
+	_, err = r.svc.ListLeases(owner, &pb.ListLeasesRequest{ConfigId: cfg.GetId()})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+// IssueLease/RevokeLease/RenewLease's mapDynamicError default branch via a
+// real backend (engine) failure — the FakeEngine's FailIssue/FailRevoke/
+// FailRenew toggles simulate the target database rejecting the operation.
+func TestDynamicSecretService_EngineFailure_IsUnavailable(t *testing.T) {
+	r := newDynTestRigWithFake(t)
+	owner := authCtx(1, "owner")
+	cfg, err := r.svc.CreateConfig(owner, &pb.CreateDynamicConfigRequest{
+		Name: "cfg", ProjectId: 1, EnvironmentId: 1, BackendType: "postgres", AdminDsn: "postgres://x",
+	})
+	require.NoError(t, err)
+
+	r.fake.FailIssue = true
+	_, err = r.svc.IssueLease(owner, &pb.IssueLeaseRequest{ConfigId: cfg.GetId()})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unavailable, status.Code(err), "IssueLease engine failure")
+	r.fake.FailIssue = false
+
+	lease, err := r.svc.IssueLease(owner, &pb.IssueLeaseRequest{ConfigId: cfg.GetId()})
+	require.NoError(t, err)
+
+	r.fake.FailRenew = true
+	_, err = r.svc.RenewLease(owner, &pb.RenewLeaseRequest{LeaseId: lease.GetLeaseId(), TtlSeconds: 7200})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unavailable, status.Code(err), "RenewLease engine failure")
+	r.fake.FailRenew = false
+
+	r.fake.FailRevoke = true
+	_, err = r.svc.RevokeLease(owner, &pb.RevokeLeaseRequest{LeaseId: lease.GetLeaseId()})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unavailable, status.Code(err), "RevokeLease engine failure")
+}
+
+// RevokeAllLeases' mapDynamicError branch: unlike RevokeLease, a per-lease
+// engine failure is swallowed into the failed/revoked counters, not
+// propagated — the only way it errors is a storage failure listing the
+// config's leases, so drop that table specifically (loadConfigScoped itself
+// reads dynamic_secret_configs, a different table, so it still succeeds).
+func TestDynamicSecretService_RevokeAllLeases_StorageErrorIsInternal(t *testing.T) {
+	r := newDynTestRigWithFake(t)
+	owner := authCtx(1, "owner")
+	cfg, err := r.svc.CreateConfig(owner, &pb.CreateDynamicConfigRequest{
+		Name: "cfg", ProjectId: 1, EnvironmentId: 1, BackendType: "postgres", AdminDsn: "postgres://x",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, r.db.Exec("DROP TABLE dynamic_secret_leases").Error)
+	_, err = r.svc.RevokeAllLeases(owner, &pb.RevokeAllLeasesRequest{ConfigId: cfg.GetId()})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+// ---------------------------------------------------------------------------
+// share_service.go
+// ---------------------------------------------------------------------------
+
+// shareProjectIDs' early-return branch (len(shares)==0): every existing
+// ListUserShares test creates a share first. A globally-granted caller with
+// NO shares of their own hits the early return before any share is created.
+func TestShareService_ListUserShares_NoShares(t *testing.T) {
+	r := newShareTestRig(t)
+	resp, err := r.svc.ListUserShares(ownerCtx(), &pb.ListUserSharesRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, resp.GetShares())
+}
+
+// authorizeShareScoped's permission-denied branch (via UpdateSharePermission/
+// RevokeShare specifically — the secret-level equivalent is exercised
+// elsewhere, but never through a share's own scoped-authz gate) and
+// mapShareError's "not authorized" branch (a non-owner who nonetheless holds
+// secrets.write in the share's project scope — passes authorizeShareScoped,
+// but core's own owner-only check inside UpdateSharePermission/RevokeShare
+// then refuses).
+func TestShareService_NonOwnerWithWriteGrant_PermissionDenied(t *testing.T) {
+	r := newShareTestRig(t)
+	rec := r.share(t, "read")
+
+	// User 4: a writer scoped to project 1 (passes authorizeShareScoped's
+	// secrets.write check) but NOT the secret's owner (user 1 is).
+	require.NoError(t, r.db.Create(&models.User{ID: 4, Username: "otherwriter", Email: "ow@example.com"}).Error)
+	require.NoError(t, r.db.Create(&models.UserRole{UserID: 4, RoleID: writerRoleID, ProjectID: 1}).Error)
+	ctx := authCtx(4, "otherwriter", "secrets.write", "secrets.read")
+
+	_, err := r.svc.UpdateSharePermission(ctx, &pb.UpdateSharePermissionRequest{ShareId: rec.GetId(), Permission: "write"})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err), "UpdateSharePermission by a non-owner writer")
+
+	_, err = r.svc.RevokeShare(ctx, &pb.RevokeShareRequest{ShareId: rec.GetId()})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err), "RevokeShare by a non-owner writer")
+}
+
+// authorizeShareScoped's outright-denied branch: a caller with NO grant on
+// the share's secret at all.
+func TestShareService_UpdateAndRevoke_Unauthorized(t *testing.T) {
+	r := newShareTestRig(t)
+	rec := r.share(t, "read")
+	// User 2 (the recipient) holds a project-scoped role with no permissions.
+	ctx := authCtx(2, "recipient", "secrets.write")
+
+	_, err := r.svc.UpdateSharePermission(ctx, &pb.UpdateSharePermissionRequest{ShareId: rec.GetId(), Permission: "write"})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// authorizeShareScoped's second not-found branch: a share row whose secret no
+// longer exists (a data-integrity edge case — the downstream GetSecret call
+// fails even though the share row itself was found).
+func TestShareService_OrphanedShare_NotFound(t *testing.T) {
+	r := newShareTestRig(t)
+	orphan := &models.ShareRecord{SecretID: 99999, OwnerID: 1, RecipientID: 2, Permission: "read"}
+	require.NoError(t, r.db.Create(orphan).Error)
+
+	_, err := r.svc.RevokeShare(ownerCtx(), &pb.RevokeShareRequest{ShareId: intToU32(int(orphan.ID))})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// ---------------------------------------------------------------------------
+// user_service.go
+// ---------------------------------------------------------------------------
+
+// CreateUser's setup-link mode success path: no existing test exercises the
+// `err == nil && prov != nil` branch that populates resp.SetupLink — the
+// existing setup-link tests only cover its rejected combinations.
+func TestUserService_CreateUser_SetupLink_Success(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+	h.CreateTestUser(t, "admin", 1)
+	h.AssignUserRole(t, 1, 1, nil)
+	require.NoError(t, h.DB.AutoMigrate(&models.SetupToken{}, &models.PasswordHistory{}))
+	svc := NewUserService(h.CoreService)
+	svc.core.SetCredentialDelivery(nil, "https://kx.example.com") // nil = out-of-band, link handed back
+
+	resp, err := svc.CreateUser(adminCtx(), &pb.CreateUserRequest{
+		Username: "bob", Email: "bob@example.com", DeliverSetupLink: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.GetUser())
+	require.NotNil(t, resp.SetupLink, "a nil credential-delivery channel must hand the link back to the caller")
+	assert.Contains(t, resp.GetSetupLink(), "https://kx.example.com/auth/setup/")
+}
+
+// ListUsers' Internal-error branch: a bare storage passthrough with no
+// validation failure, so force a genuine error by dropping the table.
+func TestUserService_ListUsers_StorageErrorIsInternal(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+	h.CreateTestUser(t, "admin", 1)
+	h.AssignUserRole(t, 1, 1, nil)
+	svc := NewUserService(h.CoreService)
+
+	require.NoError(t, h.DB.Exec("DROP TABLE users").Error)
+	_, err := svc.ListUsers(authCtx(1, "admin", "users.read"), &pb.ListUsersRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+// projectCounts' success-return branch: every existing user_service test
+// runs on the RBAC helper's DB, which never migrates ProjectMembership, so
+// ProjectMembershipCounts always errors and projectCounts' early-return-nil
+// path is the only one ever taken. Migrate it and seed a real membership row
+// so the storage call actually succeeds and the counts flow into the proto.
+func TestUserService_ListUsers_ProjectCountsPopulated(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	t.Cleanup(h.Cleanup)
+	h.CreateTestUser(t, "admin", 1)
+	h.AssignUserRole(t, 1, 1, nil)
+	require.NoError(t, h.DB.AutoMigrate(&models.ProjectMembership{}))
+	require.NoError(t, h.DB.Create(&models.ProjectMembership{
+		ProjectID: 1, UserID: 1, State: "active", InvitedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+	svc := NewUserService(h.CoreService)
+
+	resp, err := svc.ListUsers(authCtx(1, "admin", "users.read"), &pb.ListUsersRequest{})
+	require.NoError(t, err)
+	var admin *pb.User
+	for _, u := range resp.GetUsers() {
+		if u.GetUsername() == "admin" {
+			admin = u
+		}
+	}
+	require.NotNil(t, admin)
+	assert.Equal(t, uint32(1), admin.GetProjectCount(), "a real active membership must surface as ProjectCount")
+	assert.Equal(t, uint32(1), admin.GetActiveProjectCount())
+}

--- a/server/grpc/services/coverage_g80_test.go
+++ b/server/grpc/services/coverage_g80_test.go
@@ -156,9 +156,9 @@ func newAuditServiceWithDB(t *testing.T) (*AuditGRPCService, *gorm.DB) {
 // shape core.LogGroupRoleAssigned/LogPermissionAssigned themselves write) via
 // the public core entry points, then read them back through GetRBACAuditLogs.
 func TestAuditService_GetRBACAuditLogs_GroupAndPermissionAndEnvironmentFields(t *testing.T) {
-	svc, db := newAuditServiceWithDB(t)
+	_, db := newAuditServiceWithDB(t)
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
-	svc = NewAuditService(c)
+	svc := NewAuditService(c)
 
 	// A group-role grant scoped to a project+environment carries GroupID,
 	// RoleID, ProjectID AND EnvironmentID — none of GetRBACAuditLogs_ReturnsRoleChanges'

--- a/server/http/handlers/contracttest/checks_internal_test.go
+++ b/server/http/handlers/contracttest/checks_internal_test.go
@@ -1,12 +1,15 @@
 package contracttest
 
 import (
+	"errors"
 	"flag"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // setFlag sets a registered testing flag for the duration of the calling
@@ -223,5 +226,301 @@ func TestAssertOpenAPIResponse_Success(t *testing.T) {
 	exercisedMu.Unlock()
 	if !got {
 		t.Error("expected healthCheck to be recorded as exercised after a successful call")
+	}
+}
+
+// TestAssertOpenAPIResponse_SpecErrFailsLoudly covers the branch no other
+// test reaches: loadSpec() having already recorded a failure (specErr set)
+// by the time AssertOpenAPIResponse runs. Every other caller in this package
+// exercises a clean spec, so this manipulates the package-global specErr
+// directly (safe: specOnce has already fired earlier in the suite, so
+// loadSpec()'s own call inside AssertOpenAPIResponse is a no-op and won't
+// clobber our injected value).
+func TestAssertOpenAPIResponse_SpecErrFailsLoudly(t *testing.T) {
+	loadSpec()
+	if specErr != nil {
+		t.Fatal(specErr)
+	}
+	original := specErr
+	boom := errors.New("TEST: synthetic spec load failure")
+	specErr = boom
+	t.Cleanup(func() { specErr = original })
+
+	fakeT := &testing.T{}
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	done := make(chan bool, 1)
+	go func() {
+		defer func() { done <- fakeT.Failed() }()
+		AssertOpenAPIResponse(fakeT, req, w)
+	}()
+	failed := <-done
+
+	if !failed {
+		t.Fatal("expected AssertOpenAPIResponse to fail loudly when specErr is already set")
+	}
+}
+
+// TestOperationHasSchema_NilResponses covers the guard at the top of
+// operationHasSchema: an operation with a nil Responses object (never
+// produced by the real, validated openapi.yaml, since OpenAPI validation
+// requires every operation to declare at least one response) must report no
+// schema rather than panic walking a nil map.
+func TestOperationHasSchema_NilResponses(t *testing.T) {
+	op := &openapi3.Operation{}
+	if operationHasSchema(op) {
+		t.Error("expected operationHasSchema to return false when Responses is nil")
+	}
+}
+
+// TestStaleRegistryEntries_FlagsUnknownKeys covers the "key not in validIDs"
+// branch directly (the real registries are always kept in sync with
+// openapi.yaml, so this branch is otherwise only reachable by staging real
+// registry corruption through CheckPartition).
+func TestStaleRegistryEntries_FlagsUnknownKeys(t *testing.T) {
+	validIDs := map[string]bool{"knownOp": true}
+	got := staleRegistryEntries("exampleRegistry", []string{"knownOp", "staleOp"}, validIDs)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one stale-entry violation, got %v", got)
+	}
+	if !strings.Contains(got[0], "staleOp") || !strings.Contains(got[0], "exampleRegistry") {
+		t.Errorf("expected the violation to name the stale key and registry, got: %q", got[0])
+	}
+}
+
+// syntheticSpecWithMissingOperationID is a valid OpenAPI document (operationId
+// is optional per the spec itself) whose single operation declares none --
+// the real openapi.yaml never has one, since every operation in it already
+// carries an operationId, so this branch needs a synthetic doc to reach.
+const syntheticSpecWithMissingOperationID = `
+openapi: 3.0.3
+info:
+  title: missing operationId test
+  version: "1.0"
+paths:
+  /no-id:
+    get:
+      responses:
+        '200':
+          description: ok
+`
+
+// loadSyntheticSpec parses and validates a literal OpenAPI document, the
+// same way harness_test.go's dualContentSpec does, for tests that need a
+// spec shape the real openapi.yaml can't express.
+func loadSyntheticSpec(t *testing.T, yaml string) *openapi3.T {
+	t.Helper()
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(yaml))
+	if err != nil {
+		t.Fatalf("loading synthetic spec: %v", err)
+	}
+	if err := doc.Validate(loader.Context); err != nil {
+		t.Fatalf("validating synthetic spec: %v", err)
+	}
+	return doc
+}
+
+// swapSpec temporarily replaces the package-global spec (already populated
+// by loadSpec() earlier in the suite, so its sync.Once won't overwrite this)
+// and restores the original on cleanup.
+func swapSpec(t *testing.T, doc *openapi3.T) {
+	t.Helper()
+	loadSpec()
+	if specErr != nil {
+		t.Fatal(specErr)
+	}
+	original := spec
+	spec = doc
+	t.Cleanup(func() { spec = original })
+}
+
+// TestOperationsWithoutID_MissingID covers operationsWithoutID's actual
+// "found a missing operationId" branch, which the real, fully-IDed
+// openapi.yaml never reaches.
+func TestOperationsWithoutID_MissingID(t *testing.T) {
+	swapSpec(t, loadSyntheticSpec(t, syntheticSpecWithMissingOperationID))
+
+	got := operationsWithoutID()
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one missing-operationId entry, got %v", got)
+	}
+	if !strings.Contains(got[0], "/no-id") {
+		t.Errorf("expected the entry to mention /no-id, got %q", got[0])
+	}
+}
+
+// TestCheckPartition_MissingOperationID covers CheckPartition's own loop
+// over operationsWithoutID() (checks.go), which the real spec never
+// populates since every real operation already carries an operationId.
+func TestCheckPartition_MissingOperationID(t *testing.T) {
+	swapSpec(t, loadSyntheticSpec(t, syntheticSpecWithMissingOperationID))
+
+	err := CheckPartition()
+	if err == nil {
+		t.Fatal("expected an error for an operation with no operationId")
+	}
+	if !strings.Contains(err.Error(), "operation has no operationId") {
+		t.Errorf("expected the missing-operationId violation, got: %v", err)
+	}
+}
+
+// TestCheckPartition_PropagatesSpecErr covers the top-of-function specErr
+// short-circuit, unreachable through the real (always-valid) openapi.yaml.
+func TestCheckPartition_PropagatesSpecErr(t *testing.T) {
+	loadSpec()
+	if specErr != nil {
+		t.Fatal(specErr)
+	}
+	boom := errors.New("TEST: synthetic spec load failure")
+	specErr = boom
+	t.Cleanup(func() { specErr = nil })
+
+	if err := CheckPartition(); !errors.Is(err, boom) {
+		t.Errorf("expected CheckPartition to propagate specErr verbatim, got: %v", err)
+	}
+}
+
+// TestCheckPartition_PendingButHasSchema covers the "pending entry whose
+// operation has since gained a schema" violation -- every operation in
+// pendingRegistry today genuinely has no schema, so this stages the
+// contradiction on a real, schema-bearing operation (healthCheck) instead
+// of relying on the registry ever actually drifting into that state.
+func TestCheckPartition_PendingButHasSchema(t *testing.T) {
+	loadSpec()
+	if specErr != nil {
+		t.Fatal(specErr)
+	}
+
+	const opID = "healthCheck" // enforced: has a real 2xx schema
+	if _, already := pendingRegistry[opID]; already {
+		t.Fatalf("test assumption violated: %s is already in pendingRegistry", opID)
+	}
+	pendingRegistry[opID] = "TEST: pending-but-has-schema case"
+	t.Cleanup(func() { delete(pendingRegistry, opID) })
+
+	err := CheckPartition()
+	if err == nil {
+		t.Fatal("expected an error when a pending entry's operation has a schema")
+	}
+	if !strings.Contains(err.Error(), "still in pendingRegistry") {
+		t.Errorf("expected the pending-but-scheduled violation, got: %v", err)
+	}
+}
+
+// TestCheckPartition_OutOfScopeButHasSchemaNotExempt covers the
+// "schema-bearing operation opted out of enforcement without an explicit
+// schemaExemptOperations entry" violation -- the only real outOfScopeRegistry
+// entry with a schema (prometheusMetrics) is already exempt, so this stages
+// the non-exempt case on a real, schema-bearing operation instead.
+func TestCheckPartition_OutOfScopeButHasSchemaNotExempt(t *testing.T) {
+	loadSpec()
+	if specErr != nil {
+		t.Fatal(specErr)
+	}
+
+	const opID = "healthCheck"
+	if _, already := outOfScopeRegistry[opID]; already {
+		t.Fatalf("test assumption violated: %s is already in outOfScopeRegistry", opID)
+	}
+	if schemaExemptOperations[opID] {
+		t.Fatalf("test assumption violated: %s is already schema-exempt", opID)
+	}
+	outOfScopeRegistry[opID] = "TEST: out-of-scope-but-has-schema case"
+	t.Cleanup(func() { delete(outOfScopeRegistry, opID) })
+
+	err := CheckPartition()
+	if err == nil {
+		t.Fatal("expected an error when a non-exempt out-of-scope entry's operation has a schema")
+	}
+	if !strings.Contains(err.Error(), "without being in schemaExemptOperations") {
+		t.Errorf("expected the not-exempt violation, got: %v", err)
+	}
+}
+
+// TestCheckPartition_UnregisteredNoSchema covers the "no schema, and not
+// registered anywhere" violation -- every real schema-less operation is
+// already in pendingRegistry, so this removes one temporarily to stage the
+// gap the check exists to catch.
+func TestCheckPartition_UnregisteredNoSchema(t *testing.T) {
+	loadSpec()
+	if specErr != nil {
+		t.Fatal(specErr)
+	}
+
+	const opID = "acknowledgeAnomalyAlert" // real, currently-pending, no-schema operation
+	if _, isOOS := outOfScopeRegistry[opID]; isOOS {
+		t.Fatalf("test assumption violated: %s is already in outOfScopeRegistry", opID)
+	}
+	original, wasPending := pendingRegistry[opID]
+	if !wasPending {
+		t.Fatalf("test assumption violated: %s is not in pendingRegistry", opID)
+	}
+	delete(pendingRegistry, opID)
+	t.Cleanup(func() { pendingRegistry[opID] = original })
+
+	err := CheckPartition()
+	if err == nil {
+		t.Fatal("expected an error when a schema-less operation is registered nowhere")
+	}
+	if !strings.Contains(err.Error(), "not registered in pendingRegistry") {
+		t.Errorf("expected the unregistered-no-schema violation, got: %v", err)
+	}
+}
+
+// TestCheckAllEnforcedExercised_PropagatesSpecErr covers its own top-of-
+// function specErr short-circuit, unreachable through the real spec.
+func TestCheckAllEnforcedExercised_PropagatesSpecErr(t *testing.T) {
+	setFlag(t, "test.list", "")
+	loadSpec()
+	if specErr != nil {
+		t.Fatal(specErr)
+	}
+	boom := errors.New("TEST: synthetic spec load failure")
+	specErr = boom
+	t.Cleanup(func() { specErr = nil })
+
+	if err := CheckAllEnforcedExercised(); !errors.Is(err, boom) {
+		t.Errorf("expected CheckAllEnforcedExercised to propagate specErr verbatim, got: %v", err)
+	}
+}
+
+// TestCheckAllEnforcedExercised_NoExercisingTestsEntry covers the
+// "enforced operation has no exercisingTests entry at all" branch, distinct
+// from the eligible-but-unexercised branch TestCheckAllEnforcedExercised
+// already covers -- every real enforced operation already has an entry, so
+// this removes one temporarily to stage the gap.
+func TestCheckAllEnforcedExercised_NoExercisingTestsEntry(t *testing.T) {
+	loadSpec()
+	if specErr != nil {
+		t.Fatal(specErr)
+	}
+
+	exercisedMu.Lock()
+	saved := exercised
+	exercised = map[string]bool{}
+	exercisedMu.Unlock()
+	t.Cleanup(func() {
+		exercisedMu.Lock()
+		exercised = saved
+		exercisedMu.Unlock()
+	})
+	setFlag(t, "test.run", "")
+
+	const opID = "healthCheck"
+	original, ok := exercisingTests[opID]
+	if !ok {
+		t.Fatalf("test assumption violated: %s has no exercisingTests entry to remove", opID)
+	}
+	delete(exercisingTests, opID)
+	t.Cleanup(func() { exercisingTests[opID] = original })
+
+	err := CheckAllEnforcedExercised()
+	if err == nil {
+		t.Fatal("expected an error when an enforced operation has no exercisingTests entry")
+	}
+	if !strings.Contains(err.Error(), "no entry in exercisingTests") {
+		t.Errorf("expected the no-entry violation message, got: %v", err)
 	}
 }

--- a/server/http/handlers/contracttest/exercising_tests_exist_internal_test.go
+++ b/server/http/handlers/contracttest/exercising_tests_exist_internal_test.go
@@ -49,6 +49,28 @@ func TestResolveGoBinary_NeitherGorootNorPATH(t *testing.T) {
 	}
 }
 
+// TestRealTestNames_PoisonedToolchainEnv exercises realTestNames() with a
+// GOROOT/PATH combination that would make goBinary() fail if runtime.GOROOT()
+// picked up the override -- it doesn't (empirically, on this toolchain,
+// runtime.GOROOT() reflects the value at process start, not later
+// os.Setenv/t.Setenv calls, so goBinaryFrom(runtime.GOROOT()) still finds the
+// real "go" via its unchanged, compiled-in GOROOT). The `go test -list`
+// *subprocess* realTestNames() then shells out to inherits this broken
+// GOROOT via its environment, though, and fails to run at all -- so this
+// still drives realTestNames() to its cmd.Run() error-wrapping branch
+// (already covered by TestRealTestNames_DirWithNoGoFiles via a different
+// trigger), just not through goBinary() itself, which this package cannot
+// force to fail without either controlling the environment before process
+// start or mocking non-test production code -- both out of reach here.
+func TestRealTestNames_PoisonedToolchainEnv(t *testing.T) {
+	t.Setenv("GOROOT", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+
+	if _, err := realTestNames(); err == nil {
+		t.Error("expected an error when the go subprocess's own GOROOT/PATH environment is broken")
+	}
+}
+
 func TestRealTestNames_DirWithNoGoFiles(t *testing.T) {
 	original := handlersPkgDir
 	handlersPkgDir = t.TempDir()

--- a/server/http/handlers/contracttest/spec_internal_test.go
+++ b/server/http/handlers/contracttest/spec_internal_test.go
@@ -16,6 +16,28 @@ info:
 paths: {}
 `
 
+// badServerURLSpec parses and passes OpenAPI validation cleanly (server URLs
+// aren't checked for validity by doc.Validate()), but its server URL's
+// invalid percent-encoding ("%zz" is not a valid URL escape) makes
+// gorillamux.NewRouter fail when it parses the URL to build the mux route --
+// the one loadSpecFrom error branch a malformed-YAML or failed-validation
+// spec can't reach.
+const badServerURLSpec = `
+openapi: 3.0.3
+info:
+  title: bad server url
+  version: "1.0"
+servers:
+  - url: "http://example.com/%zz"
+paths:
+  /foo:
+    get:
+      operationId: foo
+      responses:
+        '200':
+          description: ok
+`
+
 func writeTempSpec(t *testing.T, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "openapi.yaml")
@@ -62,6 +84,17 @@ func TestLoadSpecFrom(t *testing.T) {
 		}
 		if doc == nil || r == nil {
 			t.Fatal("expected a non-nil doc and router")
+		}
+	})
+
+	t.Run("valid spec whose router fails to build", func(t *testing.T) {
+		path := writeTempSpec(t, badServerURLSpec)
+		_, _, err := loadSpecFrom(path)
+		if err == nil {
+			t.Fatal("expected an error when gorillamux.NewRouter cannot build a router from the doc")
+		}
+		if !strings.Contains(err.Error(), "building operation router") {
+			t.Errorf("expected a router-build error, got: %v", err)
 		}
 	})
 }

--- a/server/middleware/auth_s25_test.go
+++ b/server/middleware/auth_s25_test.go
@@ -1,0 +1,203 @@
+package middleware
+
+// auth_s25_test.go — targeted coverage for the low-% branches left after the
+// s23/s24 blitzes (see g80 coverage sweep). All tests are white-box (same
+// package) so they can touch unexported helpers and package-level vars
+// directly.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// ── handleAuthRequest — 429 too-many-requests branch ─────────────────────────
+
+// TestHandleAuthRequest_TooManyInvalidAttempts_Returns429 drives the full
+// Authentication middleware past tokenAuthFailureBurst invalid-token attempts
+// from a single source IP and proves the NEXT attempt is rejected with 429
+// (tooManyRequestsResponse), rather than the ordinary 401 — the PAT-003
+// brute-force backstop, exercised end to end rather than just at the
+// recordTokenAuthFailure unit level.
+func TestHandleAuthRequest_TooManyInvalidAttempts_Returns429(t *testing.T) {
+	const remoteAddr = "203.0.113.30:5555"
+
+	handler := newTestAuthMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	doRequest := func(token string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.RemoteAddr = remoteAddr
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr
+	}
+
+	// Burn through the failure budget with distinct invalid tokens (a repeated
+	// token would hit the negative cache instead of re-entering the slow path).
+	for i := 0; i < tokenAuthFailureBurst; i++ {
+		rr := doRequest("s25-burst-token-" + string(rune('a'+i)))
+		require.Equal(t, http.StatusUnauthorized, rr.Code, "attempt %d should still be an ordinary 401", i)
+	}
+
+	// The next distinct invalid token exhausts the budget and must 429.
+	rr := doRequest("s25-burst-token-final")
+	assert.Equal(t, http.StatusTooManyRequests, rr.Code,
+		"the attempt beyond tokenAuthFailureBurst must be rate-limited, not just rejected as invalid")
+	assert.Equal(t, "60", rr.Header().Get("Retry-After"))
+	assert.Contains(t, rr.Body.String(), "too many invalid token attempts")
+}
+
+// ── serveAuthCacheHit — negative-cache fast path ──────────────────────────────
+
+// TestHandleAuthRequest_NegativeCacheHit_Returns401 pre-populates the token
+// cache with a negative (known-bad) entry and proves a subsequent request with
+// that exact token is rejected via the fast cache-hit path (serveAuthCacheHit's
+// entry.userCtx == nil branch) without ever reaching the validator.
+func TestHandleAuthRequest_NegativeCacheHit_Returns401(t *testing.T) {
+	token := "s25-negative-cache-token"
+	key := tokenKey(token)
+	cacheSet(key, tokenCacheEntry{userCtx: nil, expiresAt: time.Now().Add(time.Minute)})
+
+	handler := newTestAuthMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("next handler must not run for a negatively-cached token")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Invalid or expired token")
+}
+
+// ── RequireScopedSecretRefPermission — middleware constructor ────────────────
+
+// TestRequireScopedSecretRefPermission_WrapsHandler covers the middleware
+// constructor itself (RequireScopedSecretRefPermission), proving it builds a
+// working http.Handler chain that delegates to
+// handleScopedSecretRefPermissionRequest, mirroring
+// TestRequireScopedSecretPermission_WrapsHandler for the by-id sibling.
+func TestRequireScopedSecretRefPermission_WrapsHandler(t *testing.T) {
+	db := newScopedTestDB(t)
+	seedAdmin(t, db, 1)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "proj"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "prod"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, ProjectID: 1, EnvironmentID: 1, Name: "db"}).Error)
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	userCtx := &UserContext{UserID: 1, ActorType: core.ActorTypeUser}
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := RequireScopedSecretRefPermission("secrets.read")(next)
+	req := makeRequest(t, http.MethodGet, "/secrets/value?ref=proj/prod/db", nil, userCtx, cs)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.True(t, nextCalled, "next handler must be called for an authorized admin")
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ── handleScopedSecretRefPermissionRequest — requireUserAndCore gate ─────────
+
+// TestHandleScopedSecretRefPermission_NoUserContext covers the requireUserAndCore
+// "no user in context" branch as reached through the by-ref handler (mirrors
+// TestHandleScopedSecretPermission_NoUserContext for the by-id sibling).
+func TestHandleScopedSecretRefPermission_NoUserContext(t *testing.T) {
+	req := makeRequest(t, http.MethodGet, "/secrets/value?ref=proj/prod/db", nil, nil, nil)
+	rec := httptest.NewRecorder()
+	nextCalled := false
+	handleScopedSecretRefPermissionRequest(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+	}), rec, req, "secrets.read")
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.False(t, nextCalled)
+}
+
+// ── ScopeFromRoleAssignmentBody — body-read error branch ─────────────────────
+
+// errorReadCloser is an io.ReadCloser whose Read always fails, simulating a
+// body-read error (e.g. a client disconnecting mid-upload).
+type errorReadCloser struct{}
+
+func (errorReadCloser) Read([]byte) (int, error) { return 0, errors.New("simulated body read error") }
+func (errorReadCloser) Close() error             { return nil }
+
+// TestScopeFromRoleAssignmentBody_BodyReadError verifies that a request body
+// that fails to read is surfaced as errInvalidTarget rather than panicking or
+// being silently swallowed.
+func TestScopeFromRoleAssignmentBody_BodyReadError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/user-roles", nil)
+	req.Body = errorReadCloser{}
+
+	_, err := ScopeFromRoleAssignmentBody(req, nil)
+	assert.ErrorIs(t, err, errInvalidTarget)
+}
+
+// ── oidcDiagnosticFields — malformed (non-dotted) token branch ───────────────
+
+// TestOidcDiagnosticFields_TooFewSegments verifies that a token with fewer
+// than 2 dot-separated segments yields empty issuer/kid rather than an
+// out-of-range slice access.
+func TestOidcDiagnosticFields_TooFewSegments(t *testing.T) {
+	issuer, kid := oidcDiagnosticFields("not-a-jwt-at-all")
+	assert.Empty(t, issuer)
+	assert.Empty(t, kid)
+}
+
+// ── validateToken — OIDC success branch ───────────────────────────────────────
+
+// TestValidateToken_OIDCSuccess verifies the success return path of the OIDC
+// branch: a validator with OIDC enabled that resolves a JWT-shaped token to a
+// machine identity produces the machine UserContext.
+func TestValidateToken_OIDCSuccess(t *testing.T) {
+	uc, err := validateToken(context.Background(), fakeValidator{}, "header.valid.sig")
+	require.NoError(t, err)
+	require.NotNil(t, uc)
+	assert.Equal(t, core.ActorTypeMachine, uc.ActorType)
+	assert.NotNil(t, uc.MachineIdentityID)
+	assert.Equal(t, uint(11), *uc.MachineIdentityID)
+}
+
+// ── ProjectsMFABlocked — duplicate project ID de-dup branch ──────────────────
+
+// TestProjectsMFABlocked_DuplicateIDsDeduped verifies that a duplicate project
+// ID in the input slice is skipped on its second occurrence (the `seen[id]`
+// branch) rather than being re-checked, while the aggregate result is still
+// correct.
+func TestProjectsMFABlocked_DuplicateIDsDeduped(t *testing.T) {
+	cs := newProjectMFACore(t)
+	sessionNoMFA := &UserContext{UserID: 1, ActorType: core.ActorTypeUser, SessionAuth: true, MFAEnabled: false}
+
+	// Project 2 (no MFA requirement) repeated, plus project 0 (must be skipped
+	// outright) mixed in — exercises both the `id == 0` and `seen[id]` arms of
+	// the same `continue` condition.
+	assert.False(t, ProjectsMFABlocked(reqWithUser(sessionNoMFA), cs, []uint{2, 2, 0, 2}),
+		"repeated/zero IDs must be deduped, not cause a spurious block")
+
+	// Same duplication pattern but with an MFA-required project included once —
+	// still must block.
+	assert.True(t, ProjectsMFABlocked(reqWithUser(sessionNoMFA), cs, []uint{1, 1, 2}),
+		"a duplicated MFA-required project ID must still block")
+}
+
+var _ io.ReadCloser = errorReadCloser{}

--- a/server/middleware/client_ip_test.go
+++ b/server/middleware/client_ip_test.go
@@ -134,6 +134,39 @@ func TestClientIP_XForwardedForFoldsMultipleHeaderLines(t *testing.T) {
 	}
 }
 
+func TestClientIP_TrustedPeerNoForwardingHeaders(t *testing.T) {
+	// The peer is trusted, but neither X-Forwarded-For nor X-Real-IP is present
+	// at all — clientIPFromRequest must fall through both branches and return
+	// "" (nothing client-attributable), leaving RemoteAddr as the TCP peer.
+	got := serveAndCaptureRemoteAddr([]string{"10.0.0.0/8"}, "10.1.2.3:443", nil)
+	if got != "10.1.2.3:443" {
+		t.Errorf("RemoteAddr = %q; want the unmodified TCP peer when no forwarding headers are present", got)
+	}
+}
+
+func TestClientIP_TrustedPeerInvalidRealIP(t *testing.T) {
+	// X-Real-IP present but not a parseable IP — must be ignored, falling
+	// through to the final "" return (RemoteAddr left unchanged).
+	got := serveAndCaptureRemoteAddr([]string{"10.0.0.0/8"}, "10.1.2.3:443", map[string]string{
+		"X-Real-IP": "not-an-ip",
+	})
+	if got != "10.1.2.3:443" {
+		t.Errorf("RemoteAddr = %q; want the unmodified TCP peer for an unparseable X-Real-IP", got)
+	}
+}
+
+func TestClientIP_MalformedPeerAddress(t *testing.T) {
+	// A RemoteAddr whose host portion isn't a valid IP at all (e.g. malformed
+	// upstream input) must not match any trusted CIDR — ipInAny's ip == nil
+	// branch — and so forwarding headers are ignored.
+	got := serveAndCaptureRemoteAddr([]string{"10.0.0.0/8"}, "not-an-ip-either:443", map[string]string{
+		"X-Forwarded-For": "203.0.113.9",
+	})
+	if got != "not-an-ip-either:443" {
+		t.Errorf("RemoteAddr = %q; want the unmodified peer when the peer itself doesn't parse as an IP", got)
+	}
+}
+
 func TestClientIP_XRealIPFoldsMultipleHeaderLines(t *testing.T) {
 	// Same scenario for X-Real-IP: the client sends its own X-Real-IP line, and the
 	// trusted proxy appends its own value as a second, separate header line rather than

--- a/server/middleware/metrics_test.go
+++ b/server/middleware/metrics_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -74,8 +75,26 @@ func TestFilteringGatherer_DropsOnlyNamedFamilies(t *testing.T) {
 
 type fakeGatherer struct {
 	mfs []*dto.MetricFamily
+	err error
 }
 
 func (f fakeGatherer) Gather() ([]*dto.MetricFamily, error) {
-	return f.mfs, nil
+	return f.mfs, f.err
+}
+
+// TestFilteringGatherer_PropagatesInnerError verifies that filteringGatherer
+// surfaces an error from the wrapped Gatherer unchanged, rather than masking
+// it or returning a partial family list.
+func TestFilteringGatherer_PropagatesInnerError(t *testing.T) {
+	wantErr := errors.New("simulated gather failure")
+	inner := fakeGatherer{err: wantErr}
+	g := filteringGatherer{inner: inner, drop: nil}
+
+	mfs, err := g.Gather()
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected the inner gatherer's error to propagate, got: %v", err)
+	}
+	if mfs != nil {
+		t.Fatalf("expected a nil family list on error, got %v", mfs)
+	}
 }

--- a/server/middleware/middleware_s2_test.go
+++ b/server/middleware/middleware_s2_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 // --- PrometheusMiddleware ---
@@ -45,6 +46,34 @@ func TestPrometheusMiddleware_UnmatchedRoute(t *testing.T) {
 	PrometheusMiddleware(handler).ServeHTTP(rec, req)
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// TestPrometheusMiddleware_HandlerWritesWithoutExplicitStatus verifies that
+// when a handler never calls WriteHeader (writing only a body, or nothing at
+// all), the RECORDED METRIC status defaults to 200 — the "ww.Status() == 0"
+// branch in PrometheusMiddleware's deferred recorder — rather than being
+// recorded as 0 or omitted. This is checked against the actual
+// httpRequestsTotal series, not just the HTTP response code (which the test
+// ResponseRecorder itself would default to 200 regardless of this branch).
+func TestPrometheusMiddleware_HandlerWritesWithoutExplicitStatus(t *testing.T) {
+	const route = "/api/v1/implicit-200-status-metric"
+	before := testutil.ToFloat64(httpRequestsTotal.WithLabelValues(http.MethodGet, route, "200"))
+
+	rctx := chi.NewRouteContext()
+	rctx.RoutePatterns = []string{route}
+	req := httptest.NewRequest(http.MethodGet, route, nil)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rec := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		// Deliberately does not call WriteHeader or Write.
+	})
+	PrometheusMiddleware(handler).ServeHTTP(rec, req)
+
+	after := testutil.ToFloat64(httpRequestsTotal.WithLabelValues(http.MethodGet, route, "200"))
+	if after != before+1 {
+		t.Errorf("httpRequestsTotal{status=200} = %v -> %v; want +1 (an unwritten response must be recorded as 200)", before, after)
 	}
 }
 

--- a/server/middleware/rate_limit_test.go
+++ b/server/middleware/rate_limit_test.go
@@ -58,6 +58,27 @@ func TestPrincipalRateLimit_EnforcesPerPrincipalBudget(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w2.Code, "a different principal must have an independent budget")
 }
 
+// When Burst is left at its zero value (config omits it), PrincipalRateLimit
+// must fall back to RequestsPerSecond as the burst size, rather than building
+// a limiter with burst 0 (which would reject every request outright).
+func TestPrincipalRateLimit_ZeroBurstFallsBackToRequestsPerSecond(t *testing.T) {
+	mw := PrincipalRateLimit(config.RateLimitConfig{Enabled: true, RequestsPerSecond: 3})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	// Exactly RequestsPerSecond (3) requests must pass as the initial burst.
+	for i := 0; i < 3; i++ {
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, newRLRequest(9))
+		require.Equal(t, http.StatusOK, w.Code, "request %d within the fallback burst must pass", i)
+	}
+	// The 4th immediate request must be limited — proving burst was set to 3
+	// (RequestsPerSecond), not left at 0 (which would already have rejected
+	// request 0 above).
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newRLRequest(9))
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
 // An unauthenticated request (no UserContext) falls back to an IP-keyed budget
 // rather than panicking or bypassing the limiter entirely.
 func TestPrincipalRateLimit_FallsBackToIPForUnauthenticated(t *testing.T) {

--- a/server/middleware/recovery_test.go
+++ b/server/middleware/recovery_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -72,6 +73,46 @@ func TestRecovery_RedactsSetupTokenInPanicContextLog(t *testing.T) {
 	logged := buf.String()
 	assert.NotContains(t, logged, token, "the setup token must never reach the panic-context log")
 	assert.Contains(t, logged, "[REDACTED]")
+}
+
+// brokenResponseWriter is an http.ResponseWriter whose Write always fails,
+// simulating a client that disconnects (or a broken transport) right as the
+// panic-recovery response is being written.
+type brokenResponseWriter struct {
+	header http.Header
+}
+
+func (b *brokenResponseWriter) Header() http.Header {
+	if b.header == nil {
+		b.header = make(http.Header)
+	}
+	return b.header
+}
+
+func (b *brokenResponseWriter) Write([]byte) (int, error) {
+	return 0, errors.New("simulated write failure")
+}
+
+func (b *brokenResponseWriter) WriteHeader(int) {}
+
+// TestRecovery_LogsWhenResponseEncodingFails covers the fallback branch taken
+// when json.Encode of the panic response itself fails to write (e.g. the
+// client already disconnected): Recovery must not panic itself, and must log
+// the encode failure rather than silently dropping it.
+func TestRecovery_LogsWhenResponseEncodingFails(t *testing.T) {
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	panicking := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { panic("boom") })
+	w := &brokenResponseWriter{}
+
+	require.NotPanics(t, func() {
+		Recovery()(panicking).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/secrets/1", nil))
+	})
+
+	assert.Contains(t, buf.String(), "Failed to encode panic response")
 }
 
 // TestRecovery_RedactsSSOCallbackQueryInPanicContextLog covers the same gap

--- a/server/middleware/scheduler_metrics_test.go
+++ b/server/middleware/scheduler_metrics_test.go
@@ -156,6 +156,23 @@ func TestSchedulerRunsTotalStillOnDefaultRegistry(t *testing.T) {
 	}
 }
 
+// TestRecordSchedulerRun_UsesRealWallClockByDefault exercises the actual
+// production nowUnix implementation (time.Now().Unix()) — every other test in
+// this file overrides nowUnix, so the default var initializer itself was
+// never invoked. Bounds the recorded timestamp against the wall clock rather
+// than asserting an exact value.
+func TestRecordSchedulerRun_UsesRealWallClockByDefault(t *testing.T) {
+	const name = "test_real_wall_clock"
+	before := time.Now().Unix()
+	RecordSchedulerRun(name, SchedulerSuccess, time.Millisecond)
+	after := time.Now().Unix()
+
+	got := gauge(t, schedulerLastRun, name)
+	if got < float64(before) || got > float64(after) {
+		t.Errorf("last_run = %v, want a value between %d and %d (the real wall clock)", got, before, after)
+	}
+}
+
 func TestSchedulerMetricsHandlerServesTimestampGauges(t *testing.T) {
 	const name = "test_scheduler_metrics_handler"
 	nowUnix = func() int64 { return 4242 }

--- a/server/middleware/session_cookie_test.go
+++ b/server/middleware/session_cookie_test.go
@@ -11,6 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// NOTE: GenerateCSRFToken's crypto/rand.Read error branch is not covered by a
+// test. Since Go 1.24, crypto/rand.Read is documented to never return an
+// error — an underlying entropy-source failure calls runtime.fatal() and
+// crashes the process outright rather than returning an error value (see
+// https://go.dev/issue/66821), so swapping crypto/rand.Reader for a failing
+// io.Reader to exercise that branch takes the whole test binary down instead
+// of exercising the branch. The branch is dead code under the Go version this
+// repo builds with; left uncovered deliberately rather than crashing the test
+// run to chase it.
+
 // TestSetSessionCookie verifies the HttpOnly, SameSite, and Secure attributes.
 func TestSetSessionCookie(t *testing.T) {
 	rr := httptest.NewRecorder()

--- a/server/tools/tools_s22_test.go
+++ b/server/tools/tools_s22_test.go
@@ -1,0 +1,96 @@
+// tools_s22_test.go — additional coverage for test_runner.go.
+//
+// Targets the one branch of RunCoverageReport still uncovered after s18/s21:
+// the `go tool cover -html` FAILURE branch (the `if err := cmd.Run(); err !=
+// nil { ... }` block around line 248 that prints "Could not generate HTML
+// coverage report"). s18/s21 only ever exercised the success side of that
+// branch (a populated coverage.out lets `go tool cover -html` succeed).
+//
+// `go tool cover -html=coverage.out -o coverage.html` fails deterministically
+// when "coverage.html" already exists as a directory (open: is a directory),
+// which lets us hit the failure branch without any flakiness or reliance on a
+// broken toolchain/environment.
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// everything written to it. RunCoverageReport's return value alone does not
+// distinguish the html/func warning branches from their success counterparts
+// (both leave the overall error nil), so asserting on printed output is the
+// only way to pin which branch actually ran.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	fn()
+
+	_ = w.Close()
+	<-done
+	return buf.String()
+}
+
+// TestRunCoverageReport_S22_HTMLWriteFailure exercises the html-generation
+// failure branch of RunCoverageReport by pre-creating "coverage.html" as a
+// directory inside the temp module. `go tool cover -html -o coverage.html`
+// cannot open a directory for writing, so it fails deterministically and
+// RunCoverageReport prints the "Could not generate HTML coverage report"
+// warning instead of the success message. The func-summary step reads only
+// coverage.out (unaffected by coverage.html), so its success branch is still
+// exercised in the same run — isolating exactly the failure branch under test
+// without disturbing the sibling success branch s21 already covers.
+func TestRunCoverageReport_S22_HTMLWriteFailure(t *testing.T) {
+	// A real non-test source file is required so `go test -coverprofile`
+	// produces a populated (not mode-only) coverage.out — see s21's
+	// makePassingModule, reused here.
+	tmp := makePassingModule(t, "covs22html")
+
+	if err := os.Mkdir(filepath.Join(tmp, "coverage.html"), 0o750); err != nil {
+		t.Fatalf("mkdir coverage.html: %v", err)
+	}
+
+	chdirTo(t, tmp)
+
+	tr := NewTestRunner(false, 60*time.Second)
+
+	var err error
+	output := captureStdout(t, func() {
+		err = tr.RunCoverageReport()
+	})
+
+	if err != nil {
+		t.Fatalf("RunCoverageReport() = %v, want nil (an html-generation failure is only a warning, not a returned error)", err)
+	}
+	if !strings.Contains(output, "Could not generate HTML coverage report") {
+		t.Errorf("output = %q, want it to contain the HTML-generation warning", output)
+	}
+	if strings.Contains(output, "Coverage report generated: coverage.html") {
+		t.Errorf("output unexpectedly contains the HTML success message: %q", output)
+	}
+	// The func-summary step is unaffected by coverage.html being a directory,
+	// so its success branch should still print.
+	if !strings.Contains(output, "Coverage Summary:") {
+		t.Errorf("output = %q, want the func-summary success block to still print", output)
+	}
+}

--- a/server/validation/validator_test.go
+++ b/server/validation/validator_test.go
@@ -454,6 +454,25 @@ func TestValidate_Identifier_NilPointer_Passes(t *testing.T) {
 	require.NoError(t, v.Validate(payload{Name: nil}))
 }
 
+func TestValidate_Identifier_NilPointer_NoOmitempty_Passes(t *testing.T) {
+	// Same as TestValidate_Identifier_NilPointer_Passes but WITHOUT an
+	// `omitempty` rule ahead of `identifier`. With `omitempty` present,
+	// validateField's own isEmpty short-circuit returns before
+	// validateIdentifier is ever reached for a nil pointer, so that test
+	// alone never exercises validateIdentifier's own derefForRule ok=false
+	// branch (line "if !ok { return nil }"). A bare `identifier` tag routes
+	// straight into applyRule -> validateIdentifier with the nil pointer
+	// field, confirming validateIdentifier itself treats "nothing to
+	// validate" as a pass, matching every other charset rule's handling of a
+	// nil pointer.
+	type payload struct {
+		Name *string `json:"name" validate:"identifier"`
+	}
+	v := NewValidator()
+
+	require.NoError(t, v.Validate(payload{Name: nil}))
+}
+
 func TestValidate_UsesJSONNameForErrorField(t *testing.T) {
 	type payload struct {
 		UserName string `json:"user_name" validate:"required"`


### PR DESCRIPTION
## Summary
- Adds tests across `cmd/`, `internal/`, and `server/` packages that had real coverage gaps, pushing most from the 80s/low-90s into the high-90s/100%.
- Biggest wins: `internal/cli/billing` 17.3%→92.6%, `cmd/keyorix-mcp` 26.8%→92.9%, `internal/storage/models` 56.8%→100%, `internal/cli/usage` 31.2%→75.0%, `cmd/system` 73.9%→100%.
- Two source files gained a small "test seam" `var` (`internal/cli/auth/auth.go`, `internal/cli/license/license.go`) to make an error path testable without changing behavior — the license.go one mirrors an existing pattern already used in `internal/cli/bundle`.
- No production logic changed; every other file touched is a `_test.go` file (new or extended).

## Test plan
- [x] `go build ./...` clean across the whole module
- [x] `go vet ./...` clean across the whole module
- [x] `gofmt -l` clean on every changed file
- [x] Coverage deltas verified against ground-truth full-suite runs (before/after), not just individual agent self-reports — two packages initially showed a false "regression" from a caching artifact in this environment's tooling; confirmed via independent re-measurement that both are flat or improved, no real regressions anywhere
- [x] The ~126 test failures present both before and after this change are a single pre-existing, local-machine-only issue: dual-mode CLI tests attempting to reach a stale `~/.keyorix/cli.yaml` endpoint and timing out after ~30s. Unrelated to this change and does not reproduce in CI.