### PR TITLE
docs(adr-085): re-scope after route classification and #1524 fix

### DIFF
--- a/docs/adr-085-node-credential-permission-scope.md
+++ b/docs/adr-085-node-credential-permission-scope.md
@@ -8,6 +8,42 @@ code changes** — the two findings below are filed and, per explicit
 instruction, not patched here. Implementation, if this ADR is accepted, is
 its own follow-up work with its own review.
 
+**Update (2026-08-23) — central recommendation is blocked, and no longer
+launch-blocking:**
+
+- **Blocked.** The route classification done for #1532 (comment on that
+  issue) confirms this ADR's recommended fix — give `MachineTypeNode` its own
+  scoped permission set via ADR-030's `machine_identity_roles`/
+  `AuthorizePrincipal` mechanism — cannot close findings (b) `AddGroupMemberProxy`
+  or (c) `ApproveRiskExceptionProxy` as proposed. Both are **per-actor
+  ceilings**: they need to know *which specific human* is acting (is this
+  human already an admin-conferring-group member who can add another; is
+  this human someone other than the exception's creator). A node identity,
+  scoped or not, is not and cannot become a specific human — `AuthorizePrincipal`
+  answers "is this principal allowed," never "which human does this
+  principal act on behalf of," and `core.CreateMachineIdentity` (`internal/core/machine_identities.go:75`)
+  independently rejects `projectID == 0`, so a node identity can never hold a
+  *global-scope* role even if this ADR's mechanism were built — and both
+  ceilings are checked at global/admin scope. Scoping the node's permission
+  set narrower does not change that a node has no per-actor identity to
+  check against. See "The two ceiling types" below — this is a structural
+  property of the ceiling, not a gap this ADR's proposed mechanism happens
+  to leave open.
+- **No longer launch-blocking.** Findings (b) and (c) are fixed independently
+  of this ADR's decision, by a narrower rule that needs no new mechanism: a
+  machine actor may not perform an operation whose safety depends on knowing
+  which human is acting — deny, fail closed (matching the precedent already
+  set by `CreateUserWithRoleGrantsProxy`). That fix is implemented, tested,
+  and adversarially verified (branch `fix-1524-machine-actor-fail-closed`).
+  This ADR's open question — whether `MachineTypeNode` should carry its own
+  scoped permission set at all — remains real and worth deciding, but nothing
+  here still blocks shipping.
+- **Decision needed by 2026-09-15.** No code depends on this ADR being
+  accepted or rejected; it will not force a build failure if left open. It is
+  tracked here, not enforced, so it needs an explicit owner and date or it
+  will age quietly — see `docs/adr-085-node-credential-permission-scope.md`
+  itself as the tracking artifact until a decision lands.
+
 ## Context
 
 ### The current gate, and why it exists
@@ -88,6 +124,37 @@ relay call ends up persisting `CreatedBy=0`/`RevokedBy=0` on governance
 records, because the wire protocol carries no acting-user identity across
 the hop at all.
 
+### The two ceiling types — why this isn't a binary "close the gate or don't"
+
+The route classification for #1532 sorted every `RequireNodeCredentialOrPermission`
+route by what kind of check its `internal/core` function needs, and found the
+gap is not uniform across the group — it splits cleanly into two kinds:
+
+- **Target-state-invariant checks** — the check depends only on the state
+  being mutated, never on who's asking. `RemoveGlobalAdminRoleGuardedProxy`'s
+  "would this strand the last admin" check, or `RemoveGroupMemberProxy`'s
+  equivalent, are safe for *any* caller including a bare node credential, by
+  construction: the question "does zero admins remain" has the same answer
+  regardless of who's asking it. These routes were never actually exposed by
+  the OR-gate in the way this ADR originally assumed — they self-protect
+  regardless of which arm of the gate let the caller in.
+- **Per-actor ceiling checks** — the check is defined in terms of *which*
+  human is asking: is this human already a member with standing to add
+  another (`AddGroupMemberProxy`), is this human someone other than the
+  exception's own creator (`ApproveRiskExceptionProxy`). These cannot be
+  satisfied by a node credential, scoped or not, because a node is not a
+  human and carries no "which human" to check — narrowing what a node is
+  *allowed to attempt* doesn't give it an identity to check *against*.
+
+This ADR's original framing treated "should a node bypass the permission
+arm" as one binary question with one mechanism (a scoped permission set) as
+its answer. It isn't. Target-state-invariant routes need no fix at all — the
+OR-gate never put them at risk. Per-actor-ceiling routes need a fail-closed
+rule that has nothing to do with what permissions a node carries — see
+"Update" above. A scoped permission set is orthogonal to both: it would
+narrow a node-legitimate route's blast radius (a real, separate benefit) but
+does not and cannot touch a per-actor ceiling either way.
+
 ### Prior art already in this codebase
 
 ADR-030 (machine-token authentication) already built the mechanism this ADR
@@ -101,26 +168,52 @@ identities (CI, k8s, automation, service, other) already go through this.
 so it stays a bare, permission-free relay identity — that carve-out is the
 thing this ADR asks whether to keep.
 
-## The design question
+## The design question (re-scoped)
 
-Should `RequireNodeCredentialOrPermission` continue to let a node credential
-bypass the permission arm entirely (today: node-ness alone is sufficient,
-independent of what the relayed action actually is), or should node
-credentials carry their own narrow, scoped permission set — reusing
-ADR-030's existing `machine_identity_roles`/`AuthorizePrincipal` mechanism —
-so that what a node can do is bounded the same way any other machine
-identity's access is bounded?
+Originally framed as: should `RequireNodeCredentialOrPermission` continue to
+let a node credential bypass the permission arm entirely, or should node
+credentials carry their own narrow, scoped permission set via ADR-030's
+`machine_identity_roles`/`AuthorizePrincipal` mechanism? The "Update" above
+and "The two ceiling types" section explain why that framing doesn't hold up
+as a single binary — the per-actor-ceiling routes this ADR was originally
+motivated by are fixed by a fail-closed rule that has nothing to do with
+what a node is scoped to do, and the target-state-invariant routes were
+never actually at risk from the OR-gate.
+
+What's left, and still genuinely open, is narrower: **should machine
+identities — starting with, but not limited to, `MachineTypeNode` — be able
+to hold global-scope roles at all?** Today `core.CreateMachineIdentity`
+(`internal/core/machine_identities.go:75`) rejects `projectID == 0`
+unconditionally; every machine identity is project-scoped by construction.
+That constraint is *why* the scoped-permission-set idea in this ADR's
+original decision can't reach any of the node-legitimate routes classified
+as global-scope for #1542 (`AssignRoleWithExpiryProxy`,
+`AssignRoleToGroupWithExpiryProxy`, `AssignMachineRoleProxy` chief among
+them) — a node's own permission set, however narrowly scoped, is inert at
+global scope if the node can never hold a global-scope grant in the first
+place. Answering this question decides whether a scoped-permission-set
+mechanism for nodes is even buildable as originally envisioned, or whether
+the project-scope constraint needs to be revisited first (its own separate
+decision, with its own blast-radius analysis — a global-scope machine role
+is a materially different risk than a project-scoped one).
 
 A node credential is the single most widely distributed credential class in
 a Keyorix deployment — every downstream node running `storage.type: remote`
 holds one. "Or it's a node" as an authorization arm makes that credential
