### PR TITLE
fix(rbac): CreateMembershipProxy/UpdateMembershipProxy re-derive requireAuthorityForRole (#1578)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,6 +511,11 @@ jobs:
           source scripts/ci-test-legs.sh
           check_exclusion_freshness
 
+      - name: Check coverage-floor exclusion freshness (fails on any TEMPORARY entry >30 days old)
+        run: |
+          source scripts/ci-test-legs.sh
+          check_coverage_floor_exclusion_freshness
+
   # G80 C5: fails when any package in `go list ./...` is covered by NEITHER
   # a CI test-suite leg NOR an entry in scripts/ci-test-legs.sh's exclusion
   # table -- the guard against a package silently landing in zero legs, the
@@ -633,26 +638,15 @@ jobs:
       - name: Merge coverage profiles
         run: |
           echo "mode: atomic" > coverage_merged.out
-          # Exclude generated code (server/proto/pb's two *.pb.go files, ~16,700
-          # lines, essentially 0% covered by design -- their one real test,
-          # TestEveryFileIsGenerated, checks file headers, not the generated
-          # marshal/unmarshal/gRPC logic itself) from the coverage FLOOR
-          # calculation specifically. #1541 (G80 Wave 1): this package was
-          # PERMANENTLY excluded from every CI leg (never ran, never measured)
-          # until the PERMANENT exclusion in scripts/ci-test-legs.sh was
-          # removed in the same change that added that real test -- which
-          # means its instrumented-but-near-entirely-generated lines would
-          # otherwise land in coverage.out for the first time and drag the
-          # floor down by nothing the test suite actually failed to cover in
-          # any meaningful sense. Same principle gosec's own -exclude-generated
-          # flag already applies (ci.yml's gosec steps) -- generated code isn't
-          # a coverage gap, it's not something anyone writes tests against line
-          # by line. Filtered by filename suffix (*.pb.go), the same protoc-
-          # gen-go/protoc-gen-go-grpc convention TestEveryFileIsGenerated's own
-          # header check verifies those two files actually satisfy --
-          # generated_code_test.go itself is NOT named *.pb.go, so it stays in
-          # the measured set (it's a real, hand-written test).
-          tail -q -n +2 coverage_root1.out coverage_root2.out coverage_root3.out coverage_root4.out coverage_handlers1.out coverage_handlers2.out coverage_handlers3.out coverage_handlers4.out coverage_http1.out coverage_http2.out coverage_http3.out coverage_http4.out coverage_http5.out coverage_http6.out | grep -v '\.pb\.go:' >> coverage_merged.out
+          # File-pattern exclusions from the coverage-FLOOR sum (as opposed to
+          # exclusion_entries() above, which controls whether a PACKAGE runs in
+          # a CI leg at all) are a machine-checked, reasoned registry --
+          # scripts/ci-test-legs.sh's coverage_floor_exclusions() -- not a bare
+          # `grep -v` here with the reasoning only asserted in a comment.
+          source scripts/ci-test-legs.sh
+          grep_args=()
+          while IFS= read -r pattern; do grep_args+=(-e "$pattern"); done < <(coverage_floor_grep_patterns)
+          tail -q -n +2 coverage_root1.out coverage_root2.out coverage_root3.out coverage_root4.out coverage_handlers1.out coverage_handlers2.out coverage_handlers3.out coverage_handlers4.out coverage_http1.out coverage_http2.out coverage_http3.out coverage_http4.out coverage_http5.out coverage_http6.out | grep -v "${grep_args[@]}" >> coverage_merged.out
           mv coverage_merged.out coverage.out
 
       - name: Check coverage floor (≥${{ env.COVERAGE_FLOOR }}%)

--- a/scripts/ci-test-legs.sh
+++ b/scripts/ci-test-legs.sh
@@ -64,6 +64,59 @@ server/http/handlers$|SHARDED|runs in its own dedicated handlers-1..4 matrix leg
 EOF
 }
 
