### PR TITLE
fix(server/http): close CreateAccessRequestProxy/UpdateAccessRequestProxy dual-control bypass (G80 Phase 1 finding)

### DIFF
--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -68,6 +68,23 @@ func (c *KeyorixCore) requireAuthorityForRole(ctx context.Context, actorID, proj
 	return nil
 }
 
+// RequireAdminAuthorityAt exports requireAdminAuthorityAt for the /system proxy
+// layer (server/http/handlers), which cannot call unexported KeyorixCore methods
+// across the package boundary. Used to re-derive, at the hub, the SAME ceiling
+// ApproveSecretAccessRequest/DeleteSoDPolicy-shaped core methods already enforce
+// locally on a downstream node before relaying a state change here -- the
+// #1542 shape, closed the same way TransitionMachineIdentityStateProxy's
+// core.IsValidMachineTransition re-derivation was.
+func (c *KeyorixCore) RequireAdminAuthorityAt(ctx context.Context, actorID, projectID uint) error {
+	return c.requireAdminAuthorityAt(ctx, actorID, projectID)
+}
+
+// RequireAuthorityForRole exports requireAuthorityForRole for the same reason as
+// RequireAdminAuthorityAt above.
+func (c *KeyorixCore) RequireAuthorityForRole(ctx context.Context, actorID, projectID uint, role string) error {
+	return c.requireAuthorityForRole(ctx, actorID, projectID, role)
+}
+
 // requireAdminAuthorityAt refuses unless actorID holds an admin role (adminRoleNames)
 // directly assigned at the given project scope (0 = global). The shared primitive
 // behind requireAuthorityForRole (gating a role GRANT) and any other action that

