### PR TITLE
fix(rbac): close RemoveGlobalAdminRoleGuardedProxy actor-authority gap (G80)

### DIFF
--- a/server/http/handlers/handlers_s13_rbac_test.go
+++ b/server/http/handlers/handlers_s13_rbac_test.go
@@ -11,16 +11,38 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// withNodeCredentialContextS13 attaches a genuine node-credential UserContext
+// (core.MachineTypeNode) to req, matching isNodeCredentialRequest's check
+// (catalog.go). RemoveGlobalAdminRoleGuardedProxy now branches on this: a
+// direct caller (no context, or a non-node context) must additionally hold
+// roles.assign at global scope (the #1552-shape fix, 2026-08-25) before
+// reaching the raw storage.RemoveGlobalAdminRoleGuarded call these tests
+// exercise -- so tests written to probe THAT call's own last-admin-guard
+// mechanics (not the new authority check) must present a node-credential
+// caller to keep reaching it, exactly as they did before the fix.
+func withNodeCredentialContextS13(req *http.Request) *http.Request {
+	nodeID := uint(9001)
+	uc := &middleware.UserContext{
+		ActorType:           core.ActorTypeMachine,
+		MachineIdentityID:   &nodeID,
+		MachineIdentityType: core.MachineTypeNode,
+	}
+	return req.WithContext(context.WithValue(req.Context(), middleware.GetUserContextKey(), uc))
+}
 
 // ── rbac.go: ListRoles ────────────────────────────────────────────────────────
 