-class a second, effectively unscoped admin path (#1524 now enumerates 10
-routes reachable this way with no matching per-action check), not a
-narrowly-scoped relay identity. Patching `AddGroupMemberProxy` and
-`ApproveRiskExceptionProxy` individually closes the two *confirmed* cases
-and leaves the *pattern* in place for route 11 — the next handler added to
-this group inherits the same OR-gate and the same `actorID(r)==0` blind spot
-by default, with nothing structural stopping it.
+class a second, effectively unscoped admin path; the #1532 classification
+enumerates **13** `RequireNodeCredentialOrPermission` routes in the RBAC/
+governance-mutation scope this ADR is about, correcting the 10 originally
+counted here (of 194 total `/system` routes, most unrelated to RBAC/
+governance and out of this ADR's scope entirely). The classification also
+surfaced routes this ADR's original count missed outright — including
+`CreateMembershipProxy`/`UpdateMembershipProxy`, separately flagged in that
+table as matching the same raw-storage-bypass shape as #1542 and not yet
+checked for reach, an open follow-up and not part of this ADR. See the full
+table on #1532 for the per-route breakdown and classification. Route-fourteen
+drift is now caught structurally: `server/http/node_credential_route_classification_test.go`
+fails CI if a route is added to this gate without being classified, closing
+the "next handler inherits the gap silently" problem this ADR originally
+raised as unaddressed.
 
 ### A second, harder question this ADR does not resolve
 
@@ -197,7 +290,19 @@ recreating the conflation.
 
 - #1524 — original node-credential/RBAC-mutation reachability sweep (9
   routes), extended with the `AddGroupMemberProxy` ceiling-bypass finding and
-  the `ApproveRiskException` dual-control-bypass finding (10 routes total).
+  the `ApproveRiskException` dual-control-bypass finding (10 routes total at
+  the time). #1532's full classification corrected this to 13 routes — see
+  "The design question (re-scoped)" above.
+- #1532 — the route classification comment: full table of all 13 routes with
+  file:line, per-actor-ceiling vs target-state-invariant vs node-legitimate
+  classification, and the completeness-guard test that keeps it from going
+  stale.
+- #1542 — human-reachable global-admin escalation via 4 raw-storage-bypass
+  proxy routes (`AssignRoleWithExpiryProxy`, `AssignRoleToGroupWithExpiryProxy`,
+  `AssignMachineRoleProxy`, `RemoveAllProjectRoleGrantsProxy`), found while
+  verifying #1532's classification. Independent of node-credential status —
+  affects any `system.write` holder — and launch-blocking in its own right,
+  not part of this ADR's decision.
 - #1529 — sites with no actor-authority check at all (a distinct but
   related gap; `DeleteSoDPolicy` flagged most concerning).
 - #1530 — unattributed audit rows for legitimate relay calls (the
