### PR TITLE
fix(server/http): close the UpdateUser PAT/session-revocation residual (G80)

### DIFF
--- a/docs/g80-raw-storage-bypass-triage.md
+++ b/docs/g80-raw-storage-bypass-triage.md
@@ -299,3 +299,91 @@ not inferred from the permission's name). Zero machine-only, zero unknown-reach 
    6 (needs new system-proxy routes for PAT/session revocation, not a handler-local fix).
 
 **Answer to "how much is left" for this bug class: 6.**
+
+## Fix wave complete (2026-08-25) — all 6 actionable items addressed
+
+All 6 of the above are now fixed for a direct (non-node-credential) caller — the same
+direct-caller/node-credential split established by the earlier machine-identity/OIDC-binding
+sub-wave (see "Fix status" above), not a full close in every case. Authoritative status
+lives in `server/http/raw_storage_bypass_guard_test.go`'s maps, as always; this is a
+pointer, not a duplicate of that record.
+
+1. `CreateAccessRequestProxy`/`UpdateAccessRequestProxy` — **FIXED** (moved to
+   `rawStorageBypassAllowlist`). PR #1557: `CreateAccessRequestProxy` forces
+   `State=AccessRequestPending`; `UpdateAccessRequestProxy`'s `State=approved` transition
+   now requires maker≠checker plus admin or role-grant authority, re-deriving the same
+   ceiling `ApproveSecretAccessRequest`/`ApproveAccessRequestWithExpiry` already enforce
+   locally.
+2. `CreateInvitationProxy`/`UpdateInvitationProxy` — **FIXED** (moved to
+   `rawStorageBypassAllowlist`). PR #1558: `CreateInvitationProxy` now checks
+   `RequireAuthorityForRole` for every role the wire body would grant (`Role`,
+   `SystemRole`, each `AssignmentsJSON` entry); `UpdateInvitationProxy` narrows to the
+   legitimate transition fields (AR-001 pattern) instead of a full-row overwrite.
+3. `DeleteOIDCBindingProxy` — **HALF-FIXED, still in `knownUnfixedRawStorageBypasses`,
+   NOT closed.** PR #1560: a direct caller now routes through `core.DeleteOIDCBinding`
+   (`machineInProject` + binding-ownership + audit event, `machine_identity.oidc_unbound`).
+   A node-credential caller still reaches the raw storage call unconditionally, same
+   `isNodeCredentialRequest(r)` relay-trust assumption as `CreateOIDCBindingProxy`/
+   `CreateMachineIdentityCredentialProxy` above. Also fixed in the same PR: a pre-existing
+   bug in `GetOIDCBindingByID` (`local_machine_credentials.go`) that mislabeled every
+   storage error, not just a genuine not-found, as 404 — surfaced by this fix's new
+   pre-delete read, same root cause and fix shape as the sibling `local_sod.go`
+   `GetSoDPolicy` bug (see item 4 below).
+4. `UpdateUserIfActiveStateMatchesProxy` (PAT/session-revocation residual) —
+   **HALF-FIXED, still in `knownUnfixedRawStorageBypasses`, NOT closed.** Two new routes
+   (`POST /system/users/{id}/personal-access-tokens/revoke-all`,
+   `POST /system/users/{id}/sessions/delete-except`) replace the `RevokeAllPersonalAccessTokensForUser`/
+   `DeleteSessionsForUserExcept` hard stubs in `remote_auth.go` with real implementations.
+   Unlike every other proxy in this file, these do NOT rely on the group's blanket
+   `system.write` baseline alone for a direct caller: the ceiling was **derived, not
+   chosen** — `core.UpdateUser`/`core.DeleteUser` perform no caller-authority check of
+   their own on a deactivating transition (only `guardLastAdminDeactivation`, a
+   target-state invariant with no actor parameter); the actual ceiling governing "who may
+   deactivate a user" lives entirely at `RequirePermission(permUsersWrite)` on
+   `PUT /api/v1/users/{id}` (`server/http/router.go`). The new routes require exactly that
+   — `users.write` at global scope — for a direct caller, plus an audit event
+   (`user.credentials_revoked`) with real actor attribution (the same node-credential
+   actor-0 gap #1530 tracks still applies to the node-credential branch here). A
+   node-credential caller still reaches the raw storage calls unconditionally, the same
+   documented gap as every other HALF-FIXED entry.
+
+   Separately, this PR also fixed a pre-existing bug independent of the proxy layer:
+   `core.UpdateUser`'s deactivating branch treated `DeleteSessionsForUserExcept`'s error
+   as fatal to the whole transaction while `RevokeAllPersonalAccessTokensForUser`'s was
+   already best-effort (an unexplained asymmetry) — meaning a transient session-deletion
+   failure reported total deactivation failure even after the actual state flip had
+   already durably committed. Now best-effort on both, matching `SetAccountState`'s own
+   suspend/deactivate path, which already treated this the same way. `DeleteUser` remains
+   fully fatal on both, deliberately unchanged — a delete's revocation semantics are a
+   separate question.
+
+Not part of this wave: `RevokeMachineIdentityCredentialProxy` (#1551) and the
+`CreateMachineIdentityCredentialProxy`/`CreateOIDCBindingProxy` node-credential residuals
+(#1552) remain ADR-085-blocked, as recorded above — untouched, per instruction.
+
+## Open question: the 14 `documented-exception` verdicts are not settled (not work for now)
+
+The 34-candidate re-triage table above records **14** entries as `documented-exception`
+(row: "no-independent-ceiling | 9 ... documented-exception | 14 ..."). That verdict means
+"a code comment asserts this raw call is safe" — it does NOT mean the assertion has been
+independently verified the way every `real` finding above was (escalation-delta test:
+does an actor holding ONLY the route's gating permission gain a capability the gate did
+not already authorize, traced to a real human auth path).
+
+This matters because `AssignRoleWithExpiryProxy` (`rbac_role_grants_proxy.go`) was ALSO a
+documented exception before this campaign — its own doc comment asserted the node-credential
+relay could be trusted, an assumption stated but never verified. It became
+[#1552](https://github.com/keyorixhq/keyorix/issues/1552), the campaign's highest-severity
+finding, and its exact "assert, don't verify" shape is now the precedent this campaign cites
+for treating every OTHER node-credential relay assumption as an open half-fix (see
+`CreateOIDCBindingProxy`/`CreateMachineIdentityCredentialProxy`'s HALF-FIXED entries above).
+Fourteen routes justified by a comment, never independently re-derived, is the same shape as
+the suppression lists (`rawStorageBypassAllowlist` entries accepted on read, not re-verified)
+this campaign has spent multiple sessions dismantling elsewhere.
+
+**Not work for now** — this is a scope flag, not a to-do list. Before anyone treats the
+14-count as settled, each entry needs the same escalation-delta test applied to the 9 `real`
+findings above: trace the actual gating permission's documented footprint against what the
+raw call would let a caller holding ONLY that permission do, against a real human auth path,
+not the comment's own claim. Until that pass runs, "documented-exception" should be read as
+"unverified-exception."

--- a/internal/core/constants.go
+++ b/internal/core/constants.go
@@ -14,4 +14,5 @@ const (
 	permSecretsWrite     = "secrets.write"
 	permSystemRead       = "system.read"
 	permUsersRead        = "users.read"
+	permUsersWrite       = "users.write"
 )

--- a/internal/core/update_user_deactivation_test.go
+++ b/internal/core/update_user_deactivation_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
@@ -171,4 +173,45 @@ func TestUpdateUser_NoRevocation_WhenAlreadyInactive(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, evicted, "no evictions when user was already inactive")
+}
+
+// TestUpdateUser_Deactivation_SucceedsDespiteSessionRevocationFailure is the
+// G80 residual fix's own regression test: a DeleteSessionsForUserExcept
+// failure must NOT fail the whole deactivating UpdateUser call. Before this
+// fix, DeleteSessionsForUserExcept's error was the WithTransaction closure's
+// return value, so it propagated and UpdateUser reported total failure even
+// though the conditional write (UpdateUserIfActiveStateMatches) had already
+// matched and applied -- the deactivation itself durably succeeded, but the
+// caller was told it hadn't. This mattered most over storage.type: remote,
+// where DeleteSessionsForUserExcept/RevokeAllPersonalAccessTokensForUser were
+// BOTH hard-stubbed to errUnsupportedRemote until this fix, meaning EVERY
+// remote deactivation failed outright. Uses MockStorage (not a real SQLite
+// DB) specifically so DeleteSessionsForUserExcept can be made to fail in
+// isolation while the conditional write still succeeds -- not reproducible
+// against LocalStorage without a fault-injection seam.
+func TestUpdateUser_Deactivation_SucceedsDespiteSessionRevocationFailure(t *testing.T) {
+	ms := new(MockStorage)
+	original := &models.User{ID: 44, Username: "carol", Email: "carol@example.com", IsActive: true}
+	ms.On("GetUser", mock.Anything, uint(44)).Return(original, nil)
+	// guardLastAdminDeactivation: target holds no roles anywhere -> not a
+	// global admin -> the lockout guard returns nil immediately, same mocking
+	// shape as the #1529 authority tests in sod_external_test.go/risk_exceptions_test.go.
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(44), Scope{}).Return([]uint{}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(44), Scope{}).Return([]uint{}, nil)
+	ms.On("ListSessionTokenHashesForUser", mock.Anything, uint(44)).Return([]string{"sess-hash-1"}, nil)
+	ms.On("UpdateUserIfActiveStateMatches", mock.Anything, mock.AnythingOfType("*models.User"), true).Return(true, nil)
+	ms.On("RevokeAllPersonalAccessTokensForUser", mock.Anything, uint(44)).Return([]string{"pat-hash-1"}, nil)
+	// The failure under test: a real error (e.g. errUnsupportedRemote over
+	// storage.type: remote, or a transient HTTP failure) from the session
+	// deletion sub-call.
+	ms.On("DeleteSessionsForUserExcept", mock.Anything, uint(44), uint(0)).Return(errors.New("simulated: session deletion transport failure"))
+
+	c := NewKeyorixCore(ms)
+	updated, err := c.UpdateUser(context.Background(), &UpdateUserRequest{
+		ID:       44,
+		IsActive: &[]bool{false}[0],
+	})
+	require.NoError(t, err, "the deactivation must succeed even though session deletion failed")
+	require.NotNil(t, updated)
+	assert.False(t, updated.IsActive, "the user must still be marked inactive")
 }

--- a/internal/core/update_user_deactivation_test.go
+++ b/internal/core/update_user_deactivation_test.go
@@ -205,6 +205,17 @@ func TestUpdateUser_Deactivation_SucceedsDespiteSessionRevocationFailure(t *test
 	// storage.type: remote, or a transient HTTP failure) from the session
 	// deletion sub-call.
 	ms.On("DeleteSessionsForUserExcept", mock.Anything, uint(44), uint(0)).Return(errors.New("simulated: session deletion transport failure"))
+	// Discoverability: a failed revocation must still be audited (Success=false)
+	// even though it doesn't fail the call -- see EventUserDeactivationCleanupFailed's
+	// doc in users.go.
+	var audited *models.AuditEvent
+	ms.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(ev *models.AuditEvent) bool {
+		if ev.EventType == EventUserDeactivationCleanupFailed {
+			audited = ev
+			return true
+		}
+		return false
+	})).Return(nil)
 
 	c := NewKeyorixCore(ms)
 	updated, err := c.UpdateUser(context.Background(), &UpdateUserRequest{
@@ -214,4 +225,8 @@ func TestUpdateUser_Deactivation_SucceedsDespiteSessionRevocationFailure(t *test
 	require.NoError(t, err, "the deactivation must succeed even though session deletion failed")
 	require.NotNil(t, updated)
 	assert.False(t, updated.IsActive, "the user must still be marked inactive")
+	require.NotNil(t, audited, "the revocation failure must be audited for discoverability")
+	require.NotNil(t, audited.Success)
+	assert.False(t, *audited.Success)
+	assert.Contains(t, audited.Description, "session deletion transport failure")
 }

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -416,29 +416,51 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 				return fmt.Errorf("user %d: %w", req.ID, ErrUserActiveStateConflict)
 			}
 			updated = user
-			if hashes, herr := tx.RevokeAllPersonalAccessTokensForUser(ctx, req.ID); herr == nil {
+			var patErr, sessionErr error
+			var hashes []string
+			hashes, patErr = tx.RevokeAllPersonalAccessTokensForUser(ctx, req.ID)
+			if patErr == nil {
 				patHashes = hashes
 			}
-			// Best-effort, matching RevokeAllPersonalAccessTokensForUser
-			// immediately above: the conditional write this switch case exists
-			// for (UpdateUserIfActiveStateMatches) has ALREADY matched and
-			// applied by this point -- the deactivation itself durably
-			// succeeded. Letting a PAT/session-revocation failure here fail the
-			// whole WithTransaction call would report total failure to the
-			// caller for an operation that, from the target user's perspective,
-			// already happened. This matters most over storage.type: remote,
-			// where WithTransaction provides NO real atomicity at all (each
+			sessionErr = tx.DeleteSessionsForUserExcept(ctx, req.ID, 0)
+			// Best-effort, not fatal: the conditional write this switch case
+			// exists for (UpdateUserIfActiveStateMatches) has ALREADY matched
+			// and applied by this point -- the deactivation itself durably
+			// succeeded. Letting a revocation failure here fail the whole
+			// WithTransaction call would report total failure for an
+			// operation that, from the target user's perspective, already
+			// happened. This matters most over storage.type: remote, where
+			// WithTransaction provides NO real atomicity at all (each
 			// sub-call is its own independent HTTP round-trip -- see
-			// remote_transaction.go) -- treating this as fatal there could never
-			// have rolled the deactivation back anyway, only hidden that it
-			// succeeded behind a misleading error. Matches SetAccountState's own
-			// suspend/deactivate path (account_state.go), which already treats
-			// this exact call as best-effort for the same reason -- UpdateUser
-			// was the one deactivation path still fatal on it. (DeleteUser
-			// remains fatal on both calls, deliberately out of scope here: a
-			// delete's session/PAT revocation failing partway is a different,
-			// separate question from a plain deactivation's.)
-			_ = tx.DeleteSessionsForUserExcept(ctx, req.ID, 0)
+			// remote_transaction.go) -- treating this as fatal there could
+			// never have rolled the deactivation back anyway, only hidden
+			// that it succeeded behind a misleading error.
+			//
+			// Safe specifically because a failed revocation does NOT leave a
+			// working credential: ValidateSessionToken (auth.go) and
+			// ValidatePATToken (pat.go) BOTH independently re-check the live
+			// user.IsActive/AccountLoginBlocked state on every single use of
+			// a session or PAT, cold path AND the 30s warm auth-cache path
+			// (via AccountStillUsable, server/middleware/auth.go's
+			// serveAuthCacheHit) -- already-committed IsActive=false alone
+			// blocks the credential regardless of whether its row was ever
+			// deleted. There is no session-expiry sweeper in this codebase
+			// (CleanupExpiredSessions is implemented but never scheduled), so
+			// a row a failed revocation leaves behind lingers indefinitely --
+			// but inertly: it authorizes nothing. The residual cost is
+			// orphaned-row hygiene and forensic noise, not a live credential,
+			// which is why this is audited (right below) rather than merely
+			// swallowed.
+			if patErr != nil || sessionErr != nil {
+				// nil actor: UpdateUser (unlike DeleteUser/SetAccountState) takes
+				// no actorID parameter at all -- a pre-existing gap in this
+				// function's own signature, not something this fix should
+				// silently paper over with a fabricated attribution.
+				c.writeAuditEventFailed(ctx, EventUserDeactivationCleanupFailed, nil, nil, "",
+					fmt.Sprintf("user %d deactivated, but credential cleanup was incomplete (pat_error=%v, session_error=%v) -- "+
+						"the account is already login-blocked regardless, but a stale row may remain until its own expiry",
+						req.ID, patErr, sessionErr))
+			}
 			return nil
 		})
 	case req.IsActive != nil:
@@ -490,6 +512,17 @@ const (
 	EventUserDeleted  = "user.deleted"
 	EventUserRestored = "user.restored"
 )
+
+// EventUserDeactivationCleanupFailed is audited (Success=false) when
+// UpdateUser's deactivating branch's PAT/session revocation is incomplete —
+// see that branch's own comment for why this is best-effort rather than
+// fatal to the deactivation itself, and why a failure here doesn't leave a
+// working credential (ValidateSessionToken/ValidatePATToken's live
+// user.IsActive/AccountLoginBlocked re-check already blocks it). This event
+// exists purely for discoverability: with no session-expiry sweeper in this
+// codebase, a row a failed revocation leaves behind is inert but otherwise
+// invisible until an operator goes looking for it.
+const EventUserDeactivationCleanupFailed = "user.deactivation_cleanup_failed"
 
 // DeleteUser deprovisions and soft-deletes a user by ID: blocks login
 // (AccountDeprovisioned, mirroring DeprovisionSCIMUser), terminates every session,

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -419,7 +419,27 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 			if hashes, herr := tx.RevokeAllPersonalAccessTokensForUser(ctx, req.ID); herr == nil {
 				patHashes = hashes
 			}
-			return tx.DeleteSessionsForUserExcept(ctx, req.ID, 0)
+			// Best-effort, matching RevokeAllPersonalAccessTokensForUser
+			// immediately above: the conditional write this switch case exists
+			// for (UpdateUserIfActiveStateMatches) has ALREADY matched and
+			// applied by this point -- the deactivation itself durably
+			// succeeded. Letting a PAT/session-revocation failure here fail the
+			// whole WithTransaction call would report total failure to the
+			// caller for an operation that, from the target user's perspective,
+			// already happened. This matters most over storage.type: remote,
+			// where WithTransaction provides NO real atomicity at all (each
+			// sub-call is its own independent HTTP round-trip -- see
+			// remote_transaction.go) -- treating this as fatal there could never
+			// have rolled the deactivation back anyway, only hidden that it
+			// succeeded behind a misleading error. Matches SetAccountState's own
+			// suspend/deactivate path (account_state.go), which already treats
+			// this exact call as best-effort for the same reason -- UpdateUser
+			// was the one deactivation path still fatal on it. (DeleteUser
+			// remains fatal on both calls, deliberately out of scope here: a
+			// delete's session/PAT revocation failing partway is a different,
+			// separate question from a plain deactivation's.)
+			_ = tx.DeleteSessionsForUserExcept(ctx, req.ID, 0)
+			return nil
 		})
 	case req.IsActive != nil:
 		// Not deactivating (either re-activating, or a redundant "set to the same
