### PR TITLE
fix(auth): validate RecordLoginAttemptProxy's ip/at fields (G80)

### DIFF
--- a/internal/core/rate_limit.go
+++ b/internal/core/rate_limit.go
@@ -28,9 +28,11 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 )
 
 // CanonicalIP returns addr's IP address in canonical (net.IP.String()) form,
@@ -117,6 +119,68 @@ func (c *KeyorixCore) RecordFailedLogin(ctx context.Context, ip string) {
 		return
 	}
 	_ = c.storage.RecordLoginAttempt(ctx, CanonicalIP(ip), c.now())
+}
+
+// ErrInvalidLoginAttemptKey is returned by RecordLoginAttemptRelay when the
+// caller-supplied key is neither a valid IP address nor a known namespace
+// prefix followed by one.
+var ErrInvalidLoginAttemptKey = errors.New("ip must be a valid IP address, optionally prefixed with a known rate-limit namespace")
+
+// loginAttemptRelayPrefixes are the only namespace prefixes a legitimate relay
+// (RecordLoginAttemptRelay's caller) ever needs to report: the same two
+// RecordPasswordResetAttempt/RecordSSOBeginAttempt apply before writing to the
+// shared login_attempts table. Anything else is not a real rate-limit key this
+// codebase produces.
+var loginAttemptRelayPrefixes = []string{passwordResetRateLimitPrefix, ssoRateLimitPrefix}
+
+// RecordLoginAttemptRelay persists a login/password-reset/SSO-begin attempt
+// relayed from a downstream server's own RecordFailedLogin/
+// RecordPasswordResetAttempt/RecordSSOBeginAttempt call
+// (server/http/handlers/login_attempts_proxy.go's RecordLoginAttemptProxy is
+// the only caller — an attacker-influenced HTTP body, not a value this
+// process derived itself). Two gaps closed here (G80 documented-exception
+// re-verification sweep, found six weeks after PruneLoginAttemptsProxy's
+// sibling CORE-RATE-003 fix in this same file — the "record" endpoint's own
+// fields were never given the equivalent scrutiny at the time):
+//
+//  1. The wire "ip" field was never validated to actually BE an IP, or a
+//     known-prefix + IP. A caller holding only system.write could submit the
+//     LITERAL string "pwreset:<victim-ip>" or "sso:<victim-ip>" as the whole
+//     key, corrupting a DIFFERENT rate limiter's bucket for a victim IP the
+//     caller doesn't control — e.g. ten such calls lock that victim out of
+//     password-reset or SSO/SAML login initiation, without ever touching the
+//     ordinary login limiter at all.
+//  2. `at` was accepted completely unbounded. PruneLoginAttempts (this file)
+//     can only ever delete rows with `attempted_at < now-LoginWindow` — a
+//     caller setting `at` to a far-future value (e.g. year 2099) creates a
+//     row NO maintenance sweep can ever become eligible to remove: a
+//     PERMANENT, unrecoverable lockout of whatever key it targets, strictly
+//     worse than the bounded-window abuse case CORE-RATE-003 closed for prune.
+//
+// A KNOWN prefix is stripped if present and the remainder is canonicalized
+// via CanonicalIP and REQUIRED to parse as a real IP — an unprefixed,
+// non-IP key is rejected outright rather than persisted verbatim. `at` is
+// clamped to now: a relay reports an event that already happened on the
+// downstream server's own clock, never one in the future.
+func (c *KeyorixCore) RecordLoginAttemptRelay(ctx context.Context, key string, at time.Time) error {
+	prefix, remainder := "", key
+	for _, p := range loginAttemptRelayPrefixes {
+		if rest, ok := strings.CutPrefix(key, p); ok {
+			prefix, remainder = p, rest
+			break
+		}
+	}
+	canon := CanonicalIP(remainder)
+	if net.ParseIP(canon) == nil {
+		return ErrInvalidLoginAttemptKey
+	}
+	if now := c.now(); at.After(now) {
+		at = now
+	}
+	if err := c.storage.RecordLoginAttempt(ctx, prefix+canon, at); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
 }
 
 // PruneLoginAttempts removes login/password-reset rate-limit rows older than

