### PR TITLE
ci: re-enable internal/core in the go test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,6 @@ jobs:
           root_base() {
             go list ./... | grep -v \
               -e 'internal/cli$' \
-              -e 'internal/core$' \
               -e 'internal/storage/remote' \
               -e 'server/http$' \
               -e 'server/http/handlers$' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,21 @@ jobs:
           - leg: root-4
             timeout: 600
             coverage-file: coverage_root4.out
+          # core (internal/core, re-enabled 2026-08-22 after ~4 months dark --
+          # see fix/ci-reenable-internal-core) gets its own pinned leg rather
+          # than folding into root-4's catch-all: measured 369.6s in isolation
+          # locally (-race, same flags as this leg) but 605s -- over root-4's
+          # 600s budget -- sharing a runner with a dozen other concurrent test
+          # binaries there. A per-package timeout exists to catch hangs, not
+          # to enforce a speed budget; 1800s here is deliberately generous so
+          # a healthy-but-slow run never trips it, rather than tuning to just
+          # past the observed duration and risking the same intermittent-red
+          # outcome that made the April exclusion look justified in hindsight.
+          # 323 test files in one package is itself worth revisiting --
+          # tracked separately, not folded into this CI-scheduling fix.
+          - leg: core
+            timeout: 1800
+            coverage-file: coverage_core.out
           # handlers (server/http/handlers, one package, 167 test files, 5151
           # top-level tests, all already t.Parallel()) measured at 911s in CI
           # -- vs. 15s wall / 37s summed-per-test locally without -race. That
@@ -430,6 +445,8 @@ jobs:
           github.com/keyorixhq/keyorix/internal/delivery
           github.com/keyorixhq/keyorix/internal/core/storage"
 
+          core_pkgs="github.com/keyorixhq/keyorix/internal/core"
+
           leg="${{ matrix.leg }}"
           # Empty matches everything (verified: `go test -run ""` and no
           # -run flag at all select the identical test set) -- root-1/2/3/4
@@ -446,11 +463,14 @@ jobs:
             root-3)
               pkgs="$root_3_pkgs"
               ;;
+            core)
+              pkgs="$core_pkgs"
+              ;;
             root-4)
               # Catch-all: every root-eligible package not pinned to root-1/2/3
-              # above, including any package added since this split was last
-              # tuned. comm needs both inputs sorted.
-              pinned=$(printf '%s\n%s\n%s\n' "$root_1_pkgs" "$root_2_pkgs" "$root_3_pkgs" | sort -u)
+              # or core above, including any package added since this split
+              # was last tuned. comm needs both inputs sorted.
+              pinned=$(printf '%s\n%s\n%s\n%s\n' "$root_1_pkgs" "$root_2_pkgs" "$root_3_pkgs" "$core_pkgs" | sort -u)
               pkgs=$(comm -23 <(root_base | sort -u) <(echo "$pinned"))
               ;;
             handlers-1|handlers-2|handlers-3|handlers-4)


### PR DESCRIPTION
## Summary
- `internal/core` has been excluded from CI since 2026-04-27 (b81829b4) over a single mock-mismatch failure in `TestListSecretsWithSharingInfo`.
- That test was rewritten as part of #1048 (2026-07-19, ACL-grant surfacing) and has passed since — verified directly with `-run '^TestListSecretsWithSharingInfo$' -v`, not just inferred from a clean package run.
- The exclusion outlived the failure it was created for by about a month, and nothing surfaced that until this audit.

## First attempt (folding into root-4) went red on the real runner
Re-verified locally against CI's exact `go test` invocation (`-race -timeout 600s -run "" -covermode=atomic`) before opening this: 0 failures, 0 data races, 369.6s wall time. But on the actual GitHub Actions runner, `root-4` (the catch-all leg `internal/core` fell into) failed: `internal/core` alone took 605.014s against the leg's 600s budget — over by ~5s, running concurrently with a dozen other root-4 packages competing for the runner's CPU under `-race`. Since both the local and CI measurements used `-race`, that flag isn't the explanatory variable; the gap is runner contention.

## Fix: dedicated leg + generous timeout, not a tuned-down one
- `internal/core` now gets its own pinned leg (`core`), removing the root-4 contention.
- That leg's timeout is `1800s` — deliberately generous. A per-package timeout exists to catch hangs (deadlocks, infinite loops), not to enforce a speed budget. 605s against a 600s budget isn't "5 seconds too slow": under variable runner load the package sits non-deterministically across a tight threshold, and tuning to just past the observed duration risks the same intermittent-red outcome that made the original exclusion look justified in hindsight. Unused headroom costs nothing; a timeout kill yields no information at all, not even which tests passed.
- `internal/cli$` and `internal/storage/remote` stay excluded — separate, already-diagnosed root cause (a test-hermeticity bug, not a CI-signal problem), fixed in #1522.
- 323 test files in one package is itself worth revisiting — that's a refactor, not a CI-scheduling fix. Will open a tracking issue with the isolated CI duration once this leg goes green.

## Test plan
- [x] `go test -race -timeout 600s -run "" -covermode=atomic ./internal/core` locally — 0 failures, 0 races, 369.6s
- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] Dry-ran the leg-splitting shell logic locally (`comm`/`grep` package partitioning) — confirmed `internal/core` appears in exactly one leg (`core`), correctly absent from `root-4`
- [ ] This PR's own CI run — the real test of the dedicated leg