### PR TITLE
fix(rbac): fail closed for machine actors on per-actor-ceiling routes

### DIFF
--- a/internal/cli/group/add-member.go
+++ b/internal/cli/group/add-member.go
@@ -50,7 +50,7 @@ func runAddMember(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
-	if err := service.AddUserToGroup(ctx, common.ResolveActorID(), addMemberUserID, addMemberGroupID, addMemberProjectID); err != nil {
+	if err := service.AddUserToGroup(ctx, common.ResolveActorID(), false, addMemberUserID, addMemberGroupID, addMemberProjectID); err != nil {
 		return fmt.Errorf("failed to add member: %w", err)
 	}
 	fmt.Printf("User %d added to group %d (project %d).\n", addMemberUserID, addMemberGroupID, addMemberProjectID)

--- a/internal/cli/group/group_g80_test.go
+++ b/internal/cli/group/group_g80_test.go
@@ -254,7 +254,7 @@ func TestRunRemoveMember_Local_Success_Isolated(t *testing.T) {
 	require.NoError(t, err)
 	g, err := svc.CreateGroup(ctx, 0, &core.CreateGroupRequest{Name: "isolated-remove-group"})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddUserToGroup(ctx, 0, u.ID, g.ID, 0))
+	require.NoError(t, svc.AddUserToGroup(ctx, 0, false, u.ID, g.ID, 0))
 
 	origG, origU := removeMemberGroupID, removeMemberUserID
 	defer func() { removeMemberGroupID = origG; removeMemberUserID = origU }()
@@ -291,7 +291,7 @@ func TestRunRemoveMember_Local_RefusesLastGlobalAdmin_Isolated(t *testing.T) {
 	require.NoError(t, err)
 	g, err := svc.CreateGroup(ctx, 0, &core.CreateGroupRequest{Name: "sole-admin-group"})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddUserToGroup(ctx, 0, u.ID, g.ID, 0))
+	require.NoError(t, svc.AddUserToGroup(ctx, 0, false, u.ID, g.ID, 0))
 
 	dbPath := filepath.Join(dir, "test.db")
 	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{Logger: logger.Discard})

--- a/internal/cli/group/group_remote_test.go
+++ b/internal/cli/group/group_remote_test.go
@@ -239,7 +239,7 @@ func TestGroupMembers_LocalMode(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add member (global membership: projectID=0)
-	err = svc.AddUserToGroup(ctx, 0, u.ID, g.ID, 0)
+	err = svc.AddUserToGroup(ctx, 0, false, u.ID, g.ID, 0)
 	require.NoError(t, err)
 
 	// List members

--- a/internal/cli/group/group_s24_test.go
+++ b/internal/cli/group/group_s24_test.go
@@ -47,7 +47,7 @@ func TestRunMembers_CLI_WithMembers(t *testing.T) {
 	require.NotEmpty(t, groups)
 
 	// Add the user to the group.
-	require.NoError(t, svc.AddUserToGroup(ctx, 0, u.ID, groups[0].ID, 0))
+	require.NoError(t, svc.AddUserToGroup(ctx, 0, false, u.ID, groups[0].ID, 0))
 
 	origMID := membersGroupID
 	defer func() { membersGroupID = origMID }()
@@ -318,8 +318,8 @@ func TestRunMembers_CLI_WithMultipleMembers(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, groups)
 
-	require.NoError(t, svc.AddUserToGroup(ctx, 0, u1.ID, groups[0].ID, 0))
-	require.NoError(t, svc.AddUserToGroup(ctx, 0, u2.ID, groups[0].ID, 0))
+	require.NoError(t, svc.AddUserToGroup(ctx, 0, false, u1.ID, groups[0].ID, 0))
+	require.NoError(t, svc.AddUserToGroup(ctx, 0, false, u2.ID, groups[0].ID, 0))
 
 	origMID := membersGroupID
 	defer func() { membersGroupID = origMID }()

--- a/internal/cli/group/group_s2_test.go
+++ b/internal/cli/group/group_s2_test.go
@@ -120,7 +120,7 @@ func TestRunMembers_WithMembersOutput(t *testing.T) {
 	require.NoError(t, err)
 	g, err := svc.CreateGroup(ctx, 0, &core.CreateGroupRequest{Name: "infra"})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddUserToGroup(ctx, 0, u.ID, g.ID, 0))
+	require.NoError(t, svc.AddUserToGroup(ctx, 0, false, u.ID, g.ID, 0))
 
 	members, err := svc.GetGroupMembers(ctx, g.ID)
 	require.NoError(t, err)
@@ -230,7 +230,7 @@ func TestRunAddMember_ThenRemove(t *testing.T) {
 	g, err := svc.CreateGroup(ctx, 0, &core.CreateGroupRequest{Name: "proj-team"})
 	require.NoError(t, err)
 
-	require.NoError(t, svc.AddUserToGroup(ctx, 0, u.ID, g.ID, 0))
+	require.NoError(t, svc.AddUserToGroup(ctx, 0, false, u.ID, g.ID, 0))
 	members, err := svc.GetGroupMembers(ctx, g.ID)
 	require.NoError(t, err)
 	assert.Len(t, members, 1)
@@ -487,7 +487,7 @@ func TestRunRemoveMember_CLI_LocalMode(t *testing.T) {
 	require.NotEmpty(t, groups)
 
 	// Add first so remove has something to do.
-	require.NoError(t, svc.AddUserToGroup(ctx, 0, u.ID, groups[0].ID, 0))
+	require.NoError(t, svc.AddUserToGroup(ctx, 0, false, u.ID, groups[0].ID, 0))
 
 	origG, origU := removeMemberGroupID, removeMemberUserID
 	defer func() { removeMemberGroupID = origG; removeMemberUserID = origU }()

--- a/internal/core/actor_sentinel_completeness_test.go
+++ b/internal/core/actor_sentinel_completeness_test.go
@@ -1,0 +1,262 @@
+// actor_sentinel_completeness_test.go — P3's chosen fix for the actorID==0
+// sentinel ambiguity (#1524, #1532): NOT a Principal type migration (rejected
+// as defence in depth behind an existing control, at 20-100x the cost -- P2's
+// node-credential route classification already closes this class at the
+// boundary where it actually bites: a machine actor can only reach a
+// per-actor ceiling through a machine-credential-authenticated route, and
+// server/http/node_credential_route_classification_test.go now classifies
+// and enforces every one of those). Instead: a frozen, exhaustive inventory
+// of every `actorID == 0` / `actorID != 0` comparison in this package,
+// classified as classPerActorCeiling (an authorization decision) or
+// classAuditOnly (attribution metadata, no authorization implication), with
+// a completeness test that fails the moment a FIFTH such comparison appears
+// anywhere in this package outside this list -- forcing the same
+// enforced/open-gap classification this file already did for the first
+// four, at authoring time, not at the next audit round. Same shape as
+// remote_unsupported_completeness_test.go's allowlist (C5's pattern).
+//
+// Keyed by "<file>:<enclosing func>", not file:line -- a line-numbered key
+// would need updating on every unrelated edit above the comparison; a
+// (file, func) key survives that churn. The trade-off: a SECOND actorID==0
+// comparison added to an ALREADY-listed function collapses into the same
+// key and isn't separately flagged. Accepted -- the dangerous case this
+// guards against is a new function introducing the pattern, not a second
+// comparison inside a function a reviewer is already touching (and which
+// this table's note already flags).
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+type actorSentinelClass int
+
+const (
+	// classAuditOnly: the branch decides only whether to attach a non-nil
+	// actor pointer to an audit/attribution record. actorID==0 there means
+	// "don't record an actor," never "skip a check" -- no authorization
+	// implication, so a machine actor producing actorID==0 is harmless here.
+	classAuditOnly actorSentinelClass = iota
+	// classPerActorCeiling: the branch gates (or should gate) a per-actor
+	// authorization ceiling -- self-approval, escalation-by-proxy,
+	// self-permission-bundling, ACL/ownership re-authorization. Exactly the
+	// site shape #1524 (b)/(c) showed can silently exempt a machine actor
+	// when the branch treats actorID==0 as "trusted local caller" instead of
+	// "caller identity unknown, deny."
+	classPerActorCeiling
+)
+
+type actorSentinelStatus int
+
+const (
+	// statusEnforced: a machine actor (actorID==0, actorIsMachine==true or
+	// no such distinction needed) is already denied here -- either the
+	// branch rejects actorID==0 outright as invalid input, or the ceiling
+	// was fixed to deny (P1's actorIsMachine parameter).
+	statusEnforced actorSentinelStatus = iota
+	// statusOpenGap: a machine actor can reach this branch with actorID==0
+	// today and the per-actor ceiling is skipped -- a confirmed, live,
+	// tracked gap, not fixed by this table. See note for the issue.
+	statusOpenGap
+)
+
+type actorSentinelEntry struct {
+	class  actorSentinelClass
+	status actorSentinelStatus
+	note   string
+}
+
+// actorSentinelAllowlist is the exhaustive, reasoned inventory of every
+// `actorID == 0` / `actorID != 0` comparison in internal/core's non-test
+// source. TestActorSentinelComparisonsAreAllowlisted asserts this is an
+// EXACT match against the real source.
+var actorSentinelAllowlist = map[string]actorSentinelEntry{
+	"access_review_campaign.go:requireHumanReviewer": {
+		class: classPerActorCeiling, status: statusEnforced,
+		note: "rejects actorID==0 outright: 'a machine identity ... is not an attributable, independent human reviewer.'",
+	},
+	"access_review_revoke.go:logAccessReviewDecision": {
+		class: classAuditOnly,
+		note:  "attribution-only: whether to attach a non-nil actor pointer to the audit record.",
+	},
+	"anomaly_alerting.go:AcknowledgeAnomalyAlert": {
+		class: classAuditOnly,
+		note:  "attribution-only audit pointer; the write-permission gate at the transport already authorized the call.",
+	},
+	"audit.go:writeRBACAudit": {
+		class: classAuditOnly,
+		note:  "attribution-only audit pointer, shared writer for RBAC audit events.",
+	},
+	"authz.go:requireGranterHoldsRolePermissions": {
+		class: classPerActorCeiling, status: statusOpenGap,
+		note: "actorID==0 skips the #93/#107/#141 grant-ceiling check. Not machine-reachable TODAY -- AssignRoleWithExpiryProxy/AssignRoleToGroupWithExpiryProxy bypass internal/core entirely via raw storage (#1542) -- but becomes reachable the moment #1542 is fixed by routing through core. Being fixed alongside #1542, not tracked as a separate issue.",
+	},
+	"bulk_delete.go:BulkDeleteSecrets": {
+		class: classPerActorCeiling, status: statusOpenGap,
+		note: "actorID==0 skips GetSecretWithPermissionCheck/DeleteSecretWithPermissionCheck's per-secret ACL/ownership check (2 occurrences, same function). Live gap: reachable by any machine identity holding project-scoped secrets.delete. #1545, not fixed here.",
+	},
+	"compliance_digest.go:SendComplianceDigest": {
+		class: classAuditOnly,
+		note:  "attribution-only: whether to attach a non-nil actor pointer to the notification/audit context.",
+	},
+	"groups.go:AddUserToGroup": {
+		class: classPerActorCeiling, status: statusEnforced,
+		note: "P1 (#1524 b): actorIsMachine parameter added; a machine actor is now denied instead of exempted alongside the trusted local-CLI case.",
+	},
+	"rate_limit.go:PruneLoginAttempts": {
+		class: classAuditOnly,
+		note:  "attribution-only: whether to attach a non-nil actor pointer to the prune audit record.",
+	},
+	"rbac_management.go:AssignPermissionToRole": {
+		class: classPerActorCeiling, status: statusOpenGap,
+		note: "actorID==0 skips the #169 self-permission-bundling check. Live gap: reachable by any machine identity holding roles.write globally. #1545, not fixed here.",
+	},
+	"secret_acl.go:GrantSecretACL": {
+		class: classPerActorCeiling, status: statusEnforced,
+		note: "rejects actorID==0 outright as invalid input -- denies every actorID==0 caller, human local-CLI included, so a machine actor is denied too.",
+	},
+	"secret_bulk_rename.go:BulkRenameSecrets": {
+		class: classPerActorCeiling, status: statusEnforced,
+		note: "rejects actorID==0 outright as invalid input.",
+	},
+	"secret_extend_expiring.go:ExtendExpiringSecrets": {
+		class: classPerActorCeiling, status: statusEnforced,
+		note: "rejects actorID==0 outright as invalid input.",
+	},
+	"secret_move.go:MoveSecret": {
+		class: classPerActorCeiling, status: statusEnforced,
+		note: "rejects actorID==0 outright as invalid input.",
+	},
+	"secret_ownership.go:transferOwnership": {
+		class: classPerActorCeiling, status: statusEnforced,
+		note: "rejects actorID==0 outright as invalid input.",
+	},
+	"secret_reassign_owner.go:ReassignOwnedSecrets": {
+		class: classPerActorCeiling, status: statusEnforced,
+		note: "rejects actorID==0 outright as invalid input.",
+	},
+	"secret_suspend.go:SuspendProjectSecrets": {
+		class: classPerActorCeiling, status: statusEnforced,
+		note: "rejects actorID==0 outright as invalid input.",
+	},
+	"secret_suspend.go:ResumeProjectSecrets": {
+		class: classPerActorCeiling, status: statusEnforced,
+		note: "rejects actorID==0 outright as invalid input.",
+	},
+}
+
+// actorSentinelFuncRe matches a top-level function declaration and captures
+// its name, with or without a method receiver.
+var actorSentinelFuncRe = regexp.MustCompile(`^func\s+(?:\([^)]*\)\s*)?([A-Za-z0-9_]+)\(`)
+
+// actorSentinelCompareRe matches a real actorID==0/actorID!=0 comparison.
+var actorSentinelCompareRe = regexp.MustCompile(`actorID\s*(==|!=)\s*0`)
+
+// actualActorSentinelSites scans every non-test *.go file directly in
+// internal/core (this package) and returns the set of "file:func" keys where
+// a real (non-comment) actorID==0/actorID!=0 comparison appears.
+func actualActorSentinelSites(t *testing.T) map[string]bool {
+	t.Helper()
+	found := map[string]bool{}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading internal/core: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(".", name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		currentFunc := ""
+		for _, line := range strings.Split(string(b), "\n") {
+			if m := actorSentinelFuncRe.FindStringSubmatch(line); m != nil {
+				currentFunc = m[1]
+			}
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "//") {
+				continue // doc/inline comment mentioning the pattern, not a real branch
+			}
+			if actorSentinelCompareRe.MatchString(line) && currentFunc != "" {
+				found[name+":"+currentFunc] = true
+			}
+		}
+	}
+	return found
+}
+
+// TestActorSentinelComparisonsAreAllowlisted is the completeness guard: every
+// actorID==0/actorID!=0 comparison in internal/core's non-test source must be
+// an EXACT match against actorSentinelAllowlist above -- no more, no less.
+//
+//   - A NEW comparison in a function not already listed fails this test
+//     immediately, forcing the same real-reachability classification
+//     (classPerActorCeiling + statusEnforced/statusOpenGap, or
+//     classAuditOnly) this table was built from before it can be merged --
+//     this is the "fifth instance" #1524's investigation warned would keep
+//     recurring if each one is just patched in isolation.
+//   - An allowlisted entry whose comparison no longer exists (the function
+//     was fixed, removed, or rewritten to avoid the sentinel) also fails,
+//     keeping the table from accumulating stale entries.
+func TestActorSentinelComparisonsAreAllowlisted(t *testing.T) {
+	actual := actualActorSentinelSites(t)
+
+	var missing []string
+	for key := range actual {
+		if _, ok := actorSentinelAllowlist[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	sort.Strings(missing)
+
+	var stale []string
+	for key := range actorSentinelAllowlist {
+		if !actual[key] {
+			stale = append(stale, key)
+		}
+	}
+	sort.Strings(stale)
+
+	if len(missing) > 0 {
+		t.Errorf("found %d actorID==0/actorID!=0 comparison(s) with NO entry in actorSentinelAllowlist "+
+			"(internal/core/actor_sentinel_completeness_test.go): %v\n"+
+			"Classify each as classAuditOnly (attribution metadata only) or classPerActorCeiling "+
+			"(an authorization decision -- trace whether a machine actor, which also produces actorID==0, "+
+			"can reach this branch, and if so whether the ceiling is actually enforced or silently skipped) "+
+			"before merging.", len(missing), missing)
+	}
+	if len(stale) > 0 {
+		t.Errorf("found %d actorSentinelAllowlist entr(y/ies) whose comparison no longer exists in source: %v\n"+
+			"Remove these entries -- if this closed a statusOpenGap finding, confirm the tracking issue is "+
+			"also resolved.", len(stale), stale)
+	}
+}
+
+// TestActorSentinelOpenGapsAreTracked lists every classPerActorCeiling entry
+// still at statusOpenGap, so the open count is visible in test output rather
+// than buried in a table -- not a failure condition (open gaps are tracked
+// via #1545, not blocked on this table), just a standing visibility check
+// that fails if the open count silently grows without anyone noticing.
+func TestActorSentinelOpenGapsAreTracked(t *testing.T) {
+	var open []string
+	for key, e := range actorSentinelAllowlist {
+		if e.class == classPerActorCeiling && e.status == statusOpenGap {
+			open = append(open, key)
+		}
+	}
+	sort.Strings(open)
+	const knownOpen = 3 // bulk_delete.go:BulkDeleteSecrets, rbac_management.go:AssignPermissionToRole (#1545); authz.go:requireGranterHoldsRolePermissions (fixed alongside #1542, task 3)
+	if len(open) != knownOpen {
+		t.Errorf("expected exactly %d statusOpenGap classPerActorCeiling entries (tracked via #1545), found %d: %v\n"+
+			"A new open gap needs its own issue filed (see #1545's shape) before this count changes; a closed "+
+			"gap needs its status flipped to statusEnforced in the same PR that fixes it.", knownOpen, len(open), open)
+	}
+}

--- a/internal/core/authz_admin_ceiling_group_test.go
+++ b/internal/core/authz_admin_ceiling_group_test.go
@@ -124,7 +124,7 @@ func TestAddUserToGroup_EscalationByProxyBlocked(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.storage.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{}))
 
-	err = c.AddUserToGroup(ctx, attacker, attacker, group.ID, 0)
+	err = c.AddUserToGroup(ctx, attacker, false, attacker, group.ID, 0)
 	require.Error(t, err, "a non-admin actor must not be able to join an admin-conferring group")
 	assert.Contains(t, err.Error(), "administrator")
 }
@@ -143,17 +143,53 @@ func TestAddUserToGroup_AdminActorAndLocalCLIAllowed(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.storage.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{}))
 
-	require.NoError(t, c.AddUserToGroup(ctx, admin, victim, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, admin, false, victim, group.ID, 0))
 	members, err := c.GetGroupMembers(ctx, group.ID)
 	require.NoError(t, err)
 	require.Len(t, members, 1)
 
-	// Local CLI (actorID 0) is exempt — it can already self-grant any role via
-	// AssignRoleToUser, so gating it here would only add friction, not security.
+	// Local CLI (actorID 0, actorIsMachine false) is exempt — it can already
+	// self-grant any role via AssignRoleToUser, so gating it here would only
+	// add friction, not security.
 	group2, err := c.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "admins3"})
 	require.NoError(t, err)
 	require.NoError(t, c.storage.AssignRoleToGroup(ctx, group2.ID, adminRole.ID, storage.Scope{}))
-	require.NoError(t, c.AddUserToGroup(ctx, 0, victim, group2.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, 0, false, victim, group2.ID, 0))
+}
+
+// #1524 finding (b): a machine credential (actorIsMachine true) resolves the
+// identical actorID==0 as the true local-CLI case above, but must NOT get the
+// same exemption — it is not the local CLI, and unlike the local CLI it has no
+// other unguarded path to self-grant admin (AssignRoleToUser is not reachable
+// via a bare machine/node credential). Companion to
+// TestAddUserToGroup_AdminActorAndLocalCLIAllowed's exemption positive control,
+// this is the negative control proving the exemption is scoped correctly.
+func TestAddUserToGroup_MachineActorBlockedFromAdminGroup(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	victim := seedUserWithRole(t, st, "grp-victim-machine", "project_viewer", storage.Scope{ProjectID: 1})
+
+	adminRole, err := c.storage.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	group, err := c.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "admins-machine"})
+	require.NoError(t, err)
+	require.NoError(t, c.storage.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{}))
+
+	err = c.AddUserToGroup(ctx, 0, true, victim, group.ID, 0)
+	require.Error(t, err, "a machine credential must not be able to join a user to an admin-conferring group")
+	assert.Contains(t, err.Error(), "administrator")
+
+	members, memErr := c.GetGroupMembers(ctx, group.ID)
+	require.NoError(t, memErr)
+	assert.Empty(t, members, "the denied join must not have partially applied")
+
+	// Positive control within the same test: a machine credential CAN still
+	// join an ORDINARY (non-admin-conferring) group -- the fix must not break
+	// the legitimate node-relay case, only the escalation path.
+	plainGroup, err := c.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "on-call-machine"})
+	require.NoError(t, err)
+	require.NoError(t, c.AddUserToGroup(ctx, 0, true, victim, plainGroup.ID, 0),
+		"a machine credential joining a group with no admin-conferring role must still succeed")
 }
 
 // #107: AssignRoleToGroup must refuse a non-admin actor granting an admin role
