### PR TITLE
ci: re-enable server/http, sharded across 6 dedicated legs (G80 C4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,39 @@ jobs:
           - leg: handlers-4
             timeout: 1800
             coverage-file: coverage_handlers4.out
+          # http (server/http, re-enabled 2026-08-23 after ~4 months dark --
+          # see docs/g80-remediation-notes.md, G80 C4). Measured 1904.015s
+          # locally (-race, unsharded, one full run, zero failures beyond
+          # two already-fixed-on-main fixtures) -- healthy and slow, not
+          # deadlocked (the prior 20-minute goroutine-dump "failure" that
+          # motivated this measurement was the default go-test timeout
+          # cutting off a genuinely still-running suite, not a hang).
+          # Sharded 6 ways by test name (same mechanism as handlers-1..4
+          # above, generalized into run_filter_for_shard) rather than left
+          # as one leg: 1904.015s * ~1.7 local->runner factor puts an
+          # unsharded run around 3237s, well past any per-leg budget this
+          # workflow uses elsewhere. 6 shards lands each at ~540s, ~30% of
+          # the 1800s timeout -- comfortably under budget with real headroom
+          # to spare, matching this workflow's generous-timeout precedent
+          # rather than tuning tight to the observed duration.
+          - leg: http-1
+            timeout: 1800
+            coverage-file: coverage_http1.out
+          - leg: http-2
+            timeout: 1800
+            coverage-file: coverage_http2.out
+          - leg: http-3
+            timeout: 1800
+            coverage-file: coverage_http3.out
+          - leg: http-4
+            timeout: 1800
+            coverage-file: coverage_http4.out
+          - leg: http-5
+            timeout: 1800
+            coverage-file: coverage_http5.out
+          - leg: http-6
+            timeout: 1800
+            coverage-file: coverage_http6.out
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -389,8 +422,8 @@ jobs:
           leg="${{ matrix.leg }}"
           # Empty matches everything (verified: `go test -run ""` and no
           # -run flag at all select the identical test set) -- every leg
-          # except handlers-N leaves this empty, since only handlers shards
-          # by test name rather than by package.
+          # except handlers-N/http-N leaves this empty, since only those
+          # shard by test name rather than by package.
           run_filter=""
           pkgs=$(pkgs_for_leg "$leg")
 
@@ -407,6 +440,14 @@ jobs:
               shard=${leg#handlers-}
               run_filter=$(run_filter_for_shard "$pkgs" "$shard" 4)
               pkgs=./server/http/handlers/...
+              ;;
+            http-1|http-2|http-3|http-4|http-5|http-6)
+              # server/http, 392 top-level tests -- same by-test-name-mod-N
+              # sharding as handlers-N above (see http_pkg's own comment in
+              # scripts/ci-test-legs.sh for the shard-count derivation).
+              shard=${leg#http-}
+              run_filter=$(run_filter_for_shard "$pkgs" "$shard" 6)
+              pkgs=./server/http
               ;;
           esac
           # $pkgs is deliberately unquoted below: it holds a space-separated
@@ -565,7 +606,7 @@ jobs:
       - name: Merge coverage profiles
         run: |
           echo "mode: atomic" > coverage_merged.out
-          tail -q -n +2 coverage_root1.out coverage_root2.out coverage_root3.out coverage_root4.out coverage_handlers1.out coverage_handlers2.out coverage_handlers3.out coverage_handlers4.out >> coverage_merged.out
+          tail -q -n +2 coverage_root1.out coverage_root2.out coverage_root3.out coverage_root4.out coverage_handlers1.out coverage_handlers2.out coverage_handlers3.out coverage_handlers4.out coverage_http1.out coverage_http2.out coverage_http3.out coverage_http4.out coverage_http5.out coverage_http6.out >> coverage_merged.out
           mv coverage_merged.out coverage.out
 
       - name: Check coverage floor (≥${{ env.COVERAGE_FLOOR }}%)

--- a/scripts/ci-test-legs.sh
+++ b/scripts/ci-test-legs.sh
@@ -45,9 +45,7 @@
 # not hidden -- it's on record in #1533/#1534/#1535 and in this comment.
 exclusion_entries() {
   cat <<'EOF'
-internal/cli$|TEMPORARY|TestRemoteCLIIntegration/TestLocalToRemoteSwitching require a running server (originally excluded 2026-04-27, commit 7ccb7dda)|#1533|2026-08-23
-internal/storage/remote|TEMPORARY|TestRemoteStorage_Health times out (originally excluded 2026-04-27, commit 7ccb7dda)|#1534|2026-08-23
-server/http$|TEMPORARY|TestSharingHTTPIntegration/TestHTTPServerErrorScenarios -- G80 campaign C4 target (originally excluded 2026-04-27, commit 7ccb7dda)|#1535|2026-08-23
+server/http$|SHARDED|runs in its own dedicated http-1..6 matrix legs below (G80 C4, 2026-08-23) -- see #1535 for the ~4-month exclusion history this closes|#1535|2026-08-23
 server/http/handlers$|SHARDED|runs in its own dedicated handlers-1..4 matrix legs below|n/a|2026-04-27
 server/proto/pb$|PERMANENT|auto-generated protobuf code (DO NOT EDIT), no tests to write|n/a|2026-07-18
 EOF
@@ -178,6 +176,20 @@ handlers_pkg() {
   echo "github.com/keyorixhq/keyorix/server/http/handlers"
 }
 
+# http_pkg: the single package every http-1..6 leg shards by test name, not
+# by package (G80 C4) -- same reasoning and mechanism as handlers_pkg above.
+# 6 shards, not 4: measured 1904.015s local (-race, unsharded, single run --
+# see docs/g80-remediation-notes.md) with zero failures beyond the two
+# already-fixed-on-main C1-scope fixtures, confirming server/http is healthy
+# and slow, not deadlocked. 1904.015s * ~1.7 (local->runner factor) ~=
+# 3237s runner-equivalent; 6 shards puts each at ~540s, ~30% of the 1800s
+# per-leg timeout budget -- comfortably under the "roughly a third" target
+# with real headroom, matching every other leg's generous-budget precedent
+# (see the timeout-raise comment above).
+http_pkg() {
+  echo "github.com/keyorixhq/keyorix/server/http"
+}
+
 # pkgs_for_leg: package list for a given leg name, space/newline-separated.
 # Matches the case statement the test-suite matrix step uses to pick $pkgs.
 pkgs_for_leg() {
@@ -188,6 +200,7 @@ pkgs_for_leg() {
     core) core_pkgs ;;
     root-4) root_4_pkgs ;;
     handlers-1|handlers-2|handlers-3|handlers-4) handlers_pkg ;;
+    http-1|http-2|http-3|http-4|http-5|http-6) http_pkg ;;
     *) echo "pkgs_for_leg: unknown leg '$1'" >&2; return 1 ;;
   esac
 }
