### PR TITLE
fix(auth): derive CreateSetupTokenProxy's ceiling from the operation, not the caller class (G80)

### DIFF
--- a/server/http/handlers/handlers_s13_proxy_test.go
+++ b/server/http/handlers/handlers_s13_proxy_test.go
@@ -1298,7 +1298,7 @@ func TestCreateSetupTokenProxy_HappyPath_S13(t *testing.T) {
 		"expires_at":      time.Now().Add(24 * time.Hour),
 		"created_by":      1,
 	})
-	req := httptest.NewRequest(http.MethodPost, "/system/setup-tokens", body)
+	req := withNodeCredentialContextS13(httptest.NewRequest(http.MethodPost, "/system/setup-tokens", body))
 	w := httptest.NewRecorder()
 	h.CreateSetupTokenProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -1379,6 +1379,58 @@ func TestCreateSetupTokenProxy_RefusesUnmatchedSubject(t *testing.T) {
 	assert.Error(t, err, "no setup token must be persisted when the subject is unverified")
 }
 
+// TestCreateSetupTokenProxy_InvitationAccept_HappyPath closes a test-coverage
+// gap the G80 documented-exception re-verification sweep found: the
+// invitation_accept branch (GetProjectInvitation + email-match check) had zero
+// test coverage anywhere in this handler's test suite. A real, matching
+// invitation must be accepted, gated on users.write per the same sweep's fix.
+func TestCreateSetupTokenProxy_InvitationAccept_HappyPath(t *testing.T) {
+	cs := newHandlerCoreS4(t)
+	h := NewAuthHandler(cs, false)
+
+	inv, err := cs.Storage().CreateProjectInvitation(context.Background(), &models.ProjectInvitation{
+		ProjectID: 1, Email: "invitee@example.com", Role: "project_developer", State: "pending",
+	})
+	require.NoError(t, err)
+
+	body := fmt.Sprintf(`{"token_hash":"invaccept1","purpose":"invitation_accept","subject_email":"invitee@example.com","invitation_id":%d,"expires_at":%q}`,
+		inv.ID, time.Now().Add(24*time.Hour).Format(time.RFC3339))
+	req := withNodeCredentialContextS13(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)))
+	w := httptest.NewRecorder()
+	h.CreateSetupTokenProxy(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "a real, matching invitation must be accepted: %s", w.Body.String())
+	tok, err := cs.Storage().GetSetupTokenByHash(context.Background(), "invaccept1")
+	require.NoError(t, err, "the token must be persisted")
+	require.NotNil(t, tok.InvitationID)
+	assert.Equal(t, inv.ID, *tok.InvitationID)
+	assert.Nil(t, tok.SubjectUserID)
+}
+
+// TestCreateSetupTokenProxy_InvitationAccept_RefusesEmailMismatch is
+// TestCreateSetupTokenProxy_InvitationAccept_HappyPath's companion: a real
+// invitation exists, but the caller's subject_email doesn't match it — must be
+// refused, and no token persisted.
+func TestCreateSetupTokenProxy_InvitationAccept_RefusesEmailMismatch(t *testing.T) {
+	cs := newHandlerCoreS4(t)
+	h := NewAuthHandler(cs, false)
+
+	inv, err := cs.Storage().CreateProjectInvitation(context.Background(), &models.ProjectInvitation{
+		ProjectID: 1, Email: "real-invitee@example.com", Role: "project_developer", State: "pending",
+	})
+	require.NoError(t, err)
+
+	body := fmt.Sprintf(`{"token_hash":"invaccept2","purpose":"invitation_accept","subject_email":"attacker@example.com","invitation_id":%d,"expires_at":%q}`,
+		inv.ID, time.Now().Add(24*time.Hour).Format(time.RFC3339))
+	req := withNodeCredentialContextS13(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)))
+	w := httptest.NewRecorder()
+	h.CreateSetupTokenProxy(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "an email mismatch against the real invitation must be refused")
+	_, err = cs.Storage().GetSetupTokenByHash(context.Background(), "invaccept2")
+	assert.Error(t, err, "no setup token must be persisted on a mismatched invitation_accept request")
+}
+
 // TestCreateUserWithRoleGrantsProxy_RefusesUnauthorizedAdminGrant is the #G79
 // regression: CreateUserWithRoleGrantsProxy previously called
 // storage.CreateUserWithRoleGrants directly, persisting whatever grants the

