### PR TITLE
fix(server/http): close CreateInvitationProxy/UpdateInvitationProxy escalation-by-proxy bypass (G80 Phase 1 finding)

### DIFF
--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -68,6 +68,23 @@ func (c *KeyorixCore) requireAuthorityForRole(ctx context.Context, actorID, proj
 	return nil
 }
 
+// RequireAdminAuthorityAt exports requireAdminAuthorityAt for the /system proxy
+// layer (server/http/handlers), which cannot call unexported KeyorixCore methods
+// across the package boundary. Used to re-derive, at the hub, the SAME ceiling
+// core methods already enforce locally on a downstream node before relaying a
+// state change here -- the #1542 shape, closed the same way
+// TransitionMachineIdentityStateProxy's core.IsValidMachineTransition
+// re-derivation was.
+func (c *KeyorixCore) RequireAdminAuthorityAt(ctx context.Context, actorID, projectID uint) error {
+	return c.requireAdminAuthorityAt(ctx, actorID, projectID)
+}
+
+// RequireAuthorityForRole exports requireAuthorityForRole for the same reason as
+// RequireAdminAuthorityAt above.
+func (c *KeyorixCore) RequireAuthorityForRole(ctx context.Context, actorID, projectID uint, role string) error {
+	return c.requireAuthorityForRole(ctx, actorID, projectID, role)
+}
+
 // requireAdminAuthorityAt refuses unless actorID holds an admin role (adminRoleNames)
 // directly assigned at the given project scope (0 = global). The shared primitive
 // behind requireAuthorityForRole (gating a role GRANT) and any other action that