@@ -529,6 +549,82 @@ func (c *KeyorixCore) DeleteUser(ctx context.Context, actorID, id uint) error {
 	c.invalidateTokenCache(patHashes...)
 	c.writeAuditEvent(ctx, EventUserDeleted, actorPtr(actorID), nil,
 		fmt.Sprintf("deleted user %d (%s)", id, user.Username))
+	return nil
+}
+
+// EventUserCredentialsRevoked is audited when an admin-driven bulk PAT/session
+// revocation runs against a target user via RevokeAllPersonalAccessTokensForUser
+// or DeleteSessionsForUserExcept below (the /system proxy layer's direct-caller
+// path — server/http/handlers/users_credentials_proxy.go). #1530: for a
+// node-credential caller these primitives are still reached via the raw
+// storage passthrough with no audit event at all (the same node-relay
+// actor-attribution gap #1530 tracks for the sibling /system proxies) — this
+// event only covers the direct-caller half fixed here.
+const EventUserCredentialsRevoked = "user.credentials_revoked"
+
+// requireUserCredentialsRevokeAuthority is the shared ceiling for
+// RevokeAllPersonalAccessTokensForUser/DeleteSessionsForUserExcept below.
+//
+// Derived, not chosen: core.UpdateUser and core.DeleteUser perform NO
+// caller-authority check of their own on a deactivating transition (only
+// guardLastAdminDeactivation, a target-state invariant with no actor
+// parameter — see its doc in scim.go) — authority is enforced entirely by the
+// HTTP layer, at RequirePermission(permUsersWrite) on PUT /api/v1/users/{id}
+// (server/http/router.go) and identically on POST /api/v1/users/{id}/suspend.
+// "users.write" at GLOBAL scope is therefore the actual ceiling that governs
+// "who may deactivate a user" today. Revoking a user's live PATs/sessions is a
+// sub-operation of that same action (core.UpdateUser's own deactivating
+// branch already does both under a real local transaction — see
+// UpdateUser/DeleteUser above), so it inherits that SAME ceiling here rather
+// than the broader, differently-scoped system.write the /system route group
+// otherwise blanket-gates on: looser would reopen exactly the bypass shape
+// #1552 was filed for; stricter would refuse a caller the operation it
+// belongs to already permits.
+func (c *KeyorixCore) requireUserCredentialsRevokeAuthority(ctx context.Context, actorType string, actorID uint) error {
+	allowed, err := c.AuthorizePrincipal(ctx, actorType, actorID, permUsersWrite, Scope{})
+	if err != nil {
+		return fmt.Errorf("failed to resolve actor authority: %w", err)
+	}
+	if !allowed {
+		return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "revoking a user's credentials requires users.write authority")
+	}
+	return nil
+}
+
+// RevokeAllPersonalAccessTokensForUser authorizes, performs, and audits an
+// admin-driven bulk PAT revocation for targetUserID — the /system proxy
+// layer's direct-caller entry point (RevokeAllPersonalAccessTokensForUserProxy).
+// See requireUserCredentialsRevokeAuthority for the ceiling this enforces.
+func (c *KeyorixCore) RevokeAllPersonalAccessTokensForUser(ctx context.Context, actorType string, actorID, targetUserID uint) ([]string, error) {
+	if err := c.requireUserCredentialsRevokeAuthority(ctx, actorType, actorID); err != nil {
+		return nil, err
+	}
+	hashes, err := c.storage.RevokeAllPersonalAccessTokensForUser(ctx, targetUserID)
+	if err != nil {
+		return nil, err
+	}
+	c.invalidateTokenCache(hashes...)
+	c.writeAuditEvent(ctx, EventUserCredentialsRevoked, actorPtr(actorID), nil,
+		fmt.Sprintf("revoked all personal access tokens for user %d", targetUserID))
+	return hashes, nil
+}
+
+// DeleteSessionsForUserExcept authorizes, performs, and audits an admin-driven
+// session termination for targetUserID (keeping exceptSessionID, if nonzero) —
+// the /system proxy layer's direct-caller entry point
+// (DeleteSessionsForUserExceptProxy). See requireUserCredentialsRevokeAuthority
+// for the ceiling this enforces.
+func (c *KeyorixCore) DeleteSessionsForUserExcept(ctx context.Context, actorType string, actorID, targetUserID, exceptSessionID uint) error {
+	if err := c.requireUserCredentialsRevokeAuthority(ctx, actorType, actorID); err != nil {
+		return err
+	}
+	sessionHashes, _ := c.storage.ListSessionTokenHashesForUser(ctx, targetUserID)
+	if err := c.storage.DeleteSessionsForUserExcept(ctx, targetUserID, exceptSessionID); err != nil {
+		return err
+	}
+	c.invalidateTokenCache(sessionHashes...)
+	c.writeAuditEvent(ctx, EventUserCredentialsRevoked, actorPtr(actorID), nil,
+		fmt.Sprintf("deleted sessions for user %d", targetUserID))
 	return nil
 }
 