+# coverage_floor_exclusions: SAME shape and discipline as exclusion_entries()
+# above (pipe-delimited <pattern>|<kind>|<reason>|<issue>|<date-added>, kind
+# TEMPORARY/PERMANENT, TEMPORARY subject to the same 30-day freshness check),
+# but a DIFFERENT axis: exclusion_entries() controls whether a PACKAGE runs in
+# any CI leg at all; this controls whether coverage.out LINES matching
+# <pattern> (a package that DOES run) are filtered out of the coverage-FLOOR
+# sum specifically ("Merge coverage profiles", ci.yml). A package excluded
+# here still runs, still gets tested, still gets its own coverage.out lines --
+# those lines are just not counted toward the floor. A package excluded via
+# exclusion_entries() never reaches coverage.out in the first place, so an
+# entry here for it would be inert -- the two tables are disjoint by
+# construction, not by convention.
+#
+# server/proto/pb's *.pb.go PERMANENT entry replaces what was, before this
+# table existed, only a bare `grep -v '\.pb\.go:'` in ci.yml with a prose
+# comment restating the reasoning inline (added alongside #1541, G80 Wave 1,
+# 2026-08-25) -- the exact "asserted, not machine-checked" shape #1541's own
+# comment above criticizes scripts/ci-test-legs.sh for having FIXED, applied
+# here to itself: the reasoning now lives in one enforced place instead of a
+# comment nobody re-reads.
+coverage_floor_exclusions() {
+  cat <<'EOF'
+\.pb\.go:|PERMANENT|generated protobuf/gRPC code (protoc-gen-go/protoc-gen-go-grpc), ~16.7k lines, ~0% covered by design -- its one real test (server/proto/pb/generated_code_test.go's TestEveryFileIsGenerated) checks file headers, not the generated marshal/unmarshal/gRPC logic itself; same principle gosec's own -exclude-generated flag already applies to this same package|#1541|2026-08-25
+EOF
+}
+
+# coverage_floor_grep_patterns: just the regex column, for ci.yml's "Merge
+# coverage profiles" step to build its `grep -v` args from -- so the pattern
+# lives in exactly one place instead of the registry and the grep flag
+# drifting apart.
+coverage_floor_grep_patterns() {
+  coverage_floor_exclusions | cut -d'|' -f1
+}
+
+# check_coverage_floor_exclusion_freshness: same discipline as
+# check_exclusion_freshness below, applied to coverage_floor_exclusions
+# instead of exclusion_entries.
+check_coverage_floor_exclusion_freshness() {
+  local today_epoch failed=0
+  today_epoch=$(date -u -d "$(date -u +%Y-%m-%d)" +%s)
+  while IFS='|' read -r pattern kind reason issue added; do
+    [ "$kind" = "TEMPORARY" ] || continue
+    local added_epoch age_days
+    added_epoch=$(date -u -d "$added" +%s)
+    age_days=$(( (today_epoch - added_epoch) / 86400 ))
+    if [ "$age_days" -gt 30 ]; then
+      echo "STALE COVERAGE-FLOOR EXCLUSION (${age_days}d > 30d budget): $pattern -- $reason ($issue, added $added)"
+      failed=1
+    fi
+  done < <(coverage_floor_exclusions)
+  return $failed
+}
+
 # exclusion_patterns: just the regex column, one per line -- the set of
 # patterns root_base() excludes from the root/core legs entirely (every kind:
 # a SHARDED package must not ALSO run via root_base's catch-all, even though

--- a/server/http/handlers/handlers_s30_test.go
+++ b/server/http/handlers/handlers_s30_test.go
@@ -162,7 +162,10 @@ func TestCountMachineIdentityCredentialsByClassificationProxy_DBError_S30(t *tes
 func TestCreateMembershipProxy_DBError_S30(t *testing.T) {
 	t.Parallel()
 	h := NewCatalogHandler(freshCoreBrokenS30(t))
-	body := bytes.NewBufferString(`{"project_id":1,"user_id":1,"role":"admin","state":"active"}`)
+	// #1578: role must be non-admin so this reaches the broken-DB path this test
+	// is actually about, rather than being rejected earlier by
+	// RequireAuthorityForRole (this request has no authenticated actor at all).
+	body := bytes.NewBufferString(`{"project_id":1,"user_id":1,"role":"viewer","state":"active"}`)
 	req := httptest.NewRequest(http.MethodPost, "/", body)
 	w := httptest.NewRecorder()
 	h.CreateMembershipProxy(w, req)

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -10921,7 +10921,12 @@ func TestCatalogHandler_DeleteProjectIfEmptyProxy_HappyPath(t *testing.T) {
 
 func TestCatalogHandler_UpdateMembershipProxy_HappyPath(t *testing.T) {
 	h := newCatalogHandlerS4(t)
-	body := `{"role":"viewer"}`
+	// #1578: project_id/user_id/state must be populated too — UpdateMembershipProxy
+	// now requires all four fields (mirroring CreateMembershipProxy) before it will
+	// even reach RequireAuthorityForRole's check, closing the projectID==0
+	// global-scope loophole. role stays non-admin so the authority check itself
+	// short-circuits, same as before the fix.
+	body := `{"project_id":1,"user_id":1,"role":"viewer","state":"invited"}`
 	req := withChiParam(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body)), "id", "1")
 	w := httptest.NewRecorder()
 	h.UpdateMembershipProxy(w, req)

--- a/server/http/handlers/project_memberships_proxy.go
+++ b/server/http/handlers/project_memberships_proxy.go
@@ -109,6 +109,18 @@ func (h *CatalogHandler) CreateMembershipProxy(w http.ResponseWriter, r *http.Re
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id, user_id, role, and state are required")
 		return
 	}
+	// #1578: this used to persist an arbitrary Role straight from the wire —
+	// the human-facing path (inviteMemberWithMode, membership_lifecycle.go)
+	// gates an admin-tier grant on RequireAuthorityForRole before it ever
+	// reaches storage; this proxy skipped that gate entirely, so any
+	// system.write-only caller (the RemoteStorage federation credential, not
+	// a project-admin credential) could mint itself or anyone else an
+	// admin-tier active membership. Derive the same ceiling the human-facing
+	// path uses, by reference, rather than re-deriving an equivalent check.
+	if err := h.coreService.RequireAuthorityForRole(r.Context(), actorID(r), body.ProjectID, body.Role); err != nil {
+		writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", err.Error())
+		return
+	}
 	// G80 documented-exception re-verification sweep (2026-08-25): InvitedBy
 	// used to persist verbatim from the wire — forgeable attribution that
 	// feeds notification routing (internal/core/notifications.go) and the
@@ -164,6 +176,23 @@ func (h *CatalogHandler) UpdateMembershipProxy(w http.ResponseWriter, r *http.Re
 	var body membershipProxyWire
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	if body.ProjectID == 0 || body.UserID == 0 || body.Role == "" || body.State == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id, user_id, role, and state are required")
+		return
+	}
+	// #1578: same gap as CreateMembershipProxy, and arguably the more direct
+	// route — this is a plain Save of the full row (see doc comment above),
+	// so it is the only code path in the repo that can rewrite an EXISTING
+	// membership's Role after creation (the human-facing path never mutates
+	// Role post-invite: TransitionMembership only touches State). Requiring
+	// ProjectID/Role above first closes the projectID==0 case, where
+	// requireAuthorityForRole would otherwise check global-scope admin
+	// authority instead of the target project's — a caller must state a real
+	// project to be checked against it.
+	if err := h.coreService.RequireAuthorityForRole(r.Context(), actorID(r), body.ProjectID, body.Role); err != nil {
+		writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", err.Error())
 		return
 	}
 	body.ID = uint(id)

--- a/server/http/remote_storage_project_memberships_test.go
+++ b/server/http/remote_storage_project_memberships_test.go
@@ -25,7 +25,7 @@ import (
 // *core.KeyorixCore configured with storage.type: remote (ADR-049), pointed at
 // "upstream" over real HTTP via store.RemoteStorage. Mirrors
 // newUpstreamDownstreamForInvitations exactly.
-func newUpstreamDownstreamForMemberships(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore, projectID uint) {
+func newUpstreamDownstreamForMemberships(t *testing.T) (upstream *core.KeyorixCore, downstream *core.KeyorixCore, projectID uint, baseURL string) {
 	t.Helper()
 	require.NoError(t, i18n.InitializeForTesting())
 	t.Cleanup(i18n.ResetForTesting)
@@ -56,7 +56,7 @@ func newUpstreamDownstreamForMemberships(t *testing.T) (upstream *core.KeyorixCo
 	ctx := context.Background()
 	project, err := upstream.CreateProject(ctx, "Memberships Test Project", "")
 	require.NoError(t, err)
-	return upstream, downstream, project.ID
+	return upstream, downstream, project.ID, upstreamSrv.URL
 }
 
 // buildInvitedMembership mirrors what internal/core/membership_lifecycle.go's
@@ -95,7 +95,7 @@ func mustCreateUser(t *testing.T, c *core.KeyorixCore, username, email string) u
 // RemoteStorage, fetchable by ID, and listed — all via storage.type: remote
 // against a real router, not a protocol mock.
 func TestRemoteStorageMembership_CreateGetList_RealServer(t *testing.T) {
-	upstream, downstream, projectID := newUpstreamDownstreamForMemberships(t)
+	upstream, downstream, projectID, _ := newUpstreamDownstreamForMemberships(t)
 	ctx := context.Background()
 	now := time.Now()
 	userID := mustCreateUser(t, upstream, "invitee1", "invitee1@example.com")
@@ -145,7 +145,7 @@ func TestRemoteStorageMembership_CreateGetList_RealServer(t *testing.T) {
 // TestRemoteStorageMembership_GetNotFound_RealServer proves a clean not-found
 // error (not a panic, not a garbage 500) for a nonexistent membership ID.
 func TestRemoteStorageMembership_GetNotFound_RealServer(t *testing.T) {
-	_, downstream, _ := newUpstreamDownstreamForMemberships(t)
+	_, downstream, _, _ := newUpstreamDownstreamForMemberships(t)
 	ctx := context.Background()
 
 	_, err := downstream.Storage().GetProjectMembership(ctx, 999999)
@@ -158,7 +158,7 @@ func TestRemoteStorageMembership_GetNotFound_RealServer(t *testing.T) {
 // doc for why no conditional-write guarantee is needed here, unlike
 // UpdateProjectInvitation).
 func TestRemoteStorageMembership_Update_RealServer(t *testing.T) {
-	upstream, downstream, projectID := newUpstreamDownstreamForMemberships(t)
+	upstream, downstream, projectID, _ := newUpstreamDownstreamForMemberships(t)
 	ctx := context.Background()
 	now := time.Now()
 	userID := mustCreateUser(t, upstream, "activatee", "activatee@example.com")
@@ -189,7 +189,7 @@ func TestRemoteStorageMembership_Update_RealServer(t *testing.T) {
 // — the read inviteMemberWithMode uses to reject a duplicate onboarding (#309) —
 // finds a non-revoked row and stops finding it once revoked.
 func TestRemoteStorageMembership_GetActive_RealServer(t *testing.T) {
-	upstream, downstream, projectID := newUpstreamDownstreamForMemberships(t)
+	upstream, downstream, projectID, _ := newUpstreamDownstreamForMemberships(t)
 	ctx := context.Background()
 	now := time.Now()
 	userID := mustCreateUser(t, upstream, "activeuser", "activeuser@example.com")
@@ -224,7 +224,7 @@ func TestRemoteStorageMembership_GetActive_RealServer(t *testing.T) {
 // sentinel inviteMemberWithMode's errors.Is check depends on — not an opaque,
 // unclassifiable storage error.
 func TestRemoteStorageMembership_DuplicateActiveMembership_RealServer(t *testing.T) {
-	upstream, downstream, projectID := newUpstreamDownstreamForMemberships(t)
+	upstream, downstream, projectID, _ := newUpstreamDownstreamForMemberships(t)
 	ctx := context.Background()
 	now := time.Now()
 	userID := mustCreateUser(t, upstream, "dupuser", "dupuser@example.com")
@@ -246,7 +246,7 @@ func TestRemoteStorageMembership_DuplicateActiveMembership_RealServer(t *testing
 // ListStaleInvitedMemberships (ADR-022 stale-invite warnings) round-trips over
 // storage.type: remote.
 func TestRemoteStorageMembership_ListStaleInvited_RealServer(t *testing.T) {
-	upstream, downstream, projectID := newUpstreamDownstreamForMemberships(t)
+	upstream, downstream, projectID, _ := newUpstreamDownstreamForMemberships(t)
 	ctx := context.Background()
 	old := time.Now().Add(-10 * 24 * time.Hour)
 	fresh := time.Now()
@@ -275,7 +275,7 @@ func TestRemoteStorageMembership_ListStaleInvited_RealServer(t *testing.T) {
 // ListUserProjectMemberships and CountProjectMembershipsByUsers (ADR-025 per-user
 // assignments/user-list views) round-trip over storage.type: remote.
 func TestRemoteStorageMembership_ListByUserAndCounts_RealServer(t *testing.T) {
-	upstream, downstream, projectID := newUpstreamDownstreamForMemberships(t)
+	upstream, downstream, projectID, _ := newUpstreamDownstreamForMemberships(t)
 	ctx := context.Background()
 	now := time.Now()
 	userID := mustCreateUser(t, upstream, "multiuser", "multiuser@example.com")
@@ -308,4 +308,93 @@ func TestRemoteStorageMembership_ListByUserAndCounts_RealServer(t *testing.T) {
 	require.Contains(t, counts, otherUserID)
 	assert.Equal(t, 0, counts[otherUserID].Active)
 	assert.Equal(t, 1, counts[otherUserID].Total)
+}
+
+// TestMembershipProxy_CreateRejectsAdminRoleWithoutAuthority (#1578) proves
+// CreateMembershipProxy re-derives inviteMemberWithMode's requireAuthorityForRole
+// escalation-by-proxy ceiling before persisting a new membership row. `downstream`
+// authenticates as a MACHINE credential (createNodeToken) — it holds system.write
+// (the gate on the whole /system group) but no roles.assign and no admin-tier
+// role anywhere, exactly the credential class this proxy is meant to serve. RED
+// without the fix: this create would have succeeded, minting an admin-tier ACTIVE
+// membership with no admin authority anywhere in the chain.
+func TestMembershipProxy_CreateRejectsAdminRoleWithoutAuthority(t *testing.T) {
+	upstream, downstream, projectID, _ := newUpstreamDownstreamForMemberships(t)
+	ctx := context.Background()
+	now := time.Now()
+	userID := mustCreateUser(t, upstream, "mem1578-target", "mem1578-target@example.com")
+
+	m := buildInvitedMembership(now, projectID, userID, "admin", 0)
+	m.State = core.MembershipActive
+	activatedAt := now
+	m.ActivatedAt = &activatedAt
+	_, err := downstream.Storage().CreateProjectMembership(ctx, m)
+	require.Error(t, err, "a system.write-only caller with no admin authority must not be able to grant an admin-tier active membership")
+}
+
+// TestMembershipProxy_CreateAllowsAdminRoleByGenuineAdmin (#1578) is the positive
+// control: a genuine project admin creating a genuine admin-role membership must
+// still succeed end-to-end over the proxy — mirrors
+// TestInvitationProxy_CreateAllowsAdminRoleByGenuineAdmin exactly, including why
+// the actor must authenticate as a real human session rather than the shared
+// machine credential (RequireAuthorityForRole's ceiling is keyed off actorID(r),
+// which is human-only by design and returns 0 for a machine actor).
+func TestMembershipProxy_CreateAllowsAdminRoleByGenuineAdmin(t *testing.T) {
+	upstream, _, projectID, baseURL := newUpstreamDownstreamForMemberships(t)
+	ctx := context.Background()
+	now := time.Now()
+	const pw = "Qr7#Kp2$Lm5@Vn9!"
+
+	admin, err := upstream.CreateUser(ctx, &core.CreateUserRequest{Username: "mem1578-admin", Email: "mem1578-admin@example.com", Password: pw})
+	require.NoError(t, err)
+	adminRole, err := upstream.Storage().GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().AssignRole(ctx, admin.ID, adminRole.ID, coreStorage.Scope{ProjectID: projectID}))
+	grantSystemWrite(t, upstream, admin.ID)
+	adminSess, _, err := upstream.Login(ctx, &core.LoginRequest{Username: "mem1578-admin", Password: pw})
+	require.NoError(t, err)
+	asAdmin := newDeleteProjectScopeRemoteClient(t, baseURL, adminSess.SessionToken)
+
+	target, err := upstream.CreateUser(ctx, &core.CreateUserRequest{Username: "mem1578-grantee", Email: "mem1578-grantee@example.com", Password: pw})
+	require.NoError(t, err)
+
+	m := buildInvitedMembership(now, projectID, target.ID, "admin", admin.ID)
+	m.State = core.MembershipActive
+	activatedAt := now
+	m.ActivatedAt = &activatedAt
+	created, err := asAdmin.CreateProjectMembership(ctx, m)
+	require.NoError(t, err, "a genuine admin creating a genuine admin-role membership must still succeed")
+	assert.Equal(t, "admin", created.Role)
+	assert.Equal(t, admin.ID, created.InvitedBy, "InvitedBy must be the authenticated admin, not the wire-supplied value")
+}
+
+// TestMembershipProxy_UpdateRejectsAdminRoleWithoutAuthority (#1578) proves
+// UpdateMembershipProxy carries the same ceiling as CreateMembershipProxy. It is
+// the more direct route: UpdateProjectMembership is a plain Save of the full row
+// (see the proxy's doc comment), so it is the only code path anywhere — proxy or
+// human-facing — that can rewrite an EXISTING membership's Role. The human-facing
+// path never mutates Role post-invite (TransitionMembership only ever touches
+// State). RED without the fix: this update would have succeeded, promoting an
+// existing "viewer" membership straight to an active admin-tier one with no
+// admin authority anywhere in the chain.
+func TestMembershipProxy_UpdateRejectsAdminRoleWithoutAuthority(t *testing.T) {
+	upstream, downstream, projectID, _ := newUpstreamDownstreamForMemberships(t)
+	ctx := context.Background()
+	now := time.Now()
+	userID := mustCreateUser(t, upstream, "mem1578-updatee", "mem1578-updatee@example.com")
+
+	m, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, "viewer", 0))
+	require.NoError(t, err)
+
+	activatedAt := time.Now()
+	m.Role = "admin"
+	m.State = core.MembershipActive
+	m.ActivatedAt = &activatedAt
+	err = downstream.Storage().UpdateProjectMembership(ctx, m)
+	require.Error(t, err, "a system.write-only caller with no admin authority must not be able to promote an existing membership to an admin-tier role")
+
+	// The row must be untouched by the rejected update.
+	direct, err := upstream.Storage().GetProjectMembership(ctx, m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "viewer", direct.Role, "a rejected update must not leave the role changed")
 }


### PR DESCRIPTION
## Summary

Closes #1578 — a live privilege escalation. `CreateMembershipProxy` persisted an arbitrary wire-supplied `Role`/`State` with **zero authority check**, so any `system.write`-only caller (the RemoteStorage federation credential, not a project-admin credential) could mint itself or anyone else an admin-tier **active** project membership in one call. `UpdateMembershipProxy` carried the identical gap and, since `UpdateProjectMembership` is a plain `Save` of the full row, is actually the *more* direct route — it is the only code path anywhere (proxy or human-facing) that can rewrite an already-existing membership's `Role`.

## The two call paths, side by side

**Human-facing path** (`internal/core/membership_lifecycle.go:148`, `inviteMemberWithMode`) — unchanged, shown for reference:
```go
// Escalation-by-proxy guard: onboarding a member as an admin role requires the
// inviter to hold admin authority at the project (parallel to the access-request
// approval ceiling).
if err := c.requireAuthorityForRole(ctx, invitedBy, projectID, role); err != nil {
    return nil, err
}
```

**Proxy path — before:**
```go
// CreateMembershipProxy (server/http/handlers/project_memberships_proxy.go)
model := body.toModel()
model.InvitedBy = actorID(r)
created, err := h.coreService.Storage().CreateProjectMembership(r.Context(), model)
// no authority check anywhere — Role/State come straight from the wire
```

**Proxy path — after:**
```go
if err := h.coreService.RequireAuthorityForRole(r.Context(), actorID(r), body.ProjectID, body.Role); err != nil {
    writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", err.Error())
    return
}
model := body.toModel()
model.InvitedBy = actorID(r)
created, err := h.coreService.Storage().CreateProjectMembership(r.Context(), model)
```

`RequireAuthorityForRole` (`internal/core/invitations.go:85`) is the exported wrapper around `requireAuthorityForRole` built specifically for the `/system` proxy layer — the same mechanism `CreateInvitationProxy` and `UpdateAccessRequestProxy` already use. This is a mirror of an existing, sanctioned pattern, not a new check.

`UpdateMembershipProxy` gets the identical check, plus required-fields validation it was missing entirely (`CreateMembershipProxy` already had it): `requireAuthorityForRole` treats `projectID==0` as *global* scope, not "invalid", so an unvalidated zero `project_id` would silently check the wrong scope.

## How #1578 was found

Two independent methods converged on the same handler: `CreateMembershipProxy` was first found as an enumerator blind spot (`core.InviteMember` reached storage through the unexported `inviteMemberWithMode`, invisible to a shallow call-graph walk), fixed by widening the enumerator one hop (Wave 1, #1581). The repo-wide extension of that same widened enumerator then found the handler wasn't merely invisible — it was actually vulnerable.

## Also folded in

Wave 1's #1541 fix required excluding `*.pb.go` from the coverage-floor sum — correctly, since generated code inflating the floor creates pressure to write meaningless tests. But that exclusion lived only as a bare `grep -v` in `ci.yml` with the reasoning asserted in a comment — the exact "asserted, not machine-checked" shape #1541 itself fixed for `scripts/ci-test-legs.sh`'s package-exclusion table, just not yet applied to this one. Added `coverage_floor_exclusions()` to `scripts/ci-test-legs.sh` (same `Kind`/`Reason`/`Issue`/`DateAdded` discipline, its own 30-day `TEMPORARY` freshness check, wired into the existing `exclusion-freshness` job), and pointed `ci.yml`'s "Merge coverage profiles" step at it instead of a hardcoded pattern.

## Test plan

- [x] `TestMembershipProxy_CreateRejectsAdminRoleWithoutAuthority` — a `system.write`-only caller (machine credential, no `roles.assign`, no admin-tier role) attempting to grant an admin-tier active membership gets `403`. Verified red against pre-fix code, green after.
- [x] `TestMembershipProxy_UpdateRejectsAdminRoleWithoutAuthority` — same, via the raw-Save update path (the more direct escalation route). Verified red, green after.
- [x] `TestMembershipProxy_CreateAllowsAdminRoleByGenuineAdmin` — positive control: a genuine project admin granting a genuine admin-role membership still succeeds end-to-end over the proxy.
- [x] Full `server/http` + `server/http/handlers` suites green, no regressions (two pre-existing unit tests — `TestCatalogHandler_UpdateMembershipProxy_HappyPath`, `TestCreateMembershipProxy_DBError_S30` — had under-specified fixtures that accidentally exercised the new check; fixed the fixtures, not the assertions).
- [x] `go build ./...`, `go vet ./...`, `gofmt -l`, `golangci-lint run` (0 issues), `gosec -severity medium -exclude-generated` (0 issues).
- [x] `coverage_floor_exclusions`/`coverage_floor_grep_patterns`/`check_coverage_floor_exclusion_freshness` exercised locally; `shellcheck scripts/ci-test-legs.sh` clean; extracted YAML `run:` blocks pass `bash -n`.

## Not in this pass

#1579 and #1580 go into Wave 2's batch (design questions). The deletion pass still waits on the partition-completeness qualification.