--- a/server/http/handlers/invitations_proxy.go
+++ b/server/http/handlers/invitations_proxy.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -120,6 +121,16 @@ func validInvitationTargetState(s string) bool {
 // (a raw storage-layer create) rather than routing through
 // InviteToProject/InviteToProjectWithLink's business logic + email delivery a
 // second time.
+//
+// #1529-shape guard: InviteToProject/InviteGlobal both call
+// requireAuthorityForRole before ever persisting -- a system.write-only caller
+// (no project-admin authority) must not be able to mint a pending admin-role
+// invitation by relaying a raw create with no upstream check having actually
+// run. Re-derive, at the hub, the SAME escalation-by-proxy ceiling for every
+// role this wire body can carry: the project-scoped Role, the global
+// SystemRole, and each project assignment bundled into AssignmentsJSON --
+// exactly the three checks InviteToProject/InviteGlobal apply before ever
+// reaching this storage primitive locally.
 func (h *CatalogHandler) CreateInvitationProxy(w http.ResponseWriter, r *http.Request) {
 	var body invitationProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -133,6 +144,31 @@ func (h *CatalogHandler) CreateInvitationProxy(w http.ResponseWriter, r *http.Re
 	if body.Email == "" || body.State == "" {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "email and state are required")
 		return
+	}
+	if body.Role != "" {
+		if err := h.coreService.RequireAuthorityForRole(r.Context(), body.InvitedBy, body.ProjectID, body.Role); err != nil {
+			writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", err.Error())
+			return
+		}
+	}
+	if body.SystemRole != "" {
+		if err := h.coreService.RequireAuthorityForRole(r.Context(), body.InvitedBy, 0, body.SystemRole); err != nil {
+			writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", err.Error())
+			return
+		}
+	}
+	if body.AssignmentsJSON != "" {
+		var assignments []core.ProjectAssignment
+		if err := json.Unmarshal([]byte(body.AssignmentsJSON), &assignments); err != nil {
+			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "assignments_json is not a valid assignment list")
+			return
+		}
+		for _, a := range assignments {
+			if err := h.coreService.RequireAuthorityForRole(r.Context(), body.InvitedBy, a.ProjectID, a.Role); err != nil {
+				writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", err.Error())
+				return
+			}
+		}
 	}
 	created, err := h.coreService.Storage().CreateProjectInvitation(r.Context(), body.toModel())
 	if err != nil {
@@ -169,6 +205,21 @@ func (h *CatalogHandler) GetInvitationProxy(w http.ResponseWriter, r *http.Reque
 // storage.Storage primitive this server's local /auth/setup/consume and
 // /projects/{id}/invitations paths use), returning whether it actually matched a
 // still-pending row — the single round trip a concurrent-accept race resolves in.
+//
+// #1529-shape guard: every legitimate caller of storage.UpdateProjectInvitation
+// (completeInvitationAccept/RevokeInvitation/expireInvitationIfOverdue, all in
+// internal/core) re-fetches the row it already has and mutates ONLY State plus
+// AcceptedAt (accept) or RevokedAt (revoke) — never Email/Role/InvitedBy/
+// SystemRole/AssignmentsJSON/ProjectID, which are set once at creation and
+// otherwise immutable. Because the underlying storage call is a `Select("*")`
+// full-row update (same AR-001 pattern as UpdateAccessRequestProxy), a
+// client-supplied wire body could otherwise rewrite an invitation's identity
+// (e.g. SystemRole) under cover of a resolution-state transition, or force
+// State=accepted on a row with no grant ever applied on this side, stranding
+// the real invitee (completeInvitationAccept's own pending check then refuses
+// them with "invitation is accepted"). Re-fetch the authoritative row and apply
+// only the legitimate transition fields from the wire, matching every real
+// caller's own behavior exactly.
 func (h *CatalogHandler) UpdateInvitationProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
@@ -184,8 +235,20 @@ func (h *CatalogHandler) UpdateInvitationProxy(w http.ResponseWriter, r *http.Re
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "state must be one of accepted, revoked, expired")
 		return
 	}
-	body.ID = uint(id)
-	updated, err := h.coreService.Storage().UpdateProjectInvitation(r.Context(), body.toModel())
+	existing, err := h.coreService.Storage().GetProjectInvitation(r.Context(), uint(id))
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "invitation not found")
+			return
+		}
+		log.Printf("invitations proxy: update lookup failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	existing.State = body.State
+	existing.AcceptedAt = body.AcceptedAt
+	existing.RevokedAt = body.RevokedAt
+	updated, err := h.coreService.Storage().UpdateProjectInvitation(r.Context(), existing)
 	if err != nil {
 		log.Printf("invitations proxy: update failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -290,6 +290,23 @@ var rawStorageBypassAllowlist = map[string]string{
 	// a caller-side concern already satisfied before the relayed call reached here.
 	"UpdateMachineIdentityCredentialProxy": "FIXED: narrowed to fetch-existing + apply-Classification-only -- see " +
 		"the FIXED comment immediately above this entry for the full reasoning.",
+	// FIXED 2026-08-24 (G80 Phase 2, #1529 re-triage): CreateInvitationProxy now
+	// re-derives InviteToProject's/InviteGlobal's own requireAuthorityForRole
+	// escalation-by-proxy ceiling for every role the wire body can carry (the
+	// project-scoped Role, the global SystemRole, and each project assignment
+	// bundled into AssignmentsJSON) -- newly exported core.RequireAuthorityForRole,
+	// since the /system proxy layer can't call unexported KeyorixCore methods
+	// across the package boundary. UpdateInvitationProxy now re-fetches the
+	// existing row and applies only State/AcceptedAt/RevokedAt from the wire
+	// (the AR-001 field-narrowing pattern, mirroring UpdateAccessRequestProxy):
+	// every real caller of storage.UpdateProjectInvitation
+	// (completeInvitationAccept/RevokeInvitation/expireInvitationIfOverdue) only
+	// ever mutates those three fields on the row it already fetched, never
+	// Email/Role/SystemRole/InvitedBy/ProjectID, which are set once at creation.
+	"CreateInvitationProxy": "FIXED: re-derives requireAuthorityForRole for Role/SystemRole/each AssignmentsJSON " +
+		"entry -- see the FIXED comment immediately above this entry for the full reasoning.",
+	"UpdateInvitationProxy": "FIXED: re-fetches the existing row and applies only State/AcceptedAt/RevokedAt from " +
+		"the wire -- see the FIXED comment immediately above this entry for the full reasoning.",
 }
 
 // knownUnfixedRawStorageBypasses is the set of /system handlers confirmed, by
@@ -320,12 +337,6 @@ var knownUnfixedRawStorageBypasses = map[string]string{
 	"UpdateAccessRequestProxy": "REAL, human-reachable, CRITICAL: same dual-control bypass as " +
 		"CreateAccessRequestProxy, applied to an EXISTING pending request via PUT {state:\"approved\", " +
 		"resolved_by:self}.",
-	"CreateInvitationProxy": "REAL, human-reachable: a system.write-only caller (no project-admin authority) can " +
-		"create a pending admin-role invitation, bypassing the escalation-by-proxy guard (requireAuthorityForRole) " +
-		"entirely -- this file's own package doc names this as NOT made here.",
-	"UpdateInvitationProxy": "REAL, human-reachable: raw proxy can flip state straight to accepted/revoked with " +
-		"NO grants ever applied and no audit -- strands the real invitee (a state-machine sequencing bypass, not " +
-		"just a permission gap).",
 	// UpdateLoginLockoutStateProxy's route was deleted (G80 23-handler no-caller
 	// deletion) -- entry removed, no longer applicable.
 	// CreateMachineIdentityProxy is FIXED (moved to rawStorageBypassAllowlist);

--- a/server/http/remote_storage_invitations_test.go
+++ b/server/http/remote_storage_invitations_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
@@ -231,4 +232,103 @@ func TestRemoteStorageInvitation_ConcurrentAcceptRace_RealServer(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, core.InvitationAccepted, final.State)
 	assert.NotNil(t, final.AcceptedAt)
+}
+
+// TestInvitationProxy_CreateRejectsProjectAdminRoleWithoutAuthority (#1529)
+// proves CreateInvitationProxy re-derives InviteToProject's
+// requireAuthorityForRole escalation-by-proxy ceiling for a project-scoped
+// invite. RED without the fix: this create would have succeeded, minting a
+// pending admin-role invitation with no project-admin authority anywhere in
+// the chain.
+func TestInvitationProxy_CreateRejectsProjectAdminRoleWithoutAuthority(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForInvitations(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	nonAdmin, err := upstream.Storage().CreateUser(ctx, &models.User{Username: "inv1529-nonadmin", Email: "inv1529-nonadmin@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	inv := buildPendingInvitation(now, projectID, "target@example.com", "admin", nonAdmin.ID)
+	_, err = downstream.Storage().CreateProjectInvitation(ctx, inv)
+	require.Error(t, err, "a non-admin caller must not be able to create a pending admin-role invitation")
+}
+
+// TestInvitationProxy_CreateRejectsGlobalSystemRoleWithoutAuthority (#1529)
+// proves the same ceiling for a global invite's SystemRole. RED without the
+// fix: this create would have succeeded.
+func TestInvitationProxy_CreateRejectsGlobalSystemRoleWithoutAuthority(t *testing.T) {
+	upstream, downstream, _ := newUpstreamDownstreamForInvitations(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	nonAdmin, err := upstream.Storage().CreateUser(ctx, &models.User{Username: "inv1529-nonadmin2", Email: "inv1529-nonadmin2@example.com", IsActive: true})
+	require.NoError(t, err)
+
+	expires := now.Add(14 * 24 * time.Hour)
+	inv := &models.ProjectInvitation{
+		Email: "target2@example.com", State: core.InvitationPending, InvitedBy: nonAdmin.ID,
+		SystemRole: "system_admin", ValidationModeAtInvite: core.ValidationModeOpen,
+		ExpiresAt: &expires, CreatedAt: now,
+	}
+	_, err = downstream.Storage().CreateProjectInvitation(ctx, inv)
+	require.Error(t, err, "a non-admin caller must not be able to create a pending global system_admin invitation")
+}
+
+// TestInvitationProxy_CreateAllowsAdminRoleByGenuineAdmin (#1529) is the
+// positive control: a genuine admin creating a genuine admin-role invitation
+// must still succeed end-to-end over the proxy.
+func TestInvitationProxy_CreateAllowsAdminRoleByGenuineAdmin(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForInvitations(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	admin, err := upstream.Storage().CreateUser(ctx, &models.User{Username: "inv1529-admin", Email: "inv1529-admin@example.com", IsActive: true})
+	require.NoError(t, err)
+	adminRole, err := upstream.Storage().GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().AssignRole(ctx, admin.ID, adminRole.ID, coreStorage.Scope{ProjectID: projectID}))
+
+	inv := buildPendingInvitation(now, projectID, "target3@example.com", "admin", admin.ID)
+	created, err := downstream.Storage().CreateProjectInvitation(ctx, inv)
+	require.NoError(t, err, "a genuine admin creating a genuine admin-role invitation must still succeed")
+	assert.Equal(t, "admin", created.Role)
+}
+
+// TestInvitationProxy_UpdateDoesNotRewriteIdentityUnderCoverOfTransition
+// (#1529) proves UpdateInvitationProxy applies only the legitimate transition
+// fields (State/AcceptedAt/RevokedAt) from the wire, discarding any
+// caller-supplied identity fields (Email/Role/SystemRole/InvitedBy/ProjectID)
+// — mirroring AR-001's field-narrowing fix for UpdateAccessRequestProxy. RED
+// without the fix: the fetched row below would read the forged SystemRole
+// and Email, not the original ones.
+func TestInvitationProxy_UpdateDoesNotRewriteIdentityUnderCoverOfTransition(t *testing.T) {
+	_, downstream, projectID := newUpstreamDownstreamForInvitations(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	inv, err := downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "real-invitee@example.com", "viewer", 1))
+	require.NoError(t, err)
+
+	acceptedAt := time.Now()
+	forged := &models.ProjectInvitation{
+		ID:         inv.ID,
+		Email:      "attacker@example.com", // forged identity rewrite attempt
+		Role:       "admin",
+		SystemRole: "super_admin",
+		InvitedBy:  9999,
+		State:      core.InvitationAccepted,
+		AcceptedAt: &acceptedAt,
+	}
+	updated, err := downstream.Storage().UpdateProjectInvitation(ctx, forged)
+	require.NoError(t, err)
+	assert.True(t, updated, "the legitimate transition (pending -> accepted) must still succeed")
+
+	fetched, err := downstream.Storage().GetProjectInvitation(ctx, inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.InvitationAccepted, fetched.State, "the state transition itself must apply")
+	assert.Equal(t, "real-invitee@example.com", fetched.Email, "the original email must survive, not the forged one")
+	assert.Equal(t, "viewer", fetched.Role, "the original role must survive, not the forged admin role")
+	assert.Empty(t, fetched.SystemRole, "no system role was ever set on this invitation; the forged one must not appear")
+	assert.Equal(t, uint(1), fetched.InvitedBy, "the original inviter must survive, not the forged one")
+	assert.Equal(t, projectID, fetched.ProjectID, "the original project must survive")
 }


### PR DESCRIPTION
## Summary
- `CreateInvitationProxy` accepted a caller-supplied `Role`/`SystemRole`/`AssignmentsJSON` with no restriction: a `system.write`-only caller (no project-admin authority) could mint a pending admin-role invitation, bypassing `InviteToProject`/`InviteGlobal`'s `requireAuthorityForRole` escalation-by-proxy guard entirely — this file's own package doc already named this as NOT made here. Confirmed in Phase 1's re-triage (`docs/g80-raw-storage-bypass-triage.md`, PR #1556).
- `UpdateInvitationProxy` had a related but distinct gap: the underlying storage call is a `Select("*")` full-row update, and the handler trusted the entire caller-supplied body verbatim — a client could rewrite an invitation's identity (`Email`/`Role`/`SystemRole`/`InvitedBy`) under cover of a resolution-state transition, or force `State=accepted` with no grant ever applied on this side, stranding the real invitee.

## Changes
- `CreateInvitationProxy`: re-derives `requireAuthorityForRole` for the project-scoped `Role`, the global `SystemRole`, and each project assignment bundled into `AssignmentsJSON` — three separate checks, matching `InviteGlobal`'s own per-assignment loop.
- `UpdateInvitationProxy`: applies the same AR-001 field-narrowing pattern already used for `UpdateAccessRequestProxy` (PR #1557) — re-fetches the existing row and applies only `State`/`AcceptedAt`/`RevokedAt` from the wire, matching every real caller of `storage.UpdateProjectInvitation` exactly.

## ⚠️ Merge-order note
This PR is based directly on `origin/main` (independent of #1557, not stacked) and re-adds the same `RequireAuthorityForRole`/`RequireAdminAuthorityAt` exported wrappers on `KeyorixCore` that #1557 also adds. Whoever merges the second of {this PR, #1557} will hit a duplicate-declaration build conflict on those two functions specifically — trivial to resolve (keep one copy), flagging so it isn't a surprise, especially since PRs in this repo have been observed auto-merging once CI is green.

## Test plan
- [x] 3 new negative tests (project-admin role without authority, global `system_admin` without authority, identity rewrite under cover of an accept transition) — confirmed RED without the fix (temporarily stashed it, reran), GREEN with it.
- [x] 1 positive control (genuine admin creating a genuine admin-role invitation) — passes either way.
- [x] All 4 pre-existing tests in `remote_storage_invitations_test.go` pass unmodified — they use a non-admin `"viewer"` role, which `RequireAuthorityForRole` correctly doesn't gate.
- [x] `TestNoUnjustifiedRawStorageBypass` green — guard list updated (both entries moved to `rawStorageBypassAllowlist` with FIXED reasoning).
- [x] `go build ./...` / `go vet ./...` clean, `gofmt` clean.
- [x] Full `server/http` + `internal/core` suites green.