### PR TITLE
fix(security): record which machine identity acted on audit events (#1530)

### DIFF
--- a/internal/core/audit_context.go
+++ b/internal/core/audit_context.go
@@ -1,4 +1,5 @@
-// audit_context.go — propagation of impersonation attribution through context.
+// audit_context.go — propagation of impersonation and machine-actor
+// attribution through context.
 //
 // When an admin acts inside an impersonation session, every audit event written
 // during that session must record who really acted. The auth middleware tags the
@@ -6,6 +7,19 @@
 // and stamps ImpersonatedBy/ActingAs/Impersonation on the row. Because audit
 // writes happen in detached goroutines (context.Background()), handlers use
 // DetachedAuditContext to carry the tag past request cancellation.
+//
+// G80 #1530: the same mechanism, mirrored, closes a sibling gap. ActorType
+// already distinguished a machine caller from a human one, but nothing carried
+// WHICH machine identity — audit.UserID is nil for actorID==0 (every machine
+// caller, by construction: middleware/auth.go's UserContext.UserID is 0 for
+// any machine token), so a machine-attributable mutation produced a row
+// correctly tagged ActorType="machine_identity" but with no identity to go
+// with it. WithMachineActor/machineActorFromContext follow WithImpersonation's
+// exact shape (not a new pattern) because that one is the working case of this
+// same problem, already threaded through context and already stamped
+// centrally in the writers -- copying a mechanism that demonstrably works is
+// not the same claim as "matches existing precedent" when the precedent is
+// itself the defect.
 package core
 
 import (
@@ -25,6 +39,8 @@ const (
 type impersonationKey struct{}
 
 type actorTypeKey struct{}
+
+type machineActorKey struct{}
 
 // WithActorType tags ctx with the principal kind for the current request
 // (ActorTypeUser/ActorTypeMachine/ActorTypeSystem). The auth middleware sets it
@@ -46,6 +62,26 @@ func actorTypeFromContext(ctx context.Context) string {
 	return ActorTypeUser
 }
 
+// WithMachineActor tags ctx with the machine identity ID authenticated for
+// the current request (ADR-030). A zero machineID is treated as "no machine
+// actor" -- same shape as WithImpersonation. The auth middleware sets this
+// alongside WithActorType(ctx, ActorTypeMachine); writeAuditEvent* reads it
+// and stamps MachineIdentityID on the row, so a machine-attributable mutation
+// records WHICH machine, not just that a machine did it.
+func WithMachineActor(ctx context.Context, machineID uint) context.Context {
+	if machineID == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, machineActorKey{}, machineID)
+}
+
+// machineActorFromContext returns the tagged machine identity ID and whether
+// the current context carries one.
+func machineActorFromContext(ctx context.Context) (uint, bool) {
+	machineID, ok := ctx.Value(machineActorKey{}).(uint)
+	return machineID, ok && machineID != 0
+}
+
 // WithImpersonation tags ctx with the admin user ID that initiated the current
 // impersonation session. A zero adminID is treated as "no impersonation".
 func WithImpersonation(ctx context.Context, adminID uint) context.Context {
@@ -63,8 +99,11 @@ func impersonatorFromContext(ctx context.Context) (uint, bool) {
 }
 
 // DetachedAuditContext returns a background-rooted context that preserves any
-// impersonation tag from parent. Audit writes run in goroutines that must
-// outlive the request, but still need to record the impersonating admin.
+// impersonation, actor-type, and machine-actor tag from parent. Audit writes
+// run in goroutines that must outlive the request, but still need to record
+// the impersonating admin / acting machine identity -- a detached write that
+// dropped the machine-actor tag would silently reintroduce #1530's gap for
+// every fire-and-forget audit call.
 func DetachedAuditContext(parent context.Context) context.Context {
 	ctx := context.Background() // NOSONAR
 	if adminID, ok := impersonatorFromContext(parent); ok {
@@ -72,6 +111,9 @@ func DetachedAuditContext(parent context.Context) context.Context {
 	}
 	if t, ok := parent.Value(actorTypeKey{}).(string); ok && t != "" {
 		ctx = WithActorType(ctx, t)
+	}
+	if machineID, ok := machineActorFromContext(parent); ok {
+		ctx = WithMachineActor(ctx, machineID)
 	}
 	return ctx
 }

--- a/internal/core/g80_1530_machine_actor_attribution_guard_test.go
+++ b/internal/core/g80_1530_machine_actor_attribution_guard_test.go
@@ -1,0 +1,112 @@
+// g80_1530_machine_actor_attribution_guard_test.go — #1530's guard: every
+// audit-emitting path funnels through emitAudit (service.go), the single
+// choke point that stamps MachineIdentityID from context when an event is
+// actor-typed "machine_identity". A call site that bypasses emitAudit and
+// writes storage.LogAuditEvent directly skips that stamp entirely -- if such
+// a site ever sets ActorType to "machine_identity" (or leaves it derivable
+// from a machine-authenticated context) without also setting
+// MachineIdentityID itself, it silently reintroduces #1530's exact gap.
+//
+// This is a small, allowlist-shaped guard, not a repo-wide AST walk: as of
+// writing there is exactly one direct storage.LogAuditEvent caller outside
+// emitAudit itself (anomaly.go's auditBusinessHoursConfig), and it correctly
+// hardcodes ActorType: "system" -- a genuine no-actor event (a scheduler
+// config change), not a machine-identity one. Cheap to keep this way: a new
+// direct LogAuditEvent caller that constructs a "machine_identity"-typed
+// event without setting MachineIdentityID fails this test immediately.
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// auditAttributionAllowlist is the exhaustive, reasoned inventory of every
+// direct storage.LogAuditEvent caller (bypassing emitAudit) reviewed as safe
+// -- either it never sets ActorType to "machine_identity" at all (a genuine
+// system/no-actor event), or it sets MachineIdentityID itself. Each entry
+// needs a reason; TestDirectLogAuditEventCallersAreSafe fails if a new
+// direct caller appears unlisted, or if a listed entry no longer matches
+// what it claims.
+var auditAttributionAllowlist = map[string]string{
+	"anomaly.go:auditBusinessHoursConfig": "hardcodes ActorType: \"system\" -- a scheduler/config-change event " +
+		"with no human or machine actor, correctly using the system-actor marker rather than a null. Never " +
+		"machine-identity-typed, so emitAudit's MachineIdentityID stamp would never apply to it anyway.",
+}
+
+var logAuditEventFuncRe = regexp.MustCompile(`^func\s+(?:\([^)]*\)\s*)?([A-Za-z0-9_]+)\(`)
+
+// findDirectLogAuditEventCallers scans every non-test *.go file in
+// internal/core for a `.LogAuditEvent(` call NOT inside emitAudit itself
+// (service.go's own funnel implementation is the one legitimate direct
+// caller of the storage interface method), returning "file:func" keys.
+func findDirectLogAuditEventCallers(t *testing.T) map[string]bool {
+	t.Helper()
+	found := map[string]bool{}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading internal/core: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(".", name))
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		currentFunc := ""
+		for _, line := range strings.Split(string(b), "\n") {
+			if m := logAuditEventFuncRe.FindStringSubmatch(line); m != nil {
+				currentFunc = m[1]
+			}
+			if currentFunc == "emitAudit" {
+				continue // the funnel itself, not a bypass
+			}
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "//") {
+				continue
+			}
+			if strings.Contains(line, ".LogAuditEvent(") && currentFunc != "" {
+				found[name+":"+currentFunc] = true
+			}
+		}
+	}
+	return found
+}
+
+// TestDirectLogAuditEventCallersAreSafe is #1530's guard: every direct
+// storage.LogAuditEvent caller (bypassing emitAudit's MachineIdentityID
+// stamp) must be in auditAttributionAllowlist with a reason, or the test
+// fails -- a new bypass site is exactly how this gap would reappear.
+func TestDirectLogAuditEventCallersAreSafe(t *testing.T) {
+	actual := findDirectLogAuditEventCallers(t)
+
+	var unjustified []string
+	for key := range actual {
+		if _, ok := auditAttributionAllowlist[key]; !ok {
+			unjustified = append(unjustified, key)
+		}
+	}
+	if len(unjustified) > 0 {
+		t.Errorf("%d direct storage.LogAuditEvent caller(s) bypass emitAudit's MachineIdentityID stamp with no "+
+			"reasoned allowlist entry: %v\nEither route through emitAudit instead, or add a reasoned entry to "+
+			"auditAttributionAllowlist explaining why this site can never emit a machine-identity-typed event "+
+			"without attribution.", len(unjustified), unjustified)
+	}
+
+	var stale []string
+	for key := range auditAttributionAllowlist {
+		if !actual[key] {
+			stale = append(stale, key+" (no longer calls LogAuditEvent directly)")
+		}
+	}
+	if len(stale) > 0 {
+		t.Errorf("auditAttributionAllowlist entr(y/ies) no longer reproduce: %v\nRemove the entry -- it's either "+
+			"been fixed to route through emitAudit, or the direct call was removed.", stale)
+	}
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -467,8 +467,18 @@ func truncateAuditField(s string, maxLen int) string {
 // All core audit writers funnel through here so SIEM forwarding is uniform —
 // which also makes it the single choke point to cap Description/Diff length
 // (#381), independent of which helper (writeAuditEvent*, writeImpersonationEvent,
-// AuditLicenseState, ...) produced the event.
+// AuditLicenseState, ...) produced the event. G80 #1530: the same choke point
+// closes the machine-actor-attribution gap for every one of those callers at
+// once, not just the two that happened to be checked first -- a machine
+// identity's own ID is stamped here from context (WithMachineActor,
+// audit_context.go) whenever the event is already actor-typed "machine_identity"
+// and no caller explicitly set MachineIdentityID itself.
 func (c *KeyorixCore) emitAudit(ctx context.Context, event *models.AuditEvent) {
+	if event.ActorType == ActorTypeMachine && event.MachineIdentityID == nil {
+		if machineID, ok := machineActorFromContext(ctx); ok {
+			event.MachineIdentityID = &machineID
+		}
+	}
 	event.Description = truncateAuditField(event.Description, auditDescriptionMaxLen)
 	event.Diff = truncateAuditField(event.Diff, auditDiffMaxLen)
 	if err := c.storage.LogAuditEvent(ctx, event); err != nil {

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -1299,6 +1299,17 @@ type AuditEvent struct {
 	// so legacy rows and back-compat writers read as human-actored.
 	ActorType string `gorm:"default:user"`
 
+	// MachineIdentityID records WHICH machine identity acted, when ActorType
+	// is "machine_identity" (G80 #1530). UserID is always nil for a machine
+	// caller (machine tokens carry no human user ID by construction), so
+	// before this field existed, ActorType correctly recorded "a machine did
+	// this" while nothing recorded which one -- a real, structural gap, not a
+	// bug in the writer: the audit model had no field to hold a machine
+	// actor. Indexed so "everything this identity did" is a real, queryable
+	// answer, not just a per-row curiosity -- an attribution field a security
+	// review can't query is only half the control.
+	MachineIdentityID *uint `gorm:"index"`
+
 	// Tamper-evidence hash chain (ADR-029). PrevHash is the EntryHash of the
 	// immediately preceding chained event (a fixed genesis constant for the
 	// first chained event); EntryHash is SHA256(canonical(fields) ‖ PrevHash).

--- a/server/http/g80_1530_machine_actor_attribution_test.go
+++ b/server/http/g80_1530_machine_actor_attribution_test.go
@@ -1,0 +1,89 @@
+// g80_1530_machine_actor_attribution_test.go — closes #1530: a security-relevant
+// mutation reachable by a machine identity produced an audit event correctly
+// tagged ActorType="machine_identity" but with no field to say WHICH machine
+// (UserID is nil for every machine caller, by construction -- machine tokens
+// carry no human user ID). The audit model had no field that could hold a
+// machine-identity actor; MachineIdentityID (internal/storage/models/models.go)
+// is that field. Reproduces the exact triage repro: a MachineTypeService
+// identity (deliberately non-node, since the underlying gap was never
+// node-specific) holding only system.write creates a group and the resulting
+// audit event must record which machine did it.
+package http
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func TestG80_1530_MachineActorAttribution_NonNodeServiceIdentity(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	testCore := newTestCore(t)
+	ctx := context.Background()
+	createTestToken(t, testCore)
+	admin, err := testCore.GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+	projects, err := testCore.Storage().ListProjects(ctx)
+	require.NoError(t, err)
+
+	mi, err := testCore.CreateMachineIdentity(ctx, projects[0].ID, "attribution-probe-service", core.MachineTypeService, "", "", admin.ID)
+	require.NoError(t, err)
+
+	role, err := testCore.Storage().CreateRole(ctx, &models.Role{Name: "g80_1530_system_writer"})
+	require.NoError(t, err)
+	perms, err := testCore.ListPermissions(ctx)
+	require.NoError(t, err)
+	var systemWriteID uint
+	for _, p := range perms {
+		if p.Name == "system.write" {
+			systemWriteID = p.ID
+		}
+	}
+	require.NotZero(t, systemWriteID)
+	require.NoError(t, testCore.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID))
+	require.NoError(t, testCore.Storage().AssignMachineRole(ctx, mi.ID, role.ID, coreStorage.Scope{}))
+
+	result, err := testCore.IssueMachineToken(ctx, projects[0].ID, mi.ID, admin.ID, core.IssueMachineTokenParams{Name: "g80-1530-probe-token"})
+	require.NoError(t, err)
+
+	cfg := &config.Config{}
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/system/groups",
+		bytes.NewReader([]byte(`{"name":"g80-1530-attribution-probe"}`)))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+result.PlainToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "a system.write-holding service machine identity must reach this route")
+
+	action := string(core.EventGroupCreated)
+	logs, _, err := testCore.Storage().GetAuditLogs(ctx, &coreStorage.AuditFilter{Action: &action})
+	require.NoError(t, err)
+	require.NotEmpty(t, logs, "the create must have produced an audit event")
+	last := logs[len(logs)-1]
+
+	require.Equal(t, core.ActorTypeMachine, last.ActorType, "sanity: this event must be actor-typed as a machine")
+	require.Nil(t, last.UserID, "sanity: UserID must still be nil for a machine caller -- confirms this isn't accidentally attributing to a human field")
+	require.NotNil(t, last.MachineIdentityID,
+		"CEILING VIOLATED: a security-relevant mutation by a machine identity produced an audit event "+
+			"with no record of WHICH machine acted -- ActorType said 'a machine did this' but nothing said which one")
+	require.Equal(t, mi.ID, *last.MachineIdentityID, "the attributed machine identity must be the one that actually made the call, not an arbitrary non-nil value")
+}

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -989,9 +989,13 @@ func buildRequestContext(parent context.Context, userCtx *UserContext, coreServi
 		ctx = core.WithImpersonation(ctx, *userCtx.ImpersonatedBy)
 	}
 	// Tag machine requests so every audit event they produce is actored as a
-	// machine identity (ADR-023/030 plumbing).
+	// machine identity (ADR-023/030 plumbing), AND record which one (G80
+	// #1530) -- ActorType alone said "a machine did this"; WithMachineActor
+	// is the field that says which machine, mirroring WithImpersonation two
+	// lines above exactly (same mechanism, not a new one).
 	if userCtx != nil && userCtx.MachineIdentityID != nil {
 		ctx = core.WithActorType(ctx, core.ActorTypeMachine)
+		ctx = core.WithMachineActor(ctx, *userCtx.MachineIdentityID)
 	}
 	// Carry a PAT's least-privilege restriction (ADR-042) so core.Authorize
 	// enforces it on every authorization check this request makes.


### PR DESCRIPTION
## Summary

Closes #1530, the last item from the G80 campaign's issue triage. Not new work from a new sweep — a known finding that changed status from "probably moot" to "live and reproduced" during the triage, and small enough to fix directly rather than leave open.

`models.AuditEvent` already stamped `ActorType="machine_identity"` for a machine-authenticated caller (ADR-023), but had no field to record **which** machine — `UserID` is nil for every machine caller by construction. A real, security-relevant mutation by a machine identity (reproduced live: a non-node `MachineTypeService` identity holding only `system.write` creating a group) produced an audit event correctly tagged as machine-actored but with no identity attached — "a machine did this, unknown which," not fully unattributed.

**Fix**: `models.AuditEvent.MachineIdentityID` (`*uint`, indexed — so "everything this identity did" is a real query, not just a per-row curiosity). Threaded through context exactly the way `ImpersonatedBy` already is — the auth middleware's `buildRequestContext` calls the new `core.WithMachineActor` alongside the existing `WithActorType` call; `emitAudit`, the single choke point every audit writer already funnels through (for `Description`/`Diff` truncation), stamps `MachineIdentityID` from context. **Zero changes to the ~45 individual `writeAuditEvent*`/`actorPtr` call sites.** Mirroring `ImpersonatedBy` is deliberate, not just convenient — it's the working case of this exact problem, already centralized, not a precedent that happens to also be the defect.

`DetachedAuditContext` (fire-and-forget audit goroutines) also carries the new tag forward — a detached write that dropped it would have silently reintroduced the gap for every async audit call.

**Guard**: `TestDirectLogAuditEventCallersAreSafe` flags any `storage.LogAuditEvent` caller that bypasses `emitAudit`'s stamp, allowlisted with a stated reason per entry (one entry today, correctly system-actored not machine-actored). Verified load-bearing by removing the entry and confirming red.

**Enumeration is bounded, not exhaustive — stated explicitly**: ~45 `actorPtr(actorID)` call sites exist; a representative sample was checked for machine-reachability (two confirmed reachable, several confirmed already blocked by an unrelated admin-tier check). The fix is complete by construction regardless of which sites were individually checked — the reachability audit itself is partial, and this PR doesn't want that read as "all sites verified."

A structurally different gap found during the same investigation — `SecretDependency.CreatedBy` (a persisted model field, not a queryable audit log; no equivalent single choke point to fix it at) — is filed separately as #1573, not bundled here.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` — 0 issues on every touched package
- [x] `gofmt -l` clean on every touched file
- [x] `TestG80_1530_MachineActorAttribution_NonNodeServiceIdentity` — reproduces the exact live repro, asserts `MachineIdentityID` is set to the acting identity. Verified red-before/green-after by temporarily disabling the `emitAudit` stamp.
- [x] `TestDirectLogAuditEventCallersAreSafe` — verified red-before/green-after by removing its one allowlist entry.
- [x] Full suites for every touched package (`internal/core`, `server/http`, `server/middleware`, `internal/storage/models`) — all green. (`internal/storage/store` has two pre-existing failures, `TestListShares_ExcludeExpiredIncludeActive`/`TestListSharesBySecretIDs` — confirmed via `git status` that this PR touches none of that package's files; unrelated, not investigated further here.)