### PR TITLE
docs: add Engineering practices to CLAUDE.md, automate base-is-current check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,3 +10,19 @@ Guidance for Claude Code (claude.ai/code) when working in this repository.
   appends a `Co-Authored-By: Claude` line.
 - PR bodies may end with the `🤖 Generated with [Claude Code]` line, but must not carry a
   `Co-Authored-By: Claude` trailer.
+- Before starting a PR series, run `scripts/preflight.sh` (checks the branch base is
+  current against `origin/main`) — see `docs/g80-remediation-notes.md` for why.
+
+## Engineering practices
+
+Reasoning and incidents behind these: `docs/g80-remediation-notes.md`.
+
+- Check reachability and liveness before designing a fix, not just call sites.
+- Ask of any mechanism: what does it silently skip, and does it say so?
+- Verify a repaired test by breaking its subject and confirming it goes red.
+- A test whose premise turns out to be untested is a coverage gap, not a stale test —
+  fix the fixture or quarantine it; never adjust the assertion to match behaviour.
+- A guard nobody has watched fail is not a guard.
+- A skip with a wrong reason is worse than no skip.
+- Timeouts detect hangs; they don't enforce speed. Set them generously, watch durations.
+- When determining whether something needs fixing costs more than fixing it, fix it.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# preflight.sh — base-is-current check. Run before starting a PR series.
+#
+# Confirms origin/main is an ancestor of HEAD, i.e. this branch was cut from
+# (or has since merged) the current tip of main, not a stale snapshot. Stale
+# branch state has cost the G80 remediation campaign real work three times —
+# see docs/g80-remediation-notes.md.
+set -e
+
+git fetch origin main --quiet
+
+if git merge-base --is-ancestor origin/main HEAD; then
+    echo "ok: origin/main is an ancestor of HEAD — branch base is current"
+else
+    echo "FAIL: origin/main is NOT an ancestor of HEAD — this branch was cut from a stale base."
+    echo "Rebase or merge origin/main before starting a PR series."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds an "Engineering practices" section to the committed `CLAUDE.md`
  (project root) — one line each for the judgment practices this session's
  RBAC remediation work (#1542/#1524/#1545/#1546/#1547) surfaced repeatedly.
  Keeping these in the committed file (not just per-account Claude memory)
  means they reach every session and every teammate, not just this account.
  Full reasoning stays in `docs/g80-remediation-notes.md`, linked once.
- Adds `scripts/preflight.sh`: `git fetch` + `merge-base --is-ancestor
  origin/main HEAD`, for the one item on the list that's enforceable rather
  than just written down. Stale/divergent branch state has cost this
  campaign real work three times. Referenced from `CLAUDE.md` as something
  to run before starting a PR series.

## Test plan

- [x] `shellcheck scripts/preflight.sh` — clean.
- [x] Verified both directions by hand: green on a current branch; checked
      out an older commit and confirmed the script fails with the expected
      message, then restored the branch.
- [x] CI runs shellcheck on `scripts/` already (`.github/workflows/ci.yml`).