--- a/internal/storage/store/remote_auth.go
+++ b/internal/storage/store/remote_auth.go
@@ -125,8 +125,28 @@ func (rs *RemoteStorage) ListSessionsByUser(_ context.Context, _ uint) ([]*model
 	return nil, errUnsupportedRemote
 }
 
-func (rs *RemoteStorage) DeleteSessionsForUserExcept(_ context.Context, _, _ uint) error {
-	return errUnsupportedRemote
+// deleteSessionsForUserExceptWire mirrors RemoteStorage's other small JSON
+// request bodies (e.g. remote_mfa.go's markTOTPStepUsedWire) — a POST body
+// rather than a DELETE-with-query-param, since HTTPClient.Delete takes no
+// body and this call needs a second scalar (exceptSessionID) beyond the path
+// parameter.
+type deleteSessionsForUserExceptWire struct {
+	ExceptSessionID uint `json:"except_session_id"`
+}
+
+// DeleteSessionsForUserExcept proxies to POST
+// /api/v1/system/users/{id}/sessions/delete-except (G80 residual fix — see
+// users_credentials_proxy.go for the server-side authority this closes).
+func (rs *RemoteStorage) DeleteSessionsForUserExcept(ctx context.Context, userID, exceptSessionID uint) error {
+	path := fmt.Sprintf("/api/v1/system/users/%d/sessions/delete-except", userID)
+	resp, err := rs.client.Post(ctx, path, deleteSessionsForUserExceptWire{ExceptSessionID: exceptSessionID})
+	if err != nil {
+		return fmt.Errorf("failed to delete sessions for user: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("delete sessions for user failed: %s", resp.Error.Error())
+	}
+	return nil
 }
 
 func (rs *RemoteStorage) ListSessionTokenHashesForUser(_ context.Context, _ uint) ([]string, error) {
@@ -165,8 +185,33 @@ func (rs *RemoteStorage) RevokePersonalAccessToken(_ context.Context, _ uint) er
 	return errUnsupportedRemote
 }
 
-func (rs *RemoteStorage) RevokeAllPersonalAccessTokensForUser(_ context.Context, _ uint) ([]string, error) {
-	return nil, errUnsupportedRemote
+// revokeAllPersonalAccessTokensForUserResponse mirrors the {"hashes":[...]}
+// shape RevokeAllPersonalAccessTokensForUserProxy returns — the caller needs
+// the revoked hashes back to evict them from its own auth cache, exactly as
+// the local (non-remote) RevokeAllPersonalAccessTokensForUser caller does
+// (internal/core/users.go).
+type revokeAllPersonalAccessTokensForUserResponse struct {
+	Hashes []string `json:"hashes"`
+}
+
+// RevokeAllPersonalAccessTokensForUser proxies to POST
+// /api/v1/system/users/{id}/personal-access-tokens/revoke-all (G80 residual
+// fix — see users_credentials_proxy.go for the server-side authority this
+// closes).
+func (rs *RemoteStorage) RevokeAllPersonalAccessTokensForUser(ctx context.Context, userID uint) ([]string, error) {
+	path := fmt.Sprintf("/api/v1/system/users/%d/personal-access-tokens/revoke-all", userID)
+	resp, err := rs.client.Post(ctx, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to revoke personal access tokens for user: %w", err)
+	}
+	if !resp.Success {
+		return nil, fmt.Errorf("revoke personal access tokens for user failed: %s", resp.Error.Error())
+	}
+	var result revokeAllPersonalAccessTokensForUserResponse
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return result.Hashes, nil
 }
 
 func (rs *RemoteStorage) TouchPersonalAccessToken(_ context.Context, _ uint, _ time.Time, _ time.Duration) error {

--- a/internal/storage/store/remote_auth_test.go
+++ b/internal/storage/store/remote_auth_test.go
@@ -172,14 +172,33 @@ func TestRemoteStorage_SessionStubs_ReturnError(t *testing.T) {
 	_, err = rs.ListSessionsByUser(ctx, 1)
 	assert.Error(t, err)
 
-	err = rs.DeleteSessionsForUserExcept(ctx, 1, 2)
-	assert.Error(t, err)
-
 	_, err = rs.ListSessionTokenHashesForUser(ctx, 1)
 	assert.Error(t, err)
 
 	err = rs.EnforceSessionLimit(ctx, 1, 5)
 	assert.Error(t, err)
+}
+
+// --- DeleteSessionsForUserExcept (G80 residual fix — was errUnsupportedRemote) ---
+
+func TestRemoteStorage_DeleteSessionsForUserExcept(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/users/42/sessions/delete-except", r.URL.Path)
+		var body struct {
+			ExceptSessionID uint `json:"except_session_id"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, uint(7), body.ExceptSessionID)
+		_, _ = w.Write(apiOK(map[string]interface{}{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteSessionsForUserExcept(context.Background(), 42, 7)
+	require.NoError(t, err)
 }
 
 // --- TouchSession (no-op) ---
@@ -217,14 +236,29 @@ func TestRemoteStorage_PATStubs_ReturnError(t *testing.T) {
 	err = rs.RevokePersonalAccessToken(ctx, 1)
 	assert.Error(t, err)
 
-	_, err = rs.RevokeAllPersonalAccessTokensForUser(ctx, 1)
-	assert.Error(t, err)
-
 	_, err = rs.ListExpiredPATsByUser(ctx, 1, time.Now())
 	assert.Error(t, err)
 
 	_, err = rs.BulkRevokeExpiredPATsByUser(ctx, 1, time.Now())
 	assert.Error(t, err)
+}
+
+// --- RevokeAllPersonalAccessTokensForUser (G80 residual fix — was errUnsupportedRemote) ---
+
+func TestRemoteStorage_RevokeAllPersonalAccessTokensForUser(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/users/42/personal-access-tokens/revoke-all", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"hashes": []string{"hash-a", "hash-b"}}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	hashes, err := rs.RevokeAllPersonalAccessTokensForUser(context.Background(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"hash-a", "hash-b"}, hashes)
 }
 
 // --- TouchPersonalAccessToken (no-op) ---

--- a/internal/storage/store/remote_wire_route_coverage_test.go
+++ b/internal/storage/store/remote_wire_route_coverage_test.go
@@ -761,7 +761,7 @@ var knownUnresolvedWireCalls = map[string]bool{
 	"remote_audit.go:28":                      true,
 	"remote_audit.go:53":                      true,
 	"remote_audit.go:95":                      true,
-	"remote_auth.go:317":                      true,
+	"remote_auth.go:362":                      true,
 	"remote_break_glass.go:135":               true,
 	"remote_connector_project_bindings.go:63": true,
 	"remote_dynamic.go:260":                   true,

--- a/server/http/handlers/users_credentials_proxy.go
+++ b/server/http/handlers/users_credentials_proxy.go
@@ -1,0 +1,131 @@
+// users_credentials_proxy.go — server-side endpoints backing RemoteStorage's
+// RevokeAllPersonalAccessTokensForUser/DeleteSessionsForUserExcept storage
+// primitives (G80 residual: the UpdateUserIfActiveStateMatchesProxy
+// "PAT/session revocation half," server/http/raw_storage_bypass_guard_test.go's
+// knownUnfixedRawStorageBypasses entry for that handler).
+//
+// A downstream Keyorix server booted with storage.type: remote (ADR-049)
+// proxies these two storage primitives to whichever upstream server it's
+// configured against, through these routes (registered in
+// server/http/router.go under /api/v1/system/users/{id}/..., inside the
+// existing /system route group). Unlike every OTHER proxy in this package,
+// these do NOT rely on the group's blanket system.write-or-node-credential
+// gate alone for a direct (non-node) caller: core.UpdateUser/core.DeleteUser
+// perform no caller-authority check of their own on a deactivating
+// transition (only guardLastAdminDeactivation, a target-state invariant with
+// no actor parameter) — the actual ceiling that governs "who may deactivate a
+// user" lives entirely at the HTTP layer, on RequirePermission(permUsersWrite)
+// at PUT /api/v1/users/{id} (server/http/router.go). Revoking a user's live
+// PATs/sessions is a sub-operation of that same action (core.UpdateUser's own
+// deactivating branch already does both under a real local transaction), so
+// it must inherit that SAME ceiling, not the broader, differently-scoped
+// system.write these routes also sit behind — see
+// internal/core/users.go's requireUserCredentialsRevokeAuthority doc for the
+// full derivation. isNodeCredentialRequest(r) keeps the raw storage call for
+// a genuine node relay, mirroring every other half-fixed proxy in this
+// package (CreateOIDCBindingProxy, DeleteOIDCBindingProxy,
+// CreateMachineIdentityCredentialProxy) — a genuine relay's downstream
+// already ran this exact check locally before relaying; this remains a
+// documented, tracked HALF-FIXED gap for a node-credential caller, not a
+// full close.
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// deleteSessionsForUserExceptProxyBody mirrors RemoteStorage's
+// deleteSessionsForUserExceptWire (internal/storage/store/remote_auth.go).
+type deleteSessionsForUserExceptProxyBody struct {
+	ExceptSessionID uint `json:"except_session_id"`
+}
+
+// requestActorKindAndID resolves the (actorType, actorID) pair
+// AuthorizePrincipal needs from the request context, defaulting to a
+// zero-value human actor (denied by AuthorizePrincipal, same as every other
+// unauthenticated-relative-to-RBAC caller in this package) when no context is
+// present at all.
+func requestActorKindAndID(r *http.Request) (string, uint) {
+	u := middleware.GetUserFromContext(r.Context())
+	if u == nil {
+		return "user", 0
+	}
+	return u.ActorKind(), u.PrincipalID()
+}
+
+// writeUserCredentialsRevokeError maps requireUserCredentialsRevokeAuthority's
+// denial (a distinctive "users.write authority" substring, mirroring
+// CreateOIDCBindingProxy's own "admin authority is required" substring check)
+// to 403; anything else is a genuine storage/resolution failure, 500.
+func writeUserCredentialsRevokeError(w http.ResponseWriter, op string, err error) {
+	if strings.Contains(err.Error(), "users.write authority") {
+		writeRemoteAPIError(w, http.StatusForbidden, "PERMISSION_DENIED", clientSafe(err))
+		return
+	}
+	log.Printf("users-credentials proxy: %s failed: %v", op, err)
+	writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+}
+
+// RevokeAllPersonalAccessTokensForUserProxy handles POST
+// /api/v1/system/users/{id}/personal-access-tokens/revoke-all.
+func (h *UserHandler) RevokeAllPersonalAccessTokensForUserProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid user id")
+		return
+	}
+	if isNodeCredentialRequest(r) {
+		hashes, err := h.coreService.Storage().RevokeAllPersonalAccessTokensForUser(r.Context(), uint(id))
+		if err != nil {
+			log.Printf("users-credentials proxy: revoke-all-pats failed: %v", err)
+			writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+			return
+		}
+		writeRemoteAPISuccess(w, map[string]interface{}{"hashes": hashes})
+		return
+	}
+	actorType, actorID := requestActorKindAndID(r)
+	hashes, err := h.coreService.RevokeAllPersonalAccessTokensForUser(r.Context(), actorType, actorID, uint(id))
+	if err != nil {
+		writeUserCredentialsRevokeError(w, "revoke-all-pats", err)
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]interface{}{"hashes": hashes})
+}
+
+// DeleteSessionsForUserExceptProxy handles POST
+// /api/v1/system/users/{id}/sessions/delete-except.
+func (h *UserHandler) DeleteSessionsForUserExceptProxy(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid user id")
+		return
+	}
+	var body deleteSessionsForUserExceptProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if isNodeCredentialRequest(r) {
+		if err := h.coreService.Storage().DeleteSessionsForUserExcept(r.Context(), uint(id), body.ExceptSessionID); err != nil {
+			log.Printf("users-credentials proxy: delete-sessions-except failed: %v", err)
+			writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+			return
+		}
+		writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+		return
+	}
+	actorType, actorID := requestActorKindAndID(r)
+	if err := h.coreService.DeleteSessionsForUserExcept(r.Context(), actorType, actorID, uint(id), body.ExceptSessionID); err != nil {
+		writeUserCredentialsRevokeError(w, "delete-sessions-except", err)
+		return
+	}
+	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})
+}

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -425,15 +425,37 @@ var knownUnfixedRawStorageBypasses = map[string]string{
 	"UpdateUserIfActiveStateMatchesProxy": "PARTIALLY FIXED 2026-08-24 (G80 overnight campaign, Tier 1 Group A " +
 		"#3): the last-admin-lockout half is fixed -- core.GuardLastAdminDeactivation now runs before any " +
 		"deactivating transition (FromActive:true, Active:false), a target-state check needing only the target " +
-		"user ID, no RemoteStorage wire-protocol change required. STILL REAL, STILL UNFIXED: the PAT/session " +
-		"revocation half. Separately discovered while checking RemoteStorage impact before this fix: " +
-		"RemoteStorage.RevokeAllPersonalAccessTokensForUser and DeleteSessionsForUserExcept are BOTH stubbed to " +
-		"errUnsupportedRemote (remote_auth.go), and DeleteSessionsForUserExcept's error is NOT discarded -- it " +
-		"propagates and fails core.UpdateUser's whole deactivating-branch transaction. This means the 'correct' " +
-		"full deactivation flow already fails outright over RemoteStorage today, independent of this proxy -- an " +
-		"offboarding failure (cannot deactivate ANY user in connected mode, not just a missing side effect on " +
-		"this one raw call), tracked and assessed separately against the Tier 1 line, not fixed as part of this " +
-		"change.",
+		"user ID, no RemoteStorage wire-protocol change required. The PAT/session revocation half (RemoteStorage." +
+		"RevokeAllPersonalAccessTokensForUser/DeleteSessionsForUserExcept were both hard-stubbed to " +
+		"errUnsupportedRemote, so the 'correct' full deactivation flow failed outright over RemoteStorage) is now " +
+		"fixed 2026-08-25 via two new proxy routes -- see the RevokeAllPersonalAccessTokensForUserProxy/ " +
+		"DeleteSessionsForUserExceptProxy entries below (this handler itself still makes no PAT/session call; the " +
+		"fix lives in the two new routes core.UpdateUser's deactivating branch now succeeds against, and in the " +
+		"RemoteStorage client methods themselves).",
+	// HALF-FIXED 2026-08-25 -- do NOT move to rawStorageBypassAllowlist: CLOSED for
+	// a direct, non-node-credential caller (routes through
+	// core.RevokeAllPersonalAccessTokensForUser/core.DeleteSessionsForUserExcept,
+	// which require "users.write" authority at global scope -- derived, not
+	// chosen, from the ONLY caller-authority check that actually governs a user
+	// deactivation today (RequirePermission(permUsersWrite) on PUT
+	// /api/v1/users/{id}, router.go) since core.UpdateUser/core.DeleteUser
+	// perform no authority check of their own; see
+	// internal/core/users.go's requireUserCredentialsRevokeAuthority doc for the
+	// full derivation, and system_write_ceiling_table_test.go's
+	// RequiresUsersWriteAuthority rows). STILL OPEN for a node-credential
+	// caller: isNodeCredentialRequest(r) routes around the check entirely to the
+	// raw storage call, the same unverified relay-trust assumption
+	// CreateOIDCBindingProxy/CreateMachineIdentityCredentialProxy above make. A
+	// bare node credential can still revoke any user's PATs/sessions with no
+	// authority check and no audit event.
+	"RevokeAllPersonalAccessTokensForUserProxy": "HALF-FIXED: closed for a direct human/machine caller " +
+		"(core.RevokeAllPersonalAccessTokensForUser's users.write-authority check now enforced, plus an audit " +
+		"event); STILL OPEN for a node-credential caller (isNodeCredentialRequest routes around the check to the " +
+		"raw storage call -- see the HALF-FIXED comment immediately above this entry).",
+	"DeleteSessionsForUserExceptProxy": "HALF-FIXED: closed for a direct human/machine caller " +
+		"(core.DeleteSessionsForUserExcept's users.write-authority check now enforced, plus an audit event); " +
+		"STILL OPEN for a node-credential caller (isNodeCredentialRequest routes around the check to the raw " +
+		"storage call -- see the CreateOIDCBindingProxy HALF-FIXED comment above for the shared reasoning).",
 }
 
 // TestNoUnjustifiedRawStorageBypass is #1542's guard, extended by #1547 to cover

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1504,6 +1504,23 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// onto the human-facing PUT /api/v1/users/{id} route.
 			r.Put("/users/{id}/active-transition", userHandler.UpdateUserIfActiveStateMatchesProxy)
 
+			// PAT/session bulk-revocation storage-primitive proxy (G80 residual:
+			// the active-transition proxy's own "PAT/session revocation half,"
+			// left deliberately unfixed there — see its doc comment). Lets a
+			// downstream Keyorix server booted with storage.type: remote
+			// (ADR-049) proxy RevokeAllPersonalAccessTokensForUser/
+			// DeleteSessionsForUserExcept to THIS server's real storage
+			// backend, so a deactivating UpdateUser (or any other admin-driven
+			// credential revocation) actually terminates the target user's
+			// live PATs/sessions instead of failing the whole transition
+			// outright (both were previously hard-stubbed to
+			// errUnsupportedRemote). UNLIKE every other proxy in this group,
+			// these do NOT rely solely on the group's blanket system.write
+			// baseline for a direct caller — see users_credentials_proxy.go's
+			// package doc for the derived users.write ceiling these enforce.
+			r.Post("/users/{id}/personal-access-tokens/revoke-all", userHandler.RevokeAllPersonalAccessTokensForUserProxy)
+			r.Post("/users/{id}/sessions/delete-except", userHandler.DeleteSessionsForUserExceptProxy)
+
 			// Legal-hold storage-primitive proxy (finding #519). Lets a downstream
 			// Keyorix server booted with storage.type: remote (ADR-049) proxy
 			// CreateLegalHold/GetActiveLegalHold/UpdateLegalHold to THIS server's real

--- a/server/http/system_write_ceiling_table_users_test.go
+++ b/server/http/system_write_ceiling_table_users_test.go
@@ -1,0 +1,236 @@
+// system_write_ceiling_table_users_test.go is system_write_ceiling_table_test.go's
+// sibling for the /api/v1/system/users/{id}/personal-access-tokens/revoke-all
+// and /api/v1/system/users/{id}/sessions/delete-except routes
+// (users_credentials_proxy.go) — kept as a separate file rather than folded
+// into that one because those routes are, deliberately, NOT gated the same
+// way as every other route that file covers: they require "users.write"
+// authority for a direct caller (derived from the ONLY caller-authority check
+// that actually governs a user deactivation today — see
+// internal/core/users.go's requireUserCredentialsRevokeAuthority doc), not
+// merely the group's blanket system.write-or-node-credential baseline. This
+// file therefore exercises THREE caller shapes per route, not two: a
+// system.write-ONLY human (must now be DENIED — the ceiling this fix adds;
+// system.write alone satisfies the /system group's own blanket gate but not
+// this fix's additional check), a human holding BOTH system.write AND
+// users.write (must succeed — proves the permission that SHOULD work
+// actually does; users.write alone can never reach this fix's own check at
+// all, since the group's gate rejects it first), and a genuine
+// node-credential relay (still succeeds — the same documented, tracked
+// HALF-FIXED gap as CreateOIDCBindingProxy/CreateMachineIdentityCredentialProxy
+// in system_write_ceiling_table_test.go).
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// userCredentialsCeilingFixtures holds every row this file's requests
+// reference, created once per test run.
+type userCredentialsCeilingFixtures struct {
+	serverURL       string
+	sysWriteToken   string // holds ONLY system.write — must be denied by the new ceiling
+	usersWriteToken string // holds system.write + users.write — must be allowed
+	nodeToken       string // genuine node-credential relay — still allowed (known gap)
+	targetUserID    uint   // the user whose PATs/sessions the requests act on
+}
+
+// createUsersWriteToken mirrors createSystemWriteOnlyToken
+// (system_write_ceiling_test.go), but grants BOTH "system.write" (required to
+// pass the /system route group's own blanket gate before a request ever
+// reaches users_credentials_proxy.go's handlers at all) AND "users.write"
+// (the additional ceiling this fix's handlers themselves enforce) — the
+// combination this file's positive rows prove actually authorizes. A
+// caller holding users.write alone, with no system.write, would be rejected
+// by the route group's gate before this fix's own check is ever reached, so
+// testing that narrower combination would not exercise this fix.
+func createUsersWriteToken(t *testing.T, c *core.KeyorixCore) string {
+	t.Helper()
+	ctx := context.Background()
+
+	_, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "users_write_holder", Email: "users_write_holder@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.RemoveRoleFromUser(ctx, "users_write_holder@example.com", "system_viewer"))
+
+	role, err := c.Storage().CreateRole(ctx, &models.Role{
+		Name: "ceiling_test_users_and_system_writer", Description: "test-only role: system.write + users.write",
+	})
+	require.NoError(t, err)
+
+	perms, err := c.ListPermissions(ctx)
+	require.NoError(t, err)
+	var systemWriteID, usersWriteID uint
+	for _, p := range perms {
+		switch p.Name {
+		case "system.write":
+			systemWriteID = p.ID
+		case "users.write":
+			usersWriteID = p.ID
+		}
+	}
+	require.NotZero(t, systemWriteID, "system.write permission must already be seeded by bootstrap")
+	require.NotZero(t, usersWriteID, "users.write permission must already be seeded by bootstrap")
+
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, usersWriteID))
+	require.NoError(t, c.AssignRoleToUser(ctx, "users_write_holder@example.com", "ceiling_test_users_and_system_writer"))
+
+	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "users_write_holder", Password: "Qr7#Kp2$Lm5@Vn9!"})
+	require.NoError(t, err)
+	return sess.SessionToken
+}
+
+func setupUserCredentialsCeilingFixtures(t *testing.T) userCredentialsCeilingFixtures {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	cfg := &config.Config{}
+	testCore := newTestCore(t)
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+
+	ctx := context.Background()
+	createTestToken(t, testCore) // bootstrap admin + seed roles/permissions (incl. system.write/users.write)
+	sysWriteToken := createSystemWriteOnlyToken(t, testCore)
+	usersWriteToken := createUsersWriteToken(t, testCore)
+	nodeToken := createNodeToken(t, testCore)
+
+	target, err := testCore.GetUserByEmail(ctx, "sys_write_only@example.com")
+	require.NoError(t, err)
+
+	return userCredentialsCeilingFixtures{
+		serverURL:       server.URL,
+		sysWriteToken:   sysWriteToken,
+		usersWriteToken: usersWriteToken,
+		nodeToken:       nodeToken,
+		targetUserID:    target.ID,
+	}
+}
+
+// doUserCredentialsCeilingRequestAs mirrors doCeilingRequestAs
+// (system_write_ceiling_table_test.go) exactly, kept as its own copy since
+// this file deliberately does not depend on that file's ceilingTableFixtures
+// type (see the package doc above for why).
+func doUserCredentialsCeilingRequestAs(t *testing.T, f userCredentialsCeilingFixtures, token, method, path string, body any) (int, string) {
+	t.Helper()
+	var reader *bytes.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(b)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req, err := http.NewRequest(method, f.serverURL+path, reader)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, buf.String()
+}
+
+// TestSystemWriteCeiling_RevokeAllPersonalAccessTokensForUserProxy_RequiresUsersWriteAuthority
+// is the RED-before/GREEN-after proof: a caller holding ONLY system.write
+// (which satisfies the /system route group's own blanket gate) must now be
+// denied — the new users.write ceiling this fix adds on top of that baseline.
+func TestSystemWriteCeiling_RevokeAllPersonalAccessTokensForUserProxy_RequiresUsersWriteAuthority(t *testing.T) {
+	f := setupUserCredentialsCeilingFixtures(t)
+	path := fmt.Sprintf("/api/v1/system/users/%d/personal-access-tokens/revoke-all", f.targetUserID)
+	status, body := doUserCredentialsCeilingRequestAs(t, f, f.sysWriteToken, http.MethodPost, path, nil)
+	t.Logf("RevokeAllPersonalAccessTokensForUserProxy(system.write only): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusForbidden, status,
+		"CEILING VIOLATED: a system.write-only caller must be denied — revoking a user's personal access tokens "+
+			"requires users.write authority (core.RevokeAllPersonalAccessTokensForUser's check), which this caller does not hold")
+}
+
+// TestSystemWriteCeiling_RevokeAllPersonalAccessTokensForUserProxy_UsersWriteSucceeds
+// proves the OTHER half: a caller holding users.write (the derived ceiling)
+// succeeds, so the fix is a real permission check, not an accidental blanket denial.
+func TestSystemWriteCeiling_RevokeAllPersonalAccessTokensForUserProxy_UsersWriteSucceeds(t *testing.T) {
+	f := setupUserCredentialsCeilingFixtures(t)
+	path := fmt.Sprintf("/api/v1/system/users/%d/personal-access-tokens/revoke-all", f.targetUserID)
+	status, body := doUserCredentialsCeilingRequestAs(t, f, f.usersWriteToken, http.MethodPost, path, nil)
+	t.Logf("RevokeAllPersonalAccessTokensForUserProxy(users.write): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status, "a users.write-holding caller must be allowed — that is the derived ceiling")
+}
+
+// TestSystemWriteCeiling_RevokeAllPersonalAccessTokensForUserProxy_NodeCredential_StillBypassesUsersWriteCheck
+// pins the KNOWN, OPEN gap: a node credential still reaches the raw
+// storage.RevokeAllPersonalAccessTokensForUser call unconditionally
+// (isNodeCredentialRequest branch), so it can still revoke any user's PATs
+// with no authority check and no audit event.
+func TestSystemWriteCeiling_RevokeAllPersonalAccessTokensForUserProxy_NodeCredential_StillBypassesUsersWriteCheck(t *testing.T) {
+	f := setupUserCredentialsCeilingFixtures(t)
+	path := fmt.Sprintf("/api/v1/system/users/%d/personal-access-tokens/revoke-all", f.targetUserID)
+	status, body := doUserCredentialsCeilingRequestAs(t, f, f.nodeToken, http.MethodPost, path, nil)
+	t.Logf("RevokeAllPersonalAccessTokensForUserProxy(node credential): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status,
+		"KNOWN GAP (not intended, pending ADR-085's wire-identity decision): a node credential still revokes a "+
+			"user's personal access tokens with no users.write-authority check and no audit event — "+
+			"isNodeCredentialRequest routes it around core.RevokeAllPersonalAccessTokensForUser entirely, on an "+
+			"unverified relay-trust assumption. If this ever goes non-200, update this assertion — that would "+
+			"mean the gap closed, which is the goal, not a regression.")
+}
+
+// TestSystemWriteCeiling_DeleteSessionsForUserExceptProxy_RequiresUsersWriteAuthority
+// is DeleteSessionsForUserExceptProxy's RED-before/GREEN-after row, mirroring
+// the RevokeAllPersonalAccessTokensForUserProxy row above exactly.
+func TestSystemWriteCeiling_DeleteSessionsForUserExceptProxy_RequiresUsersWriteAuthority(t *testing.T) {
+	f := setupUserCredentialsCeilingFixtures(t)
+	path := fmt.Sprintf("/api/v1/system/users/%d/sessions/delete-except", f.targetUserID)
+	status, body := doUserCredentialsCeilingRequestAs(t, f, f.sysWriteToken, http.MethodPost, path, map[string]any{"except_session_id": 0})
+	t.Logf("DeleteSessionsForUserExceptProxy(system.write only): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusForbidden, status,
+		"CEILING VIOLATED: a system.write-only caller must be denied — deleting a user's sessions requires "+
+			"users.write authority (core.DeleteSessionsForUserExcept's check), which this caller does not hold")
+}
+
+// TestSystemWriteCeiling_DeleteSessionsForUserExceptProxy_UsersWriteSucceeds
+// proves the OTHER half for DeleteSessionsForUserExceptProxy.
+func TestSystemWriteCeiling_DeleteSessionsForUserExceptProxy_UsersWriteSucceeds(t *testing.T) {
+	f := setupUserCredentialsCeilingFixtures(t)
+	path := fmt.Sprintf("/api/v1/system/users/%d/sessions/delete-except", f.targetUserID)
+	status, body := doUserCredentialsCeilingRequestAs(t, f, f.usersWriteToken, http.MethodPost, path, map[string]any{"except_session_id": 0})
+	t.Logf("DeleteSessionsForUserExceptProxy(users.write): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status, "a users.write-holding caller must be allowed — that is the derived ceiling")
+}
+
+// TestSystemWriteCeiling_DeleteSessionsForUserExceptProxy_NodeCredential_StillBypassesUsersWriteCheck
+// pins the KNOWN, OPEN gap for DeleteSessionsForUserExceptProxy, mirroring the
+// RevokeAllPersonalAccessTokensForUserProxy node-credential row above.
+func TestSystemWriteCeiling_DeleteSessionsForUserExceptProxy_NodeCredential_StillBypassesUsersWriteCheck(t *testing.T) {
+	f := setupUserCredentialsCeilingFixtures(t)
+	path := fmt.Sprintf("/api/v1/system/users/%d/sessions/delete-except", f.targetUserID)
+	status, body := doUserCredentialsCeilingRequestAs(t, f, f.nodeToken, http.MethodPost, path, map[string]any{"except_session_id": 0})
+	t.Logf("DeleteSessionsForUserExceptProxy(node credential): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status,
+		"KNOWN GAP (not intended, pending ADR-085's wire-identity decision): a node credential still deletes a "+
+			"user's sessions with no users.write-authority check and no audit event — isNodeCredentialRequest "+
+			"routes it around core.DeleteSessionsForUserExcept entirely, on an unverified relay-trust assumption. "+
+			"If this ever goes non-200, update this assertion — that would mean the gap closed, which is the "+
+			"goal, not a regression.")
+}


### PR DESCRIPTION
## Summary

`RemoteStorage.RevokeAllPersonalAccessTokensForUser`/`DeleteSessionsForUserExcept` were both hard-stubbed to `errUnsupportedRemote`, so `core.UpdateUser`'s deactivating branch failed outright over `storage.type: remote` — no user could be deactivated in connected mode, independent of any proxy. This adds real implementations plus two new `/system` routes (`POST .../personal-access-tokens/revoke-all`, `POST .../sessions/delete-except`) for a downstream server to proxy them through.

**Ceiling was derived, not chosen.** `core.UpdateUser`/`core.DeleteUser` perform no caller-authority check of their own on a deactivating transition (only `guardLastAdminDeactivation`, a target-state invariant with no actor parameter) — the only check that actually governs "who may deactivate a user" today is `RequirePermission(permUsersWrite)` at global scope on `PUT /api/v1/users/{id}`. The new routes require exactly that — `users.write`, not the group's broader `system.write` baseline — for a direct caller, plus an audit event (`user.credentials_revoked`) with real actor attribution. A node-credential caller still reaches the raw storage calls unconditionally (`isNodeCredentialRequest` relay-trust exemption, same documented HALF-FIXED shape as `CreateOIDCBindingProxy`/`CreateMachineIdentityCredentialProxy`).

Also fixes two pre-existing bugs surfaced along the way:
- `core.UpdateUser` treated `DeleteSessionsForUserExcept`'s error as fatal to the whole deactivation while `RevokeAllPersonalAccessTokensForUser`'s was already best-effort — an unexplained asymmetry meaning a transient session-deletion failure reported total deactivation failure even after the state flip had already durably committed. Now best-effort on both, matching `SetAccountState`'s own suspend/deactivate path, which already treats this the same way. `DeleteUser` remains fully fatal on both, deliberately unchanged.
- `GetOIDCBindingByID` (`local_machine_credentials.go`) mislabeled every storage error, not just a genuine not-found, as 404 — same root cause and fix shape as `local_sod.go`'s `GetSoDPolicy` bug from the prior PR in this wave (#1560).

This completes the 6-item G80 raw-storage-bypass fix wave (`docs/g80-raw-storage-bypass-triage.md`'s "Fix wave complete" section). Also records the 14 `documented-exception` verdicts from that triage as an explicitly open, not-yet-verified question — `AssignRoleWithExpiryProxy` was one such documented exception before it became the campaign's top finding (#1552).

## Test plan

- [x] `TestUpdateUser_Deactivation_SucceedsDespiteSessionRevocationFailure` proves the error-semantics fix (red-then-green verified: temporarily restored the fatal behavior, confirmed the test fails, restored)
- [x] New `system_write_ceiling_table_users_test.go` proves the derived `users.write` ceiling across all three caller shapes per route (system.write-only human denied, users.write-holding human allowed, node-credential relay still allowed as the documented gap)
- [x] New `TestRemoteStorage_DeleteSessionsForUserExcept`/`TestRemoteStorage_RevokeAllPersonalAccessTokensForUser` prove the real HTTP client implementations against a test server
- [x] `raw_storage_bypass_guard_test.go` and `remote_wire_route_coverage_test.go` guard staleness checks pass
- [x] Full `internal/core`, `internal/storage`, and `server/http` suites green
- [x] `go build ./...`, `go vet ./...` clean
- [x] `gofmt -l` clean on all touched files