### PR TITLE
test(operator): raise coverage across all 4 operator packages

### DIFF
--- a/operator/api/v1alpha1/groupversion_info_test.go
+++ b/operator/api/v1alpha1/groupversion_info_test.go
@@ -1,0 +1,73 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestAddToScheme_RegistersTypes(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	require.NoError(t, AddToScheme(scheme))
+
+	assert.True(t, scheme.Recognizes(GroupVersion.WithKind("KeyorixSecret")),
+		"AddToScheme must register KeyorixSecret under the secrets.keyorix.io/v1alpha1 group/version")
+	assert.True(t, scheme.Recognizes(GroupVersion.WithKind("KeyorixSecretList")),
+		"AddToScheme must register KeyorixSecretList under the secrets.keyorix.io/v1alpha1 group/version")
+
+	// New must produce usable instances of the registered types.
+	obj, err := scheme.New(GroupVersion.WithKind("KeyorixSecret"))
+	require.NoError(t, err)
+	_, ok := obj.(*KeyorixSecret)
+	assert.True(t, ok, "scheme.New(KeyorixSecret) must return a *KeyorixSecret")
+
+	listObj, err := scheme.New(GroupVersion.WithKind("KeyorixSecretList"))
+	require.NoError(t, err)
+	_, ok = listObj.(*KeyorixSecretList)
+	assert.True(t, ok, "scheme.New(KeyorixSecretList) must return a *KeyorixSecretList")
+}
+
+func TestAddToScheme_RegistersListKindMetadata(t *testing.T) {
+	// metav1.AddToGroupVersion (called from addKnownTypes) additionally registers the
+	// generic List/ListOptions/etc. kinds for the group/version; assert one of those to
+	// confirm that call actually ran, not just AddKnownTypes.
+	scheme := runtime.NewScheme()
+	require.NoError(t, AddToScheme(scheme))
+
+	assert.True(t, scheme.Recognizes(GroupVersion.WithKind("ListOptions")),
+		"metav1.AddToGroupVersion must register the generic ListOptions kind for this group/version")
+}
+
+func TestGroupVersion_Value(t *testing.T) {
+	assert.Equal(t, "secrets.keyorix.io", GroupVersion.Group)
+	assert.Equal(t, "v1alpha1", GroupVersion.Version)
+}
+
+func TestSchemeBuilder_AddToSchemeIsAddToScheme(t *testing.T) {
+	// AddToScheme is assigned from SchemeBuilder.AddToScheme; assert it behaves the same
+	// way a fresh call through SchemeBuilder would (guards against the var wiring rotting
+	// silently if the package is ever refactored).
+	scheme := runtime.NewScheme()
+	require.NoError(t, SchemeBuilder.AddToScheme(scheme))
+	assert.True(t, scheme.Recognizes(GroupVersion.WithKind("KeyorixSecret")))
+}
+
+func TestAddToScheme_ObjectKindsRoundTrip(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, AddToScheme(scheme))
+
+	kinds, _, err := scheme.ObjectKinds(&KeyorixSecret{})
+	require.NoError(t, err)
+	require.Len(t, kinds, 1)
+	assert.Equal(t, GroupVersion.WithKind("KeyorixSecret"), kinds[0])
+
+	// Sanity: metav1.TypeMeta embedding didn't break normal object identification.
+	ks := &KeyorixSecret{ObjectMeta: metav1.ObjectMeta{Name: "x"}}
+	kinds, _, err = scheme.ObjectKinds(ks)
+	require.NoError(t, err)
+	assert.Equal(t, GroupVersion.WithKind("KeyorixSecret"), kinds[0])
+}