@@ -206,6 +219,12 @@ handlers-1
 handlers-2
 handlers-3
 handlers-4
+http-1
+http-2
+http-3
+http-4
+http-5
+http-6
 EOF
 }
 


### PR DESCRIPTION
## Summary

Part of the G80 CI-baseline campaign. \`server/http\` has been excluded from the test-suite matrix since 2026-04-27 (commit \`7ccb7dda\`) with no dedicated leg even if un-excluded — the exact shape C5's completeness guard now exists to catch.

## Is it safe to re-enable?

Investigated before sharding: ran the full unsharded package locally with \`-race\` and a 3600s timeout, specifically to distinguish "healthy and slow" from "genuinely deadlocked." An earlier attempt hit a 20-minute goroutine-dump "failure" that turned out to be the default \`go test\` timeout cutting off a still-running suite, not a hang — zero \`--- FAIL\` lines anywhere in that log.

This run completed cleanly in **1904.015s**: only the 2 already-known, already-fixed-on-main C1-scope fixture failures (\`RemoveGlobalAdminRoleGuarded_RealServer\`, \`ConcurrentRace_LastAdminNeverStranded_RealServer\` — the branch this ran on predates #1525's merge), nothing else. **Confirms server/http is healthy and slow, not deadlocked.**

## Shard sizing

6 shards (\`http-1..6\`), by test name — mirrors \`handlers-1..4\`'s existing mod-N mechanism exactly (generalized into \`run_filter_for_shard\` in #1536, reused here rather than reimplemented).

- 1904.015s local × ~1.7 (local→runner factor, same one used for \`internal/core\`'s leg) ≈ 3237s runner-equivalent, unsharded.
- Target: each shard under ~1/3 of the 1800s per-leg timeout (~600s).
- 6 shards → ~540s/shard, ~30% of budget — comfortably under, with real headroom, matching this workflow's generous-timeout precedent rather than tuning tight to the observed duration.

## Also swept in

\`internal/cli\$\` and \`internal/storage/remote\` — both measured clean locally (0.558s and 31.201s, zero failures) — fold into \`root-4\`'s dynamic catch-all; too small to need a dedicated leg. Closes #1533, #1534, #1535.

\`scripts/ci-test-legs.sh\`'s exclusion table: the three \`TEMPORARY\` entries for these packages are removed; \`server/http\$\`'s entry changes to \`SHARDED\` (it now has its own legs) rather than being deleted outright, matching \`server/http/handlers\$\`'s existing treatment — still excluded from \`root_base()\` so it doesn't double-run, still accounted for in the completeness union via its own legs.

## Verification

- [x] \`actionlint\` clean
- [x] \`shellcheck -x\` clean on the updated script
- [x] \`exclusion-freshness\`/\`assert-leg-completeness\` (from #1536) both re-verified locally against this branch's real \`go list ./...\`, in a container matching the pinned CI Go version — both pass
- [x] \`internal/cli\`/\`internal/storage/remote\` locally confirmed clean (see above)
- [ ] Full CI run, all legs including \`http-1..6\`, must be green before merge (per the campaign's standing rule: a red C4 stays unmerged — intermittently-red CI is worse than one more day of \`server/http\` dark)