--- a/server/http/handlers/handlers_s13_proxy_test.go
+++ b/server/http/handlers/handlers_s13_proxy_test.go
@@ -212,6 +212,67 @@ func TestRecordLoginAttemptProxy_HappyPath_S13(t *testing.T) {
 	assert.True(t, resp.Success)
 }
 
+// TestRecordLoginAttemptProxy_RejectsNonIPKey_S13 is the G80 documented-
+// exception fix's regression test (2026-08-25): a caller-supplied "ip" that
+// isn't a real IP, or a known rate-limit namespace prefix followed by one,
+// must be refused rather than persisted verbatim — the field used to accept
+// ANY string with no validation at all.
+func TestRecordLoginAttemptProxy_RejectsNonIPKey_S13(t *testing.T) {
+	h := freshAuthHandlerS13(t)
+	body := proxyJSON(map[string]interface{}{"ip": "not-an-ip-or-known-prefix", "at": time.Now()})
+	req := httptest.NewRequest(http.MethodPost, "/system/login-attempts", body)
+	w := httptest.NewRecorder()
+	h.RecordLoginAttemptProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.False(t, resp.Success)
+}
+
+// TestRecordLoginAttemptProxy_AllowsKnownPrefixes_S13 is
+// TestRecordLoginAttemptProxy_RejectsNonIPKey_S13's companion control: the two
+// namespace prefixes RecordPasswordResetAttempt/RecordSSOBeginAttempt
+// legitimately produce ("pwreset:"/"sso:") followed by a real IP must still
+// be accepted — the fix must not turn into a blanket rejection of anything
+// but a bare IP.
+func TestRecordLoginAttemptProxy_AllowsKnownPrefixes_S13(t *testing.T) {
+	for _, ip := range []string{"pwreset:203.0.113.9", "sso:203.0.113.9", "203.0.113.9:54321"} {
+		h := freshAuthHandlerS13(t)
+		body := proxyJSON(map[string]interface{}{"ip": ip, "at": time.Now()})
+		req := httptest.NewRequest(http.MethodPost, "/system/login-attempts", body)
+		w := httptest.NewRecorder()
+		h.RecordLoginAttemptProxy(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, "ip=%q must still be accepted", ip)
+	}
+}
+
+// TestRecordLoginAttemptProxy_ClampsFutureTimestamp_S13 is the fix's second
+// regression test: before it, a far-future `at` created a row
+// PruneLoginAttempts (clamped to now-LoginWindow) could NEVER become eligible
+// to delete — a permanent, unrecoverable lockout of whatever key it targets.
+// Confirmed by checking the row lands within the real (recent) window a
+// legitimate call would use, not 100 years in the future.
+func TestRecordLoginAttemptProxy_ClampsFutureTimestamp_S13(t *testing.T) {
+	cs := freshCoreS12(t)
+	h := NewAuthHandler(cs, false)
+	farFuture := time.Now().AddDate(100, 0, 0)
+	body := proxyJSON(map[string]interface{}{"ip": "198.51.100.42", "at": farFuture})
+	req := httptest.NewRequest(http.MethodPost, "/system/login-attempts", body)
+	w := httptest.NewRecorder()
+	h.RecordLoginAttemptProxy(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// A cutoff strictly AFTER "now" only counts the row if its AttemptedAt is
+	// itself in the future — i.e. NOT clamped. (A ">= since" cutoff in the past
+	// would trivially count a far-future row too, so it can't distinguish
+	// "clamped to now" from "left 100 years in the future" — this must query
+	// forward of now instead.)
+	n, err := cs.Storage().CountRecentLoginAttempts(context.Background(), "198.51.100.42", time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n,
+		"CEILING VIOLATED: the recorded attempt's timestamp must be clamped to now, not persisted 100 years in "+
+			"the future where no maintenance sweep can ever reach it")
+}
+
 // ── misc_remote_proxy.go: accessActivityProxy ────────────────────────────────
 
 // TestAccessActivityProxy_MissingProjectID_S13 — no project_id → 400.

--- a/server/http/handlers/login_attempts_proxy.go
+++ b/server/http/handlers/login_attempts_proxy.go
@@ -9,18 +9,28 @@
 // client already needs for every other proxied call, e.g. full user CRUD, so this
 // introduces no new privilege class).
 //
-// These are thin passthroughs onto the SAME storage.Storage primitives
-// (RecordLoginAttempt/CountRecentLoginAttempts/PruneLoginAttempts) the local
-// /auth/login path already uses (ADR-040) — no rate-limiting POLICY decision (the
-// threshold, the window) is made here; that stays entirely in the CALLING server's
-// own internal/core.KeyorixCore, exactly as it does against a local backend. This
-// file only persists/counts/prunes the raw (key, timestamp) rows. The one exception
-// is PruneLoginAttemptsProxy (CORE-RATE-003): it deliberately does NOT call
-// storage.Storage.PruneLoginAttempts directly, because the request body's `before`
-// is attacker-influenced and an unbounded passthrough let any system.write
-// principal wipe the entire table on demand. It routes through
-// core.KeyorixCore.PruneLoginAttempts instead, which clamps the cutoff and audits
-// the deletion — see that handler's own doc comment.
+// CountLoginAttemptsProxy remains a thin passthrough onto storage.Storage's
+// CountRecentLoginAttempts (a pure read — no rate-limiting POLICY decision, the
+// threshold/window, is made here; that stays entirely in the CALLING server's
+// own internal/core.KeyorixCore, exactly as it does against a local backend).
+// RecordLoginAttemptProxy and PruneLoginAttemptsProxy are NOT thin passthroughs:
+// both had a wire-body field an attacker-influenced caller controls, unvalidated,
+// with concrete abuse consequences.
+//
+//   - PruneLoginAttemptsProxy (CORE-RATE-003): the request body's `before` let
+//     any system.write principal wipe the entire table on demand. Routes through
+//     core.KeyorixCore.PruneLoginAttempts instead, which clamps the cutoff and
+//     audits the deletion — see that handler's own doc comment.
+//   - RecordLoginAttemptProxy (found 6 weeks later, in the G80 documented-
+//     exception re-verification sweep — its own "no policy decision" framing
+//     was true but beside the point): the `ip`/`at` fields were completely
+//     unvalidated, letting a caller poison a DIFFERENT rate limiter's namespace
+//     with a fabricated key, or set `at` to a far-future timestamp that
+//     PruneLoginAttempts (clamped to now-LoginWindow) could never become
+//     eligible to delete — a permanent lockout. Routes through
+//     core.KeyorixCore.RecordLoginAttemptRelay instead, which
+//     validates/canonicalizes the key and clamps the timestamp — see that
+//     method's own doc comment (internal/core/rate_limit.go).
 //
 // Response envelope: these three handlers deliberately do NOT use the package's
 // generic sendSuccess/sendError helpers. Those write {"data":...}/{"error":"...",
@@ -33,10 +43,12 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
@@ -84,6 +96,23 @@ type loginAttemptPruneBody struct {
 }
 
 // RecordLoginAttemptProxy handles POST /api/v1/system/login-attempts.
+//
+// FALSE justification, found and fixed (G80 documented-exception re-
+// verification sweep, 2026-08-25): this handler's "no rate-limit POLICY
+// decision is made here" claim (package doc above) is true but beside the
+// point — it used to call storage.RecordLoginAttempt directly with the wire
+// body's `ip`/`at` fields completely unvalidated. That let a system.write-only
+// or node-credential caller (a) inject a fabricated key under ANOTHER rate
+// limiter's namespace ("pwreset:<victim-ip>"/"sso:<victim-ip>") to lock a
+// victim IP out of password-reset/SSO rather than ordinary login, and (b) set
+// `at` to a far-future timestamp, creating a row PruneLoginAttempts (clamped
+// to now-LoginWindow) can never become eligible to delete — a permanent
+// lockout. Its sibling PruneLoginAttemptsProxy (below) got the equivalent
+// validation as CORE-RATE-003, six weeks before this handler's own fields were
+// looked at; that gap in scrutiny, not a different threat model, is why this
+// one went unnoticed. Now routes through core.KeyorixCore.RecordLoginAttemptRelay,
+// which validates/canonicalizes the key and clamps the timestamp — see its own
+// doc comment (internal/core/rate_limit.go) for the full reasoning.
 func (h *AuthHandler) RecordLoginAttemptProxy(w http.ResponseWriter, r *http.Request) {
 	var body loginAttemptRecordBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -94,7 +123,11 @@ func (h *AuthHandler) RecordLoginAttemptProxy(w http.ResponseWriter, r *http.Req
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "ip is required")
 		return
 	}
-	if err := h.coreService.Storage().RecordLoginAttempt(r.Context(), body.IP, body.At); err != nil {
+	if err := h.coreService.RecordLoginAttemptRelay(r.Context(), body.IP, body.At); err != nil {
+		if errors.Is(err, core.ErrInvalidLoginAttemptKey) {
+			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
+			return
+		}
 		log.Printf("login-attempts proxy: record failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -249,9 +249,14 @@ var rawStorageBypassAllowlist = map[string]string{
 		"chain it claimed to travel through never existed end-to-end, #1511) -- now self-contained (state guard " +
 		"+ RemoveUserRole + conditional revoke + LogBreakGlassRevoked audit), see the FIXED comment immediately " +
 		"above this entry.",
-	"RecordLoginAttemptProxy": "documented-exception, per this file's own package doc: the real rate-limit policy " +
-		"(threshold/window) lives in the separate IsLoginRateLimited READ path, not in the record path -- " +
-		"RecordFailedLogin itself does nothing but canonicalize the IP and persist.",
+	// RecordLoginAttemptProxy: FIXED 2026-08-25 (G80 documented-exception
+	// re-verification sweep) -- was a FALSE documented-exception (ip/at were
+	// completely unvalidated, enabling cross-namespace rate-limit poisoning and
+	// a permanent future-timestamp lockout; see internal/core/rate_limit.go's
+	// RecordLoginAttemptRelay doc comment for the full finding). Entry removed
+	// (not moved) -- the handler now routes through core.RecordLoginAttemptRelay
+	// instead of calling Storage().RecordLoginAttempt directly, so this guard's
+	// AST scan no longer flags it at all.
 	"CreateSetupTokenProxy": "documented-exception: the handler's own #G79 comment explicitly re-derives and " +
 		"closes the gap a naive raw call would have (a direct system.write caller minting a takeover token) by " +
 		"implementing the invitation/user cross-reference check itself before persisting.",


### PR DESCRIPTION
## Summary
- `RecordLoginAttemptProxy`'s documented-exception ("no rate-limit POLICY decision is made here") was true but beside the point: the `ip`/`at` wire fields were never validated at all. A caller holding only `system.write` or a node credential could (a) inject a fabricated key under a DIFFERENT rate limiter's namespace (`pwreset:<victim-ip>`/`sso:<victim-ip>`), locking a victim IP out of password-reset/SSO rather than ordinary login, and (b) set `at` to a far-future timestamp, creating a row `PruneLoginAttempts` (clamped to `now-LoginWindow`) could never become eligible to delete — a permanent, unrecoverable lockout.
- Its sibling `PruneLoginAttemptsProxy` got equivalent validation as CORE-RATE-003 six weeks earlier; that gap in scrutiny, not a different threat model, is why this handler's own fields went unnoticed until now.
- Adds `core.KeyorixCore.RecordLoginAttemptRelay`, which strips a known namespace prefix if present, canonicalizes the remainder via `CanonicalIP` (rejecting anything that doesn't parse as a real IP), and clamps `at` to now. `RecordLoginAttemptProxy` now routes through it instead of calling `storage.RecordLoginAttempt` directly.

## Test plan
- [x] `TestRecordLoginAttemptProxy_RejectsNonIPKey_S13` and `TestRecordLoginAttemptProxy_ClampsFutureTimestamp_S13` confirmed failing against the unfixed handler before this change (red-then-green).
- [x] Full `server/http`, `internal/core`, `internal/storage` suites green.
- [x] `gosec -severity medium -exclude-generated` clean.