@@ -688,6 +710,7 @@ func TestRemoveGlobalAdminRoleGuardedProxy_NotAssigned_S13(t *testing.T) {
 		"/api/v1/system/rbac/global-admin-role/remove-guarded",
 		bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withNodeCredentialContextS13(req)
 	w := httptest.NewRecorder()
 	h.RemoveGlobalAdminRoleGuardedProxy(w, req)
 	// guard passes (user2 still has admin), user3 never had role → ErrRoleNotAssigned → 404
@@ -713,6 +736,7 @@ func TestRemoveGlobalAdminRoleGuardedProxy_LastAdmin_S13(t *testing.T) {
 		"/api/v1/system/rbac/global-admin-role/remove-guarded",
 		bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withNodeCredentialContextS13(req)
 	w := httptest.NewRecorder()
 	h.RemoveGlobalAdminRoleGuardedProxy(w, req)
 	// Only one admin → last-admin guard → 409
@@ -742,6 +766,7 @@ func TestRemoveGlobalAdminRoleGuardedProxy_IgnoresWireSuppliedAdminRoleIDs(t *te
 		"/api/v1/system/rbac/global-admin-role/remove-guarded",
 		bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
+	req = withNodeCredentialContextS13(req)
 	w := httptest.NewRecorder()
 	h.RemoveGlobalAdminRoleGuardedProxy(w, req)
 	assert.Equal(t, http.StatusConflict, w.Code, "an empty wire-supplied admin_role_ids must not bypass the last-admin guard")

--- a/server/http/handlers/rbac_role_grants_proxy.go
+++ b/server/http/handlers/rbac_role_grants_proxy.go
@@ -45,17 +45,22 @@
 // for the routes in this group that remain plain passthroughs). Exactly the
 // same reasoning the #519/#520/#527 proxies in this package already established.
 //
-// One deliberate exception: RemoveGlobalAdminRoleGuardedProxy calls
-// storage.RemoveGlobalAdminRoleGuarded, which DOES evaluate the last-global-admin
-// invariant server-side — not because that's this server's OWN policy decision,
-// but because no real transaction can span the HTTP hop back to the calling
-// server (RemoteStorage.WithTransaction is a no-op passthrough), so whichever
-// server ultimately owns the row is the only one that CAN enforce it atomically.
-// See the storage.Storage interface doc (internal/core/storage/interface.go) and
-// internal/core/rbac_management.go's RemoveUserRole doc for the full reasoning —
-// the same pattern CreateSecretDependencyExclusiveProxy (#260) and
-// AdvanceWebAuthnCredentialCounterProxy (#306/#517) already established for their
-// own TOCTOU classes.
+// One exception with its own atomicity story: RemoveGlobalAdminRoleGuardedProxy
+// calls storage.RemoveGlobalAdminRoleGuarded (for a node-credential relay) or
+// core.RemoveUserRole (for a direct caller) rather than a plain passthrough —
+// not because that's this server's OWN policy decision, but because no real
+// transaction can span the HTTP hop back to the calling server (RemoteStorage.
+// WithTransaction is a no-op passthrough), so whichever server ultimately owns
+// the row is the only one that CAN enforce the last-global-admin invariant
+// atomically. See the storage.Storage interface doc (internal/core/storage/
+// interface.go) and internal/core/rbac_management.go's RemoveUserRole doc for
+// the full reasoning — the same pattern CreateSecretDependencyExclusiveProxy
+// (#260) and AdvanceWebAuthnCredentialCounterProxy (#306/#517) already
+// established for their own TOCTOU classes. HALF-FIXED, see the handler's own
+// doc: the atomicity claim was always true, but it said nothing about WHO may
+// invoke the removal — a direct caller now needs roles.assign at global scope
+// (matching the human-facing DELETE /api/v1/user-roles gate); a node-credential
+// relay is still trusted unconditionally (ADR-085, not yet closed).
 //
 // Response envelope: like the other proxies, these do NOT use the package's
 // generic sendSuccess/sendError helpers — they construct the exact
@@ -76,6 +81,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
 // roleWithExpiryProxyWire mirrors internal/storage/store/remote_rbac.go's
@@ -393,9 +399,31 @@ const (
 
 // RemoveGlobalAdminRoleGuardedProxy handles POST
 // /api/v1/system/rbac/global-admin-role/remove-guarded. See the package doc and
-// the storage.Storage interface doc for why this atomically validates the
-// last-global-admin invariant rather than being a raw passthrough like every
-// other method here.
+// the storage.Storage interface doc for the atomic last-global-admin invariant
+// this preserves across the HTTP hop (both branches below).
+//
+// HALF-FIXED (found during the G80 documented-exception re-verification sweep,
+// same shape as CreateMachineIdentityCredentialProxy/CreateOIDCBindingProxy):
+// the atomicity of the guard was never in question, but the package doc's
+// "deliberate exception" reasoning only defended THAT — it never argued who is
+// allowed to invoke the removal at all, and the raw call had no actor check of
+// any kind. The human-facing equivalent (DELETE /api/v1/user-roles) is gated on
+// roles.assign AT THE TARGET SCOPE (router.go's user-roles route, #342); this
+// route's own gate is only system.write (RequireNodeCredentialOrPermission),
+// materially weaker and, per auth_bootstrap.go's own doc, granted for unrelated
+// reasons (audit checkpoints, legal holds, SoD policies) — a system.write-only
+// caller with no roles.assign, or a bare node credential, could strip a named
+// admin's global-admin role with no audit trail. A direct (non-node-credential)
+// caller is now routed through core.RemoveUserRole after an explicit
+// roles.assign-at-global-scope check (mirroring the human-facing gate), which
+// also closes the missing-audit-event gap for free (RemoveUserRole calls
+// LogRoleRemoved + evictUserSessionCache). A genuine node-credential relay is
+// STILL trusted unconditionally, on the same ADR-085 relay-trust assumption
+// AssignRoleWithExpiryProxy's node branch makes (isNodeCredentialRequest always
+// resolves actorID(r)==0, and AuthorizePrincipal would deny a node's own
+// by-design-permission-free identity outright, denying every legitimate relay
+// too) — NOT closed, tracked the same way as the machine-identity/OIDC-binding
+// HALF-FIXED entries in raw_storage_bypass_guard_test.go.
 func (h *RBACHandler) RemoveGlobalAdminRoleGuardedProxy(w http.ResponseWriter, r *http.Request) {
 	var body removeGlobalAdminRoleGuardedProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -406,8 +434,25 @@ func (h *RBACHandler) RemoveGlobalAdminRoleGuardedProxy(w http.ResponseWriter, r
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id and role_id are required")
 		return
 	}
-	adminRoleIDs := resolveInstallAdminRoleIDsProxy(r.Context(), h.coreService.Storage())
-	err := h.coreService.Storage().RemoveGlobalAdminRoleGuarded(r.Context(), body.UserID, body.RoleID, adminRoleIDs)
+
+	var err error
+	if isNodeCredentialRequest(r) {
+		adminRoleIDs := resolveInstallAdminRoleIDsProxy(r.Context(), h.coreService.Storage())
+		err = h.coreService.Storage().RemoveGlobalAdminRoleGuarded(r.Context(), body.UserID, body.RoleID, adminRoleIDs)
+	} else {
+		userCtx := middleware.GetUserFromContext(r.Context())
+		if userCtx == nil {
+			writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN",
+				"removing a global-admin role grant requires the roles.assign permission at global scope")
+			return
+		}
+		if ok, aerr := h.coreService.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), "roles.assign", coreStorage.Scope{}); aerr != nil || !ok {
+			writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN",
+				"removing a global-admin role grant requires the roles.assign permission at global scope")
+			return
+		}
+		err = h.coreService.RemoveUserRole(r.Context(), actorID(r), body.UserID, body.RoleID, coreStorage.Scope{})
+	}
 	if err != nil {
 		switch {
 		case errors.Is(err, coreStorage.ErrWouldStrandLastAdmin):

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -182,9 +182,6 @@ func isReadShapedStorageMethod(method string) bool {
 // found calling a wrapped storage method (the #1542 shape recurring), or if a
 // listed entry no longer applies (fixed and forgotten).
 var rawStorageBypassAllowlist = map[string]string{
-	"RemoveGlobalAdminRoleGuardedProxy": "deliberate exception, not a gap: no real transaction spans the HTTP hop " +
-		"back to the calling server (RemoteStorage.WithTransaction is a no-op), so the last-global-admin invariant " +
-		"can only be enforced atomically by whichever server owns the row -- see rbac_role_grants_proxy.go's package doc.",
 	"ClearProjectSecretOwnershipProxy": "false positive: the exported core wrapper (RemoveProjectMember) calls this " +
 		"storage method only as a best-effort CLEANUP side effect of removing a member, not as its own gated " +
 		"operation -- there is no independent ceiling for 'clear ownership' alone to bypass.",
@@ -349,6 +346,29 @@ var rawStorageBypassAllowlist = map[string]string{
 // originally-listed entries were deleted outright — G80 liveness sweep found no
 // live caller for any of them; see docs/g80-remediation-notes.md.)
 var knownUnfixedRawStorageBypasses = map[string]string{
+	// HALF-FIXED 2026-08-25 (G80 documented-exception re-verification sweep) --
+	// do NOT move to rawStorageBypassAllowlist: CLOSED for a direct,
+	// non-node-credential caller (now routed through core.RemoveUserRole after
+	// an explicit AuthorizePrincipal(roles.assign, global scope) check --
+	// mirroring the human-facing DELETE /api/v1/user-roles gate -- which also
+	// fixes the missing audit event, since RemoveUserRole calls LogRoleRemoved +
+	// evictUserSessionCache. STILL OPEN for a node-credential caller:
+	// isNodeCredentialRequest(r) routes around the check entirely to the raw
+	// storage.RemoveGlobalAdminRoleGuarded call, on the same unverified
+	// relay-trust assumption AssignRoleWithExpiryProxy's node branch made before
+	// #1552 (ADR-085's still-unresolved "harder question" -- the wire carries no
+	// field attesting which human/decision a relayed action actually traces to).
+	// A bare node credential -- zero RBAC permissions by design (ADR-030) --
+	// can still strip any admin's global-admin role (down to the last one) by
+	// calling this route directly, with nothing distinguishing that from a
+	// genuine relay. See system_write_ceiling_table_test.go's
+	// RemoveGlobalAdminRoleGuardedProxy rows for the live, asserted evidence
+	// (both the fixed direct-caller path and the still-open node-credential
+	// path).
+	"RemoveGlobalAdminRoleGuardedProxy": "HALF-FIXED: closed for a direct system.write-only human/machine caller " +
+		"(core.RemoveUserRole + an explicit roles.assign-at-global-scope check now enforced, which also adds the " +
+		"previously-missing audit event); STILL OPEN for a node-credential caller (isNodeCredentialRequest routes " +
+		"around the check to the raw storage call -- see the HALF-FIXED comment immediately above this entry).",
 	"TransitionMembershipProxy": "UNRESOLVED, not confirmed real or safe -- filed as #1546. The exported wrapper " +
 		"(TransitionMembership) gates activation with requireAuthorityForRole and grants/revokes the underlying " +
 		"role grant as a side effect neither of which this raw call performs; whether that's covered by a " +

--- a/server/http/system_write_ceiling_table_test.go
+++ b/server/http/system_write_ceiling_table_test.go
@@ -60,18 +60,65 @@ import (
 // mutate state use their OWN dedicated fixture, never one another case depends on
 // reading unmutated).
 type ceilingTableFixtures struct {
-	serverURL     string
-	token         string // system.write-only human caller under test
-	nodeToken     string // genuine node-credential relay caller (createNodeToken)
-	projectID     uint
-	plainMachine  uint // ordinary machine identity, no roles
-	adminMachine  uint // holds the admin-tier "system_admin" role at global scope
-	revokedMach   uint // machine identity already in state=revoked
-	plainCredID   uint // existing, non-revoked credential on plainMachine
-	revokedCredID uint // existing, ALREADY-revoked credential on plainMachine
-	bindingID     uint // existing OIDC binding on plainMachine
-	normalRoleID  uint // a non-admin-tier role
-	adminRoleID   uint // system_admin's role ID
+	serverURL         string
+	token             string // system.write-only human caller under test
+	nodeToken         string // genuine node-credential relay caller (createNodeToken)
+	rolesAssignToken  string // system.write + roles.assign human caller (createSystemWriteAndRolesAssignToken)
+	projectID         uint
+	plainMachine      uint // ordinary machine identity, no roles
+	adminMachine      uint // holds the admin-tier "system_admin" role at global scope
+	revokedMach       uint // machine identity already in state=revoked
+	plainCredID       uint // existing, non-revoked credential on plainMachine
+	revokedCredID     uint // existing, ALREADY-revoked credential on plainMachine
+	bindingID         uint // existing OIDC binding on plainMachine
+	normalRoleID      uint // a non-admin-tier role
+	adminRoleID       uint // system_admin's role ID
+	secondAdminUserID uint // a SECOND global-admin user (system_admin), distinct from the bootstrap admin
+}
+
+// createSystemWriteAndRolesAssignToken creates a human user holding system.write
+// AND roles.assign, via a custom role well outside adminRoleNames (same rationale
+// as createSystemWriteOnlyToken — an admin-tier role would bypass every
+// permission check and make a test asserting on roles.assign specifically
+// vacuous). Represents the legitimate direct caller RemoveGlobalAdminRoleGuardedProxy's
+// fix is meant to keep working: someone who actually holds the same authority the
+// human-facing DELETE /api/v1/user-roles route already requires for this operation.
+func createSystemWriteAndRolesAssignToken(t *testing.T, c *core.KeyorixCore) string {
+	t.Helper()
+	ctx := context.Background()
+
+	_, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "sys_write_roles_assign", Email: "sys_write_roles_assign@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.RemoveRoleFromUser(ctx, "sys_write_roles_assign@example.com", "system_viewer"))
+
+	role, err := c.Storage().CreateRole(ctx, &models.Role{
+		Name: "ceiling_test_system_writer_roles_assign", Description: "test-only role: system.write + roles.assign, nothing else",
+	})
+	require.NoError(t, err)
+
+	perms, err := c.ListPermissions(ctx)
+	require.NoError(t, err)
+	var systemWriteID, rolesAssignID uint
+	for _, p := range perms {
+		switch p.Name {
+		case "system.write":
+			systemWriteID = p.ID
+		case "roles.assign":
+			rolesAssignID = p.ID
+		}
+	}
+	require.NotZero(t, systemWriteID, "system.write permission must already be seeded by bootstrap")
+	require.NotZero(t, rolesAssignID, "roles.assign permission must already be seeded by bootstrap")
+
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, rolesAssignID))
+	require.NoError(t, c.AssignRoleToUser(ctx, "sys_write_roles_assign@example.com", "ceiling_test_system_writer_roles_assign"))
+
+	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "sys_write_roles_assign", Password: "Qr7#Kp2$Lm5@Vn9!"})
+	require.NoError(t, err)
+	return sess.SessionToken
 }
 
 func setupCeilingTableFixtures(t *testing.T) ceilingTableFixtures {
@@ -129,25 +176,41 @@ func setupCeilingTableFixtures(t *testing.T) ceilingTableFixtures {
 	normalRole, err := testCore.Storage().CreateRole(ctx, &models.Role{Name: "ceiling_table_normal_role", Description: "non-admin"})
 	require.NoError(t, err)
 
+	// A SECOND global admin, distinct from the bootstrap admin, so
+	// RemoveGlobalAdminRoleGuardedProxy rows can remove ITS system_admin grant
+	// without tripping the last-admin guard (the bootstrap admin survives as the
+	// remaining admin either way) -- isolating the actor-authority ceiling this
+	// row tests from the target-state ceiling other tests already cover.
+	_, err = testCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "ceiling-table-second-admin", Email: "ceiling-table-second-admin@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	require.NoError(t, testCore.AssignRoleToUser(ctx, "ceiling-table-second-admin@example.com", "system_admin"))
+	secondAdmin, err := testCore.GetUserByEmail(ctx, "ceiling-table-second-admin@example.com")
+	require.NoError(t, err)
+
 	token := createSystemWriteOnlyToken(t, testCore)
 	// createNodeToken (integration_test.go) also calls createTestToken internally —
 	// safe to call again here since createTestToken tolerates an already-initialized
 	// system (logs and continues rather than failing).
 	nodeToken := createNodeToken(t, testCore)
+	rolesAssignToken := createSystemWriteAndRolesAssignToken(t, testCore)
 
 	return ceilingTableFixtures{
-		serverURL:     server.URL,
-		token:         token,
-		nodeToken:     nodeToken,
-		projectID:     projectID,
-		plainMachine:  plainMachine.ID,
-		adminMachine:  adminMachine.ID,
-		revokedMach:   revokedMachine.ID,
-		plainCredID:   plainCred.ID,
-		revokedCredID: revokedCred.ID,
-		bindingID:     binding.ID,
-		normalRoleID:  normalRole.ID,
-		adminRoleID:   adminRole.ID,
+		serverURL:         server.URL,
+		token:             token,
+		nodeToken:         nodeToken,
+		rolesAssignToken:  rolesAssignToken,
+		projectID:         projectID,
+		plainMachine:      plainMachine.ID,
+		adminMachine:      adminMachine.ID,
+		revokedMach:       revokedMachine.ID,
+		plainCredID:       plainCred.ID,
+		revokedCredID:     revokedCred.ID,
+		bindingID:         binding.ID,
+		normalRoleID:      normalRole.ID,
+		adminRoleID:       adminRole.ID,
+		secondAdminUserID: secondAdmin.ID,
 	}
 }
 
@@ -343,6 +406,43 @@ func TestSystemWriteCeiling_DeleteOIDCBindingProxy_VerifiesOwnership(t *testing.
 	require.Equal(t, http.StatusOK, status, "the delete itself is expected to succeed for a binding that IS legitimately owned by its machine")
 }
 
+// TestSystemWriteCeiling_RemoveGlobalAdminRoleGuardedProxy_DeniesWithoutRolesAssign
+// is the table's RemoveGlobalAdminRoleGuardedProxy row (G80 documented-exception
+// re-verification sweep, 2026-08-25). Ceiling: the human-facing equivalent
+// (DELETE /api/v1/user-roles) requires roles.assign AT THE TARGET SCOPE
+// (router.go's user-roles route, #342); this proxy's OWN gate was only
+// system.write (RequireNodeCredentialOrPermission), materially weaker and, per
+// auth_bootstrap.go's own doc, granted for unrelated reasons (audit checkpoints,
+// legal holds, SoD policies). FIXED: a direct (non-node-credential) caller now
+// needs roles.assign at global scope. RED before the fix: f.token (system.write,
+// no roles.assign) could strip f.secondAdminUserID's system_admin grant outright.
+func TestSystemWriteCeiling_RemoveGlobalAdminRoleGuardedProxy_DeniesWithoutRolesAssign(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequest(t, f, http.MethodPost, "/api/v1/system/rbac/global-admin-role/remove-guarded", map[string]any{
+		"user_id": f.secondAdminUserID, "role_id": f.adminRoleID,
+	})
+	t.Logf("RemoveGlobalAdminRoleGuardedProxy(system.write only, target=second-admin): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusForbidden, status,
+		"CEILING VIOLATED: a system.write-only caller with no roles.assign must be denied removal of another "+
+			"user's global-admin role grant — the atomicity of the last-admin guard was never the gap; the missing "+
+			"actor-authority check was")
+}
+
+// TestSystemWriteCeiling_RemoveGlobalAdminRoleGuardedProxy_AllowsWithRolesAssign is
+// this row's companion control: a caller who legitimately holds roles.assign (the
+// SAME authority the human-facing route already requires) must still be able to
+// perform this operation — the fix must not turn into a blanket denial.
+func TestSystemWriteCeiling_RemoveGlobalAdminRoleGuardedProxy_AllowsWithRolesAssign(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequestAs(t, f, f.rolesAssignToken, http.MethodPost, "/api/v1/system/rbac/global-admin-role/remove-guarded", map[string]any{
+		"user_id": f.secondAdminUserID, "role_id": f.adminRoleID,
+	})
+	t.Logf("RemoveGlobalAdminRoleGuardedProxy(roles.assign holder, target=second-admin): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status,
+		"a caller who genuinely holds roles.assign at global scope must still be able to remove another admin's "+
+			"grant — the last-admin guard passes here because the bootstrap admin survives as the remaining admin")
+}
+
 // ── Node-credential-path rows ────────────────────────────────────────────────
 //
 // The three rows below exercise the SAME routes above, but with f.nodeToken (a
@@ -449,4 +549,24 @@ func TestSystemWriteCeiling_DeleteOIDCBindingProxy_NodeCredential_StillBypassesO
 			"OIDC binding with no ownership check and no audit event — isNodeCredentialRequest routes it around "+
 			"core.DeleteOIDCBinding entirely, on an unverified relay-trust assumption. If this ever goes non-200, "+
 			"update this assertion — that would mean the gap closed, which is the goal, not a regression.")
+}
+
+// TestSystemWriteCeiling_RemoveGlobalAdminRoleGuardedProxy_NodeCredential_StillBypassesAuthorityCheck
+// pins the KNOWN, OPEN gap: unlike the human-caller row above (now 403), a node
+// credential still reaches the raw storage.RemoveGlobalAdminRoleGuarded call
+// unconditionally (isNodeCredentialRequest branch, rbac_role_grants_proxy.go),
+// so it can still strip any admin's global-admin role (down to the last one) with
+// no roles.assign check and no audit event.
+func TestSystemWriteCeiling_RemoveGlobalAdminRoleGuardedProxy_NodeCredential_StillBypassesAuthorityCheck(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequestAs(t, f, f.nodeToken, http.MethodPost, "/api/v1/system/rbac/global-admin-role/remove-guarded", map[string]any{
+		"user_id": f.secondAdminUserID, "role_id": f.adminRoleID,
+	})
+	t.Logf("RemoveGlobalAdminRoleGuardedProxy(node credential, target=second-admin): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status,
+		"KNOWN GAP (not intended, pending ADR-085's wire-identity decision): a node credential still strips a "+
+			"named admin's global-admin role grant with no roles.assign check and no audit event — "+
+			"isNodeCredentialRequest routes it around the new check entirely, on an unverified relay-trust "+
+			"assumption. If this ever goes non-200, update this assertion — that would mean the gap closed, which "+
+			"is the goal, not a regression.")
 }


### PR DESCRIPTION
## Summary
- `RemoveGlobalAdminRoleGuardedProxy`'s documented-exception only defended the atomicity of its last-global-admin guard — it never argued who may invoke the removal at all, and had no actor check of any kind. Its gate (`system.write`) is materially weaker than the human-facing `DELETE /api/v1/user-roles` route's `roles.assign`-at-scope gate for the identical operation, and a bare node credential (zero RBAC permissions by design) could reach it too.
- A direct (non-node-credential) caller is now required to hold `roles.assign` at global scope before the removal proceeds through `core.RemoveUserRole`, which also closes the missing-audit-event gap for free (`LogRoleRemoved` + `evictUserSessionCache`).
- A genuine node-credential relay is still trusted unconditionally on the same ADR-085 relay-trust assumption `AssignRoleWithExpiryProxy`'s node branch makes — HALF-FIXED, not closed, tracked the same way as the machine-identity/OIDC-binding HALF-FIXED entries.

## Test plan
- [x] `system_write_ceiling_table_test.go`'s three new rows (`DeniesWithoutRolesAssign` / `AllowsWithRolesAssign` / `NodeCredential_StillBypassesAuthorityCheck`) confirmed failing against the unfixed handler before this change (red-then-green).
- [x] Full `server/http`, `internal/core`, `internal/storage` suites green.
- [x] `gosec -severity medium -exclude-generated` clean.