### PR TITLE
test(web): sweep remaining frontend coverage gaps (52 files)

### DIFF
--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../pages/audit/AuditLogPage', () => ({ AuditLogPage: () => <div>Audit L
 vi.mock('../pages/sharing', () => ({ SharingManagementPage: () => <div>Sharing Page</div> }));
 vi.mock('../pages/profile', () => ({ ProfilePage: () => <div>Profile Page</div> }));
 vi.mock('../pages/admin/AdminPage', () => ({ AdminPage: () => <div>Admin Page</div> }));
+vi.mock('../pages/billing/BillingPage', () => ({ BillingPage: () => <div>Billing Page</div> }));
 vi.mock('../pages/admin/UserDetailPage', () => ({ UserDetailPage: () => <div>User Detail</div> }));
 vi.mock('../pages/admin/RolesPoliciesPage', () => ({ RolesPoliciesPage: () => <div>Roles Policies</div> }));
 vi.mock('../pages/admin/GroupsPage', () => ({ GroupsPage: () => <div>Groups Page</div> }));
@@ -49,6 +50,7 @@ vi.mock('../pages/settings/AppearancePage', () => ({ AppearancePage: () => <div>
 vi.mock('../pages/settings/SystemHealthPage', () => ({ SystemHealthPage: () => <div>System Health</div> }));
 vi.mock('../pages/settings/AuthenticationPage', () => ({ AuthenticationPage: () => <div>Authentication</div> }));
 vi.mock('../pages/settings/EncryptionPage', () => ({ EncryptionPage: () => <div>Encryption & Keys</div> }));
+vi.mock('../pages/settings/LicensePage', () => ({ LicensePage: () => <div>License Page</div> }));
 vi.mock('../pages/compliance/CompliancePage', () => ({ CompliancePage: () => <div>Compliance</div> }));
 vi.mock('../pages/integrations/KeyorixConnectPage', () => ({
     KeyorixConnectPage: () => <div>Keyorix Connect</div>,
@@ -154,6 +156,7 @@ describe('App', () => {
         it.each([
             ['/dashboard', 'Dashboard Page'],
             ['/secrets', 'Secrets Page'],
+            ['/secrets/dynamic', 'Dynamic Secrets'],
             ['/profile', 'Profile Page'],
             ['/audit', 'Audit Log'],
             ['/integrations/sdks', 'SDKs & CLI'],
@@ -167,6 +170,7 @@ describe('App', () => {
             ['/settings/appearance', 'Appearance'],
             ['/compliance', 'Compliance'],
             ['/integrations/connect', 'Keyorix Connect'],
+            ['/roadmap', 'Roadmap'],
         ])('renders %s for an authenticated user', async (path, expectedText) => {
             setAuth({ isAuthenticated: true, user: { role: 'user' } });
             renderAt(path);
@@ -187,11 +191,14 @@ describe('App', () => {
 
         it.each([
             ['/admin/users', 'Admin Page'],
+            ['/admin/billing', 'Billing Page'],
             ['/admin/roles', 'Roles Policies'],
+            ['/admin/groups', 'Groups Page'],
             ['/admin/notification-channels', 'Notification Channels'],
             ['/settings/health', 'System Health'],
             ['/settings/auth', 'Authentication'],
             ['/settings/encryption', 'Encryption & Keys'],
+            ['/settings/license', 'License Page'],
             ['/admin/users/42', 'User Detail'],
             ['/admin/service-accounts', 'Service Accounts'],
             ['/admin/api-tokens', 'API Tokens'],
@@ -203,10 +210,13 @@ describe('App', () => {
         });
 
         it.each([
+            '/admin/billing',
+            '/admin/groups',
             '/admin/notification-channels',
             '/settings/health',
             '/settings/auth',
             '/settings/encryption',
+            '/settings/license',
             '/admin/users/42',
             '/admin/service-accounts',
             '/admin/api-tokens',

--- a/web/src/components/ui/__tests__/CmdKSearch.test.tsx
+++ b/web/src/components/ui/__tests__/CmdKSearch.test.tsx
@@ -348,6 +348,27 @@ describe('CmdKSearch', () => {
         await waitFor(() => expect(screen.getByText('NoDescription Project')).toBeInTheDocument());
     });
 
+    it('excludes a non-matching project whose description is undefined (nullish-coalescing fallback evaluated)', async () => {
+        // Zeta's name does not match the query, so the `||` in the filter falls
+        // through to `(p.description ?? '').includes(q)` — and since Zeta has no
+        // `description` field at all, this exercises the `?? ''` fallback branch
+        // itself (as opposed to the earlier "no description" test, where the
+        // name already matches and the description check is short-circuited away).
+        mockUseProjects.mockReturnValue({
+            data: [
+                { id: 1, name: 'Alpha Project', description: 'Core alpha stuff' },
+                { id: 42, name: 'Zeta Project' },
+            ],
+        });
+        render(<CmdKSearch onClose={onClose} />);
+        const input = screen.getByPlaceholderText('Search projects and secrets…');
+
+        await typeAndWaitForSettle(input, 'alpha');
+
+        await waitFor(() => expect(screen.getByText('Alpha Project')).toBeInTheDocument());
+        expect(screen.queryByText('Zeta Project')).not.toBeInTheDocument();
+    });
+
     it('treats a missing secrets payload (no data.data) as an empty result set', async () => {
         mockGet.mockResolvedValue({ data: {} });
 

--- a/web/src/components/ui/__tests__/Modal.test.tsx
+++ b/web/src/components/ui/__tests__/Modal.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 import { Modal } from '../Modal';
+
+afterEach(() => {
+    vi.useRealTimers();
+});
 
 describe('Modal', () => {
     it('renders nothing visible when isOpen is false', () => {
@@ -83,6 +87,49 @@ describe('Modal', () => {
                 <p>Body</p>
             </Modal>
         );
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('does not close when the overlay is clicked and closeOnOverlayClick is false', () => {
+        const onClose = vi.fn();
+        const { baseElement } = render(
+            <Modal isOpen onClose={onClose} title="Details" closeOnOverlayClick={false}>
+                <p>Body</p>
+            </Modal>
+        );
+        const overlay = baseElement.querySelector('.bg-black\\/40') as HTMLElement;
+        fireEvent.pointerDown(overlay);
+        fireEvent.click(overlay);
+        expect(onClose).not.toHaveBeenCalled();
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it("suppresses the outside-interaction dismiss once Radix's dismissable layer actually processes it when closeOnOverlayClick is false", async () => {
+        // Radix's DismissableLayer defers attaching its document-level "outside
+        // pointerdown" listener by a setTimeout(0) (to avoid reacting to the same
+        // interaction that opened the dialog), and with a modal Dialog.Content the
+        // pointerdown-outside dismissal itself is deferred again until the
+        // following click. Both hops need real elapsed time to run, so fake timers
+        // + a full pointerdown-then-click sequence are required to actually reach
+        // Modal's onInteractOutside handler (it never fires on a synchronous
+        // fireEvent in the same tick as render).
+        vi.useFakeTimers();
+        const onClose = vi.fn();
+        const { baseElement } = render(
+            <Modal isOpen onClose={onClose} title="Details" closeOnOverlayClick={false}>
+                <p>Body</p>
+            </Modal>
+        );
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        const overlay = baseElement.querySelector('.bg-black\\/40') as HTMLElement;
+        fireEvent.pointerDown(overlay, { button: 0 });
+        fireEvent.click(overlay);
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(onClose).not.toHaveBeenCalled();
         expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 

--- a/web/src/components/ui/__tests__/SessionTimeoutWarning.test.tsx
+++ b/web/src/components/ui/__tests__/SessionTimeoutWarning.test.tsx
@@ -70,6 +70,18 @@ describe('SessionTimeoutWarning', () => {
         expect(screen.getByText(expected)).toBeInTheDocument();
     });
 
+    it('falls back to 0:00 when sessionTimeLeftMs is undefined despite passing the not-null check', () => {
+        // sessionTimeLeftMs is typed as number | null, but showWarning's
+        // `sessionTimeLeftMs !== null` guard does not exclude `undefined` -
+        // strict inequality treats undefined as not-null, so showWarning can
+        // still trip true. formatTime's `sessionTimeLeftMs ?? 0` fallback is
+        // what keeps the countdown from rendering "NaN:NaN" in that case.
+        setAuth({ sessionTimeLeftMs: undefined });
+        render(<SessionTimeoutWarning />);
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText('0:00')).toBeInTheDocument();
+    });
+
     it('updates the displayed countdown when sessionTimeLeftMs ticks down on rerender', () => {
         setAuth({ sessionTimeLeftMs: 65000 });
         const { rerender } = render(<SessionTimeoutWarning />);

--- a/web/src/features/account/__tests__/MfaSection.test.tsx
+++ b/web/src/features/account/__tests__/MfaSection.test.tsx
@@ -7,6 +7,9 @@ let recoveryStatus: { remaining: number; total: number } | undefined;
 let statusLoading = false;
 let statusError = false;
 let enrollPending = false;
+let activatePending = false;
+let disablePending = false;
+let regeneratePending = false;
 
 const enrollMutate = vi.fn();
 const activateMutate = vi.fn();
@@ -16,9 +19,9 @@ const regenerateMutate = vi.fn();
 vi.mock('../index', () => ({
     useMfaRecoveryStatus: () => ({ data: recoveryStatus, isLoading: statusLoading, isError: statusError }),
     useEnrollMfa: () => ({ mutate: enrollMutate, isPending: enrollPending }),
-    useActivateMfa: () => ({ mutate: activateMutate, isPending: false }),
-    useDisableMfa: () => ({ mutateAsync: disableMutate, isPending: false }),
-    useRegenerateRecoveryCodes: () => ({ mutateAsync: regenerateMutate, isPending: false }),
+    useActivateMfa: () => ({ mutate: activateMutate, isPending: activatePending }),
+    useDisableMfa: () => ({ mutateAsync: disableMutate, isPending: disablePending }),
+    useRegenerateRecoveryCodes: () => ({ mutateAsync: regenerateMutate, isPending: regeneratePending }),
 }));
 
 beforeEach(() => {
@@ -26,6 +29,9 @@ beforeEach(() => {
     statusLoading = false;
     statusError = false;
     enrollPending = false;
+    activatePending = false;
+    disablePending = false;
+    regeneratePending = false;
     enrollMutate.mockReset();
     activateMutate.mockReset();
     disableMutate.mockReset();
@@ -194,6 +200,20 @@ describe('MfaSection enrolment flow', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Enable' }));
         expect(screen.queryByLabelText('6-digit code')).not.toBeInTheDocument();
     });
+
+    it('shows a spinner on the Verify & enable button while activation is pending', () => {
+        activatePending = true;
+        enrollMutate.mockImplementation((_vars, opts) => {
+            opts.onSuccess({ secret: 'SECRET', otpauth_uri: 'otpauth://x' });
+        });
+
+        render(<MfaSection />);
+        fireEvent.click(screen.getByRole('button', { name: 'Enable' }));
+
+        const submitButton = screen.getByRole('button', { name: /verify/i });
+        expect(submitButton).toBeDisabled();
+        expect(submitButton.querySelector('svg.animate-spin')).toBeInTheDocument();
+    });
 });
 
 describe('MfaSection regenerate flow', () => {
@@ -276,6 +296,18 @@ describe('MfaSection disable flow', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Disable 2FA' }));
 
         expect(await screen.findByText('Invalid code or password.')).toBeInTheDocument();
+    });
+
+    it('shows a spinner on the confirm button of a ReauthModal while the action is pending', () => {
+        disablePending = true;
+
+        render(<MfaSection />);
+        fireEvent.click(screen.getByRole('button', { name: 'Disable' }));
+        fireEvent.change(screen.getByLabelText('Authenticator code or password'), { target: { value: '123456' } });
+
+        const confirmButton = screen.getByRole('button', { name: 'Disable 2FA' });
+        expect(confirmButton).toBeDisabled();
+        expect(confirmButton.querySelector('svg.animate-spin')).toBeInTheDocument();
     });
 });
 

--- a/web/src/features/account/__tests__/index.test.ts
+++ b/web/src/features/account/__tests__/index.test.ts
@@ -28,14 +28,40 @@ vi.mock('../../../services/mfa', () => ({
     },
 }));
 
+import { accountApi } from '../../../services/account';
 import { personalTokensApi } from '../../../services/personalTokens';
 import { mfaApi } from '../../../services/mfa';
-import { useCreatePersonalToken, useEnrollMfa, useActivateMfa, useRegenerateRecoveryCodes } from '../index';
+import {
+    useUpdateProfile,
+    useChangePassword,
+    useSessions,
+    useRevokeSession,
+    usePersonalTokens,
+    useCreatePersonalToken,
+    useRevokePersonalToken,
+    useMfaRecoveryStatus,
+    useEnrollMfa,
+    useActivateMfa,
+    useDisableMfa,
+    useRegenerateRecoveryCodes,
+} from '../index';
 
-const personalTokensMock = personalTokensApi as unknown as { createToken: ReturnType<typeof vi.fn> };
+const accountMock = accountApi as unknown as {
+    updateProfile: ReturnType<typeof vi.fn>;
+    changePassword: ReturnType<typeof vi.fn>;
+    listSessions: ReturnType<typeof vi.fn>;
+    revokeSession: ReturnType<typeof vi.fn>;
+};
+const personalTokensMock = personalTokensApi as unknown as {
+    listTokens: ReturnType<typeof vi.fn>;
+    createToken: ReturnType<typeof vi.fn>;
+    revokeToken: ReturnType<typeof vi.fn>;
+};
 const mfaMock = mfaApi as unknown as {
     enroll: ReturnType<typeof vi.fn>;
     activate: ReturnType<typeof vi.fn>;
+    disable: ReturnType<typeof vi.fn>;
+    recoveryCodesStatus: ReturnType<typeof vi.fn>;
     regenerateRecoveryCodes: ReturnType<typeof vi.fn>;
 };
 
@@ -111,5 +137,109 @@ describe('sensitive mutation cache eviction (G28)', () => {
 
         unmount();
         await waitFor(() => expect(queryClient.getMutationCache().getAll()).toHaveLength(0));
+    });
+});
+
+describe('profile + password mutations', () => {
+    it('useUpdateProfile calls accountApi.updateProfile with the given body', async () => {
+        accountMock.updateProfile.mockResolvedValueOnce({});
+        const { wrapper } = createWrapper();
+        const { result } = renderHook(() => useUpdateProfile(), { wrapper });
+
+        act(() => {
+            result.current.mutate({ display_name: 'Ada', email: 'ada@example.com' });
+        });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(accountMock.updateProfile).toHaveBeenCalledWith({ display_name: 'Ada', email: 'ada@example.com' });
+    });
+
+    it('useChangePassword calls accountApi.changePassword with the given body', async () => {
+        accountMock.changePassword.mockResolvedValueOnce({});
+        const { wrapper } = createWrapper();
+        const { result } = renderHook(() => useChangePassword(), { wrapper });
+
+        act(() => {
+            result.current.mutate({ current_password: 'old', new_password: 'new' });
+        });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(accountMock.changePassword).toHaveBeenCalledWith({ current_password: 'old', new_password: 'new' });
+    });
+});
+
+describe('active sessions', () => {
+    it('useSessions fetches the session list', async () => {
+        accountMock.listSessions.mockResolvedValueOnce([{ id: 1 }]);
+        const { wrapper } = createWrapper();
+        const { result } = renderHook(() => useSessions(), { wrapper });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(result.current.data).toEqual([{ id: 1 }]);
+    });
+
+    it('useRevokeSession revokes a session and invalidates the sessions query', async () => {
+        accountMock.listSessions.mockResolvedValue([]);
+        accountMock.revokeSession.mockResolvedValueOnce({});
+        const { wrapper, queryClient } = createWrapper();
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+        const { result } = renderHook(() => useRevokeSession(), { wrapper });
+
+        act(() => {
+            result.current.mutate(7);
+        });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(accountMock.revokeSession).toHaveBeenCalledWith(7);
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['account-sessions'] });
+    });
+});
+
+describe('personal access tokens', () => {
+    it('usePersonalTokens fetches the token list', async () => {
+        personalTokensMock.listTokens.mockResolvedValueOnce([{ id: 1 }]);
+        const { wrapper } = createWrapper();
+        const { result } = renderHook(() => usePersonalTokens(), { wrapper });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(result.current.data).toEqual([{ id: 1 }]);
+    });
+
+    it('useRevokePersonalToken revokes a token and invalidates the tokens query', async () => {
+        personalTokensMock.listTokens.mockResolvedValue([]);
+        personalTokensMock.revokeToken.mockResolvedValueOnce({});
+        const { wrapper, queryClient } = createWrapper();
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+        const { result } = renderHook(() => useRevokePersonalToken(), { wrapper });
+
+        act(() => {
+            result.current.mutate(3);
+        });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(personalTokensMock.revokeToken).toHaveBeenCalledWith(3);
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['account-tokens'] });
+    });
+});
+
+describe('MFA self-service', () => {
+    it('useMfaRecoveryStatus fetches the recovery-code status', async () => {
+        mfaMock.recoveryCodesStatus.mockResolvedValueOnce({ total: 5, remaining: 3 });
+        const { wrapper } = createWrapper();
+        const { result } = renderHook(() => useMfaRecoveryStatus(), { wrapper });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(result.current.data).toEqual({ total: 5, remaining: 3 });
+    });
+
+    it('useDisableMfa disables MFA and invalidates the recovery-status query', async () => {
+        mfaMock.recoveryCodesStatus.mockResolvedValue({ total: 0, remaining: 0 });
+        mfaMock.disable.mockResolvedValueOnce({});
+        const { wrapper, queryClient } = createWrapper();
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+        const { result } = renderHook(() => useDisableMfa(), { wrapper });
+
+        act(() => {
+            result.current.mutate({ code: '123456' });
+        });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(mfaMock.disable).toHaveBeenCalledWith({ code: '123456' });
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['account-mfa-recovery'] });
     });
 });

--- a/web/src/features/admin/__tests__/MaintenanceSection.test.tsx
+++ b/web/src/features/admin/__tests__/MaintenanceSection.test.tsx
@@ -52,11 +52,25 @@ describe('MaintenanceSection', () => {
         expect(await screen.findByText(/Sent 5 rotation reminder\(s\)\./)).toBeInTheDocument();
     });
 
+    it('defaults the rotation-reminders count to 0 when the result omits it', async () => {
+        rotationMutate.mockImplementation((_v, opts) => opts.onSuccess({}));
+        render(<MaintenanceSection />);
+        fireEvent.click(screen.getByRole('button', { name: 'Rotation reminders' }));
+        expect(await screen.findByText(/Sent 0 rotation reminder\(s\)\./)).toBeInTheDocument();
+    });
+
     it('runs the expiry-reminders job and surfaces the sent count on success', async () => {
         expiryMutate.mockImplementation((_v, opts) => opts.onSuccess({ sent: 2 }));
         render(<MaintenanceSection />);
         fireEvent.click(screen.getByRole('button', { name: 'Expiry reminders' }));
         expect(await screen.findByText(/Sent 2 expiry reminder\(s\)\./)).toBeInTheDocument();
+    });
+
+    it('defaults the expiry-reminders count to 0 when the result omits it', async () => {
+        expiryMutate.mockImplementation((_v, opts) => opts.onSuccess({}));
+        render(<MaintenanceSection />);
+        fireEvent.click(screen.getByRole('button', { name: 'Expiry reminders' }));
+        expect(await screen.findByText(/Sent 0 expiry reminder\(s\)\./)).toBeInTheDocument();
     });
 
     it('surfaces an error message when the expiry-reminders job fails', async () => {

--- a/web/src/features/admin/__tests__/StaleAccountsSection.test.tsx
+++ b/web/src/features/admin/__tests__/StaleAccountsSection.test.tsx
@@ -132,6 +132,18 @@ describe('StaleAccountsSection', () => {
         expect(screen.getByRole('button', { name: /^revoke$/i })).toBeInTheDocument();
     });
 
+    it('resets the confirm state on successful revoke', () => {
+        suspendMutate.mockImplementation((_id, opts) => opts.onSuccess());
+        render(<StaleAccountsSection />);
+        fireEvent.click(screen.getByRole('button', { name: /^revoke$/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+        expect(suspendMutate).toHaveBeenCalledTimes(1);
+        // Back to the initial "Revoke" affordance, confirm/cancel are gone.
+        expect(screen.getByRole('button', { name: /^revoke$/i })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /^confirm$/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /^cancel$/i })).not.toBeInTheDocument();
+    });
+
     it('surfaces a server error message when revoke fails', async () => {
         suspendMutate.mockImplementation((_id, opts) => opts.onError({ response: { data: { error: 'nope' } } }));
         render(<StaleAccountsSection />);

--- a/web/src/features/auth/__tests__/api.test.ts
+++ b/web/src/features/auth/__tests__/api.test.ts
@@ -142,6 +142,38 @@ describe('useAuth session timeout', () => {
         expect(result.current.sessionTimeLeftMs).toBeNull();
     });
 
+    it('resets the deadline and re-arms the timer on user activity', () => {
+        vi.useFakeTimers();
+        storeState.isAuthenticated = true;
+        const { result } = renderHook(() => useAuth(), { wrapper });
+
+        // Enter the warning window.
+        act(() => {
+            vi.advanceTimersByTime(3_300_000);
+        });
+        expect(result.current.sessionTimeLeftMs).not.toBeNull();
+
+        // Activity should reset the deadline (resetDeadline -> schedule), so we
+        // leave the warning window again instead of continuing to count down.
+        act(() => {
+            document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        });
+        expect(result.current.sessionTimeLeftMs).toBeNull();
+
+        // Not enough time has passed since the reset for a new warning/logout.
+        act(() => {
+            vi.advanceTimersByTime(3_300_000);
+        });
+        expect(logout).not.toHaveBeenCalled();
+        expect(result.current.sessionTimeLeftMs).not.toBeNull();
+
+        // Push past the reset deadline to confirm it actually took effect.
+        act(() => {
+            vi.advanceTimersByTime(300_000);
+        });
+        expect(logout).toHaveBeenCalledTimes(1);
+    });
+
     it('clears the pending timeout and removes activity listeners on unmount', () => {
         vi.useFakeTimers();
         storeState.isAuthenticated = true;

--- a/web/src/features/dashboard/__tests__/systemHealth.test.ts
+++ b/web/src/features/dashboard/__tests__/systemHealth.test.ts
@@ -110,6 +110,18 @@ describe('getSystemHealthSeverity', () => {
         };
         expect(getSystemHealthSeverity(metrics, healthySysInfo)).toBe('neutral');
     });
+
+    it('treats a missing sysInfo as connected rather than alerting', () => {
+        // Metrics have loaded but sysInfo hasn't yet — dbConnected should default
+        // to true instead of flashing an alert while sysInfo is still in flight.
+        expect(getSystemHealthSeverity(healthyMetrics, undefined)).toBe('neutral');
+    });
+
+    it('treats a missing metrics object as all-zero rather than throwing', () => {
+        // sysInfo has loaded but metrics hasn't yet — every metrics-derived value
+        // should fall back to 0 via optional chaining instead of throwing.
+        expect(getSystemHealthSeverity(undefined, healthySysInfo)).toBe('neutral');
+    });
 });
 
 describe('HEALTH_STATUS_STYLES', () => {

--- a/web/src/features/dynamic-secrets/__tests__/LeasesPanel.test.tsx
+++ b/web/src/features/dynamic-secrets/__tests__/LeasesPanel.test.tsx
@@ -322,6 +322,65 @@ describe('LeasesPanel', () => {
         });
     });
 
+    it('dismisses the "Revoke all" partial-failure/success notice via its own dismiss control', () => {
+        leasesData = [{ leaseId: 'lease-1', roleName: 'role', status: 'active' }];
+        revokeAllMutate.mockImplementation((_vars, opts) => opts.onSuccess({ revoked: 1, failed: 0 }));
+
+        render(<LeasesPanel configId={5} canManage />);
+        fireEvent.click(screen.getByRole('button', { name: /revoke all/i }));
+        expect(screen.getByText('Revoked 1 lease(s).')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+        expect(screen.queryByText('Revoked 1 lease(s).')).not.toBeInTheDocument();
+    });
+
+    it('reverts a copy button from "Copied" back to "Copy" after the timeout elapses', async () => {
+        issueMutate.mockImplementation((_vars, opts) =>
+            opts.onSuccess({ leaseId: 'lease-copy', username: 'app_user', password: 'super-secret' })
+        );
+        vi.useFakeTimers();
+
+        render(<LeasesPanel configId={5} canManage />);
+        fireEvent.click(screen.getByRole('button', { name: /issue credential/i }));
+
+        const copyButtons = screen.getAllByRole('button', { name: 'Copy' });
+        fireEvent.click(copyButtons[0]);
+        expect(screen.getAllByRole('button', { name: 'Copied' })).toHaveLength(1);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(2000);
+        });
+
+        expect(screen.queryByRole('button', { name: 'Copied' })).not.toBeInTheDocument();
+        expect(screen.getAllByRole('button', { name: 'Copy' })).toHaveLength(2);
+
+        vi.useRealTimers();
+    });
+
+    it('falls back to an empty string for a cloud-credential field whose value is missing', () => {
+        issueMutate.mockImplementation((_vars, opts) =>
+            opts.onSuccess({
+                leaseId: 'lease-cloud-missing-field',
+                username: '',
+                password: '',
+                fields: {
+                    access_key_id: 'AKIAEXAMPLE',
+                    secret_access_key: undefined,
+                },
+            })
+        );
+
+        render(<LeasesPanel configId={5} canManage />);
+        fireEvent.click(screen.getByRole('button', { name: /issue credential/i }));
+
+        expect(screen.getByText('Secret access key')).toBeInTheDocument();
+        // The field's value is undefined, so the row falls back to rendering an
+        // empty string rather than throwing or literally showing "undefined".
+        const label = screen.getByText('Secret access key');
+        const row = label.closest('.flex.items-stretch');
+        expect(row?.querySelector('code')).toHaveTextContent('');
+    });
+
     it('closes the credential modal via the close (X) control and via Done', () => {
         issueMutate.mockImplementation((_vars, opts) =>
             opts.onSuccess({ leaseId: 'lease-x', username: 'u', password: 'p' })

--- a/web/src/features/invitations/__tests__/GlobalInviteUserModal.test.tsx
+++ b/web/src/features/invitations/__tests__/GlobalInviteUserModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '../../../test/test-utils';
+import { render, screen, fireEvent, act } from '../../../test/test-utils';
 import { GlobalInviteUserModal } from '../GlobalInviteUserModal';
 
 const mutate = vi.fn();
@@ -202,6 +202,69 @@ describe('GlobalInviteUserModal', () => {
 
         expect(screen.getByText(/a setup link was sent to/i)).toBeInTheDocument();
         expect(screen.getByText(/via smtp/i)).toBeInTheDocument();
+    });
+
+    it('Done is a no-op while the invitation is (still) pending, unlike Cancel', () => {
+        // Unlike Cancel, the "Done" button on the success view isn't gated by a
+        // `disabled={invite.isPending}` prop — handleClose's own internal guard is
+        // the only thing standing between a stale in-flight request and a premature
+        // close/reset. Simulate that window by flipping isPending back on after the
+        // success view is already showing.
+        mutate.mockImplementation((_vars, opts) =>
+            opts.onSuccess({
+                invitation: { id: 20 },
+                setup_link: {
+                    email: 'carol@x.io',
+                    channel: 'out_of_band',
+                    delivered: false,
+                    link_for_admin: 'https://k/x/done',
+                },
+            })
+        );
+
+        const { rerender } = render(<GlobalInviteUserModal isOpen onClose={onClose} />);
+        fireEvent.change(screen.getByPlaceholderText('jane@example.com'), { target: { value: 'carol@x.io' } });
+        fireEvent.click(screen.getByRole('button', { name: /send invitation/i }));
+
+        expect(screen.getByText('https://k/x/done')).toBeInTheDocument();
+
+        isPending = true;
+        rerender(<GlobalInviteUserModal isOpen onClose={onClose} />);
+        fireEvent.click(screen.getByRole('button', { name: /^done$/i }));
+
+        expect(onClose).not.toHaveBeenCalled();
+        // reset() didn't run either — the success view (and its link) is still shown.
+        expect(screen.getByText('https://k/x/done')).toBeInTheDocument();
+    });
+
+    it('falls back to the server-returned email in the success banner when the field was cleared mid-flight', () => {
+        // The email input has no disabled={invite.isPending} guard, so a user can
+        // clear it while the request is still in flight. sentEmail (derived from the
+        // live input) then goes blank before onSuccess fires, and the banner should
+        // fall back to the email the server echoes back on the created invitation.
+        let onSuccess: ((res: any) => void) | undefined;
+        mutate.mockImplementation((_vars, opts) => {
+            onSuccess = opts.onSuccess;
+        });
+
+        render(<GlobalInviteUserModal isOpen onClose={onClose} />);
+        fireEvent.change(screen.getByPlaceholderText('jane@example.com'), { target: { value: 'carol@x.io' } });
+        fireEvent.click(screen.getByRole('button', { name: /send invitation/i }));
+        fireEvent.change(screen.getByPlaceholderText('jane@example.com'), { target: { value: '' } });
+
+        act(() => {
+            onSuccess?.({
+                invitation: { id: 21 },
+                setup_link: {
+                    email: 'server@x.io',
+                    channel: 'smtp',
+                    delivered: true,
+                    link_for_admin: 'https://k/x/fallback',
+                },
+            });
+        });
+
+        expect(screen.getByText('Invitation created for server@x.io.')).toBeInTheDocument();
     });
 
     it('omits the "via <channel>" clause when no channel is present', () => {

--- a/web/src/features/invitations/__tests__/InviteToProjectModal.test.tsx
+++ b/web/src/features/invitations/__tests__/InviteToProjectModal.test.tsx
@@ -81,6 +81,19 @@ describe('InviteToProjectModal', () => {
         expect(onClose).not.toHaveBeenCalled();
     });
 
+    it("handleClose is also a no-op while pending via the modal's own close button", () => {
+        // The Cancel button is `disabled` while pending, so clicking it never
+        // actually reaches handleClose's body. Radix's dialog close ("X") button
+        // isn't wired to isPending, so it's the only DOM path that exercises
+        // handleClose's early-return guard during a pending mutation.
+        isPending = true;
+        render(<InviteToProjectModal isOpen onClose={onClose} projectId={3} projectName="mobile-app" />);
+
+        fireEvent.click(screen.getByRole('button', { name: /close/i }));
+
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
     it('resets fields and closes on a successful submission', () => {
         mutate.mockImplementation((_vars, opts) => opts.onSuccess());
 

--- a/web/src/features/invitations/__tests__/PendingOnboardingSection.test.tsx
+++ b/web/src/features/invitations/__tests__/PendingOnboardingSection.test.tsx
@@ -129,6 +129,15 @@ describe('PendingOnboardingSection', () => {
         expect(screen.getByText('user 50')).toBeInTheDocument();
     });
 
+    it('falls back to the raw state string when it has no known label', () => {
+        memberships = [{ id: 1, projectId: 3, userId: 42, role: 'project_developer', state: 'some_unmapped_state' }];
+        render(<PendingOnboardingSection projectId={3} users={users} />);
+
+        expect(screen.getByText('some_unmapped_state')).toBeInTheDocument();
+        // No known next action for an unmapped state — only the revoke button renders.
+        expect(screen.queryByRole('button', { name: /Mark|Activate/ })).not.toBeInTheDocument();
+    });
+
     it('revokes (cancels) an onboarding membership', () => {
         memberships = [
             { id: 1, projectId: 3, userId: 42, role: 'project_developer', state: 'invited', invitedAt: daysAgo(1) },

--- a/web/src/features/invitations/__tests__/ProjectInvitationsSection.test.tsx
+++ b/web/src/features/invitations/__tests__/ProjectInvitationsSection.test.tsx
@@ -164,6 +164,43 @@ describe('ProjectInvitationsSection — stale warnings', () => {
         expect(screen.getByText('expired')).toBeInTheDocument();
     });
 
+    it('falls back to the muted badge style for a revoked invite (own switch case)', () => {
+        // 'revoked' and 'expired' share a fallthrough case in stateStyle's switch;
+        // the 'expired' test above enters that block via the 'expired' label, never
+        // via 'revoked', so this exercises the 'revoked' case label directly.
+        invitations = [
+            {
+                id: 15,
+                projectId: 3,
+                email: 'revoked@demo.test',
+                role: 'project_viewer',
+                state: 'revoked',
+                invitedBy: 1,
+                createdAt: daysAgo(30),
+            },
+        ];
+        render(<ProjectInvitationsSection projectId={3} />);
+        expect(screen.getByText('revoked')).toBeInTheDocument();
+    });
+
+    it('falls back to the muted badge style for an unrecognized state (default case)', () => {
+        // stateStyle's switch has no case for arbitrary backend states; this
+        // exercises the `default:` branch itself.
+        invitations = [
+            {
+                id: 16,
+                projectId: 3,
+                email: 'unknown-state@demo.test',
+                role: 'project_viewer',
+                state: 'cancelled',
+                invitedBy: 1,
+                createdAt: daysAgo(30),
+            },
+        ];
+        render(<ProjectInvitationsSection projectId={3} />);
+        expect(screen.getByText('cancelled')).toBeInTheDocument();
+    });
+
     it('shows the expiry date for a non-stale pending invite with expiresAt', () => {
         const expiresAt = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
         invitations = [

--- a/web/src/features/machine-identities/__tests__/MachineIdentitiesSection.test.tsx
+++ b/web/src/features/machine-identities/__tests__/MachineIdentitiesSection.test.tsx
@@ -108,6 +108,17 @@ describe('MachineIdentitiesSection', () => {
         });
     });
 
+    it('clears the name field once creation succeeds', () => {
+        createMutate.mockImplementation((_vars, opts) => opts.onSuccess());
+        render(<MachineIdentitiesSection projectId={3} />);
+        const nameInput = screen.getByPlaceholderText('Machine identity name…') as HTMLInputElement;
+
+        fireEvent.change(nameInput, { target: { value: 'deploy-key' } });
+        fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
+
+        expect(nameInput.value).toBe('');
+    });
+
     it('creates via the Enter key using the chosen identity type', () => {
         render(<MachineIdentitiesSection projectId={3} />);
         const nameInput = screen.getByPlaceholderText('Machine identity name…');
@@ -307,5 +318,74 @@ describe('MachineIdentitiesSection', () => {
 
         expect(confirmSpy).not.toHaveBeenCalled();
         expect(transitionMutate).toHaveBeenCalledWith({ machineId: 2, action: 'activate' }, expect.anything());
+    });
+
+    it('falls back to the raw identityType when it has no known label', () => {
+        identitiesData = [
+            {
+                id: 7,
+                projectId: 3,
+                name: 'mystery-bot',
+                identityType: 'legacy-batch',
+                state: 'active',
+                description: '',
+                classification: '',
+            },
+        ];
+        render(<MachineIdentitiesSection projectId={3} />);
+
+        expect(screen.getByText('legacy-batch')).toBeInTheDocument();
+    });
+
+    it('the admin classification picker falls back to an empty value when classification is unset', () => {
+        identitiesData = [
+            {
+                id: 8,
+                projectId: 3,
+                name: 'unclassified-svc',
+                identityType: 'service',
+                state: 'active',
+                description: '',
+            },
+        ];
+        render(<MachineIdentitiesSection projectId={3} />);
+
+        const picker = screen.getByLabelText('Classification for unclassified-svc') as HTMLSelectElement;
+        expect(picker.value).toBe('');
+    });
+
+    it('the read-only classification badge falls back to unclassified styling when classification is unset', () => {
+        isAdmin = false;
+        identitiesData = [
+            {
+                id: 9,
+                projectId: 3,
+                name: 'unclassified-svc',
+                identityType: 'service',
+                state: 'active',
+                description: '',
+            },
+        ];
+        render(<MachineIdentitiesSection projectId={3} />);
+
+        expect(screen.getByTestId('mi-classification-badge')).toHaveTextContent('Unclassified');
+    });
+
+    it('flags an active identity not seen in 90+ days as stale', () => {
+        identitiesData = [
+            {
+                id: 10,
+                projectId: 3,
+                name: 'dormant-runner',
+                identityType: 'ci',
+                state: 'active',
+                description: '',
+                classification: '',
+                lastSeenAt: new Date(Date.now() - 120 * 24 * 60 * 60 * 1000).toISOString(),
+            },
+        ];
+        render(<MachineIdentitiesSection projectId={3} />);
+
+        expect(screen.getByTestId('mi-stale-badge')).toBeInTheDocument();
     });
 });

--- a/web/src/features/machine-identities/__tests__/MachineTokensPanel.test.tsx
+++ b/web/src/features/machine-identities/__tests__/MachineTokensPanel.test.tsx
@@ -82,6 +82,16 @@ describe('MachineTokensPanel', () => {
         expect(issueMutate).not.toHaveBeenCalled();
     });
 
+    it('does not issue when Enter is pressed with a blank/whitespace-only name', () => {
+        // The Issue button is disabled for a blank name, but Enter bypasses it —
+        // the handler's own trim() guard is what stops the issue here.
+        render(<MachineTokensPanel projectId={3} machineId={7} canManage />);
+        const nameInput = screen.getByPlaceholderText('Token name…');
+        fireEvent.change(nameInput, { target: { value: '   ' } });
+        fireEvent.keyDown(nameInput, { key: 'Enter' });
+        expect(issueMutate).not.toHaveBeenCalled();
+    });
+
     it('issues via the Enter key and shows the one-time token modal, then Copy + Done', async () => {
         issueMutate.mockImplementation((_vars, opts) => {
             opts.onSuccess({ token: 'kx_machine_raw_secret', id: 99, prefix: 'kx_machine_9999', classification: '' });
@@ -104,6 +114,52 @@ describe('MachineTokensPanel', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Done' }));
         expect(screen.queryByText('Machine token issued')).not.toBeInTheDocument();
+    });
+
+    it('clears the issued token modal when closed via the Modal close button', () => {
+        issueMutate.mockImplementation((_vars, opts) => {
+            opts.onSuccess({ token: 'kx_machine_x_close', id: 103, prefix: 'kx_machine_xc', classification: '' });
+        });
+
+        render(<MachineTokensPanel projectId={3} machineId={7} canManage />);
+        fireEvent.change(screen.getByPlaceholderText('Token name…'), { target: { value: 'x-close-test' } });
+        fireEvent.click(screen.getByRole('button', { name: /issue token/i }));
+        expect(screen.getByText('Machine token issued')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+        expect(screen.queryByText('Machine token issued')).not.toBeInTheDocument();
+    });
+
+    describe('copy-to-clipboard reset', () => {
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('reverts the Copy button label back to "Copy" after the timeout elapses', () => {
+            issueMutate.mockImplementation((_vars, opts) => {
+                opts.onSuccess({
+                    token: 'kx_machine_copy_secret',
+                    id: 102,
+                    prefix: 'kx_machine_copy',
+                    classification: '',
+                });
+            });
+            vi.useFakeTimers();
+
+            render(<MachineTokensPanel projectId={3} machineId={7} canManage />);
+            fireEvent.change(screen.getByPlaceholderText('Token name…'), { target: { value: 'copy-test' } });
+            fireEvent.click(screen.getByRole('button', { name: /issue token/i }));
+
+            fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+            expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+
+            act(() => {
+                vi.advanceTimersByTime(2000);
+            });
+
+            expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+        });
     });
 
     it('an Enter keypress on the name field is a no-op when Enter is not pressed', () => {
@@ -155,6 +211,38 @@ describe('MachineTokensPanel', () => {
 
         expect(revokeMutate).toHaveBeenCalledWith(11, expect.anything());
         expect(screen.getByText('Failed to revoke token.')).toBeInTheDocument();
+    });
+
+    it('falls back to "(unnamed)" and Unclassified for a token with no name/classification, and can reclassify it', () => {
+        tokensData = [{ id: 13, name: '', prefix: 'kx_machine_zz00', revoked: false, classification: undefined }];
+
+        render(<MachineTokensPanel projectId={3} machineId={7} canManage />);
+
+        expect(screen.getByText('(unnamed)')).toBeInTheDocument();
+        const picker = screen.getByLabelText('Classification for token kx_machine_zz00') as HTMLSelectElement;
+        expect(picker.value).toBe('');
+
+        fireEvent.change(picker, { target: { value: 'confidential' } });
+        expect(classifyMutate).toHaveBeenCalledWith({ tokenId: 13, classification: 'confidential' }, expect.anything());
+    });
+
+    it('shows the Unclassified badge for a token with no classification (read-only view)', () => {
+        tokensData = [{ id: 13, name: 'svc', prefix: 'kx_machine_zz00', revoked: false, classification: undefined }];
+
+        render(<MachineTokensPanel projectId={3} machineId={7} canManage={false} />);
+
+        expect(screen.getByTestId('mt-classification-badge')).toHaveTextContent('Unclassified');
+    });
+
+    it('falls back to the prefix in the revoke confirmation when the token has no name', () => {
+        tokensData = [{ id: 13, name: '', prefix: 'kx_machine_zz00', revoked: false, classification: '' }];
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+        render(<MachineTokensPanel projectId={3} machineId={7} canManage />);
+        fireEvent.click(screen.getByTitle('Revoke token'));
+
+        expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining('kx_machine_zz00'));
+        expect(revokeMutate).toHaveBeenCalledWith(13, expect.anything());
     });
 
     it('hides the revoke action for already-revoked tokens', () => {

--- a/web/src/features/notifications/__tests__/NotificationBell.test.tsx
+++ b/web/src/features/notifications/__tests__/NotificationBell.test.tsx
@@ -30,7 +30,7 @@ const baseNotifications = [
 // Mutable so individual tests can swap in different unread counts / notification
 // lists without redefining the whole mock factory (vi.mock factories can't
 // close over per-test locals).
-let mockData: { unread_count: number; notifications: typeof baseNotifications } = {
+let mockData: { unread_count: number; notifications: typeof baseNotifications } | undefined = {
     unread_count: 2,
     notifications: baseNotifications,
 };
@@ -121,6 +121,15 @@ describe('NotificationBell', () => {
         expect(backdrop).not.toBeNull();
         fireEvent.click(backdrop as Element);
         expect(screen.queryByText('Approved')).not.toBeInTheDocument();
+    });
+
+    it('falls back to an empty list and zero unread count when the query has no data yet', () => {
+        mockData = undefined;
+        render(<NotificationBell />);
+        expect(screen.queryByText('2')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Notifications' })).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Notifications' }));
+        expect(screen.getByText('You’re all caught up.')).toBeInTheDocument();
     });
 
     it('renders relative time labels for minutes/hours/days-old notifications', () => {

--- a/web/src/features/secrets/__tests__/SecretDetailView.test.tsx
+++ b/web/src/features/secrets/__tests__/SecretDetailView.test.tsx
@@ -180,6 +180,22 @@ describe('SecretDetailView version rollback', () => {
         expect(mockRollbackMutate).not.toHaveBeenCalled();
         confirmSpy.mockRestore();
     });
+
+    it('re-masks a revealed value after a successful rollback', () => {
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+        mockRollbackMutate.mockImplementationOnce((_version: number, opts?: { onSuccess?: () => void }) => {
+            opts?.onSuccess?.();
+        });
+        render(<SecretDetailView secret={makeSecret()} />);
+        fireEvent.click(screen.getByRole('button', { name: /^Reveal$/i }));
+        expect(screen.getByRole('button', { name: /^Hide$/i })).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /Roll back/i }));
+
+        expect(screen.getByRole('button', { name: /^Reveal$/i })).toBeInTheDocument();
+        expect(screen.getByText(/Secret value is hidden/i)).toBeInTheDocument();
+        confirmSpy.mockRestore();
+    });
 });
 
 describe('SecretDetailView access list', () => {
@@ -237,6 +253,28 @@ describe('SecretDetailView suspend/resume', () => {
         expect(mockSuspendMutate).not.toHaveBeenCalled();
         confirmSpy.mockRestore();
     });
+
+    it('flips to the Suspended badge after the suspend mutation succeeds', () => {
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+        mockSuspendMutate.mockImplementationOnce((_payload: unknown, opts?: { onSuccess?: () => void }) => {
+            opts?.onSuccess?.();
+        });
+        render(<SecretDetailView secret={makeSecret({ status: 'active' })} />);
+        fireEvent.click(screen.getByRole('button', { name: /^Suspend$/i }));
+        expect(screen.getByTestId('suspended-badge')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^Resume$/i })).toBeInTheDocument();
+        confirmSpy.mockRestore();
+    });
+
+    it('flips back to active after the resume mutation succeeds', () => {
+        mockResumeMutate.mockImplementationOnce((_payload: unknown, opts?: { onSuccess?: () => void }) => {
+            opts?.onSuccess?.();
+        });
+        render(<SecretDetailView secret={makeSecret({ status: 'suspended' })} />);
+        fireEvent.click(screen.getByRole('button', { name: /^Resume$/i }));
+        expect(screen.queryByTestId('suspended-badge')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^Suspend$/i })).toBeInTheDocument();
+    });
 });
 
 describe('SecretDetailView recent access', () => {
@@ -272,6 +310,7 @@ describe('SecretDetailView recent access', () => {
         const today = new Date(Date.now() - 60 * 1000).toISOString();
         const yesterday = new Date(Date.now() - 36 * 60 * 60 * 1000).toISOString();
         const fiveDaysAgo = new Date(Date.now() - (5 * 86_400_000 + 3_600_000)).toISOString();
+        const oneMonthAgo = new Date(Date.now() - (45 * 86_400_000 + 3_600_000)).toISOString();
         const threeMonthsAgo = new Date(Date.now() - (90 * 86_400_000 + 3_600_000)).toISOString();
         const oneYearAgo = new Date(Date.now() - (400 * 86_400_000 + 3_600_000)).toISOString();
         const twoYearsAgo = new Date(Date.now() - (800 * 86_400_000 + 3_600_000)).toISOString();
@@ -279,6 +318,7 @@ describe('SecretDetailView recent access', () => {
             { AccessedBy: 'alice', AccessTime: today, Action: 'read', IPAddress: '' },
             { AccessedBy: 'bob', AccessTime: yesterday, Action: 'read', IPAddress: '' },
             { AccessedBy: 'carol', AccessTime: fiveDaysAgo, Action: 'read', IPAddress: '' },
+            { AccessedBy: 'grace', AccessTime: oneMonthAgo, Action: 'read', IPAddress: '' },
             { AccessedBy: 'frank', AccessTime: threeMonthsAgo, Action: 'read', IPAddress: '' },
             { AccessedBy: 'dave', AccessTime: oneYearAgo, Action: 'read', IPAddress: '' },
             { AccessedBy: 'erin', AccessTime: twoYearsAgo, Action: 'read', IPAddress: '' },
@@ -287,6 +327,7 @@ describe('SecretDetailView recent access', () => {
         expect(screen.getByText('today')).toBeInTheDocument();
         expect(screen.getByText('yesterday')).toBeInTheDocument();
         expect(screen.getByText('5 days ago')).toBeInTheDocument();
+        expect(screen.getByText('1 month ago')).toBeInTheDocument();
         expect(screen.getByText('3 months ago')).toBeInTheDocument();
         expect(screen.getByText('1 year ago')).toBeInTheDocument();
         expect(screen.getByText('2 years ago')).toBeInTheDocument();
@@ -432,6 +473,18 @@ describe('SecretDetailView tags', () => {
         expect(setTagsMutate).not.toHaveBeenCalled();
         expect(input.value).toBe('');
     });
+
+    it('clears the tag draft input after the add mutation succeeds', () => {
+        setTagsMutate.mockImplementationOnce((_tags: string[], opts?: { onSuccess?: () => void }) => {
+            opts?.onSuccess?.();
+        });
+        render(<SecretDetailView secret={makeSecret()} />);
+        const input = screen.getByPlaceholderText(/add a tag/i) as HTMLInputElement;
+        fireEvent.change(input, { target: { value: 'web' } });
+        fireEvent.keyDown(input, { key: 'Enter' });
+        expect(setTagsMutate).toHaveBeenCalledTimes(1);
+        expect(input.value).toBe('');
+    });
 });
 
 describe('SecretDetailView description', () => {
@@ -482,6 +535,21 @@ describe('SecretDetailView description', () => {
         rerender(<SecretDetailView secret={makeSecret()} />);
 
         expect(screen.getByRole('button', { name: /Saving…/i })).toBeInTheDocument();
+    });
+
+    it('clears the draft after the description mutation succeeds', () => {
+        setDescriptionMutate.mockImplementationOnce((_value: string, opts?: { onSuccess?: () => void }) => {
+            opts?.onSuccess?.();
+        });
+        render(<SecretDetailView secret={makeSecret()} />);
+        const box = screen.getByDisplayValue('the prod DB');
+        fireEvent.change(box, { target: { value: 'a saved draft' } });
+        fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+        expect(setDescriptionMutate).toHaveBeenCalledTimes(1);
+        // The mutation's onSuccess clears the draft — back to showing the persisted
+        // description (still mocked as unchanged), and no Save/Cancel buttons.
+        expect(screen.getByDisplayValue('the prod DB')).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /^Save$/i })).not.toBeInTheDocument();
     });
 });
 
@@ -697,6 +765,35 @@ describe('SecretDetailView secret value reveal', () => {
 
             expect(screen.queryByText('sup3r-secret')).not.toBeInTheDocument();
             expect(screen.getByText(/Secret value is hidden/i)).toBeInTheDocument();
+        });
+    });
+
+    describe('copy-success reset', () => {
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('reverts the "Copied!" label back to "Copy" after the timeout elapses', async () => {
+            mockVersions = [
+                { VersionNumber: 1, EncryptedValue: btoa('sup3r-secret'), CreatedAt: '2026-06-10T00:00:00Z' },
+            ];
+            vi.useFakeTimers();
+            render(<SecretDetailView secret={makeSecret()} />);
+
+            fireEvent.click(screen.getByRole('button', { name: /^Reveal$/i }));
+            const copyButtons = screen.getAllByRole('button', { name: /^Copy$/i });
+            await act(async () => {
+                fireEvent.click(copyButtons[copyButtons.length - 1]!);
+                await vi.advanceTimersByTimeAsync(0);
+            });
+            expect(screen.getByText('Copied!')).toBeInTheDocument();
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(2000);
+            });
+
+            expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
+            expect(screen.getAllByRole('button', { name: /^Copy$/i })).toHaveLength(2);
         });
     });
 });

--- a/web/src/features/secrets/__tests__/SecretTableRow.test.tsx
+++ b/web/src/features/secrets/__tests__/SecretTableRow.test.tsx
@@ -267,4 +267,22 @@ describe('SecretTableRow', () => {
         const badge = screen.getByText('password');
         expect(badge.getAttribute('style')).toContain('rgba(99, 102, 241, 0.15)'); // password's darkBg
     });
+
+    it('uses the dark-theme colors when theme is "system" and the OS prefers dark', () => {
+        vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: true } as MediaQueryList);
+        useUIStore.setState({ theme: 'system' });
+        renderRow({ secret: { ...baseSecret, type: 'password' } });
+        const badge = screen.getByText('password');
+        expect(badge.getAttribute('style')).toContain('rgba(99, 102, 241, 0.15)'); // password's darkBg
+        vi.restoreAllMocks();
+    });
+
+    it('uses the light-theme colors when theme is "system" and the OS does not prefer dark', () => {
+        vi.spyOn(window, 'matchMedia').mockReturnValue({ matches: false } as MediaQueryList);
+        useUIStore.setState({ theme: 'system' });
+        renderRow({ secret: { ...baseSecret, type: 'password' } });
+        const badge = screen.getByText('password');
+        expect(badge.getAttribute('style')).toContain('rgb(224, 231, 255)'); // password's lightBg (#e0e7ff)
+        vi.restoreAllMocks();
+    });
 });

--- a/web/src/features/secrets/__tests__/TransferOwnership.test.tsx
+++ b/web/src/features/secrets/__tests__/TransferOwnership.test.tsx
@@ -135,6 +135,33 @@ describe('TransferOwnership', () => {
         consoleErrorSpy.mockRestore();
     });
 
+    it('does not update state from a search that rejects after the query changed (cancelled)', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        let rejectSearch!: (err: unknown) => void;
+        vi.mocked(usersApi.search).mockImplementationOnce(
+            () =>
+                new Promise((_resolve, reject) => {
+                    rejectSearch = reject;
+                })
+        );
+        const { unmount } = render(<TransferOwnership secretId={1} currentOwner="bob" />);
+        fireEvent.click(screen.getByText('Transfer ownership'));
+        fireEvent.change(screen.getByPlaceholderText(/Search by name/i), { target: { value: 'a' } });
+
+        // Wait for the 200ms debounce to fire and invoke usersApi.search.
+        await waitFor(() => expect(usersApi.search).toHaveBeenCalledWith('a'));
+
+        // Unmount before the search rejects — the effect cleanup marks it cancelled, so the
+        // catch block's `if (!cancelled)` guard must skip the setResults([]) call.
+        unmount();
+        rejectSearch(new Error('network down'));
+        await Promise.resolve();
+
+        // No "state update on an unmounted component" warning was logged.
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+        consoleErrorSpy.mockRestore();
+    });
+
     it('shows the pending label while a transfer is in flight', () => {
         mockTransferState = { isPending: true, isError: false, error: null };
         render(<TransferOwnership secretId={1} currentOwner="bob" />);

--- a/web/src/features/sharing/__tests__/ShareSecretModal.test.tsx
+++ b/web/src/features/sharing/__tests__/ShareSecretModal.test.tsx
@@ -148,6 +148,96 @@ describe('ShareSecretModal recipient search', () => {
         expect(await screen.findByText(/No users found/)).toBeInTheDocument();
     });
 
+    // Unlike the test above (where "No users found" is also the dropdown's default
+    // empty state, so it can pass before the fetch ever settles), this waits for the
+    // in-flight "Searching…" state first and only then rejects — so the assertion can
+    // only succeed if the effect's catch handler actually ran.
+    it('reaches the catch handler and clears results when a fetch genuinely rejects mid-flight', async () => {
+        let rejectSearch: (e: Error) => void = () => {};
+        searchImpl = () =>
+            new Promise((_resolve, reject) => {
+                rejectSearch = reject;
+            });
+
+        render(<ShareSecretModal secret={secret} isOpen onClose={() => {}} />);
+        fireEvent.change(screen.getByPlaceholderText(/Search by name/i), { target: { value: 'bob' } });
+
+        expect(await screen.findByText('Searching…')).toBeInTheDocument();
+        rejectSearch(new Error('network down'));
+        expect(await screen.findByText(/No users found/)).toBeInTheDocument();
+    });
+
+    // "No users found" is also the dropdown's default empty state, so a search that
+    // starts from empty results can't prove this ran. Show a real match first, then
+    // switch to a response missing the `users` field and wait for the transition
+    // back to "No users found" — that can only happen via the `?? []` fallback.
+    it('falls back to an empty result list when the search response omits the users field', async () => {
+        render(<ShareSecretModal secret={secret} isOpen onClose={() => {}} />);
+        fireEvent.change(screen.getByPlaceholderText(/Search by name/i), { target: { value: 'bob' } });
+        await screen.findByText('Bob');
+
+        searchImpl = async () => ({}) as unknown as { users: unknown[] };
+        fireEvent.change(screen.getByPlaceholderText(/Search by name/i), { target: { value: 'zzz' } });
+
+        expect(await screen.findByText(/No users found/)).toBeInTheDocument();
+    });
+
+    // Regression / race-condition guard: if the query changes again before an
+    // in-flight search settles, the stale response must be ignored so it can't
+    // clobber results/loading state that belong to the newer query.
+    it('ignores a stale successful response for a query that was superseded before it resolved', async () => {
+        let callCount = 0;
+        let resolveFirst: (v: { users: unknown[] }) => void = () => {};
+        searchImpl = async () => {
+            callCount += 1;
+            if (callCount === 1) {
+                return new Promise<{ users: unknown[] }>((resolve) => {
+                    resolveFirst = resolve;
+                });
+            }
+            return { users: [{ id: 9, username: 'carol', display_name: 'Carol', email: 'carol@test.com' }] };
+        };
+
+        render(<ShareSecretModal secret={secret} isOpen onClose={() => {}} />);
+        fireEvent.change(screen.getByPlaceholderText(/Search by name/i), { target: { value: 'bo' } });
+        expect(await screen.findByText('Searching…')).toBeInTheDocument();
+
+        fireEvent.change(screen.getByPlaceholderText(/Search by name/i), { target: { value: 'car' } });
+        expect(await screen.findByText('Carol')).toBeInTheDocument();
+
+        // Resolve the superseded first request only after the second has already won.
+        resolveFirst({ users: [{ id: 1, username: 'stale', display_name: 'Stale', email: 'stale@test.com' }] });
+        await waitFor(() => expect(screen.queryByText('Stale')).not.toBeInTheDocument());
+        expect(screen.getByText('Carol')).toBeInTheDocument();
+    });
+
+    // Same guard, but for the catch path: a superseded request that later rejects
+    // must not be allowed to clear results that belong to the newer, already-resolved query.
+    it('ignores a stale rejected response for a query that was superseded before it settled', async () => {
+        let callCount = 0;
+        let rejectFirst: (e: Error) => void = () => {};
+        searchImpl = async () => {
+            callCount += 1;
+            if (callCount === 1) {
+                return new Promise<{ users: unknown[] }>((_resolve, reject) => {
+                    rejectFirst = reject;
+                });
+            }
+            return { users: [{ id: 9, username: 'carol', display_name: 'Carol', email: 'carol@test.com' }] };
+        };
+
+        render(<ShareSecretModal secret={secret} isOpen onClose={() => {}} />);
+        fireEvent.change(screen.getByPlaceholderText(/Search by name/i), { target: { value: 'bo' } });
+        expect(await screen.findByText('Searching…')).toBeInTheDocument();
+
+        fireEvent.change(screen.getByPlaceholderText(/Search by name/i), { target: { value: 'car' } });
+        expect(await screen.findByText('Carol')).toBeInTheDocument();
+
+        rejectFirst(new Error('stale network error'));
+        await waitFor(() => expect(screen.getByText('Carol')).toBeInTheDocument());
+        expect(screen.queryByText(/No users found/)).not.toBeInTheDocument();
+    });
+
     it('falls back to username when a matched user has no display name', async () => {
         searchImpl = async () => ({
             users: [{ id: 8, username: 'nodisplay', display_name: '', email: 'nd@test.com' }],
@@ -181,6 +271,18 @@ describe('ShareSecretModal recipient search', () => {
         expect(screen.queryByText('Bob')).not.toBeInTheDocument();
     });
 
+    // Counterpart to the "outside click" test above: a mousedown that lands inside
+    // the search input itself is not "outside", so the dropdown must stay open.
+    it('keeps the dropdown open when the click lands on the search input itself', async () => {
+        render(<ShareSecretModal secret={secret} isOpen onClose={() => {}} />);
+        const input = screen.getByPlaceholderText(/Search by name/i);
+        fireEvent.change(input, { target: { value: 'bob' } });
+        await screen.findByText('Bob');
+
+        fireEvent.mouseDown(input);
+        expect(screen.getByText('Bob')).toBeInTheDocument();
+    });
+
     it('reopens the dropdown on focus when a query is already present', async () => {
         render(<ShareSecretModal secret={secret} isOpen onClose={() => {}} />);
         const input = screen.getByPlaceholderText(/Search by name/i);
@@ -190,6 +292,14 @@ describe('ShareSecretModal recipient search', () => {
 
         fireEvent.focus(input);
         expect(await screen.findByText('Bob')).toBeInTheDocument();
+    });
+
+    it('does not reopen the dropdown on focus when the query is empty', () => {
+        render(<ShareSecretModal secret={secret} isOpen onClose={() => {}} />);
+        const input = screen.getByPlaceholderText(/Search by name/i);
+
+        fireEvent.focus(input);
+        expect(screen.queryByText(/No users found/)).not.toBeInTheDocument();
     });
 });
 

--- a/web/src/pages/admin/__tests__/OIDCFederationSection.test.tsx
+++ b/web/src/pages/admin/__tests__/OIDCFederationSection.test.tsx
@@ -97,6 +97,23 @@ describe('OIDCFederationSection — list states', () => {
         expect(screen.getByText('—')).toBeInTheDocument();
     });
 
+    it('falls back to the raw string when date formatting throws', async () => {
+        // toLocaleDateString doesn't throw for merely-unparseable strings (it returns
+        // "Invalid Date"), so force the underlying formatter to throw to exercise
+        // formatDate's defensive catch branch.
+        const toLocaleDateStringSpy = vi.spyOn(Date.prototype, 'toLocaleDateString').mockImplementation(() => {
+            throw new RangeError('Invalid time value');
+        });
+        try {
+            mockGet.mockResolvedValue({ data: { data: [{ ...trustConfig, created_at: 'not-a-real-date' }] } });
+            render(<OIDCFederationSection serviceAccounts={serviceAccounts} />);
+            expect(await screen.findByText('github-deploy')).toBeInTheDocument();
+            expect(screen.getByText('not-a-real-date')).toBeInTheDocument();
+        } finally {
+            toLocaleDateStringSpy.mockRestore();
+        }
+    });
+
     it('falls back to an empty list when the response has no data field', async () => {
         mockGet.mockResolvedValue({ data: {} });
         render(<OIDCFederationSection serviceAccounts={serviceAccounts} />);

--- a/web/src/pages/admin/__tests__/RolesPoliciesPage.test.tsx
+++ b/web/src/pages/admin/__tests__/RolesPoliciesPage.test.tsx
@@ -186,6 +186,21 @@ describe('RolesPoliciesPage — roles list states', () => {
         fireEvent.mouseEnter(deleteButton);
         expect(deleteButton.style.color).toBe('var(--text-muted)');
     });
+
+    it('skips the hover tint inside the handler itself when the built-in guard is exercised directly', () => {
+        // Browsers (and jsdom) never dispatch mouse events to a `disabled` button, so the
+        // "does not tint" test above never actually runs the `if (!builtIn)` guard body —
+        // it only shows the color was never touched because no event fired at all. Forcing
+        // the DOM node's `disabled` flag off just before dispatching lets the mouseenter
+        // event reach the same onMouseEnter closure (which still reads `builtIn` from the
+        // admin role's render, not from the DOM), genuinely exercising the guard's skip path.
+        render(<RolesPoliciesPage />);
+        const adminCard = getRoleCard('admin');
+        const deleteButton = within(adminCard).getByTitle('Built-in roles cannot be deleted') as HTMLButtonElement;
+        deleteButton.disabled = false;
+        fireEvent.mouseEnter(deleteButton);
+        expect(deleteButton.style.color).toBe('var(--text-muted)');
+    });
 });
 
 describe('RolesPoliciesPage — create role', () => {
@@ -244,6 +259,25 @@ describe('RolesPoliciesPage — create role', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Close' }));
         expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        expect(createMutate).not.toHaveBeenCalled();
+    });
+
+    it("guards handleCreate against an empty name even if the disabled Create button's disabled state is bypassed", () => {
+        // The Create button's `disabled` prop and handleCreate's own
+        // `if (!formData.name.trim()) return;` guard both derive from the same
+        // `formData.name`, so a normal click can never reach the guard's true branch.
+        // Forcing the disabled attribute off (same rationale as the built-in hover-guard
+        // test above) lets us verify the internal guard independently still protects
+        // against submitting an empty name, in case the disabled wiring ever regresses.
+        render(<RolesPoliciesPage />);
+        fireEvent.click(screen.getByRole('button', { name: 'New Role' }));
+
+        const dialog = screen.getByRole('dialog');
+        const createButton = within(dialog).getByRole('button', { name: 'Create' }) as HTMLButtonElement;
+        expect(createButton).toBeDisabled();
+
+        createButton.disabled = false;
+        fireEvent.click(createButton);
         expect(createMutate).not.toHaveBeenCalled();
     });
 });

--- a/web/src/pages/admin/__tests__/UserDetailPage.test.tsx
+++ b/web/src/pages/admin/__tests__/UserDetailPage.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
-import { render, screen, fireEvent, within, waitFor } from '../../../test/test-utils';
+import { render, screen, fireEvent, within, waitFor, act } from '../../../test/test-utils';
 import { UserDetailPage } from '../UserDetailPage';
 
 let userData: Record<string, unknown> | null;
@@ -396,6 +396,16 @@ describe('UserDetailPage — account action confirm flows', () => {
 });
 
 describe('UserDetailPage — resend setup link', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    // Note: copyLink() also guards on `!resentLink?.link_for_admin` before copying, but
+    // ResentLinkPanel applies that exact same check before it ever renders the Copy button
+    // (see ResentLinkPanel in UserDetailPage.tsx) — so that guard's early-return branch can
+    // never actually be reached by clicking through the UI. It isn't exercised here for the
+    // same reason formatDate's catch branch isn't (see the "date formatting" describe above).
+
     it('shows the single-use link panel and lets the admin copy it', async () => {
         resendMutate.mockImplementation((_id, opts) => opts.onSuccess({ link_for_admin: 'https://x/setup/abc' }));
         userData = { ...baseUser, account_state: 'pending_first_login' };
@@ -438,6 +448,25 @@ describe('UserDetailPage — resend setup link', () => {
         await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalled());
         expect(screen.getByText('https://x/setup/abc')).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: 'Copied' })).not.toBeInTheDocument();
+    });
+
+    it('reverts the Copy button label back to "Copy" after the timeout elapses', async () => {
+        resendMutate.mockImplementation((_id, opts) => opts.onSuccess({ link_for_admin: 'https://x/setup/abc' }));
+        userData = { ...baseUser, account_state: 'pending_first_login' };
+        vi.useFakeTimers();
+        render(<UserDetailPage />);
+        fireEvent.click(screen.getByRole('button', { name: 'Resend setup link' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(2000);
+        });
+        expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
     });
 });
 

--- a/web/src/pages/audit/__tests__/AuditLogPage.test.tsx
+++ b/web/src/pages/audit/__tests__/AuditLogPage.test.tsx
@@ -212,6 +212,13 @@ describe('AuditLogPage — Anomaly Alerts tab', () => {
         fireEvent.click(screen.getByRole('button', { name: /anomaly alerts/i }));
         expect(screen.getByText('No anomalies detected')).toBeInTheDocument();
     });
+
+    it('shows a spinner while anomalies are loading', () => {
+        mockAnomalies([], true);
+        const { container } = render(<AuditLogPage />);
+        fireEvent.click(screen.getByRole('button', { name: /anomaly alerts/i }));
+        expect(container.querySelector('svg.animate-spin')).toBeInTheDocument();
+    });
 });
 
 describe('AuditLogPage — initial tab from URL', () => {
@@ -382,6 +389,26 @@ describe('AuditLogPage — theme variants', () => {
         render(<AuditLogPage />);
         expect(screen.getByText('alice')).toBeInTheDocument();
     });
+
+    it('applies default severity styling in light theme for an unrecognized severity value', () => {
+        useUIStore.setState({ theme: 'light' });
+        mockAnomalies([
+            {
+                ID: 5,
+                AlertType: 'geo_anomaly',
+                SecretName: 'mystery-key',
+                AccessedBy: 'zoe',
+                IPAddress: '10.0.0.9',
+                Severity: 'unmapped',
+                DetectedAt: '2026-01-05T00:00:00Z',
+                Acknowledged: false,
+                Description: '',
+            },
+        ]);
+        render(<AuditLogPage />);
+        fireEvent.click(screen.getByRole('button', { name: /anomaly alerts/i }));
+        expect(screen.getByText('mystery-key')).toBeInTheDocument();
+    });
 });
 
 describe('AuditLogPage — URL filters', () => {
@@ -534,8 +561,9 @@ describe('AuditLogPage — anomaly table filtering and sorting', () => {
 
     function openAnomalies() {
         mockAnomalies(richAlerts);
-        render(<AuditLogPage />);
+        const utils = render(<AuditLogPage />);
         fireEvent.click(screen.getByRole('button', { name: /anomaly alerts/i }));
+        return utils;
     }
 
     it('renders a "—" for a missing detected-at timestamp and an unrecognized severity with default styling', () => {
@@ -575,11 +603,46 @@ describe('AuditLogPage — anomaly table filtering and sorting', () => {
         fireEvent.click(screen.getByRole('button', { name: /secret/i }));
         fireEvent.click(screen.getByRole('button', { name: /actor/i }));
         fireEvent.click(screen.getByRole('button', { name: /severity/i }));
-        // Toggle the same column twice to flip sort direction.
+        // Toggle the same column twice more to flip sort direction back and forth (desc -> asc -> desc).
+        fireEvent.click(screen.getByRole('button', { name: /severity/i }));
         fireEvent.click(screen.getByRole('button', { name: /severity/i }));
 
         const table = within(screen.getByRole('table'));
         expect(table.getByText('db-password')).toBeInTheDocument();
+    });
+
+    it('sorts by severity when two alerts both have an unrecognized severity value', () => {
+        mockAnomalies([
+            {
+                ID: 10,
+                AlertType: 'geo_anomaly',
+                SecretName: 'first-key',
+                AccessedBy: 'amy',
+                IPAddress: '10.0.0.10',
+                Severity: 'unmapped',
+                DetectedAt: '2026-01-06T00:00:00Z',
+                Acknowledged: false,
+                Description: '',
+            },
+            {
+                ID: 11,
+                AlertType: 'bulk_download',
+                SecretName: 'second-key',
+                AccessedBy: 'ben',
+                IPAddress: '10.0.0.11',
+                Severity: 'unmapped',
+                DetectedAt: '2026-01-07T00:00:00Z',
+                Acknowledged: false,
+                Description: '',
+            },
+        ]);
+        render(<AuditLogPage />);
+        fireEvent.click(screen.getByRole('button', { name: /anomaly alerts/i }));
+        fireEvent.click(screen.getByRole('button', { name: /severity/i }));
+
+        const table = within(screen.getByRole('table'));
+        expect(table.getByText('first-key')).toBeInTheDocument();
+        expect(table.getByText('second-key')).toBeInTheDocument();
     });
 
     it('expands a high-severity row and a low-severity row, then collapses', () => {
@@ -590,5 +653,17 @@ describe('AuditLogPage — anomaly table filtering and sorting', () => {
 
         fireEvent.click(screen.getByText('zeta-key')); // unknown severity -> expand
         expect(screen.getByText('#3')).toBeInTheDocument();
+    });
+
+    it('shows a "—" detected-at and "Acknowledged" status in the expanded detail panel for an acknowledged alert with no detected-at time', () => {
+        const { container } = openAnomalies();
+        // Reveal acknowledged alerts too (bulk_download/api-key is Acknowledged: true, DetectedAt: '').
+        fireEvent.click(screen.getAllByRole('button', { name: 'All' })[1]);
+
+        fireEvent.click(screen.getByText('api-key')); // expand
+
+        const statusSpan = container.querySelector('span.text-emerald-600');
+        expect(statusSpan).toHaveTextContent('Acknowledged');
+        expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
     });
 });

--- a/web/src/pages/auth/__tests__/SSOCompletePage.test.tsx
+++ b/web/src/pages/auth/__tests__/SSOCompletePage.test.tsx
@@ -59,6 +59,13 @@ describe('SSOCompletePage', () => {
         await waitFor(() => expect(mockComplete).toHaveBeenCalledWith('2026-12-31T00:00:00Z', '2027-01-01T00:00:00Z'));
     });
 
+    it('passes undefined for expires_at when the fragment omits it', async () => {
+        window.location.hash = '#return_to=/secrets';
+        render(<SSOCompletePage />);
+        await waitFor(() => expect(mockComplete).toHaveBeenCalledWith(undefined, undefined));
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/secrets', { replace: true }));
+    });
+
     it('redirects to /login with a generic error when completeSSOLogin rejects', async () => {
         mockComplete.mockRejectedValueOnce(new Error('network down'));
         window.location.hash = '#expires_at=2026-12-31T00:00:00Z';

--- a/web/src/pages/billing/__tests__/BillingPage.test.tsx
+++ b/web/src/pages/billing/__tests__/BillingPage.test.tsx
@@ -137,6 +137,15 @@ describe('BillingPage', () => {
         expect(screen.getByText('No secrets or activity recorded for any project in this window.')).toBeInTheDocument();
     });
 
+    it('falls back to "(project <id>)" when a project has no name', () => {
+        const report = sampleReport();
+        report.projects[0].projectName = '';
+        useBillingReportMock.mockReturnValue(reportState({ report }));
+        render(<BillingPage />);
+
+        expect(screen.getByText('(project 1)')).toBeInTheDocument();
+    });
+
     it('defaults to the "This month" preset and recomputes the window on preset change', () => {
         render(<BillingPage />);
 
@@ -158,5 +167,34 @@ describe('BillingPage', () => {
 
         const lastCall = useBillingReportMock.mock.calls[useBillingReportMock.mock.calls.length - 1][0];
         expect(lastCall.from).toBe('2026-01-05T00:00:00Z');
+    });
+
+    it('switches to a custom range when the "To date" input is edited directly', () => {
+        render(<BillingPage />);
+
+        fireEvent.change(screen.getByLabelText('To date'), { target: { value: '2026-01-20' } });
+
+        const lastCall = useBillingReportMock.mock.calls[useBillingReportMock.mock.calls.length - 1][0];
+        expect(lastCall.to).toBe('2026-01-20T00:00:00Z');
+    });
+
+    it('computes the "Last month" window', () => {
+        render(<BillingPage />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Last month' }));
+
+        const lastCall = useBillingReportMock.mock.calls[useBillingReportMock.mock.calls.length - 1][0];
+        expect(lastCall.from).toBe(new Date(Date.UTC(2026, 0, 1)).toISOString());
+        expect(lastCall.to).toBe(new Date(Date.UTC(2026, 1, 1)).toISOString());
+    });
+
+    it('computes the "Last 90 days" window', () => {
+        render(<BillingPage />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Last 90 days' }));
+
+        const lastCall = useBillingReportMock.mock.calls[useBillingReportMock.mock.calls.length - 1][0];
+        expect(lastCall.from).toBe(new Date(Date.UTC(2026, 1, 15) - 90 * 86_400_000).toISOString());
+        expect(lastCall.to).toBe(new Date(Date.UTC(2026, 1, 15)).toISOString());
     });
 });

--- a/web/src/pages/compliance/__tests__/CompliancePage.test.tsx
+++ b/web/src/pages/compliance/__tests__/CompliancePage.test.tsx
@@ -459,7 +459,12 @@ describe('CompliancePage posture panel', () => {
     // a control can never actually reach this component missing one. Forcing a
     // missing key in test data to exercise the fallback instead crashes `refLine`
     // just above (`c.frameworks.iso27001.length` with no guard), which assumes the
-    // same invariant. Left uncovered as defensive-only dead code.
+    // same invariant. Tried excluding the malformed control from the rendered list
+    // by filtering it out on the target framework tab — doesn't help: the panel
+    // mounts with `activeFramework` defaulted to `'all'`, which renders (and calls
+    // refLine on) every control before any tab click, so the crash happens on the
+    // very first render regardless of which framework is later selected. Left
+    // uncovered as defensive-only dead code.
 
     it('uses the warning color for a mid-range per-framework compliance score', async () => {
         (complianceApi.getPosture as any).mockResolvedValue(posture);

--- a/web/src/pages/dashboard/__tests__/DashboardPage.test.tsx
+++ b/web/src/pages/dashboard/__tests__/DashboardPage.test.tsx
@@ -194,6 +194,18 @@ describe('DashboardPage — operational signals', () => {
         expect(screen.getByText('within 30 days')).toBeInTheDocument();
     });
 
+    it('shows "alert" severity colors in light theme when failed auth attempts are high', () => {
+        useUIStore.setState({ theme: 'light' });
+        mockHooks({ stats: { ...baseStats, failedAuthAttempts24h: 5 } });
+        render(<DashboardPage />);
+        const card = screen.getByText('Failed Auth (24h)').closest('button')!;
+        expect(card).toHaveStyle({
+            backgroundColor: 'rgba(239,68,68,0.06)',
+            borderColor: 'rgba(239,68,68,0.30)',
+            color: '#991b1b',
+        });
+    });
+
     it('shows the expired-count hint when a secret has already expired', () => {
         mockHooks({
             stats: {
@@ -414,6 +426,30 @@ describe('DashboardPage — recent activity edge cases', () => {
         render(<DashboardPage />);
         expect(screen.getByText('carol')).toBeInTheDocument();
         expect(screen.getByText('custom_event')).toBeInTheDocument();
+    });
+});
+
+describe('DashboardPage — greeting by time of day', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('shows "Good morning" before noon', () => {
+        vi.setSystemTime(new Date('2026-01-01T08:00:00'));
+        render(<DashboardPage />);
+        expect(screen.getByText('Good morning')).toBeInTheDocument();
+    });
+
+    it('shows "Good afternoon" between noon and 6pm', () => {
+        vi.setSystemTime(new Date('2026-01-01T14:00:00'));
+        render(<DashboardPage />);
+        expect(screen.getByText('Good afternoon')).toBeInTheDocument();
+    });
+
+    it('shows "Good evening" from 6pm onward', () => {
+        vi.setSystemTime(new Date('2026-01-01T20:00:00'));
+        render(<DashboardPage />);
+        expect(screen.getByText('Good evening')).toBeInTheDocument();
     });
 });
 

--- a/web/src/pages/integrations/__tests__/KeyorixConnectPage.test.tsx
+++ b/web/src/pages/integrations/__tests__/KeyorixConnectPage.test.tsx
@@ -99,6 +99,31 @@ describe('KeyorixConnectPage', () => {
         await waitFor(() => expect(screen.getByText('s3cr3t')).toBeInTheDocument());
     });
 
+    it('surfaces an error when the re-fetch triggered by re-revealing after a hide fails', async () => {
+        readMutate
+            .mockImplementationOnce((_vars, opts) =>
+                opts.onSuccess({ connector: 'prod-aws', ref: 'prod/db', value: 's3cr3t' })
+            )
+            .mockImplementationOnce((_vars, opts) =>
+                opts.onError({ response: { data: { message: 're-fetch failed' } } })
+            );
+        render(<KeyorixConnectPage />);
+
+        fireEvent.change(screen.getByLabelText('Reference'), { target: { value: 'prod/db' } });
+        fireEvent.click(screen.getByRole('button', { name: /Read secret/i }));
+        fireEvent.click(screen.getByRole('button', { name: /Reveal value/i }));
+        await waitFor(() => expect(screen.getByText('s3cr3t')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole('button', { name: /Hide value/i }));
+        fireEvent.click(screen.getByRole('button', { name: /Reveal value/i }));
+
+        expect(readMutate).toHaveBeenCalledTimes(2);
+        // The failed re-fetch must not flip `revealed` — the toggle stays a
+        // "Reveal" affordance, not a stale/incorrect "Hide".
+        expect(screen.getByRole('button', { name: /Reveal value/i })).toBeInTheDocument();
+        expect(screen.getByText('re-fetch failed')).toBeInTheDocument();
+    });
+
     it('clears the fetched value on unmount without throwing', () => {
         readMutate.mockImplementation((_vars, opts) =>
             opts.onSuccess({ connector: 'prod-aws', ref: 'prod/db', value: 's3cr3t' })
@@ -261,6 +286,68 @@ describe('KeyorixConnectPage — federated read panel additional coverage', () =
         connectorsState = { data: [], isLoading: false, isError: true };
         render(<KeyorixConnectPage />);
         expect(screen.getByText('Could not load connectors')).toBeInTheDocument();
+    });
+
+    it('defaults to an empty connector when the configured list has no non-empty entries', () => {
+        connectorsState = { data: [''], isLoading: false, isError: false };
+        render(<KeyorixConnectPage />);
+        fireEvent.change(screen.getByLabelText('Reference'), { target: { value: 'prod/db' } });
+        fireEvent.click(screen.getByRole('button', { name: /Read secret/i }));
+        expect(readMutate).toHaveBeenCalledWith({ connector: '', ref: 'prod/db' }, expect.anything());
+    });
+
+    it('ignores a Copy click once Hide has cleared the value back to null', async () => {
+        readMutate.mockImplementation((_vars, opts) =>
+            opts.onSuccess({ connector: 'prod-aws', ref: 'prod/db', value: 's3cr3t' })
+        );
+        render(<KeyorixConnectPage />);
+        fireEvent.change(screen.getByLabelText('Reference'), { target: { value: 'prod/db' } });
+        fireEvent.click(screen.getByRole('button', { name: /Read secret/i }));
+        fireEvent.click(screen.getByRole('button', { name: /Reveal value/i }));
+        await waitFor(() => expect(screen.getByText('s3cr3t')).toBeInTheDocument());
+
+        fireEvent.click(screen.getByRole('button', { name: /Hide value/i }));
+        const callsBeforeClick = vi.mocked(navigator.clipboard.writeText).mock.calls.length;
+
+        const copyButton = screen.getByRole('button', { name: 'Copy value' });
+        expect(copyButton).toBeDisabled();
+        fireEvent.click(copyButton);
+
+        expect(vi.mocked(navigator.clipboard.writeText).mock.calls.length).toBe(callsBeforeClick);
+    });
+
+    it('reverts the copy icon back to clipboard once the copied indicator times out', async () => {
+        readMutate.mockImplementation((_vars, opts) =>
+            opts.onSuccess({ connector: 'prod-aws', ref: 'prod/db', value: 's3cr3t' })
+        );
+        // Fake timers must be active before the Copy click so the 1500ms
+        // reset timer it schedules is itself a fake timer (see the G28 idle
+        // test below for why enabling fake timers afterward wouldn't work).
+        vi.useFakeTimers();
+        try {
+            render(<KeyorixConnectPage />);
+            fireEvent.change(screen.getByLabelText('Reference'), { target: { value: 'prod/db' } });
+            fireEvent.click(screen.getByRole('button', { name: /Read secret/i }));
+
+            const copyButton = screen.getByRole('button', { name: 'Copy value' });
+            const before = copyButton.innerHTML;
+            fireEvent.click(copyButton);
+
+            // copyToClipboard awaits navigator.clipboard.writeText (an already-
+            // resolved mock) before flipping the icon; flush that microtask.
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(0);
+            });
+            expect(navigator.clipboard.writeText).toHaveBeenCalledWith('s3cr3t');
+            expect(copyButton.innerHTML).not.toBe(before);
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(1500);
+            });
+            expect(copyButton.innerHTML).toBe(before);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('reads from an explicitly selected connector', () => {

--- a/web/src/pages/integrations/__tests__/SdksPage.test.tsx
+++ b/web/src/pages/integrations/__tests__/SdksPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '../../../test/test-utils';
+import { render, screen, fireEvent, waitFor, act } from '../../../test/test-utils';
 import { SdksPage } from '../SdksPage';
 
 describe('SdksPage', () => {
@@ -49,5 +49,35 @@ describe('SdksPage', () => {
         fireEvent.click(copyButtons[0]!);
 
         await waitFor(() => expect(writeText).toHaveBeenCalled());
+    });
+
+    it('reverts the copy icon back to clipboard once the copied indicator times out', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.assign(navigator, { clipboard: { writeText } });
+
+        // Fake timers must be active before the click so the 1500ms reset
+        // timer it schedules is itself a fake timer.
+        vi.useFakeTimers();
+        try {
+            render(<SdksPage />);
+            const copyButton = screen.getAllByRole('button', { name: 'Copy to clipboard' })[0]!;
+            const before = copyButton.innerHTML;
+            fireEvent.click(copyButton);
+
+            // copyToClipboard awaits navigator.clipboard.writeText (an already-
+            // resolved mock) before flipping the icon; flush that microtask.
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(0);
+            });
+            expect(writeText).toHaveBeenCalled();
+            expect(copyButton.innerHTML).not.toBe(before);
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(1500);
+            });
+            expect(copyButton.innerHTML).toBe(before);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/web/src/pages/profile/__tests__/ProfilePage.test.tsx
+++ b/web/src/pages/profile/__tests__/ProfilePage.test.tsx
@@ -489,7 +489,14 @@ describe('ProfilePage — Basic Info tab additional coverage', () => {
         render(<ProfilePage />);
         expect(screen.getByLabelText('Display Name')).toHaveValue('');
         expect(screen.getByLabelText('Email')).toHaveValue('');
+        // Required fields must be filled for the form to actually submit (jsdom
+        // enforces native HTML5 required-field validation) — the point of this
+        // test is what happens once onSuccess fires with no signed-in user, not
+        // the empty-fallback rendering checked just above.
+        fireEvent.change(screen.getByLabelText('Display Name'), { target: { value: 'X' } });
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'x@example.com' } });
         fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+        expect(mocks.updateProfileMutate).toHaveBeenCalled();
         expect(mocks.setUser).not.toHaveBeenCalled();
         (mocks as { user: unknown }).user = originalUser;
     });

--- a/web/src/pages/projects/__tests__/ProjectAccessReviewCampaigns.test.tsx
+++ b/web/src/pages/projects/__tests__/ProjectAccessReviewCampaigns.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '../../../test/test-utils';
-import { ProjectAccessReviewCampaigns } from '../ProjectAccessReviewCampaigns';
+import { ProjectAccessReviewCampaigns, lastUsedInfo } from '../ProjectAccessReviewCampaigns';
 
 const mockUseCampaigns = vi.fn();
 const mockUseCampaign = vi.fn();
@@ -254,5 +254,90 @@ describe('ProjectAccessReviewCampaigns', () => {
         expect(screen.getByText('All items decided')).toBeInTheDocument();
         fireEvent.click(screen.getByText('Close campaign'));
         expect(mockCloseMutate).toHaveBeenCalledWith({ campaignId: 1, force: false }, expect.any(Object));
+    });
+
+    it('toggles the detail panel closed when "Hide" is clicked', () => {
+        mockUseCampaigns.mockReturnValue({ data: campaigns, isLoading: false });
+        render(<ProjectAccessReviewCampaigns projectId={2} />);
+        fireEvent.click(screen.getByText('Review'));
+        expect(screen.getByText(/alice/)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Hide'));
+        expect(screen.queryByText(/alice/)).not.toBeInTheDocument();
+        expect(screen.getByText('Review')).toBeInTheDocument();
+    });
+
+    it('computes a non-today "used Nd ago" label for a principal used several days back', () => {
+        // lastUsedInfo's label isn't rendered in the DOM directly (only its `dormant` flag
+        // drives the " · dormant" suffix), so exercise the exported pure function itself for
+        // the "used Nd ago" / not-dormant branch (5 days is under the 90-day dormancy cutoff).
+        const fiveDaysAgo = new Date(Date.now() - 5 * 86_400_000).toISOString();
+        const info = lastUsedInfo({ principalType: 'user', lastUsedAt: fiveDaysAgo });
+        expect(info).toEqual({ label: 'used 5d ago', dormant: false });
+    });
+
+    it('computes a "used today" label for a principal used moments ago', () => {
+        const info = lastUsedInfo({ principalType: 'user', lastUsedAt: new Date().toISOString() });
+        expect(info).toEqual({ label: 'used today', dormant: false });
+    });
+
+    it('marks a principal dormant once its last use crosses the 90-day cutoff', () => {
+        const ninetyDaysAgo = new Date(Date.now() - 90 * 86_400_000).toISOString();
+        const info = lastUsedInfo({ principalType: 'user', lastUsedAt: ninetyDaysAgo });
+        expect(info).toEqual({ label: 'used 90d ago', dormant: true });
+    });
+
+    it('returns an empty, non-dormant label for group principals (no aggregated last-use)', () => {
+        const info = lastUsedInfo({ principalType: 'group', lastUsedAt: undefined });
+        expect(info).toEqual({ label: '', dormant: false });
+    });
+
+    it('falls back to the role placeholder "—" when a role-sourced item has no role name', () => {
+        mockUseCampaigns.mockReturnValue({ data: campaigns, isLoading: false });
+        mockUseCampaign.mockReturnValue({
+            data: {
+                ...detail,
+                // lastUsedAt is set (recently) so the dormant " · dormant" suffix doesn't get
+                // appended to the same text node, which would break an exact-text match below.
+                items: [
+                    { ...detail.items[0], id: 31, roleName: '', source: 'role', lastUsedAt: new Date().toISOString() },
+                ],
+            },
+            isLoading: false,
+        });
+        render(<ProjectAccessReviewCampaigns projectId={2} />);
+        fireEvent.click(screen.getByText('Review'));
+        expect(screen.getByText('Role: —')).toBeInTheDocument();
+    });
+
+    it('clears the revoke confirmation once the decision succeeds', () => {
+        mockUseCampaigns.mockReturnValue({ data: campaigns, isLoading: false });
+        mockDecideMutate.mockImplementationOnce((_vars, opts) => opts.onSuccess());
+        render(<ProjectAccessReviewCampaigns projectId={2} />);
+        fireEvent.click(screen.getByText('Review'));
+
+        fireEvent.click(screen.getByText('Revoke'));
+        fireEvent.click(screen.getByText('Confirm'));
+        // onSuccess cleared confirmItem, so the item is back to its unconfirmed "Revoke" state.
+        expect(screen.queryByText('Confirm')).not.toBeInTheDocument();
+        expect(screen.getByText('Revoke')).toBeInTheDocument();
+    });
+
+    it('falls back to the response message when no error field is present', () => {
+        mockUseCampaigns.mockReturnValue({ data: [], isLoading: false });
+        mockOpenMutate.mockImplementationOnce((_name, opts) =>
+            opts.onError({ response: { data: { message: 'message only' } } })
+        );
+        render(<ProjectAccessReviewCampaigns projectId={2} />);
+        fireEvent.click(screen.getByText('Open'));
+        expect(screen.getByText('message only')).toBeInTheDocument();
+    });
+
+    it('falls back to the generic "Action failed." message when the error has no details', () => {
+        mockUseCampaigns.mockReturnValue({ data: [], isLoading: false });
+        mockOpenMutate.mockImplementationOnce((_name, opts) => opts.onError({}));
+        render(<ProjectAccessReviewCampaigns projectId={2} />);
+        fireEvent.click(screen.getByText('Open'));
+        expect(screen.getByText('Action failed.')).toBeInTheDocument();
     });
 });

--- a/web/src/pages/projects/__tests__/ProjectAccessReviewTab.test.tsx
+++ b/web/src/pages/projects/__tests__/ProjectAccessReviewTab.test.tsx
@@ -229,4 +229,57 @@ describe('ProjectAccessReviewTab', () => {
         render(<ProjectAccessReviewTab projectId={1} />);
         expect(screen.getByText('—')).toBeInTheDocument();
     });
+
+    it('falls back to an em dash for a role grant with no role name', () => {
+        const unnamedRoleEntry = {
+            principalType: 'user',
+            principalId: 40,
+            principalName: 'dave',
+            email: 'dave@x.io',
+            source: 'role',
+            roleId: 6,
+            roleName: '',
+            accessLevel: 'read',
+            environmentId: 0,
+        };
+        mockUseAccessReview.mockReturnValue({ isLoading: false, isError: false, data: [unnamedRoleEntry] });
+        render(<ProjectAccessReviewTab projectId={1} />);
+        expect(screen.getByText('Role: — (project-wide)')).toBeInTheDocument();
+    });
+
+    it('shows a non-dormant recency badge for a user principal used recently', () => {
+        const recentEntry = {
+            principalType: 'user',
+            principalId: 41,
+            principalName: 'erin',
+            email: 'erin@x.io',
+            source: 'role',
+            roleId: 7,
+            roleName: 'viewer',
+            accessLevel: 'read',
+            environmentId: 0,
+            lastUsedAt: new Date().toISOString(),
+        };
+        mockUseAccessReview.mockReturnValue({ isLoading: false, isError: false, data: [recentEntry] });
+        render(<ProjectAccessReviewTab projectId={1} />);
+
+        const badge = screen.getByText('used today');
+        expect(badge).toBeInTheDocument();
+        expect(badge).toHaveAttribute('title', 'Last secret access in this project');
+    });
+
+    it('resets the revoke confirmation after a successful revoke', () => {
+        mockUseAccessReview.mockReturnValue({ isLoading: false, isError: false, data: [entries[2]] });
+        mockRevokeMutate.mockImplementationOnce((_decision, opts) => opts.onSuccess());
+        render(<ProjectAccessReviewTab projectId={1} />);
+
+        fireEvent.click(screen.getByText('Revoke'));
+        expect(screen.getByText('Confirm')).toBeInTheDocument();
+        fireEvent.click(screen.getByText('Confirm'));
+
+        expect(mockRevokeMutate).toHaveBeenCalledTimes(1);
+        // Confirmation state is cleared, so the row is back to a plain Revoke button.
+        expect(screen.getByText('Revoke')).toBeInTheDocument();
+        expect(screen.queryByText('Confirm')).not.toBeInTheDocument();
+    });
 });

--- a/web/src/pages/projects/__tests__/ProjectMembersTab.test.tsx
+++ b/web/src/pages/projects/__tests__/ProjectMembersTab.test.tsx
@@ -36,6 +36,15 @@ vi.mock('../../../store/authStore', () => ({
     useAuthStore: () => ({ user: { id: 1 } }),
 }));
 
+// Every real entry in PROJECT_ROLES currently has a matching ROLE_CAPABILITIES
+// entry with at least one granted capability, so RoleLegend's `?? []` and
+// `|| 'No project-level permissions'` fallbacks are otherwise unreachable.
+// Append one extra role name absent from the capability map to exercise them.
+vi.mock('../../../services/projects', async (importOriginal) => {
+    const actual = (await importOriginal()) as object;
+    return { ...actual, PROJECT_ROLES: [...(actual as any).PROJECT_ROLES, 'mystery_role'] };
+});
+
 // The invite flow is owned by features/invitations and covered by its own
 // tests (Phase 1). Here we only verify this tab opens/closes it and passes
 // the right project context — not the modal's internal form behavior.
@@ -444,6 +453,17 @@ describe('ProjectMembersTab', () => {
             // also renders an <option>Admin</option> / <option>Auditor</option>.
             expect(within(legendRoot).getByText('Admin')).toBeInTheDocument();
             expect(within(legendRoot).getByText('Auditor')).toBeInTheDocument();
+        });
+
+        it('falls back to a generic label and "no permissions" copy for a role missing from the capability map', () => {
+            mockMembers([]);
+            render(<ProjectMembersTab projectId={1} />);
+
+            const legendRoot = screen.getByText('Role permissions reference').closest('div')!;
+            fireEvent.click(screen.getByText('Role permissions reference'));
+
+            expect(within(legendRoot).getByText('Mystery_role')).toBeInTheDocument();
+            expect(within(legendRoot).getByText('No project-level permissions')).toBeInTheDocument();
         });
     });
 

--- a/web/src/pages/projects/__tests__/ProjectSecretsTab.test.tsx
+++ b/web/src/pages/projects/__tests__/ProjectSecretsTab.test.tsx
@@ -479,6 +479,21 @@ describe('ProjectSecretsTab — view modal share/delete/close wiring', () => {
         expect(screen.queryByText('Detail: db-pass')).not.toBeInTheDocument();
     });
 
+    it("closes the view modal via the Modal chrome's own close button (not the detail view's)", () => {
+        // Distinct from the "Detail Close" test above: this exercises the Modal
+        // component's own `onClose` prop (ProjectSecretsTab.tsx ~line 273), wired to
+        // its built-in dismiss (X) button, rather than SecretDetailView's separate
+        // onClose prop reached via the mocked "Detail Close" button.
+        listState.secrets = secretsFixture;
+        render(<ProjectSecretsTab projectId={1} />);
+
+        fireEvent.click(screen.getByText('View db-pass'));
+        expect(screen.getByText('Detail: db-pass')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+        expect(screen.queryByText('Detail: db-pass')).not.toBeInTheDocument();
+    });
+
     it('shares a secret from the view modal', () => {
         listState.secrets = secretsFixture;
         render(<ProjectSecretsTab projectId={1} />);
@@ -687,3 +702,13 @@ describe('ProjectSecretsTab — rotate modal extras', () => {
 // dead code given the component's own invariants; a genuine test would need a
 // malformed environment record that also crashes an earlier line, which is not a
 // meaningful case to fabricate.
+//
+// Similarly, the `if (!list.modalData?.secret) return;` guards inside
+// EditSecretModal's and RotateSecretModal's onSubmit (~lines 465 and 624) are
+// defensive dead code under this component's own invariants: `list.openModal(
+// 'edit-secret', …)` / `list.openModal('rotate-secret', …)` are only ever called
+// from row/detail actions that already close over a real `secret`, so `modalData`
+// is guaranteed to carry one whenever those modals can be open and submitted. There
+// is no legitimate UI path — only a synthetic mock of `useProjectSecrets` calling
+// `openModal` with no data, which the app itself never does — that would exercise
+// the early-return branch, so it's left uncovered rather than fabricated.

--- a/web/src/pages/projects/__tests__/ProjectSettingsTab.test.tsx
+++ b/web/src/pages/projects/__tests__/ProjectSettingsTab.test.tsx
@@ -382,6 +382,56 @@ describe('ProjectSettingsTab — promote environment', () => {
         ).toBeInTheDocument();
     });
 
+    it('falls back to the secret id in the skip list when a skipped outcome has no old_name', async () => {
+        mockGet.mockImplementation((url: string) =>
+            url.includes('/secrets/name-conformance')
+                ? Promise.resolve({
+                      data: {
+                          data: {
+                              policy_enabled: true,
+                              total_secrets: 1,
+                              violations: [
+                                  {
+                                      id: 8,
+                                      name: 'db-pass',
+                                      type: 'password',
+                                      reason: 'does not match the required pattern',
+                                  },
+                              ],
+                          },
+                      },
+                  })
+                : Promise.resolve({ data: { data: {} } })
+        );
+        mockPost.mockResolvedValue({
+            data: {
+                data: {
+                    dry_run: false,
+                    renamed: 0,
+                    skipped: 1,
+                    outcomes: [
+                        {
+                            id: 8,
+                            new_name: 'still-bad',
+                            status: 'skipped',
+                            reason: 'secret name does not match the required pattern',
+                        },
+                    ],
+                },
+            },
+        });
+
+        render(<ProjectSettingsTab projectId={1} />);
+
+        fireEvent.change(await screen.findByDisplayValue('db-pass'), { target: { value: 'still-bad' } });
+        fireEvent.click(screen.getByRole('button', { name: /Apply renames/i }));
+
+        // No old_name on the outcome -> the skip list falls back to the secret id.
+        expect(
+            await screen.findByText(/0 secret\(s\), 1 skipped.*Skipped: 8 \(secret name does not match/i)
+        ).toBeInTheDocument();
+    });
+
     it('defaults the rename counts and skip list when the server response omits them', async () => {
         mockGet.mockImplementation((url: string) =>
             url.includes('/secrets/name-conformance')

--- a/web/src/pages/projects/__tests__/ProjectsListPage.test.tsx
+++ b/web/src/pages/projects/__tests__/ProjectsListPage.test.tsx
@@ -420,6 +420,21 @@ describe('ProjectsListPage', () => {
         expect(within(recentSection).getByText('no-date')).toBeInTheDocument();
     });
 
+    it('sorts two projects that both lack an updatedAt without throwing', () => {
+        // With exactly two recent projects, Array.prototype.sort makes a single comparator
+        // call for the pair, so both `a.updatedAt` and `b.updatedAt` are nullish in that one
+        // call — exercising the `?? ''` fallback on both sides of the comparator at once.
+        hookState.projects = [
+            makeProject({ id: 24, name: 'no-date-one', updatedAt: undefined }),
+            makeProject({ id: 25, name: 'no-date-two', updatedAt: undefined }),
+        ];
+        render(<ProjectsListPage />);
+
+        const recentSection = screen.getByText('Recent').closest('section') as HTMLElement;
+        expect(within(recentSection).getByText('no-date-one')).toBeInTheDocument();
+        expect(within(recentSection).getByText('no-date-two')).toBeInTheDocument();
+    });
+
     it('does not navigate on a non-Enter/Space key, and does not navigate on any key for a deleted row', () => {
         hookState.projects = [
             makeProject({ id: 17, name: 'active-row' }),

--- a/web/src/pages/secrets/__tests__/SecretExpiryPage.test.tsx
+++ b/web/src/pages/secrets/__tests__/SecretExpiryPage.test.tsx
@@ -296,6 +296,21 @@ describe('SecretExpiryPage', () => {
         expect(within(rows[0]!).getByText('api_key')).toHaveStyle({ backgroundColor: '#dcfce7', color: '#166534' });
     });
 
+    it('falls back to the "text" type badge style for an unrecognized secret type', async () => {
+        const unknownTypeSecret = makeSecret({
+            id: 8,
+            name: 'mystery-type-secret',
+            type: 'sometype' as unknown as Secret['type'],
+            Expiration: '2024-02-15T00:00:00.000Z',
+        });
+        listMock.mockResolvedValue(listResponse([unknownTypeSecret]));
+        render(<SecretExpiryPage />);
+
+        await screen.findByText('mystery-type-secret');
+        // unrecognized types fall back to TYPE_STYLES.text's label + dark-theme colors
+        expect(screen.getByText('text')).toHaveStyle({ backgroundColor: 'rgba(148,163,184,0.15)', color: '#94a3b8' });
+    });
+
     it('resolves the system theme via matchMedia and uses dark colors when the system prefers dark', async () => {
         useUIStore.setState({ theme: 'system' });
         (window.matchMedia as unknown as ReturnType<typeof vi.fn>).mockReturnValue({

--- a/web/src/pages/secrets/__tests__/SecretsHealthPage.test.tsx
+++ b/web/src/pages/secrets/__tests__/SecretsHealthPage.test.tsx
@@ -283,6 +283,36 @@ describe('SecretsHealthPage', () => {
         expect(screen.getByText('Auto: vault')).toBeInTheDocument();
     });
 
+    it('shows an auto-rotate badge without a backend suffix and a generic tooltip when no backend is set', () => {
+        mockUseSecretsHealth.mockReturnValue(
+            makeHealth({
+                rotation: {
+                    available: true,
+                    pct: 10,
+                    covered: 1,
+                    overdue: 1,
+                    dueSoon: 0,
+                    ok: 0,
+                    items: [
+                        {
+                            policy_id: 1,
+                            secret_id: 1,
+                            secret_name: 'DB_PASSWORD',
+                            status: 'overdue',
+                            days_overdue: 5,
+                            interval_days: 30,
+                            auto_rotate: true,
+                        },
+                    ],
+                },
+            })
+        );
+        render(<SecretsHealthPage />);
+        expect(screen.getByText('Auto')).toBeInTheDocument();
+        expect(screen.queryByText('Auto: vault')).not.toBeInTheDocument();
+        expect(screen.getByTitle('Auto-rotates (Keyorix-generated)')).toBeInTheDocument();
+    });
+
     // ── access card ─────────────────────────────────────────────────────────
 
     it('renders access stats', () => {
@@ -307,6 +337,14 @@ describe('SecretsHealthPage', () => {
         mockUseSecretsHealth.mockReturnValue(makeHealth({ access: { ...baseHealth.access, failedAuth24h: 4 } }));
         render(<SecretsHealthPage />);
         expect(screen.queryByText(/High number of failed auth attempts/)).not.toBeInTheDocument();
+    });
+
+    it('shows an amber dot for inactive users when there are any', () => {
+        mockUseSecretsHealth.mockReturnValue(makeHealth({ access: { ...baseHealth.access, inactiveUsers: 3 } }));
+        render(<SecretsHealthPage />);
+        const inactiveRow = screen.getByText('Inactive users (no login 30d)').closest('div')!;
+        const dot = inactiveRow.querySelector('div')!;
+        expect(dot).toHaveStyle({ backgroundColor: '#f59e0b' });
     });
 
     // ── anomalies card ──────────────────────────────────────────────────────

--- a/web/src/pages/secrets/__tests__/SecretsListPage.test.tsx
+++ b/web/src/pages/secrets/__tests__/SecretsListPage.test.tsx
@@ -597,6 +597,21 @@ describe('SecretsListPage — create secret: naming policy validation', () => {
         );
     });
 
+    it('allows a name under the max length when no pattern is configured, and submits', () => {
+        secretPolicyState.data = { name: { enabled: true, max_length: 20 } };
+        render(<SecretsListPage />);
+        fireEvent.click(screen.getAllByTestId('create-secret-button')[0]!);
+
+        expect(screen.getByText('Naming policy: max 20 chars.')).toBeInTheDocument();
+
+        fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: 'short-name' } });
+        fireEvent.change(screen.getByLabelText(/^Value/), { target: { value: 'super-secret' } });
+        fireEvent.click(screen.getByTestId('create-secret-submit'));
+
+        expect(screen.queryByText('Name exceeds the 20-character maximum.')).not.toBeInTheDocument();
+        expect(createMutate).toHaveBeenCalled();
+    });
+
     // Documented, not fixed (out of scope for this coverage-only PR): a naming
     // pattern that looks catastrophically-backtracking (per safe-regex's
     // heuristic, e.g. `(a+)+$`) is never validated client-side — this is the

--- a/web/src/pages/secrets/__tests__/UsageAnalyticsPage.test.tsx
+++ b/web/src/pages/secrets/__tests__/UsageAnalyticsPage.test.tsx
@@ -39,6 +39,16 @@ function getSectionCard(headingText: string): HTMLElement {
     return card as HTMLElement;
 }
 
+// COVERAGE NOTE (not a test, no source change made): UsageAnalyticsPage.tsx's
+// unexported `relativeFromNow` helper has a defensive `if (!d) return 'never';`
+// branch (source line 11). Its only call site (line 124) already narrows on
+// `s.last_read` truthiness before invoking the helper — `s.last_read ? \`last read
+// ${relativeFromNow(s.last_read)}\` : 'never read'` — so the helper is never invoked
+// with a falsy argument through the component. The helper also isn't exported, so it
+// can't be unit-tested directly. That branch is structurally unreachable via this
+// component's rendered output, which is why this file's branch coverage tops out at
+// 35/36 (97.22%) rather than 100% even with an otherwise exhaustive suite.
+
 beforeEach(() => {
     mostAccessedMock.mockReset();
     unusedMock.mockReset();

--- a/web/src/pages/settings/__tests__/LicensePage.test.tsx
+++ b/web/src/pages/settings/__tests__/LicensePage.test.tsx
@@ -132,4 +132,26 @@ describe('LicensePage — success state', () => {
         expect(screen.getByText('Expired')).toBeInTheDocument();
         expect(screen.getByText('license expired on 2026-01-01 — running the community baseline')).toBeInTheDocument();
     });
+
+    it('falls back to the community-baseline badge style for an unrecognized state', () => {
+        // Simulates a server rolling out a new LicenseState value the web build
+        // doesn't know about yet — STATE_META[state] ?? STATE_META.none.
+        useLicenseStatus.mockReturnValue({
+            data: { ...activeLicense, state: 'some_future_state' as any },
+            isLoading: false,
+            isError: false,
+        });
+        render(<LicensePage />);
+        expect(screen.getByText('Community baseline')).toBeInTheDocument();
+    });
+
+    it('falls back to the em dash for an unparseable expiry date', () => {
+        useLicenseStatus.mockReturnValue({
+            data: { ...activeLicense, expiresAt: 'not-a-real-date' },
+            isLoading: false,
+            isError: false,
+        });
+        render(<LicensePage />);
+        expect(screen.getByText('—')).toBeInTheDocument();
+    });
 });

--- a/web/src/services/__tests__/auth.test.ts
+++ b/web/src/services/__tests__/auth.test.ts
@@ -129,6 +129,12 @@ describe('authService.logout', () => {
         mockPost.mockRejectedValueOnce(axiosErr(500, {}));
         await expect(authService.logout()).rejects.toThrow('Logout failed');
     });
+
+    it('rethrows a non-axios error unchanged (e.g. a network-level failure)', async () => {
+        const networkError = new Error('Network Error');
+        mockPost.mockRejectedValueOnce(networkError);
+        await expect(authService.logout()).rejects.toBe(networkError);
+    });
 });
 
 // ── refreshToken ──────────────────────────────────────────────────────────────

--- a/web/src/services/__tests__/billing.test.ts
+++ b/web/src/services/__tests__/billing.test.ts
@@ -68,10 +68,108 @@ describe('billingApi.getReport', () => {
         });
     });
 
+    it('normalizes a camelCase report payload', async () => {
+        mock.get.mockResolvedValueOnce({
+            data: {
+                data: {
+                    from: '2026-01-01T00:00:00Z',
+                    to: '2026-02-01T00:00:00Z',
+                    generatedAt: '2026-02-01T00:00:00Z',
+                    totals: {
+                        projects: 1,
+                        secretCount: 1,
+                        secretReads: 2,
+                        secretWrites: 3,
+                        secretRotations: 4,
+                        uniqueUsers: 5,
+                        machineReads: 6,
+                    },
+                    projects: [
+                        {
+                            projectId: 7,
+                            projectName: 'camel-case-proj',
+                            secretCount: 1,
+                            secretReads: 2,
+                            secretWrites: 3,
+                            secretRotations: 4,
+                            uniqueUsers: 5,
+                            machineReads: 6,
+                        },
+                    ],
+                },
+            },
+        });
+
+        const report = await billingApi.getReport({
+            from: '2026-01-01T00:00:00Z',
+            to: '2026-02-01T00:00:00Z',
+        });
+
+        expect(report.projects[0]).toEqual({
+            projectId: 7,
+            projectName: 'camel-case-proj',
+            secretCount: 1,
+            secretReads: 2,
+            secretWrites: 3,
+            secretRotations: 4,
+            uniqueUsers: 5,
+            machineReads: 6,
+        });
+    });
+
+    it('falls back to the raw response body when there is no nested "data" envelope, defaulting missing fields', async () => {
+        mock.get.mockResolvedValueOnce({
+            data: {
+                totals: {},
+            },
+        });
+
+        const report = await billingApi.getReport({
+            from: '2026-01-01T00:00:00Z',
+            to: '2026-02-01T00:00:00Z',
+        });
+
+        expect(report.from).toBe('');
+        expect(report.to).toBe('');
+        expect(report.projects).toEqual([]);
+    });
+
+    it('defaults a project stat with no name field to an empty string', async () => {
+        mock.get.mockResolvedValueOnce({
+            data: {
+                data: {
+                    projects: [{ project_id: 9 }],
+                    totals: {},
+                },
+            },
+        });
+
+        const report = await billingApi.getReport({
+            from: '2026-01-01T00:00:00Z',
+            to: '2026-02-01T00:00:00Z',
+        });
+
+        expect(report.projects[0].projectName).toBe('');
+    });
+
     it('omits project_id from the query when no filter is given', async () => {
         mock.get.mockResolvedValueOnce({ data: { data: { projects: [], totals: {} } } });
 
         await billingApi.getReport({ from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' });
+
+        expect(mock.get).toHaveBeenCalledWith('/api/v1/admin/billing/report', {
+            params: { from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' },
+        });
+    });
+
+    it('omits project_id from the query when projectIds is an empty array', async () => {
+        mock.get.mockResolvedValueOnce({ data: { data: { projects: [], totals: {} } } });
+
+        await billingApi.getReport({
+            from: '2026-01-01T00:00:00Z',
+            to: '2026-02-01T00:00:00Z',
+            projectIds: [],
+        });
 
         expect(mock.get).toHaveBeenCalledWith('/api/v1/admin/billing/report', {
             params: { from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' },
@@ -102,6 +200,15 @@ describe('billingApi.getReport', () => {
         await expect(
             billingApi.getReport({ from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' })
         ).rejects.not.toBeInstanceOf(BillingLicenseRequiredError);
+    });
+
+    it('rethrows a 403 without a response body as-is (not a license error)', async () => {
+        const err = { isAxiosError: true, response: { status: 403 } };
+        mock.get.mockRejectedValueOnce(err);
+
+        await expect(billingApi.getReport({ from: '2026-01-01T00:00:00Z', to: '2026-02-01T00:00:00Z' })).rejects.toBe(
+            err
+        );
     });
 
     it('rethrows a non-403 error unchanged', async () => {

--- a/web/src/services/__tests__/compliance.test.ts
+++ b/web/src/services/__tests__/compliance.test.ts
@@ -158,6 +158,12 @@ describe('complianceApi.getControls', () => {
         const matrix = await complianceApi.getControls();
         expect(matrix.generatedAt).toBe('2026-03-01T00:00:00Z');
     });
+
+    it('defaults a control id to an empty string when missing', async () => {
+        mock.get.mockResolvedValueOnce({ data: { data: { controls: [{ name: 'No id control' }] } } });
+        const matrix = await complianceApi.getControls();
+        expect(matrix.controls[0]?.id).toBe('');
+    });
 });
 
 // ── getRiskExceptions ────────────────────────────────────────────────────────
@@ -298,5 +304,11 @@ describe('complianceApi.getSoDViolations', () => {
     it('returns [] when neither wrapper is present', async () => {
         mock.get.mockResolvedValueOnce({ data: {} });
         await expect(complianceApi.getSoDViolations()).resolves.toEqual([]);
+    });
+
+    it('defaults username to an empty string when missing', async () => {
+        mock.get.mockResolvedValueOnce({ data: { data: { violations: [{ policy_name: 'Segregation' }] } } });
+        const violations = await complianceApi.getSoDViolations();
+        expect(violations[0]?.username).toBe('');
     });
 });

--- a/web/src/services/__tests__/license.test.ts
+++ b/web/src/services/__tests__/license.test.ts
@@ -56,4 +56,41 @@ describe('licenseApi.getStatus', () => {
         expect(status.maxSeats).toBe(0);
         expect(status.features).toEqual([]);
     });
+
+    it('defaults state to "none" and features to [] when the fields are missing entirely', async () => {
+        mock.get.mockResolvedValueOnce({ data: { data: {} } });
+
+        const status = await licenseApi.getStatus();
+
+        expect(status.state).toBe('none');
+        expect(status.features).toEqual([]);
+    });
+
+    it('unwraps a payload that is not itself wrapped in an envelope data field', async () => {
+        mock.get.mockResolvedValueOnce({
+            data: {
+                state: 'expired',
+                licensee: 'Direct Co',
+                plan: 'community',
+                features: [],
+                grants: false,
+                expires_at: '2025-01-01T00:00:00Z',
+                max_seats: 5,
+                reason: 'past due',
+            },
+        });
+
+        const status = await licenseApi.getStatus();
+
+        expect(status).toEqual({
+            state: 'expired',
+            licensee: 'Direct Co',
+            plan: 'community',
+            features: [],
+            grants: false,
+            expiresAt: '2025-01-01T00:00:00Z',
+            maxSeats: 5,
+            reason: 'past due',
+        });
+    });
 });

--- a/web/src/services/__tests__/machineIdentities.test.ts
+++ b/web/src/services/__tests__/machineIdentities.test.ts
@@ -110,6 +110,14 @@ describe('machineIdentitiesApi.transition', () => {
 
         expect(m.state).toBe('active');
     });
+
+    it('falls back to bare response.data when data.data is absent', async () => {
+        mocked.put.mockResolvedValue({ data: { ID: 9, State: 'revoked' } });
+
+        const m = await machineIdentitiesApi.transition(2, 9, 'revoke');
+
+        expect(m.state).toBe('revoked');
+    });
 });
 
 describe('normalizeMachineIdentity defaults', () => {

--- a/web/src/services/__tests__/projectsDrift.test.ts
+++ b/web/src/services/__tests__/projectsDrift.test.ts
@@ -107,4 +107,16 @@ describe('projectsApi.drift', () => {
         const report = await projectsApi.drift(6);
         expect(report.projectId).toBe(6);
     });
+
+    it('defaults presentIn/missingFrom to [] when a drifted key has neither snake_case nor camelCase variant', async () => {
+        mocked.get.mockResolvedValue({
+            data: { data: { project_id: 7, drifted_keys: [{ name: 'ORPHAN_KEY', status: 'missing_in_some' }] } },
+        });
+
+        const report = await projectsApi.drift(7);
+
+        expect(report.driftedKeys).toEqual([
+            { name: 'ORPHAN_KEY', presentIn: [], missingFrom: [], status: 'missing_in_some', driftFields: [] },
+        ]);
+    });
 });

--- a/web/src/services/__tests__/rbac.test.ts
+++ b/web/src/services/__tests__/rbac.test.ts
@@ -202,6 +202,14 @@ describe('rbacApi.getRoles', () => {
         mocked.get.mockResolvedValueOnce({ data: { data: {} } });
         await expect(rbacApi.getRoles()).resolves.toEqual([]);
     });
+
+    it('defaults permissions to [] when neither permissions nor Permissions is present', async () => {
+        mocked.get.mockResolvedValueOnce({
+            data: { data: [{ id: 1, name: 'no-perms-field' }] },
+        });
+        const roles = await rbacApi.getRoles();
+        expect(roles[0].permissions).toEqual([]);
+    });
 });
 
 // ── getRole ───────────────────────────────────────────────────────────────────

--- a/web/src/store/__tests__/authStore.test.ts
+++ b/web/src/store/__tests__/authStore.test.ts
@@ -650,4 +650,30 @@ describe('authStore', () => {
             expect(isTokenExpired()).toBe(false);
         });
     });
+
+    describe('module-level browser guard (typeof window !== "undefined")', () => {
+        // This suite runs under jsdom, where `window` always exists, so the
+        // `typeof window !== 'undefined'` guard around the cross-tab storage
+        // listener registration (bottom of authStore.ts) only ever takes its
+        // true branch through every other test in this file. Force a fresh
+        // module evaluation with `window` shadowed to undefined — simulating
+        // the SSR/non-browser context the guard exists for — to prove the
+        // module still loads cleanly and skips registering the listener,
+        // without touching product code to make the branch reachable another
+        // way.
+        it('reimporting the module without a global window does not throw and skips wiring the storage listener', async () => {
+            const originalWindow = globalThis.window;
+            vi.resetModules();
+            // @ts-expect-error deliberately simulating an environment without `window`
+            globalThis.window = undefined;
+
+            try {
+                const mod = await import('../authStore');
+                expect(mod.useAuthStore).toBeDefined();
+                expect(mod.useAuthStore.getState().isLoading).toBe(true);
+            } finally {
+                globalThis.window = originalWindow;
+            }
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- Raises frontend coverage from 98.42%/97.41%/98.35%/99.31% to 99.35%/98.98%/100%/99.95% (statements/branches/functions/lines).
- Covers real behavioral gaps: Radix dismissable-layer timing in `Modal`, session-timeout reset-on-activity in `useAuth`, preset-window math and empty-state fallbacks across the billing/usage/secrets pages, and several previously-untested hooks.
- A small number of branches are left intentionally uncovered where they're structurally unreachable through real UI interaction (e.g. a guard mirrored by a disabled button's own condition, or Radix unmounting modal content on close) — each documented inline.
- No production/source files changed; every file touched is a test file.
- Supersedes an earlier, smaller branch (`test/web-coverage-modal-billing-account`) that only covered 3 of these files — this branch is a strict superset, so that one can be discarded rather than merged separately.

## Test plan
- [x] 177/177 test files pass, 3151/3151 tests pass
- [x] `eslint` and `prettier --check` clean on every changed file
- [x] No regressions in pre-existing tests