### PR TITLE
fix(cli): isolate $HOME in tests so they never read a developer's real ~/.keyorix/cli.yaml

### DIFF
--- a/internal/cli/accessreview/testmain_test.go
+++ b/internal/cli/accessreview/testmain_test.go
@@ -1,0 +1,19 @@
+package accessreview
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/audit/testmain_test.go
+++ b/internal/cli/audit/testmain_test.go
@@ -1,0 +1,19 @@
+package audit
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/breakglass/testmain_test.go
+++ b/internal/cli/breakglass/testmain_test.go
@@ -1,0 +1,19 @@
+package breakglass
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/dynamic/testmain_test.go
+++ b/internal/cli/dynamic/testmain_test.go
@@ -1,0 +1,19 @@
+package dynamic
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/group/testmain_test.go
+++ b/internal/cli/group/testmain_test.go
@@ -1,0 +1,19 @@
+package group
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/machine/testmain_test.go
+++ b/internal/cli/machine/testmain_test.go
@@ -1,0 +1,19 @@
+package machine
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/notification/testmain_test.go
+++ b/internal/cli/notification/testmain_test.go
@@ -1,0 +1,19 @@
+package notification
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/pat/testmain_test.go
+++ b/internal/cli/pat/testmain_test.go
@@ -1,0 +1,19 @@
+package pat
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/rbac/rbac_integration_test.go
+++ b/internal/cli/rbac/rbac_integration_test.go
@@ -463,9 +463,15 @@ func TestMain(m *testing.M) {
 	_ = os.Setenv("KEYORIX_ENV", "test")
 	_ = os.Setenv("KEYORIX_LOG_LEVEL", "error")
 
+	// Isolate $HOME so tests never read a developer's real ~/.keyorix/cli.yaml
+	// (internal/cli/config.LoadCLIConfig) -- see testhelper.IsolateCLIHome's
+	// doc comment for why this must happen once here, not per-test.
+	cleanupHome := testhelper.IsolateCLIHome()
+
 	// Run tests
 	code := m.Run()
 
 	// Cleanup
+	cleanupHome()
 	os.Exit(code)
 }

--- a/internal/cli/risk/testmain_test.go
+++ b/internal/cli/risk/testmain_test.go
@@ -1,0 +1,19 @@
+package risk
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/secret/testmain_test.go
+++ b/internal/cli/secret/testmain_test.go
@@ -1,0 +1,19 @@
+package secret
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/share/testmain_test.go
+++ b/internal/cli/share/testmain_test.go
@@ -1,0 +1,19 @@
+package share
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/sod/testmain_test.go
+++ b/internal/cli/sod/testmain_test.go
@@ -1,0 +1,19 @@
+package sod
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/system/testmain_test.go
+++ b/internal/cli/system/testmain_test.go
@@ -1,0 +1,19 @@
+package system
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/cli/user/testmain_test.go
+++ b/internal/cli/user/testmain_test.go
@@ -1,0 +1,19 @@
+package user
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+)
+
+// TestMain isolates $HOME so tests never read a developer's real
+// ~/.keyorix/cli.yaml (internal/cli/config.LoadCLIConfig) -- see
+// testhelper.IsolateCLIHome's doc comment for why this belongs here, not in
+// each test.
+func TestMain(m *testing.M) {
+	cleanup := testhelper.IsolateCLIHome()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/internal/testhelper/cli_home.go
+++ b/internal/testhelper/cli_home.go
@@ -1,0 +1,45 @@
+package testhelper
+
+import "os"
+
+// IsolateCLIHome points $HOME at a fresh temp directory (and clears
+// XDG_CONFIG_HOME) for the duration of a package's test binary run, so tests
+// that transitively read ~/.keyorix/cli.yaml via
+// internal/cli/config.LoadCLIConfig never see a developer's real config.
+// getDefaultCLIConfigPath (internal/cli/config/cli_config.go) checks
+// XDG_CONFIG_HOME first, then falls back to os.UserHomeDir() ($HOME on
+// unix) -- both must be overridden for isolation to hold.
+//
+// Call from TestMain, not from individual tests: env vars are process-wide,
+// so a per-test t.Setenv would still leave a window where a test running
+// before HOME is overridden (or a t.Parallel() sibling) reads the real file.
+// Returns a cleanup func restoring the previous environment and removing the
+// temp directory; call it after m.Run() and before os.Exit.
+func IsolateCLIHome() (cleanup func()) {
+	dir, err := os.MkdirTemp("", "keyorix-cli-test-home-*")
+	if err != nil {
+		// TestMain has no *testing.T to fail through; a broken temp dir
+		// means every test in the package would silently fall through to
+		// the real $HOME instead, which is worse than crashing loudly here.
+		panic("testhelper.IsolateCLIHome: " + err.Error())
+	}
+
+	prevHome, hadHome := os.LookupEnv("HOME")
+	prevXDG, hadXDG := os.LookupEnv("XDG_CONFIG_HOME")
+	_ = os.Setenv("HOME", dir)
+	_ = os.Unsetenv("XDG_CONFIG_HOME")
+
+	return func() {
+		if hadHome {
+			_ = os.Setenv("HOME", prevHome)
+		} else {
+			_ = os.Unsetenv("HOME")
+		}
+		if hadXDG {
+			_ = os.Setenv("XDG_CONFIG_HOME", prevXDG)
+		} else {
+			_ = os.Unsetenv("XDG_CONFIG_HOME")
+		}
+		_ = os.RemoveAll(dir)
+	}
+}


### PR DESCRIPTION
## Summary
- 107 subtests across 15 `internal/cli` subpackages (accessreview, audit, breakglass, dynamic, group, machine, notification, pat, rbac, risk, secret, share, sod, system, user) were failing on this machine — not from a code bug, but because `internal/cli/config.LoadCLIConfig("")` resolves to `os.UserHomeDir()/.keyorix/cli.yaml` with no override, and every dual-mode/remote-mode test that transitively calls it reads whatever real config happens to exist on the machine running the tests.
- This is a **test hermeticity bug**, not an environment quirk: a test that reads real user config behaves differently on every machine and only passes on a clean one by accident — CI runners have no such file, so they never surfaced this class of coupling at all.
- Fix: `testhelper.IsolateCLIHome` (`internal/testhelper/cli_home.go`) points `$HOME` at a fresh temp dir and clears `XDG_CONFIG_HOME` for a package's whole test binary run. Applied via `TestMain` in all 15 affected packages (14 new, one merged into `rbac`'s existing `TestMain`) — one shared helper, not per-test `t.Setenv` scattered across 107 functions. `TestMain` rather than `t.Setenv` because env vars are process-wide: a per-test override would still leave a window where an earlier test, or a `t.Parallel()` sibling, reads the real file.
- Related but out of scope here: the 30s-per-test cost itself (before this fix) traces to `http.Client.Timeout` bounding the whole round trip rather than just the connect phase — filed separately as #1521.

## Test plan
- [x] Verified against CI's exact invocation (`-race -count=1 -timeout 600s`) before and after this fix, with the stale `~/.keyorix/cli.yaml` still in place: all 15 packages now pass, zero data races. Previously up to 600s (timeout) per package; now the slowest is 224s (`internal/cli/user`), most under 5s.
- [x] `go vet` on all 16 touched files — clean