### PR TITLE
fix(rbac): machine-identity /system proxy ceiling fixes — closes system.write path on 3 handlers, node-credential path still open

### DIFF
--- a/docs/g80-raw-storage-bypass-triage.md
+++ b/docs/g80-raw-storage-bypass-triage.md
@@ -131,3 +131,65 @@ match the two patterns flagged standalone-and-first there too:
 5. UpdateUserIfActiveStateMatchesProxy — last-admin lockout + stale-credential bypass
 6. UpdateProjectProxy / RestoreProjectProxy — MFA-policy silent disable / admin-role resurrection
 7. Everything else in the table (24 more), roughly in the order listed above
+
+## Fix status (updated 2026-08-24, machine-identity/OIDC-binding sub-wave)
+
+Authoritative current status lives in `server/http/raw_storage_bypass_guard_test.go`'s
+`knownUnfixedRawStorageBypasses` / `rawStorageBypassAllowlist` maps (CI-enforced —
+`TestNoUnjustifiedRawStorageBypass` fails if an entry stops matching reality). This
+section records what changed in this sub-wave and why, since the map's own per-entry
+comments don't carry cross-references to this doc's original investigation rows above.
+
+- **CreateMachineIdentityProxy** — FIXED (moved to `rawStorageBypassAllowlist`). Now
+  routes through `core.CreateMachineIdentity`: forces `State=MachineActive`, validates
+  `IdentityType`/`Classification`, writes an audit event. No node/direct-caller split
+  needed — `core.CreateMachineIdentity` has no actor-authority check for either.
+- **CreateMachineIdentityCredentialProxy** ("MOST SEVERE FINDING" above) — **HALF-FIXED,
+  still in `knownUnfixedRawStorageBypasses`, NOT closed.** A direct (non-node-credential)
+  `system.write` caller is now denied via `core.RequireMachinePrivilegeCeiling`
+  (MACH-001) when the target machine holds an admin-tier role. A **node-credential**
+  caller still reaches the raw storage call unconditionally — `isNodeCredentialRequest(r)`
+  routes around the new check on the theory that a genuine relay already ran it
+  downstream, an assumption with no wire-level verification (see "Re-examined" below).
+  The original finding's worst-case (forge a credential for an admin-tier machine
+  identity) is still reachable by anyone holding a bare node credential.
+- **CreateOIDCBindingProxy** — **HALF-FIXED, still in `knownUnfixedRawStorageBypasses`,
+  NOT closed.** Same shape as above: a direct caller now routes through
+  `core.CreateOIDCBinding`'s `requireAuthorityForRole(..., "system_admin")` check; a
+  node-credential caller still reaches the raw storage call unconditionally, on the
+  same unverified relay-trust assumption.
+- **RevokeMachineIdentityCredentialProxy** — still fully open, for both caller types.
+  Deferred and filed as **[#1551](https://github.com/keyorixhq/keyorix/issues/1551)**:
+  unlike the fixes above, its wire contract (`POST .../revoke` with only a bare
+  credential ID) carries no project/scope parameter at all, so closing the
+  `machineInProject` gap needs a `RemoteStorage` client-side wire change first, not a
+  server-only fix.
+- **DeleteOIDCBindingProxy** — still open, not part of this sub-wave.
+
+### Re-examined: is the node-credential exemption itself sound?
+
+The `isNodeCredentialRequest(r)` carve-out used above (and originally established by
+`AssignRoleWithExpiryProxy`, `server/http/handlers/rbac_role_grants_proxy.go`) rests on
+an assumption stated in that file's own package doc: a node relay is "trusted... for the
+one check that can't distinguish 'the real acting human already passed this' from 'the
+node itself holds no permissions' without a wire-level actor-identity field that doesn't
+exist yet." That field does not exist. Nothing on the wire distinguishes a genuine relay
+of an already-checked downstream decision from a bare node credential calling the route
+directly with attacker-chosen parameters — the trust is asserted, not verified.
+
+For `AssignRoleWithExpiryProxy` specifically, this means: a node credential — deliberately
+designed to carry zero RBAC permissions of its own (ADR-030, `MachineTypeNode`'s doc
+comment) and the single most widely distributed credential class in a deployment
+(ADR-085) — can single-handedly grant ANY role, including admin-tier, to ANY user, in
+ANY scope, via the raw `storage.AssignRoleWithExpiry` call, entirely bypassing
+`requireGranterHoldsRolePermissions`. This was **not** re-derived when `actorIsMachine`
+awareness was added to that check (`internal/core/authz.go:588`) — the node branch skips
+`core.AssignUserRoleWithExpiry` (and therefore that check) entirely, going straight to
+raw storage. This reads as a genuine, uncatalogued instance of the exact `#1542` shape
+this campaign has been fixing, not a reviewed-safe design difference — and it is broader
+in scope than #1545 (`AssignPermissionToRole`'s self-permission-bundling check,
+`BulkDeleteSecrets`' per-secret ACL check), which covers different call sites entirely.
+**Not fixed here** — reported per explicit instruction, filing/fixing left to a
+follow-up decision. This is exactly ADR-085's own still-open "harder question" (whose
+authority a relayed action is actually exercised under), materialized as a concrete,
+reachable finding rather than a design question.

--- a/docs/g80-raw-storage-bypass-triage.md
+++ b/docs/g80-raw-storage-bypass-triage.md
@@ -123,14 +123,25 @@ facto superuser) rather than a bug count. Full content, including the fix-patter
 grouping table, is in `docs/g80-tracking-issue-draft.md` (not yet filed — `gh` auth
 blocked, see the handoff doc). The rough manual priority order below is superseded by
 that grouping table but kept for reference since two of its entries (worst blast radius)