--- a/server/http/handlers/setup_tokens_proxy.go
+++ b/server/http/handlers/setup_tokens_proxy.go
@@ -21,6 +21,12 @@
 // on survives this HTTP hop unchanged; there is no separate "check active, then
 // write" sequence here to reintroduce that TOCTOU.
 //
+// One exception: CreateSetupTokenProxy is NOT a thin passthrough for a direct
+// (non-node-credential) caller — see its own doc comment. Minting a setup token
+// for user X is equivalent to taking control of X, so it now requires the SAME
+// users.write authority every other admin-facing route that mints one already
+// requires (POST /api/v1/users, POST /api/v1/users/{id}/resend-setup-link).
+//
 // Response envelope: like invitations_proxy.go/login_attempts_proxy.go, these do
 // NOT use the package's generic sendSuccess/sendError helpers — they construct the
 // exact {"success":bool,"data":...,"error":{"code","message"}} shape
@@ -36,7 +42,9 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
 // setupTokenProxyWire mirrors models.SetupToken's fields exactly (snake_case) — the
@@ -112,24 +120,58 @@ const maxSetupTokenProxyTTL = 30 * 24 * time.Hour
 // CreateSetupTokenProxy handles POST /api/v1/system/setup-tokens. The caller (the
 // downstream server's own core.KeyorixCore.IssueSetupToken) has already computed
 // every field — the hash, purpose, TTL, subject — exactly as it would for
-// LocalStorage; this is otherwise a raw persist, no policy decision.
+// LocalStorage; this is otherwise a raw persist, no POLICY decision (which fields
+// a real IssueSetupToken call would compute).
 //
 // #G79: token_hash is, by design, always caller-supplied — the raw token is
 // generated with crypto/rand on whichever node calls IssueSetupToken (local or
 // remote), and only its hash ever crosses this wire; there is no way to
 // regenerate or independently verify it here without defeating the entire