@@ -231,7 +267,7 @@ func TestRemoveUserFromGroup_LastMemberBlocked(t *testing.T) {
 	group, err := c.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "sole-admins3"})
 	require.NoError(t, err)
 	require.NoError(t, c.AssignRoleToGroup(ctx, bootstrapAdmin.ID, group.ID, adminRole.ID, Scope{}))
-	require.NoError(t, c.AddUserToGroup(ctx, bootstrapAdmin.ID, bootstrapAdmin.ID, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, bootstrapAdmin.ID, false, bootstrapAdmin.ID, group.ID, 0))
 	require.NoError(t, c.RemoveUserRole(ctx, bootstrapAdmin.ID, bootstrapAdmin.ID, adminRole.ID, Scope{}))
 
 	// bootstrapAdmin is now the group's only member and the install's only
@@ -256,8 +292,8 @@ func TestRemoveUserFromGroup_OtherMemberSurvivesAllowed(t *testing.T) {
 	group, err := c.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "two-admins"})
 	require.NoError(t, err)
 	require.NoError(t, c.AssignRoleToGroup(ctx, bootstrapAdmin.ID, group.ID, adminRole.ID, Scope{}))
-	require.NoError(t, c.AddUserToGroup(ctx, bootstrapAdmin.ID, bootstrapAdmin.ID, group.ID, 0))
-	require.NoError(t, c.AddUserToGroup(ctx, bootstrapAdmin.ID, second, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, bootstrapAdmin.ID, false, bootstrapAdmin.ID, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, bootstrapAdmin.ID, false, second, group.ID, 0))
 	require.NoError(t, c.RemoveUserRole(ctx, bootstrapAdmin.ID, bootstrapAdmin.ID, adminRole.ID, Scope{}))
 
 	require.NoError(t, c.RemoveUserFromGroup(ctx, bootstrapAdmin.ID, bootstrapAdmin.ID, group.ID, 0),

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -144,20 +144,28 @@ func (c *KeyorixCore) ListGroups(ctx context.Context) ([]*models.Group, error) {
 }
 
 // AddUserToGroup adds a user to a group. actorID is the admin performing it (0 = no
-// authenticated principal, e.g. a local CLI invocation). projectID scopes the
-// membership: 0 = global (applies in every project), non-zero = this project only.
-// Membership confers every role the group holds at the matching scope, so this is
-// recorded in the RBAC audit trail (#233).
+// authenticated principal, e.g. a local CLI invocation). actorIsMachine distinguishes
+// that true "no principal" case from a machine-credential-authenticated caller — both
+// present as actorID==0, but only the former is exempt from the ceiling check below;
+// see #1524. projectID scopes the membership: 0 = global (applies in every project),
+// non-zero = this project only. Membership confers every role the group holds at the
+// matching scope, so this is recorded in the RBAC audit trail (#233).
 //
 // Joining an admin-conferring group inherits that access just as directly as a
 // role grant, so every global-scope admin role the group already holds is gated
 // by the same escalation-by-proxy ceiling AssignRoleToGroup applies
 // (requireAuthorityForRole): a non-admin roles.assign holder must not be able to
 // self-escalate by joining a privileged group instead of being granted the role.
-// The local CLI (actorID 0) is exempt — it is already fully trusted (it can grant
-// any role directly via AssignRoleToUser, which bypasses this ceiling entirely) and
-// the exemption avoids forcing an existing admin group deployment through this new
-// check retroactively.
+// The local CLI (actorID 0, actorIsMachine false) is exempt — it is already fully
+// trusted (it can grant any role directly via AssignRoleToUser, which bypasses this
+// ceiling entirely) and the exemption avoids forcing an existing admin group
+// deployment through this new check retroactively. A MACHINE credential (actorID 0,
+// actorIsMachine true — e.g. a RemoteStorage node relay, #1524 finding (b)) is NOT
+// exempt: it is not the local CLI, and requireAuthorityForRole already fails closed
+// correctly for actorID 0 when the check actually runs (no real user holds the
+// admin-tier role an escalation attempt would need) — an ordinary, non-admin-conferring
+// group join still succeeds unaffected, since requireAuthorityForRole only evaluates
+// anything for admin-tier roles in the first place.
 // validateGroupJoinRoles checks that actorID has the authority to grant all roles
 // the group already holds, and that userID would not gain a SoD-violating role
 // combination by joining (AUTHZ-007). Skips roles whose definition cannot be loaded.
@@ -214,7 +222,7 @@ func (c *KeyorixCore) domainAllowedForGroupJoin(ctx context.Context, userID, gro
 	return nil
 }
 
-func (c *KeyorixCore) AddUserToGroup(ctx context.Context, actorID, userID, groupID, projectID uint) error {
+func (c *KeyorixCore) AddUserToGroup(ctx context.Context, actorID uint, actorIsMachine bool, userID, groupID, projectID uint) error {
 	if userID == 0 || groupID == 0 {
 		return fmt.Errorf("%s: user ID and group ID are required", i18n.T("ErrorValidation", nil))
 	}
@@ -237,7 +245,7 @@ func (c *KeyorixCore) AddUserToGroup(ctx context.Context, actorID, userID, group
 	// race).
 	c.sodGrantMu.Lock()
 	defer c.sodGrantMu.Unlock()
-	if actorID != 0 {
+	if actorID != 0 || actorIsMachine {
 		if err := c.validateGroupJoinRoles(ctx, actorID, userID, groupID); err != nil {
 			return err
 		}
@@ -252,8 +260,8 @@ func (c *KeyorixCore) AddUserToGroup(ctx context.Context, actorID, userID, group
 // AddUserToGroupGlobal is a convenience wrapper that adds a global membership
 // (projectID=0). Callers that do not need project-scoped membership (e.g. SSO
 // JIT provisioning, SCIM) should call this rather than hard-coding 0.
-func (c *KeyorixCore) AddUserToGroupGlobal(ctx context.Context, actorID, userID, groupID uint) error {
-	return c.AddUserToGroup(ctx, actorID, userID, groupID, 0)
+func (c *KeyorixCore) AddUserToGroupGlobal(ctx context.Context, actorID uint, actorIsMachine bool, userID, groupID uint) error {
+	return c.AddUserToGroup(ctx, actorID, actorIsMachine, userID, groupID, 0)
 }
 
 // RemoveUserFromGroup removes a user from a group at the given projectID scope.

--- a/internal/core/groups_audit_test.go
+++ b/internal/core/groups_audit_test.go
@@ -83,7 +83,7 @@ func TestGroupMembershipAudit(t *testing.T) {
 	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
 	ctx := context.Background()
 
-	require.NoError(t, c.AddUserToGroup(ctx, 42, 11, 7, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, 42, false, 11, 7, 0))
 
 	entries, total, err := c.ListRBACAuditLogs(ctx, 1, 50)
 	require.NoError(t, err)

--- a/internal/core/groups_domain_allowlist_test.go
+++ b/internal/core/groups_domain_allowlist_test.go
@@ -55,7 +55,7 @@ func TestAddUserToGroup_RejectsDisallowedDomain_ProjectScopedGrant(t *testing.T)
 	// actorID 99 is arbitrary/unprivileged: domain_gate_role is not an
 	// admin-tier role name, so requireAuthorityForRole imposes no ceiling here
 	// — only the domain-allowlist gate under test is exercised.
-	err := h.CoreService.AddUserToGroup(ctx, 99, mallory.ID, 60, proj)
+	err := h.CoreService.AddUserToGroup(ctx, 99, false, mallory.ID, 60, proj)
 	require.Error(t, err, "adding a disallowed-domain user to a group that confers project access must be refused")
 	assert.Contains(t, err.Error(), "not on the allowlist")
 
@@ -88,7 +88,7 @@ func TestAddUserToGroup_RejectsDisallowedDomain_GlobalMembershipReachesProjectGr
 	h.CoreService.SetMembershipDomainAllowlist([]string{"allowed.com"})
 
 	// projectID 0 == a GLOBAL membership, not a project-scoped one.
-	err := h.CoreService.AddUserToGroup(ctx, 99, trent.ID, 61, 0)
+	err := h.CoreService.AddUserToGroup(ctx, 99, false, trent.ID, 61, 0)
 	require.Error(t, err, "a global group join that reaches a project-scoped grant must still be refused")
 	assert.Contains(t, err.Error(), "not on the allowlist")
 }
@@ -112,7 +112,7 @@ func TestAddUserToGroup_AllowsAllowedDomain(t *testing.T) {
 
 	h.CoreService.SetMembershipDomainAllowlist([]string{"allowed.com"})
 
-	err := h.CoreService.AddUserToGroup(ctx, 99, peggy.ID, 62, proj)
+	err := h.CoreService.AddUserToGroup(ctx, 99, false, peggy.ID, 62, proj)
 	require.NoError(t, err, "an allowed-domain user must still be able to join a project-conferring group")
 
 	groups, gerr := h.Storage.GetUserGroups(ctx, peggy.ID)
@@ -142,6 +142,6 @@ func TestAddUserToGroup_NoRoleGrant_NotGatedByDomainAllowlist(t *testing.T) {
 
 	h.CoreService.SetMembershipDomainAllowlist([]string{"allowed.com"})
 
-	err := h.CoreService.AddUserToGroup(ctx, 99, oscar.ID, 63, 0)
+	err := h.CoreService.AddUserToGroup(ctx, 99, false, oscar.ID, 63, 0)
 	require.NoError(t, err, "joining a group with no role grants confers no access and must not be gated")
 }

--- a/internal/core/groups_join_sod_set_test.go
+++ b/internal/core/groups_join_sod_set_test.go
@@ -61,7 +61,7 @@ func TestAddUserToGroup_BlocksSoDViolationAcrossGroupRoleSet(t *testing.T) {
 	// combo_read_only nor combo_write_only is an admin-tier role name, so
 	// requireAuthorityForRole imposes no ceiling here — only the SoD gate under
 	// test is exercised.
-	err = h.CoreService.AddUserToGroup(ctx, 71, 70, 50, 0)
+	err = h.CoreService.AddUserToGroup(ctx, 71, false, 70, 50, 0)
 	require.Error(t, err, "joining a group whose OWN role grants combine into a toxic pair must be refused")
 	assert.Contains(t, err.Error(), "separation-of-duties")
 
@@ -98,7 +98,7 @@ func TestAddUserToGroup_BlocksSoDViolationWithExistingRole(t *testing.T) {
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
-	err = h.CoreService.AddUserToGroup(ctx, 73, 72, 51, 0)
+	err = h.CoreService.AddUserToGroup(ctx, 73, false, 72, 51, 0)
 	require.Error(t, err, "joining a group that grants a role completing a policy with an already-held role must be refused")
 	assert.Contains(t, err.Error(), "separation-of-duties")
 }
@@ -125,7 +125,7 @@ func TestAddUserToGroup_AllowsNonViolatingGroupJoin(t *testing.T) {
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
-	err = h.CoreService.AddUserToGroup(ctx, 75, 74, 52, 0)
+	err = h.CoreService.AddUserToGroup(ctx, 75, false, 74, 52, 0)
 	require.NoError(t, err, "a non-violating group join must succeed unimpeded")
 
 	groups, gerr := h.Storage.GetUserGroups(ctx, 74)

--- a/internal/core/groups_membership_s38_test.go
+++ b/internal/core/groups_membership_s38_test.go
@@ -46,7 +46,7 @@ func newGroupsS38Core(t *testing.T) (*KeyorixCore, *gorm.DB) {
 func TestAddUserToGroup_ZeroUserID(t *testing.T) {
 	c, db := newGroupsS38Core(t)
 	require.NoError(t, db.Create(&models.Group{ID: 5, Name: "dev"}).Error)
-	err := c.AddUserToGroupGlobal(context.Background(), 1, 0, 5)
+	err := c.AddUserToGroupGlobal(context.Background(), 1, false, 0, 5)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required")
 }
@@ -55,7 +55,7 @@ func TestAddUserToGroup_ZeroUserID(t *testing.T) {
 func TestAddUserToGroup_ZeroGroupID(t *testing.T) {
 	c, db := newGroupsS38Core(t)
 	require.NoError(t, db.Create(&models.User{ID: 7, Username: "bob", Email: "bob@example.com"}).Error)
-	err := c.AddUserToGroupGlobal(context.Background(), 1, 7, 0)
+	err := c.AddUserToGroupGlobal(context.Background(), 1, false, 7, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required")
 }
@@ -66,7 +66,7 @@ func TestAddUserToGroup_CLIActor_ZeroActorID(t *testing.T) {
 	c, db := newGroupsS38Core(t)
 	require.NoError(t, db.Create(&models.Group{ID: 10, Name: "cli-group"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 20, Username: "cli-user", Email: "cli@example.com"}).Error)
-	err := c.AddUserToGroupGlobal(context.Background(), 0, 20, 10)
+	err := c.AddUserToGroupGlobal(context.Background(), 0, false, 20, 10)
 	require.NoError(t, err)
 }
 
@@ -110,8 +110,8 @@ func TestGetGroupMembers_HappyPath(t *testing.T) {
 	require.NoError(t, db.Create(&models.User{ID: 41, Username: "member2", Email: "m2@example.com"}).Error)
 
 	// Add members directly via store (bypasses guard that checks last admin).
-	require.NoError(t, c.AddUserToGroupGlobal(ctx, 0, 40, 30))
-	require.NoError(t, c.AddUserToGroupGlobal(ctx, 0, 41, 30))
+	require.NoError(t, c.AddUserToGroupGlobal(ctx, 0, false, 40, 30))
+	require.NoError(t, c.AddUserToGroupGlobal(ctx, 0, false, 41, 30))
 
 	members, err := c.GetGroupMembers(ctx, 30)
 	require.NoError(t, err)

--- a/internal/core/project_scoped_group_admin_guard_test.go
+++ b/internal/core/project_scoped_group_admin_guard_test.go
@@ -35,7 +35,7 @@ func TestDeleteGroup_RefusesLastProjectAdmin(t *testing.T) {
 	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
-	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, false, u.ID, group.ID, 0))
 
 	err = c.DeleteGroup(ctx, actor, group.ID)
 	require.Error(t, err, "must refuse to delete a group holding project 7's last roles.assign grant")
@@ -62,7 +62,7 @@ func TestDeleteGroup_AllowsWhenAnotherProjectAdminExists(t *testing.T) {
 	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
-	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, false, u.ID, group.ID, 0))
 	// An independent, direct project_admin grant at the same project survives
 	// the group's deletion.
 	require.NoError(t, c.AddProjectMember(ctx, actor, proj, other.ID, "project_admin"))
@@ -102,7 +102,7 @@ func TestDeleteGroup_RefusesWhenGroupAdminsMultipleProjects(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: projA}))
 	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: projB}))
-	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, false, u.ID, group.ID, 0))
 	// projB has an independent survivor; projA does not.
 	require.NoError(t, c.AddProjectMember(ctx, actor, projB, other.ID, "project_admin"))
 
@@ -126,7 +126,7 @@ func TestRemoveUserFromGroup_RefusesLastProjectAdminMember(t *testing.T) {
 	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
-	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, false, u.ID, group.ID, 0))
 
 	err = c.RemoveUserFromGroup(ctx, actor, u.ID, group.ID, 0)
 	require.Error(t, err, "must refuse to remove the group's only member when that member is project 7's last admin route")
@@ -154,8 +154,8 @@ func TestRemoveUserFromGroup_AllowsWhenAnotherGroupMemberSurvives(t *testing.T) 
 	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
-	require.NoError(t, c.AddUserToGroup(ctx, actor, u1.ID, group.ID, 0))
-	require.NoError(t, c.AddUserToGroup(ctx, actor, u2.ID, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, false, u1.ID, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, false, u2.ID, group.ID, 0))
 
 	err = c.RemoveUserFromGroup(ctx, actor, u1.ID, group.ID, 0)
 	require.NoError(t, err, "removing one of two group members is fine — the other still derives project-admin authority")
@@ -184,7 +184,7 @@ func TestDeprovisionSCIMGroup_RefusesLastProjectAdmin(t *testing.T) {
 	group, err := st.CreateGroup(ctx, &models.Group{Name: "scim-proj7-admins"})
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
-	require.NoError(t, c.AddUserToGroup(ctx, actor, u.ID, group.ID, 0))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, false, u.ID, group.ID, 0))
 
 	err = c.DeprovisionSCIMGroup(ctx, actor, group.ID)
 	require.Error(t, err, "SCIM group deprovisioning must also refuse to strip project 7's last admin route")

--- a/internal/core/risk_exceptions.go
+++ b/internal/core/risk_exceptions.go
@@ -217,7 +217,16 @@ func (c *KeyorixCore) RevokeRiskException(ctx context.Context, actorID, id uint)
 // exception suppresses its matched violation from the compliance posture — before
 // approval the raw violation keeps counting, so a self-dealt exception has no
 // effect. A denied self-approval attempt is itself audited distinctly from a grant.
-func (c *KeyorixCore) ApproveRiskException(ctx context.Context, actorID, id uint) error {
+//
+// actorIsMachine: dual control's entire premise is "a different HUMAN reviewed
+// this" — a machine credential can never BE that different human, by definition,
+// regardless of any other detail (#1524 finding (c)). This is not a narrower
+// version of the self-approval check (actorID == e.CreatedBy): a node relaying a
+// HUMAN-created exception (CreatedBy != 0) doesn't collide with that comparison
+// at all and would otherwise approve with no authority check whatsoever. Deny
+// unconditionally rather than trying to make the comparison "work" for a
+// principal type it was never written to represent.
+func (c *KeyorixCore) ApproveRiskException(ctx context.Context, actorID uint, actorIsMachine bool, id uint) error {
 	e, err := c.storage.GetRiskException(ctx, id)
 	if err != nil {
 		return err
@@ -230,6 +239,11 @@ func (c *KeyorixCore) ApproveRiskException(ctx context.Context, actorID, id uint
 	}
 	if e.Approved {
 		return fmt.Errorf("risk exception %d is already approved", id)
+	}
+	if actorIsMachine {
+		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), nil, "",
+			fmt.Sprintf("risk exception %d approval DENIED: a machine credential cannot satisfy dual control", id))
+		return fmt.Errorf("dual control requires a human approver; a machine credential cannot approve a risk exception")
 	}
 	if actorID == e.CreatedBy {
 		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), nil, "",

--- a/internal/core/risk_exceptions_live_violation_external_test.go
+++ b/internal/core/risk_exceptions_live_violation_external_test.go
@@ -101,7 +101,7 @@ func TestApproveRiskException_RejectsSoDReferenceThatWentStale(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, sodAfter.Violations, "the violation must be gone")
 
-	err = h.CoreService.ApproveRiskException(ctx, 2, exc.ID)
+	err = h.CoreService.ApproveRiskException(ctx, 2, false, exc.ID)
 	require.Error(t, err, "approval must re-validate against a fresh scan and refuse a now-stale reference")
 	assert.Contains(t, err.Error(), "does not match any currently-detected SoD violation")
 }

--- a/internal/core/risk_exceptions_test.go
+++ b/internal/core/risk_exceptions_test.go
@@ -127,7 +127,7 @@ func TestApproveRiskException_DeniesSelfApproval(t *testing.T) {
 	})).Return(nil)
 
 	c := riskCore(store, now)
-	err := c.ApproveRiskException(context.Background(), 9, 5) // actor 9 == creator 9
+	err := c.ApproveRiskException(context.Background(), 9, false, 5) // actor 9 == creator 9
 	require.Error(t, err, "the creator must not be able to approve their own exception")
 	assert.Contains(t, err.Error(), "cannot approve it")
 	require.NotNil(t, audited, "the denial must still be audited")
@@ -148,7 +148,39 @@ func TestApproveRiskException_DifferentActorSucceeds(t *testing.T) {
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
 	c := riskCore(store, now)
-	require.NoError(t, c.ApproveRiskException(context.Background(), 3, 5))
+	require.NoError(t, c.ApproveRiskException(context.Background(), 3, false, 5))
+}
+
+// #1524 finding (c): a machine credential relaying a HUMAN-created exception
+// (CreatedBy=9, actorID=0) does NOT collide with the self-approval comparison
+// (actorID == e.CreatedBy) the way a node-created-and-node-approved exception
+// would -- it must still be denied, unconditionally, because dual control
+// requires a different HUMAN reviewed it, which a machine can never be.
+// Companion to TestApproveRiskException_DifferentActorSucceeds (a real
+// different human succeeds) and TestApproveRiskException_DeniesSelfApproval
+// (the same human is refused) -- this is the third case neither of those
+// covers: a non-human actor, regardless of whose exception it is.
+func TestApproveRiskException_DeniesMachineActor(t *testing.T) {
+	now := time.Now()
+	store := new(MockStorage)
+	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 9, ExpiresAt: now.Add(24 * time.Hour)}, nil)
+	var audited *models.AuditEvent
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(ev *models.AuditEvent) bool {
+		if ev.EventType == EventRiskExceptionApproved {
+			audited = ev
+			return true
+		}
+		return false
+	})).Return(nil)
+
+	c := riskCore(store, now)
+	err := c.ApproveRiskException(context.Background(), 0, true, 5) // actorID 0, actorIsMachine true, CreatedBy 9 -- no sentinel collision
+	require.Error(t, err, "a machine credential must not be able to approve a risk exception, even one it did not create")
+	assert.Contains(t, err.Error(), "human")
+	require.NotNil(t, audited, "the denial must still be audited")
+	require.NotNil(t, audited.Success)
+	assert.False(t, *audited.Success)
+	store.AssertNotCalled(t, "ApproveRiskExceptionIfPending", mock.Anything, mock.Anything)
 }
 
 // StateTransitionMissingCAS.ql: a lost race on approve — the row's persisted