--- a/server/http/handlers/access_request_proxy.go
+++ b/server/http/handlers/access_request_proxy.go
@@ -55,6 +55,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -153,6 +154,17 @@ func validAccessRequestTargetState(s string) bool {
 // access request as-is (a raw storage-layer create) rather than routing
 // through RequestProjectAccess/RequestSecretAccess's business logic (audit
 // writes, notifications) a second time.
+//
+// #1529-shape guard: every legitimate creation path (RequestProjectAccess,
+// RequestSecretAccess) always creates with State=pending -- approval is a
+// SEPARATE, subsequent action (UpdateAccessRequestProxy), never something the
+// creator decides for themselves. Before this fix, State was caller-writable
+// with no restriction: POST {state:"approved", secret_id, user_id:self}
+// bypassed ApproveSecretAccessRequest's admin-authority + maker≠checker dual
+// control entirely, in one call. Reject anything but "pending" -- this needs
+// no RemoteStorage wire-protocol change, since the only real caller (a
+// downstream node's own RequestProjectAccess/RequestSecretAccess, relayed)
+// only ever sends "pending" in the first place.
 func (h *CatalogHandler) CreateAccessRequestProxy(w http.ResponseWriter, r *http.Request) {
 	var body accessRequestProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -163,8 +175,8 @@ func (h *CatalogHandler) CreateAccessRequestProxy(w http.ResponseWriter, r *http
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id and user_id are required")
 		return
 	}
-	if body.State == "" {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "state is required")
+	if body.State != core.AccessRequestPending {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "state must be \"pending\" -- a new access request is never created pre-resolved")
 		return
 	}
 	created, err := h.coreService.Storage().CreateAccessRequest(r.Context(), body.toModel())
@@ -240,6 +252,44 @@ func (h *CatalogHandler) UpdateAccessRequestProxy(w http.ResponseWriter, r *http
 		log.Printf("access-requests proxy: update lookup failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
+	}
+	// #1529-shape guard: approving is the one transition that grants something
+	// (secret-scoped: read access, the instant the row reads State=approved --
+	// see ApproveSecretAccessRequest's package doc; project/role-scoped: the
+	// GrantedRole record a later AssignRoleWithExpiryProxy call relies on being
+	// trustworthy). Before this fix, a caller could PUT {state:"approved",
+	// resolved_by:self} on an existing pending request with NO check at all --
+	// same finding as CreateAccessRequestProxy above, applied to an update
+	// instead of a create. Re-derive, at the hub, exactly the ceiling the
+	// matching core method already applies before ever reaching this storage
+	// primitive locally: maker≠checker, then admin authority (secret-scoped,
+	// mirroring ApproveSecretAccessRequest) or role-grant authority
+	// (project/role-scoped, mirroring ApproveAccessRequestWithExpiry's
+	// RequireAuthorityForRole call). Reject/withdraw/expire are left as before:
+	// core.RejectAccessRequest has no actor-authority check of its own (any
+	// project member may reject), and core.WithdrawAccessRequest's self-only
+	// check has no wire-carried actor field distinct from ResolvedBy to
+	// re-derive against here -- out of scope for this fix.
+	if body.State == core.AccessRequestApproved {
+		if body.ResolvedBy == existing.UserID {
+			writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", "a requester cannot approve their own access request")
+			return
+		}
+		if existing.SecretID != nil {
+			if err := h.coreService.RequireAdminAuthorityAt(r.Context(), body.ResolvedBy, existing.ProjectID); err != nil {
+				writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", "only an administrator can approve access to a restricted secret: "+err.Error())
+				return
+			}
+		} else {
+			role := body.GrantedRole
+			if role == "" {
+				role = existing.SuggestedRole
+			}
+			if err := h.coreService.RequireAuthorityForRole(r.Context(), body.ResolvedBy, existing.ProjectID, role); err != nil {
+				writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", err.Error())
+				return
+			}
+		}
 	}
 	existing.State = body.State
 	existing.GrantedRole = body.GrantedRole

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -290,6 +290,28 @@ var rawStorageBypassAllowlist = map[string]string{
 	// a caller-side concern already satisfied before the relayed call reached here.
 	"UpdateMachineIdentityCredentialProxy": "FIXED: narrowed to fetch-existing + apply-Classification-only -- see " +
 		"the FIXED comment immediately above this entry for the full reasoning.",
+	// FIXED 2026-08-24 (G80 Phase 2, #1529 re-triage): CreateAccessRequestProxy no
+	// longer accepts a caller-supplied non-pending State -- every legitimate
+	// creation path (RequestProjectAccess/RequestSecretAccess) always creates
+	// with State=pending, so rejecting anything else needed no RemoteStorage
+	// wire-protocol change (the only real caller never sent anything else in the
+	// first place). UpdateAccessRequestProxy now re-derives, at the hub, the SAME
+	// ceiling the matching core method already applies before ever reaching this
+	// storage primitive locally: maker≠checker plus admin authority
+	// (core.RequireAdminAuthorityAt, secret-scoped, mirroring
+	// ApproveSecretAccessRequest) or role-grant authority
+	// (core.RequireAuthorityForRole, project/role-scoped, mirroring
+	// ApproveAccessRequestWithExpiry's own ceiling call) -- both newly exported
+	// from internal/core since the /system proxy layer can't call unexported
+	// KeyorixCore methods across the package boundary. Only the "approved"
+	// transition is gated: core.RejectAccessRequest has no actor-authority check
+	// of its own (any project member may reject), and core.WithdrawAccessRequest's
+	// self-only check has no wire-carried actor field distinct from ResolvedBy to
+	// re-derive against here -- left as-is, not silently narrowed.
+	"CreateAccessRequestProxy": "FIXED: State is forced to \"pending\" at creation -- see the FIXED comment " +
+		"immediately above this entry for the full reasoning.",
+	"UpdateAccessRequestProxy": "FIXED: re-derives maker≠checker + admin/role-grant authority on the \"approved\" " +
+		"transition -- see the FIXED comment immediately above this entry for the full reasoning.",
 }
 
 // knownUnfixedRawStorageBypasses is the set of /system handlers confirmed, by
@@ -314,12 +336,6 @@ var knownUnfixedRawStorageBypasses = map[string]string{
 		"(TransitionMembership) gates activation with requireAuthorityForRole and grants/revokes the underlying " +
 		"role grant as a side effect neither of which this raw call performs; whether that's covered by a " +
 		"separate relayed call from the downstream's own core.TransitionMembership, or a real gap, is undetermined.",
-	"CreateAccessRequestProxy": "REAL, human-reachable, CRITICAL: State is caller-writable with no restriction -- " +
-		"POST {state:\"approved\", secret_id, user_id:self} bypasses ApproveSecretAccessRequest's admin-authority " +
-		"+ maker≠checker dual-control entirely for restricted-secret access.",
-	"UpdateAccessRequestProxy": "REAL, human-reachable, CRITICAL: same dual-control bypass as " +
-		"CreateAccessRequestProxy, applied to an EXISTING pending request via PUT {state:\"approved\", " +
-		"resolved_by:self}.",
 	"CreateInvitationProxy": "REAL, human-reachable: a system.write-only caller (no project-admin authority) can " +
 		"create a pending admin-role invitation, bypassing the escalation-by-proxy guard (requireAuthorityForRole) " +
 		"entirely -- this file's own package doc names this as NOT made here.",

--- a/server/http/remote_storage_access_request_test.go
+++ b/server/http/remote_storage_access_request_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
@@ -287,4 +288,149 @@ func TestRemoteStorageAccessRequest_Approvals_RealServer(t *testing.T) {
 	approvals, err = downstream.Storage().ListAccessRequestApprovals(ctx, created.ID)
 	require.NoError(t, err)
 	assert.Len(t, approvals, 2, "a duplicate approver sign-off must not insert a second row")
+}
+
+// seedAccessRequestSecretFixture creates a project, a requester (owner of the
+// secret and project viewer), a real user with NO special authority, a real
+// admin, and a restricted secret with one version — mirroring
+// internal/core/classification_gate_test.go's seedClassificationGateFixture
+// exactly, against the upstream's own storage so the fixture is real rows,
+// not a mock.
+func seedAccessRequestSecretFixture(t *testing.T, upstream *core.KeyorixCore) (secretID, requesterID, nonAdminID, adminID, projectID uint) {
+	t.Helper()
+	ctx := context.Background()
+	st := upstream.Storage()
+
+	proj, err := st.CreateProject(ctx, &models.Project{Name: "ar-1529-fixture"})
+	require.NoError(t, err)
+
+	requester, err := st.CreateUser(ctx, &models.User{Username: "ar1529-requester", Email: "ar1529-requester@example.com", IsActive: true})
+	require.NoError(t, err)
+	viewerRole, err := st.GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, requester.ID, viewerRole.ID, coreStorage.Scope{ProjectID: proj.ID}))
+
+	nonAdmin, err := st.CreateUser(ctx, &models.User{Username: "ar1529-nonadmin", Email: "ar1529-nonadmin@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	admin, err := st.CreateUser(ctx, &models.User{Username: "ar1529-admin", Email: "ar1529-admin@example.com", IsActive: true})
+	require.NoError(t, err)
+	adminRole, err := st.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, admin.ID, adminRole.ID, coreStorage.Scope{}))
+
+	secret, err := st.CreateSecret(ctx, &models.SecretNode{
+		Name: "ar1529-secret", ProjectID: proj.ID, EnvironmentID: 1, Type: "password",
+		IsSecret: true, OwnerID: requester.ID, Status: "active", Classification: "restricted",
+	})
+	require.NoError(t, err)
+	_, err = st.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: secret.ID, VersionNumber: 1, EncryptedValue: []byte("s3cr3t-value"),
+	})
+	require.NoError(t, err)
+
+	return secret.ID, requester.ID, nonAdmin.ID, admin.ID, proj.ID
+}
+
+// TestAccessRequestProxy_CreateRejectsNonPendingState (#1529) proves
+// CreateAccessRequestProxy no longer accepts a caller-supplied non-pending
+// State. Before the fix, POST {state:"approved", secret_id, user_id:self}
+// created an access request that read as already-approved on its very first
+// GET, bypassing ApproveSecretAccessRequest's dual control entirely — the
+// CRITICAL finding. RED without the fix: the create below would have
+// succeeded and the fetched row would have read State=="approved".
+func TestAccessRequestProxy_CreateRejectsNonPendingState(t *testing.T) {
+	upstream, downstream, _ := newUpstreamDownstreamForAccessRequests(t)
+	secretID, requesterID, _, _, projectID := seedAccessRequestSecretFixture(t, upstream)
+	ctx := context.Background()
+	sid := secretID
+
+	forged := &models.AccessRequest{
+		ProjectID: projectID, UserID: requesterID, SecretID: &sid,
+		State: "approved", ResolvedBy: requesterID, CreatedAt: time.Now(),
+	}
+	_, err := downstream.Storage().CreateAccessRequest(ctx, forged)
+	require.Error(t, err, "creating an access request pre-approved must be refused")
+}
+
+// TestAccessRequestProxy_UpdateApprove_RejectsSelfApproval (#1529) proves
+// UpdateAccessRequestProxy re-derives ApproveSecretAccessRequest's maker≠checker
+// check. RED without the fix: this update would have succeeded.
+func TestAccessRequestProxy_UpdateApprove_RejectsSelfApproval(t *testing.T) {
+	upstream, downstream, _ := newUpstreamDownstreamForAccessRequests(t)
+	secretID, requesterID, _, _, projectID := seedAccessRequestSecretFixture(t, upstream)
+	ctx := context.Background()
+	sid := secretID
+
+	req, err := downstream.Storage().CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: projectID, UserID: requesterID, SecretID: &sid, State: "pending", CreatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	req.State = "approved"
+	req.ResolvedBy = requesterID // the requester approving their own request
+	now := time.Now()
+	req.ResolvedAt = &now
+	_, err = downstream.Storage().UpdateAccessRequest(ctx, req)
+	require.Error(t, err, "a requester approving their own access request must be refused")
+}
+
+// TestAccessRequestProxy_UpdateApprove_RejectsNonAdminApprover (#1529) proves
+// UpdateAccessRequestProxy re-derives ApproveSecretAccessRequest's
+// admin-authority ceiling for a secret-scoped request. This is the CRITICAL
+// finding itself: before the fix, ANY caller holding only system.write (no
+// admin authority at all) could approve access to a restricted secret via
+// this raw call. RED without the fix: this update would have succeeded.
+func TestAccessRequestProxy_UpdateApprove_RejectsNonAdminApprover(t *testing.T) {
+	upstream, downstream, _ := newUpstreamDownstreamForAccessRequests(t)
+	secretID, requesterID, nonAdminID, _, projectID := seedAccessRequestSecretFixture(t, upstream)
+	ctx := context.Background()
+	sid := secretID
+
+	req, err := downstream.Storage().CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: projectID, UserID: requesterID, SecretID: &sid, State: "pending", CreatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	req.State = "approved"
+	req.ResolvedBy = nonAdminID // real user, real account, zero admin authority
+	now := time.Now()
+	req.ResolvedAt = &now
+	_, err = downstream.Storage().UpdateAccessRequest(ctx, req)
+	require.Error(t, err, "a non-admin approver must not be able to approve access to a restricted secret")
+
+	// The row must still read pending — the rejected attempt must not have
+	// partially applied.
+	fetched, err := downstream.Storage().GetAccessRequest(ctx, req.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", fetched.State)
+}
+
+// TestAccessRequestProxy_UpdateApprove_AllowsAdminApprover (#1529) is the
+// positive control: a genuine admin approving a genuine restricted-secret
+// request must still succeed end-to-end over the proxy — the fix closes the
+// bypass without breaking the legitimate path.
+func TestAccessRequestProxy_UpdateApprove_AllowsAdminApprover(t *testing.T) {
+	upstream, downstream, _ := newUpstreamDownstreamForAccessRequests(t)
+	secretID, requesterID, _, adminID, projectID := seedAccessRequestSecretFixture(t, upstream)
+	ctx := context.Background()
+	sid := secretID
+
+	req, err := downstream.Storage().CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: projectID, UserID: requesterID, SecretID: &sid, State: "pending", CreatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	req.State = "approved"
+	req.ResolvedBy = adminID
+	now := time.Now()
+	req.ResolvedAt = &now
+	updated, err := downstream.Storage().UpdateAccessRequest(ctx, req)
+	require.NoError(t, err, "a genuine admin approving a genuine request must still succeed")
+	assert.True(t, updated)
+
+	fetched, err := downstream.Storage().GetAccessRequest(ctx, req.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "approved", fetched.State)
+	assert.Equal(t, adminID, fetched.ResolvedBy)
 }


### PR DESCRIPTION
## Summary
- `CreateAccessRequestProxy` accepted a caller-supplied `State` with no restriction: `POST {state:"approved", secret_id, user_id:self}` created an access request that read as already-approved on its first GET, bypassing `ApproveSecretAccessRequest`'s admin-authority + maker≠checker dual control entirely — CRITICAL, human-reachable, confirmed in Phase 1's re-triage (`docs/g80-raw-storage-bypass-triage.md`, PR #1556).
- `UpdateAccessRequestProxy` had the same gap on an existing pending request via `PUT {state:"approved", resolved_by:self}`.
- Fix re-derives, at the hub, the same ceiling the matching core method already applies before ever reaching the storage primitive locally — the established #1542-shape precedent (`TransitionMachineIdentityStateProxy`'s `core.IsValidMachineTransition` re-derivation) — rather than reimplementing the full approval workflow (M-of-K dual control, the role grant itself) inside the proxy.

## Changes
- `CreateAccessRequestProxy`: `State` is forced to `"pending"` — every legitimate creation path always creates pending; approval is a separate, subsequent action.
- `UpdateAccessRequestProxy`: on a transition to `"approved"`, requires maker≠checker plus admin authority (secret-scoped, mirrors `ApproveSecretAccessRequest`) or role-grant authority (project/role-scoped, mirrors `ApproveAccessRequestWithExpiry`'s own ceiling call). Reject/withdraw/expire transitions are unchanged — the real core methods for those have no comparable actor-authority check to re-derive.
- Added exported `RequireAdminAuthorityAt`/`RequireAuthorityForRole` on `KeyorixCore` (the existing checks were unexported, unreachable from `server/http/handlers` across the package boundary) — same pattern as the prior `RequireMachinePrivilegeCeiling` fix.

## Test plan
- [x] 3 new negative tests (self-approval, non-admin approver, forged create-time state) — confirmed RED without the fix (temporarily stashed it, reran), GREEN with it.
- [x] 1 positive control (genuine admin approving a genuine request) — passes either way, proving the fix doesn't break the legitimate path.
- [x] All 5 pre-existing tests in `remote_storage_access_request_test.go` pass unmodified — they use a non-admin `"developer"` role, which `RequireAuthorityForRole` correctly doesn't gate.
- [x] `TestNoUnjustifiedRawStorageBypass` green — guard list updated (both entries moved to `rawStorageBypassAllowlist` with FIXED reasoning).
- [x] `go build ./...` / `go vet ./...` clean, `gofmt` clean.
- [x] Full `server/http` + `internal/core` suites green.