-// point of hashing (the plaintext must never reach this layer). What WAS
-// missing is any check tying the token to a real, already-vetted record: a
-// caller reachable directly via system.write (bypassing the calling server's
-// own IssueSetupToken) could otherwise mint an active token binding an
-// arbitrary token_hash of a plaintext value it already knows to an arbitrary
-// subject_email, then immediately redeem it via the public, unauthenticated
-// /auth/setup/consume endpoint — full account takeover with no invitation or
-// existing account required at all. Every legitimate IssueSetupToken call site
-// (invitations.go/auth.go/setup_delivery.go) either supplies an InvitationID
-// referencing a real, matching-email invitation (invitation_accept) or a
-// SubjectUserID referencing a real, matching-email user (account_setup/
-// password_reset_link) — never neither, never both. Re-verify that shape here.
+// point of hashing (the plaintext must never reach this layer). The
+// invitation/user cross-reference check below ties the token to a real,
+// already-vetted record — but it only enforces INTERNAL CONSISTENCY between
+// the caller-supplied fields, never caller AUTHORITY to target the account
+// those fields name.
+//
+// G80 documented-exception re-verification sweep (2026-08-25): confirmed
+// exploitable as a result. Every human-facing operation that mints a setup
+// token for an admin-CHOSEN target requires users.write elsewhere in this
+// codebase -- POST /api/v1/users (CreateUser -> CreateUserWithSetupLink/
+// CreateUserWithOneTimePassword, router.go, RequirePermission(permUsersWrite))
+// and POST /api/v1/users/{id}/resend-setup-link (ResendSetupLink ->
+// ResendAccountSetupLink, same gate) -- but this route's own gate was only
+// system.write (RequireNodeCredentialOrPermission), a narrower-scoped
+// permission per auth_bootstrap.go's own documented footprint (audit
+// checkpoints/legal holds/risk exceptions/SoD policies, not user credential
+// control). A caller holding only system.write who already knew (or guessed)
+// a real target's email/user-ID could mint a fully-valid, immediately-
+// redeemable takeover token for that target via the public, unauthenticated
+// POST /auth/setup/consume -- overwriting the target's real password and, for
+// a non-MFA account, receiving a live session AS them.
+//
+// Rejected fix: narrowing this route to the node-credential arm only. Two
+// reasons. First, that reasoning is the SAME "the package doc says so" class
+// of claim this sweep already disproved 3 times elsewhere (verify, don't
+// trust the doc) -- and liveness-checking it here confirms the opposite: a
+// node-credential relay of THIS specific route is real and load-bearing
+// (RemoteStorage.CreateSetupToken, internal/storage/store/remote_auth.go:211,
+// is a genuine implementation invoked by ordinary product flows -- every
+// project invite, every admin "create user"/"resend setup link" action, the
+// self-service forgot-password flow -- not dead code). Second, and more
+// important: per #1552, a bare node credential can already be used to grant
+// ANY role including admin-tier -- it is the single most widely distributed
+// credential class in a deployment (ADR-085), not a stronger boundary than
+// system.write. Narrowing an account-takeover primitive to node-credential-
+// only would LOWER the effective bar, not raise it.
+//
+// Fixed instead by deriving the ceiling from the operation itself: a direct
+// (non-node-credential) caller must now hold users.write (global scope,
+// matching the human-facing routes above) before this handler persists a
+// token. A genuine node-credential relay is still trusted unconditionally, on
+// the same ADR-085 relay-trust assumption this campaign's other node branches
+// make -- HALF-FIXED, not closed; the wire carries no field distinguishing a
+// genuine relay of an already-authorized downstream decision from a bare node
+// credential calling this route directly with attacker-chosen parameters.
 func (h *AuthHandler) CreateSetupTokenProxy(w http.ResponseWriter, r *http.Request) {
 	var body setupTokenProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -167,6 +209,17 @@ func (h *AuthHandler) CreateSetupTokenProxy(w http.ResponseWriter, r *http.Reque
 		user, err := h.coreService.Storage().GetUser(r.Context(), *body.SubjectUserID)
 		if err != nil || !strings.EqualFold(strings.TrimSpace(user.Email), subjectEmail) {
 			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "subject_user_id does not reference a matching user")
+			return
+		}
+	}
+	if !isNodeCredentialRequest(r) {
+		userCtx := middleware.GetUserFromContext(r.Context())
+		if userCtx == nil {
+			writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", "minting a setup token requires the users.write permission")
+			return
+		}
+		if ok, aerr := h.coreService.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), "users.write", coreStorage.Scope{}); aerr != nil || !ok {
+			writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", "minting a setup token requires the users.write permission")
 			return
 		}
 	}

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -525,34 +525,54 @@ var rawStorageBypassAllowlist = map[string]string{
 // originally-listed entries were deleted outright — G80 liveness sweep found no
 // live caller for any of them; see docs/g80-remediation-notes.md.)
 var knownUnfixedRawStorageBypasses = map[string]string{
-	// MOVED HERE 2026-08-25 (G80 documented-exception re-verification sweep):
-	// was classified documented-exception in rawStorageBypassAllowlist on the
-	// theory that the handler's own #G79 comment "re-derives and closes the gap"
-	// (an internal invitation/user cross-reference check before persisting).
-	// That check is real and correctly written for what it explicitly
-	// validates (existence + case-insensitive email match) -- but it enforces
-	// internal CONSISTENCY between the caller-supplied token_hash/subject_email/
-	// subject_user_id/invitation_id, not caller AUTHORIZATION to target a
-	// specific account. Because this handler lets the caller choose token_hash
-	// directly (the plaintext the caller itself generates and hashes, per its
-	// own #G79 comment -- "by design, always caller-supplied"), a caller
-	// holding only system.write who already knows (or guesses) a real target's
-	// email/user-ID can mint a fully-valid, immediately-redeemable takeover
-	// token for that target via the public POST /auth/setup/consume --
-	// overwriting the target's real password (and, for a non-MFA account,
-	// receiving a live session AS them). Escalation-delta confirmed: no other
-	// system.write-gated route in this proxy group lets a caller overwrite an
-	// EXISTING arbitrary user's password + mint a session under that identity.
-	// The invitation_accept branch (setup_tokens_proxy.go's GetProjectInvitation
-	// + email-match check) additionally has ZERO test coverage. NOT fixed here
-	// -- reported per explicit instruction, fix approach pending a decision
-	// (narrow this route to the node-credential arm only vs. a core-level
-	// re-check) since the package doc's own stated legitimate caller is a
-	// genuine RemoteStorage node, never a human/service system.write role.
-	"CreateSetupTokenProxy": "REAL, human-reachable: the #G79 cross-reference check enforces internal " +
-		"consistency of caller-supplied fields, not caller authorization to target the account those fields " +
-		"name -- a system.write holder who already knows a target's email/ID can mint and immediately redeem a " +
-		"takeover token for that target via the public /auth/setup/consume endpoint.",
+	// HALF-FIXED 2026-08-25 (G80 documented-exception re-verification sweep) --
+	// do NOT move to rawStorageBypassAllowlist. Was classified documented-
+	// exception on the theory that the handler's own #G79 comment "re-derives
+	// and closes the gap" (an internal invitation/user cross-reference check
+	// before persisting). That check is real and correctly written for what it
+	// explicitly validates (existence + case-insensitive email match) -- but it
+	// enforces internal CONSISTENCY between the caller-supplied fields, not
+	// caller AUTHORIZATION to target the account those fields name. Confirmed
+	// exploitable: a caller holding only system.write who already knew (or
+	// guessed) a real target's email/user-ID could mint a fully-valid,
+	// immediately-redeemable takeover token via the public POST
+	// /auth/setup/consume -- overwriting the target's real password and, for a
+	// non-MFA account, receiving a live session AS them.
+	//
+	// Rejected fix: narrowing to the node-credential arm only. Liveness-checked
+	// first (per this sweep's own standing method): RemoteStorage.CreateSetupToken
+	// (internal/storage/store/remote_auth.go:211) is a genuine implementation
+	// invoked by ordinary product flows (every project invite/resend, every
+	// admin create-user/resend-setup-link action, the self-service forgot-
+	// password flow) -- not dead code, so node-only would not have been a
+	// no-op restriction. More importantly: per #1552, a bare node credential can
+	// already grant ANY role including admin-tier -- the single most widely
+	// distributed credential class in a deployment (ADR-085) -- so gatekeeping
+	// on "is this a node credential" would LOWER the effective bar, not raise
+	// it, for an account-takeover primitive.
+	//
+	// CLOSED for a direct (non-node-credential) caller instead, by deriving the
+	// ceiling from the operation: minting a setup token for user X is
+	// equivalent to taking control of X, and every other admin-facing route
+	// that mints one (POST /api/v1/users, POST /api/v1/users/{id}/resend-setup-
+	// link, router.go, RequirePermission(permUsersWrite)) already requires
+	// users.write. CreateSetupTokenProxy now requires the same for a direct
+	// caller (AuthorizePrincipal(users.write, global scope)) before persisting.
+	// STILL OPEN for a node-credential caller: isNodeCredentialRequest(r)
+	// routes around the check entirely to the raw storage.CreateSetupToken
+	// call, on the same unverified relay-trust assumption this campaign's other
+	// node branches make (ADR-085's still-unresolved "harder question"). See
+	// system_write_ceiling_table_test.go's CreateSetupTokenProxy rows for the
+	// live, asserted evidence (both the fixed direct-caller path and the
+	// still-open node-credential path). The invitation_accept branch's
+	// previously-zero test coverage is also closed
+	// (TestCreateSetupTokenProxy_InvitationAccept_HappyPath/
+	// ..._RefusesEmailMismatch, handlers_s4_test.go).
+	"CreateSetupTokenProxy": "HALF-FIXED: closed for a direct system.write-only human/machine caller " +
+		"(AuthorizePrincipal(users.write, global scope) now enforced -- derived from the operation itself, " +
+		"matching every other route that mints a setup token); STILL OPEN for a node-credential caller " +
+		"(isNodeCredentialRequest routes around the check to the raw storage call -- see the HALF-FIXED comment " +
+		"immediately above this entry).",
 	// HALF-FIXED 2026-08-25 (G80 documented-exception re-verification sweep) --
 	// do NOT move to rawStorageBypassAllowlist: CLOSED for a direct,
 	// non-node-credential caller (now routed through core.RemoveUserRole after

--- a/server/http/system_write_ceiling_table_test.go
+++ b/server/http/system_write_ceiling_table_test.go
@@ -74,6 +74,8 @@ type ceilingTableFixtures struct {
 	normalRoleID      uint // a non-admin-tier role
 	adminRoleID       uint // system_admin's role ID
 	secondAdminUserID uint // a SECOND global-admin user (system_admin), distinct from the bootstrap admin
+	usersWriteToken   string // system.write + users.write human caller (createSystemWriteAndUsersWriteToken)
+	setupTargetUserID uint   // a real user, distinct from the caller, to target with a setup token
 }
 
 // createSystemWriteAndRolesAssignToken creates a human user holding system.write
@@ -117,6 +119,50 @@ func createSystemWriteAndRolesAssignToken(t *testing.T, c *core.KeyorixCore) str
 	require.NoError(t, c.AssignRoleToUser(ctx, "sys_write_roles_assign@example.com", "ceiling_test_system_writer_roles_assign"))
 
 	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "sys_write_roles_assign", Password: "Qr7#Kp2$Lm5@Vn9!"})