@@ -215,10 +320,13 @@ recreating the conflation.
 
 ## Out of scope
 
-- Implementing the node-scoped permission set, the route-group split, or any
-  fix to the two confirmed findings (#1524's `AddGroupMemberProxy`/
-  `ApproveRiskException` items). Each is its own follow-up once this ADR is
-  accepted.
+- Implementing the node-scoped permission set or the route-group split, if
+  this ADR is accepted — its own follow-up work with its own review.
+- The two confirmed findings (#1524's `AddGroupMemberProxy`/
+  `ApproveRiskException` items) are **no longer** gated on this ADR — see
+  "Update" above. They're fixed independently by a fail-closed rule for
+  machine actors on per-actor-ceiling operations, not by anything this ADR
+  decides.
 - Designing the downstream-actor-identity wire mechanism (the "harder
   question"). Flagged as a second, later ADR if the team wants to pursue it;
   not decided here.
@@ -230,17 +338,28 @@ recreating the conflation.
 
 ## Consequences (if accepted)
 
-- Node credentials stop being an unscoped bypass of every route in this
-  group and become a bounded principal type like every other machine
-  identity, closing the pattern (not just the two current instances) that
-  #1524 found.
-- Every route in the `/system` group needs an explicit decision — node-scoped
-  permission suffices, or the route is human-only, or it needs the
-  not-yet-designed actor-identity mechanism — rather than inheriting the
-  group's blanket OR-gate by default. This is real, non-trivial audit work
-  across the group's full route list, not a one-line change.
+- Node credentials stop being an unscoped bypass of the **node-legitimate**
+  routes in this group and become a bounded principal type like every other
+  machine identity — narrowing blast radius on routes like
+  `AssignRoleWithExpiryProxy`/`AssignMachineRoleProxy` (also implicated in
+  #1542, independent of this ADR). This does **not** close the per-actor-
+  ceiling routes (`AddGroupMemberProxy`/`ApproveRiskExceptionProxy`) — those
+  are already fixed, independently, by the fail-closed rule described in
+  "Update" above, and stay fixed regardless of this ADR's outcome.
+- The per-route classification this consequence used to require as new work
+  already exists and is enforced: #1532's table sorts all 13 in-scope routes
+  into node-legitimate / target-state-invariant / per-actor-ceiling, with
+  `server/http/node_credential_route_classification_test.go` failing CI if a
+  new route joins the gate unclassified. Accepting this ADR would add a
+  fourth per-route decision on top of that table (does this node-legitimate
+  route get a scoped permission, and which one) rather than starting the
+  classification from scratch.
 - `MachineTypeNode`'s current "carries no implicit RBAC permission" invariant
   is retired in favor of "carries a narrow, explicitly-granted permission
-  set" — a real behavior change for every node credential in every existing
-  deployment, requiring a migration/rollout story (out of scope here, part
-  of implementation).
+  set" for node-legitimate routes — a real behavior change for every node
+  credential in every existing deployment, requiring a migration/rollout
+  story (out of scope here, part of implementation) — and only matters once
+  the re-scoped open question ("should machine identities hold global-scope
+  roles?") is answered, since several node-legitimate routes classified for
+  #1532 are global-scope operations a project-scoped machine identity cannot
+  reach today regardless of what permission set it's given.


### PR DESCRIPTION
## Summary

ADR-085's central recommendation (give `MachineTypeNode` its own scoped
permission set via ADR-030's `AuthorizePrincipal` mechanism) is blocked: the
two per-actor-ceiling findings it was motivated by (#1524 (b) `AddGroupMemberProxy`,
(c) `ApproveRiskExceptionProxy`) need to know *which specific human* is
acting, and no node identity — scoped or not — can supply that. Both are
already fixed independently (see the companion PR from
`fix-1524-machine-actor-fail-closed`), so this ADR is no longer launch-blocking.

- States the blocked recommendation and no-longer-launch-blocking status up
  front, with evidence and a 2026-09-15 decision-by date.
- Adds the target-state-invariant vs per-actor-ceiling distinction (from
  #1532's route classification) that refutes the ADR's original binary framing.
- Re-scopes the open question to: should machine identities be able to hold
  global-scope roles at all?
- Corrects the route count from 10 to 13 per #1532's full classification.

No code changes. Status stays **Proposed**.

## Test plan

- [x] Docs-only change; no build/test impact.

Refs #1524, #1532.