### PR TITLE
fix(internal/core): close SoD policy and risk-exception authority gaps (#1529)

### DIFF
--- a/internal/core/groups_join_sod_set_test.go
+++ b/internal/core/groups_join_sod_set_test.go
@@ -54,6 +54,7 @@ func TestAddUserToGroup_BlocksSoDViolationAcrossGroupRoleSet(t *testing.T) {
 	h.AssignGroupRole(t, 50, 71, nil) // combo_write_only — combined with the
 	// above, this is the toxic pair; neither role alone carries both sides.
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -95,6 +96,7 @@ func TestAddUserToGroup_BlocksSoDViolationWithExistingRole(t *testing.T) {
 	h.CreateTestGroup(t, "existing-group", "", 51)
 	h.AssignGroupRole(t, 51, 73, nil) // existing_write_only
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -122,6 +124,7 @@ func TestAddUserToGroup_AllowsNonViolatingGroupJoin(t *testing.T) {
 	h.AssignGroupRole(t, 52, 74, nil) // safe_read_only
 	h.AssignGroupRole(t, 52, 75, nil) // safe_other_only — no policy pairs these
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 

--- a/internal/core/risk_exceptions.go
+++ b/internal/core/risk_exceptions.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -91,7 +92,23 @@ func (c *KeyorixCore) validateSoDReferenceIsLiveViolation(ctx context.Context, c
 // own. For category "sod", reference should be the matching SoDViolation's
 // Reference field (as returned by GET /sod/violations) so the exception, once
 // approved, suppresses that one violation specifically.
-func (c *KeyorixCore) CreateRiskException(ctx context.Context, actorID uint, title, category, reference, justification string, expiresAt time.Time) (*models.RiskException, error) {
+//
+// #1529: actorIsMachine mirrors ApproveRiskException's own reasoning exactly —
+// "governed acceptance of a control gap" only means something if a HUMAN took
+// responsibility for proposing it; a machine credential (including a bare node
+// credential, zero RBAC permissions by design) creating the row with
+// CreatedBy==0 would also silently weaken ApproveRiskException's own
+// self-approval check (actorID != e.CreatedBy trivially passes for ANY real
+// approver against CreatedBy==0). CreateRiskException itself was missing this
+// check even though the sibling Approve function already had it — an
+// asymmetry, not a deliberate design (dual control's whole premise is two
+// humans, not "one human plus whatever created the row").
+func (c *KeyorixCore) CreateRiskException(ctx context.Context, actorID uint, actorIsMachine bool, title, category, reference, justification string, expiresAt time.Time) (*models.RiskException, error) {
+	if actorIsMachine {
+		c.writeAuditEventFailed(ctx, EventRiskExceptionCreated, nil, nil, "",
+			"risk exception create DENIED: a machine-authenticated actor cannot propose a governed risk acceptance")
+		return nil, fmt.Errorf("only a human principal may create a risk exception")
+	}
 	if title == "" || justification == "" {
 		return nil, fmt.Errorf("title and justification are required")
 	}
@@ -183,10 +200,23 @@ func (c *KeyorixCore) CountExpiredRiskExceptions(ctx context.Context) (int, erro
 }
 
 // RevokeRiskException withdraws an exception before its expiry. actorID is the admin.
+//
+// #1529: actorID used to be threaded through ONLY for attribution (RevokedBy),
+// with no authority check at all -- unlike ApproveRiskException's own careful
+// dual-control gate, revocation got no equivalent thought. Mirrors
+// LiftLegalHold's creator-or-admin precedent exactly: only the principal who
+// created the exception, or a global-admin-tier principal, may revoke it. A
+// denied attempt is itself audited.
 func (c *KeyorixCore) RevokeRiskException(ctx context.Context, actorID, id uint) error {
 	e, err := c.storage.GetRiskException(ctx, id)
 	if err != nil {
 		return err
+	}
+	if actorID != e.CreatedBy && c.isGlobalAdminRoleName(ctx, actorID) == "" {
+		c.writeAuditEventFailed(ctx, EventRiskExceptionRevoked, actorPtr(actorID), nil, "",
+			fmt.Sprintf("risk exception %d revoke DENIED: actor %d is neither the creator (%d) nor an admin-tier principal", id, actorID, e.CreatedBy))
+		return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
+			"only the creating admin or an admin-tier principal may revoke this risk exception")
 	}
 	if e.Revoked {
 		return fmt.Errorf("risk exception %d is already revoked", id)

--- a/internal/core/risk_exceptions_live_violation_external_test.go
+++ b/internal/core/risk_exceptions_live_violation_external_test.go
@@ -32,6 +32,7 @@ func TestCreateRiskException_RejectsNonExistentSoDReference(t *testing.T) {
 	// (sod:policy:<id>:<principalType>:<principalID>) from public policy/user
 	// IDs, which is exactly the exploit: a bogus or future-looking reference
 	// naming a (policy, principal) pair that has no live violation yet.
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
 	require.NoError(t, err)
 
@@ -40,7 +41,7 @@ func TestCreateRiskException_RejectsNonExistentSoDReference(t *testing.T) {
 	require.Empty(t, sod.Violations, "no one holds both sides yet")
 
 	bogusRef := "sod:policy:1:user:9999" // matches the reference format, but no such violation exists
-	_, err = h.CoreService.CreateRiskException(ctx, 1, "pre-authorize future SoD gap", "sod", bogusRef, "just in case", time.Now().Add(30*24*time.Hour))
+	_, err = h.CoreService.CreateRiskException(ctx, 1, false, "pre-authorize future SoD gap", "sod", bogusRef, "just in case", time.Now().Add(30*24*time.Hour))
 	require.Error(t, err, "a reference that names no live SoD violation must be refused")
 	assert.Contains(t, err.Error(), "does not match any currently-detected SoD violation")
 }
@@ -55,6 +56,7 @@ func TestCreateRiskException_AcceptsLiveSoDReference(t *testing.T) {
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
 	h.AssignUserRole(t, 10, 3, nil) // editor → secrets.write + users.read
+	h.AssignUserRole(t, 1, 1, nil)  // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
 	require.NoError(t, err)
 
@@ -63,7 +65,7 @@ func TestCreateRiskException_AcceptsLiveSoDReference(t *testing.T) {
 	require.NotEmpty(t, sod.Violations)
 	ref := sod.Violations[0].Reference
 
-	exc, err := h.CoreService.CreateRiskException(ctx, 1, "accept for Q3 migration", "sod", ref, "temporary", time.Now().Add(30*24*time.Hour))
+	exc, err := h.CoreService.CreateRiskException(ctx, 1, false, "accept for Q3 migration", "sod", ref, "temporary", time.Now().Add(30*24*time.Hour))
 	require.NoError(t, err, "a reference matching a live violation must be accepted")
 	assert.Equal(t, ref, exc.Reference)
 }
@@ -80,6 +82,7 @@ func TestApproveRiskException_RejectsSoDReferenceThatWentStale(t *testing.T) {
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
 	h.AssignUserRole(t, 10, 3, nil) // editor → secrets.write + users.read
+	h.AssignUserRole(t, 1, 1, nil)  // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
 	require.NoError(t, err)
 
@@ -88,7 +91,7 @@ func TestApproveRiskException_RejectsSoDReferenceThatWentStale(t *testing.T) {
 	require.NotEmpty(t, sod.Violations)
 	ref := sod.Violations[0].Reference
 
-	exc, err := h.CoreService.CreateRiskException(ctx, 1, "accept for Q3 migration", "sod", ref, "temporary", time.Now().Add(30*24*time.Hour))
+	exc, err := h.CoreService.CreateRiskException(ctx, 1, false, "accept for Q3 migration", "sod", ref, "temporary", time.Now().Add(30*24*time.Hour))
 	require.NoError(t, err)
 
 	// The violation resolves before anyone approves the exception (e.g. alice's

--- a/internal/core/risk_exceptions_test.go
+++ b/internal/core/risk_exceptions_test.go
@@ -36,7 +36,7 @@ func TestCreateRiskException_ValidatesAndAudits(t *testing.T) {
 	})).Return(nil)
 
 	c := riskCore(store, now)
-	_, err := c.CreateRiskException(context.Background(), 9, "accept dormant access for migration", "mfa", "alice@example.com", "temporary during cutover", now.AddDate(0, 0, 30))
+	_, err := c.CreateRiskException(context.Background(), 9, false, "accept dormant access for migration", "mfa", "alice@example.com", "temporary during cutover", now.AddDate(0, 0, 30))
 	require.NoError(t, err)
 	assert.Equal(t, EventRiskExceptionCreated, audited)
 }
@@ -45,20 +45,45 @@ func TestCreateRiskException_Rejects(t *testing.T) {
 	now := time.Now()
 	c := riskCore(new(MockStorage), now)
 
-	_, err := c.CreateRiskException(context.Background(), 1, "", "sod", "", "", now.Add(time.Hour))
+	_, err := c.CreateRiskException(context.Background(), 1, false, "", "sod", "", "", now.Add(time.Hour))
 	require.Error(t, err, "title + justification required")
 
-	_, err = c.CreateRiskException(context.Background(), 1, "t", "bogus", "", "j", now.Add(time.Hour))
+	_, err = c.CreateRiskException(context.Background(), 1, false, "t", "bogus", "", "j", now.Add(time.Hour))
 	require.Error(t, err, "invalid category")
 
-	_, err = c.CreateRiskException(context.Background(), 1, "t", "sod", "", "j", now.Add(-time.Hour))
+	_, err = c.CreateRiskException(context.Background(), 1, false, "t", "sod", "", "j", now.Add(-time.Hour))
 	require.Error(t, err, "expiry must be in the future")
 
 	// Must sunset: an expiry beyond the max duration is refused (no effectively-forever
 	// waiver).
-	_, err = c.CreateRiskException(context.Background(), 1, "t", "sod", "", "j", now.AddDate(5, 0, 0))
+	_, err = c.CreateRiskException(context.Background(), 1, false, "t", "sod", "", "j", now.AddDate(5, 0, 0))
 	require.Error(t, err, "expiry beyond the cap is rejected")
 	require.Contains(t, err.Error(), "must be within")
+}
+
+// #1529: a machine-authenticated actor (e.g. a node credential proxying a
+// call from a downstream server, or a CI machine identity) can never propose
+// a governed risk acceptance -- only a human principal may. The denial is
+// audited (Success=false) via the SAME EventRiskExceptionCreated constant a
+// successful create uses, matching this file's own creator-or-admin denial
+// convention for Revoke/Approve below.
+func TestCreateRiskException_DeniesMachineActor(t *testing.T) {
+	now := time.Now()
+	store := new(MockStorage)
+	var audited string
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(ev *models.AuditEvent) bool {
+		if ev.EventType == EventRiskExceptionCreated && ev.Success != nil && !*ev.Success {
+			audited = ev.EventType
+			return true
+		}
+		return false
+	})).Return(nil)
+
+	c := riskCore(store, now)
+	_, err := c.CreateRiskException(context.Background(), 9, true, "accept dormant access", "mfa", "alice@example.com", "justification", now.Add(time.Hour))
+	require.Error(t, err)
+	assert.Equal(t, EventRiskExceptionCreated, audited, "the denial must be audited")
+	store.AssertNotCalled(t, "CreateRiskException", mock.Anything, mock.Anything)
 }
 
 func TestListRiskExceptions_ComputesStatusAndFilters(t *testing.T) {
@@ -83,7 +108,10 @@ func TestListRiskExceptions_ComputesStatusAndFilters(t *testing.T) {
 func TestRevokeRiskException(t *testing.T) {
 	now := time.Now()
 	store := new(MockStorage)
-	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x"}, nil)
+	// #1529: RevokeRiskException now requires creator-or-admin. CreatedBy: 3
+	// makes actor 3 the creator, satisfying the check without needing to stand
+	// up an RBAC mock chain for the admin branch.
+	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 3}, nil)
 	store.On("RevokeRiskExceptionIfNotRevoked", mock.Anything, mock.MatchedBy(func(e *models.RiskException) bool {
 		return e.ID == 5 && e.Revoked && e.RevokedBy == 3 && e.RevokedAt != nil
 	})).Return(true, nil)
@@ -93,6 +121,51 @@ func TestRevokeRiskException(t *testing.T) {
 	require.NoError(t, c.RevokeRiskException(context.Background(), 3, 5))
 }
 
+// #1529: an actor who neither created the exception nor holds an admin-tier
+// role must be denied -- proves the creator-or-admin gate actually rejects
+// the negative case, not just accepts the positive one (TestRevokeRiskException
+// above only exercises the creator branch).
+func TestRevokeRiskException_DeniesNonCreatorNonAdmin(t *testing.T) {
+	now := time.Now()
+	store := new(MockStorage)
+	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 3}, nil)
+	store.On("GetUserRoleIDsAt", mock.Anything, uint(7), Scope{}).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", mock.Anything, uint(7), Scope{}).Return([]uint{}, nil)
+	var audited string
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(ev *models.AuditEvent) bool {
+		if ev.EventType == EventRiskExceptionRevoked && ev.Success != nil && !*ev.Success {
+			audited = ev.EventType
+			return true
+		}
+		return false
+	})).Return(nil)
+
+	c := riskCore(store, now)
+	err := c.RevokeRiskException(context.Background(), 7, 5)
+	require.Error(t, err)
+	assert.Equal(t, EventRiskExceptionRevoked, audited, "the denial must be audited")
+	store.AssertNotCalled(t, "RevokeRiskExceptionIfNotRevoked", mock.Anything, mock.Anything)
+}
+
+// #1529: an admin-tier actor who did NOT create the exception may still
+// revoke it -- the OTHER half of the creator-OR-admin gate, proving admin
+// status alone is sufficient without being the creator.
+func TestRevokeRiskException_AdminNonCreatorSucceeds(t *testing.T) {
+	now := time.Now()
+	store := new(MockStorage)
+	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 3}, nil)
+	store.On("GetUserRoleIDsAt", mock.Anything, uint(8), Scope{}).Return([]uint{1}, nil)
+	store.On("GetUserGroupRoleIDsAt", mock.Anything, uint(8), Scope{}).Return([]uint{}, nil)
+	store.On("GetRole", mock.Anything, uint(1)).Return(&models.Role{ID: 1, Name: "system_admin"}, nil)
+	store.On("RevokeRiskExceptionIfNotRevoked", mock.Anything, mock.MatchedBy(func(e *models.RiskException) bool {
+		return e.ID == 5 && e.Revoked && e.RevokedBy == 8
+	})).Return(true, nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	c := riskCore(store, now)
+	require.NoError(t, c.RevokeRiskException(context.Background(), 8, 5))
+}
+
 // StateTransitionMissingCAS.ql: a lost race — the row's persisted revoked flag
 // moved to true between the GetRiskException read and this write (e.g. a
 // concurrent racing RevokeRiskException/ApproveRiskException) — must surface as
@@ -100,7 +173,10 @@ func TestRevokeRiskException(t *testing.T) {
 func TestRevokeRiskException_LostRaceReturnsError(t *testing.T) {
 	now := time.Now()
 	store := new(MockStorage)
-	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x"}, nil)
+	// #1529: CreatedBy: 3 makes actor 3 the creator, satisfying the
+	// creator-or-admin check so this test still exercises the lost-race path
+	// it's actually about.
+	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 3}, nil)
 	store.On("RevokeRiskExceptionIfNotRevoked", mock.Anything, mock.Anything).Return(false, nil)
 
 	c := riskCore(store, now)

--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -16,7 +16,11 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-// SoD audit event types.
+// SoD audit event types. Create/Delete denial paths below reuse these SAME
+// constants (Success=false via writeAuditEventFailed distinguishes a denied
+// attempt from a successful one) — the established convention this file's own
+// PlaceLegalHold/LiftLegalHold precedent uses, not a separate "_denied" event
+// type per action.
 const (
 	EventSoDPolicyCreated         = "sod.policy_created"          // #nosec G101 -- audit event type, not a credential
 	EventSoDPolicyDeleted         = "sod.policy_deleted"          // #nosec G101 -- audit event type, not a credential
@@ -80,6 +84,18 @@ func (r *SoDViolationsReport) degrade(area string, err error) {
 
 // CreateSoDPolicy defines a toxic-combination rule. The two permissions must be
 // present and distinct. actorID is the creating admin.
+//
+// #1529: actorID used to be threaded through ONLY for audit attribution, with
+// no authority check at all -- any system.write holder (the route's own gate;
+// this is also reachable via the /system proxy, where "any caller" widens to
+// include a bare node credential, actorID==0) could unilaterally define a new
+// deployment-wide governance control. Defining a toxic-permission-pair rule is
+// a policy-SETTING action with no existing object to compare a "creator" against
+// (unlike delete/revoke below), so it mirrors PlaceLegalHold's admin-tier gate,
+// not LiftLegalHold's creator-or-admin one. A denied attempt is itself audited,
+// distinctly from a successful create -- confirmed via CI: no test asserted a
+// non-admin could create a policy, so this was an oversight, not a documented
+// design choice.
 func (c *KeyorixCore) CreateSoDPolicy(ctx context.Context, actorID uint, name, description, permA, permB string) (*models.SoDPolicy, error) {
 	name = strings.TrimSpace(name)
 	permA = strings.TrimSpace(permA)
@@ -92,6 +108,15 @@ func (c *KeyorixCore) CreateSoDPolicy(ctx context.Context, actorID uint, name, d
 	}
 	if permA == permB {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "the two permissions must be different")
+	}
+	// #1529 authority check runs AFTER field validation (mirrors PlaceLegalHold's
+	// own order: cheap input checks before a DB-backed authority resolution) --
+	// see this function's doc comment above for the full reasoning.
+	if c.isGlobalAdminRoleName(ctx, actorID) == "" {
+		c.writeAuditEventFailed(ctx, EventSoDPolicyCreated, actorPtr(actorID), nil, "",
+			fmt.Sprintf("SoD policy create DENIED: actor %d is not an admin-tier principal", actorID))
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
+			"only an admin-tier principal may define a SoD policy")
 	}
 	policy, err := c.storage.CreateSoDPolicy(ctx, &models.SoDPolicy{
 		Name: name, Description: description, PermissionA: permA, PermissionB: permB,
@@ -124,7 +149,23 @@ func (c *KeyorixCore) ListSoDPolicies(ctx context.Context) ([]*models.SoDPolicy,
 }
 
 // DeleteSoDPolicy retires a policy. actorID is the acting admin.
+//
+// #1529: same gap as CreateSoDPolicy above, but retiring an EXISTING policy has
+// a natural "creator" to compare against (unlike defining a new one), so this
+// mirrors LiftLegalHold's creator-or-admin precedent exactly: only the
+// principal who originally created the policy, or a global-admin-tier
+// principal, may delete it. A denied attempt is itself audited.
 func (c *KeyorixCore) DeleteSoDPolicy(ctx context.Context, actorID, id uint) error {
+	policy, err := c.storage.GetSoDPolicy(ctx, id)
+	if err != nil {
+		return err
+	}
+	if actorID != policy.CreatedBy && c.isGlobalAdminRoleName(ctx, actorID) == "" {
+		c.writeAuditEventFailed(ctx, EventSoDPolicyDeleted, actorPtr(actorID), nil, "",
+			fmt.Sprintf("SoD policy %d delete DENIED: actor %d is neither the creator (%d) nor an admin-tier principal", id, actorID, policy.CreatedBy))
+		return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
+			"only the creating admin or an admin-tier principal may delete this SoD policy")
+	}
 	if err := c.storage.DeleteSoDPolicy(ctx, id); err != nil {
 		return err
 	}

--- a/internal/core/sod_compliance_external_test.go
+++ b/internal/core/sod_compliance_external_test.go
@@ -24,6 +24,7 @@ func TestSoD_SurfacesInPostureAndEvidence(t *testing.T) {
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
 	h.AssignUserRole(t, 10, 3, nil) // editor → secrets.write + users.read
+	h.AssignUserRole(t, 1, 1, nil)  // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
 	require.NoError(t, err)
 
@@ -54,6 +55,7 @@ func TestSoD_SuppressedByApprovedRiskException(t *testing.T) {
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
 	h.AssignUserRole(t, 10, 3, nil) // editor → secrets.write + users.read
+	h.AssignUserRole(t, 1, 1, nil)  // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
 	require.NoError(t, err)
 
@@ -69,7 +71,7 @@ func TestSoD_SuppressedByApprovedRiskException(t *testing.T) {
 	require.NotEmpty(t, ref, "every violation must carry a stable reference to except against")
 
 	// Create the exception — NOT yet approved. Still counts.
-	exc, err := h.CoreService.CreateRiskException(ctx, 1, "accept for Q3 migration", "sod", ref, "temporary", time.Now().Add(30*24*time.Hour))
+	exc, err := h.CoreService.CreateRiskException(ctx, 1, false, "accept for Q3 migration", "sod", ref, "temporary", time.Now().Add(30*24*time.Hour))
 	require.NoError(t, err)
 	p, err = h.CoreService.GetCompliancePosture(ctx)
 	require.NoError(t, err)

--- a/internal/core/sod_external_test.go
+++ b/internal/core/sod_external_test.go
@@ -25,6 +25,7 @@ func TestDetectSoDViolations(t *testing.T) {
 	h.CreateTestUser(t, "bob", 11)
 	h.AssignUserRole(t, 11, 4, nil) // viewer → only users.read
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-useradmin", "", "secrets.write", "users.read")
 	require.NoError(t, err)
 
@@ -63,6 +64,7 @@ func TestDetectSoDViolations_GroupInheritedPermission(t *testing.T) {
 	h.CreateTestUser(t, "dave", 13)
 	h.AssignUserRole(t, 13, 4, nil)
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -97,6 +99,7 @@ func TestDetectSoDViolations_AdminBypass(t *testing.T) {
 	h.AssignUserRole(t, 15, 4, nil)
 
 	// A policy over two permissions the admin role does NOT explicitly enumerate.
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "approve-vs-admin", "", "access_requests.approve", "system.write")
 	require.NoError(t, err)
 
@@ -142,6 +145,7 @@ func TestDetectSoDViolations_MachinePrincipal(t *testing.T) {
 	require.NoError(t, h.DB.Create(&models.MachineIdentityRole{MachineIdentityID: 71, RoleID: 3}).Error)
 	require.NoError(t, h.DB.Create(&models.MachineIdentityRole{MachineIdentityID: 71, RoleID: 5}).Error)
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-audit", "", "secrets.write", "audit.read")
 	require.NoError(t, err)
 
@@ -181,6 +185,12 @@ func TestCreateSoDPolicy_Validation(t *testing.T) {
 	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
 	ctx := context.Background()
 
+	// #1529: actor 1 must be admin-tier to manage SoD policies now -- granted
+	// once, covers every call below (validation failures never reach the
+	// authority check at all, since it runs after field validation; the check
+	// only matters for the valid-policy calls further down).
+	h.AssignUserRole(t, 1, 1, nil)
+
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "", "", "a", "b")
 	require.Error(t, err, "name required")
 	_, err = h.CoreService.CreateSoDPolicy(ctx, 1, "n", "", "secrets.read", "secrets.read")
@@ -196,4 +206,68 @@ func TestCreateSoDPolicy_Validation(t *testing.T) {
 	require.Len(t, list, 1)
 	require.NoError(t, h.CoreService.DeleteSoDPolicy(ctx, 1, p.ID))
 	require.Error(t, h.CoreService.DeleteSoDPolicy(ctx, 1, p.ID), "already deleted")
+}
+
+// #1529: a non-admin-tier actor cannot define a SoD policy at all -- proves
+// CreateSoDPolicy's authority gate actually rejects the negative case, not
+// just the validation errors TestCreateSoDPolicy_Validation exercises above.
+func TestCreateSoDPolicy_DeniesNonAdmin(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.CreateTestUser(t, "eve", 20)
+	h.AssignUserRole(t, 20, 3, nil) // editor -- not admin-tier
+
+	_, err := h.CoreService.CreateSoDPolicy(ctx, 20, "no-approve-and-admin", "", "access_requests.approve", "secrets.admin")
+	require.Error(t, err, "a non-admin-tier actor must not be able to define a SoD policy")
+
+	list, err := h.CoreService.ListSoDPolicies(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, list, "the denied create must not have persisted a policy")
+}
+
+// #1529: an actor who neither created the policy nor holds an admin-tier
+// role must be denied a delete -- the negative case for DeleteSoDPolicy's
+// creator-or-admin gate.
+func TestDeleteSoDPolicy_DeniesNonCreatorNonAdmin(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.AssignUserRole(t, 1, 1, nil) // actor 1: admin-tier, creates the policy
+	p, err := h.CoreService.CreateSoDPolicy(ctx, 1, "no-write-and-audit", "", "secrets.write", "audit.read")
+	require.NoError(t, err)
+
+	h.CreateTestUser(t, "frank", 21)
+	h.AssignUserRole(t, 21, 4, nil) // viewer -- neither the creator nor admin-tier
+
+	err = h.CoreService.DeleteSoDPolicy(ctx, 21, p.ID)
+	require.Error(t, err, "a non-creator, non-admin actor must not be able to delete the policy")
+
+	list, err := h.CoreService.ListSoDPolicies(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1, "the denied delete must not have removed the policy")
+}
+
+// #1529: the creator of a policy can still delete it even after losing
+// admin-tier status -- proves the creator branch of the creator-OR-admin
+// gate is sufficient on its own, not merely redundant with the admin check.
+func TestDeleteSoDPolicy_CreatorSucceedsEvenIfNoLongerAdmin(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.AssignUserRole(t, 1, 1, nil) // actor 1: admin-tier, creates the policy
+	p, err := h.CoreService.CreateSoDPolicy(ctx, 1, "no-create-and-delete-users", "", "users.create", "users.delete")
+	require.NoError(t, err)
+
+	// Simulate the creator being demoted after creation: revoke the admin-tier
+	// role grant directly (no helper for role removal, so raw SQL).
+	h.ExecuteRawSQL(t, "DELETE FROM user_roles WHERE user_id = ? AND role_id = ?", 1, 1)
+
+	require.NoError(t, h.CoreService.DeleteSoDPolicy(ctx, 1, p.ID), "the creator must still be able to delete their own policy without admin-tier status")
 }

--- a/internal/core/sod_preventive_gate_external_test.go
+++ b/internal/core/sod_preventive_gate_external_test.go
@@ -39,6 +39,7 @@ func TestAssignUserRole_BlocksNewSoDViolation(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)
 	h.AssignUserRole(t, 10, 4, nil) // viewer (global) → secrets.read, users.read
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -66,6 +67,7 @@ func TestAssignUserRole_AllowsNonViolatingGrant(t *testing.T) {
 	h.CreateTestUser(t, "bob", 11)
 	h.AssignUserRole(t, 11, 4, nil) // viewer → secrets.read, users.read
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -99,6 +101,7 @@ func TestAssignUserRoleWithExpiry_BlocksJITSoDViolation(t *testing.T) {
 	// specifically, not the ceiling check).
 	h.AssignUserRole(t, 1, 2, nil)
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -127,6 +130,7 @@ func TestAssignUserRoleWithExpiry_AllowsNonViolatingGrant(t *testing.T) {
 	// ceiling check's admin bypass applies.
 	h.AssignUserRole(t, 1, 2, nil)
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -153,6 +157,7 @@ func TestAssignRoleToGroup_BlocksNewSoDViolationForMember(t *testing.T) {
 	h.CreateTestGroup(t, "writers", "", 30)
 	h.AssignUserToGroup(t, 14, 30)
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -182,6 +187,7 @@ func TestAssignRoleToGroup_AllowsNonViolatingGrant(t *testing.T) {
 	h.CreateTestGroup(t, "auditors", "", 31)
 	h.AssignUserToGroup(t, 15, 31)
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -209,6 +215,7 @@ func TestCreateUserWithAssignments_BlocksNewSoDViolationAcrossGrantSet(t *testin
 	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
 	ctx := context.Background()
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -234,6 +241,7 @@ func TestCreateUserWithAssignments_AllowsNonViolatingGrantSet(t *testing.T) {
 	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
 	ctx := context.Background()
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -268,6 +276,7 @@ func TestActivateBreakGlass_NotBlockedBySoD(t *testing.T) {
 
 	// This policy would ordinarily block granting "editor" (secrets.write) to a
 	// principal who already holds secrets.read.
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -293,6 +302,7 @@ func TestAssignUserRole_AdminBypassNotBlockedBySoD(t *testing.T) {
 	h.CreateTestUser(t, "judy", 17)
 	h.AssignUserRole(t, 17, 2, nil) // admin (permission-bypass)
 
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
@@ -321,6 +331,7 @@ func TestAssignUserRole_ProjectScopedAdminNotExemptFromSoD(t *testing.T) {
 
 	// Policy pairs secrets.write (already in kim's project-scoped admin bundle)
 	// with audit.admin (only "auditor", role 5, bundles it).
+	h.AssignUserRole(t, 1, 1, nil) // #1529: actor 1 must now be admin-tier to manage SoD policies
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-audit-admin", "", "secrets.write", "audit.admin")
 	require.NoError(t, err)
 

--- a/internal/storage/store/local_sod.go
+++ b/internal/storage/store/local_sod.go
@@ -4,7 +4,10 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
+	"gorm.io/gorm"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -17,10 +20,23 @@ func (ls *LocalStorage) CreateSoDPolicy(ctx context.Context, p *models.SoDPolicy
 	return p, nil
 }
 
+// GetSoDPolicy used to wrap EVERY error from First (not just a genuine
+// gorm.ErrRecordNotFound) with the "not found" i18n string -- surfaced by
+// #1529's DeleteSoDPolicy fix, which now reads the policy before deleting it
+// (to check creator-or-admin authority): a real connection failure ("database
+// is closed") got mislabeled as "not found" and the proxy handler's
+// isNotFoundErr string match (checking for "not found" in the error text) then
+// reported 404 instead of 500 for a genuine storage outage. Matches the
+// established gorm.ErrRecordNotFound-vs-everything-else pattern this package
+// already uses elsewhere (e.g. local_alert_escalation.go's GetAlertEscalationPolicy).
 func (ls *LocalStorage) GetSoDPolicy(ctx context.Context, id uint) (*models.SoDPolicy, error) {
 	var p models.SoDPolicy
-	if err := ls.db.WithContext(ctx).First(&p, id).Error; err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	err := ls.db.WithContext(ctx).First(&p, id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return &p, nil
 }

--- a/server/http/deployment_disclosure_family_test.go
+++ b/server/http/deployment_disclosure_family_test.go
@@ -137,7 +137,7 @@ func seedFamilyFixtures(t *testing.T, c *core.KeyorixCore) familyFixtures {
 
 	// A risk exception with free-text Reference/Justification, so /risk-exceptions
 	// (#255 bundled sub-finding) has a real row to disclose (or correctly withhold).
-	_, err = c.CreateRiskException(ctx, admin.ID, "family risk", "other", "secret:family-disclosure-canary",
+	_, err = c.CreateRiskException(ctx, admin.ID, false, "family risk", "other", "secret:family-disclosure-canary",
 		"accepted pending rotation", time.Now().Add(48*time.Hour))
 	require.NoError(t, err)
 

--- a/server/http/handlers/handlers_s11_test.go
+++ b/server/http/handlers/handlers_s11_test.go
@@ -223,9 +223,17 @@ func TestRotationPolicyCreate_ValidationError_S11(t *testing.T) {
 func TestRotationPolicyCreate_Forbidden_S11(t *testing.T) {
 	t.Parallel()
 	h := newRotationPolicyHandlerS11(t)
-	// global scope (project_id=0) — AuthorizePrincipal will fail for bare user
+	// global scope (project_id=0) — AuthorizePrincipal will fail for bare user.
+	// Can't use withUserCtx's hardcoded UserID:1 here: this handler is backed
+	// by sharedS4Core, reused across the whole package, and ID 1 is whichever
+	// user a concurrent test's bootstrap happens to auto-assign first — which
+	// can be a real super_admin, making this negative-permission check flaky.
+	// Sentinel ID mirrors s4AdminActorID's approach in handlers_s4_test.go.
+	const unprivilegedActorID uint = 900000099
+	userCtx := &middleware.UserContext{UserID: unprivilegedActorID, Username: "s11-unpriv", Email: "s11-unpriv@example.com"}
 	body := `{"name":"test-pol","scope":"project","interval_days":30}`
-	r := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/rotation-policies", strings.NewReader(body)))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rotation-policies", strings.NewReader(body))
+	r := req.WithContext(context.WithValue(req.Context(), middleware.GetUserContextKey(), userCtx))
 	w := httptest.NewRecorder()
 	h.Create(w, r)
 	// shared-DB user has no permissions → 403

--- a/server/http/handlers/handlers_s26_test.go
+++ b/server/http/handlers/handlers_s26_test.go
@@ -1429,8 +1429,13 @@ func TestListMachineIdentities_HappyPath_S26(t *testing.T) {
 
 // TestCreateSoDPolicyProxy_HappyPath_S26 verifies that creating a SoD policy
 // returns 200 (proxy path).
+//
+// #1529: CreateSoDPolicy now requires admin-tier authority, so this needs
+// freshCoreS26WithAdmin (seeds UserID=1 as admin) + withUserCtx (attaches
+// UserID=1 to the request context) instead of the plain freshCoreS26 +
+// bare-context request this test used before.
 func TestCreateSoDPolicyProxy_HappyPath_S26(t *testing.T) {
-	cs := freshCoreS26(t)
+	cs, _ := freshCoreS26WithAdmin(t)
 	h := NewCatalogHandler(cs)
 
 	body, _ := json.Marshal(map[string]interface{}{
@@ -1438,8 +1443,8 @@ func TestCreateSoDPolicyProxy_HappyPath_S26(t *testing.T) {
 		"permission_a": "secrets.write",
 		"permission_b": "roles.assign",
 	})
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/sod-policies",
-		bytes.NewReader(body))
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/system/sod-policies",
+		bytes.NewReader(body)))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	h.CreateSoDPolicyProxy(w, req)

--- a/server/http/handlers/handlers_s31_test.go
+++ b/server/http/handlers/handlers_s31_test.go
@@ -248,13 +248,20 @@ func TestCreateSoDPolicyProxy_DBError_S31(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
+// #1529: local_sod.go's GetSoDPolicy used to wrap EVERY storage error (not
+// just gorm.ErrRecordNotFound) with the "not found" i18n string, so a genuine
+// outage like this test's broken DB got mislabeled as 404 -- the same
+// pre-existing bug DeleteSoDPolicyProxy_DBError_S31 below already expects 500
+// for. Now that GetSoDPolicy distinguishes a real not-found from any other
+// error (matching local_alert_escalation.go's established pattern), a broken
+// DB correctly surfaces as 500 here too.
 func TestGetSoDPolicyProxy_DBError_S31(t *testing.T) {
 	t.Parallel()
 	h := NewCatalogHandler(freshCoreBrokenS31(t))
 	r := withChiParamS7(httptest.NewRequest(http.MethodGet, "/api/v1/system/sod-policies/1", nil), "id", "1")
 	w := httptest.NewRecorder()
 	h.GetSoDPolicyProxy(w, r)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestDeleteSoDPolicyProxy_DBError_S31(t *testing.T) {

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -26,6 +26,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -779,6 +780,35 @@ var (
 // the sN DBCounter DSN-uniqueness vars elsewhere in this package) because all
 // of s4/s5/s9 write into the SAME sharedS4Core DB, not independent ones.
 var s4UniqueCounter atomic.Int64
+
+// s4AdminActorID is a fixed, deliberately-out-of-range UserID reserved for
+// the one admin-tier actor seeded into the shared sharedS4Core DB (see
+// seedS4AdminActor below) -- chosen high enough to never collide with any
+// other s4/s5/s9 test's hardcoded actor ID.
+const s4AdminActorID uint = 900000001
+
+var seedS4AdminActorOnce sync.Once
+
+// seedS4AdminActor grants s4AdminActorID a global-admin-tier role in the
+// shared sharedS4Core DB, exactly once for the whole test binary. #1529:
+// CreateSoDPolicy/DeleteSoDPolicy now require admin-tier authority, so any
+// s4/s5/s9 test exercising CreateSoDPolicyProxy/DeleteSoDPolicyProxy against
+// the shared core needs a real admin actor in request context -- mirrors
+// sod_s13_test.go's own inline admin seed, but done once (idempotently) since
+// this DB is shared across many test functions rather than fresh per test.
+func seedS4AdminActor(t *testing.T, cs *core.KeyorixCore) {
+	t.Helper()
+	seedS4AdminActorOnce.Do(func() {
+		ctx := context.Background()
+		role, err := cs.Storage().CreateRole(ctx, &models.Role{Name: "system_admin", Description: "shared S4 admin fixture"})
+		if err != nil {
+			panic("seedS4AdminActor: CreateRole: " + err.Error())
+		}
+		if err := cs.Storage().AssignRole(ctx, s4AdminActorID, role.ID, corestorage.Scope{}); err != nil {
+			panic("seedS4AdminActor: AssignRole: " + err.Error())
+		}
+	})
+}
 
 // newHandlerCoreS4 returns a shared *core.KeyorixCore backed by a single
 // in-memory SQLite DB whose schema is migrated exactly once per test binary.
@@ -11655,8 +11685,9 @@ func TestCatalogHandler_CreateSoDPolicyProxy_MissingFields(t *testing.T) {
 
 func TestCatalogHandler_CreateSoDPolicyProxy_HappyPath(t *testing.T) {
 	h := newCatalogHandlerS4(t)
+	seedS4AdminActor(t, h.coreService)
 	body := `{"name":"test","permission_a":"read","permission_b":"write"}`
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req := withUserCtxID(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), s4AdminActorID, "s4admin")
 	w := httptest.NewRecorder()
 	h.CreateSoDPolicyProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -11670,10 +11701,19 @@ func TestCatalogHandler_CreateSoDPolicyProxy_HappyPath(t *testing.T) {
 func TestCreateSoDPolicyProxy_WritesAuditEvent(t *testing.T) {
 	db := openHandlerTestDB(t)
 	require.NoError(t, i18n.InitializeForTesting())
-	h := NewCatalogHandler(core.NewKeyorixCore(store.NewLocalStorage(db)))
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	h := NewCatalogHandler(cs)
+
+	// #1529: CreateSoDPolicy now requires admin-tier authority -- this test's
+	// DB is fresh per-run (openHandlerTestDB), so seed it directly rather than
+	// via the shared-DB seedS4AdminActor helper.
+	ctx := context.Background()
+	role, err := cs.Storage().CreateRole(ctx, &models.Role{Name: "system_admin", Description: "admin"})
+	require.NoError(t, err)
+	require.NoError(t, cs.Storage().AssignRole(ctx, 500, role.ID, corestorage.Scope{}))
 
 	body := `{"name":"test-audit","permission_a":"read","permission_b":"write"}`
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req := withUserCtxID(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), 500, "audituser")
 	w := httptest.NewRecorder()
 	h.CreateSoDPolicyProxy(w, req)
 	require.Equal(t, http.StatusOK, w.Code)

--- a/server/http/handlers/handlers_s5_test.go
+++ b/server/http/handlers/handlers_s5_test.go
@@ -2440,8 +2440,9 @@ func TestBreakGlassProxy_RevokeActivation_BadJSON(t *testing.T) {
 
 func TestCreateSoDPolicyProxy_HappyPath(t *testing.T) {
 	h := newCatalogHandlerS4(t)
+	seedS4AdminActor(t, h.coreService)
 	body := `{"name":"policy-s5","permission_a":"secrets.read","permission_b":"secrets.write"}`
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req := withUserCtxID(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), s4AdminActorID, "s4admin")
 	w := httptest.NewRecorder()
 	h.CreateSoDPolicyProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -2450,8 +2451,9 @@ func TestCreateSoDPolicyProxy_HappyPath(t *testing.T) {
 func TestGetSoDPolicyProxy_HappyPath(t *testing.T) {
 	// Create then Get
 	h := newCatalogHandlerS4(t)
+	seedS4AdminActor(t, h.coreService)
 	body := `{"name":"get-test-s5","permission_a":"audit.read","permission_b":"secrets.read"}`
-	reqCreate := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	reqCreate := withUserCtxID(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), s4AdminActorID, "s4admin")
 	wCreate := httptest.NewRecorder()
 	h.CreateSoDPolicyProxy(wCreate, reqCreate)
 	require.Equal(t, http.StatusOK, wCreate.Code)

--- a/server/http/handlers/risk_exceptions.go
+++ b/server/http/handlers/risk_exceptions.go
@@ -54,7 +54,7 @@ func (h *DashboardHandler) CreateRiskException(w http.ResponseWriter, r *http.Re
 		sendError(w, "InvalidParameter", "expires_at must be an RFC3339 timestamp", http.StatusBadRequest, nil)
 		return
 	}
-	exc, err := h.coreService.CreateRiskException(r.Context(), actor.UserID, body.Title, body.Category, body.Reference, body.Justification, expiresAt)
+	exc, err := h.coreService.CreateRiskException(r.Context(), actor.UserID, isMachineActor(r), body.Title, body.Category, body.Reference, body.Justification, expiresAt)
 	if err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()

--- a/server/http/handlers/risk_exceptions_proxy.go
+++ b/server/http/handlers/risk_exceptions_proxy.go
@@ -123,7 +123,7 @@ func (h *DashboardHandler) CreateRiskExceptionProxy(w http.ResponseWriter, r *ht
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "title and justification are required")
 		return
 	}
-	created, err := h.coreService.CreateRiskException(r.Context(), actorID(r), body.Title, body.Category, body.Reference, body.Justification, body.ExpiresAt)
+	created, err := h.coreService.CreateRiskException(r.Context(), actorID(r), isMachineActor(r), body.Title, body.Category, body.Reference, body.Justification, body.ExpiresAt)
 	if err != nil {
 		log.Printf("risk-exceptions proxy: create failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))

--- a/server/http/handlers/sod_s13_test.go
+++ b/server/http/handlers/sod_s13_test.go
@@ -4,12 +4,16 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newCatalogHandlerSoDSodS13 returns a CatalogHandler backed by a fresh isolated DB.
@@ -128,10 +132,19 @@ func TestCreateSoDPolicyProxy_MissingFields_S13(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// #1529: CreateSoDPolicy now requires admin-tier authority. freshCoreS12 seeds
+// no roles at all, so this seeds a minimal admin role + UserID=1 assignment
+// directly (matching withUserCtx's hardcoded UserID=1) rather than pulling in
+// a whole new fixture helper for one test.
 func TestCreateSoDPolicyProxy_HappyPath_S13(t *testing.T) {
 	h := newCatalogHandlerSoDSodS13(t)
-	req := httptest.NewRequest(http.MethodPost, "/",
-		strings.NewReader(`{"name":"proxy-pol","permission_a":"secrets.read","permission_b":"secrets.write"}`))
+	ctx := context.Background()
+	adminRole, err := h.coreService.Storage().CreateRole(ctx, &models.Role{Name: "system_admin", Description: "Administrator"})
+	require.NoError(t, err)
+	require.NoError(t, h.coreService.Storage().AssignRole(ctx, 1, adminRole.ID, storage.Scope{}))
+
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/",
+		strings.NewReader(`{"name":"proxy-pol","permission_a":"secrets.read","permission_b":"secrets.write"}`)))
 	w := httptest.NewRecorder()
 	h.CreateSoDPolicyProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/server/http/remote_storage_risk_exceptions_test.go
+++ b/server/http/remote_storage_risk_exceptions_test.go
@@ -169,7 +169,7 @@ func TestRemoteStorageRiskExceptions_Approve_DeniesNodeCredential(t *testing.T) 
 	ctx := context.Background()
 
 	const humanCreator = uint(5)
-	exc, err := upstream.CreateRiskException(ctx, humanCreator, "Human-created, node must not approve",
+	exc, err := upstream.CreateRiskException(ctx, humanCreator, false, "Human-created, node must not approve",
 		"other", "", "seeded directly on upstream for #1524 (c) regression coverage", time.Now().Add(30*24*time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, humanCreator, exc.CreatedBy)

--- a/server/http/remote_storage_sod_test.go
+++ b/server/http/remote_storage_sod_test.go
@@ -28,7 +28,13 @@ func newUpstreamDownstreamForSoD(t *testing.T) (upstream *core.KeyorixCore, down
 	t.Cleanup(i18n.ResetForTesting)
 
 	upstream = newTestCore(t)
-	upstreamToken := createNodeToken(t, upstream)
+	// #1529: CreateSoDPolicy/DeleteSoDPolicy now require admin-tier authority
+	// (a bare node credential, zero RBAC permissions by design, can no longer
+	// define or retire a governance control) -- use a real admin session token
+	// (createTestToken's "testadmin", admin-tier, bypasses permission checks
+	// including system.write) instead of a node token, so this file's tests
+	// keep proving the CRUD round-trip, unaffected by the new authority gate.
+	upstreamToken := createTestToken(t, upstream)
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{


### PR DESCRIPTION
## Summary

- `CreateSoDPolicy`/`DeleteSoDPolicy` had no authority check at all: any authenticated actor — including a bare node credential proxied through `sod_proxy.go` — could define or retire a separation-of-duties governance control. `CreateSoDPolicy` now requires admin-tier authority; `DeleteSoDPolicy` requires the policy's creator or an admin-tier principal.
- `CreateRiskException` accepted a machine-authenticated actor as the proposer of a governed risk acceptance. It now denies any `actorIsMachine` caller — only a human principal may propose one.
- `RevokeRiskException` had no gate at all. It now requires the exception's creator or an admin-tier principal, mirroring the SoD-policy delete gate and `ApproveRiskException`'s existing dual-control check.
- Denials are audited (Success=false) via the same event-type constants the success paths use, matching this file's own `PlaceLegalHold`/`LiftLegalHold` precedent.
- Fixes a pre-existing bug in `local_sod.go`'s `GetSoDPolicy`, surfaced by `DeleteSoDPolicy`'s new pre-delete read: every storage error (not just a genuine not-found) was mislabeled as "not found", so a real DB outage returned 404 instead of 500. Fixed to match the established `errors.Is(err, gorm.ErrRecordNotFound)` pattern used elsewhere (e.g. `local_alert_escalation.go`).

Part of the G80 raw-storage-bypass remediation wave (order: access-request pair → **this fix** → invitation pair → OIDC binding → UpdateUser residual).

## Test plan

- [x] New dedicated tests proving each authority gate rejects the negative case: `TestCreateSoDPolicy_DeniesNonAdmin`, `TestDeleteSoDPolicy_DeniesNonCreatorNonAdmin`, `TestDeleteSoDPolicy_CreatorSucceedsEvenIfNoLongerAdmin`, `TestCreateRiskException_DeniesMachineActor`, `TestRevokeRiskException_DeniesNonCreatorNonAdmin`, `TestRevokeRiskException_AdminNonCreatorSucceeds`
- [x] Each new test verified red (temporarily disabled its guarded check, confirmed failure) then green (restored)
- [x] Full `internal/core` suite green
- [x] Full `server/http` suite green (includes `server/http/handlers`)
- [x] `go build ./...`, `go vet ./...` clean
- [x] `gofmt -l` clean on all touched files