+	require.NoError(t, err)
+	return sess.SessionToken
+}
+
+// createSystemWriteAndUsersWriteToken creates a human user holding system.write
+// AND users.write, via a custom role well outside adminRoleNames (same rationale
+// as createSystemWriteOnlyToken). Represents the legitimate direct caller
+// CreateSetupTokenProxy's fix is meant to keep working: someone who actually holds
+// the same authority every other admin-facing route that mints a setup token
+// (POST /api/v1/users, POST /api/v1/users/{id}/resend-setup-link) already requires.
+func createSystemWriteAndUsersWriteToken(t *testing.T, c *core.KeyorixCore) string {
+	t.Helper()
+	ctx := context.Background()
+
+	_, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "sys_write_users_write", Email: "sys_write_users_write@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.RemoveRoleFromUser(ctx, "sys_write_users_write@example.com", "system_viewer"))
+
+	role, err := c.Storage().CreateRole(ctx, &models.Role{
+		Name: "ceiling_test_system_writer_users_write", Description: "test-only role: system.write + users.write, nothing else",
+	})
+	require.NoError(t, err)
+
+	perms, err := c.ListPermissions(ctx)
+	require.NoError(t, err)
+	var systemWriteID, usersWriteID uint
+	for _, p := range perms {
+		switch p.Name {
+		case "system.write":
+			systemWriteID = p.ID
+		case "users.write":
+			usersWriteID = p.ID
+		}
+	}
+	require.NotZero(t, systemWriteID, "system.write permission must already be seeded by bootstrap")
+	require.NotZero(t, usersWriteID, "users.write permission must already be seeded by bootstrap")
+
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, usersWriteID))
+	require.NoError(t, c.AssignRoleToUser(ctx, "sys_write_users_write@example.com", "ceiling_test_system_writer_users_write"))
+
+	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "sys_write_users_write", Password: "Qr7#Kp2$Lm5@Vn9!"})
 	require.NoError(t, err)
 	return sess.SessionToken
 }