--- a/operator/api/v1alpha1/zz_generated.deepcopy_test.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy_test.go
@@ -1,0 +1,299 @@
+package v1alpha1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// populatedKeyorixSecret builds a KeyorixSecret with every slice/pointer field
+// filled in, so DeepCopy tests can catch a forgotten deep-copy of any of them
+// (a shallow copy would let mutating the copy's slice/pointer fields bleed
+// back into the original).
+func populatedKeyorixSecret() *KeyorixSecret {
+	refresh := metav1.Duration{Duration: 5 * time.Minute}
+	lastSync := metav1.NewTime(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
+
+	return &KeyorixSecret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KeyorixSecret",
+			APIVersion: "secrets.keyorix.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-secret",
+			Namespace: "default",
+			Labels:    map[string]string{"team": "platform"},
+		},
+		Spec: KeyorixSecretSpec{
+			Server: "https://keyorix.internal",
+			TokenSecretRef: SecretKeySelector{
+				Name: "token-secret",
+				Key:  "token",
+			},
+			RefreshInterval: &refresh,
+			Target: KeyorixSecretTarget{
+				Name: "target-secret",
+				Type: corev1.SecretTypeOpaque,
+			},
+			Data: []KeyorixSecretData{
+				{SecretKey: "db-password", Ref: "proj/env/db-password"},
+				{SecretKey: "api-key", Ref: "proj/env/api-key"},
+			},
+		},
+		Status: KeyorixSecretStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					Reason:             "Synced",
+					Message:            "ok",
+					LastTransitionTime: lastSync,
+				},
+			},
+			LastSyncTime:       &lastSync,
+			SyncedHash:         "abc123",
+			ObservedGeneration: 3,
+			LastTargetName:     "target-secret",
+		},
+	}
+}
+
+func TestKeyorixSecret_DeepCopy_IndependentOfOriginal(t *testing.T) {
+	orig := populatedKeyorixSecret()
+	cp := orig.DeepCopy()
+
+	require.NotNil(t, cp)
+	assert.Equal(t, orig, cp, "copy must be equal to the original right after copying")
+	// Must not be the same object.
+	assert.NotSame(t, orig, cp)
+
+	// Mutate every slice/pointer field on the copy and assert the original is untouched.
+	cp.ObjectMeta.Labels["team"] = "mutated"
+	cp.Spec.RefreshInterval.Duration = 99 * time.Minute
+	cp.Spec.Data[0].SecretKey = "mutated"
+	cp.Spec.Data = append(cp.Spec.Data, KeyorixSecretData{SecretKey: "new", Ref: "new/new/new"})
+	cp.Status.Conditions[0].Message = "mutated"
+	cp.Status.LastSyncTime.Time = cp.Status.LastSyncTime.Time.Add(time.Hour)
+	cp.Status.SyncedHash = "mutated"
+
+	assert.Equal(t, "platform", orig.ObjectMeta.Labels["team"], "label map must be deep-copied")
+	assert.Equal(t, 5*time.Minute, orig.Spec.RefreshInterval.Duration, "RefreshInterval pointer must be deep-copied")
+	assert.Equal(t, "db-password", orig.Spec.Data[0].SecretKey, "Data slice elements must be deep-copied")
+	assert.Len(t, orig.Spec.Data, 2, "appending to the copy's Data slice must not affect the original")
+	assert.Equal(t, "ok", orig.Status.Conditions[0].Message, "Conditions slice elements must be deep-copied")
+	assert.Equal(t, time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), orig.Status.LastSyncTime.Time,
+		"LastSyncTime pointer must be deep-copied")
+	assert.Equal(t, "abc123", orig.Status.SyncedHash)
+}
+
+func TestKeyorixSecret_DeepCopy_Nil(t *testing.T) {
+	var in *KeyorixSecret
+	assert.Nil(t, in.DeepCopy())
+}
+
+func TestKeyorixSecret_DeepCopyObject(t *testing.T) {
+	orig := populatedKeyorixSecret()
+	obj := orig.DeepCopyObject()
+
+	require.NotNil(t, obj)
+	cp, ok := obj.(*KeyorixSecret)
+	require.True(t, ok, "DeepCopyObject must return a *KeyorixSecret usable via type assertion")
+	assert.Equal(t, orig, cp)
+
+	var _ runtime.Object = obj
+}
+
+func TestKeyorixSecret_DeepCopyInto_ZeroValue_NoPanic(t *testing.T) {
+	in := &KeyorixSecret{}
+	out := &KeyorixSecret{}
+	assert.NotPanics(t, func() {
+		in.DeepCopyInto(out)
+	})
+	assert.Equal(t, in, out)
+	assert.Nil(t, out.Spec.RefreshInterval)
+	assert.Nil(t, out.Status.LastSyncTime)
+	assert.Nil(t, out.Spec.Data)
+	assert.Nil(t, out.Status.Conditions)
+}
+
+func TestKeyorixSecretList_DeepCopy_IndependentOfOriginal(t *testing.T) {
+	orig := &KeyorixSecretList{
+		TypeMeta: metav1.TypeMeta{Kind: "KeyorixSecretList", APIVersion: "secrets.keyorix.io/v1alpha1"},
+		ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+		Items: []KeyorixSecret{
+			*populatedKeyorixSecret(),
+			*populatedKeyorixSecret(),
+		},
+	}
+	orig.Items[1].Name = "second-secret"
+
+	cp := orig.DeepCopy()
+	require.NotNil(t, cp)
+	assert.Equal(t, orig, cp)
+	assert.NotSame(t, orig, cp)
+
+	// Mutate the copy's items and nested fields; original must be unaffected.
+	cp.Items[0].Spec.Data[0].SecretKey = "mutated"
+	cp.Items = append(cp.Items, KeyorixSecret{})
+
+	assert.Equal(t, "db-password", orig.Items[0].Spec.Data[0].SecretKey,
+		"List.Items elements must be deep-copied, not just slice-copied")
+	assert.Len(t, orig.Items, 2, "appending to the copy's Items slice must not affect the original")
+}
+
+func TestKeyorixSecretList_DeepCopy_Nil(t *testing.T) {
+	var in *KeyorixSecretList
+	assert.Nil(t, in.DeepCopy())
+}
+
+func TestKeyorixSecretList_DeepCopy_NilItems_NoPanic(t *testing.T) {
+	in := &KeyorixSecretList{}
+	var out *KeyorixSecretList
+	assert.NotPanics(t, func() {
+		out = in.DeepCopy()
+	})
+	assert.Nil(t, out.Items)
+}
+
+func TestKeyorixSecretList_DeepCopyObject(t *testing.T) {
+	orig := &KeyorixSecretList{Items: []KeyorixSecret{*populatedKeyorixSecret()}}
+	obj := orig.DeepCopyObject()
+
+	require.NotNil(t, obj)
+	cp, ok := obj.(*KeyorixSecretList)
+	require.True(t, ok, "DeepCopyObject must return a *KeyorixSecretList usable via type assertion")
+	assert.Equal(t, orig, cp)
+}
+
+func TestKeyorixSecret_DeepCopyObject_NilReceiver(t *testing.T) {
+	var in *KeyorixSecret
+	assert.Nil(t, in.DeepCopyObject(), "DeepCopyObject on a nil receiver must return a true nil runtime.Object")
+}
+
+func TestKeyorixSecretList_DeepCopyObject_NilReceiver(t *testing.T) {
+	var in *KeyorixSecretList
+	assert.Nil(t, in.DeepCopyObject(), "DeepCopyObject on a nil receiver must return a true nil runtime.Object")
+}
+
+func TestKeyorixSecretSpec_DeepCopy_IndependentOfOriginal(t *testing.T) {
+	refresh := metav1.Duration{Duration: time.Minute}
+	orig := &KeyorixSecretSpec{
+		Server:          "https://keyorix.internal",
+		TokenSecretRef:  SecretKeySelector{Name: "token-secret", Key: "token"},
+		RefreshInterval: &refresh,
+		Target:          KeyorixSecretTarget{Name: "t", Type: corev1.SecretTypeOpaque},
+		Data:            []KeyorixSecretData{{SecretKey: "a", Ref: "p/e/a"}},
+	}
+	cp := orig.DeepCopy()
+	require.NotNil(t, cp)
+	assert.Equal(t, orig, cp)
+
+	cp.RefreshInterval.Duration = time.Hour
+	cp.Data[0].SecretKey = "mutated"
+
+	assert.Equal(t, time.Minute, orig.RefreshInterval.Duration)
+	assert.Equal(t, "a", orig.Data[0].SecretKey)
+}
+
+func TestKeyorixSecretSpec_DeepCopy_Nil(t *testing.T) {
+	var in *KeyorixSecretSpec
+	assert.Nil(t, in.DeepCopy())
+}
+
+func TestKeyorixSecretSpec_DeepCopyInto_NilOptionalFields_NoPanic(t *testing.T) {
+	in := &KeyorixSecretSpec{Server: "https://x"}
+	out := &KeyorixSecretSpec{}
+	assert.NotPanics(t, func() {
+		in.DeepCopyInto(out)
+	})
+	assert.Nil(t, out.RefreshInterval)
+	assert.Nil(t, out.Data)
+}
+
+func TestKeyorixSecretStatus_DeepCopy_IndependentOfOriginal(t *testing.T) {
+	lastSync := metav1.NewTime(time.Date(2026, 5, 6, 7, 8, 9, 0, time.UTC))
+	orig := &KeyorixSecretStatus{
+		Conditions:         []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Synced", Message: "ok"}},
+		LastSyncTime:       &lastSync,
+		SyncedHash:         "hash",
+		ObservedGeneration: 1,
+		LastTargetName:     "name",
+	}
+	cp := orig.DeepCopy()
+	require.NotNil(t, cp)
+	assert.Equal(t, orig, cp)
+
+	cp.Conditions[0].Message = "mutated"
+	cp.LastSyncTime.Time = cp.LastSyncTime.Time.Add(time.Hour)
+
+	assert.Equal(t, "ok", orig.Conditions[0].Message)
+	assert.Equal(t, time.Date(2026, 5, 6, 7, 8, 9, 0, time.UTC), orig.LastSyncTime.Time)
+}
+
+func TestKeyorixSecretStatus_DeepCopy_Nil(t *testing.T) {
+	var in *KeyorixSecretStatus
+	assert.Nil(t, in.DeepCopy())
+}
+
+func TestKeyorixSecretStatus_DeepCopyInto_NilOptionalFields_NoPanic(t *testing.T) {
+	in := &KeyorixSecretStatus{}
+	out := &KeyorixSecretStatus{}
+	assert.NotPanics(t, func() {
+		in.DeepCopyInto(out)
+	})
+	assert.Nil(t, out.Conditions)
+	assert.Nil(t, out.LastSyncTime)
+}
+
+func TestKeyorixSecretTarget_DeepCopy(t *testing.T) {
+	orig := &KeyorixSecretTarget{Name: "t", Type: corev1.SecretTypeOpaque}
+	cp := orig.DeepCopy()
+	require.NotNil(t, cp)
+	assert.Equal(t, orig, cp)
+	assert.NotSame(t, orig, cp)
+
+	cp.Name = "mutated"
+	assert.Equal(t, "t", orig.Name)
+}
+
+func TestKeyorixSecretTarget_DeepCopy_Nil(t *testing.T) {
+	var in *KeyorixSecretTarget
+	assert.Nil(t, in.DeepCopy())
+}
+
+func TestKeyorixSecretData_DeepCopy(t *testing.T) {
+	orig := &KeyorixSecretData{SecretKey: "k", Ref: "p/e/k"}
+	cp := orig.DeepCopy()
+	require.NotNil(t, cp)
+	assert.Equal(t, orig, cp)
+	assert.NotSame(t, orig, cp)
+
+	cp.SecretKey = "mutated"
+	assert.Equal(t, "k", orig.SecretKey)
+}
+
+func TestKeyorixSecretData_DeepCopy_Nil(t *testing.T) {
+	var in *KeyorixSecretData
+	assert.Nil(t, in.DeepCopy())
+}
+
+func TestSecretKeySelector_DeepCopy(t *testing.T) {
+	orig := &SecretKeySelector{Name: "s", Key: "k"}
+	cp := orig.DeepCopy()
+	require.NotNil(t, cp)
+	assert.Equal(t, orig, cp)
+	assert.NotSame(t, orig, cp)
+
+	cp.Key = "mutated"
+	assert.Equal(t, "k", orig.Key)
+}
+
+func TestSecretKeySelector_DeepCopy_Nil(t *testing.T) {
+	var in *SecretKeySelector
+	assert.Nil(t, in.DeepCopy())
+}