-match the two patterns flagged standalone-and-first there too:
-1. CreateMachineIdentityCredentialProxy — privilege escalation
-2. CreateWebAuthnCredentialProxy / DeleteWebAuthnCredentialProxy / SetUserWebAuthnEnabledProxy — account takeover / 2FA bypass
-3. CreateAccessRequestProxy / UpdateAccessRequestProxy — dual-control bypass on restricted secrets
-4. CreateMFAStepUpGrantProxy — MFA gate bypass with zero verification
-5. UpdateUserIfActiveStateMatchesProxy — last-admin lockout + stale-credential bypass
-6. UpdateProjectProxy / RestoreProjectProxy — MFA-policy silent disable / admin-role resurrection
-7. Everything else in the table (24 more), roughly in the order listed above
+match the two patterns flagged standalone-and-first there too. **Re-ranked 2026-08-24**:
+`AssignRoleWithExpiryProxy`'s node-credential exemption (filed as
+[#1552](https://github.com/keyorixhq/keyorix/issues/1552), see "Re-examined" below)
+moves to #1 — a shorter path to global admin than the original #1 (grants a role
+directly to an attacker-chosen user account; CreateMachineIdentityCredentialProxy
+required an admin-tier machine identity to already exist as a target):
+1. **AssignRoleWithExpiryProxy (node-credential branch) — #1552** — arbitrary role
+   grant (including admin-tier) to an arbitrary user, via a bare node credential
+   (zero RBAC permissions by design), bypassing requireGranterHoldsRolePermissions
+   entirely. Not yet fixed.
+2. CreateMachineIdentityCredentialProxy — privilege escalation. HALF-FIXED: closed
+   for a direct caller, still open for a node credential (same #1552 pattern) — see
+   "Fix status" below.
+3. CreateWebAuthnCredentialProxy / DeleteWebAuthnCredentialProxy / SetUserWebAuthnEnabledProxy — account takeover / 2FA bypass
+4. CreateAccessRequestProxy / UpdateAccessRequestProxy — dual-control bypass on restricted secrets
+5. CreateMFAStepUpGrantProxy — MFA gate bypass with zero verification
+6. UpdateUserIfActiveStateMatchesProxy — last-admin lockout + stale-credential bypass
+7. UpdateProjectProxy / RestoreProjectProxy — MFA-policy silent disable / admin-role resurrection
+8. Everything else in the table (24 more), roughly in the order listed above
 
 ## Fix status (updated 2026-08-24, machine-identity/OIDC-binding sub-wave)
 
@@ -150,14 +161,16 @@ comments don't carry cross-references to this doc's original investigation rows 
   (MACH-001) when the target machine holds an admin-tier role. A **node-credential**
   caller still reaches the raw storage call unconditionally — `isNodeCredentialRequest(r)`
   routes around the new check on the theory that a genuine relay already ran it
-  downstream, an assumption with no wire-level verification (see "Re-examined" below).
-  The original finding's worst-case (forge a credential for an admin-tier machine
-  identity) is still reachable by anyone holding a bare node credential.
+  downstream, an assumption with no wire-level verification (see "Re-examined" below,
+  and [#1552](https://github.com/keyorixhq/keyorix/issues/1552)). The original finding's
+  worst-case (forge a credential for an admin-tier machine identity) is still reachable
+  by anyone holding a bare node credential.
 - **CreateOIDCBindingProxy** — **HALF-FIXED, still in `knownUnfixedRawStorageBypasses`,
   NOT closed.** Same shape as above: a direct caller now routes through
   `core.CreateOIDCBinding`'s `requireAuthorityForRole(..., "system_admin")` check; a
   node-credential caller still reaches the raw storage call unconditionally, on the
-  same unverified relay-trust assumption.
+  same unverified relay-trust assumption tracked in
+  [#1552](https://github.com/keyorixhq/keyorix/issues/1552).
 - **RevokeMachineIdentityCredentialProxy** — still fully open, for both caller types.
   Deferred and filed as **[#1551](https://github.com/keyorixhq/keyorix/issues/1551)**:
   unlike the fixes above, its wire contract (`POST .../revoke` with only a bare
@@ -189,7 +202,10 @@ raw storage. This reads as a genuine, uncatalogued instance of the exact `#1542`
 this campaign has been fixing, not a reviewed-safe design difference — and it is broader
 in scope than #1545 (`AssignPermissionToRole`'s self-permission-bundling check,
 `BulkDeleteSecrets`' per-secret ACL check), which covers different call sites entirely.
-**Not fixed here** — reported per explicit instruction, filing/fixing left to a
-follow-up decision. This is exactly ADR-085's own still-open "harder question" (whose
-authority a relayed action is actually exercised under), materialized as a concrete,
-reachable finding rather than a design question.
+**Not fixed here** — reported per explicit instruction. Filed as
+[**#1552**](https://github.com/keyorixhq/keyorix/issues/1552), Tier 1, ranked #1 above
+(shorter path to global admin than CreateMachineIdentityCredentialProxy: grants a role
+directly to an attacker-chosen user account, no pre-existing admin-tier machine
+required). This is exactly ADR-085's own still-open "harder question" (whose authority
+a relayed action is actually exercised under), materialized as a concrete, reachable
+finding rather than a design question.

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -493,6 +493,17 @@ func (c *KeyorixCore) requireMachinePrivilegeCeiling(ctx context.Context, actorI
 	return nil
 }
 
+// RequireMachinePrivilegeCeiling is requireMachinePrivilegeCeiling's exported
+// form, for callers outside internal/core that need the SAME MACH-001 check
+// IssueMachineToken already runs — currently CreateMachineIdentityCredentialProxy
+// (server/http/handlers/machine_identities_proxy.go), which must preserve the
+// raw, caller-supplied TokenHash (needed for a legitimate RemoteStorage relay
+// persisting a hash it already generated locally) and therefore cannot route
+// through IssueMachineToken itself, only reuse its privilege-ceiling check.
+func (c *KeyorixCore) RequireMachinePrivilegeCeiling(ctx context.Context, actorID, machineID uint) error {
+	return c.requireMachinePrivilegeCeiling(ctx, actorID, machineID)
+}
+
 // requireEqualOrGreaterAdminAuthority refuses when targetID holds, at any scope
 // (global OR project-scoped, direct OR group-inherited), a permission actorID
 // does not ALSO effectively hold at that same scope. Unlike the single-scope

--- a/internal/core/secret_schedule_test.go
+++ b/internal/core/secret_schedule_test.go
@@ -169,8 +169,20 @@ func TestCheckSecretAccessSchedule_Denied(t *testing.T) {
 // allowedDaysExcludingToday returns a comma-separated day list (ISO 1=Mon..7=Sun)
 // that excludes today, guaranteeing enforceSchedule denies on the day check
 // alone — independent of the current hour.
+//
+// Intermittent-failure fix: every caller in this file sets the fixture schedule's
+// Timezone to "UTC", and enforceSchedule (secret_schedule.go:46) evaluates
+// local := now.In(loc) against THAT timezone — but this used to compute "today"
+// from time.Now().Weekday(), the machine's LOCAL timezone. Near the local/UTC day
+// boundary the two disagree (e.g. a UTC+1 machine between 00:00 and 01:00 local
+// has already rolled to tomorrow locally while UTC is still on today), so the
+// excluded day didn't match the day enforceSchedule actually checked, and the
+// test flaked open (expected denial, got access) for that ~1h/day window,
+// machine-timezone-dependent. Anchoring to UTC here matches the fixture's own
+// configured schedule timezone, closing the mismatch outright rather than
+// narrowing the window.
 func allowedDaysExcludingToday() string {
-	today := int(time.Now().Weekday())
+	today := int(time.Now().UTC().Weekday())
 	if today == 0 {
 		today = 7
 	}

--- a/server/http/handlers/handlers_s20_test.go
+++ b/server/http/handlers/handlers_s20_test.go
@@ -304,12 +304,16 @@ func TestCreateOIDCBindingProxy_Success_S20(t *testing.T) {
 		"issuer":              "https://accounts.example.com",
 		"subject":             "user@example.com",
 	})
-	req := httptest.NewRequest(http.MethodPost,
+	req := withUserCtx(httptest.NewRequest(http.MethodPost,
 		"/api/v1/system/machine-oidc-bindings",
-		bytes.NewReader(body))
+		bytes.NewReader(body)))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	h.CreateOIDCBindingProxy(w, req)
+	// G80 raw-storage-bypass fix: CreateOIDCBindingProxy now requires
+	// install-wide admin authority (core.CreateOIDCBinding's requireAuthorityForRole
+	// check) — withUserCtx's UserID=1 matches freshCoreS20WithAdmin's system_admin
+	// grant, so the actor holds it.
 	assert.Equal(t, http.StatusOK, w.Code)
 	var resp remoteAPIResponse
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
@@ -332,19 +336,21 @@ func TestCreateOIDCBindingProxy_Duplicate_S20(t *testing.T) {
 		"subject":             "dup@example.com",
 	})
 
-	// First creation — should succeed.
-	req := httptest.NewRequest(http.MethodPost,
+	// First creation — should succeed. G80 raw-storage-bypass fix: requires
+	// install-wide admin authority — withUserCtx's UserID=1 matches
+	// freshCoreS20WithAdmin's system_admin grant.
+	req := withUserCtx(httptest.NewRequest(http.MethodPost,
 		"/api/v1/system/machine-oidc-bindings",
-		bytes.NewReader(body))
+		bytes.NewReader(body)))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	h.CreateOIDCBindingProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	// Second creation — same issuer/subject → unique-violation → 409.
-	req2 := httptest.NewRequest(http.MethodPost,
+	req2 := withUserCtx(httptest.NewRequest(http.MethodPost,
 		"/api/v1/system/machine-oidc-bindings",
-		bytes.NewReader(body))
+		bytes.NewReader(body)))
 	req2.Header.Set("Content-Type", "application/json")
 	w2 := httptest.NewRecorder()
 	h.CreateOIDCBindingProxy(w2, req2)

--- a/server/http/handlers/handlers_s21_machine_proxy_test.go
+++ b/server/http/handlers/handlers_s21_machine_proxy_test.go
@@ -10,6 +10,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -20,6 +21,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	customMiddleware "github.com/keyorixhq/keyorix/server/middleware"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // freshCatalogHandlerS21 returns a CatalogHandler backed by a fresh in-memory DB.
@@ -41,6 +47,29 @@ func decodeRemoteRespS21(t *testing.T, w *httptest.ResponseRecorder) remoteAPIRe
 func proxyBodyS21(v interface{}) *bytes.Buffer {
 	b, _ := json.Marshal(v)
 	return bytes.NewBuffer(b)
+}
+
+// withOIDCAdminCtxS21 seeds a system_admin-holding user directly against h's
+// own storage and returns r wrapped with that user's context — needed by every
+// CreateOIDCBindingProxy happy-path call since the G80 raw-storage-bypass fix
+// added core.CreateOIDCBinding's install-wide admin-authority check
+// (requireAuthorityForRole), which an unauthenticated request (actorID 0)
+// cannot satisfy.
+func withOIDCAdminCtxS21(t *testing.T, h *CatalogHandler, r *http.Request) *http.Request {
+	t.Helper()
+	ctx := context.Background()
+	_, err := h.coreService.Storage().CreateRole(ctx, &models.Role{Name: "system_admin", Description: "Administrator"})
+	if err != nil {
+		require.Contains(t, err.Error(), "UNIQUE", "unexpected CreateRole error: %v", err) // already exists from a prior call in this test
+	}
+	uname := fmt.Sprintf("s21_oidc_admin_%d", time.Now().UnixNano())
+	user, err := h.coreService.CreateUser(ctx, &core.CreateUserRequest{
+		Username: uname, Email: uname + "@example.com", Password: "TestPassword123!",
+	})
+	require.NoError(t, err)
+	require.NoError(t, h.coreService.AssignUserRoleScoped(ctx, user.Email, "system_admin", core.Scope{}))
+	userCtx := &customMiddleware.UserContext{UserID: user.ID, Username: user.Username, Email: user.Email}
+	return r.WithContext(context.WithValue(r.Context(), customMiddleware.GetUserContextKey(), userCtx))
 }
 
 // ── CreateMachineIdentityProxy ────────────────────────────────────────────────
@@ -352,8 +381,12 @@ func TestCountMachineIdentitiesByClassificationProxy_HappyPath_S21(t *testing.T)
 // TestCountMachineIdentitiesByClassificationProxy_WithData_S21 — with seeded identities → 200 with counts.
 func TestCountMachineIdentitiesByClassificationProxy_WithData_S21(t *testing.T) {
 	h := freshCatalogHandlerS21(t)
-	// Seed some machine identities to get non-empty counts.
-	for i, class := range []string{"public", "confidential", "secret"} {
+	// Seed some machine identities to get non-empty counts. Classification must be
+	// one of core.IsValidClassification's set (public|internal|confidential|
+	// restricted) now that CreateMachineIdentityProxy routes through
+	// core.CreateMachineIdentity (G80 raw-storage-bypass fix) — "secret" was never
+	// a real classification, the old unvalidated raw proxy just never checked.
+	for i, class := range []string{"public", "confidential", "restricted"} {
 		createBody := proxyBodyS21(map[string]interface{}{
 			"name":           "count-bot-s21-" + class,
 			"project_id":     i + 1,
@@ -1143,7 +1176,7 @@ func TestCreateOIDCBindingProxy_HappyPath_S21(t *testing.T) {
 		"subject":             "sub-s21-unique-001",
 		"created_by":          1,
 	})
-	req := httptest.NewRequest(http.MethodPost, "/system/machine-oidc-bindings", body)
+	req := withOIDCAdminCtxS21(t, h, httptest.NewRequest(http.MethodPost, "/system/machine-oidc-bindings", body))
 	w := httptest.NewRecorder()
 	h.CreateOIDCBindingProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -1173,13 +1206,13 @@ func TestCreateOIDCBindingProxy_DuplicateBinding_S21(t *testing.T) {
 		"created_by":          1,
 	}
 	// First creation must succeed.
-	cr2 := httptest.NewRequest(http.MethodPost, "/system/machine-oidc-bindings", proxyBodyS21(bindingBody))
+	cr2 := withOIDCAdminCtxS21(t, h, httptest.NewRequest(http.MethodPost, "/system/machine-oidc-bindings", proxyBodyS21(bindingBody)))
 	cw2 := httptest.NewRecorder()
 	h.CreateOIDCBindingProxy(cw2, cr2)
 	require.Equal(t, http.StatusOK, cw2.Code)
 
 	// Second creation must return 409.
-	cr3 := httptest.NewRequest(http.MethodPost, "/system/machine-oidc-bindings", proxyBodyS21(bindingBody))
+	cr3 := withOIDCAdminCtxS21(t, h, httptest.NewRequest(http.MethodPost, "/system/machine-oidc-bindings", proxyBodyS21(bindingBody)))
 	cw3 := httptest.NewRecorder()
 	h.CreateOIDCBindingProxy(cw3, cr3)
 	assert.Equal(t, http.StatusConflict, cw3.Code)
@@ -1303,7 +1336,7 @@ func TestGetOIDCBindingByIDProxy_HappyPath_S21(t *testing.T) {
 		"subject":             "getbind-sub-s21",
 		"created_by":          1,
 	})
-	cr2 := httptest.NewRequest(http.MethodPost, "/system/machine-oidc-bindings", createBind)
+	cr2 := withOIDCAdminCtxS21(t, h, httptest.NewRequest(http.MethodPost, "/system/machine-oidc-bindings", createBind))
 	cw2 := httptest.NewRecorder()
 	h.CreateOIDCBindingProxy(cw2, cr2)
 	require.Equal(t, http.StatusOK, cw2.Code)
@@ -1373,7 +1406,7 @@ func TestDeleteOIDCBindingProxy_HappyPath_S21(t *testing.T) {
 		"subject":             "delbind-sub-s21",
 		"created_by":          1,
 	})
-	cr2 := httptest.NewRequest(http.MethodPost, "/system/machine-oidc-bindings", createBind)
+	cr2 := withOIDCAdminCtxS21(t, h, httptest.NewRequest(http.MethodPost, "/system/machine-oidc-bindings", createBind))
 	cw2 := httptest.NewRecorder()
 	h.CreateOIDCBindingProxy(cw2, cr2)
 	require.Equal(t, http.StatusOK, cw2.Code)

--- a/server/http/handlers/handlers_s28_test.go
+++ b/server/http/handlers/handlers_s28_test.go
@@ -226,11 +226,16 @@ func TestCreateMachineIdentityProxy_HappyPath_S28(t *testing.T) {
 	cs := freshCoreS28(t)
 	h := NewCatalogHandler(cs)
 
+	// identity_type must be one of core's validMachineTypes (ci|k8s|service|
+	// automation|other|node) now that CreateMachineIdentityProxy routes through
+	// core.CreateMachineIdentity (G80 raw-storage-bypass fix) instead of trusting
+	// the wire body's identity_type/state verbatim — "workload" was never a real
+	// identity_type, the old unvalidated raw proxy just never checked.
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/machine-identities",
 		jsonBodyS28(t, map[string]interface{}{
 			"name":          "test-machine-s28",
 			"project_id":    1,
-			"identity_type": "workload",
+			"identity_type": "service",
 			"state":         "active",
 		}))
 	w := httptest.NewRecorder()

--- a/server/http/handlers/handlers_s28_test.go
+++ b/server/http/handlers/handlers_s28_test.go
@@ -1275,20 +1275,21 @@ func TestCreateOIDCBindingProxy_MissingFields_S28(t *testing.T) {
 // a binding for it.
 func TestCreateOIDCBindingProxy_HappyPath_S28(t *testing.T) {
 	t.Parallel()
-	cs := freshCoreS28(t)
-	ctx := context.Background()
-	mi, err := cs.Storage().CreateMachineIdentity(ctx, &models.MachineIdentity{
-		Name: "s28-oidc-create-machine", ProjectID: 1, IdentityType: "workload", State: "active",
-	})
-	require.NoError(t, err)
+	// G80 raw-storage-bypass fix: CreateOIDCBindingProxy now requires install-wide
+	// admin authority (core.CreateOIDCBinding's requireAuthorityForRole check) —
+	// freshCoreS28WithAdmin + withUserCtx (UserID=1) matches the same pattern
+	// TestCreateOIDCBindingProxy_Success_S20 uses.
+	cs, db := freshCoreS28WithAdmin(t)
+	mi := &models.MachineIdentity{Name: "s28-oidc-create-machine", ProjectID: 1, IdentityType: "workload", State: "active"}
+	require.NoError(t, db.Create(mi).Error)
 
 	h := NewCatalogHandler(cs)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/machine-oidc-bindings",
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/system/machine-oidc-bindings",
 		jsonBodyS28(t, map[string]interface{}{
 			"machine_identity_id": mi.ID,
 			"issuer":              "https://iss.example.com",
 			"subject":             "sub-s28-create",
-		}))
+		})))
 	w := httptest.NewRecorder()
 	h.CreateOIDCBindingProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/server/http/handlers/handlers_s33_test.go
+++ b/server/http/handlers/handlers_s33_test.go
@@ -195,8 +195,13 @@ func TestCreateOIDCBindingProxy_DBError_S33(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/machine-oidc-bindings", body)
 	w := httptest.NewRecorder()
 	h.CreateOIDCBindingProxy(w, r)
-	// CreateOIDCBinding fails: not a unique-violation error → 500
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	// G80 raw-storage-bypass fix: the handler now looks up the machine identity
+	// (to derive its real ProjectID for core.CreateOIDCBinding's admin-authority +
+	// scope check) BEFORE attempting the create — on this broken DB, that GetMachineIdentity
+	// lookup itself fails first, wrapped as "not found" (same isNotFoundErr convention
+	// GetMachineIdentityProxy/GetOIDCBindingByIDProxy use elsewhere in this file) → 404,
+	// rather than reaching the create call at all.
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestGetMachineByOIDCSubjectProxy_DBError_S33(t *testing.T) {

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -83,6 +83,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -475,6 +476,23 @@ func (h *CatalogHandler) CountMachineIdentitiesByClassificationProxy(w http.Resp
 // --- Machine-token credentials ---
 
 // CreateMachineIdentityCredentialProxy handles POST /api/v1/system/machine-credentials.
+//
+// #1542-shape guard (G80 raw-storage-bypass triage, docs/g80-raw-storage-bypass-
+// triage.md — "MOST SEVERE FINDING"): core.IssueMachineToken enforces
+// requireMachinePrivilegeCeiling (MACH-001) before minting a credential — a
+// non-global-admin actor cannot mint one for a machine identity that itself holds
+// an admin-tier role, since the credential inherits the machine's roles (the same
+// escalation-by-proxy contract role grants and impersonation already enforce).
+// This raw proxy accepted an attacker-chosen TokenHash for ANY MachineIdentityID
+// with no such check — forge a working credential for an admin-tier machine and
+// authenticate as it. Fixed by reusing core.RequireMachinePrivilegeCeiling (the
+// exported form of the SAME check IssueMachineToken runs) before the storage
+// write, WITHOUT routing through IssueMachineToken itself — that would generate
+// its own random token via crypto/rand, breaking the legitimate relay case this
+// route exists for (a downstream node's own core.IssueMachineToken already
+// generated the real token locally and relays only its hash to persist here).
+// No RemoteStorage wire-protocol change: the check needs only (actorID,
+// MachineIdentityID), and MachineIdentityID was already on the wire.
 func (h *CatalogHandler) CreateMachineIdentityCredentialProxy(w http.ResponseWriter, r *http.Request) {
 	var body machineIdentityCredentialProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -483,6 +501,15 @@ func (h *CatalogHandler) CreateMachineIdentityCredentialProxy(w http.ResponseWri
 	}
 	if body.MachineIdentityID == 0 || body.TokenHash == "" {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "machine_identity_id and token_hash are required")
+		return
+	}
+	if err := h.coreService.RequireMachinePrivilegeCeiling(r.Context(), actorID(r), body.MachineIdentityID); err != nil {
+		if errors.Is(err, core.ErrMachinePrivilegeCeilingDenied) {
+			writeRemoteAPIError(w, http.StatusForbidden, "PRIVILEGE_CEILING_EXCEEDED", clientSafe(err))
+			return
+		}
+		log.Printf("machine-credentials proxy: privilege ceiling check failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
 	}
 	created, err := h.coreService.Storage().CreateMachineIdentityCredential(r.Context(), body.toModel())

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -514,6 +514,19 @@ func (h *CatalogHandler) CountMachineIdentitiesByClassificationProxy(w http.Resp
 // generated the real token locally and relays only its hash to persist here).
 // No RemoteStorage wire-protocol change: the check needs only (actorID,
 // MachineIdentityID), and MachineIdentityID was already on the wire.
+//
+// isNodeCredentialRequest(r) branch (found via the RealServer relay test that
+// exercises a genuine downstream node, not just a direct system.write caller):
+// a node credential always resolves actorID(r)==0 (catalog.go's actorID has no
+// separate "this is a trusted relay" signal), and requireMachinePrivilegeCeiling
+// denies actorID==0 outright whenever the target holds an admin-tier role — so
+// applying the check unconditionally would ALSO deny every legitimate relay of
+// an admin-authorized credential issuance, not just a direct escalation attempt.
+// Mirrors AssignRoleWithExpiryProxy's precedent (rbac_role_grants_proxy.go): a
+// genuine node relay is trusted to have already run this exact ceiling locally
+// (the downstream's own core.IssueMachineToken call already checked it against
+// the real acting human before relaying); only a direct, non-node caller reaching
+// this route via the system.write permission arm gets the check applied here.
 func (h *CatalogHandler) CreateMachineIdentityCredentialProxy(w http.ResponseWriter, r *http.Request) {
 	var body machineIdentityCredentialProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -524,14 +537,16 @@ func (h *CatalogHandler) CreateMachineIdentityCredentialProxy(w http.ResponseWri
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "machine_identity_id and token_hash are required")
 		return
 	}
-	if err := h.coreService.RequireMachinePrivilegeCeiling(r.Context(), actorID(r), body.MachineIdentityID); err != nil {
-		if errors.Is(err, core.ErrMachinePrivilegeCeilingDenied) {
-			writeRemoteAPIError(w, http.StatusForbidden, "PRIVILEGE_CEILING_EXCEEDED", clientSafe(err))
+	if !isNodeCredentialRequest(r) {
+		if err := h.coreService.RequireMachinePrivilegeCeiling(r.Context(), actorID(r), body.MachineIdentityID); err != nil {
+			if errors.Is(err, core.ErrMachinePrivilegeCeilingDenied) {
+				writeRemoteAPIError(w, http.StatusForbidden, "PRIVILEGE_CEILING_EXCEEDED", clientSafe(err))
+				return
+			}
+			log.Printf("machine-credentials proxy: privilege ceiling check failed: %v", err)
+			writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 			return
 		}
-		log.Printf("machine-credentials proxy: privilege ceiling check failed: %v", err)
-		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
-		return
 	}
 	created, err := h.coreService.Storage().CreateMachineIdentityCredential(r.Context(), body.toModel())
 	if err != nil {
@@ -903,6 +918,32 @@ func (h *CatalogHandler) GetMachineRolesProxy(w http.ResponseWriter, r *http.Req
 // --- OIDC bindings ---
 
 // CreateOIDCBindingProxy handles POST /api/v1/system/machine-oidc-bindings.
+//
+// #1542-shape guard (G80 raw-storage-bypass triage): core.CreateOIDCBinding
+// requires GLOBAL admin authority (requireAuthorityForRole(..., "system_admin"),
+// #127) before creating a binding — (issuer, subject) is a global namespace (the
+// token-verify path resolves it with no project scoping), so claiming a slice of
+// it needs more than project-scoped roles.assign, which is all admin-tier-or-
+// system.write (this route's own gate) implies. This raw proxy had no such
+// check. Fixed by routing through core.CreateOIDCBinding instead of the raw
+// storage call for a DIRECT caller. The wire body carries no project_id (only
+// MachineIdentityID), so the project is derived from the machine identity's own
+// real ProjectID (never a caller-asserted value the check could be fooled by)
+// rather than requiring a wire-protocol change.
+//
+// isNodeCredentialRequest(r) branch (found via the RealServer relay test that
+// exercises a genuine downstream node, not just a direct system.write caller):
+// a node credential always resolves actorID(r)==0, and requireAuthorityForRole
+// explicitly refuses actorID==0 ("a system/unauthenticated path cannot grant an
+// admin role") — applying the check unconditionally would ALSO deny every
+// legitimate relay of an admin-authorized binding creation, not just a direct
+// escalation attempt. Mirrors AssignRoleWithExpiryProxy's precedent
+// (rbac_role_grants_proxy.go): a genuine node relay is trusted to have already
+// run this exact ceiling locally (the downstream's own core.CreateOIDCBinding
+// call already checked it against the real acting human before relaying), so it
+// still goes through the raw storage call; only a direct, non-node caller
+// reaching this route via the system.write permission arm gets routed through
+// core.CreateOIDCBinding here.
 func (h *CatalogHandler) CreateOIDCBindingProxy(w http.ResponseWriter, r *http.Request) {
 	var body machineIdentityOIDCBindingProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -913,14 +954,34 @@ func (h *CatalogHandler) CreateOIDCBindingProxy(w http.ResponseWriter, r *http.R
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "machine_identity_id, issuer, and subject are required")
 		return
 	}
-	created, err := h.coreService.Storage().CreateOIDCBinding(r.Context(), body.toModel())
-	if err != nil {
-		if isUniqueViolationErr(err) {
-			writeRemoteAPIError(w, http.StatusConflict, "DUPLICATE_BINDING", "a binding for this issuer/subject already exists")
+	var created *models.MachineIdentityOIDCBinding
+	var err error
+	if isNodeCredentialRequest(r) {
+		created, err = h.coreService.Storage().CreateOIDCBinding(r.Context(), body.toModel())
+	} else {
+		var machine *models.MachineIdentity
+		machine, err = h.coreService.Storage().GetMachineIdentity(r.Context(), body.MachineIdentityID)
+		if err != nil {
+			if isNotFoundErr(err) {
+				writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "machine identity not found")
+				return
+			}
+			log.Printf("machine-oidc-bindings proxy: create lookup failed: %v", err)
+			writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 			return
 		}
-		log.Printf("machine-oidc-bindings proxy: create failed: %v", err)
-		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		created, err = h.coreService.CreateOIDCBinding(r.Context(), machine.ProjectID, body.MachineIdentityID, body.Issuer, body.Subject, actorID(r))
+	}
+	if err != nil {
+		switch {
+		case isUniqueViolationErr(err):
+			writeRemoteAPIError(w, http.StatusConflict, "DUPLICATE_BINDING", "a binding for this issuer/subject already exists")
+		case strings.Contains(err.Error(), "admin authority is required"):
+			writeRemoteAPIError(w, http.StatusForbidden, "ADMIN_AUTHORITY_REQUIRED", clientSafe(err))
+		default:
+			log.Printf("machine-oidc-bindings proxy: create failed: %v", err)
+			writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		}
 		return
 	}
 	writeRemoteAPISuccess(w, newMachineIdentityOIDCBindingProxyWire(created))

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -289,6 +289,20 @@ func newRoleProxyWire(r *models.Role) roleProxyWire {
 // --- Machine identities ---
 
 // CreateMachineIdentityProxy handles POST /api/v1/system/machine-identities.
+//
+// #1542-shape guard (G80 raw-storage-bypass triage): core.CreateMachineIdentity
+// validates IdentityType/Classification and unconditionally forces
+// State=MachineActive (a machine identity is never born in any other state) —
+// this raw proxy used to persist whatever State/IdentityType/Classification the
+// caller supplied verbatim, letting a caller mint an identity already revoked (or
+// any other state) with no validation. Fixed by routing through
+// core.CreateMachineIdentity instead of the raw storage call: State/ID/timestamps
+// are no longer caller-controlled (core.CreateMachineIdentity doesn't accept a
+// State parameter at all), and IdentityType/Classification are validated. No
+// wire-protocol change — every input core.CreateMachineIdentity needs
+// (name/project_id/identity_type/description/classification/created_by) was
+// already on the wire; only the fields a legitimate relay never had a reason to
+// set (State, arbitrary ID/timestamps) are now ignored rather than trusted.
 func (h *CatalogHandler) CreateMachineIdentityProxy(w http.ResponseWriter, r *http.Request) {
 	var body machineIdentityProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -299,10 +313,17 @@ func (h *CatalogHandler) CreateMachineIdentityProxy(w http.ResponseWriter, r *ht
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "name and project_id are required")
 		return
 	}
-	created, err := h.coreService.Storage().CreateMachineIdentity(r.Context(), body.toModel())
+	created, err := h.coreService.CreateMachineIdentity(r.Context(), body.ProjectID, body.Name, body.IdentityType, body.Description, body.Classification, body.CreatedBy)
 	if err != nil {
-		log.Printf("machine-identities proxy: create failed: %v", err)
-		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		msg := err.Error()
+		status := http.StatusInternalServerError
+		if strings.Contains(msg, "invalid identity_type") || strings.Contains(msg, "classification must be") || strings.Contains(msg, "required") {
+			status = http.StatusBadRequest
+		} else {
+			log.Printf("machine-identities proxy: create failed: %v", err)
+			msg = clientSafe(err)
+		}
+		writeRemoteAPIError(w, status, "STORAGE_ERROR", msg)
 		return
 	}
 	writeRemoteAPISuccess(w, newMachineIdentityProxyWire(created))

--- a/server/http/handlers/machine_identities_s13_test.go
+++ b/server/http/handlers/machine_identities_s13_test.go
@@ -571,10 +571,15 @@ func TestCreateMachineIdentityProxy_MissingFields_S13(t *testing.T) {
 
 func TestCreateMachineIdentityProxy_HappyPath_S13(t *testing.T) {
 	h, projID := machineHandlerWithProjectS13(t)
+	// identity_type must be one of core's validMachineTypes (ci|k8s|service|
+	// automation|other|node) now that CreateMachineIdentityProxy routes through
+	// core.CreateMachineIdentity (G80 raw-storage-bypass fix) instead of trusting
+	// the wire body's identity_type/state verbatim — "service_account" was never a
+	// real identity_type, the old unvalidated raw proxy just never checked.
 	body, _ := json.Marshal(map[string]interface{}{
 		"name":          "proxy-bot",
 		"project_id":    projID,
-		"identity_type": "service_account",
+		"identity_type": "service",
 		"state":         "active",
 	})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/machine-identities",

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -290,46 +290,6 @@ var rawStorageBypassAllowlist = map[string]string{
 	// a caller-side concern already satisfied before the relayed call reached here.
 	"UpdateMachineIdentityCredentialProxy": "FIXED: narrowed to fetch-existing + apply-Classification-only -- see " +
 		"the FIXED comment immediately above this entry for the full reasoning.",
-	// FIXED 2026-08-24 (was in knownUnfixedRawStorageBypasses as "MOST SEVERE
-	// FINDING"): the raw storage.CreateMachineIdentityCredential call is still here
-	// deliberately -- it must persist the caller-supplied TokenHash verbatim, which
-	// a legitimate RemoteStorage relay computed itself locally (via its own
-	// core.IssueMachineToken call) and is only relaying the hash of; routing this
-	// through IssueMachineToken here would instead generate a NEW random token via
-	// crypto/rand, breaking that relay. What's added is the ceiling
-	// IssueMachineToken itself enforces before generating a token:
-	// core.RequireMachinePrivilegeCeiling (a newly-exported wrapper around the
-	// existing requireMachinePrivilegeCeiling / MACH-001 check), called before the
-	// storage write and mapped to 403. No RemoteStorage wire-protocol change: the
-	// check needs only (actorID, MachineIdentityID), both already available/on the
-	// wire. Verified via server/http/system_write_ceiling_table_test.go's
-	// CreateMachineIdentityCredentialProxy_EnforcesPrivilegeCeiling row (previously
-	// red under a real server + real auth, now green) and confirmed no regression
-	// on the base non-admin-tier-target case (system_write_ceiling_test.go).
-	"CreateMachineIdentityCredentialProxy": "FIXED: raw storage call preserved for the caller-supplied-TokenHash " +
-		"relay case, but now preceded by core.RequireMachinePrivilegeCeiling -- see the FIXED comment immediately " +
-		"above this entry for the full reasoning.",
-	// FIXED 2026-08-24 (was in knownUnfixedRawStorageBypasses): a direct,
-	// non-node-credential caller now routes through core.CreateOIDCBinding, which
-	// enforces requireAuthorityForRole(..., "system_admin") (#127) -- install-wide
-	// admin authority, since (issuer, subject) is a global namespace. The raw
-	// storage.CreateOIDCBinding call is preserved ONLY for a genuine node-credential
-	// relay (isNodeCredentialRequest(r)): a node always resolves actorID(r)==0, and
-	// requireAuthorityForRole explicitly refuses actorID==0, so applying the check
-	// unconditionally would deny every legitimate relay too, not just a direct
-	// escalation attempt -- the downstream node's own core.CreateOIDCBinding call
-	// already ran this exact check against the real acting human before relaying
-	// (same trust boundary as AssignRoleWithExpiryProxy's precedent,
-	// rbac_role_grants_proxy.go). No RemoteStorage wire-protocol change: the wire
-	// body carries no project_id, so the direct-caller path derives it from the
-	// machine identity's own real ProjectID rather than trusting a caller-asserted
-	// value. Verified via server/http/system_write_ceiling_table_test.go's
-	// CreateOIDCBindingProxy_RequiresInstallWideAdminAuthority row (previously red,
-	// now green) and TestRemoteStorageMachineIdentities_OIDCBindingCreateGetListDelete_RealServer
-	// (a genuine node-credential relay, confirmed still succeeds).
-	"CreateOIDCBindingProxy": "FIXED: raw storage call preserved ONLY for a genuine node-credential relay; a " +
-		"direct caller now routes through core.CreateOIDCBinding's install-wide admin-authority check -- see the " +
-		"FIXED comment immediately above this entry for the full reasoning.",
 }
 
 // knownUnfixedRawStorageBypasses is the set of /system handlers confirmed, by
@@ -396,9 +356,48 @@ var knownUnfixedRawStorageBypasses = map[string]string{
 		"(DoS).",
 	"RevokeMachineIdentityCredentialProxy": "REAL, human-reachable, narrower: revokes by bare credential ID with " +
 		"no project-membership check, skips audit + cache-eviction hand-off. Mirrors this file's own " +
-		"already-fixed RemoveMachineRoleProxy pattern; impact is cross-tenant DoS/tampering, not escalation.",
+		"already-fixed RemoveMachineRoleProxy pattern; impact is cross-tenant DoS/tampering, not escalation. " +
+		"Deferred (not a wire-compatible fix like its siblings): the wire contract carries no project/scope " +
+		"parameter at all, so closing it needs a RemoteStorage client-side change first -- filed as #1551.",
 	"DeleteOIDCBindingProxy": "REAL, human-reachable: deletes any binding ID with no ownership/project-scope " +
 		"check and no audit event, versus core.DeleteOIDCBinding's machineInProject + binding-ownership checks.",
+	// HALF-FIXED 2026-08-24 -- do NOT move to rawStorageBypassAllowlist: CLOSED
+	// for a direct, non-node-credential caller (routes through
+	// core.RequireMachinePrivilegeCeiling, MACH-001, now denying a system.write-only
+	// caller minting a credential for an admin-tier machine identity -- see
+	// system_write_ceiling_table_test.go's EnforcesPrivilegeCeiling row). STILL OPEN
+	// for a node-credential caller: isNodeCredentialRequest(r) routes around the
+	// check entirely to the raw storage.CreateMachineIdentityCredential call, on the
+	// theory that a genuine relay already ran this check downstream -- an assertion
+	// with no wire-level verification (ADR-085's unresolved "harder question": the
+	// wire carries no field attesting which human/decision a relayed action actually
+	// traces to). A bare node credential -- the single most widely distributed
+	// credential class in a deployment (ADR-085) -- can still forge a credential for
+	// an admin-tier machine identity by calling this route directly, with nothing
+	// distinguishing that from a genuine relay. See system_write_ceiling_table_test.go's
+	// node-credential-path rows for the live, asserted-red-in-spirit (documented
+	// current-behavior) evidence.
+	"CreateMachineIdentityCredentialProxy": "HALF-FIXED: closed for a direct system.write-only human/machine " +
+		"caller (core.RequireMachinePrivilegeCeiling now enforced); STILL OPEN for a node-credential caller " +
+		"(isNodeCredentialRequest routes around the check to the raw storage call, on an unverified relay-trust " +
+		"assumption -- see the HALF-FIXED comment immediately above this entry).",
+	// HALF-FIXED 2026-08-24 -- do NOT move to rawStorageBypassAllowlist: CLOSED for
+	// a direct, non-node-credential caller (routes through core.CreateOIDCBinding's
+	// requireAuthorityForRole(..., "system_admin") install-wide admin-authority
+	// check -- see system_write_ceiling_table_test.go's
+	// RequiresInstallWideAdminAuthority row). STILL OPEN for a node-credential
+	// caller: isNodeCredentialRequest(r) routes around the check entirely to the raw
+	// storage.CreateOIDCBinding call, same unverified relay-trust assumption as
+	// CreateMachineIdentityCredentialProxy above (and the same assumption
+	// AssignRoleWithExpiryProxy's node branch makes, rbac_role_grants_proxy.go --
+	// re-examined during this fix wave and reported, not itself changed, as a
+	// separate, real, uncatalogued instance of this exact pattern). A bare node
+	// credential can still pre-claim any (issuer, subject) OIDC binding for a
+	// machine of its choosing by calling this route directly.
+	"CreateOIDCBindingProxy": "HALF-FIXED: closed for a direct system.write-only human/machine caller " +
+		"(core.CreateOIDCBinding's install-wide admin-authority check now enforced); STILL OPEN for a " +
+		"node-credential caller (isNodeCredentialRequest routes around the check to the raw storage call -- see " +
+		"the HALF-FIXED comment immediately above this entry).",
 	"UpsertMFASecretProxy": "REAL, human-reachable: raw proxy takes user_id/SecretEnc/Activated straight from the " +
 		"JSON body -- plant or overwrite an \"Activated\" MFA secret for ANY user, even an already-MFA-enabled " +
 		"one, even with at-rest encryption disabled, versus BeginMFAEnrollment's fail-closed + already-enabled " +

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -309,6 +309,27 @@ var rawStorageBypassAllowlist = map[string]string{
 	"CreateMachineIdentityCredentialProxy": "FIXED: raw storage call preserved for the caller-supplied-TokenHash " +
 		"relay case, but now preceded by core.RequireMachinePrivilegeCeiling -- see the FIXED comment immediately " +
 		"above this entry for the full reasoning.",
+	// FIXED 2026-08-24 (was in knownUnfixedRawStorageBypasses): a direct,
+	// non-node-credential caller now routes through core.CreateOIDCBinding, which
+	// enforces requireAuthorityForRole(..., "system_admin") (#127) -- install-wide
+	// admin authority, since (issuer, subject) is a global namespace. The raw
+	// storage.CreateOIDCBinding call is preserved ONLY for a genuine node-credential
+	// relay (isNodeCredentialRequest(r)): a node always resolves actorID(r)==0, and
+	// requireAuthorityForRole explicitly refuses actorID==0, so applying the check
+	// unconditionally would deny every legitimate relay too, not just a direct
+	// escalation attempt -- the downstream node's own core.CreateOIDCBinding call
+	// already ran this exact check against the real acting human before relaying
+	// (same trust boundary as AssignRoleWithExpiryProxy's precedent,
+	// rbac_role_grants_proxy.go). No RemoteStorage wire-protocol change: the wire
+	// body carries no project_id, so the direct-caller path derives it from the
+	// machine identity's own real ProjectID rather than trusting a caller-asserted
+	// value. Verified via server/http/system_write_ceiling_table_test.go's
+	// CreateOIDCBindingProxy_RequiresInstallWideAdminAuthority row (previously red,
+	// now green) and TestRemoteStorageMachineIdentities_OIDCBindingCreateGetListDelete_RealServer
+	// (a genuine node-credential relay, confirmed still succeeds).
+	"CreateOIDCBindingProxy": "FIXED: raw storage call preserved ONLY for a genuine node-credential relay; a " +
+		"direct caller now routes through core.CreateOIDCBinding's install-wide admin-authority check -- see the " +
+		"FIXED comment immediately above this entry for the full reasoning.",
 }
 
 // knownUnfixedRawStorageBypasses is the set of /system handlers confirmed, by
@@ -376,9 +397,6 @@ var knownUnfixedRawStorageBypasses = map[string]string{
 	"RevokeMachineIdentityCredentialProxy": "REAL, human-reachable, narrower: revokes by bare credential ID with " +
 		"no project-membership check, skips audit + cache-eviction hand-off. Mirrors this file's own " +
 		"already-fixed RemoveMachineRoleProxy pattern; impact is cross-tenant DoS/tampering, not escalation.",
-	"CreateOIDCBindingProxy": "REAL, human-reachable: core.CreateOIDCBinding requires install-wide system_admin " +
-		"authority (requireAuthorityForRole, #127) plus machine-project scope + issuer-trust validation, none of " +
-		"which admin-tier-or-system.write (the route's own gate) implies.",
 	"DeleteOIDCBindingProxy": "REAL, human-reachable: deletes any binding ID with no ownership/project-scope " +
 		"check and no audit event, versus core.DeleteOIDCBinding's machineInProject + binding-ownership checks.",
 	"UpsertMFASecretProxy": "REAL, human-reachable: raw proxy takes user_id/SecretEnc/Activated straight from the " +

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -290,6 +290,25 @@ var rawStorageBypassAllowlist = map[string]string{
 	// a caller-side concern already satisfied before the relayed call reached here.
 	"UpdateMachineIdentityCredentialProxy": "FIXED: narrowed to fetch-existing + apply-Classification-only -- see " +
 		"the FIXED comment immediately above this entry for the full reasoning.",
+	// FIXED 2026-08-24 (was in knownUnfixedRawStorageBypasses as "MOST SEVERE
+	// FINDING"): the raw storage.CreateMachineIdentityCredential call is still here
+	// deliberately -- it must persist the caller-supplied TokenHash verbatim, which
+	// a legitimate RemoteStorage relay computed itself locally (via its own
+	// core.IssueMachineToken call) and is only relaying the hash of; routing this
+	// through IssueMachineToken here would instead generate a NEW random token via
+	// crypto/rand, breaking that relay. What's added is the ceiling
+	// IssueMachineToken itself enforces before generating a token:
+	// core.RequireMachinePrivilegeCeiling (a newly-exported wrapper around the
+	// existing requireMachinePrivilegeCeiling / MACH-001 check), called before the
+	// storage write and mapped to 403. No RemoteStorage wire-protocol change: the
+	// check needs only (actorID, MachineIdentityID), both already available/on the
+	// wire. Verified via server/http/system_write_ceiling_table_test.go's
+	// CreateMachineIdentityCredentialProxy_EnforcesPrivilegeCeiling row (previously
+	// red under a real server + real auth, now green) and confirmed no regression
+	// on the base non-admin-tier-target case (system_write_ceiling_test.go).
+	"CreateMachineIdentityCredentialProxy": "FIXED: raw storage call preserved for the caller-supplied-TokenHash " +
+		"relay case, but now preceded by core.RequireMachinePrivilegeCeiling -- see the FIXED comment immediately " +
+		"above this entry for the full reasoning.",
 }
 
 // knownUnfixedRawStorageBypasses is the set of /system handlers confirmed, by
@@ -354,16 +373,6 @@ var knownUnfixedRawStorageBypasses = map[string]string{
 		"permission from this route's system.write) and always audits; the raw proxy lets any system.write " +
 		"holder silently clear a lockout (no audit, no users.write) or force-lock any account for up to 30 days " +
 		"(DoS).",
-	"CreateMachineIdentityProxy": "REAL, human-reachable: raw proxy only checks Name/ProjectID non-empty -- " +
-		"arbitrary IdentityType/Classification/State, zero audit, versus core.CreateMachineIdentity's validation " +
-		"+ forced State=MachineActive + audit.",
-	"CreateMachineIdentityCredentialProxy": "REAL, human-reachable, MOST SEVERE FINDING -- full privilege " +
-		"escalation: IssueMachineToken enforces requireMachinePrivilegeCeiling (a non-admin cannot mint a " +
-		"credential for a machine identity holding admin-tier roles, MACH-001) and generates TokenHash itself via " +
-		"crypto/rand. The raw proxy accepts an attacker-CHOSEN TokenHash for any existing MachineIdentityID with " +
-		"NO privilege-ceiling check -- forge a working credential for an admin-tier machine identity and " +
-		"authenticate as it. Verified against the escalation-delta test: requireMachinePrivilegeCeiling checks " +
-		"IsGlobalAdmin (role-name membership), which system.write alone does not satisfy.",
 	"RevokeMachineIdentityCredentialProxy": "REAL, human-reachable, narrower: revokes by bare credential ID with " +
 		"no project-membership check, skips audit + cache-eviction hand-off. Mirrors this file's own " +
 		"already-fixed RemoveMachineRoleProxy pattern; impact is cross-tenant DoS/tampering, not escalation.",

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -374,9 +374,10 @@ var knownUnfixedRawStorageBypasses = map[string]string{
 	// traces to). A bare node credential -- the single most widely distributed
 	// credential class in a deployment (ADR-085) -- can still forge a credential for
 	// an admin-tier machine identity by calling this route directly, with nothing
-	// distinguishing that from a genuine relay. See system_write_ceiling_table_test.go's
-	// node-credential-path rows for the live, asserted-red-in-spirit (documented
-	// current-behavior) evidence.
+	// distinguishing that from a genuine relay. Tracked under #1552 (the same
+	// AssignRoleWithExpiryProxy-precedent pattern, filed Tier 1, ranked above this
+	// finding). See system_write_ceiling_table_test.go's node-credential-path rows
+	// for the live, asserted-red-in-spirit (documented current-behavior) evidence.
 	"CreateMachineIdentityCredentialProxy": "HALF-FIXED: closed for a direct system.write-only human/machine " +
 		"caller (core.RequireMachinePrivilegeCeiling now enforced); STILL OPEN for a node-credential caller " +
 		"(isNodeCredentialRequest routes around the check to the raw storage call, on an unverified relay-trust " +
@@ -390,8 +391,8 @@ var knownUnfixedRawStorageBypasses = map[string]string{
 	// storage.CreateOIDCBinding call, same unverified relay-trust assumption as
 	// CreateMachineIdentityCredentialProxy above (and the same assumption
 	// AssignRoleWithExpiryProxy's node branch makes, rbac_role_grants_proxy.go --
-	// re-examined during this fix wave and reported, not itself changed, as a
-	// separate, real, uncatalogued instance of this exact pattern). A bare node
+	// filed as #1552, Tier 1, ranked above CreateMachineIdentityCredentialProxy: a
+	// shorter path to global admin, attacker-chosen target account). A bare node
 	// credential can still pre-claim any (issuer, subject) OIDC binding for a
 	// machine of its choosing by calling this route directly.
 	"CreateOIDCBindingProxy": "HALF-FIXED: closed for a direct system.write-only human/machine caller " +

--- a/server/http/remote_storage_machine_identities_test.go
+++ b/server/http/remote_storage_machine_identities_test.go
@@ -387,6 +387,21 @@ func TestRemoteStorageMachineIdentities_RoleGrantAssignRemoveListIDs_RealServer(
 // TestRemoteStorageMachineIdentities_OIDCBindingCreateGetListDelete_RealServer
 // proves the fix for CreateOIDCBinding/GetMachineByOIDCSubject/
 // ListOIDCBindings/GetOIDCBindingByID/DeleteOIDCBinding.
+//
+// Caveat (2026-08-24, G80 raw-storage-bypass fix wave): `downstream` authenticates
+// to `upstream` as a genuine node credential, and the create call below succeeds
+// via CreateOIDCBindingProxy's isNodeCredentialRequest(r) branch — the same branch
+// that routes AROUND core.CreateOIDCBinding's install-wide admin-authority check
+// (see server/http/handlers/machine_identities_proxy.go's CreateOIDCBindingProxy
+// doc, and #1552 / docs/g80-raw-storage-bypass-triage.md's "Re-examined" section).
+// This test's "creating an oidc binding must succeed via storage.type: remote"
+// assertion may therefore be encoding that open vulnerability (a node credential
+// can create a binding with no admin-authority check at all) rather than
+// validating genuinely intended behavior — the two are indistinguishable from
+// this test's vantage point, since nothing here asserts WHY the create succeeded.
+// Pending ADR-085's wire-identity decision / #1552's resolution. Not changed or
+// reverted here per explicit instruction — the node-credential exemption itself
+// stays as-is; this is a note for whoever revisits it next.
 func TestRemoteStorageMachineIdentities_OIDCBindingCreateGetListDelete_RealServer(t *testing.T) {
 	upstream, downstream, projectID := newUpstreamDownstreamForMachineIdentities(t)
 	ctx := context.Background()

--- a/server/http/system_write_ceiling_table_test.go
+++ b/server/http/system_write_ceiling_table_test.go
@@ -1,0 +1,320 @@
+// system_write_ceiling_table_test.go generalizes system_write_ceiling_test.go's
+// single finding into the fix wave's acceptance criteria: every write-shaped route
+// in the /api/v1/system/machine-identities, /machine-credentials, and
+// /machine-oidc-bindings groups (server/http/handlers/machine_identities_proxy.go),
+// exercised end-to-end through a real HTTP server + real router + real auth
+// middleware, as the SAME human caller — one holding ONLY system.write, no
+// admin-tier role, no node credential (see createSystemWriteOnlyToken in
+// system_write_ceiling_test.go).
+//
+// Each row's "ceiling" column names the internal/core check that route's OWN core
+// wrapper enforces and the raw proxy either does or doesn't (see
+// docs/g80-raw-storage-bypass-triage.md for the full investigation each row is
+// drawn from). A row is RED today if its handler is still an unguarded raw
+// storage passthrough; fixing that handler (routing the specific missing check
+// through, without breaking the legitimate RemoteStorage-relay wire contract —
+// see e.g. machine_identities_proxy_transition_ceiling_test.go's already-fixed
+// precedent) must turn it green. This file is deliberately committed red for the
+// still-open rows — that red set IS the fix wave's checklist; the all-green state
+// is its definition of done.
+//
+// Scope note: this table does not cover the group's pure GET routes (no
+// escalation-relevant ceiling — the group's own system.write-or-node-credential
+// gate is the only check that applies to a read) or routes already confirmed
+// no-independent-ceiling / documented-exception in the triage doc (e.g.
+// TouchMachineIdentityCredentialProxy, UpdateMachineIdentityProxy). It also does
+// not (yet) cover RevokeMachineIdentityCredentialProxy: the current wire contract
+// (DELETE-by-bare-credential-ID, no project/scope parameter at all) can't express
+// a scope check without a RemoteStorage client-side change first — a different,
+// harder fix shape than the other rows here, tracked but not asserted on below.
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ceilingTableFixtures holds every real row this table's requests reference,
+// created once per test run and shared read-only across table cases (cases that
+// mutate state use their OWN dedicated fixture, never one another case depends on
+// reading unmutated).
+type ceilingTableFixtures struct {
+	serverURL     string
+	token         string // system.write-only human caller under test
+	projectID     uint
+	plainMachine  uint // ordinary machine identity, no roles
+	adminMachine  uint // holds the admin-tier "system_admin" role at global scope
+	revokedMach   uint // machine identity already in state=revoked
+	plainCredID   uint // existing, non-revoked credential on plainMachine
+	revokedCredID uint // existing, ALREADY-revoked credential on plainMachine
+	bindingID     uint // existing OIDC binding on plainMachine
+	normalRoleID  uint // a non-admin-tier role
+	adminRoleID   uint // system_admin's role ID
+}
+
+func setupCeilingTableFixtures(t *testing.T) ceilingTableFixtures {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	cfg := &config.Config{}
+	testCore := newTestCore(t)
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+
+	ctx := context.Background()
+	createTestToken(t, testCore) // bootstrap admin + seed roles/permissions
+	admin, err := testCore.GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+	projects, err := testCore.Storage().ListProjects(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, projects)
+	projectID := projects[0].ID
+
+	plainMachine, err := testCore.CreateMachineIdentity(ctx, projectID, "ceiling-table-plain", core.MachineTypeService, "", "", admin.ID)
+	require.NoError(t, err)
+
+	adminMachine, err := testCore.CreateMachineIdentity(ctx, projectID, "ceiling-table-admin-tier", core.MachineTypeService, "", "", admin.ID)
+	require.NoError(t, err)
+	adminRole, err := testCore.Storage().GetRoleByName(ctx, "system_admin")
+	require.NoError(t, err)
+	require.NoError(t, testCore.AssignMachineRole(ctx, adminMachine.ID, adminRole.ID, core.Scope{ProjectID: projectID}, admin.ID))
+
+	revokedMachine, err := testCore.CreateMachineIdentity(ctx, projectID, "ceiling-table-revoked", core.MachineTypeService, "", "", admin.ID)
+	require.NoError(t, err)
+	revokedMachine.State = core.MachineRevoked
+	matched, err := testCore.Storage().TransitionMachineIdentityState(ctx, revokedMachine, core.MachineActive)
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	plainCred, err := testCore.Storage().CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{
+		MachineIdentityID: plainMachine.ID, Name: "plain-cred", TokenHash: "aaaa000000000000000000000000000000000000000000000000000000000001", TokenPrefix: "mid_a",
+	})
+	require.NoError(t, err)
+
+	revokedCred, err := testCore.Storage().CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{
+		MachineIdentityID: plainMachine.ID, Name: "revoked-cred", TokenHash: "bbbb000000000000000000000000000000000000000000000000000000000002", TokenPrefix: "mid_b", Revoked: true,
+	})
+	require.NoError(t, err)
+
+	binding, err := testCore.Storage().CreateOIDCBinding(ctx, &models.MachineIdentityOIDCBinding{
+		MachineIdentityID: plainMachine.ID, Issuer: "https://ceiling-table.example", Subject: "table-subject", CreatedBy: admin.ID, CreatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	normalRole, err := testCore.Storage().CreateRole(ctx, &models.Role{Name: "ceiling_table_normal_role", Description: "non-admin"})
+	require.NoError(t, err)
+
+	token := createSystemWriteOnlyToken(t, testCore)
+
+	return ceilingTableFixtures{
+		serverURL:     server.URL,
+		token:         token,
+		projectID:     projectID,
+		plainMachine:  plainMachine.ID,
+		adminMachine:  adminMachine.ID,
+		revokedMach:   revokedMachine.ID,
+		plainCredID:   plainCred.ID,
+		revokedCredID: revokedCred.ID,
+		bindingID:     binding.ID,
+		normalRoleID:  normalRole.ID,
+		adminRoleID:   adminRole.ID,
+	}
+}
+
+// doCeilingRequest issues method/path with body (nil for none) as the table
+// fixture's system.write-only caller and returns the status code + raw body.
+func doCeilingRequest(t *testing.T, f ceilingTableFixtures, method, path string, body any) (int, string) {
+	t.Helper()
+	var reader *bytes.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req, err := http.NewRequest(method, f.serverURL+path, reader)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+f.token)
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, buf.String()
+}
+
+// TestSystemWriteCeiling_CreateMachineIdentityProxy_ForcesActiveState is the
+// table's CreateMachineIdentityProxy row. Ceiling: core.CreateMachineIdentity
+// unconditionally forces State=MachineActive on every create (machine_identities.go
+// :99) — a machine identity is never born in any other state. The raw proxy
+// currently persists whatever State the caller supplies verbatim. RED today: a
+// system.write-only caller can mint an identity already in state "revoked" (or
+// any other value), never having been active.
+func TestSystemWriteCeiling_CreateMachineIdentityProxy_ForcesActiveState(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequest(t, f, http.MethodPost, "/api/v1/system/machine-identities", map[string]any{
+		"name": "ceiling-table-forged-state", "project_id": f.projectID,
+		"identity_type": core.MachineTypeService, "state": core.MachineRevoked,
+	})
+	t.Logf("CreateMachineIdentityProxy(state=%s): status=%d body=%s", core.MachineRevoked, status, body)
+	require.Equal(t, http.StatusOK, status, "request itself must be accepted (a 4xx here would mean a different regression)")
+	var parsed struct {
+		Data struct {
+			State string `json:"state"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &parsed))
+	require.Equal(t, core.MachineActive, parsed.Data.State,
+		"CEILING VIOLATED: CreateMachineIdentityProxy must force State=MachineActive like core.CreateMachineIdentity does, "+
+			"not persist a caller-supplied state verbatim")
+}
+
+// TestSystemWriteCeiling_CreateMachineIdentityCredentialProxy_EnforcesPrivilegeCeiling
+// is the table's CreateMachineIdentityCredentialProxy row — the campaign's own
+// "MOST SEVERE FINDING". Ceiling: core.IssueMachineToken calls
+// requireMachinePrivilegeCeiling (MACH-001) — a non-global-admin actor cannot mint
+// a credential for a machine identity that itself holds an admin-tier role,
+// because that credential inherits the machine's roles (equivalent to a role
+// grant). The raw proxy has no such check. RED today: a system.write-only caller
+// (confirmed non-global-admin) can forge a working credential for f.adminMachine
+// (holds system_admin) and authenticate as an admin-tier principal.
+func TestSystemWriteCeiling_CreateMachineIdentityCredentialProxy_EnforcesPrivilegeCeiling(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequest(t, f, http.MethodPost, "/api/v1/system/machine-credentials", map[string]any{
+		"machine_identity_id": f.adminMachine,
+		"token_hash":          "cccc000000000000000000000000000000000000000000000000000000000003",
+		"token_prefix":        "mid_forged_admin",
+	})
+	t.Logf("CreateMachineIdentityCredentialProxy(machine_identity_id=admin-tier %d): status=%d body=%s", f.adminMachine, status, body)
+	require.Equal(t, http.StatusForbidden, status,
+		"CEILING VIOLATED: a system.write-only, non-global-admin caller must be denied a credential for an "+
+			"admin-tier machine identity (requireMachinePrivilegeCeiling, MACH-001) — got a real forged credential instead")
+}
+
+// TestSystemWriteCeiling_TransitionMachineIdentityStateProxy_RejectsIllegalTransition
+// is the table's already-FIXED TransitionMachineIdentityStateProxy row (G80 Group
+// A #1 — see machine_identities_proxy_transition_ceiling_test.go for the
+// handler-level version of this same assertion). Included here for completeness
+// of the acceptance-criteria table and to prove the fix holds at the real-server,
+// real-auth layer too, not only in the direct handler-call test.
+func TestSystemWriteCeiling_TransitionMachineIdentityStateProxy_RejectsIllegalTransition(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequest(t, f, http.MethodPut,
+		fmt.Sprintf("/api/v1/system/machine-identities/%d/transition", f.revokedMach),
+		map[string]any{
+			"machine_identity": map[string]any{"id": f.revokedMach, "project_id": f.projectID, "name": "x", "state": core.MachineActive},
+			"from_state":       core.MachineRevoked,
+		})
+	t.Logf("TransitionMachineIdentityStateProxy(revoked->active): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusBadRequest, status,
+		"revoked must stay terminal (core.IsValidMachineTransition) — a 200 here would mean this Group A fix regressed")
+}
+
+// TestSystemWriteCeiling_AssignMachineRoleProxy_DeniesAdminTierGrant is the
+// table's AssignMachineRoleProxy row — already routed through core.AssignMachineRole
+// (#1542), which calls requireAuthorityForRole. A non-admin caller may still grant
+// a NON-admin-tier role (roles.assign's own footprint); only an admin-tier grant
+// must be refused.
+func TestSystemWriteCeiling_AssignMachineRoleProxy_DeniesAdminTierGrant(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	path := fmt.Sprintf("/api/v1/system/machine-identities/%d/roles/%d?project_id=%d&environment_id=0", f.plainMachine, f.adminRoleID, f.projectID)
+	status, body := doCeilingRequest(t, f, http.MethodPost, path, nil)
+	t.Logf("AssignMachineRoleProxy(role=system_admin): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusInternalServerError, status,
+		"a system.write-only caller must be refused when granting an admin-tier role (requireAuthorityForRole) — "+
+			"internal/core wraps the denial as a storage error today (500), which is a real behavior gap of its own, "+
+			"but the grant itself must not succeed")
+}
+
+// TestSystemWriteCeiling_AssignMachineRoleProxy_AllowsNonAdminGrant is the same
+// route's companion control: a non-admin-tier grant is roles.assign's own,
+// legitimate footprint and must still succeed for this caller.
+func TestSystemWriteCeiling_AssignMachineRoleProxy_AllowsNonAdminGrant(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	path := fmt.Sprintf("/api/v1/system/machine-identities/%d/roles/%d?project_id=%d&environment_id=0", f.plainMachine, f.normalRoleID, f.projectID)
+	status, body := doCeilingRequest(t, f, http.MethodPost, path, nil)
+	t.Logf("AssignMachineRoleProxy(role=non-admin): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status, "a non-admin-tier role grant is not gated by requireAuthorityForRole and must succeed")
+}
+
+// TestSystemWriteCeiling_UpdateMachineIdentityCredentialProxy_CannotResurrectRevoked
+// is the table's already-FIXED UpdateMachineIdentityCredentialProxy row (G80 Group
+// A #2): the handler now only ever applies Classification from the wire body,
+// never Revoked/TokenHash/ExpiresAt.
+func TestSystemWriteCeiling_UpdateMachineIdentityCredentialProxy_CannotResurrectRevoked(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequest(t, f, http.MethodPut,
+		fmt.Sprintf("/api/v1/system/machine-credentials/%d", f.revokedCredID),
+		map[string]any{"id": f.revokedCredID, "machine_identity_id": f.plainMachine, "revoked": false, "classification": "internal"})
+	t.Logf("UpdateMachineIdentityCredentialProxy(resurrect attempt): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status, "the update call itself must still succeed (it's a legitimate classification change)")
+
+	status, body = doCeilingRequest(t, f, http.MethodGet, fmt.Sprintf("/api/v1/system/machine-credentials/%d", f.revokedCredID), nil)
+	require.Equal(t, http.StatusOK, status)
+	var parsed struct {
+		Data struct {
+			Revoked bool `json:"revoked"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &parsed))
+	require.True(t, parsed.Data.Revoked,
+		"the attempted resurrection (revoked:false in the update body) must have been silently ignored — "+
+			"a real resurrection here would mean this Group A fix regressed")
+}
+
+// TestSystemWriteCeiling_CreateOIDCBindingProxy_RequiresInstallWideAdminAuthority
+// is the table's CreateOIDCBindingProxy row. Ceiling: core.CreateOIDCBinding
+// requires GLOBAL admin authority (requireAuthorityForRole(..., "system_admin"),
+// #127) — (issuer, subject) is a global namespace, so binding one is scoped to
+// what it actually claims, not merely project-scoped roles.assign. The raw proxy
+// has no such check. RED today: a system.write-only caller can pre-claim any
+// (issuer, subject) pair for a machine of their choosing.
+func TestSystemWriteCeiling_CreateOIDCBindingProxy_RequiresInstallWideAdminAuthority(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequest(t, f, http.MethodPost, "/api/v1/system/machine-oidc-bindings", map[string]any{
+		"machine_identity_id": f.plainMachine, "issuer": "https://ceiling-table-preclaim.example", "subject": "preclaimed-subject",
+	})
+	t.Logf("CreateOIDCBindingProxy: status=%d body=%s", status, body)
+	require.Equal(t, http.StatusForbidden, status,
+		"CEILING VIOLATED: a system.write-only caller must be denied — binding an OIDC subject requires install-wide "+
+			"admin authority (core.CreateOIDCBinding's requireAuthorityForRole check), which this caller does not hold")
+}
+
+// TestSystemWriteCeiling_DeleteOIDCBindingProxy_VerifiesOwnership is the table's
+// DeleteOIDCBindingProxy row. Ceiling: core.DeleteOIDCBinding verifies the binding
+// actually belongs to the named machine (machineInProject + a MachineIdentityID
+// match) before deleting. The raw proxy deletes any binding ID unconditionally.
+// This row is necessarily a narrower assertion than "denied outright" — deleting
+// a binding you're relaying on behalf of IS legitimate for the relay's own
+// purpose; what's missing is verifying it's the RIGHT binding, which this table
+// can only observe indirectly (the binding disappears with zero ownership check
+// performed). RED today in the sense that the check never runs at all, though the
+// single-binding-exists-and-belongs-to-itself case can't distinguish "checked and
+// passed" from "never checked" — see the fix commit for the real regression test
+// once core.DeleteOIDCBinding is wired through.
+func TestSystemWriteCeiling_DeleteOIDCBindingProxy_VerifiesOwnership(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequest(t, f, http.MethodDelete, fmt.Sprintf("/api/v1/system/machine-oidc-bindings/%d", f.bindingID), nil)
+	t.Logf("DeleteOIDCBindingProxy: status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status, "the delete itself is expected to succeed for a binding that IS legitimately owned by its machine")
+}

--- a/server/http/system_write_ceiling_table_test.go
+++ b/server/http/system_write_ceiling_table_test.go
@@ -26,7 +26,15 @@
 // not (yet) cover RevokeMachineIdentityCredentialProxy: the current wire contract
 // (DELETE-by-bare-credential-ID, no project/scope parameter at all) can't express
 // a scope check without a RemoteStorage client-side change first — a different,
-// harder fix shape than the other rows here, tracked but not asserted on below.
+// harder fix shape than the other rows here; deferred and filed as #1551, not
+// asserted on below.
+//
+// A second dimension, added after the first fix pass: "Node-credential-path
+// rows" below exercise the human-caller rows' SAME three write routes again, but
+// as a genuine node-credential relay (f.nodeToken) instead of the system.write-
+// only human (f.token) — see that section's own doc for why, and
+// docs/g80-raw-storage-bypass-triage.md's "Fix status" section for the
+// authoritative half-fixed/open status these rows pin.
 package http
 
 import (
@@ -54,6 +62,7 @@ import (
 type ceilingTableFixtures struct {
 	serverURL     string
 	token         string // system.write-only human caller under test
+	nodeToken     string // genuine node-credential relay caller (createNodeToken)
 	projectID     uint
 	plainMachine  uint // ordinary machine identity, no roles
 	adminMachine  uint // holds the admin-tier "system_admin" role at global scope
@@ -121,10 +130,15 @@ func setupCeilingTableFixtures(t *testing.T) ceilingTableFixtures {
 	require.NoError(t, err)
 
 	token := createSystemWriteOnlyToken(t, testCore)
+	// createNodeToken (integration_test.go) also calls createTestToken internally —
+	// safe to call again here since createTestToken tolerates an already-initialized
+	// system (logs and continues rather than failing).
+	nodeToken := createNodeToken(t, testCore)
 
 	return ceilingTableFixtures{
 		serverURL:     server.URL,
 		token:         token,
+		nodeToken:     nodeToken,
 		projectID:     projectID,
 		plainMachine:  plainMachine.ID,
 		adminMachine:  adminMachine.ID,
@@ -138,8 +152,17 @@ func setupCeilingTableFixtures(t *testing.T) ceilingTableFixtures {
 }
 
 // doCeilingRequest issues method/path with body (nil for none) as the table
-// fixture's system.write-only caller and returns the status code + raw body.
+// fixture's system.write-only human caller and returns the status code + raw body.
 func doCeilingRequest(t *testing.T, f ceilingTableFixtures, method, path string, body any) (int, string) {
+	t.Helper()
+	return doCeilingRequestAs(t, f, f.token, method, path, body)
+}
+
+// doCeilingRequestAs is doCeilingRequest generalized to an explicit bearer token,
+// so a row can exercise the SAME route as a different caller class — e.g.
+// f.nodeToken (a genuine node-credential relay) instead of f.token (the
+// system.write-only human).
+func doCeilingRequestAs(t *testing.T, f ceilingTableFixtures, token, method, path string, body any) (int, string) {
 	t.Helper()
 	var reader *bytes.Reader
 	if body != nil {
@@ -151,7 +174,7 @@ func doCeilingRequest(t *testing.T, f ceilingTableFixtures, method, path string,
 	}
 	req, err := http.NewRequest(method, f.serverURL+path, reader)
 	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer "+f.token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
@@ -317,4 +340,95 @@ func TestSystemWriteCeiling_DeleteOIDCBindingProxy_VerifiesOwnership(t *testing.
 	status, body := doCeilingRequest(t, f, http.MethodDelete, fmt.Sprintf("/api/v1/system/machine-oidc-bindings/%d", f.bindingID), nil)
 	t.Logf("DeleteOIDCBindingProxy: status=%d body=%s", status, body)
 	require.Equal(t, http.StatusOK, status, "the delete itself is expected to succeed for a binding that IS legitimately owned by its machine")
+}
+
+// ── Node-credential-path rows ────────────────────────────────────────────────
+//
+// The three rows below exercise the SAME routes above, but with f.nodeToken (a
+// genuine node-type machine credential — createNodeToken, integration_test.go)
+// instead of f.token (the system.write-only human). They exist because fixing
+// CreateMachineIdentityCredentialProxy and CreateOIDCBindingProxy for a DIRECT
+// caller (above) required an isNodeCredentialRequest(r) branch that routes a
+// node-credential caller around the new check entirely, to the raw storage
+// call — otherwise every legitimate node relay would ALSO be denied (a node
+// always resolves actorID(r)==0, and both requireMachinePrivilegeCeiling and
+// requireAuthorityForRole refuse actorID==0 outright). That branch is
+// necessary — but it also means the exemption is real, not hypothetical, and
+// needed its own visible, asserted coverage rather than living implicitly
+// inside an if-statement with no test pinning what it actually permits.
+//
+// These rows assert CURRENT behavior (allowed) exactly as it is today — this
+// is a KNOWN, DOCUMENTED GAP (see docs/g80-raw-storage-bypass-triage.md's "Fix
+// status" section and knownUnfixedRawStorageBypasses' HALF-FIXED entries for
+// CreateMachineIdentityCredentialProxy/CreateOIDCBindingProxy), NOT intended,
+// approved-safe behavior. Nothing on the wire distinguishes a genuine relay of
+// an already-checked downstream decision from a bare node credential calling
+// the route directly with attacker-chosen parameters (ADR-085's still-unresolved
+// "harder question" — see docs/adr-085-node-credential-permission-scope.md). If
+// a future fix closes this (a wire-level actor-identity field, or removing the
+// node bypass per ADR-085's proposed direction), these rows must go RED and get
+// updated to assert denial — they are pinning the gap, not blessing it.
+
+// TestSystemWriteCeiling_CreateMachineIdentityProxy_NodeCredential_AlsoForcesActiveState
+// is NOT a gap: core.CreateMachineIdentity has no actor-authority check at all
+// (only State/IdentityType/Classification validation), for ANY caller. A node
+// credential behaves identically to the human caller in the row above. Included
+// for symmetry/completeness of the node-credential dimension, not because this
+// route has a caller-class-dependent exemption to pin.
+func TestSystemWriteCeiling_CreateMachineIdentityProxy_NodeCredential_AlsoForcesActiveState(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequestAs(t, f, f.nodeToken, http.MethodPost, "/api/v1/system/machine-identities", map[string]any{
+		"name": "ceiling-table-node-create", "project_id": f.projectID,
+		"identity_type": core.MachineTypeService, "state": core.MachineRevoked,
+	})
+	t.Logf("CreateMachineIdentityProxy(node credential, state=%s): status=%d body=%s", core.MachineRevoked, status, body)
+	require.Equal(t, http.StatusOK, status, "no actor-authority check exists for either caller class on this route")
+	var parsed struct {
+		Data struct {
+			State string `json:"state"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &parsed))
+	require.Equal(t, core.MachineActive, parsed.Data.State, "same forced-active behavior as the human-caller row — no caller-class difference here")
+}
+
+// TestSystemWriteCeiling_CreateMachineIdentityCredentialProxy_NodeCredential_StillBypassesPrivilegeCeiling
+// pins the KNOWN, OPEN gap: unlike the human-caller row above (now 403), a node
+// credential still reaches the raw storage.CreateMachineIdentityCredential call
+// unconditionally (isNodeCredentialRequest branch, machine_identities_proxy.go),
+// so it can still forge a working credential for f.adminMachine (holds
+// system_admin) — the campaign's original "MOST SEVERE FINDING", now reachable
+// only via a node credential instead of any system.write holder, not closed.
+func TestSystemWriteCeiling_CreateMachineIdentityCredentialProxy_NodeCredential_StillBypassesPrivilegeCeiling(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequestAs(t, f, f.nodeToken, http.MethodPost, "/api/v1/system/machine-credentials", map[string]any{
+		"machine_identity_id": f.adminMachine,
+		"token_hash":          "dddd000000000000000000000000000000000000000000000000000000000004",
+		"token_prefix":        "mid_forged_admin_node",
+	})
+	t.Logf("CreateMachineIdentityCredentialProxy(node credential, machine_identity_id=admin-tier %d): status=%d body=%s", f.adminMachine, status, body)
+	require.Equal(t, http.StatusOK, status,
+		"KNOWN GAP (not intended, pending ADR-085's wire-identity decision): a node credential still forges a "+
+			"credential for an admin-tier machine identity — isNodeCredentialRequest routes it around "+
+			"requireMachinePrivilegeCeiling entirely, on an unverified relay-trust assumption. If this ever goes "+
+			"non-200, update this assertion — that would mean the gap closed, which is the goal, not a regression.")
+}
+
+// TestSystemWriteCeiling_CreateOIDCBindingProxy_NodeCredential_StillBypassesAdminAuthority
+// pins the KNOWN, OPEN gap: unlike the human-caller row above (now 403), a node
+// credential still reaches the raw storage.CreateOIDCBinding call unconditionally
+// (isNodeCredentialRequest branch), so it can still pre-claim any (issuer,
+// subject) pair for a machine of its choosing with no install-wide admin-authority
+// check at all.
+func TestSystemWriteCeiling_CreateOIDCBindingProxy_NodeCredential_StillBypassesAdminAuthority(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequestAs(t, f, f.nodeToken, http.MethodPost, "/api/v1/system/machine-oidc-bindings", map[string]any{
+		"machine_identity_id": f.plainMachine, "issuer": "https://ceiling-table-node-preclaim.example", "subject": "node-preclaimed-subject",
+	})
+	t.Logf("CreateOIDCBindingProxy(node credential): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status,
+		"KNOWN GAP (not intended, pending ADR-085's wire-identity decision): a node credential still creates an "+
+			"OIDC binding with no install-wide admin-authority check — isNodeCredentialRequest routes it around "+
+			"requireAuthorityForRole entirely, on an unverified relay-trust assumption. If this ever goes non-200, "+
+			"update this assertion — that would mean the gap closed, which is the goal, not a regression.")
 }

--- a/server/http/system_write_ceiling_test.go
+++ b/server/http/system_write_ceiling_test.go
@@ -1,0 +1,179 @@
+// system_write_ceiling_test.go answers, empirically against a real HTTP server, a
+// question the G80 raw-storage-bypass triage (docs/g80-raw-storage-bypass-triage.md)
+// depended on but never tested directly: is the /system RemoteStorage-sync proxy
+// tier (server/http/router.go's `r.Route("/system", ...)`, gated by
+// RequireNodeCredentialOrPermission(permSystemWrite) — server/middleware/
+// node_credential.go) reachable by a HUMAN principal holding ONLY the system.write
+// permission — no admin-tier role, no node credential?
+//
+// RequireNodeCredentialOrPermission's code already documents the answer
+// (router.go's comment above r.Route("/system", ...): "a node-type machine
+// credential ... OR the existing system.write permission"), and ADR-085
+// independently confirms system.write is intentionally grantable to a narrow,
+// documented custom role (audit checkpoints, legal holds, risk exceptions, SoD
+// policies, admin job triggers) — not admin-only. This test proves reachability
+// end-to-end through the real router + real auth + a real RBAC-gated storage
+// backend, and system_write_ceiling_table_test.go builds on the SAME harness to
+// cover the rest of the machine-identity/credential/OIDC-binding proxy surface.
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// createSystemWriteOnlyToken creates a human user holding ONLY the system.write
+// permission, via a custom role named well outside adminRoleNames
+// (internal/core/authz.go: "super_admin"/"admin"/"system_admin"/"project_admin" all
+// unconditionally bypass every permission check, which would make this test
+// vacuously pass). The auto-assigned system_viewer baseline (system.read only, see
+// createNoPermissionToken in deployment_disclosure_family_test.go) is stripped so
+// system.write is the ONLY permission this principal holds anywhere, at any scope.
+func createSystemWriteOnlyToken(t *testing.T, c *core.KeyorixCore) string {
+	t.Helper()
+	ctx := context.Background()
+
+	_, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "sys_write_only", Email: "sys_write_only@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.RemoveRoleFromUser(ctx, "sys_write_only@example.com", "system_viewer"))
+
+	role, err := c.Storage().CreateRole(ctx, &models.Role{
+		Name: "ceiling_test_system_writer", Description: "test-only role: system.write and nothing else",
+	})
+	require.NoError(t, err)
+
+	perms, err := c.ListPermissions(ctx)
+	require.NoError(t, err)
+	var systemWriteID uint
+	for _, p := range perms {
+		if p.Name == "system.write" {
+			systemWriteID = p.ID
+			break
+		}
+	}
+	require.NotZero(t, systemWriteID, "system.write permission must already be seeded by bootstrap")
+
+	// actorID 0 = the system pseudo-actor (skips AssignPermissionToRole's #169
+	// self-permission-holding check, which a fixture setup step has no actor for).
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID))
+	require.NoError(t, c.AssignRoleToUser(ctx, "sys_write_only@example.com", "ceiling_test_system_writer"))
+
+	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "sys_write_only", Password: "Qr7#Kp2$Lm5@Vn9!"})
+	require.NoError(t, err)
+	return sess.SessionToken
+}
+
+func TestSystemWriteOnlyCeiling_RealServer(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	testCore := newTestCore(t)
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	ctx := context.Background()
+	createTestToken(t, testCore) // bootstrap admin + seed roles/permissions (incl. system.write)
+	admin, err := testCore.GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+	projects, err := testCore.Storage().ListProjects(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, projects, "createTestToken must have seeded a default project")
+
+	// A real target machine identity for the proxy call to attach a credential to —
+	// created by the admin, exactly as a real deployment would have one.
+	targetMI, err := testCore.CreateMachineIdentity(ctx, projects[0].ID,
+		"ceiling-test-target", core.MachineTypeService, "target for the ceiling test", "", admin.ID)
+	require.NoError(t, err)
+
+	token := createSystemWriteOnlyToken(t, testCore)
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	// --- Task 1: the finding under test ---
+	// CreateMachineIdentityCredentialProxy performs no per-caller authorization check
+	// of its own (machine_identities_proxy.go's package doc: "NO authorization/
+	// business-logic decision is made here"). If system.write alone reaches this
+	// handler, the request must succeed and mint a real credential.
+	reqBody, err := json.Marshal(map[string]any{
+		"machine_identity_id": targetMI.ID,
+		"token_hash":          "0000000000000000000000000000000000000000000000000000000000000001",
+		"token_prefix":        "mid_ceiling_test",
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/system/machine-credentials", bytes.NewReader(reqBody))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	var respBuf bytes.Buffer
+	_, err = respBuf.ReadFrom(resp.Body)
+	require.NoError(t, err)
+	t.Logf("Task 1 — POST /api/v1/system/machine-credentials as a system.write-only human (no admin role, no node credential): status=%d body=%s",
+		resp.StatusCode, respBuf.String())
+
+	// --- Task 2 (control): the SAME caller/token against a route with its ceiling intact ---
+	// IssueMachineToken (server/http/handlers/machine_identities.go — the direct/
+	// human-facing endpoint backing CreateMachineIdentityCredentialProxy's CLI
+	// equivalent) requires roles.assign in the TARGET project's scope
+	// (RequireScopedPermission(permRolesAssign, projectScope), router.go). This caller
+	// holds neither roles.assign nor any project-scoped role at all — a 403 here proves
+	// the harness genuinely constructed a scoped, non-admin caller (not one silently
+	// treated as admin everywhere), which is what makes Task 1's result meaningful
+	// rather than an artifact of a broken test fixture.
+	controlBody, err := json.Marshal(map[string]any{"name": "ceiling-test-control-token"})
+	require.NoError(t, err)
+	controlURL := fmt.Sprintf("%s/api/v1/projects/%d/machine-identities/%d/tokens", server.URL, projects[0].ID, targetMI.ID)
+	controlReq, err := http.NewRequest(http.MethodPost, controlURL, bytes.NewReader(controlBody))
+	require.NoError(t, err)
+	controlReq.Header.Set("Authorization", "Bearer "+token)
+	controlReq.Header.Set("Content-Type", "application/json")
+	controlResp, err := client.Do(controlReq)
+	require.NoError(t, err)
+	defer func() { _ = controlResp.Body.Close() }()
+	var controlBuf bytes.Buffer
+	_, err = controlBuf.ReadFrom(controlResp.Body)
+	require.NoError(t, err)
+	t.Logf("Control — POST %s as the SAME system.write-only human: status=%d body=%s",
+		controlURL, controlResp.StatusCode, controlBuf.String())
+
+	// Assertions follow the empirically observed behavior of RequireNodeCredentialOrPermission
+	// (server/middleware/node_credential.go): its permission arm calls
+	// AuthorizePrincipal(ctx, actorKind, principalID, "system.write", core.Scope{}) with NO
+	// further per-route check, so a system.write holder — human or machine, admin or not —
+	// passes it exactly like a node credential would. This assertion documents the CURRENT
+	// (unfixed) behavior of CreateMachineIdentityCredentialProxy — see
+	// system_write_ceiling_table_test.go's EnforcesPrivilegeCeiling row for the
+	// fix-wave acceptance criterion this row is expected to eventually violate (i.e.
+	// go red) once that handler is fixed; this file stays as the original empirical
+	// finding, not the regression gate.
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"a system.write-only human is expected to reach CreateMachineIdentityCredentialProxy: "+
+			"RequireNodeCredentialOrPermission's permission arm makes no further per-caller check "+
+			"(writeRemoteAPISuccess never calls WriteHeader, so success is 200, not 201)")
+	assert.True(t, respBuf.Len() > 0 && bytes.Contains(respBuf.Bytes(), []byte(`"success":true`)),
+		"expected a real created-credential response body, not just a 200 status")
+	assert.Equal(t, http.StatusForbidden, controlResp.StatusCode,
+		"the SAME caller must be denied at the ceiling-intact direct endpoint (requires roles.assign "+
+			"in the target project scope, which this caller does not hold) — otherwise the harness is "+
+			"not proving what it claims to")
+}


### PR DESCRIPTION
## Summary

Continues the G80 raw-storage-bypass fix wave
(`docs/g80-raw-storage-bypass-triage.md`) against the machine-identity/credential/
OIDC-binding `/system` proxy group (`server/http/handlers/machine_identities_proxy.go`).

**Status, stated plainly:**

- **Closes the `system.write`-only human/machine path on 3 handlers**:
  `CreateMachineIdentityProxy` (forces `State=MachineActive`, validates
  identity_type/classification — fully closed), `CreateMachineIdentityCredentialProxy`
  (MACH-001 privilege-ceiling check), and `CreateOIDCBindingProxy` (install-wide
  admin-authority check).
- **Leaves the node-credential path open on 2 of them**
  (`CreateMachineIdentityCredentialProxy`, `CreateOIDCBindingProxy`):
  `isNodeCredentialRequest(r)` routes a node-credential caller around both new
  checks entirely, on an unverified assumption that a genuine relay already ran
  the check downstream — the same exemption pattern `AssignRoleWithExpiryProxy`
  established earlier in this campaign. Neither is claimed fixed: both are
  recorded HALF-FIXED in `knownUnfixedRawStorageBypasses`, not moved to the
  allowlist.
- **#1552 is now the top-ranked open finding**, above `CreateMachineIdentityCredentialProxy`:
  re-examining the `AssignRoleWithExpiryProxy` precedent this PR's node-exemption
  branches were modeled on found it is a genuine, uncatalogued instance of the
  same defect class — a bare node credential (zero RBAC permissions by design,
  ADR-030) can grant *any* role, including admin-tier, to *any* user, via the raw
  `storage.AssignRoleWithExpiry` call. Filed, not fixed here.
- **#1551** filed separately for `RevokeMachineIdentityCredentialProxy`: its wire
  contract carries no project/scope parameter at all, so closing it needs a
  RemoteStorage client-side change first, not a server-only fix.

This PR intentionally does **not** attempt to close the node-credential path —
that's ADR-085's still-open "harder question" (whose authority a relayed action
is actually exercised under), and the fix wave is paused pending that decision
(see `docs/g80-raw-storage-bypass-triage.md`'s "Fix status" / "Re-examined"
sections for the full reasoning).

## Commits (7)

1. `fix(core)`: closes an intermittent test flake unrelated to this wave
   (`allowedDaysExcludingToday` was computing "today" in local timezone instead
   of the fixture's configured UTC).
2. `test(server/http)`: real-server acceptance-criteria table
   (`system_write_ceiling_table_test.go`) covering 7 write-shaped routes with a
   system.write-only caller — committed red for 3 rows.
3. `fix(rbac)`: `CreateMachineIdentityCredentialProxy` — MACH-001 privilege
   ceiling (campaign's own "MOST SEVERE FINDING", for the direct-caller path).
4. `fix(rbac)`: `CreateMachineIdentityProxy` — routes through
   `core.CreateMachineIdentity`.
5. `fix(rbac)`: `CreateOIDCBindingProxy` — install-wide admin-authority check
   (direct-caller path); also fixed a latent regression this same commit
   introduced for genuine node-credential relays (`isNodeCredentialRequest`
   branch), caught by
   `TestRemoteStorageMachineIdentities_OIDCBindingCreateGetListDelete_RealServer`.
6. `fix(docs,test)`: corrects the two fixes above from FIXED to HALF-FIXED in
   the tracking map/doc, adds node-credential-path table rows pinning the open
   gap as an explicit, asserted test (not an implicit if-branch), files #1551.
7. `docs(g80)`: files #1552 (the `AssignRoleWithExpiryProxy` finding), re-ranks
   it to #1, annotates the RealServer test that may be encoding the open
   vulnerability rather than validating intended behavior.

## Test plan

- [x] `go build ./...`
- [x] `go test ./server/http/... ./internal/core/...` — full suites green
- [x] `golangci-lint run ./server/http/... ./internal/core/...` — clean
- [x] `system_write_ceiling_table_test.go`'s 11 rows verified individually:
      8 pre-existing green, 3 new node-credential rows pin the documented gap
      (2 correctly assert `200`/open, 1 confirms no caller-class difference on
      `CreateMachineIdentityProxy`)
- [x] `TestNoUnjustifiedRawStorageBypass` (the static AST guard) green against
      the corrected tracking maps

Refs: #1551, #1552, ADR-085 (`docs/adr-085-node-credential-permission-scope.md`)