@@ -189,18 +235,29 @@ func setupCeilingTableFixtures(t *testing.T) ceilingTableFixtures {
 	secondAdmin, err := testCore.GetUserByEmail(ctx, "ceiling-table-second-admin@example.com")
 	require.NoError(t, err)
 
+	// A real target user, distinct from every caller above, for
+	// CreateSetupTokenProxy rows to mint an account_setup token against.
+	_, err = testCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "ceiling-table-setup-target", Email: "ceiling-table-setup-target@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	setupTarget, err := testCore.GetUserByEmail(ctx, "ceiling-table-setup-target@example.com")
+	require.NoError(t, err)
+
 	token := createSystemWriteOnlyToken(t, testCore)
 	// createNodeToken (integration_test.go) also calls createTestToken internally —
 	// safe to call again here since createTestToken tolerates an already-initialized
 	// system (logs and continues rather than failing).
 	nodeToken := createNodeToken(t, testCore)
 	rolesAssignToken := createSystemWriteAndRolesAssignToken(t, testCore)
+	usersWriteToken := createSystemWriteAndUsersWriteToken(t, testCore)
 
 	return ceilingTableFixtures{
 		serverURL:         server.URL,
 		token:             token,
 		nodeToken:         nodeToken,
 		rolesAssignToken:  rolesAssignToken,
+		usersWriteToken:   usersWriteToken,
 		projectID:         projectID,
 		plainMachine:      plainMachine.ID,
 		adminMachine:      adminMachine.ID,
@@ -211,6 +268,7 @@ func setupCeilingTableFixtures(t *testing.T) ceilingTableFixtures {
 		normalRoleID:      normalRole.ID,
 		adminRoleID:       adminRole.ID,
 		secondAdminUserID: secondAdmin.ID,
+		setupTargetUserID: setupTarget.ID,
 	}
 }
 
@@ -441,6 +499,70 @@ func TestSystemWriteCeiling_RemoveGlobalAdminRoleGuardedProxy_AllowsWithRolesAss
 	require.Equal(t, http.StatusOK, status,
 		"a caller who genuinely holds roles.assign at global scope must still be able to remove another admin's "+
 			"grant — the last-admin guard passes here because the bootstrap admin survives as the remaining admin")
+}
+
+// TestSystemWriteCeiling_CreateSetupTokenProxy_DeniesWithoutUsersWrite is the
+// table's CreateSetupTokenProxy row (G80 documented-exception re-verification
+// sweep, 2026-08-25). Ceiling: minting a setup token for user X is equivalent to
+// taking control of X -- every other admin-facing route that mints one
+// (POST /api/v1/users, POST /api/v1/users/{id}/resend-setup-link) requires
+// users.write. FIXED: a direct (non-node-credential) caller now needs users.write
+// too. RED before the fix: f.token (system.write, no users.write) could mint a
+// fully-valid, immediately-redeemable account_setup token for f.setupTargetUserID.
+func TestSystemWriteCeiling_CreateSetupTokenProxy_DeniesWithoutUsersWrite(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequest(t, f, http.MethodPost, "/api/v1/system/setup-tokens", map[string]any{
+		"token_hash":      "ceiling-table-forged-hash-0000000000000000000000000000001",
+		"purpose":         "account_setup",
+		"subject_email":   "ceiling-table-setup-target@example.com",
+		"subject_user_id": f.setupTargetUserID,
+		"expires_at":      time.Now().Add(time.Hour),
+	})
+	t.Logf("CreateSetupTokenProxy(system.write only, target=setup-target): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusForbidden, status,
+		"CEILING VIOLATED: a system.write-only caller with no users.write must be denied minting a setup token "+
+			"for another user — the internal invitation/user cross-reference check was never the gap; the "+
+			"missing actor-authority check was")
+}
+
+// TestSystemWriteCeiling_CreateSetupTokenProxy_AllowsWithUsersWrite is this row's
+// companion control: a caller who legitimately holds users.write (the SAME
+// authority every other route that mints a setup token already requires) must
+// still be able to perform this operation.
+func TestSystemWriteCeiling_CreateSetupTokenProxy_AllowsWithUsersWrite(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequestAs(t, f, f.usersWriteToken, http.MethodPost, "/api/v1/system/setup-tokens", map[string]any{
+		"token_hash":      "ceiling-table-legit-hash-00000000000000000000000000000001",
+		"purpose":         "account_setup",
+		"subject_email":   "ceiling-table-setup-target@example.com",
+		"subject_user_id": f.setupTargetUserID,
+		"expires_at":      time.Now().Add(time.Hour),
+	})
+	t.Logf("CreateSetupTokenProxy(users.write holder, target=setup-target): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status,
+		"a caller who genuinely holds users.write must still be able to mint a setup token for another user")
+}
+
+// TestSystemWriteCeiling_CreateSetupTokenProxy_NodeCredential_StillBypassesAuthorityCheck
+// pins the KNOWN, OPEN gap: unlike the human-caller row above (now 403), a node
+// credential still reaches the raw storage.CreateSetupToken call unconditionally
+// (isNodeCredentialRequest branch, setup_tokens_proxy.go), so it can still mint a
+// setup token for any user with no users.write check.
+func TestSystemWriteCeiling_CreateSetupTokenProxy_NodeCredential_StillBypassesAuthorityCheck(t *testing.T) {
+	f := setupCeilingTableFixtures(t)
+	status, body := doCeilingRequestAs(t, f, f.nodeToken, http.MethodPost, "/api/v1/system/setup-tokens", map[string]any{
+		"token_hash":      "ceiling-table-node-hash-000000000000000000000000000000001",
+		"purpose":         "account_setup",
+		"subject_email":   "ceiling-table-setup-target@example.com",
+		"subject_user_id": f.setupTargetUserID,
+		"expires_at":      time.Now().Add(time.Hour),
+	})
+	t.Logf("CreateSetupTokenProxy(node credential, target=setup-target): status=%d body=%s", status, body)
+	require.Equal(t, http.StatusOK, status,
+		"KNOWN GAP (not intended, pending ADR-085's wire-identity decision): a node credential still mints a "+
+			"setup token for any user with no users.write check — isNodeCredentialRequest routes it around the "+
+			"new check entirely, on an unverified relay-trust assumption. If this ever goes non-200, update this "+
+			"assertion — that would mean the gap closed, which is the goal, not a regression.")
 }
 
 // ── Node-credential-path rows ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `CreateSetupTokenProxy`'s #G79 cross-reference check was classified documented-exception on the theory that it "re-derives and closes the gap." It doesn't: the check enforces internal consistency between caller-supplied `token_hash`/`subject_email`/`subject_user_id`/`invitation_id`, never caller authorization to target the account those fields name. A caller holding only `system.write` who already knew (or guessed) a real target's email/user-ID could mint a fully-valid, immediately-redeemable takeover token via the public `POST /auth/setup/consume` — overwriting the target's real password and, for a non-MFA account, receiving a live session as them.
