### PR TITLE
fix(break-glass): make RevokeBreakGlassActivationProxy self-contained (G80)

### DIFF
--- a/docs/g80-documented-exception-sweep-findings.md
+++ b/docs/g80-documented-exception-sweep-findings.md
@@ -1,0 +1,79 @@
+# G80 documented-exception re-verification sweep — findings pending GitHub filing
+
+`gh` is broken in the working environment (invalid keyring token, plus a TLS
+certificate error on the device-auth flow: `x509: OSStatus -26276`). The items
+below are staged here so they can be pasted into GitHub once `gh auth` (or
+manual web filing) is available. Do not let this doc substitute for the actual
+issue/comment — file these for real as soon as possible.
+
+## New issue: CleanupExpiredSessions is implemented but wired to no scheduler
+
+**Confirmed**: `CleanupExpiredSessions` (`internal/core/storage/interface.go:1318`,
+implemented in `internal/storage/store/local_auth.go:224` and
+`internal/storage/store/remote_auth.go:83`) has zero callers anywhere in the
+repo. `server/main.go:1187`'s `startSchedulers` registers 18 named background
+schedulers (anomaly_detection, retention_purge, data_retention,
+rotation_reminder, expiry_reminder, certificate_expiry, license_expiry,
+auto_rotation, compliance_digest, recertification, evidence_delivery,
+audit_checkpoint, jit_access_expiry, dynamic_secret_sweep,
+login_attempt_prune, mfa_stepup_grant_prune, read_quota_alerts) — none of them
+sweep expired sessions.
+
+**Not a vulnerability**: `ValidateSessionToken` (`internal/core/auth.go:461`)
+re-checks expiry and account state on every use, so an orphaned session row is
+inert — it can never be used to authenticate once past its `ExpiresAt`.
+
+**Why it still matters**: Keyorix is designed to run on-prem, unattended, for
+years. With no sweep, the `sessions` table accumulates one dead row per login
+forever — an unbounded-growth/table-bloat issue in a long-lived deployment,
+not a security bypass.
+
+**Suggested issue title**: "CleanupExpiredSessions has no scheduler — sessions
+table grows unbounded in long-running deployments"
+
+**Suggested body**: as the "Confirmed"/"Not a vulnerability"/"Why it still
+matters" text above, with the four file:line references.
+
+**Labels**: `tech-debt`, `ops`. Not `security` — validation already fails
+closed on an expired/orphaned row.
+
+---
+
+## Comment on #1511 (missing `/api/v1/rbac/remove-role` wire route)
+
+**Context**: #1511 already tracks that `POST /api/v1/rbac/remove-role` and
+`POST /api/v1/rbac/assign-role` are unregistered
+(`internal/storage/store/remote_wire_route_coverage_test.go`'s
+`knownMissingRoutes`). This was previously filed as a coverage gap. The G80
+documented-exception re-verification sweep (2026-08-25) found it has now
+caused a **confirmed live security failure**, not just a theoretical gap.
+
+**Comment text to post**:
+
+> Confirmed live impact, not just a coverage gap: `/api/v1/rbac/remove-role`
+> being unregistered isn't only a theoretical wire-coverage hole — it broke a
+> real security control. `RevokeBreakGlassActivationProxy`
+> (`server/http/handlers/break_glass_proxy.go`) was documented as safe on the
+> assumption that its offsetting role-removal effect travels through
+> `core.RevokeBreakGlass`'s own separate call chain. It doesn't:
+> `core.RevokeBreakGlass` (`internal/core/break_glass.go:272`) calls
+> `RemoveUserRole` → `storage.RemoveRole` → `RemoteStorage.RemoveRole` →
+> `POST /api/v1/rbac/remove-role`, which 404s because the route was never
+> registered. Under `storage.type: remote`, this meant the legitimate
+> break-glass revoke flow could never complete at all when a role grant was
+> still live — and the raw storage proxy
+> (`POST /api/v1/system/break-glass/{id}/revoke`), independently reachable by
+> anyone holding `system.write`, was the only path that succeeded, doing so
+> without removing the underlying role grant or writing an audit event.
+>
+> Fixed at the proxy layer directly (2026-08-25): it now performs the role
+> removal and audit write itself, inline, rather than relying on the missing
+> route. But the missing route itself is still open and affects every other
+> project-scoped `RemoveUserRole` caller under `storage.type: remote` (SSO
+> deprovisioning, project-member removal, access-review revocation,
+> invitation cleanup, the direct RBAC handler, the gRPC role service) —
+> recommend prioritizing `/api/v1/rbac/remove-role` (and its mirror-image gap
+> `/api/v1/rbac/assign-role`) ahead of the rest of this backlog.
+
+**Escalation note**: consider whether #1511's severity/priority label should
+change given this is no longer purely theoretical.