--- a/operator/api/v1alpha1/zz_generated.deepcopy_test.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // populatedKeyorixSecret builds a KeyorixSecret with every slice/pointer field
@@ -104,8 +103,6 @@ func TestKeyorixSecret_DeepCopyObject(t *testing.T) {
 	cp, ok := obj.(*KeyorixSecret)
 	require.True(t, ok, "DeepCopyObject must return a *KeyorixSecret usable via type assertion")
 	assert.Equal(t, orig, cp)
-
-	var _ runtime.Object = obj
 }
 
 func TestKeyorixSecret_DeepCopyInto_ZeroValue_NoPanic(t *testing.T) {

--- a/operator/cmd/main_test.go
+++ b/operator/cmd/main_test.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"errors"
+	"flag"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -260,4 +266,217 @@ func TestMetricsFilterProvider_RequiresMatchingBearerToken(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.True(t, reached, "a matching bearer token must reach the real metrics handler")
 	})
+}
+
+// mainSubprocessEnv, when set to "1" in the process environment, tells
+// TestMainSubprocessHelper below to actually invoke the real main() instead of skipping --
+// it is only ever set by runMainSubprocess on a forked child, never present in a normal `go
+// test` invocation of this package.
+const mainSubprocessEnv = "KEYORIX_OPERATOR_MAIN_SUBPROCESS"
+
+// mainSubprocessArgsEnv, when set, supplies extra command-line arguments (space-separated --
+// only simple flag forms like "-all-namespaces" are needed here, so no quoting support) for
+// TestMainSubprocessHelper to hand to main() via os.Args. main() reads boolean flags like
+// -all-namespaces only from argv, with no environment-variable equivalent (unlike the string
+// flags, which all default from a KEYORIX_* env var and so need no special argv handling), so
+// this is the only way to drive those flags from runMainSubprocess.
+const mainSubprocessArgsEnv = "KEYORIX_OPERATOR_MAIN_ARGS"
+
+// TestMainSubprocessHelper is not itself a meaningful test of anything: it exists purely so
+// runMainSubprocess can re-exec this same compiled test binary as a child process and have
+// that child run the real, unmodified main() from main.go. This is the standard Go idiom for
+// testing a function that calls os.Exit (see e.g. the os/exec package's own
+// TestHelperProcess pattern) -- main() legitimately calls os.Exit(1) on its fail-closed
+// paths, and calling it in-process would kill the real test binary and lose every other
+// test's result, not just this one's.
+func TestMainSubprocessHelper(t *testing.T) {
+	if os.Getenv(mainSubprocessEnv) != "1" {
+		t.Skip("helper process for runMainSubprocess; not a standalone test")
+	}
+	if extra := os.Getenv(mainSubprocessArgsEnv); extra != "" {
+		// main() defines its flags on the package-level flag.CommandLine and calls
+		// flag.Parse() against os.Args[1:]; testing.Main() already parsed flag.CommandLine
+		// once (for -test.* flags) by the time this test body runs, so main()'s own
+		// StringVar/BoolVar calls need a fresh FlagSet to register into, and os.Args needs
+		// to hold exactly the args main() should see (not the -test.run=... this process
+		// was actually invoked with).
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+		os.Args = append([]string{os.Args[0]}, strings.Fields(extra)...)
+	}
+	main()
+}
+
+// buildSubprocessEnv returns a copy of the current process environment with the given
+// key/value overrides applied. Overridden keys are removed from the inherited environment
+// first, then re-appended -- exec.Cmd does not deduplicate Env entries, and on most libc
+// implementations the FIRST matching entry wins, so simply appending an override after
+// os.Environ() would silently be shadowed by any inherited value of the same key.
+func buildSubprocessEnv(overrides map[string]string) []string {
+	env := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, kv := range os.Environ() {
+		key, _, found := strings.Cut(kv, "=")
+		if found {
+			if _, overridden := overrides[key]; overridden {
+				continue
+			}
+		}
+		env = append(env, kv)
+	}
+	for k, v := range overrides {
+		env = append(env, k+"="+v)
+	}
+	return env
+}
+
+// runMainSubprocess execs this test binary as a child process, restricted (via -test.run) to
+// only run TestMainSubprocessHelper, which in turn invokes the real main(). env supplies the
+// child's environment overrides (see buildSubprocessEnv); mainSubprocessEnv is always added
+// automatically. Returns the child's combined stdout+stderr and its exit code.
+func runMainSubprocess(t *testing.T, env map[string]string) (output string, exitCode int) {
+	t.Helper()
+	overrides := make(map[string]string, len(env)+1)
+	for k, v := range env {
+		overrides[k] = v
+	}
+	overrides[mainSubprocessEnv] = "1"
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestMainSubprocessHelper$")
+	cmd.Env = buildSubprocessEnv(overrides)
+	out, err := cmd.CombinedOutput()
+	output = string(out)
+	if err == nil {
+		return output, 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return output, exitErr.ExitCode()
+	}
+	t.Fatalf("failed to run main() subprocess: %v\noutput:\n%s", err, output)
+	return "", -1
+}
+
+// TestMain_ExitsOnInvalidNamespaceScope drives the real main() through its
+// resolveScope-failure branch (POD_NAMESPACE empty/unset with neither -watch-namespaces nor
+// -all-namespaces set, ADR-076's fail-closed default) end to end: main() must actually stop
+// the process with a non-zero exit and must actually log the failure through its own
+// setupLog.Error call, not just return an error resolveScope-side that main() forgets to
+// act on.
+func TestMain_ExitsOnInvalidNamespaceScope(t *testing.T) {
+	output, exitCode := runMainSubprocess(t, map[string]string{
+		"POD_NAMESPACE":            "",
+		"KEYORIX_WATCH_NAMESPACES": "",
+	})
+	assert.Equal(t, 1, exitCode, "main() must exit(1) when resolveScope fails closed; output:\n%s", output)
+	assert.Contains(t, output, "POD_NAMESPACE",
+		"main() must surface the fail-closed error through its own logging, not swallow it; output:\n%s", output)
+}
+
+// TestMain_LogsWarningsBeforeFailingWithoutClusterCredentials drives main() past namespace
+// scope resolution (a valid POD_NAMESPACE this time) through its -metrics-bearer-token
+// startup WARNING log line and into ctrl.GetConfigOrDie() -- the call that builds the
+// manager's REST config, which in main.go happens before the -allowed-servers list is even
+// parsed, so that warning isn't reachable from this path (it's covered instead by
+// TestResolveScope_* and main.go's own control flow ordering; a genuinely successful manager
+// startup is integration-test territory, out of scope for a unit test). With KUBECONFIG
+// pointed at a nonexistent file, no in-cluster service-account environment, and HOME pointed
+// at an empty temp dir (so there's no ambient $HOME/.kube/config on the machine running the
+// test to fall back to), GetConfigOrDie's own config resolution deterministically fails and
+// calls os.Exit(1) itself -- entirely locally, no network access -- which is what proves
+// main() actually reached that call rather than stopping earlier for an unrelated reason.
+func TestMain_LogsWarningsBeforeFailingWithoutClusterCredentials(t *testing.T) {
+	tmpHome := t.TempDir()
+	output, exitCode := runMainSubprocess(t, map[string]string{
+		"POD_NAMESPACE":            "test-ns",
+		"KEYORIX_WATCH_NAMESPACES": "",
+		"KEYORIX_ALLOWED_SERVERS":  "",
+		"KEYORIX_METRICS_TOKEN":    "",
+		"KUBECONFIG":               filepath.Join(tmpHome, "does-not-exist"),
+		"HOME":                     tmpHome,
+		"KUBERNETES_SERVICE_HOST":  "",
+		"KUBERNETES_SERVICE_PORT":  "",
+	})
+	assert.NotEqual(t, 0, exitCode,
+		"main() must not proceed to mgr.Start() without any cluster credentials; output:\n%s", output)
+	assert.Contains(t, output, "metrics-bearer-token",
+		"the -metrics-bearer-token warning must be logged before manager startup; output:\n%s", output)
+	assert.Contains(t, output, "restricting watched namespaces",
+		"main() must reach and log the resolved namespace scope before attempting manager startup; output:\n%s", output)
+}
+
+// TestMain_LogsAllNamespacesWhenAllNamespacesFlagSet covers the other half of main()'s
+// scope-resolution logging (TestMain_LogsWarningsBeforeFailingWithoutClusterCredentials above
+// only exercises the "restricting watched namespaces" branch): with -all-namespaces passed on
+// argv, main() must log the cluster-wide watch explicitly rather than silently going
+// cluster-wide, per ADR-076 (see resolveScope's own doc comment on why -all-namespaces is the
+// only route there). Reuses the same KUBECONFIG/HOME-isolation trick as the test above to fail
+// deterministically, locally, before mgr.Start() -- once this far, which specific way it later
+// fails is not this test's concern.
+func TestMain_LogsAllNamespacesWhenAllNamespacesFlagSet(t *testing.T) {
+	tmpHome := t.TempDir()
+	output, exitCode := runMainSubprocess(t, map[string]string{
+		"POD_NAMESPACE":            "",
+		"KEYORIX_WATCH_NAMESPACES": "",
+		mainSubprocessArgsEnv:      "-all-namespaces",
+		"KUBECONFIG":               filepath.Join(tmpHome, "does-not-exist"),
+		"HOME":                     tmpHome,
+		"KUBERNETES_SERVICE_HOST":  "",
+		"KUBERNETES_SERVICE_PORT":  "",
+	})
+	assert.NotEqual(t, 0, exitCode,
+		"main() must not proceed to mgr.Start() without any cluster credentials; output:\n%s", output)
+	assert.Contains(t, output, "watching all namespaces",
+		"an explicit -all-namespaces must be logged, not silently applied; output:\n%s", output)
+}
+
+// fakeUnreachableKubeconfig writes a syntactically valid kubeconfig, in dir, that points at a
+// local loopback port nothing listens on. Pointing at 127.0.0.1 (rather than an off-host or
+// DNS-resolved address) means any connection attempt gets an immediate local "connection
+// refused" from the OS -- deterministic and instant, no DNS lookup and no timeout wait, so
+// this is safe to use from a unit test despite exercising a real client-go dial attempt.
+func fakeUnreachableKubeconfig(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "kubeconfig")
+	const content = `apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: https://127.0.0.1:1
+    insecure-skip-tls-verify: true
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user: {}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// TestMain_ExitsOnManagerCreationFailure covers main()'s own "unable to start manager" error
+// branch (the one guarding ctrl.NewManager, as opposed to ctrl.GetConfigOrDie's own separate
+// os.Exit(1) exercised by the tests above) -- reachable only when GetConfigOrDie itself
+// succeeds. fakeUnreachableKubeconfig supplies a syntactically valid config so GetConfigOrDie
+// succeeds, but pointed at an address nothing serves, so the manager's own setup (which
+// contacts the API server, e.g. to build its RESTMapper) fails -- deterministically and
+// without a hang, since the target is local loopback (see fakeUnreachableKubeconfig).
+func TestMain_ExitsOnManagerCreationFailure(t *testing.T) {
+	tmpHome := t.TempDir()
+	output, exitCode := runMainSubprocess(t, map[string]string{
+		"POD_NAMESPACE":            "test-ns",
+		"KEYORIX_WATCH_NAMESPACES": "",
+		"KEYORIX_METRICS_TOKEN":    "irrelevant-token",
+		"KUBECONFIG":               fakeUnreachableKubeconfig(t, tmpHome),
+		"HOME":                     tmpHome,
+		"KUBERNETES_SERVICE_HOST":  "",
+		"KUBERNETES_SERVICE_PORT":  "",
+	})
+	assert.Equal(t, 1, exitCode,
+		"main() must exit(1) when ctrl.NewManager itself fails, not just when GetConfigOrDie fails; output:\n%s", output)
+	assert.Contains(t, output, "unable to start manager",
+		"main() must log through its own ctrl.NewManager error branch; output:\n%s", output)
 }

--- a/operator/internal/controller/keyorixsecret_controller_test.go
+++ b/operator/internal/controller/keyorixsecret_controller_test.go
@@ -950,6 +950,266 @@ func TestReconcile_RefusesToAdoptSecretOwnedByAnotherCR(t *testing.T) {
 	assert.Equal(t, "other-cr", got.OwnerReferences[0].Name, "ownership must not have moved to the new CR")
 }
 
+// TestNewReconciler_ProducesUsableReconciler covers the constructor's happy path (the
+// error branch — crypto/rand.Read failing — isn't reasonably triggerable without
+// injecting a fake randomness source, and NewReconciler intentionally has none). It
+// checks the returned reconciler wires all four constructor args straight through, and
+// that hashKey is populated with real per-call randomness (#124: a fresh, non-empty key
+// every process start), not a fixed/zero value.
+func TestNewReconciler_ProducesUsableReconciler(t *testing.T) {
+	s := testScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	apiReader := fake.NewClientBuilder().WithScheme(s).Build()
+	allowed := []string{"https://keyorix.internal"}
+
+	r, err := NewReconciler(c, s, apiReader, allowed)
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	assert.Same(t, s, r.Scheme)
+	assert.Equal(t, allowed, r.AllowedServers)
+	require.Len(t, r.hashKey, 32, "hashKey must be a full 32-byte HMAC key")
+
+	r2, err := NewReconciler(c, s, apiReader, allowed)
+	require.NoError(t, err)
+	assert.NotEqual(t, r.hashKey, r2.hashKey, "each constructed reconciler gets its own fresh random key")
+}
+
+// TestFetcher_DefaultsToRealKeyorixClient covers the production path of fetcher() — when
+// newClient is unset (nil), which is always true outside tests (only test fixtures ever
+// override it) — building a real *keyorix.Client rather than the test seam.
+func TestFetcher_DefaultsToRealKeyorixClient(t *testing.T) {
+	r := &KeyorixSecretReconciler{}
+	f := r.fetcher("https://keyorix.internal", "tok")
+	require.NotNil(t, f)
+	_, ok := f.(*keyorix.Client)
+	assert.True(t, ok, "with no newClient override, fetcher must build the real keyorix.Client")
+}
+
+// TestReconcile_TokenKeyDefaultsToToken covers buildDesired's default for an unset
+// spec.tokenSecretRef.key: it must fall back to the literal key "token" rather than
+// failing to find any key at all.
+func TestReconcile_TokenKeyDefaultsToToken(t *testing.T) {
+	ks := ksFixture()
+	ks.Spec.TokenSecretRef.Key = "" // unset → defaults to "token"
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"), "app/production/api-key": []byte("k3y"),
+	}}
+	r, c := newReconciler(t, fetcher, ks, tokenSecret())
+
+	_, err := reconcile(t, r)
+	require.NoError(t, err, "an unset tokenSecretRef.key must default to reading the 'token' key")
+
+	var got corev1.Secret
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got))
+	assert.Equal(t, []byte("p4ss"), got.Data["DB_PASSWORD"])
+}
+
+// TestReconcile_EmptyTokenValueFails covers buildDesired's guard against a token Secret
+// that carries the expected key but an empty value — distinct from the key being
+// entirely absent (already covered by TestReconcile_MissingTokenSecretFails's sibling
+// paths): an empty bearer token must not be sent to the upstream server as if it were a
+// real credential.
+func TestReconcile_EmptyTokenValueFails(t *testing.T) {
+	emptyToken := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kx-token",
+			Namespace: "app",
+			Labels:    map[string]string{tokenSecretLabel: tokenSecretValue},
+		},
+		Data: map[string][]byte{"token": []byte("")},
+	}
+	r, c := newReconciler(t, &fakeFetcher{}, ksFixture(), emptyToken)
+
+	_, err := reconcile(t, r)
+	require.Error(t, err, "an empty token value must not be used as a bearer credential")
+	assert.Contains(t, err.Error(), "has no key")
+
+	var got corev1.Secret
+	err = c.Get(context.Background(), types.NamespacedName{Name: "db-creds", Namespace: "app"}, &got)
+	require.Error(t, err, "no Secret is created when the token value is empty")
+}
+
+// statusUpdateBlockingClient wraps a client.Client but fails every Status().Update call,
+// simulating an API-server error (etcd unavailable, conflict, RBAC drift) while writing
+// the CR's status subresource — used to exercise the error-return branches in fail(),
+// failGone(), and Reconcile's own succeed() call, none of which are reachable by making
+// the underlying fetch/apply fail (those already return before status-write failure can
+// occur) or succeed (succeed()'s own status write must independently be able to fail).
+type statusUpdateBlockingClient struct {
+	client.Client
+}
+
+func (c *statusUpdateBlockingClient) Status() client.SubResourceWriter {
+	return &blockingStatusWriter{SubResourceWriter: c.Client.Status()}
+}
+
+type blockingStatusWriter struct {
+	client.SubResourceWriter
+}
+
+func (w *blockingStatusWriter) Update(_ context.Context, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+	return errors.New("simulated status subresource update failure")
+}
+
+func newStatusBlockedReconciler(t *testing.T, fetcher valueFetcher, objs ...client.Object) (*KeyorixSecretReconciler, client.Client) {
+	t.Helper()
+	s := testScheme(t)
+	inner := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&secretsv1alpha1.KeyorixSecret{}).
+		WithObjects(objs...).
+		Build()
+	blocked := &statusUpdateBlockingClient{Client: inner}
+	return &KeyorixSecretReconciler{
+		Client:         blocked,
+		Scheme:         s,
+		AllowedServers: []string{"https://keyorix.internal"},
+		newClient:      func(_, _ string) valueFetcher { return fetcher },
+		hashKey:        []byte("test-fixture-hmac-key"),
+	}, blocked
+}
+
+// TestReconcile_SucceedStatusUpdateFailureSurfaces covers Reconcile's own error check on
+// succeed()'s return (the branch right after "spec.target.name is mutable..."): when the
+// fetch and apply both succeed but writing the success status back fails, Reconcile must
+// propagate that status-write error instead of silently reporting success.
+func TestReconcile_SucceedStatusUpdateFailureSurfaces(t *testing.T) {
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"),
+		"app/production/api-key":     []byte("k3y"),
+	}}
+	r, _ := newStatusBlockedReconciler(t, fetcher, ksFixture(), tokenSecret())
+
+	_, err := reconcile(t, r)
+	require.Error(t, err, "a status-write failure on an otherwise-successful sync must still be surfaced")
+	assert.Contains(t, err.Error(), "simulated status subresource update failure")
+}
+
+// TestReconcile_FailStatusUpdateFailureSurfaces covers fail()'s own status-write error
+// branch: an ordinary sync failure (a plain fetch error) whose status write ALSO fails
+// must return the status-write error (so the workqueue backs off), not silently drop it.
+func TestReconcile_FailStatusUpdateFailureSurfaces(t *testing.T) {
+	fetcher := &fakeFetcher{failRefs: map[string]bool{"app/production/db-password": true}}
+	r, _ := newStatusBlockedReconciler(t, fetcher, ksFixture(), tokenSecret())
+
+	_, err := reconcile(t, r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "simulated status subresource update failure",
+		"fail()'s own Status().Update error must be returned, not the original fetch cause")
+}
+
+// TestReconcile_FailGoneStatusUpdateFailureSurfaces is FailStatusUpdateFailureSurfaces's
+// sibling for the confirmed-gone path: failGone()'s own status-write error branch.
+func TestReconcile_FailGoneStatusUpdateFailureSurfaces(t *testing.T) {
+	fetcher := &fakeFetcher{goneRefs: map[string]bool{"app/production/db-password": true}}
+	r, _ := newStatusBlockedReconciler(t, fetcher, ksFixture(), tokenSecret())
+
+	_, err := reconcile(t, r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "simulated status subresource update failure",
+		"failGone()'s own Status().Update error must be returned, not the original ErrSecretGone cause")
+}
+
+// getErrorClient wraps a client.Client but fails every Get for an object named
+// errorGetName with a plain (non-NotFound) error, simulating a transient API-server
+// error distinct from "the object doesn't exist" — used to exercise wipeTargetSecret's
+// error-propagation branch (client.IgnoreNotFound(err) only swallows NotFound; any other
+// error must still surface as wipeErr).
+type getErrorClient struct {
+	client.Client
+	errorGetName string
+	// active gates when errorGetName starts erroring, so the FIRST reconcile (whose
+	// applySecret also Gets the target Secret, via controllerutil.CreateOrUpdate, to
+	// decide create-vs-update) can still succeed normally; only the LATER
+	// wipeTargetSecret call under test should observe the simulated error.
+	active bool
+}
+
+func (c *getErrorClient) Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+	if c.active && key.Name == c.errorGetName {
+		return errors.New("simulated transient API error reading target Secret")
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+// TestReconcile_WipeTargetSecretGetErrorSurfacedInStatus covers wipeTargetSecret's other
+// failure branch (besides Delete failing, already pinned by
+// TestReconcile_WipeFailureSurfacedInStatus): the preliminary r.Get(ctx, key, &secret)
+// itself erroring with something other than NotFound (e.g. a transient API-server
+// error). That must be treated the same as a Delete failure — surfaced via the
+// "WipeFailed" status suffix — not swallowed the way a genuine NotFound is.
+func TestReconcile_WipeTargetSecretGetErrorSurfacedInStatus(t *testing.T) {
+	fetcher := &fakeFetcher{values: map[string][]byte{
+		"app/production/db-password": []byte("p4ss"),
+		"app/production/api-key":     []byte("k3y"),
+	}}
+	s := testScheme(t)
+	inner := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&secretsv1alpha1.KeyorixSecret{}).
+		WithObjects(ksFixture(), tokenSecret()).
+		Build()
+	erroring := &getErrorClient{Client: inner, errorGetName: "db-creds"}
+	r := &KeyorixSecretReconciler{
+		Client:         erroring,
+		Scheme:         s,
+		AllowedServers: []string{"https://keyorix.internal"},
+		newClient:      func(_, _ string) valueFetcher { return fetcher },
+		hashKey:        []byte("test-fixture-hmac-key"),
+	}
+
+	_, err := reconcile(t, r)
+	require.NoError(t, err)
+
+	// Confirmed gone on the next reconcile; wipeTargetSecret's own Get on the target
+	// Secret now fails with a non-NotFound error.
+	erroring.active = true
+	fetcher.goneRefs = map[string]bool{"app/production/db-password": true}
+	_, err = reconcile(t, r)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, keyorix.ErrSecretGone))
+
+	erroring.active = false // let the final status re-read through
+	var ks secretsv1alpha1.KeyorixSecret
+	require.NoError(t, erroring.Get(context.Background(), types.NamespacedName{Name: "db", Namespace: "app"}, &ks))
+	require.Len(t, ks.Status.Conditions, 1)
+	assert.Equal(t, "UpstreamSecretGoneWipeFailed", ks.Status.Conditions[0].Reason,
+		"a non-NotFound Get error inside wipeTargetSecret must surface the same way a Delete failure does")
+}
+
+// TestSetupWithManager_PropagatesBuildError covers SetupWithManager itself
+// (setupController's thin public wrapper, which discards the built
+// controller.Controller and returns only the error) — everything else in this file
+// exercises setupController directly so it can inspect the built controller, but
+// nothing had called the actual public entrypoint cmd/main.go uses.
+//
+// This deliberately builds the manager with a scheme that does NOT have
+// secretsv1alpha1 registered, so ctrl.NewControllerManagedBy(...).For(&KeyorixSecret{})
+// fails at the GVK lookup — a deterministic, self-contained failure. This is used
+// (rather than a scheme built via testScheme, which WOULD succeed) specifically to
+// avoid controller-runtime's process-global controller-name registry: a second
+// successful build of a "keyorixsecret"-named controller in this same test binary
+// would collide with the one TestSetupController_SetsMaxConcurrentReconciles already
+// registers ("controller with name keyorixsecret already exists"), regardless of test
+// execution order. SetupWithManager's body has no branch of its own — it's a single
+// assign-then-return block — so exercising either outcome (error or success) covers it
+// equally; the error path is the only one that's order-independent here.
+func TestSetupWithManager_PropagatesBuildError(t *testing.T) {
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s)) // no secretsv1alpha1 registered
+
+	mgr, err := ctrl.NewManager(&rest.Config{Host: "https://127.0.0.1:1"}, ctrl.Options{
+		Scheme:                 s,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	require.NoError(t, err, "manager construction must not require a live API server connection")
+
+	r := &KeyorixSecretReconciler{Client: fake.NewClientBuilder().WithScheme(s).Build(), Scheme: s, hashKey: []byte("test-fixture-hmac-key")}
+	err = r.SetupWithManager(mgr)
+	assert.Error(t, err, "SetupWithManager must propagate setupController's build error, not swallow it")
+}
+
 // SetupWithManager must configure a small, fixed MaxConcurrentReconciles (r143). Without
 // it, controller-runtime's default of exactly 1 means one shared worker services every
 // KeyorixSecret in every namespace cluster-wide — a single slow/malicious CR (large Data

--- a/operator/internal/keyorix/client_test.go
+++ b/operator/internal/keyorix/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -166,4 +167,85 @@ func TestClient_RefusesRedirect(t *testing.T) {
 	_, err := New(redirector.URL, "tok").FetchValue(context.Background(), "a/b/c")
 	require.Error(t, err, "a redirect must be refused, not silently followed")
 	assert.Contains(t, err.Error(), "redirect")
+}
+
+// TestClient_FetchValueMalformedJSONBodyErrors pins that a 200 response whose body is
+// not valid JSON at all (a proxy/gateway mangling the body, a non-JSON error page
+// mistakenly served with a 200 status, etc.) surfaces as a decode error rather than a
+// panic or a silently empty value.
+func TestClient_FetchValueMalformedJSONBodyErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{not valid json`))
+	}))
+	defer srv.Close()
+
+	v, err := New(srv.URL, "tok").FetchValue(context.Background(), "a/b/c")
+	require.Error(t, err)
+	assert.Nil(t, v)
+	assert.Contains(t, err.Error(), "decode response")
+}
+
+// TestClient_FetchValueRejectsInvalidBaseURL pins that FetchValue itself re-validates
+// c.baseURL (not just at construction time) before ever issuing a request — see the
+// validateClientBaseURL doc comment on why this direct read of c.baseURL matters for
+// static analysis. A Client built with a non-https, non-loopback base URL must fail
+// closed instead of sending the bearer token anywhere.
+func TestClient_FetchValueRejectsInvalidBaseURL(t *testing.T) {
+	c := &Client{baseURL: "ftp://example.com", token: "tok", hc: &http.Client{Timeout: time.Second}}
+	v, err := c.FetchValue(context.Background(), "a/b/c")
+	require.Error(t, err)
+	assert.Nil(t, v)
+	assert.Contains(t, err.Error(), "must use https")
+}
+
+// TestValidateClientBaseURL exercises every branch of validateClientBaseURL directly:
+// unparseable URLs, missing hosts, the https-always-ok path, the http-loopback-only
+// exception, and rejection of both non-loopback http and non-http/https schemes.
+func TestValidateClientBaseURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr string // substring; empty means no error
+	}{
+		{"unparseable URL", "http://example.com/%zz", "invalid base URL"},
+		{"missing host", "not-a-url", "missing a host"},
+		{"missing host, scheme only", "http://", "missing a host"},
+		{"https any host accepted", "https://example.com", ""},
+		{"http loopback hostname accepted", "http://localhost:8080", ""},
+		{"http loopback IP accepted", "http://127.0.0.1:8080", ""},
+		{"http non-loopback host rejected", "http://example.com", "must use https"},
+		{"non-http/https scheme rejected", "ftp://localhost", "must use https"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateClientBaseURL(tc.raw)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestIsLoopbackHost exercises every branch of isLoopbackHost: the literal "localhost"
+// shortcut, IPv4/IPv6 loopback addresses, a parseable-but-non-loopback IP, and a
+// non-IP, non-"localhost" hostname.
+func TestIsLoopbackHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"localhost", true},
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"8.8.8.8", false},
+		{"example.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			assert.Equal(t, tc.want, isLoopbackHost(tc.host))
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- `api/v1alpha1`: 0%→100% — DeepCopy round-trip tests for every CRD type (catching the real bug class of a forgotten deep-copy on a slice/pointer field) plus `AddToScheme` registration coverage.
- `cmd`: 39.3%→72.6% — fills gaps in the existing `main_test.go`, including subprocess-based tests for `os.Exit` paths in `main()`.
- `internal/controller`: 91.4%→99.3%.
- `internal/keyorix`: 78.6%→97.6%.
- No production logic changed; every file touched is a `_test.go` file (new or extended).

## Test plan
- [x] `GOWORK=off go -C operator test ./...` — all packages pass
- [x] `GOWORK=off go -C operator vet ./...` clean
- [x] `gofmt -l` clean on every changed file