### PR TITLE
fix(server/http): route DeleteOIDCBindingProxy through core.DeleteOIDCBinding for direct callers (G80)

### DIFF
--- a/internal/storage/store/local_machine_credentials.go
+++ b/internal/storage/store/local_machine_credentials.go
@@ -270,10 +270,23 @@ func (ls *LocalStorage) ListOIDCBindings(ctx context.Context, machineID uint) ([
 	return rows, nil
 }
 
+// GetOIDCBindingByID used to wrap EVERY error from First (not just a genuine
+// gorm.ErrRecordNotFound) with the "not found" i18n string -- surfaced by
+// DeleteOIDCBindingProxy's G80 fix, which now reads the binding before
+// deleting it (to resolve its owning machine/project): a real connection
+// failure got mislabeled as "not found" and the proxy handler's
+// isNotFoundErr string match then reported 404 instead of 500 for a genuine
+// storage outage. Matches the established gorm.ErrRecordNotFound-vs-
+// everything-else pattern this package already uses elsewhere (e.g.
+// local_sod.go's GetSoDPolicy, fixed the same way for the identical reason).
 func (ls *LocalStorage) GetOIDCBindingByID(ctx context.Context, id uint) (*models.MachineIdentityOIDCBinding, error) {
 	var b models.MachineIdentityOIDCBinding
-	if err := ls.db.WithContext(ctx).First(&b, id).Error; err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+	err := ls.db.WithContext(ctx).First(&b, id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return &b, nil
 }

--- a/server/http/handlers/handlers_s21_machine_proxy_test.go
+++ b/server/http/handlers/handlers_s21_machine_proxy_test.go
@@ -25,6 +25,7 @@ import (
 	customMiddleware "github.com/keyorixhq/keyorix/server/middleware"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -1420,6 +1421,59 @@ func TestDeleteOIDCBindingProxy_HappyPath_S21(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	resp := decodeRemoteRespS21(t, w)
 	assert.True(t, resp.Success)
+}
+
+// G80 raw-storage-bypass fix: DeleteOIDCBindingProxy previously called
+// storage.DeleteOIDCBinding directly for every caller, writing no audit
+// trail at all -- unbinding a federated workload identity via this proxy
+// left no record. Now that a direct (non-node) caller routes through
+// core.DeleteOIDCBinding, the delete is audited exactly like the
+// human-facing route (server/http/handlers/machine_identities.go's
+// DeleteOIDCBinding).
+func TestDeleteOIDCBindingProxy_WritesAuditEvent_S21(t *testing.T) {
+	h := freshCatalogHandlerS21(t)
+	createMI := proxyBodyS21(map[string]interface{}{
+		"name": "audit-mi-s21", "project_id": 81, "state": "active",
+	})
+	cr := httptest.NewRequest(http.MethodPost, "/system/machine-identities", createMI)
+	cw := httptest.NewRecorder()
+	h.CreateMachineIdentityProxy(cw, cr)
+	require.Equal(t, http.StatusOK, cw.Code)
+	var miResp remoteAPIResponse
+	require.NoError(t, json.NewDecoder(cw.Body).Decode(&miResp))
+	machineID := uint(miResp.Data.(map[string]interface{})["id"].(float64))
+
+	createBind := proxyBodyS21(map[string]interface{}{
+		"machine_identity_id": machineID,
+		"issuer":              "https://audit-issuer.example.com",
+		"subject":             "audit-sub-s21",
+		"created_by":          1,
+	})
+	cr2 := withOIDCAdminCtxS21(t, h, httptest.NewRequest(http.MethodPost, "/system/machine-oidc-bindings", createBind))
+	cw2 := httptest.NewRecorder()
+	h.CreateOIDCBindingProxy(cw2, cr2)
+	require.Equal(t, http.StatusOK, cw2.Code)
+	var bindResp remoteAPIResponse
+	require.NoError(t, json.NewDecoder(cw2.Body).Decode(&bindResp))
+	bindingID := uint(bindResp.Data.(map[string]interface{})["id"].(float64))
+
+	req := withChiParam(
+		httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/system/machine-oidc-bindings/%d", bindingID), nil),
+		"id", fmt.Sprintf("%d", bindingID),
+	)
+	w := httptest.NewRecorder()
+	h.DeleteOIDCBindingProxy(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	action := "machine_identity.oidc_unbound"
+	events, count, err := h.coreService.Storage().GetAuditLogs(context.Background(), &storage.AuditFilter{
+		Action: &action, Page: 1, PageSize: 10,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count, "deleting the binding via the proxy must write exactly one audit event")
+	require.Len(t, events, 1)
+	require.NotNil(t, events[0].ProjectID)
+	assert.EqualValues(t, 81, *events[0].ProjectID, "the audit event carries the binding's owning project, matching logMachineEvent's convention")
 }
 
 // ── Error helper functions (package-level, used only by proxy handlers) ────────

--- a/server/http/handlers/handlers_s33_test.go
+++ b/server/http/handlers/handlers_s33_test.go
@@ -223,14 +223,20 @@ func TestListOIDCBindingsProxy_DBError_S33(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
+// G80: GetOIDCBindingByID used to wrap EVERY First() error (not just a real
+// gorm.ErrRecordNotFound) as "not found" -> 404, the same pre-existing bug
+// TestGetSoDPolicyProxy_DBError_S31 documented for local_sod.go. Surfaced by
+// DeleteOIDCBindingProxy's own G80 fix (it now reads the binding before
+// deleting), so GetOIDCBindingByID was fixed to distinguish a genuine
+// not-found from any other storage error -- a broken DB now correctly
+// surfaces as 500 here too.
 func TestGetOIDCBindingByIDProxy_DBError_S33(t *testing.T) {
 	t.Parallel()
 	h := NewCatalogHandler(freshCoreBrokenS33(t))
 	r := withChiParamS7(httptest.NewRequest(http.MethodGet, "/api/v1/system/machine-oidc-bindings/1", nil), "id", "1")
 	w := httptest.NewRecorder()
 	h.GetOIDCBindingByIDProxy(w, r)
-	// GetOIDCBindingByID wraps First() errors as "not found" → 404
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestDeleteOIDCBindingProxy_DBError_S33(t *testing.T) {

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -1053,13 +1053,62 @@ func (h *CatalogHandler) GetOIDCBindingByIDProxy(w http.ResponseWriter, r *http.
 }
 
 // DeleteOIDCBindingProxy handles DELETE /api/v1/system/machine-oidc-bindings/{id}.
+//
+// G80 raw-storage-bypass triage: the raw storage.DeleteOIDCBinding call this
+// used to make unconditionally skips core.DeleteOIDCBinding's own
+// machineInProject + binding-ownership resolution (only a defense-in-depth
+// double-check there, but still real: it confirms the binding's machine
+// actually resolves) and its audit trail (logMachineEvent
+// "machine_identity.oidc_unbound") entirely — an unbind via this proxy left
+// no record a human-facing delete always leaves. Fixed the same way
+// CreateOIDCBindingProxy above was: for a DIRECT (non-node) caller, derive
+// the binding's real (project, machine) from storage and route through
+// core.DeleteOIDCBinding so the ownership check and audit event both run.
+// isNodeCredentialRequest(r) keeps the raw storage call for a genuine node
+// relay, mirroring Create's precedent — the downstream's own
+// core.DeleteOIDCBinding call already ran this exact check locally before
+// relaying, and actorID(r)==0 for a node credential would make the audit
+// event's actor attribution meaningless anyway.
 func (h *CatalogHandler) DeleteOIDCBindingProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid binding id")
 		return
 	}
-	if err := h.coreService.Storage().DeleteOIDCBinding(r.Context(), uint(id)); err != nil {
+	if isNodeCredentialRequest(r) {
+		if err := h.coreService.Storage().DeleteOIDCBinding(r.Context(), uint(id)); err != nil {
+			if isNotFoundErr(err) {
+				writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "oidc binding not found")
+				return
+			}
+			log.Printf("machine-oidc-bindings proxy: delete failed: %v", err)
+			writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+			return
+		}
+		writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+		return
+	}
+	binding, err := h.coreService.Storage().GetOIDCBindingByID(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "oidc binding not found")
+			return
+		}
+		log.Printf("machine-oidc-bindings proxy: delete lookup failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	machine, err := h.coreService.Storage().GetMachineIdentity(r.Context(), binding.MachineIdentityID)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "oidc binding not found")
+			return
+		}
+		log.Printf("machine-oidc-bindings proxy: delete lookup failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	if err := h.coreService.DeleteOIDCBinding(r.Context(), machine.ProjectID, binding.MachineIdentityID, uint(id), actorID(r)); err != nil {
 		if isNotFoundErr(err) {
 			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "oidc binding not found")
 			return

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -352,8 +352,21 @@ var knownUnfixedRawStorageBypasses = map[string]string{
 		"already-fixed RemoveMachineRoleProxy pattern; impact is cross-tenant DoS/tampering, not escalation. " +
 		"Deferred (not a wire-compatible fix like its siblings): the wire contract carries no project/scope " +
 		"parameter at all, so closing it needs a RemoteStorage client-side change first -- filed as #1551.",
-	"DeleteOIDCBindingProxy": "REAL, human-reachable: deletes any binding ID with no ownership/project-scope " +
-		"check and no audit event, versus core.DeleteOIDCBinding's machineInProject + binding-ownership checks.",
+	// HALF-FIXED 2026-08-24 -- do NOT move to rawStorageBypassAllowlist: CLOSED for
+	// a direct, non-node-credential caller (routes through core.DeleteOIDCBinding,
+	// which resolves the binding's real owning machine/project and runs the
+	// machineInProject + binding-ownership checks, plus writes the
+	// machine_identity.oidc_unbound audit event -- see
+	// TestDeleteOIDCBindingProxy_WritesAuditEvent_S21). STILL OPEN for a
+	// node-credential caller: isNodeCredentialRequest(r) routes around all of that
+	// to the raw storage.DeleteOIDCBinding call, the same unverified relay-trust
+	// assumption CreateOIDCBindingProxy/CreateMachineIdentityCredentialProxy above
+	// make. A bare node credential can still delete any binding ID with no
+	// ownership/project-scope check and no audit event.
+	"DeleteOIDCBindingProxy": "HALF-FIXED: closed for a direct system.write-only human/machine caller " +
+		"(routes through core.DeleteOIDCBinding's machineInProject + binding-ownership checks and its audit " +
+		"event); STILL OPEN for a node-credential caller (isNodeCredentialRequest routes around the check to " +
+		"the raw storage call -- see the HALF-FIXED comment immediately above this entry).",
 	// HALF-FIXED 2026-08-24 -- do NOT move to rawStorageBypassAllowlist: CLOSED
 	// for a direct, non-node-credential caller (routes through
 	// core.RequireMachinePrivilegeCeiling, MACH-001, now denying a system.write-only

--- a/server/http/system_write_ceiling_table_test.go
+++ b/server/http/system_write_ceiling_table_test.go
@@ -326,15 +326,16 @@ func TestSystemWriteCeiling_CreateOIDCBindingProxy_RequiresInstallWideAdminAutho
 // TestSystemWriteCeiling_DeleteOIDCBindingProxy_VerifiesOwnership is the table's
 // DeleteOIDCBindingProxy row. Ceiling: core.DeleteOIDCBinding verifies the binding
 // actually belongs to the named machine (machineInProject + a MachineIdentityID
-// match) before deleting. The raw proxy deletes any binding ID unconditionally.
-// This row is necessarily a narrower assertion than "denied outright" — deleting
-// a binding you're relaying on behalf of IS legitimate for the relay's own
-// purpose; what's missing is verifying it's the RIGHT binding, which this table
-// can only observe indirectly (the binding disappears with zero ownership check
-// performed). RED today in the sense that the check never runs at all, though the
-// single-binding-exists-and-belongs-to-itself case can't distinguish "checked and
-// passed" from "never checked" — see the fix commit for the real regression test
-// once core.DeleteOIDCBinding is wired through.
+// match) before deleting, and writes the machine_identity.oidc_unbound audit
+// event. FIXED for a direct, non-node-credential caller (see the
+// TestDeleteOIDCBindingProxy_WritesAuditEvent_S21 regression test in
+// server/http/handlers, which pins the audit trail this row's own status-code
+// assertion can't observe). This row is necessarily a narrower assertion than
+// "denied outright" — deleting a binding you're relaying on behalf of IS
+// legitimate; the fix routes through core.DeleteOIDCBinding to resolve the
+// real owning machine/project rather than trusting a caller-supplied one (this
+// proxy takes no project parameter at all, so there is no mismatched-project
+// fixture to assert a 403/404 against here).
 func TestSystemWriteCeiling_DeleteOIDCBindingProxy_VerifiesOwnership(t *testing.T) {
 	f := setupCeilingTableFixtures(t)
 	status, body := doCeilingRequest(t, f, http.MethodDelete, fmt.Sprintf("/api/v1/system/machine-oidc-bindings/%d", f.bindingID), nil)
@@ -430,5 +431,22 @@ func TestSystemWriteCeiling_CreateOIDCBindingProxy_NodeCredential_StillBypassesA
 		"KNOWN GAP (not intended, pending ADR-085's wire-identity decision): a node credential still creates an "+
 			"OIDC binding with no install-wide admin-authority check — isNodeCredentialRequest routes it around "+
 			"requireAuthorityForRole entirely, on an unverified relay-trust assumption. If this ever goes non-200, "+
+			"update this assertion — that would mean the gap closed, which is the goal, not a regression.")
+}
+
+// TestSystemWriteCeiling_DeleteOIDCBindingProxy_NodeCredential_StillBypassesOwnershipCheck
+// pins the KNOWN, OPEN gap: unlike the direct-caller row above (now routed
+// through core.DeleteOIDCBinding), a node credential still reaches the raw
+// storage.DeleteOIDCBinding call unconditionally (isNodeCredentialRequest
+// branch), so it can still delete any binding ID with no ownership/project
+// resolution and no audit event at all.
+func TestSystemWriteCeiling_DeleteOIDCBindingProxy_NodeCredential_StillBypassesOwnershipCheck(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequestAs(t, f, f.nodeToken, http.MethodDelete, fmt.Sprintf("/api/v1/system/machine-oidc-bindings/%d", f.bindingID), nil)
+	t.Logf("DeleteOIDCBindingProxy(node credential): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status,
+		"KNOWN GAP (not intended, pending ADR-085's wire-identity decision): a node credential still deletes an "+
+			"OIDC binding with no ownership check and no audit event — isNodeCredentialRequest routes it around "+
+			"core.DeleteOIDCBinding entirely, on an unverified relay-trust assumption. If this ever goes non-200, "+
 			"update this assertion — that would mean the gap closed, which is the goal, not a regression.")
 }


### PR DESCRIPTION
## Summary

- `DeleteOIDCBindingProxy` called `storage.DeleteOIDCBinding` unconditionally for every caller, skipping `core.DeleteOIDCBinding`'s `machineInProject` + binding-ownership resolution and its audit trail (`machine_identity.oidc_unbound`) entirely — unbinding a federated workload identity via this proxy left no record at all.
- Fixed the same way `CreateOIDCBindingProxy` was: for a direct (non-node) caller, resolve the binding's real owning machine/project from storage and route through `core.DeleteOIDCBinding` so the ownership check and audit event both run. `isNodeCredentialRequest(r)` keeps the raw storage call for a genuine node relay (mirrors Create's precedent) — this remains a documented, tracked HALF-FIXED gap (guard-list entry updated accordingly), not a full close.
- Also fixes the same pre-existing "every storage error mislabeled as not found" bug in `GetOIDCBindingByID` (`local_machine_credentials.go`), surfaced by this fix's new pre-delete read — same root cause and fix shape as the sibling `local_sod.go` `GetSoDPolicy` bug fixed in #1559. One sibling test in `handlers_s33_test.go` asserted the old buggy 404 behavior directly; updated to expect 500, matching its own `DeleteOIDCBindingProxy_DBError_S33` sibling in the same file.

Part of the G80 raw-storage-bypass remediation wave (order: access-request pair → SoD/RiskException authority (#1559) → invitation pair → **this fix** → UpdateUser residual).

## Test plan

- [x] New test `TestDeleteOIDCBindingProxy_WritesAuditEvent_S21` proves the audit trail this fix adds (red-then-green verified: temporarily reverted to the raw storage call, confirmed the test fails, restored)
- [x] New `system_write_ceiling_table_test.go` row (`TestSystemWriteCeiling_DeleteOIDCBindingProxy_NodeCredential_StillBypassesOwnershipCheck`) pins the node-credential gap that remains open, matching the existing Create-side precedent
- [x] `raw_storage_bypass_guard_test.go`'s `DeleteOIDCBindingProxy` entry updated from REAL/unfixed to HALF-FIXED, matching current behavior; guard staleness checks pass
- [x] Full `server/http` suite green (includes `server/http/handlers`)
- [x] Full `internal/core` and `internal/storage` suites green
- [x] `go build ./...`, `go vet ./...` clean
- [x] `gofmt -l` clean on all touched files