### PR TITLE
test(security): resolve CreateSetupTokenProxy contradiction, add closure-guard markers

### DIFF
--- a/docs/g80-handoff-2026-08-26.md
+++ b/docs/g80-handoff-2026-08-26.md
@@ -1,0 +1,180 @@
+# G80 handoff — stack landed, follow-up verification (2026-08-25 → 2026-08-26)
+
+## Bottom line
+
+The G80 #1563–#1566 stack + ADR-085 node-arm removal is **on `main`** (PR #1569, merge
+commit `d4248bc2`). All seven originally-tracked exploits (A–G) are fixed and
+mutation-verified. A follow-up independent verification round found one contradiction
+(resolved: the exploit was real) and one real gap in the closure-guard mechanism itself
+(fixed). That follow-up work is in **PR #1570**, open, CI pending, not yet merged.
+
+## What landed on `main` (PR #1569, merge `d4248bc2`)
+
+PR #1568 (`g80-fixland-main` branch) was the original attempt to land this stack. Its
+branch was based on a stale `main` and had two real CI failures (see below); a
+force-push to update it in place was blocked twice at the tool-permission layer, so the
+same content — rebased onto current `main`, plus the CI fixes — was pushed as a new
+branch (`g80-remediation-verified-2026-08-25`) and merged as **#1569**. **#1568 is
+closed**, superseded, comment posted pointing to #1569. If you're looking for "the PR
+that landed this," it's #1569, not #1568, despite #1568 having more history in this
+document's own earlier commentary.
+
+Content (verified via mutation testing — broke each fix, confirmed its test went red,
+reverted, confirmed green — not just read):
+
+- **ADR-085**: `RequireNodeCredentialOrPermission` deleted repo-wide
+  (`server/middleware/node_credential.go`). `/api/v1/system` now gated by plain
+  `RequirePermission(permSystemWrite)`. `MachineTypeNode` retained as an identity type.
+- **Exploit A** (two-call `system.write` → global `system_admin`): `requireMachinePrivilegeCeiling`
+  (`internal/core/authz.go:494`) now derives the ceiling from the ACTOR's `roles.assign`
+  authority, not just the target's current roles, applied at identity creation
+  (`machineID==0`) as well as credential-mint time.
+- **Exploit B** (`CreateInvitationProxy`, `server/http/handlers/invitations_proxy.go:134`):
+  authority checks and persisted `InvitedBy` now derive from `actorID(r)`, not the wire
+  body's `invited_by`.
+- **Exploit C** (`UpdateAccessRequestProxy`, `server/http/handlers/access_request_proxy.go:236`):
+  same shape, `requestActorKindAndID(r)` for `resolved_by`.
+- **Exploit D** (`CreateSetupTokenProxy`, `server/http/handlers/setup_tokens_proxy.go:175`):
+  now requires `users.write` (global scope) unconditionally — this route used to have
+  ZERO actor-authority check. See "CreateSetupTokenProxy contradiction" below; this is
+  the fix that closes the exploit confirmed real there.
+- **Exploit E** (`RevokeBreakGlassActivationProxy`, `server/http/handlers/break_glass_proxy.go:218`):
+  now actually removes the role grant (`RemoveUserRole`) before marking the activation
+  revoked, and derives `revokedBy` from `actorID(r)`.
+- **Exploit F** (`RecordLoginAttemptProxy`, `server/http/handlers/login_attempts_proxy.go:116`):
+  routes through `core.RecordLoginAttemptRelay` (`internal/core/rate_limit.go:179`),
+  which validates the `ip` key and REJECTS (not clamps) a future `at` timestamp.
+- **Exploit G** (`DeleteProjectProxy`): `server/http/router.go` now layers
+  `RequireScopedPermission(permSecretsDelete, projectScope)` on top of the group's
+  `system.write` gate, mirroring the human-facing route.
+- **Wire-actor-identity-forgery class**: named and guarded
+  (`server/http/wire_actor_identity_forgery_guard_test.go`,
+  `TestNoUnjustifiedActorIdentityForgery`) — an AST-ish scan of every `/system` handler
+  for a wire-supplied actor field (`invited_by`, `resolved_by`, `created_by`,
+  `decided_by`, `approver_id`, `revoked_by`) read without deriving from the authenticated
+  caller. Currently 0 flagged / 172 handlers checked (allowlists empty).
+- **Raw-storage-bypass enumerator** (`scripts/analysis/raw_storage_bypass_enumerate.go`)
+  extended one hop into unexported same-package `internal/core` helpers — 30→42
+  write-shaped candidates, recovering `CreateMembershipProxy` (missed the previous
+  version because `core.InviteMember` → unexported `inviteMemberWithMode` →
+  `storage.CreateProjectMembership`). A one-time unlimited-depth BFS confirmed one hop
+  is a fixed point for the current tree (42==42; every extra method the deeper walk
+  found was read-shaped) — see `docs/g80-raw-storage-bypass-enumeration.md`.
+- **New test coverage added during verification** (gaps the original fixes' own tests
+  didn't cover, found because every existing test hit an authorization-denial path
+  before the attribution-override line ever ran):
+  `TestWireActorForgery_CreateInvitationProxy_PersistedInvitedByIsAlwaysCaller`,
+  `TestWireActorForgery_UpdateAccessRequestProxy_PersistedResolvedByIsAlwaysCaller`
+  (both `server/http/wire_actor_identity_forgery_test.go`), and
+  `TestSystemWriteCeiling_CreateSetupTokenProxy_CreatedByIsAlwaysCaller`
+  (`server/http/system_write_ceiling_table_test.go`).
+- **Doc corrections**: `CLAUDE.md` and `docs/g80-raw-storage-bypass-triage.md` both
+  previously stated `git merge-base --is-ancestor <branch> origin/main` as a general
+  trusted signal for "did this PR land." That's unsound under this repo's squash-merge
+  convention — it returns false for every landed PR, not just the #1563–#1566 chain it
+  originally caught. Corrected both to the real check: `gh pr view --json baseRefName` +
+  empty `git diff <branch> origin/main --stat`.
+
+### Two CI-only bugs found and fixed while landing #1569 (not present in the exploit set above)
+
+1. **Lint**: `breakGlassContainmentAdminRoleNames`
+   (`server/http/handlers/break_glass_proxy.go`) was dead code — fed
+   `CreateBreakGlassActivationProxy`/`UpdateBreakGlassActivationProxy`, both deleted in
+   an earlier no-live-caller sweep. Deleted.
+2. **`TestG80TriageDocClosuresAreAncestorsOfHEAD` failed unconditionally in CI**: CI's
+   default `actions/checkout` is a shallow clone (`fetch-depth: 1`); the guard's
+   `git merge-base --is-ancestor <sha> HEAD` couldn't even resolve the older SHAs it
+   checks ("fatal: Not a valid commit name"), not "not an ancestor." This test had
+   likely never actually passed on CI. Fixed by having the guard detect a shallow repo
+   and run `git fetch --unshallow` first (`ensureFullHistory`,
+   `server/http/g80_triage_doc_closure_guard_test.go`). Verified by reproducing the
+   exact failure in a real `git clone --depth 1 file://...` clone, then confirming the
+   fixed test self-heals.
+
+## Follow-up verification round (PR #1570, open, not yet merged)
+
+A second independent verification pass raised two items. Both resolved, both landed as
+new commits, both on **PR #1570** (branch `g80-followup-verification-2026-08-26`, based
+on current `main` post-#1569). Not yet merged — CI was still pending as of this
+handoff; check `gh pr checks 1570` before assuming it's clean.
+
+### 1. CreateSetupTokenProxy contradiction — resolved, exploit was real
+
+Claim under test: "an independent verification session, working from clean origin/main,
+observed a system.write-only caller mint+redeem a setup token and take over an
+account" — contradicting an earlier "already correct" report from this campaign.
+
+Resolved with a test, not an argument
+(`server/http/g80_setup_token_exploit_verification_test.go`,
+`TestG80Exploit_CreateSetupTokenProxy_SystemWriteOnly_AccountTakeover`): builds a
+`system.write`-only caller (no admin-tier role, via `createSystemWriteOnlyToken`), mints
+a setup token for a real target account's known email via
+`POST /api/v1/system/setup-tokens`, then redeems it unauthenticated via
+`POST /auth/setup/consume`, and asserts the resulting session's `user_id`/`email` do NOT
+match the target.
+
+Run against two trees:
+- **Pre-remediation `main` (`45ae4bbe`)**: mint 200, redeem 200, session `user_id=2`
+  matched the target exactly — **RED, full account takeover confirmed real.**
+- **Post-remediation (current)**: mint denied 403 (`requires the users.write
+  permission`) — **GREEN, blocked at mint.**
+
+Verdict: the exploit was real; exploit D's fix (`users.write` requirement, see above)
+closes it. The earlier "already correct" report was accurate only because it was made
+*after* the fix had already been cherry-picked into that worktree, not because the
+exploit was never real. To reproduce this check on a fresh tree: check out the target
+commit, copy `g80_setup_token_exploit_verification_test.go` in, `go test -run
+TestG80Exploit_CreateSetupTokenProxy_SystemWriteOnly_AccountTakeover -v`.
+
+### 2. Closure guard given a "still present" check, not just "did this land"
+
+Problem: `git merge-base --is-ancestor <sha> HEAD` only proves the commit landed once.
+A LATER commit that reverts, refactors away, or loses the fix in a bad merge resolution
+leaves the original SHA an ancestor of HEAD forever — the guard stays green with the fix
+gone.
+
+Fix: every entry in `g80TriageClosureClaims`
+(`server/http/g80_triage_doc_closure_guard_test.go`) now carries a `marker`
+(`g80ClosureMarker`) — a symbol that must still exist in a named file, or (for the
+ADR-085/#1563–#1566 entry, which has no single commit) a symbol that must be absent
+repo-wide (`RequireNodeCredentialOrPermission`'s deletion). Checked independently of the
+SHA in the same test.
+
+Verified load-bearing: temporarily removed `RequireAdminAuthorityAt`'s call site in
+`UpdateAccessRequestProxy` (leaving its commit `2b888df7` in history) — marker check
+went red, SHA-ancestor check stayed green (proving the SHA check alone would have missed
+it), reverted, green again.
+
+Two real bugs in the marker mechanism itself, found while building it, both fixed:
+- `git grep` resolves pathspecs relative to the test binary's cwd (`server/http`, its
+  package dir), not the repo root — every marker was silently flagged absent until
+  `git -C ../.. grep` anchored it.
+- A `mustNotExist` marker's own string literal (`"func RequireNodeCredentialOrPermission"`,
+  written directly in `g80TriageClosureClaims`) self-matched a naive repo-wide search
+  for that same string, since the check scanned this test file too — would have made
+  that marker permanently unable to fail. Fixed by excluding the guard file itself from
+  the repo-wide scan, and separately made file-scoped `mustExist` checks skip
+  comment-only lines (a doc comment mentioning a removed symbol's name must not itself
+  satisfy the marker after the real call is gone — this file's own commentary routinely
+  mentions symbol names in prose).
+
+## What's still open
+
+- **PR #1570 needs to be merged** (or its CI checked first — status unknown as of this
+  handoff). Nothing else is blocking it; it's additive test/guard-infrastructure only.
+- **`docs/g80-raw-storage-bypass-triage.md`'s 14 `documented-exception` verdicts are
+  explicitly flagged in that doc as "not settled"** — each asserts safety via a code
+  comment, never independently re-derived the way the 9 `real` findings were (see that
+  doc's "Open question" section). Three of the original documented-exceptions
+  (`RemoveGlobalAdminRoleGuardedProxy`, `RevokeBreakGlassActivationProxy`,
+  `RecordLoginAttemptProxy`) turned out false this campaign; the other 14 haven't been
+  re-checked with the same rigor.
+- **`RevokeMachineIdentityCredentialProxy`** (#1551) and the
+  `CreateMachineIdentityCredentialProxy`/`CreateOIDCBindingProxy` node-credential
+  residuals (#1552) are recorded in `knownUnfixedRawStorageBypasses`
+  (`server/http/raw_storage_bypass_guard_test.go`) as real, tracked, not-yet-fixed gaps
+  — unrelated to ADR-085, still open.
+- **`CreateDynamicSecretConfigProxy`**'s `created_by` (display string, low severity) is a
+  documented, disclosed blind spot of the wire-actor-identity guard (reaches the field
+  only via `body.toModel()`'s nested struct hop, which the guard's literal
+  `body.<Field>` scan can't see) — not fixed, not silently missed either.

--- a/server/http/g80_setup_token_exploit_verification_test.go
+++ b/server/http/g80_setup_token_exploit_verification_test.go
@@ -1,0 +1,148 @@
+// g80_setup_token_exploit_verification_test.go — independent reproduction of the
+// CreateSetupTokenProxy account-takeover exploit an independent verification
+// session reported (2026-08-25) as observed against clean origin/main, contradicting
+// an earlier report in this campaign that the handler was "already correct." Both
+// cannot be true of the same tree. This test resolves it empirically rather than
+// by re-reading the handler: the exact three-step exploit chain the verification
+// session described, run against a real httptest server + real storage + real
+// router/middleware chain, with an assertion on the actual end state (was the
+// account taken over), not on an intermediate status code alone.
+//
+// Run this same file against pre-remediation main (45ae4bbe) and post-remediation
+// main and compare: red-then-green means the exploit was real and the fix closed
+// it; green-on-both means the verification session's report was itself wrong.
+package http
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+)
+
+// TestG80Exploit_CreateSetupTokenProxy_SystemWriteOnly_AccountTakeover is the
+// independent verification session's reported exploit, reproduced verbatim:
+//  1. An attacker holds a custom role granting EXACTLY system.write -- no
+//     admin-tier role, no users.write, nothing else.
+//  2. The attacker knows a real target account's email (a realistic assumption --
+//     emails are not secret) and mints a setup token for that target via
+//     POST /api/v1/system/setup-tokens.
+//  3. The attacker attempts to redeem that token, UNAUTHENTICATED, via
+//     POST /auth/setup/consume, setting a password the attacker chose.
+//
+// The account is considered taken over if step 3 returns a live session --
+// verified by reading the returned session token back against a real
+// authenticated call, not just checking the HTTP status of step 3 alone.
+func TestG80Exploit_CreateSetupTokenProxy_SystemWriteOnly_AccountTakeover(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	testCore := newTestCore(t)
+	ctx := context.Background()
+	createTestToken(t, testCore) // bootstrap admin + seed roles/permissions
+
+	// The target: a real, pre-existing account the attacker does NOT control,
+	// whose email the attacker knows (this is the entire "known" input the
+	// exploit requires -- no password, no prior access).
+	_, err := testCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "g80_exploit_target", Email: "g80-exploit-target@example.com", Password: "OriginalStr0ng!Passw0rd#1",
+	})
+	require.NoError(t, err)
+	target, err := testCore.GetUserByEmail(ctx, "g80-exploit-target@example.com")
+	require.NoError(t, err)
+
+	// The attacker: system.write and NOTHING else -- reuses this campaign's own
+	// standard fixture for that exact caller class.
+	attackerToken := createSystemWriteOnlyToken(t, testCore)
+
+	cfg := &config.Config{}
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	// Step 2: mint. The attacker picks the plaintext token themselves (a real
+	// attacker would) and submits only its SHA-256 hash, exactly like a
+	// legitimate RemoteStorage relay would -- the proxy's own documented
+	// contract, not a shortcut this test is taking.
+	rawToken := "kx_setup_g80_exploit_attacker_chosen_00000000000000000000000000"
+	sum := sha256.Sum256([]byte(rawToken))
+	tokenHash := hex.EncodeToString(sum[:])
+
+	mintBody, _ := json.Marshal(map[string]any{
+		"token_hash":      tokenHash,
+		"purpose":         "account_setup",
+		"subject_email":   target.Email,
+		"subject_user_id": target.ID,
+		"expires_at":      time.Now().Add(time.Hour),
+	})
+	mintReq, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/system/setup-tokens", bytes.NewReader(mintBody))
+	require.NoError(t, err)
+	mintReq.Header.Set("Authorization", "Bearer "+attackerToken)
+	mintReq.Header.Set("Content-Type", "application/json")
+	mintResp, err := http.DefaultClient.Do(mintReq)
+	require.NoError(t, err)
+	mintRespBody := new(bytes.Buffer)
+	_, _ = mintRespBody.ReadFrom(mintResp.Body)
+	_ = mintResp.Body.Close()
+	t.Logf("step 2 (mint setup token, system.write-only attacker, known target email): status=%d body=%s",
+		mintResp.StatusCode, mintRespBody.String())
+
+	if mintResp.StatusCode != http.StatusOK {
+		t.Logf("EXPLOIT BLOCKED at step 2 (mint denied) -- account takeover did not occur")
+		return
+	}
+
+	// Step 3: redeem, unauthenticated, setting a password the attacker chose.
+	consumeBody, _ := json.Marshal(map[string]any{
+		"token":    rawToken,
+		"password": "AttackerChosenStr0ng!Passw0rd#2",
+	})
+	consumeReq, err := http.NewRequest(http.MethodPost, server.URL+"/auth/setup/consume", bytes.NewReader(consumeBody))
+	require.NoError(t, err)
+	consumeReq.Header.Set("Content-Type", "application/json")
+	consumeResp, err := http.DefaultClient.Do(consumeReq)
+	require.NoError(t, err)
+	consumeRespBody := new(bytes.Buffer)
+	_, _ = consumeRespBody.ReadFrom(consumeResp.Body)
+	_ = consumeResp.Body.Close()
+	t.Logf("step 3 (unauthenticated redeem): status=%d body=%s", consumeResp.StatusCode, consumeRespBody.String())
+
+	if consumeResp.StatusCode != http.StatusOK {
+		t.Logf("EXPLOIT BLOCKED at step 3 (redeem denied) -- account takeover did not occur")
+		return
+	}
+
+	// Confirm the takeover for real: the consume response itself is the login
+	// response shape (loginResponseBody) -- its user_id/email fields identify
+	// WHICH account the newly-issued session belongs to. A non-empty token
+	// alone would only prove "some session was minted"; matching it to the
+	// target's own ID and email is the actual account-takeover confirmation
+	// the verification session performed by reading the target's profile.
+	var parsed struct {
+		Data struct {
+			Token  string `json:"token"`
+			UserID uint   `json:"user_id"`
+			Email  string `json:"email"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(consumeRespBody.Bytes(), &parsed))
+	require.NotEmpty(t, parsed.Data.Token, "consume returned 200 but no session token was present in the response")
+
+	require.Fail(t, "CEILING VIOLATED: a system.write-only caller minted a setup token for a target whose email "+
+		"they knew, redeemed it unauthenticated, and obtained a live session identifying as that exact target "+
+		"account.",
+		"mint status=%d, consume status=%d, session user_id=%d (target=%d), session email=%q (target=%q)",
+		mintResp.StatusCode, consumeResp.StatusCode, parsed.Data.UserID, target.ID, parsed.Data.Email, target.Email)
+}

--- a/server/http/g80_triage_doc_closure_guard_test.go
+++ b/server/http/g80_triage_doc_closure_guard_test.go
@@ -32,10 +32,33 @@
 package http
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// g80ClosureMarker is the "still present" half of a closure claim -- an
+// ancestor-of-HEAD check on a SHA only answers "did this land"; it says
+// nothing about whether a LATER commit reverted, refactored away, or lost
+// the fix in a bad merge resolution. A later commit can't remove itself from
+// an earlier commit's ancestry, so the SHA check stays green forever even
+// after the fix is gone. Exactly one of mustExist/mustNotExist is set.
+type g80ClosureMarker struct {
+	// file is the repo-relative path the marker is checked against. Empty
+	// means repo-wide (via `git grep`) -- used for mustNotExist markers
+	// where the fix's signature is the absence of a symbol anywhere, not
+	// its presence in one particular file (the ADR-085 entry below).
+	file string
+	// mustExist is a literal substring that must still be present in `file`
+	// (or repo-wide if file is empty) for the fix to be considered intact.
+	mustExist string
+	// mustNotExist is a literal substring that must still be ABSENT from
+	// `file` (or repo-wide if file is empty) for the fix to be considered
+	// intact -- e.g. a removed function's own name.
+	mustNotExist string
+}
 
 // g80ClosureClaim is one triage-doc reference this guard verifies (or
 // explicitly declines to, with a stated reason).
@@ -53,29 +76,46 @@ type g80ClosureClaim struct {
 	// it is not a silent exemption because it appears in this file's
 	// registry and is asserted non-empty by the test below.
 	noSingleCommitReason string
+	// marker is the "still present" check, independent of the SHA's ancestry
+	// -- see g80ClosureMarker's doc. Required for every entry: an entry with
+	// no marker is exactly the unverifiable-closure shape this guard exists
+	// to catch, whether or not it also carries a SHA.
+	marker g80ClosureMarker
 }
 
 // g80TriageClosureClaims is the registry TestG80TriageDocClosuresAreAncestorsOfHEAD
 // checks. Add an entry here whenever a triage doc records a new "FIXED"
 // claim against a real commit; add a noSingleCommitReason entry instead when
-// the fix has no single commit to point at.
+// the fix has no single commit to point at. Every entry needs a marker.
 var g80TriageClosureClaims = []g80ClosureClaim{
 	// docs/g80-raw-storage-bypass-triage.md "Fix wave complete (2026-08-25)"
 	// section, verified against origin/main by this same correction pass
 	// (2026-08-25) -- see that section's own "Corrections from an
 	// independent verification session" subsection.
 	{label: "docs/g80-raw-storage-bypass-triage.md: PR #1557 (CreateAccessRequestProxy/UpdateAccessRequestProxy dual-control bypass)",
-		sha: "2b888df72c322563030dbd7a7b996c022cf08061"},
+		sha: "2b888df72c322563030dbd7a7b996c022cf08061",
+		marker: g80ClosureMarker{file: "server/http/handlers/access_request_proxy.go",
+			mustExist: "RequireAdminAuthorityAt"}},
 	{label: "docs/g80-raw-storage-bypass-triage.md: PR #1558 (CreateInvitationProxy/UpdateInvitationProxy escalation-by-proxy bypass)",
-		sha: "28b52cfbeec5a1acd2bf2d81e32afb42328e4590"},
+		sha: "28b52cfbeec5a1acd2bf2d81e32afb42328e4590",
+		marker: g80ClosureMarker{file: "server/http/handlers/invitations_proxy.go",
+			mustExist: "RequireAuthorityForRole"}},
 	{label: "docs/g80-raw-storage-bypass-triage.md: PR #1559 (SoD policy and risk-exception authority gaps)",
-		sha: "f83d63c63a03a6bedc79a4440eb84def3805a471"},
+		sha: "f83d63c63a03a6bedc79a4440eb84def3805a471",
+		marker: g80ClosureMarker{file: "internal/core/sod.go",
+			mustExist: "isGlobalAdminRoleName"}},
 	{label: "docs/g80-raw-storage-bypass-triage.md: PR #1560 (DeleteOIDCBindingProxy direct-caller routing)",
-		sha: "33eaf8df9dd5faaac77d11979b3e65c267ca9ca4"},
+		sha: "33eaf8df9dd5faaac77d11979b3e65c267ca9ca4",
+		marker: g80ClosureMarker{file: "server/http/handlers/machine_identities_proxy.go",
+			mustExist: "coreService.DeleteOIDCBinding"}},
 	{label: "docs/g80-raw-storage-bypass-triage.md: PR #1561 (UpdateUser PAT/session-revocation residual)",
-		sha: "10fdb34ab705448bd6bdf6f6e0193a1555dad430"},
+		sha: "10fdb34ab705448bd6bdf6f6e0193a1555dad430",
+		marker: g80ClosureMarker{file: "server/http/router.go",
+			mustExist: "RevokeAllPersonalAccessTokensForUserProxy"}},
 	{label: "docs/g80-raw-storage-bypass-triage.md: PR #1562 (RemoveGlobalAdminRoleGuardedProxy actor-authority gap)",
-		sha: "cb26f4f0baed17ffe0c89a9fc93635d613ae6307"},
+		sha: "cb26f4f0baed17ffe0c89a9fc93635d613ae6307",
+		marker: g80ClosureMarker{file: "server/http/handlers/rbac_role_grants_proxy.go",
+			mustExist: "coreService.RemoveUserRole"}},
 	// PRs #1563-#1566 (server/http proxy Tier-2 fixes) and the ADR-085
 	// node-credential-arm removal: an independent verification session's
 	// headline finding (2026-08-25) is that all four PRs showed
@@ -89,11 +129,15 @@ var g80TriageClosureClaims = []g80ClosureClaim{
 	// equivalent). There is no single commit that represents "PR #1563's
 	// fix" (or #1564/#1565/#1566's) anymore, distinct from the whole
 	// re-applied stack -- stated explicitly here, not silently exempted.
+	// Its marker is repo-wide absence of RequireNodeCredentialOrPermission,
+	// the exact function ADR-085 deletes -- the natural, and only, marker
+	// for a stack with no single commit to point at.
 	{label: "PRs #1563-#1566 + ADR-085 node-credential-arm removal",
 		noSingleCommitReason: "re-applied as one flat diff onto a fresh branch (git apply, not a rebase) after " +
 			"the original branch-into-branch merge chain was found to never reach main and the pre-squash " +
 			"commits were confirmed unrecoverable as ancestors of their post-squash equivalents; verify this " +
-			"content's presence by reading the diff/tests it introduced, not by any single commit hash"},
+			"content's presence by reading the diff/tests it introduced, not by any single commit hash",
+		marker: g80ClosureMarker{mustNotExist: "func RequireNodeCredentialOrPermission"}},
 }
 
 // ensureFullHistory deepens a shallow clone before this guard runs its
@@ -126,12 +170,111 @@ func ensureFullHistory(t *testing.T) {
 	}
 }
 
-// TestG80TriageDocClosuresAreAncestorsOfHEAD is Task 0b's guard: every claim
-// in g80TriageClosureClaims that names a commit must be an ancestor of HEAD
-// (git merge-base --is-ancestor <sha> HEAD) -- a merge badge, a PR's
-// "Merged" label, or an approval is never sufficient evidence on its own.
+// fileContains reports whether path's current working-tree content contains
+// substr in a NON-COMMENT line. path is repo-relative; this test binary runs
+// with its package directory (server/http) as cwd, so path is resolved
+// against "../..". Comment lines (trimmed content starting with "//") are
+// skipped before searching -- mirrors wire_actor_identity_forgery_guard_test.go's
+// actorFieldReads, and for the same reason: a doc comment mentioning a
+// removed symbol's name (this file's own fix commentary routinely does
+// exactly that, describing what a fix now checks) must not itself satisfy a
+// mustExist marker after the real call is gone -- that would make the
+// marker unable to fail on a genuine revert, which defeats the point of
+// having it.
+func fileContains(t *testing.T, path, substr string) bool {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("..", "..", path))
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		if strings.Contains(line, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// repoContains reports whether substr appears ANYWHERE in the current
+// working tree's tracked *.go files -- used for mustNotExist markers that
+// check a symbol's absence repo-wide (a removed function could be
+// re-introduced under a different file without a single-file check catching
+// it). Excludes THIS file from the scan: a mustNotExist marker necessarily
+// spells out the exact string it's checking for as a Go string literal in
+// g80TriageClosureClaims below, which would otherwise self-match on every
+// run regardless of whether the real symbol is actually gone.
+func repoContains(t *testing.T, substr string) bool {
+	t.Helper()
+	out, err := exec.Command("git", "-C", "../..", "grep", "-q", "-F", substr, "--",
+		"*.go", ":!server/http/g80_triage_doc_closure_guard_test.go").CombinedOutput()
+	if err == nil {
+		return true
+	}
+	if len(out) == 0 {
+		return false
+	}
+	t.Fatalf("git grep failed unexpectedly for %q repo-wide: %v (%s)", substr, err, string(out))
+	return false
+}
+
+// checkMarker evaluates one g80ClosureMarker against the current working
+// tree and returns a non-empty failure description if the marker doesn't
+// hold (empty string means the marker is satisfied).
+func checkMarker(t *testing.T, m g80ClosureMarker) string {
+	t.Helper()
+	switch {
+	case m.mustExist != "" && m.mustNotExist != "":
+		return "marker malformed: both mustExist and mustNotExist set -- pick one"
+	case m.mustExist == "" && m.mustNotExist == "":
+		return "marker malformed: neither mustExist nor mustNotExist set -- every closure claim needs a marker"
+	case m.mustExist != "":
+		var present bool
+		if m.file != "" {
+			present = fileContains(t, m.file, m.mustExist)
+		} else {
+			present = repoContains(t, m.mustExist)
+		}
+		if !present {
+			where := m.file
+			if where == "" {
+				where = "anywhere in the repo"
+			}
+			return "marker NOT satisfied: " + m.mustExist + " no longer found in " + where +
+				" -- the fix this entry claims may have been reverted, refactored away, or lost in a merge"
+		}
+	case m.mustNotExist != "":
+		var present bool
+		if m.file != "" {
+			present = fileContains(t, m.file, m.mustNotExist)
+		} else {
+			present = repoContains(t, m.mustNotExist)
+		}
+		if present {
+			where := m.file
+			if where == "" {
+				where = "the repo"
+			}
+			return "marker NOT satisfied: " + m.mustNotExist + " is back in " + where +
+				" -- this entry's closure claims its removal, but it has reappeared"
+		}
+	}
+	return ""
+}
+
+// TestG80TriageDocClosuresAreAncestorsOfHEAD is Task 0b's guard, now two
+// independent checks per entry: the SHA answers "did this land" (git
+// merge-base --is-ancestor <sha> HEAD -- a merge badge, a PR's "Merged"
+// label, or an approval is never sufficient evidence on its own), and the
+// marker answers "is the fix still present" (a later commit can revert,
+// refactor away, or lose a fix in a bad merge resolution without ever
+// removing the original SHA from HEAD's ancestry, so the SHA check alone
+// stays green forever after the fix is gone -- see g80ClosureMarker's doc).
 // Every claim with no single commit must say so via noSingleCommitReason,
-// not be silently absent from this registry.
+// not be silently absent from this registry. Every claim, with or without a
+// SHA, must carry a marker.
 func TestG80TriageDocClosuresAreAncestorsOfHEAD(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available on PATH")
@@ -140,7 +283,11 @@ func TestG80TriageDocClosuresAreAncestorsOfHEAD(t *testing.T) {
 	var notAncestor []string
 	var unresolvable []string
 	var malformed []string
+	var markerFailed []string
 	for _, c := range g80TriageClosureClaims {
+		if m := checkMarker(t, c.marker); m != "" {
+			markerFailed = append(markerFailed, c.label+": "+m)
+		}
 		if c.sha == "" {
 			if strings.TrimSpace(c.noSingleCommitReason) == "" {
 				malformed = append(malformed, c.label+" (neither sha nor noSingleCommitReason set)")
@@ -168,6 +315,10 @@ func TestG80TriageDocClosuresAreAncestorsOfHEAD(t *testing.T) {
 	}
 	if len(malformed) > 0 {
 		t.Errorf("%d closure claim(s) malformed in this file's registry: %v", len(malformed), malformed)
+	}
+	if len(markerFailed) > 0 {
+		t.Errorf("%d closure claim(s) failed their marker check (SHA landed, but the fix is no longer present in "+
+			"the working tree): %v", len(markerFailed), markerFailed)
 	}
 	if len(unresolvable) > 0 {
 		t.Errorf("%d closure claim(s) reference a commit this checkout could not resolve, even after attempting "+


### PR DESCRIPTION
## Summary

Two independent follow-up verifications requested against the already-merged G80 stack (#1569):

**1. CreateSetupTokenProxy contradiction, resolved empirically.** An independent verification session reported a live account-takeover exploit against clean origin/main, contradicting an earlier "already correct" report from this campaign. Rather than re-reading code, the exact exploit was written as a test (`TestG80Exploit_CreateSetupTokenProxy_SystemWriteOnly_AccountTakeover`) and run against both trees:

- **Pre-remediation main (`45ae4bbe`): RED.** Mint succeeded (200), unauthenticated redeem succeeded (200), and the returned session's `user_id`/`email` matched the target exactly — a confirmed, full account takeover by a caller holding only `system.write`.
- **Post-remediation main (current): GREEN.** Mint is denied with 403 (`requires the users.write permission`).

Conclusion: the exploit was real, and the `users.write` authority check added during this campaign closes it. The earlier "already correct" report was accurate only because it was made after the fix had already been cherry-picked into that worktree — not because the exploit was never real.

**2. Closure guard given a "still present" check, not just "did this land."** `git merge-base --is-ancestor <sha> HEAD` only answers whether a commit landed; it says nothing about whether a *later* commit reverted, refactored away, or lost the fix in a bad merge — the SHA stays an ancestor of HEAD forever regardless. Added a marker (a symbol that must still exist, or must still be absent) to every entry in `g80TriageClosureClaims`, checked independently of the SHA. `RequireNodeCredentialOrPermission`'s repo-wide absence is the marker for the ADR-085/#1563–#1566 entry that has no single commit to point at.

Verified by temporarily deleting one fix's call site (leaving its commit in history) and confirming the marker check goes red while the SHA check stays green, then reverting. Two real bugs in the marker mechanism itself were found and fixed along the way:
- `git grep` resolves pathspecs relative to the test binary's cwd (its package directory), not the repo root — this silently flagged every marker as absent until fixed.
- A `mustNotExist` marker's own string literal, written in this very file, matched its own repo-wide search for that string — which would have made that marker permanently unable to fail. Fixed by excluding the guard file itself from the scan, and by making file-scoped markers skip comment-only lines (a doc comment mentioning a removed symbol's name must not itself satisfy a `mustExist` marker after the real call is gone).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean (0 issues)
- [x] `go test ./server/http/... ./server/http/handlers/... ./internal/core/...` all pass
- [x] Exploit test run against pre-remediation main (45ae4bbe): confirmed RED
- [x] Exploit test run against post-remediation main: confirmed GREEN
- [x] Closure guard marker verified red-before/green-after by temporarily reverting one fix