--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -285,9 +285,20 @@ func (c *KeyorixCore) RevokeBreakGlass(ctx context.Context, actorID, projectID, 
 		}
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
-	c.auditProjectScoped(ctx, EventBreakGlassRevoked, actorID, projectID,
-		fmt.Sprintf("break-glass: revoked activation %d (user %d, role %q) early", activation.ID, activation.UserID, activation.RoleName))
+	c.LogBreakGlassRevoked(ctx, actorID, projectID, activation.ID, activation.UserID, activation.RoleID, activation.RoleName)
 	return nil
+}
+
+// LogBreakGlassRevoked records an EventBreakGlassRevoked audit event for an early
+// (pre-TTL) break-glass revocation. Exported so a raw storage-primitive proxy
+// (RevokeBreakGlassActivationProxy, server/http/handlers/break_glass_proxy.go) that
+// deliberately does not call RevokeBreakGlass itself — the proxy must not rerun
+// this server's own project-affiliation validation against a caller relaying
+// another server's already-decided revoke — can still record the same audit
+// event RevokeBreakGlass does, instead of silently skipping it.
+func (c *KeyorixCore) LogBreakGlassRevoked(ctx context.Context, actorID, projectID, activationID, userID, roleID uint, roleName string) {
+	c.auditProjectScoped(ctx, EventBreakGlassRevoked, actorID, projectID,
+		fmt.Sprintf("break-glass: revoked activation %d (user %d, role %q) early", activationID, userID, roleName))
 }
 
 // notifyBreakGlassAdmins alerts the project's approver-role members that emergency

--- a/internal/storage/store/local_break_glass.go
+++ b/internal/storage/store/local_break_glass.go
@@ -4,12 +4,14 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
@@ -42,7 +44,20 @@ func (ls *LocalStorage) CreateBreakGlassActivation(ctx context.Context, a *model
 func (ls *LocalStorage) GetBreakGlassActivation(ctx context.Context, id uint) (*models.BreakGlassActivation, error) {
 	var a models.BreakGlassActivation
 	if err := ls.db.WithContext(ctx).First(&a, id).Error; err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+		// Was an unconditional "not found" wrap regardless of the underlying error,
+		// so a genuine storage failure (e.g. a closed/unreachable DB) read
+		// identically to a real not-found to any caller doing the same string-match
+		// server/http/handlers.isNotFoundErr does -- RevokeBreakGlassActivationProxy
+		// (server/http/handlers/break_glass_proxy.go), which started calling this
+		// method as part of the G80 documented-exception fix, surfaced this as a
+		// wrong 404 instead of 500 for a real storage error. Distinguish genuine
+		// not-found (gorm.ErrRecordNotFound) from everything else, matching
+		// GetMachineIdentityCredentialByID's (local_machine_credentials.go) already-
+		// established pattern for the same bug class.
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
+		}
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	return &a, nil
 }

--- a/server/http/handlers/break_glass_proxy.go
+++ b/server/http/handlers/break_glass_proxy.go
@@ -15,16 +15,24 @@
 //
 // These are thin passthroughs onto the SAME storage.Storage primitives
 // internal/core/break_glass.go already uses against a local backend — NO
-// break-glass POLICY decision (policy-enabled check, project-affiliation check,
-// emergency-role containment checks, TTL clamping, the actual JIT role grant) is
-// made here; all of that stays entirely in the CALLING server's own
-// internal/core.KeyorixCore, exactly as it does against a local backend. The
-// existing human-facing /api/v1/projects/{id}/break-glass routes
-// (server/http/handlers/break_glass.go, CatalogHandler.ActivateBreakGlass/
+// break-glass ACTIVATION policy decision (policy-enabled check, project-
+// affiliation check, emergency-role containment checks, TTL clamping, the
+// actual JIT role grant) is made here; all of that stays entirely in the
+// CALLING server's own internal/core.KeyorixCore, exactly as it does against a
+// local backend. The existing human-facing /api/v1/projects/{id}/break-glass
+// routes (server/http/handlers/break_glass.go, CatalogHandler.ActivateBreakGlass/
 // ListBreakGlassActivations/RevokeBreakGlass) are NOT reused for this proxy: they
 // run this server's OWN core.ActivateBreakGlass/RevokeBreakGlass against the HTTP
 // caller's own identity, which is the wrong semantics for a raw storage-primitive
 // passthrough whose caller already ran all of that on the downstream side.