@@ -162,7 +194,7 @@ func TestApproveRiskException_LostRaceReturnsError(t *testing.T) {
 	store.On("ApproveRiskExceptionIfPending", mock.Anything, mock.Anything).Return(false, nil)
 
 	c := riskCore(store, now)
-	err := c.ApproveRiskException(context.Background(), 3, 5)
+	err := c.ApproveRiskException(context.Background(), 3, false, 5)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "concurrently revoked or approved")
 	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
@@ -175,7 +207,7 @@ func TestApproveRiskException_RejectsAlreadyApproved(t *testing.T) {
 	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 9, Approved: true, ExpiresAt: now.Add(24 * time.Hour)}, nil)
 
 	c := riskCore(store, now)
-	err := c.ApproveRiskException(context.Background(), 3, 5)
+	err := c.ApproveRiskException(context.Background(), 3, false, 5)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already approved")
 }

--- a/internal/core/sod_compliance_external_test.go
+++ b/internal/core/sod_compliance_external_test.go
@@ -76,7 +76,7 @@ func TestSoD_SuppressedByApprovedRiskException(t *testing.T) {
 	assert.GreaterOrEqual(t, p.AccessGovernance.SoDViolations, 1, "an unapproved exception must not suppress anything yet")
 
 	// A different actor approves it — now suppressed.
-	require.NoError(t, h.CoreService.ApproveRiskException(ctx, 2, exc.ID))
+	require.NoError(t, h.CoreService.ApproveRiskException(ctx, 2, false, exc.ID))
 	p, err = h.CoreService.GetCompliancePosture(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 0, p.AccessGovernance.SoDViolations, "an approved, matching-reference exception suppresses the violation")

--- a/server/grpc/services/group_service.go
+++ b/server/grpc/services/group_service.go
@@ -160,7 +160,7 @@ func (s *GroupGRPCService) AddGroupMember(ctx context.Context, req *pb.GroupMemb
 	if err := authorizeGlobal(ctx, s.core, actor, "roles.assign"); err != nil {
 		return nil, err
 	}
-	if err := s.core.AddUserToGroup(ctx, actor.UserID, uint(req.GetUserId()), uint(req.GetGroupId()), 0); err != nil { // gRPC: global membership (projectID=0)
+	if err := s.core.AddUserToGroup(ctx, actor.UserID, false, uint(req.GetUserId()), uint(req.GetGroupId()), 0); err != nil { // gRPC: global membership (projectID=0); requireUser above guarantees a real human actor, never a machine
 		return nil, groupError(err)
 	}
 	return &emptypb.Empty{}, nil

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -16,11 +16,35 @@ import (
 )
 
 // actorID returns the acting user's ID from the request context (0 when absent).
+//
+// actorID(r)==0 is ambiguous by construction: it means EITHER no request
+// context at all (a true local/embedded call — see isMachineActor's doc
+// comment) OR a machine-authenticated request (a machine identity has no
+// UserID). A caller whose ceiling check treats actorID==0 as "trusted, skip
+// the check" — rather than letting it flow through and fail closed like an
+// ordinary unauthorized actor would — is silently trusting every machine
+// credential too. Check isMachineActor(r) explicitly wherever that
+// distinction matters (see #1524).
 func actorID(r *http.Request) uint {
 	if u := middleware.GetUserFromContext(r.Context()); u != nil {
 		return u.UserID
 	}
 	return 0
+}
+
+// isMachineActor reports whether the request's authenticated principal is a
+// machine identity (any type, including a node credential) rather than a
+// user or a true unauthenticated/embedded call. Unlike actorID(r), this
+// distinguishes "no context at all" (nil UserContext — an in-process/local
+// caller, e.g. the CLI's embedded LocalStorage path) from "authenticated as
+// a machine" (non-nil UserContext with ActorType machine_identity,
+// UserID==0) — the two cases actorID(r) alone cannot tell apart. #1524: a
+// per-actor ceiling check that only tests `actorID != 0` treats both the
+// same, silently trusting a machine credential the way it was only ever
+// meant to trust a genuinely-local call.
+func isMachineActor(r *http.Request) bool {
+	u := middleware.GetUserFromContext(r.Context())
+	return u != nil && u.ActorKind() == core.ActorTypeMachine
 }
 
 // CatalogHandler handles project and environment endpoints.

--- a/server/http/handlers/groups_members.go
+++ b/server/http/handlers/groups_members.go
@@ -73,7 +73,7 @@ func (h *GroupHandler) AddGroupMember(w http.ResponseWriter, r *http.Request) {
 		sendError(w, "ValidationError", "user_id is required", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.AddUserToGroup(r.Context(), userCtx.UserID, body.UserID, uint(groupID), body.ProjectID); err != nil {
+	if err := h.coreService.AddUserToGroup(r.Context(), userCtx.UserID, false, body.UserID, uint(groupID), body.ProjectID); err != nil {
 		log.Printf("Error adding group member: %v", err)
 		switch {
 		case strings.Contains(err.Error(), "not found"):

--- a/server/http/handlers/groups_proxy.go
+++ b/server/http/handlers/groups_proxy.go
@@ -272,7 +272,13 @@ type groupMemberBody struct {
 // through core.KeyorixCore.AddUserToGroup (not a bare storage.AddUserToGroup)
 // so the escalation-by-proxy ceiling and SoD checks (validateGroupJoinRoles)
 // on joining an admin-conferring group also cover a membership add via
-// node-sync (#G79).
+// node-sync (#G79). #1524 finding (b): a bare node credential resolves
+// actorID(r)==0, the same value AddUserToGroup's local-CLI exemption treats
+// as fully trusted — passing isMachineActor(r) explicitly closes that gap
+// without touching the local-CLI case (both remain distinguishable at the
+// HTTP layer even though actorID(r) alone can't tell them apart). A machine
+// relay joining an ordinary, non-admin-conferring group is unaffected —
+// AddUserToGroup's ceiling only evaluates anything for admin-tier roles.
 func (h *GroupHandler) AddGroupMemberProxy(w http.ResponseWriter, r *http.Request) {
 	groupID, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
@@ -288,7 +294,7 @@ func (h *GroupHandler) AddGroupMemberProxy(w http.ResponseWriter, r *http.Reques
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id is required")
 		return
 	}
-	if err := h.coreService.AddUserToGroup(r.Context(), actorID(r), body.UserID, uint(groupID), body.ProjectID); err != nil {
+	if err := h.coreService.AddUserToGroup(r.Context(), actorID(r), isMachineActor(r), body.UserID, uint(groupID), body.ProjectID); err != nil {
 		if isGroupNotFound(err) {
 			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "user or group not found")
 			return

--- a/server/http/handlers/groups_s13_test.go
+++ b/server/http/handlers/groups_s13_test.go
@@ -383,7 +383,7 @@ func TestRemoveGroupMember_ProjectScoped_S13(t *testing.T) {
 	require.NoError(t, err)
 
 	// Add a project-scoped membership first.
-	require.NoError(t, cs.AddUserToGroup(ctx, 0, user.ID, grp.ID, 5))
+	require.NoError(t, cs.AddUserToGroup(ctx, 0, false, user.ID, grp.ID, 5))
 
 	// Now remove it via the handler with ?project_id=5.
 	url := "/?project_id=5"

--- a/server/http/handlers/risk_exceptions.go
+++ b/server/http/handlers/risk_exceptions.go
@@ -87,7 +87,7 @@ func (h *DashboardHandler) ApproveRiskException(w http.ResponseWriter, r *http.R
 		sendError(w, "InvalidParameter", "Invalid exception ID", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.ApproveRiskException(r.Context(), actor.UserID, uint(id)); err != nil {
+	if err := h.coreService.ApproveRiskException(r.Context(), actor.UserID, isMachineActor(r), uint(id)); err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()
 		switch {

--- a/server/http/handlers/risk_exceptions_proxy.go
+++ b/server/http/handlers/risk_exceptions_proxy.go
@@ -215,14 +215,19 @@ func (h *DashboardHandler) RevokeRiskExceptionProxy(w http.ResponseWriter, r *ht
 // never checked at all by this proxy — also covers an approval via node-sync
 // (#G79); ApproveRiskException re-fetches the row and resolves
 // Approved/ApprovedBy/ApprovedAt itself, so none of that (nor any other field
-// on the row) is accepted from the wire body anymore.
+// on the row) is accepted from the wire body anymore. #1524 finding (c): a
+// node credential relaying a human-created exception collided with neither
+// side of the old actorID==e.CreatedBy comparison, so approval proceeded with
+// no authority check. isMachineActor(r) closes it unconditionally — dual
+// control requires a different HUMAN, which a machine credential can never
+// be, independent of the self-approval comparison.
 func (h *DashboardHandler) ApproveRiskExceptionProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", errInvalidExceptionID)
 		return
 	}
-	if err := h.coreService.ApproveRiskException(r.Context(), actorID(r), uint(id)); err != nil {
+	if err := h.coreService.ApproveRiskException(r.Context(), actorID(r), isMachineActor(r), uint(id)); err != nil {
 		log.Printf("risk-exceptions proxy: approve failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return

--- a/server/http/node_credential_route_classification_test.go
+++ b/server/http/node_credential_route_classification_test.go
@@ -36,6 +36,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -432,24 +433,79 @@ func TestNodeCredentialRoutes_MatchClassification(t *testing.T) {
 	}
 }
 
-// TestNodeCredentialRoutes_PerActorCeilingsAreEnforced is a smoke check, not
-// a substitute for the real behavioral tests: every classPerActorCeiling
-// route must be one this package's tests actually exercise a machine-actor
-// outcome for -- either a dedicated denial regression test (P1:
-// AddGroupMemberProxy, ApproveRiskExceptionProxy -- see
-// server/http/remote_storage_groups_test.go,
-// remote_storage_risk_exceptions_test.go) or an already-correct fail-closed
-// path proven by an existing fixture swap (CreateUserWithRoleGrantsProxy,
-// C2 -- ValidateRoleGrantAuthority has no actorID==0 exemption to begin
-// with, so a node caller was already refused before this campaign; see
-// remote_storage_misc_proxy_test.go). This does not re-run those tests -- it
-// only guards against a FOURTH per-actor-ceiling route being classified
-// correctly here but never getting equivalent coverage at all.
+// perActorCeilingCoverage maps every classPerActorCeiling route to the test
+// function(s) that actually assert a machine actor is denied on that route --
+// not just that the route is classified. TestNodeCredentialRoutes_PerActorCeilingsAreEnforced
+// verifies these functions still exist in source; it does not re-run them
+// (that's `go test ./server/http/... ./internal/core/...`'s job). This is
+// still weaker than invoking the deny path from inside this test directly --
+// seeing an assertion that once verified a real 403/error, break-tested by
+// hand during P1 (see PR #1544's test plan) -- but it closes the actual gap
+// the original version of this test had: a prior version asserted only
+// perActorCount == 3, a pure count that would stay green even if every
+// listed test function were deleted. Route -> function name(s) is checked
+// against the real file, so a renamed/deleted test fails this immediately.
+var perActorCeilingCoverage = map[string][]struct {
+	file string // relative to repo root
+	fn   string
+}{
+	"POST /api/v1/system/groups/{id}/members": {
+		{file: "internal/core/authz_admin_ceiling_group_test.go", fn: "TestAddUserToGroup_MachineActorBlockedFromAdminGroup"},
+		{file: "server/http/remote_storage_groups_test.go", fn: "TestRemoteStorageGroup_Membership_AdminConferringGroup_DeniesNodeCredential"},
+	},
+	"PUT /api/v1/system/risk-exceptions/{id}/approve": {
+		{file: "internal/core/risk_exceptions_test.go", fn: "TestApproveRiskException_DeniesMachineActor"},
+		{file: "server/http/remote_storage_risk_exceptions_test.go", fn: "TestRemoteStorageRiskExceptions_Approve_DeniesNodeCredential"},
+	},
+	"POST /api/v1/system/users/with-role-grants": {
+		// ValidateRoleGrantAuthority has no actorID==0 exemption to begin with
+		// (C2) -- this test's name reflects its original DB-error purpose, but
+		// its assertion (403 before the broken DB is ever reached) is exactly
+		// the fail-closed-first behavior this table exists to pin.
+		{file: "server/http/handlers/handlers_s32_test.go", fn: "TestCreateUserWithRoleGrantsProxy_DBError_S32"},
+	},
+}
+
+// testFuncExists reports whether `func <fn>(` appears in the named file,
+// relative to the repo root (two levels up from server/http).
+func testFuncExists(t *testing.T, relPath, fn string) bool {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("..", "..", relPath))
+	if err != nil {
+		t.Fatalf("reading %s: %v", relPath, err)
+	}
+	return regexp.MustCompile(`(?m)^func `+regexp.QuoteMeta(fn)+`\(`).Match(b)
+}
+
+// TestNodeCredentialRoutes_PerActorCeilingsAreEnforced verifies every
+// classPerActorCeiling route has real, still-present, machine-actor-denial
+// test coverage listed in perActorCeilingCoverage -- not a route count that
+// happens to match. Two independent failure modes: a classPerActorCeiling
+// route with no coverage entry at all (a new ceiling route was classified
+// but never given its own fix + test, matching P1's `actorIsMachine` shape),
+// or a coverage entry naming a test function that no longer exists (renamed
+// or deleted without updating this table).
 func TestNodeCredentialRoutes_PerActorCeilingsAreEnforced(t *testing.T) {
 	perActorCount := 0
 	for _, c := range classifiedNodeCredentialRoutes {
-		if c.Class == classPerActorCeiling {
-			perActorCount++
+		if c.Class != classPerActorCeiling {
+			continue
+		}
+		perActorCount++
+		key := c.Method + " " + c.Path
+		coverage, ok := perActorCeilingCoverage[key]
+		if !ok || len(coverage) == 0 {
+			t.Errorf("classPerActorCeiling route %q has no entry in perActorCeilingCoverage — "+
+				"a per-actor ceiling route needs its own fail-closed fix AND a dedicated machine-actor "+
+				"denial test before it can be classified here, not just a table entry (see P1, #1524 b/c)", key)
+			continue
+		}
+		for _, tc := range coverage {
+			if !testFuncExists(t, tc.file, tc.fn) {
+				t.Errorf("classPerActorCeiling route %q: perActorCeilingCoverage names %s in %s, "+
+					"but that function no longer exists — it was renamed or deleted without updating "+
+					"this table, silently losing enforcement coverage for this ceiling", key, tc.fn, tc.file)
+			}
 		}
 	}
 	const knownEnforced = 3 // AddGroupMemberProxy, ApproveRiskExceptionProxy (P1), CreateUserWithRoleGrantsProxy (C2, already fail-closed)

--- a/server/http/node_credential_route_classification_test.go
+++ b/server/http/node_credential_route_classification_test.go
@@ -1,0 +1,460 @@
+// node_credential_route_classification_test.go — #1524/ADR-085's per-actor-
+// ceiling vs target-state-invariant distinction encoded as data, not just ADR
+// prose, with a completeness test cross-checking it against the real
+// RequireNodeCredentialOrPermission route set in router.go. Mirrors the
+// shape of the #1511 AST wire-route-coverage guard
+// (internal/storage/store/remote_wire_route_coverage_test.go): a hand-copied
+// list that nobody re-checks against the source is exactly how server/http
+// sat excluded from CI for ~4 months and #1524's 9-route enumeration missed
+// AddGroupMemberProxy the first time around — the only version of a
+// classification table that survives is one a test fails against.
+//
+// Classification (see docs/adr-085-node-credential-permission-scope.md and
+// the #1532 comment this test's own findings were posted to):
+//
+//   - classNodeLegitimate: no actor-authority check is reached on this route
+//     at all (via any caller, human or machine) — a bare node credential is
+//     fine here. Some of these bypass a REAL ceiling that exists elsewhere in
+//     internal/core by calling raw storage.Storage instead (see #1542) — that
+//     is a distinct, separately-tracked finding, not something this
+//     classification re-litigates.
+//   - classTargetStateInvariant: a real check runs, but it depends on target
+//     or global state (e.g. "would this strand the last admin"), never on
+//     who the caller is — safe for any caller including a bare node
+//     credential, by construction. Must never be "fixed" into denying node
+//     callers outright; that would break a genuine, tested relay path (the
+//     specific failure mode #1532's classification found the ADR's original
+//     binary framing would have caused).
+//   - classPerActorCeiling: the check depends on caller identity
+//     (self-approval, escalation-by-proxy). A bare machine actor can never
+//     satisfy this by definition — must be denied outright (see P1's
+//     actorIsMachine fix, groups.go's AddUserToGroup and
+//     risk_exceptions.go's ApproveRiskException).
+package http
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+type nodeRouteClass int
+
+const (
+	classNodeLegitimate nodeRouteClass = iota
+	classTargetStateInvariant
+	classPerActorCeiling
+)
+
+func (c nodeRouteClass) String() string {
+	switch c {
+	case classNodeLegitimate:
+		return "node-legitimate"
+	case classTargetStateInvariant:
+		return "target-state-invariant"
+	case classPerActorCeiling:
+		return "per-actor-ceiling"
+	default:
+		return "unknown"
+	}
+}
+
+type nodeRouteEntry struct {
+	Method string
+	Path   string
+	Class  nodeRouteClass
+	Note   string
+}
+
+// classifiedNodeCredentialRoutes is every route this classification currently
+// covers. Update it (with a reason) whenever a route is added to, removed
+// from, or moved within the RequireNodeCredentialOrPermission-gated /system
+// group — TestNodeCredentialRoutes_MatchClassification fails otherwise.
+var classifiedNodeCredentialRoutes = []nodeRouteEntry{
+	{"POST", "/api/v1/system/rbac/global-admin-role/remove-guarded", classTargetStateInvariant,
+		"RemoveGlobalAdminRoleGuardedProxy: refuses only if removal would strand the last global admin -- evaluated against the target's own state, not the caller"},
+	{"POST", "/api/v1/system/users/with-role-grants", classPerActorCeiling,
+		"CreateUserWithRoleGrantsProxy: ValidateRoleGrantAuthority(actorID(r), grants) -- escalation-by-proxy, genuinely actor-dependent"},
+	{"POST", "/api/v1/system/rbac/assign-role-with-expiry", classNodeLegitimate,
+		"AssignRoleWithExpiryProxy calls storage.AssignRoleWithExpiry directly, bypassing core.AssignUserRoleWithExpiry's real ceiling -- #1542, not a node-specific gap"},
+	{"POST", "/api/v1/system/rbac/assign-role-to-group-with-expiry", classNodeLegitimate,
+		"AssignRoleToGroupWithExpiryProxy: same #1542 raw-storage bypass as above, for groups"},
+	{"POST", "/api/v1/system/machine-identities/{id}/roles/{roleId}", classNodeLegitimate,
+		"AssignMachineRoleProxy: same #1542 raw-storage bypass, bypasses core.AssignMachineRole's requireAuthorityForRole + machineInProject"},
+	{"DELETE", "/api/v1/system/machine-identities/{id}/roles/{roleId}", classNodeLegitimate,
+		"RemoveMachineRoleProxy: no ceiling anywhere, local or proxy -- removal is safe-direction"},
+	{"POST", "/api/v1/system/rbac/remove-all-project-role-grants", classNodeLegitimate,
+		"RemoveAllProjectRoleGrantsProxy: bypasses core.RemoveProjectMember's guardLastProjectAdmin (a target-state guard, like row 1 above, but silently unreachable here rather than re-implemented) -- #1542"},
+	{"POST", "/api/v1/system/rbac/clear-project-secret-ownership", classNodeLegitimate,
+		"ClearProjectSecretOwnershipProxy: no ceiling anywhere -- defense-in-depth cleanup, not a grant"},
+	{"POST", "/api/v1/system/rbac/delete-secret-acls-by-user-and-project", classNodeLegitimate,
+		"DeleteSecretACLsByUserAndProjectProxy: no ceiling anywhere -- same shape as clear-project-secret-ownership"},
+	{"POST", "/api/v1/system/retention/role-grants/purge-expired", classNodeLegitimate,
+		"DeleteExpiredRoleGrantsProxy: no ceiling; bounded to time-bound grants by the caller-supplied 'before' timestamp -- #1529 territory, not a per-actor question"},
+	{"POST", "/api/v1/system/groups/{id}/members", classPerActorCeiling,
+		"AddGroupMemberProxy: #1524 finding (b) -- core.AddUserToGroup's validateGroupJoinRoles, now enforced for a machine actor via actorIsMachine (P1 fix)"},
+	{"DELETE", "/api/v1/system/groups/{id}/members/{userId}", classTargetStateInvariant,
+		"RemoveGroupMemberProxy: core.RemoveUserFromGroup's guardLastGlobalAdminMembership/guardLastProjectAdminGroupMembership -- target-state (would this strand an admin path), not actor-dependent, like row 1"},
+	{"POST", "/api/v1/system/risk-exceptions", classNodeLegitimate,
+		"CreateRiskExceptionProxy: no actor-authority check -- creation alone confers nothing, dual control's real gate is the separate approve step"},
+	{"PUT", "/api/v1/system/risk-exceptions/{id}/revoke", classNodeLegitimate,
+		"RevokeRiskExceptionProxy: core.RevokeRiskException has no actor-authority check at all -- #1529 territory"},
+	{"PUT", "/api/v1/system/risk-exceptions/{id}/approve", classPerActorCeiling,
+		"ApproveRiskExceptionProxy: #1524 finding (c) -- dual control's self-approval check, now enforced for a machine actor via actorIsMachine (P1 fix)"},
+	{"POST", "/api/v1/system/project-memberships", classNodeLegitimate,
+		"CreateMembershipProxy: body.Role is required and passed straight to a raw storage.CreateProjectMembership call, no ceiling anywhere -- SAME #1542-shaped raw-storage-bypass pattern (a real ROLE field, not just a status field), NOT YET VERIFIED for reach -- noted in the P0/P2 report as a follow-up candidate, not investigated further here per scope"},
+	{"PUT", "/api/v1/system/project-memberships/{id}", classNodeLegitimate,
+		"UpdateMembershipProxy: same raw-storage shape as CreateMembershipProxy above -- same follow-up flag"},
+	{"PUT", "/api/v1/system/project-memberships/{id}/transition", classNodeLegitimate,
+		"TransitionMembershipProxy: state transition (e.g. pending->active), not a role change -- lower concern than Create/Update above but same raw-storage shape"},
+}
+
+// --- Route extraction from router.go (scoped-down sibling of the #1511 AST
+// guard's extractRouterRoutes -- this only needs the router side, and only
+// needs it for routes actually gated by RequireNodeCredentialOrPermission,
+// identified by the "/api/v1/system" path prefix; router.go registers that
+// gate exactly once, at a single r.Route("/system", ...) block, verified by
+// this test's own sibling assertion below). ---
+
+type routerRoute struct {
+	Method  string
+	Path    string
+	Handler string // e.g. "AssignRoleWithExpiryProxy" -- the handler method name, not the receiver
+}
+
+// rbacMutationHandlerRe matches handler method names this classification's
+// scope actually covers: RBAC/group-membership/machine-role/risk-exception
+// MUTATIONS specifically (never a bare "Role"/"Member" READ -- see the
+// GET-method exclusion in extractSystemGroupRoutes' caller). This is a
+// judgment call, not something derivable from router.go alone: it is what
+// makes "18 routes," not "194," this test's universe, matching #1524's own
+// original scope (RBAC-mutating proxy routes, plus the two risk-exception
+// dual-control routes found alongside them) rather than every /system route.
+// A future RBAC/group/machine-role/risk-exception mutation handler that
+// doesn't match this pattern (an unusual name) would be a real gap this
+// regex can't catch -- the completeness test only guards against a
+// keyword-matching route being added without a classification entry, not
+// against every conceivable future name.
+var rbacMutationHandlerRe = regexp.MustCompile(`Role|Member|RiskException`)
+
+func normalizeRouterPath(p string) string {
+	// #1511's guard also collapses {param} to "*" for wire-call comparison;
+	// this guard keeps params literal (chi's own {id}/{roleId} names) since
+	// it only ever compares router.go against itself (the classification
+	// table above), never against a client-side Sprintf-built path.
+	if len(p) > 1 && strings.HasSuffix(p, "/") {
+		p = p[:len(p)-1]
+	}
+	return p
+}
+
+// extractSystemGroupRoutes parses router.go and returns every (method, path)
+// pair registered anywhere inside the r.Route("/system", ...) block --
+// including nested r.Route/r.Group sub-blocks -- resolving path constants
+// and string-concatenation the same way #1511's guard does.
+func extractSystemGroupRoutes(t *testing.T, path string) []routerRoute {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+
+	constPaths := map[string]string{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok || len(vs.Names) != 1 || len(vs.Values) != 1 {
+				continue
+			}
+			lit, ok := vs.Values[0].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				continue
+			}
+			if s, ok := unquoteRouterLit(lit.Value); ok {
+				constPaths[vs.Names[0].Name] = s
+			}
+		}
+	}
+
+	var resolvePathArg func(arg ast.Expr) (string, bool)
+	resolvePathArg = func(arg ast.Expr) (string, bool) {
+		switch e := arg.(type) {
+		case *ast.BasicLit:
+			if e.Kind != token.STRING {
+				return "", false
+			}
+			return unquoteRouterLit(e.Value)
+		case *ast.Ident:
+			s, ok := constPaths[e.Name]
+			return s, ok
+		case *ast.BinaryExpr:
+			if e.Op != token.ADD {
+				return "", false
+			}
+			l, lok := resolvePathArg(e.X)
+			r, rok := resolvePathArg(e.Y)
+			if !lok || !rok {
+				return "", false
+			}
+			return l + r, true
+		}
+		return "", false
+	}
+
+	var routes []routerRoute
+	var insideSystemGroup bool
+	systemGroupDepth := 0
+
+	httpMethods := map[string]string{"Get": "GET", "Post": "POST", "Put": "PUT", "Patch": "PATCH", "Delete": "DELETE"}
+
+	var walkBlock func(prefix string, body *ast.BlockStmt, inSystem bool, depth int)
+	var walkCall func(prefix string, expr ast.Expr, inSystem bool, depth int)
+
+	walkBlock = func(prefix string, body *ast.BlockStmt, inSystem bool, depth int) {
+		if body == nil {
+			return
+		}
+		for _, stmt := range body.List {
+			exprStmt, ok := stmt.(*ast.ExprStmt)
+			if !ok {
+				continue
+			}
+			walkCall(prefix, exprStmt.X, inSystem, depth)
+		}
+	}
+
+	walkCall = func(prefix string, expr ast.Expr, inSystem bool, depth int) {
+		call, ok := expr.(*ast.CallExpr)
+		if !ok {
+			return
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return
+		}
+		// r.Use(...) marks entry into the node-credential-gated group -- only
+		// meaningful at the top of the /system block itself, detected by the
+		// caller (walkCall for r.Route("/system", ...)) rather than here.
+		switch sel.Sel.Name {
+		case "Route", "Group":
+			var sub *ast.FuncLit
+			var subPrefix string
+			if sel.Sel.Name == "Route" {
+				if len(call.Args) != 2 {
+					return
+				}
+				p, ok := resolvePathArg(call.Args[0])
+				if !ok {
+					return
+				}
+				subPrefix = prefix + p
+				lit, ok := call.Args[1].(*ast.FuncLit)
+				if !ok {
+					return
+				}
+				sub = lit
+			} else {
+				if len(call.Args) != 1 {
+					return
+				}
+				lit, ok := call.Args[0].(*ast.FuncLit)
+				if !ok {
+					return
+				}
+				sub = lit
+				subPrefix = prefix
+			}
+			nowInSystem := inSystem
+			if depth == 0 && subPrefix == "/api/v1/system" {
+				nowInSystem = true
+				systemGroupDepth++
+			}
+			walkBlock(subPrefix, sub.Body, nowInSystem, depth+1)
+		case "Get", "Post", "Put", "Patch", "Delete":
+			if !inSystem || len(call.Args) < 2 {
+				return
+			}
+			p, ok := resolvePathArg(call.Args[0])
+			if !ok {
+				return
+			}
+			handlerName := ""
+			if hsel, ok := call.Args[1].(*ast.SelectorExpr); ok {
+				handlerName = hsel.Sel.Name
+			}
+			routes = append(routes, routerRoute{Method: httpMethods[sel.Sel.Name], Path: normalizeRouterPath(prefix + p), Handler: handlerName})
+		case "With":
+			// r.With(mw...).Post("/path", handler) -- the method call is the
+			// outer CallExpr's own Fun.X, e.g. r.With(...).Post(...): walk
+			// into it as if it were a direct call on r.
+		}
+		// r.With(...).Get/Post/etc(...) chains: the outer call's Fun is a
+		// SelectorExpr whose X is itself the r.With(...) call -- handled by
+		// recursing into X when the top-level selector isn't itself a known
+		// HTTP method/Route/Group name.
+		if _, known := httpMethods[sel.Sel.Name]; !known && sel.Sel.Name != "Route" && sel.Sel.Name != "Group" {
+			return
+		}
+	}
+
+	// Walk every top-level statement in every function looking for the
+	// r.Route("/system", ...) registration -- router.go registers routes
+	// inside NewRouter's own body (and possibly helper functions it calls),
+	// so this walks every FuncDecl's body rather than assuming a single
+	// known function name.
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Route" || len(call.Args) != 2 {
+				return true
+			}
+			p, ok := resolvePathArg(call.Args[0])
+			if !ok || p != "/system" {
+				return true
+			}
+			lit, ok := call.Args[1].(*ast.FuncLit)
+			if !ok {
+				return true
+			}
+			insideSystemGroup = true
+			walkBlock("/api/v1/system", lit.Body, true, 1)
+			return false
+		})
+	}
+
+	if !insideSystemGroup {
+		t.Fatal("could not find r.Route(\"/system\", ...) in router.go -- extractSystemGroupRoutes needs updating, or the gate moved/was removed")
+	}
+	return routes
+}
+
+func unquoteRouterLit(lit string) (string, bool) {
+	if len(lit) >= 2 && lit[0] == '"' {
+		return lit[1 : len(lit)-1], true
+	}
+	return "", false
+}
+
+// TestNodeCredentialRoutes_MatchClassification is the completeness guard:
+// every route actually registered under RequireNodeCredentialOrPermission in
+// router.go must appear in classifiedNodeCredentialRoutes, and vice versa.
+// Fails (not warns) on either direction -- an unclassified new route (#1524's
+// "route fourteen") and a stale classification entry both go unnoticed
+// otherwise, exactly like the pre-C5 CI exclusion list and the pre-hardening
+// #1511 guard both did before this campaign.
+func TestNodeCredentialRoutes_MatchClassification(t *testing.T) {
+	routerPath := filepath.Join(".", "router.go")
+	all := extractSystemGroupRoutes(t, routerPath)
+
+	// Scope to this classification's actual universe: RBAC/group-membership/
+	// machine-role/risk-exception MUTATIONS (never GET -- a read carries no
+	// escalation-ceiling concern in this codebase's pattern) whose handler
+	// name matches rbacMutationHandlerRe. 194 routes are registered under
+	// RequireNodeCredentialOrPermission total; this classification covers the
+	// 13 #1524 investigated, not the other 181 (dynamic-secrets/invitations/
+	// login-attempts/etc. proxies, which are #1529's territory, not this
+	// one).
+	var actual []routerRoute
+	for _, r := range all {
+		if r.Method == "GET" {
+			continue
+		}
+		if !rbacMutationHandlerRe.MatchString(r.Handler) {
+			continue
+		}
+		actual = append(actual, r)
+	}
+
+	// actualSet: the regex-filtered candidate set, used ONLY for the
+	// unclassified-route check below -- the heuristic can under-match (see
+	// ClearProjectSecretOwnershipProxy/DeleteSecretACLsByUserAndProjectProxy,
+	// both genuinely in scope but named after neither Role/Member/
+	// RiskException), so it must never be the set a classified entry is
+	// checked for staleness against.
+	actualSet := map[string]bool{}
+	for _, r := range actual {
+		actualSet[r.Method+" "+r.Path] = true
+	}
+	// allSet: every route actually registered under RequireNodeCredentialOr-
+	// Permission, unfiltered -- the staleness check's source of truth. A
+	// classified entry is stale only if NO real router.go registration
+	// matches it at all, regardless of whether that registration happens to
+	// match the unclassified-route heuristic.
+	allSet := map[string]bool{}
+	for _, r := range all {
+		allSet[r.Method+" "+r.Path] = true
+	}
+	classifiedSet := map[string]bool{}
+	for _, c := range classifiedNodeCredentialRoutes {
+		classifiedSet[c.Method+" "+c.Path] = true
+	}
+
+	var unclassified []string
+	for key := range actualSet {
+		if !classifiedSet[key] {
+			unclassified = append(unclassified, key)
+		}
+	}
+	sort.Strings(unclassified)
+	if len(unclassified) > 0 {
+		t.Errorf("%d route(s) registered under RequireNodeCredentialOrPermission have no entry in classifiedNodeCredentialRoutes (server/http/node_credential_route_classification_test.go) -- classify each as node-legitimate, target-state-invariant, or per-actor-ceiling before this test can pass:\n%s",
+			len(unclassified), strings.Join(unclassified, "\n"))
+	}
+
+	var stale []string
+	for key := range classifiedSet {
+		if !allSet[key] {
+			stale = append(stale, key)
+		}
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Errorf("%d classifiedNodeCredentialRoutes entries no longer match a real router.go registration -- the route moved, was removed, or the path changed; update or remove the entry:\n%s",
+			len(stale), strings.Join(stale, "\n"))
+	}
+}
+
+// TestNodeCredentialRoutes_PerActorCeilingsAreEnforced is a smoke check, not
+// a substitute for the real behavioral tests: every classPerActorCeiling
+// route must be one this package's tests actually exercise a machine-actor
+// outcome for -- either a dedicated denial regression test (P1:
+// AddGroupMemberProxy, ApproveRiskExceptionProxy -- see
+// server/http/remote_storage_groups_test.go,
+// remote_storage_risk_exceptions_test.go) or an already-correct fail-closed
+// path proven by an existing fixture swap (CreateUserWithRoleGrantsProxy,
+// C2 -- ValidateRoleGrantAuthority has no actorID==0 exemption to begin
+// with, so a node caller was already refused before this campaign; see
+// remote_storage_misc_proxy_test.go). This does not re-run those tests -- it
+// only guards against a FOURTH per-actor-ceiling route being classified
+// correctly here but never getting equivalent coverage at all.
+func TestNodeCredentialRoutes_PerActorCeilingsAreEnforced(t *testing.T) {
+	perActorCount := 0
+	for _, c := range classifiedNodeCredentialRoutes {
+		if c.Class == classPerActorCeiling {
+			perActorCount++
+		}
+	}
+	const knownEnforced = 3 // AddGroupMemberProxy, ApproveRiskExceptionProxy (P1), CreateUserWithRoleGrantsProxy (C2, already fail-closed)
+	if perActorCount != knownEnforced {
+		t.Errorf("expected exactly %d classPerActorCeiling routes, found %d — a new classPerActorCeiling route needs its own fix and its own machine-actor test coverage before this count changes, not just a table entry",
+			knownEnforced, perActorCount)
+	}
+}

--- a/server/http/node_credential_route_classification_test.go
+++ b/server/http/node_credential_route_classification_test.go
@@ -474,7 +474,7 @@ func testFuncExists(t *testing.T, relPath, fn string) bool {
 	if err != nil {
 		t.Fatalf("reading %s: %v", relPath, err)
 	}
-	return regexp.MustCompile(`(?m)^func `+regexp.QuoteMeta(fn)+`\(`).Match(b)
+	return regexp.MustCompile(`(?m)^func ` + regexp.QuoteMeta(fn) + `\(`).Match(b)
 }
 
 // TestNodeCredentialRoutes_PerActorCeilingsAreEnforced verifies every

--- a/server/http/remote_storage_groups_test.go
+++ b/server/http/remote_storage_groups_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
@@ -142,7 +143,12 @@ func TestRemoteStorageGroup_ListAndListPage_RealServer(t *testing.T) {
 
 // TestRemoteStorageGroup_Membership_RealServer proves the user-membership fix:
 // AddUserToGroup, ListGroupMembers, GetUserGroups, and RemoveUserFromGroup all
-// work correctly via storage.type: remote against a real server.
+// work correctly via storage.type: remote against a real server. "on-call"
+// carries no role grants, so this alone cannot distinguish "the
+// escalation-ceiling check ran and found nothing to object to" from "the
+// check was skipped outright" -- that distinction is what
+// TestRemoteStorageGroup_Membership_AdminConferringGroup_DeniesNodeCredential
+// (#1524 finding (b)) exists to prove instead.
 func TestRemoteStorageGroup_Membership_RealServer(t *testing.T) {
 	upstream, downstream := newUpstreamDownstreamForGroups(t)
 	ctx := context.Background()
@@ -196,4 +202,49 @@ func TestRemoteStorageGroup_Membership_RealServer(t *testing.T) {
 	userGroups, err = downstream.Storage().GetUserGroups(ctx, user.ID)
 	require.NoError(t, err)
 	assert.Empty(t, userGroups)
+}
+
+// TestRemoteStorageGroup_Membership_AdminConferringGroup_DeniesNodeCredential
+// is the real regression test for #1524 finding (b): a node credential
+// (this file's harness default -- see newUpstreamDownstreamForGroups) must
+// NOT be able to add a user to a group that holds an admin-conferring role.
+// Before the fix, AddUserToGroup's `if actorID != 0` exemption treated a node
+// credential's actorID(r)==0 identically to the true local-CLI case it was
+// written for, silently skipping the escalation-ceiling check entirely.
+// Unlike TestRemoteStorageGroup_Membership_RealServer's zero-grant "on-call"
+// group, this one genuinely exercises the check: a real HTTP round trip
+// through AddGroupMemberProxy against a group holding "admin" must come back
+// as an error, and the membership must never land on the upstream's own
+// storage -- proving the ceiling ran, not just that the wire call returned
+// something.
+func TestRemoteStorageGroup_Membership_AdminConferringGroup_DeniesNodeCredential(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForGroups(t)
+	ctx := context.Background()
+
+	group, err := downstream.Storage().CreateGroup(ctx, &models.Group{Name: "admins-node-test"})
+	require.NoError(t, err)
+	adminRole, err := upstream.Storage().GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().AssignRoleToGroup(ctx, group.ID, adminRole.ID, coreStorage.Scope{}))
+
+	user, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "wouldbeadmin",
+		Email:    "wouldbeadmin@example.com",
+		Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+
+	// The proxy's error handling runs every error through clientSafe (a
+	// blanket "an internal error occurred" string, deliberately never
+	// leaking detail to the wire caller), so the real "only an administrator
+	// can grant..." message is only visible server-side (log output during a
+	// local run of this test). What the CLIENT can observe -- and what
+	// actually matters for this regression -- is that the call errors at
+	// all, and that the membership never lands.
+	err = downstream.Storage().AddUserToGroup(ctx, user.ID, group.ID, 0)
+	require.Error(t, err, "a node credential must not be able to add a user to an admin-conferring group")
+
+	directMembers, err := upstream.Storage().ListGroupMembers(ctx, group.ID)
+	require.NoError(t, err)
+	assert.Empty(t, directMembers, "the denied join must never land on the upstream's own storage")
 }

--- a/server/http/remote_storage_risk_exceptions_test.go
+++ b/server/http/remote_storage_risk_exceptions_test.go
@@ -152,6 +152,42 @@ func TestRemoteStorageRiskExceptions_GetNotFound_RealServer(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestRemoteStorageRiskExceptions_Approve_DeniesNodeCredential is the real
+// regression test for #1524 finding (c): a node credential (this file's
+// harness default -- newUpstreamDownstreamForRiskExceptions) must not be
+// able to approve a HUMAN-created exception. Before the fix, the only
+// gate was actorID == e.CreatedBy (self-approval); a node relaying an
+// exception it did not create (CreatedBy a real human ID, actorID(r)==0)
+// never collided with that comparison and approved with no authority check
+// at all. The exception here is created directly on the upstream's own
+// core (bypassing the node-token wire entirely) specifically so CreatedBy
+// is a real, nonzero human ID, not the node's own actorID(r)==0 -- proving
+// this is the reversed-direction case #1531's investigation found, not the
+// already-correctly-denied node-created-and-node-approved collision.
+func TestRemoteStorageRiskExceptions_Approve_DeniesNodeCredential(t *testing.T) {
+	upstream, downstream := newUpstreamDownstreamForRiskExceptions(t)
+	ctx := context.Background()
+
+	const humanCreator = uint(5)
+	exc, err := upstream.CreateRiskException(ctx, humanCreator, "Human-created, node must not approve",
+		"other", "", "seeded directly on upstream for #1524 (c) regression coverage", time.Now().Add(30*24*time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, humanCreator, exc.CreatedBy)
+
+	// clientSafe sanitizes every proxy error to a blanket "an internal error
+	// occurred" string before it reaches the wire caller (the real "dual
+	// control requires a human approver" message is only visible server-side
+	// -- log output during a local run of this test). What the client can
+	// observe is that the call errors and never reports a match.
+	matched, err := downstream.Storage().ApproveRiskExceptionIfPending(ctx, exc)
+	assert.False(t, matched, "a node credential must never report a successful approval")
+	require.Error(t, err, "a node credential must not be able to approve a risk exception it did not create")
+
+	direct, err := upstream.Storage().GetRiskException(ctx, exc.ID)
+	require.NoError(t, err)
+	assert.False(t, direct.Approved, "the denied approval must never land on the upstream's own storage")
+}
+
 // TestRemoteStorageRiskExceptions_ActiveOnlyExcludesRevoked_RealServer proves
 // ListRiskExceptions(activeOnly=true) excludes revoked rows at the storage
 // layer, matching local_risk_exceptions.go's contract exactly (expiry itself is


### PR DESCRIPTION
## Summary

`actorID(r)` collapses "no request context" and "machine-credential-
authenticated caller" onto the identical value 0. Two per-actor ceiling
checks written as an exemption for the trusted local-CLI case (`actorID==0`)
silently also exempted any node/machine credential:

- `AddUserToGroup` (#1524 finding b): the escalation-by-proxy/SoD ceiling on
  joining an admin-conferring group was skipped entirely for a machine actor
  — a node credential could add a user to an admin-conferring group with no
  check at all.
- `ApproveRiskException` (#1524 finding c): dual control's self-approval
  guard (`actorID == e.CreatedBy`) doesn't collide when `actorID=0`, so a
  machine credential could approve any human-created risk exception with no
  authority check of any kind.

Both are per-actor ceilings — they need to know *which specific human* is
acting, which no machine credential can supply. Fix: deny, fail closed,
matching the precedent already set by `CreateUserWithRoleGrantsProxy`. The
target-state-invariant `RemoveGlobalAdminRoleGuardedProxy` path is untouched
— it never depended on caller identity and keeps working for any caller,
including a node.

Also adds `server/http/node_credential_route_classification_test.go`: an
AST-derived, CI-enforced classification of every
`RequireNodeCredentialOrPermission` route (node-legitimate /
target-state-invariant / per-actor-ceiling), failing if a new route joins
the gate unclassified — same completeness-guard shape used elsewhere in this
campaign, extended to this gate.

## Test plan

- [x] `internal/core`: 2 new tests (`TestAddUserToGroup_MachineActorBlockedFromAdminGroup`,
      `TestApproveRiskException_DeniesMachineActor`), each verified by
      breaking the fix and confirming red before reverting.
- [x] `server/http`: 2 new remote-storage-level tests
      (`TestRemoteStorageGroup_Membership_AdminConferringGroup_DeniesNodeCredential`,
      `TestRemoteStorageRiskExceptions_Approve_DeniesNodeCredential`), same
      adversarial verification.
- [x] `server/http/node_credential_route_classification_test.go`: verified
      both failure modes (unclassified route added, classified-but-removed
      route) go red, then reverted.
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run`, `gosec` all clean.
- [x] `go test ./internal/core/...`, `./internal/cli/...`, `./server/grpc/...` all pass.
- [x] `go test -race -timeout 3600s ./server/http/...`: passes except
      `TestRemoteStorageMFAManagement_FullLifecycle_RealServer`, a
      pre-existing local-only TOTP-timing flake unrelated to this change
      (nothing here touches MFA).

Refs #1524 (b), (c); #1532.