- Rejected the obvious-looking fix (narrow this route to the node-credential arm only) for two reasons, checked rather than assumed: (1) liveness — `RemoteStorage.CreateSetupToken` is a genuine, non-stub implementation invoked by ordinary product flows (every project invite/resend, every admin create-user/resend-setup-link action, the self-service forgot-password flow), not dead code, so a node-only restriction would not have been a no-op; (2) per #1552, a bare node credential can already be used to grant any role including admin-tier — the single most widely distributed credential class in a deployment (ADR-085) — so gatekeeping an account-takeover primitive on "is this a node credential" would lower the effective bar, not raise it.
- Fixed instead by deriving the ceiling from the operation itself: minting a setup token for user X is equivalent to taking control of X, and every other admin-facing route that mints one (`POST /api/v1/users`, `POST /api/v1/users/{id}/resend-setup-link`) already requires `users.write`. A direct (non-node-credential) caller now needs the same. A genuine node-credential relay is still trusted unconditionally — HALF-FIXED, not closed.
- Also closes a real test-coverage gap: the `invitation_accept` branch had zero test coverage anywhere in this handler's test suite.

## Test plan
- [x] `TestSystemWriteCeiling_CreateSetupTokenProxy_DeniesWithoutUsersWrite` confirmed failing against the unfixed handler before this change (red-then-green).
- [x] `TestSystemWriteCeiling_CreateSetupTokenProxy_AllowsWithUsersWrite` / `..._NodeCredential_StillBypassesAuthorityCheck` control the fix's boundaries.
- [x] `TestCreateSetupTokenProxy_InvitationAccept_HappyPath` / `..._RefusesEmailMismatch` close the invitation_accept coverage gap.
- [x] Full `server/http`, `internal/core`, `internal/storage` suites green.
- [x] `gosec -severity medium -exclude-generated` clean.