+//
+// One exception: RevokeBreakGlassActivationProxy is NOT a thin passthrough (see
+// its own doc). A prior version of this comment claimed the role-removal
+// side effect of a revoke "travels through its own separate proxied call
+// chain" — that claim was false (the chain's wire route was never registered,
+// #1511) and the raw passthrough it justified left revoked activations with a
+// still-live role grant and no audit trail. The handler now performs the
+// state guard + role removal + audit inline itself.
 //
 // Atomicity note — the critical property for this subsystem (docs/security/
 // BUGS.md #104, PR #670): RevokeBreakGlassActivation is a single conditional
@@ -49,6 +57,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -170,12 +179,40 @@ type breakGlassRevokeProxyRequest struct {
 }
 
 // RevokeBreakGlassActivationProxy handles POST
-// /api/v1/system/break-glass/{id}/revoke. Calls storage.RevokeBreakGlassActivation
-// DIRECTLY — the SAME single conditional `UPDATE ... WHERE id = ? AND
-// state = 'active'` local_break_glass.go's RevokeBreakGlassActivation performs —
-// rather than a client-side "GET, check state, then PUT" sequence, which would
-// reopen the exact double-revoke TOCTOU race that conditional write exists to
-// close. One HTTP round trip maps to one atomic server-side conditional UPDATE.
+// /api/v1/system/break-glass/{id}/revoke.
+//
+// FALSE justification, found and fixed (G80 documented-exception re-verification
+// sweep): this handler used to call storage.RevokeBreakGlassActivation ALONE, on
+// the theory that the offsetting role-removal effect "travels through its own
+// separate proxied call chain" (core.RevokeBreakGlass's own RemoveUserRole step).
+// That chain does not exist end-to-end: core.RevokeBreakGlass's RemoveUserRole
+// call, for a project-scoped role, resolves to RemoteStorage.RemoveRole POSTing
+// to /api/v1/rbac/remove-role — a route that was never registered
+// (remote_wire_route_coverage_test.go's knownMissingRoutes, #1511). Under
+// storage.type: remote, that means core.RevokeBreakGlass could never actually
+// complete a revoke with a live role grant at all; this raw proxy — independently
+// reachable by anyone holding system.write, per #1542's router-group reasoning —
+// was the ONLY path that succeeded, and it left the emergency role grant LIVE in
+// user_roles (the table RBAC actually reads) while reporting the activation
+// revoked, with no audit event. Fixed by making the proxy self-contained: it now
+// performs the same effects core.RevokeBreakGlass would (state guard, role
+// removal, conditional revoke, audit), inline, with no new wire hop — mirroring
+// the precedent this same #1542 campaign already set for
+// AssignRoleWithExpiryProxy/RemoveAllProjectRoleGrantsProxy on this same
+// RequireNodeCredentialOrPermission gate. It deliberately does NOT call
+// core.RevokeBreakGlass directly: that function wraps storage.ErrBreakGlassNotActive
+// in a new plain-text error rather than propagating it via %w, which would break
+// this route's wire contract (breakGlassNotActiveCode, which
+// RemoteStorage.RevokeBreakGlassActivation's client depends on to reconstruct the
+// sentinel) — the raw conditional-UPDATE call and its existing error translation
+// are kept exactly as they were; only the missing role-removal and audit steps
+// were added around it.
+//
+// The missing /api/v1/rbac/remove-role route itself (#1511) is a separate,
+// broader fix — internal/core.RemoveUserRole's OTHER project-scoped callers (SSO
+// deprovisioning, project-member removal, access-review revocation, invitation
+// cleanup, the direct RBAC handler, the gRPC role service) are equally affected
+// under storage.type: remote — tracked there, not fixed here.
 func (h *CatalogHandler) RevokeBreakGlassActivationProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
@@ -191,6 +228,41 @@ func (h *CatalogHandler) RevokeBreakGlassActivationProxy(w http.ResponseWriter, 
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "revoked_by is required")
 		return
 	}
+
+	activation, err := h.coreService.Storage().GetBreakGlassActivation(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "break-glass activation not found")
+			return
+		}
+		log.Printf("break-glass proxy: revoke activation: get failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+
+	// Fast-path guard BEFORE touching the role grant, mirroring core.RevokeBreakGlass's
+	// own ordering: without this, a stale/duplicate revoke replayed against an
+	// ALREADY-revoked activation would still remove RoleID from UserID even if that
+	// same role had since been re-granted for an unrelated, legitimate reason — the
+	// conditional UPDATE below only protects the STATE TRANSITION from a concurrent
+	// double-revoke race, not this sequential case.
+	if activation.State != core.BreakGlassActive {
+		writeRemoteAPIError(w, http.StatusConflict, breakGlassNotActiveCode, coreStorage.ErrBreakGlassNotActive.Error())
+		return
+	}
+
+	// Remove the grant early — best-effort, mirroring core.RevokeBreakGlass: it may
+	// already be gone (auto-expired, or a racing revoke's own removal already ran);
+	// only a genuine storage failure aborts here, since proceeding to mark the
+	// record revoked while removal itself failed would leave the grant LIVE in
+	// user_roles but reported revoked everywhere else.
+	scope := coreStorage.Scope{ProjectID: activation.ProjectID}
+	if err := h.coreService.RemoveUserRole(r.Context(), body.RevokedBy, activation.UserID, activation.RoleID, scope); err != nil && !errors.Is(err, coreStorage.ErrRoleNotAssigned) {
+		log.Printf("break-glass proxy: revoke activation: role removal failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+
 	if err := h.coreService.Storage().RevokeBreakGlassActivation(r.Context(), uint(id), body.RevokedBy, body.RevokedAt); err != nil {
 		if errors.Is(err, coreStorage.ErrBreakGlassNotActive) {
 			writeRemoteAPIError(w, http.StatusConflict, breakGlassNotActiveCode, coreStorage.ErrBreakGlassNotActive.Error())
@@ -200,5 +272,6 @@ func (h *CatalogHandler) RevokeBreakGlassActivationProxy(w http.ResponseWriter, 
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
 	}
+	h.coreService.LogBreakGlassRevoked(r.Context(), body.RevokedBy, activation.ProjectID, activation.ID, activation.UserID, activation.RoleID, activation.RoleName)
 	writeRemoteAPISuccess(w, map[string]bool{"revoked": true})
 }

--- a/server/http/handlers/handlers_s26_test.go
+++ b/server/http/handlers/handlers_s26_test.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -1069,9 +1070,18 @@ func TestListBreakGlassActivationsProxy_HappyPath_S26(t *testing.T) {
 
 // ── RevokeBreakGlassActivationProxy happy path ───────────────────────────────
 
-// TestRevokeBreakGlassActivationProxy_NotActive_S26 verifies 409 when revoke
-// targets a non-existent (or already revoked) activation.
-func TestRevokeBreakGlassActivationProxy_NotActive_S26(t *testing.T) {
+// TestRevokeBreakGlassActivationProxy_NotFound_S26 verifies 404 when revoke
+// targets a non-existent activation.
+//
+// Was asserting 409 (ErrBreakGlassNotActive) before the G80 documented-exception
+// fix added a GetBreakGlassActivation lookup ahead of the conditional revoke: the
+// old raw single-conditional-UPDATE passthrough couldn't distinguish "no such
+// row" from "row exists but isn't active" — both looked like zero rows affected.
+// The fix's existence check makes that distinction correctly; a truly
+// non-existent ID is now 404, not 409. See
+// TestRevokeBreakGlassActivationProxy_AlreadyRevoked_S26 below for the 409 case
+// this test used to also (imprecisely) cover.
+func TestRevokeBreakGlassActivationProxy_NotFound_S26(t *testing.T) {
 	cs := freshCoreS26(t)
 	h := NewCatalogHandler(cs)
 
@@ -1088,8 +1098,88 @@ func TestRevokeBreakGlassActivationProxy_NotActive_S26(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.RevokeBreakGlassActivationProxy(w, req)
 
-	// Non-existent activation → ErrBreakGlassNotActive → 409 Conflict
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestRevokeBreakGlassActivationProxy_AlreadyRevoked_S26 verifies 409 when revoke
+// targets an activation that exists but is already in state=revoked — the case
+// TestRevokeBreakGlassActivationProxy_NotFound_S26 used to (imprecisely) assert
+// via a non-existent ID instead.
+func TestRevokeBreakGlassActivationProxy_AlreadyRevoked_S26(t *testing.T) {
+	cs := freshCoreS26(t)
+	h := NewCatalogHandler(cs)
+
+	revokedAt := time.Now().UTC()
+	activation, err := cs.Storage().CreateBreakGlassActivation(context.Background(), &models.BreakGlassActivation{
+		ProjectID: 1, UserID: 1, RoleID: 1, RoleName: "test_role",
+		Justification: "already revoked fixture", State: "revoked",
+		RevokedBy: 1, RevokedAt: &revokedAt,
+	})
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"revoked_by": 1,
+		"revoked_at": time.Now(),
+	})
+	req := withChiParam_S25(
+		httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/system/break-glass-activations/%d/revoke", activation.ID),
+			bytes.NewReader(body)),
+		"id", fmt.Sprintf("%d", activation.ID),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.RevokeBreakGlassActivationProxy(w, req)
+
 	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+// TestRevokeBreakGlassActivationProxy_RemovesRoleGrant is the G80 documented-
+// exception fix's own regression test: before the fix, this handler flipped the
+// activation to state=revoked WITHOUT ever removing the underlying role
+// assignment (its offsetting effect was claimed to travel through a separate
+// call chain that turned out not to exist — the missing /api/v1/rbac/remove-role
+// wire route, #1511). A live emergency role grant must actually be gone from
+// user_roles (the table RBAC reads) after a successful revoke, not just
+// reported revoked in the activation row.
+func TestRevokeBreakGlassActivationProxy_RemovesRoleGrant(t *testing.T) {
+	cs := freshCoreS26(t)
+	h := NewCatalogHandler(cs)
+	ctx := context.Background()
+
+	role, err := cs.Storage().CreateRole(ctx, &models.Role{Name: "s26_break_glass_emergency_role"})
+	require.NoError(t, err)
+	scope := core.Scope{ProjectID: 1}
+	require.NoError(t, cs.Storage().AssignRole(ctx, 1, role.ID, scope))
+
+	roleIDs, err := cs.Storage().GetUserRoleIDsAt(ctx, 1, scope)
+	require.NoError(t, err)
+	require.Contains(t, roleIDs, role.ID, "fixture setup: role grant must exist before the revoke")
+
+	activation, err := cs.Storage().CreateBreakGlassActivation(ctx, &models.BreakGlassActivation{
+		ProjectID: 1, UserID: 1, RoleID: role.ID, RoleName: role.Name,
+		Justification: "regression test for the role-removal fix", State: "active",
+	})
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"revoked_by": 1,
+		"revoked_at": time.Now(),
+	})
+	req := withChiParam_S25(
+		httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/system/break-glass-activations/%d/revoke", activation.ID),
+			bytes.NewReader(body)),
+		"id", fmt.Sprintf("%d", activation.ID),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.RevokeBreakGlassActivationProxy(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "revoke of a genuinely active activation must succeed: %s", w.Body.String())
+
+	roleIDs, err = cs.Storage().GetUserRoleIDsAt(ctx, 1, scope)
+	require.NoError(t, err)
+	assert.NotContains(t, roleIDs, role.ID,
+		"CEILING VIOLATED: the emergency role grant must be removed from user_roles by a successful revoke, "+
+			"not merely reported revoked in the activation row")
 }
 
 // ── catalog.go: DeleteEnvironment error branches ──────────────────────────────

--- a/server/http/handlers/handlers_s31_test.go
+++ b/server/http/handlers/handlers_s31_test.go
@@ -207,13 +207,20 @@ func TestListAccessRequestApprovalsProxy_DBError_S31(t *testing.T) {
 
 // ── CatalogHandler / break_glass_proxy.go ─────────────────────────────────────
 
+// TestGetBreakGlassActivationProxy_DBError_S31 was asserting 404 before the G80
+// documented-exception fix corrected GetBreakGlassActivation's error wrapping
+// (local_break_glass.go): it used to wrap EVERY error, including a genuine
+// storage failure, with the same "not found" prefix isNotFoundErr string-
+// matches on. A closed/unreachable DB is a real 500, not a 404 — see
+// GetMachineIdentityCredentialByID's identical, already-fixed precedent
+// (local_machine_credentials.go) for the same bug class.
 func TestGetBreakGlassActivationProxy_DBError_S31(t *testing.T) {
 	t.Parallel()
 	h := NewCatalogHandler(freshCoreBrokenS31(t))
 	r := withChiParamS7(httptest.NewRequest(http.MethodGet, "/api/v1/system/break-glass/1", nil), "id", "1")
 	w := httptest.NewRecorder()
 	h.GetBreakGlassActivationProxy(w, r)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestListBreakGlassActivationsProxy_DBError_S31(t *testing.T) {

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -230,10 +230,25 @@ var rawStorageBypassAllowlist = map[string]string{
 	"CreateAccessReviewItemsProxy": "documented-exception: the only caller-relevant invariant (a fresh item starts " +
 		"Decision=pending/DecidedBy=0) is already enforced server-side by the handler (ARC-004); item content " +
 		"mirrors a live snapshot, not a core-enforced authorization ceiling.",
-	"RevokeBreakGlassActivationProxy": "documented-exception, per this file's own package doc (lines 15-26, " +
-		"38-42): the role-removal side effect (RemoveUserRole) travels through its own separate proxied call " +
-		"chain, not through RevokeBreakGlassActivation; the conditional WHERE state='active' update this handler " +
-		"performs is faithfully preserved.",
+	// CORRECTED 2026-08-25 (G80 documented-exception re-verification sweep): the
+	// prior "documented-exception" reason here was FALSE. The claimed "separate
+	// proxied call chain" (core.RevokeBreakGlass's RemoveUserRole step) does not
+	// exist end-to-end: for a project-scoped role it resolves to POST
+	// /api/v1/rbac/remove-role, a route that was never registered
+	// (remote_wire_route_coverage_test.go's knownMissingRoutes, #1511) --
+	// confirmed checked in BEFORE this classification was originally written.
+	// Under storage.type: remote, this raw proxy was the ONLY path that could
+	// ever complete a revoke with a live grant, and it left the role grant LIVE
+	// in user_roles with no audit event. FIXED: the handler is now
+	// self-contained (state guard, RemoveUserRole, conditional revoke, new
+	// LogBreakGlassRevoked audit call) -- see its own doc comment
+	// (break_glass_proxy.go) for the full reasoning, including why it does NOT
+	// call core.RevokeBreakGlass directly (would break this route's own wire
+	// error-code contract).
+	"RevokeBreakGlassActivationProxy": "FIXED: was a false documented-exception (the offsetting role-removal " +
+		"chain it claimed to travel through never existed end-to-end, #1511) -- now self-contained (state guard " +
+		"+ RemoveUserRole + conditional revoke + LogBreakGlassRevoked audit), see the FIXED comment immediately " +
+		"above this entry.",
 	"RecordLoginAttemptProxy": "documented-exception, per this file's own package doc: the real rate-limit policy " +
 		"(threshold/window) lives in the separate IsLoginRateLimited READ path, not in the record path -- " +
 		"RecordFailedLogin itself does nothing but canonicalize the IP and persist.",


### PR DESCRIPTION
## Summary
- `RevokeBreakGlassActivationProxy`'s documented-exception claimed the role-removal side effect "travels through its own separate proxied call chain" (`core.RevokeBreakGlass`'s `RemoveUserRole` step). That chain does not exist end-to-end: for a project-scoped role it resolves to `POST /api/v1/rbac/remove-role`, a route that was never registered (`remote_wire_route_coverage_test.go`'s `knownMissingRoutes`, #1511) — the falsifying evidence was already checked into the repo two days before this classification was written.
- Under `storage.type: remote` this meant `core.RevokeBreakGlass` could never complete a revoke with a live role grant at all, and this raw proxy — independently reachable by anyone holding `system.write` — was the only path that succeeded, doing so without removing the underlying role grant or writing an audit event.
- Fixed by making the proxy self-contained (state guard, `RemoveUserRole`, conditional revoke, new `core.LogBreakGlassRevoked` audit call), inline, with no new wire hop. Deliberately does NOT call `core.RevokeBreakGlass` directly: that function wraps `storage.ErrBreakGlassNotActive` in a new plain-text error rather than propagating it via `%w`, which would break this route's own wire error-code contract.
- Also fixes a latent bug this surfaced: `GetBreakGlassActivation` unconditionally wrapped every error as "not found", so a genuine storage failure read identically to a real not-found — fixed to distinguish `gorm.ErrRecordNotFound` from everything else, matching `GetMachineIdentityCredentialByID`'s already-established pattern. Two existing tests updated to match the more precise behavior (404 for truly nonexistent, 500 for genuine storage failure).
- Root-cause comment for GitHub issue #1511 is queued in `docs/g80-documented-exception-sweep-findings.md` (`gh` was broken in the working environment when this was written).

## Test plan
- [x] `TestRevokeBreakGlassActivationProxy_RemovesRoleGrant` confirmed failing against the unfixed handler before this change (red-then-green).
- [x] Full `server/http`, `internal/core`, `internal/storage` suites green.
- [x] `gosec -severity medium -exclude-generated` clean.