### PR TITLE
fix(storage): delete #1511's 13 dead RemoteStorage wire calls (G80 deletion pass)

### DIFF
--- a/docs/adr-087-remote-storage-deletion-pass.md
+++ b/docs/adr-087-remote-storage-deletion-pass.md
@@ -1,0 +1,262 @@
+# ADR-087: RemoteStorage deletion pass — a verified-dead subset, not a sweep
+
+## Status
+
+**Accepted (2026-08-28).** Executes the deletion Wave 0
+(`docs/g80-wave0-remote-storage-partition.md`) sized but explicitly held —
+"nothing gets deleted this pass," Wave 0c — pending review of its corrected
+partition. This ADR is that review, plus the deletion itself.
+
+## What this is, precisely
+
+Wave 0 partitioned `RemoteStorage`'s stub/wire-call surface, believed at the
+time to be 88 stub-shaped methods (75 already-classified `remoteUnsupported()`
+stubs + 13 raw `fmt.Errorf` stubs). Wave 1 (#1576) replaced regex-based stub
+detection with AST-structural reachability and found the true population is
+**171**. That correction does two different things, and conflating them is
+the mistake this ADR exists to avoid:
+
+- **It does not, by itself, invalidate any individual DEAD verdict.** A
+  larger denominator doesn't make a correctly-classified DEAD method live —
+  DEAD-ness is a property of the method's own call graph, not of how many
+  siblings exist. Every DEAD verdict this pass acts on was re-traced against
+  current `origin/main` (post-#1576, post-#1582), not carried forward
+  unverified from Wave 0's original evidence — see "Re-verification, and one
+  correction" below.
+- **It does invalidate the completeness claim.** Wave 0's own partition work
+  (Task 1 of its doc) individually examined and classified exactly **13**
+  methods — the 13 raw stubs, before #1576 existed. The other 158 of the
+  171 (149 marked `statusIntentional`, 22 marked `statusUnverified` in
+  `remote_unsupported_completeness_test.go`'s `remoteUnsupportedAllowlist`)
+  were classified by other processes — ~10 prior campaign rounds for the
+  original 75, and #1576's widening pass for the other 96 — never by Wave
+  0's LIVE/DEAD/UNRESOLVED lens specifically. **158 of 171 structurally-stub
+  `RemoteStorage` methods have never been examined for deletion-worthiness
+  at all.** They are correctly classified as legitimate, permanent-or-
+  provisional stubs (the guard is green); whether any of them could instead
+  be *deleted* — narrowing `storage.Storage`'s interface, or simplifying a
+  method body — is a question nobody has asked yet, not one that's been
+  asked and answered "no."
+
+**This pass removes a verified-dead subset. It does not remove "the dead
+RemoteStorage surface," and does not claim to.** The 158 unexamined methods
+are out of scope for this pass and are not touched.
+
+## The criterion
+
+A `RemoteStorage` method is DEAD (safe to delete its wire-call body) if,
+tracing every caller transitively from `internal/core` through to the CLI,
+HTTP handlers, and gRPC services on current `origin/main`:
+
+1. Every CLI entry point that could reach it is either (a) guarded by one of
+   the three established remote/local dual-path idioms —
+   `common.NewRemoteClient()` / `common.NewRemoteClientWithCredentials()` /
+   `common.ResolveRemote()` / `common.IsClientMode()` (the complete,
+   campaign-derived idiom set — see Wave 0's own "Task 1 (Wave 0c)" section
+   for how completeness was established, correcting an earlier miss where
+   `run.go`'s direct `ResolveRemote()` call wasn't yet known as a fourth
+   idiom shape) — which diverts to a raw-HTTP passthrough that never
+   constructs a `RemoteStorage`-backed core at all, taking precedence over
+   the wire call in every complete `storage.type: remote` configuration; OR
+   (b) itself blocked by a separate, independently-verified barrier (see
+   `AssignRole`/`RemoveRole` below for the one case where this applies); and
+2. Every non-CLI caller (HTTP handler, gRPC service, server-boot path) is
+   confirmed server-only — never constructed against a `RemoteStorage`-backed
+   core (ADR-083: `validateRemoteStorageNotServer` rejects that topology at
+   config-validation time, unconditionally); and
+3. The corresponding `server/http/router.go` route does not exist at all —
+   confirmed by direct read, not inferred from the wire call's own success —
+   so even a caller that reached this method would get a 404/405 on every
+   real attempt, never real behavior.
+
+This is exactly `TestRemoteStorageWireCalls_HaveMatchingRoute`'s own
+structural definition of "missing route," combined with Wave 0's own
+call-chain tracing discipline, re-applied to current source.
+
+## Re-verification, and one correction
+
+All 13 of issue #1511's orphaned wire-call methods were re-traced against
+current `origin/main` (post-#1576/#1581, post-#1582) before this pass acted
+on any of them. All 13 confirmed DEAD. One correction to Wave 0's own stated
+evidence surfaced during re-verification:
+
+**`AssignRole`/`RemoveRole`.** Wave 0's doc cites each as "DEAD-in-practice
+(guarded)," listing only their `NewRemoteClient()`-guarded CLI call sites
+(`rbac/assign_role.go`, `rbac/remove_role.go`, plus `user/create.go` for
+`AssignRole`). Re-tracing found a caller Wave 0's evidence never examined:
+`internal/cli/request/review.go` — on the campaign's own 22-file "unguarded"
+list, but never checked against these two specific methods — reaches
+`core.finalizeAccessRequestApproval` → `AssignUserRole`/`RemoveUserRole` →
+`storage.AssignRole`/`RemoveRole`, with **no** `NewRemoteClient`-family guard
+anywhere in the chain.
+
+The corrected picture is not "Wave 0 was wrong that these are dead" — they
+are dead, confirmed — but the REASON is different and, on inspection,
+stronger: `request review`'s path is blocked by **two independent barriers**
+on the same permanently-stubbed RBAC primitive chain
+(`GetUserRoleIDsAt`/`GetUserGroupRoleIDsAt`/`RoleSetHasPermission`, which
+ADR-086 keeps stubbed by design, not as a temporary gap) —
+`requireReviewAuthority`'s own `Authorize` call at the CLI entrypoint, AND
+`core.ApproveAccessRequestWithExpiry`'s own `requireAuthorityForRole` call
+inside `internal/core` itself. Neither depends on a `NewRemoteClient()`-style
+guard at all. Both fail closed today, and both rest on a stub chain ADR-086
+commits to keeping permanently — this is more durable evidence than the
+guarded-CLI-path shape Wave 0 originally cited, not less. Recorded here so a
+future reader doesn't inherit "guarded by NewRemoteClient()" as this pair's
+reason when it never was.
+
+While re-deriving the CLI guard-idiom file list against current source (the
+same derivation Wave 0c performed), two files not on Wave 0's original
+22-file list were found: `secret/delete.go` and `secret/versions.go`. Both
+traced to completion; neither reaches any of the 13 methods in this pass's
+deletion set. No verdict changed as a result.
+
+## What was NOT deleted, and why
+
+**Three of Wave 0's originally-sized "raw stub" deletion candidates required
+no action.** Wave 0 sized `CreatePermission`, `CreateProject`, and
+`CreateEnvironment` (plus `AssignPermissionToRole`, see below) as ~3-4
+additional deletions alongside #1511's 13. Re-checking current source: all
+three are *already* bare `fmt.Errorf("not supported in remote storage")`
+stubs with no wire-call body ever present to remove, and all three are
+already registered in `remoteUnsupportedAllowlist` as `statusIntentional`
+(Wave 1's #1576 widening absorbed and correctly classified them before this
+pass started). There is nothing left to delete for these three — Wave 0's
+sizing predates #1576's registry existing at all. This pass's actual
+deletion set is **13 methods**, not 16-17: #1511's full list, and nothing
+else.
+
+**Kept, per ADR-086 (LIVE — do not delete, do not implement over the
+wire):**
+
+- `GetUserRoleIDsAt`
+- `GetUserGroupRoleIDsAt`
+- `RoleSetHasPermission`
+
+Reached directly by `core.Authorize` (bypassing any HTTP/gRPC middleware
+entirely), called by 11 CLI commands under `storage.type: remote` (#1575).
+Deliberately kept stubbed — implementing them over the wire would have the
+CLI fetch role/permission data and decide authorization client-side, the
+fat-client anti-pattern this campaign has dismantled elsewhere. The correct
+fix is hub-side authorization, deferred to Wave 2 (unifies #1546, #1551,
+#1572, #1575).
+
+**Kept, UNRESOLVED (evidence gap named, not resolved — kept means kept, not
+"probably fine"):**
+
+- `IsProjectMember` — evidence leans DEAD-in-practice; both plausible call
+  chains sit behind a `NewRemoteClient()` guard (#1512, closed on this
+  verdict, Wave 0c).
+- `IsGroupProjectScoped` — same shape and citation as `IsProjectMember`.
+- `GetUserRoleIDsExact` — reached from `internal/core/project_members.go`
+  (add/remove project member); no CLI caller found in the time available;
+  not confirmed HTTP-only either.
+- `GetUserRoleScopes` — evidence leans LIVE via the Keyorix Connect CLI
+  subtree (`internal/cli/connect`); not fully traced.
+- `GetMachineRoleScopes` — mirrors `GetUserRoleScopes`; same Connect-subtree
+  gap.
+- `GetUserGroupPermissions` — reached from SoD conflict detection
+  (`internal/core/sod.go`) and `rbac_management.go`; not traced to a CLI
+  entry point.
+- `AssignPermissionToRole` — evidence leans DEAD (reached only from
+  `server/http`/`server/grpc` handlers plus boot-time-only
+  bootstrap/reconcile callers; no CLI caller found), but not individually
+  re-verified to the same depth as the 13 methods this pass acts on — stays
+  UNRESOLVED, not promoted to DEAD, on that basis alone.
+
+None of these seven were touched. Closing any of them requires either a
+live-mode integration test (the `NewRemoteClient()`-guard-absent edge case
+Wave 0's own doc names as unresolved) or a deeper Connect-subtree trace —
+Wave 2 or a dedicated follow-up, not this pass.
+
+## The deletion
+
+13 `RemoteStorage` methods across `internal/storage/store/` (8 files:
+`remote_secrets.go`, `remote_auth.go`, `remote_rbac.go`,
+`remote_risk_exceptions.go`, `remote_sharing.go`, `remote_stats.go`), each
+converted from a live-but-permanently-404ing `rs.client.<Verb>(...)` call to
+`remoteUnsupported("MethodName")` — the same pattern the other 158
+classified stubs already use — except `GetSecretVersion`, which is not
+declared in the `storage.Storage` interface at all (an orphan method on the
+concrete `*RemoteStorage` type; `core.GetSecretVersion` calls the plural
+`GetSecretVersions` instead, never this one) and so was removed entirely,
+not stubbed:
+
+`CreateSecretVersion`, `CleanupExpiredSessions`, `AssignRole`, `RemoveRole`,
+`UpdateRiskException`, `CreateShareRecord`, `GetShareRecord`, `GetStats`,
+`GetSecretVersion` (fully removed), `GetLatestSecretVersion`,
+`IncrementSecretReadCount`, `ListSharedSecrets`, `CheckSharePermission`.
+
+Each now has a `remoteUnsupportedAllowlist` entry
+(`remote_deletion_pass_completeness_test.go`) citing its individual DEAD
+evidence, and `remote_wire_route_coverage_test.go`'s `knownMissingRoutes` —
+the map that tracked all 13 as "confirmed missing route" — is now empty; a
+future genuinely-new gap gets a fresh entry there, triaged the same way, not
+by resurrecting these.
+
+This is a method-body deletion, not an interface change (per Wave 0's own
+framing): `storage.Storage` is unchanged for all 12 stubbed methods.
+`GetSecretVersion` is the one exception, and it was never part of the
+interface to begin with, so nothing there changed either. **No interface
+narrowing was performed or is proposed by this pass** — the 158 never-
+examined methods, and whether `LocalStorage`'s side of any of them is also
+dead, remain a separate, larger, unstarted investigation.
+
+**Findability.** Tag `pre-remote-topology-deletion`, annotated, at the
+commit immediately before the first removal (mirrors `g80-pre-remediation`'s
+own convention) — `git show pre-remote-topology-deletion:<path>` retrieves
+any of these 13 methods' original wire-call bodies. The deletion commit
+enumerates all 13 by name.
+
+## #1511 final accounting
+
+Issue #1511's body lists exactly these 13 wire calls and no others (confirmed
+by reading the issue directly, not assumed from this document). The split:
+
+| Category | Count | Methods |
+|---|---|---|
+| Closed by this deletion (stub conversion) | 11 | `CreateSecretVersion`, `CleanupExpiredSessions`, `AssignRole`, `RemoveRole`, `CreateShareRecord`, `GetShareRecord`, `GetStats`, `GetLatestSecretVersion`, `IncrementSecretReadCount`, `ListSharedSecrets`, `CheckSharePermission` |
+| Closed by this deletion (outright removal, not in the interface) | 1 | `GetSecretVersion` |
+| Stale — already fixed in a prior round, this pass closes the remaining client-side half | 1 | `UpdateRiskException` (server route deliberately removed in a prior G79 round; the client's dead wire call, the actual #1511 defect, is what this pass converts to a stub) |
+| Closed by a NEW route/fix | 0 | — |
+| Still open | 0 | — |
+
+**13 of 13 resolved. Issue #1511 closes with this pass**, cited by the
+deletion commit and this ADR — not left open with residue, since none
+remains.
+
+## A finding surfaced, not fixed, during re-verification
+
+Un-skipping `server/http/remote_storage_risk_exceptions_test.go`'s two
+`t.Skip()`-quarantined tests (to confirm `UpdateRiskException`'s fix
+actually resolves what they were skipped for) surfaced a **second,
+previously-invisible blocker**, unrelated to #1511: both tests' harness
+authenticates as a machine/node credential
+(`createNodeToken`), and `CreateRiskExceptionProxy` requires a human
+principal ("only a human principal may create a risk exception"). This
+predates this pass — the original `t.Skip()` short-circuited before the
+`Create` call ever ran, so it was never actually observed. Both tests were
+re-skipped with an updated, accurate reason (the original #1511/#G79 cause
+no longer applies; this second one does) rather than fixed — out of scope
+for a dead-wire-call deletion pass. Flagged for its own follow-up.
+
+## The invariant, not just the list (#1578/#1582)
+
+`core.RequireAuthorityForRole` now protects three handlers —
+`CreateInvitationProxy`, `CreateMembershipProxy`, `UpdateMembershipProxy` —
+each found by a different method, one at a time. A guard now asserts the
+invariant directly: `server/http/role_grant_authority_guard_test.go`'s
+`TestEveryDirectRoleGrantChecksAuthority` flags any `/system` handler that
+persists a Role-shaped field directly via storage without calling
+`RequireAuthorityForRole`. Verified red (against a deliberately-reintroduced
+gap in `CreateMembershipProxy`) and green (all three intact).
+
+## Guardrail check: does anything here overturn ADR-083/ADR-086?
+
+No. ADR-083's server-topology gate is unaffected — nothing in this pass
+touches `validateRemoteStorageNotServer` or the route-registration/proxy-
+tier cleanup ADR-083 defers. ADR-086's three-method keep-list is unaffected
+and explicitly re-confirmed above. The `AssignRole`/`RemoveRole` correction
+strengthens, rather than contradicts, ADR-086's premise that the RBAC stub
+chain is a durable, by-design barrier — it's now confirmed to gate a SECOND
+call path ADR-086's own investigation didn't examine.

--- a/internal/storage/store/remote_auth.go
+++ b/internal/storage/store/remote_auth.go
@@ -79,16 +79,13 @@ func (rs *RemoteStorage) DeleteSession(ctx context.Context, id uint) error {
 	return nil
 }
 
-// CleanupExpiredSessions triggers server-side session cleanup via remote API.
-func (rs *RemoteStorage) CleanupExpiredSessions(ctx context.Context) error {
-	resp, err := rs.client.Post(ctx, "/api/v1/sessions/cleanup", nil)
-	if err != nil {
-		return fmt.Errorf("failed to cleanup expired sessions: %w", err)
-	}
-	if !resp.Success {
-		return fmt.Errorf("cleanup expired sessions failed: %s", resp.Error.Error())
-	}
-	return nil
+// CleanupExpiredSessions: #1511/G80 deletion pass — POST
+// /api/v1/sessions/cleanup has no matching route, and the core method itself
+// has zero callers in any topology (internal/core/users.go's own doc comment
+// already noted "implemented but never scheduled"). See
+// docs/adr-087-remote-storage-deletion-pass.md.
+func (rs *RemoteStorage) CleanupExpiredSessions(_ context.Context) error {
+	return remoteUnsupported("CleanupExpiredSessions")
 }
 
 // --- Sessions (My Account) + Personal Access Tokens ---

--- a/internal/storage/store/remote_auth_test.go
+++ b/internal/storage/store/remote_auth_test.go
@@ -3,6 +3,7 @@ package store_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -120,19 +121,16 @@ func TestRemoteStorage_DeleteSession_Error(t *testing.T) {
 
 // --- CleanupExpiredSessions ---
 
-func TestRemoteStorage_CleanupExpiredSessions(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v1/sessions/cleanup", r.URL.Path)
-		_, _ = w.Write(apiOK(nil))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+// TestRemoteStorage_CleanupExpiredSessions_Unsupported: #1511/G80 deletion
+// pass — no matching route, zero callers in any topology; see
+// docs/adr-087-remote-storage-deletion-pass.md.
+func TestRemoteStorage_CleanupExpiredSessions_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.CleanupExpiredSessions(context.Background())
-	require.NoError(t, err)
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
 }
 
 // --- CreateSession (unsupported stub) ---

--- a/internal/storage/store/remote_coverage_mfa_rbac_secrets_test.go
+++ b/internal/storage/store/remote_coverage_mfa_rbac_secrets_test.go
@@ -674,60 +674,6 @@ func TestRemoteCov_ListSecrets_BadJSON(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestRemoteCov_CreateSecretVersion_APIError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(apiNotOK("INTERNAL_ERROR", "create failed"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	_, err = rs.CreateSecretVersion(context.Background(), &models.SecretVersion{SecretNodeID: 42, VersionNumber: 1})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "create secret version failed")
-}
-
-func TestRemoteCov_CreateSecretVersion_BadJSON(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(apiOK("not-a-version-object"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	_, err = rs.CreateSecretVersion(context.Background(), &models.SecretVersion{SecretNodeID: 1, VersionNumber: 1})
-	assert.Error(t, err)
-}
-
-func TestRemoteCov_GetSecretVersion_APIError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(apiNotOK("NOT_FOUND", "version not found"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	_, err = rs.GetSecretVersion(context.Background(), 42, 99)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "get secret version failed")
-}
-
-func TestRemoteCov_GetSecretVersion_BadJSON(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(apiOK("not-a-version-object"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	_, err = rs.GetSecretVersion(context.Background(), 1, 1)
-	assert.Error(t, err)
-}
-
 func TestRemoteCov_ListSecretVersions_APIError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(apiNotOK("NOT_FOUND", "secret not found"))
@@ -753,47 +699,6 @@ func TestRemoteCov_ListSecretVersions_BadJSON(t *testing.T) {
 
 	_, err = rs.ListSecretVersions(context.Background(), 1)
 	assert.Error(t, err)
-}
-
-func TestRemoteCov_GetLatestSecretVersion_APIError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(apiNotOK("NOT_FOUND", "no versions found"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	_, err = rs.GetLatestSecretVersion(context.Background(), 99)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "get latest secret version failed")
-}
-
-func TestRemoteCov_GetLatestSecretVersion_BadJSON(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(apiOK("not-a-version-object"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	_, err = rs.GetLatestSecretVersion(context.Background(), 1)
-	assert.Error(t, err)
-}
-
-func TestRemoteCov_IncrementSecretReadCount_APIError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(apiNotOK("NOT_FOUND", "version not found"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	err = rs.IncrementSecretReadCount(context.Background(), 999)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "increment read count failed")
 }
 
 // --------------------------------------------------------------------------

--- a/internal/storage/store/remote_coverage_policies_memberships_auth_test.go
+++ b/internal/storage/store/remote_coverage_policies_memberships_auth_test.go
@@ -342,22 +342,9 @@ func TestRemoteCov_GetRiskException_NotSuccess(t *testing.T) {
 	assert.Contains(t, err.Error(), "get risk exception failed")
 }
 
-func TestRemoteCov_UpdateRiskException_NotSuccess(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(apiNotOK("INTERNAL_ERROR", "update failed"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	err = rs.UpdateRiskException(context.Background(), &models.RiskException{
-		ID: 6, Title: "test", Category: "sod", Justification: "still needed", CreatedBy: 1,
-		ExpiresAt: time.Now().Add(24 * time.Hour),
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "update risk exception failed")
-}
+// UpdateRiskException is a permanent stub as of the #1511/G80 deletion pass
+// (#G79 already removed its server route) — see
+// TestRemoteStorage_UpdateRiskException_Unsupported (remote_misc_test.go).
 
 // decodeRiskExceptionResponse is exercised by GetRiskException.
 // Test that a bad JSON body returns an error from the decode helper.
@@ -379,36 +366,9 @@ func TestRemoteCov_DecodeRiskExceptionResponse_BadJSON(t *testing.T) {
 // remote_auth.go — !resp.Success branches
 // ============================================================
 
-func TestRemoteCov_CleanupExpiredSessions_NotSuccess(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v1/sessions/cleanup", r.URL.Path)
-		_, _ = w.Write(apiNotOK("INTERNAL_ERROR", "cleanup failed"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	err = rs.CleanupExpiredSessions(context.Background())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cleanup expired sessions failed")
-}
-
-func TestRemoteCov_CleanupExpiredSessions_Success(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v1/sessions/cleanup", r.URL.Path)
-		_, _ = w.Write(apiOK(nil))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	err = rs.CleanupExpiredSessions(context.Background())
-	require.NoError(t, err)
-}
+// CleanupExpiredSessions is a permanent stub as of the #1511/G80 deletion
+// pass — see TestRemoteStorage_CleanupExpiredSessions_Unsupported
+// (remote_auth_test.go).
 
 // decodeSetupTokenResponse: exercise by CreateSetupToken returning a valid body.
 func TestRemoteCov_DecodeSetupTokenResponse_BadJSON(t *testing.T) {

--- a/internal/storage/store/remote_coverage_test.go
+++ b/internal/storage/store/remote_coverage_test.go
@@ -22,6 +22,7 @@ package store_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -54,38 +55,15 @@ func apiNotOK(code, message string) []byte {
 
 // ─── remote_stats.go ────────────────────────────────────────────────────────
 
-func TestRemoteCov_GetStats_Success(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/stats", r.URL.Path)
-		_, _ = w.Write(apiOK(map[string]any{
-			"total_secrets": float64(42),
-			"total_users":   float64(7),
-		}))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	stats, err := rs.GetStats(context.Background())
-	require.NoError(t, err)
-	assert.NotNil(t, stats)
-}
-
-func TestRemoteCov_GetStats_Error(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// HTTP 200 + success:false is the only way to reach the !resp.Success branch.
-		_, _ = w.Write(apiNotOK("INTERNAL", "stats unavailable"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+// TestRemoteCov_GetStats_Unsupported: #1511/G80 deletion pass — no matching
+// route, server-only caller; see docs/adr-087-remote-storage-deletion-pass.md.
+func TestRemoteCov_GetStats_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.GetStats(context.Background())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "get stats failed")
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
 }
 
 // ─── remote_sod.go ──────────────────────────────────────────────────────────
@@ -409,19 +387,8 @@ func TestRemoteCov_CreateWebAuthnSession_Error(t *testing.T) {
 
 // ─── remote_sharing.go ──────────────────────────────────────────────────────
 
-func TestRemoteCov_CheckSharePermission_Error(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(apiNotOK("NOT_FOUND", "share not found"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	_, err = rs.CheckSharePermission(context.Background(), 10, 3)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "check share permission failed")
-}
+// CheckSharePermission is a permanent stub as of the #1511/G80 deletion pass
+// — see TestRemoteStorage_CheckSharePermission_Unsupported (remote_sharing_test.go).
 
 func TestRemoteCov_DeleteExpiredShareRecords_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -502,33 +469,9 @@ func TestRemoteCov_decodeUserResponse_BadJSON(t *testing.T) {
 
 // ─── Additional error paths for existing sharing functions ──────────────────
 
-func TestRemoteCov_CreateShareRecord_Error(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(apiNotOK("INTERNAL", "db error"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	_, err = rs.CreateShareRecord(context.Background(), &models.ShareRecord{SecretID: 1, OwnerID: 2})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "create share record failed")
-}
-
-func TestRemoteCov_GetShareRecord_Error(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(apiNotOK("NOT_FOUND", "share not found"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	_, err = rs.GetShareRecord(context.Background(), 999)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "get share record failed")
-}
+// CreateShareRecord/GetShareRecord are permanent stubs as of the #1511/G80
+// deletion pass — see TestRemoteStorage_CreateShareRecord_Unsupported/
+// TestRemoteStorage_GetShareRecord_Unsupported (remote_sharing_test.go).
 
 func TestRemoteCov_UpdateShareRecord_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -600,19 +543,8 @@ func TestRemoteCov_ListSharesByGroup_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "list shares by group failed")
 }
 
-func TestRemoteCov_ListSharedSecrets_Error(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(apiNotOK("NOT_FOUND", "user not found"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	_, err = rs.ListSharedSecrets(context.Background(), 999)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "list shared secrets failed")
-}
+// ListSharedSecrets is a permanent stub as of the #1511/G80 deletion pass —
+// see TestRemoteStorage_ListSharedSecrets_Unsupported (remote_sharing_test.go).
 
 // ─── LogAuditEvent error path ─────────────────────────────────────────────
 

--- a/internal/storage/store/remote_deletion_pass_completeness_test.go
+++ b/internal/storage/store/remote_deletion_pass_completeness_test.go
@@ -1,0 +1,38 @@
+package store
+
+// G80 deletion pass (docs/adr-087-remote-storage-deletion-pass.md): these 13
+// methods are issue #1511's full orphaned-wire-call list — every one made a
+// real rs.client.<Verb>(...) call to a route that has no matching
+// registration in server/http/router.go, confirmed DEAD (every real caller is
+// either behind a CLI NewRemoteClient()-family guard, server-only, or has
+// zero callers anywhere) and converted from a live-but-permanently-404ing
+// wire call to a remoteUnsupported() stub in this pass. See the deletion
+// commit and the ADR for the full per-method evidence and the criterion used.
+func init() {
+	addRemoteUnsupported(map[string]remoteUnsupportedEntry{
+		"CreateSecretVersion": {statusIntentional,
+			"#1511/G80 deletion pass: POST /api/v1/secrets/*/versions has no matching route. Every core caller (storeSecretVersion/storeNextSecretVersion, reached via CreateSecret/UpdateSecret/CopySecret/RotateSecret) is behind a NewRemoteClient() CLI guard or server-only."},
+		"CleanupExpiredSessions": {statusIntentional,
+			"#1511/G80 deletion pass: POST /api/v1/sessions/cleanup has no matching route, and the core method itself has zero callers in any topology (internal/core/users.go's own doc comment already noted \"implemented but never scheduled\")."},
+		"AssignRole": {statusIntentional,
+			"#1511/G80 deletion pass: POST /api/v1/rbac/assign-role has no matching route. Dead via two independent barriers on the permanent RBAC stub chain (GetUserRoleIDsAt/GetUserGroupRoleIDsAt/RoleSetHasPermission, ADR-086): request/review.go's own requireReviewAuthority, AND core.ApproveAccessRequestWithExpiry's own requireAuthorityForRole, both fail closed before this method is ever reached — corrects Wave 0's original evidence, which only cited the NewRemoteClient()-guarded call sites and missed this path."},
+		"RemoveRole": {statusIntentional,
+			"#1511/G80 deletion pass: POST /api/v1/rbac/remove-role has no matching route. Same corrected evidence as AssignRole — dead via the same double barrier on the permanent RBAC stub chain, not merely a NewRemoteClient() guard."},
+		"UpdateRiskException": {statusIntentional,
+			"#1511/G80 deletion pass: PUT /api/v1/system/risk-exceptions/{id} has no matching route — UpdateRiskExceptionProxy was deliberately never registered (#G79, server/http/handlers/risk_exceptions_proxy.go: \"a repo-wide search found no caller of it anywhere, local or remote\"). This #1511 entry was already stale (the route removal already happened server-side); this pass closes it client-side too."},
+		"CreateShareRecord": {statusIntentional,
+			"#1511/G80 deletion pass: POST /api/v1/shares has no matching route (confirmed real: the /shares group has no POST). Every caller (ShareSecret/ShareSecretWithGroup) is behind share/create.go's NewRemoteClient() guard."},
+		"GetShareRecord": {statusIntentional,
+			"#1511/G80 deletion pass: GET /api/v1/shares/{id} has no matching route (confirmed real: the /shares group has no GET/{id}). Every caller (UpdateSharePermission, RevokeShare) is behind a NewRemoteClient() guard."},
+		"GetStats": {statusIntentional,
+			"#1511/G80 deletion pass: GET /api/v1/stats has no matching route (confirmed real: only scoped */stats variants exist). Sole caller GetDashboardStats is server-only — no CLI path at all."},
+		"GetLatestSecretVersion": {statusIntentional,
+			"#1511/G80 deletion pass: GET /api/v1/secrets/*/versions/latest has no matching route. The one CLI path that looked unguarded (run/run.go) is not: run.go calls common.ResolveRemote() directly (Wave 0c correction), so it never reaches this method under any complete storage.type: remote config. Every other caller is behind a NewRemoteClient() guard or server-only."},
+		"IncrementSecretReadCount": {statusIntentional,
+			"#1511/G80 deletion pass: POST /api/v1/secret-versions/*/increment-read-count has no matching route and zero callers anywhere in internal/core (distinct from the separate, already-classified TryIncrementSecretReadCount)."},
+		"ListSharedSecrets": {statusIntentional,
+			"#1511/G80 deletion pass: GET /api/v1/users/*/shared-secrets has no matching route (confirmed real: only GET /shared-secrets, the caller's own, exists). Sole CLI caller (share/shared_secrets.go) is behind a NewRemoteClient() guard."},
+		"CheckSharePermission": {statusIntentional,
+			"#1511/G80 deletion pass: GET /api/v1/secrets/*/permissions has no matching route, and core.CheckSharePermission itself has zero callers anywhere (no HTTP handler, no gRPC service, no CLI) — orphaned server-side, not just under storage.type: remote."},
+	})
+}

--- a/internal/storage/store/remote_misc_test.go
+++ b/internal/storage/store/remote_misc_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -598,31 +599,17 @@ func TestRemoteStorage_GetRiskException(t *testing.T) {
 	assert.Equal(t, "Rotation skip", exc.Title)
 }
 
-func TestRemoteStorage_UpdateRiskException(t *testing.T) {
-	now := time.Now().UTC().Truncate(time.Second)
-	exp := now.Add(30 * 24 * time.Hour)
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPut, r.Method)
-		assert.Equal(t, "/api/v1/system/risk-exceptions/6", r.URL.Path)
-		_, _ = w.Write(apiOK(nil))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+// TestRemoteStorage_UpdateRiskException_Unsupported: #1511/G80 deletion pass
+// — no matching route (#G79 already removed it server-side, confirmed
+// UpdateRiskExceptionProxy is not registered in router.go); zero production
+// callers. See docs/adr-087-remote-storage-deletion-pass.md.
+func TestRemoteStorage_UpdateRiskException_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
-	err = rs.UpdateRiskException(context.Background(), &models.RiskException{
-		ID:            6,
-		Title:         "updated",
-		Category:      "mfa",
-		Justification: "still needed",
-		CreatedBy:     1,
-		CreatedAt:     now,
-		ExpiresAt:     exp,
-		Revoked:       true,
-	})
-	require.NoError(t, err)
+	err = rs.UpdateRiskException(context.Background(), &models.RiskException{ID: 6})
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
 }
 
 // TestRemoteStorage_RevokeRiskExceptionIfNotRevoked proves the conditional
@@ -1276,31 +1263,8 @@ func TestRemoteStorage_ConsumeSSOLoginState(t *testing.T) {
 // remote_stats.go
 // ============================================================
 
-func TestRemoteStorage_GetStats(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/stats", r.URL.Path)
-		_, _ = w.Write(apiOK(map[string]interface{}{
-			"total_secrets":       5,
-			"total_users":         3,
-			"total_roles":         2,
-			"total_sessions":      1,
-			"total_audit_logs":    100,
-			"database_size_bytes": 4096,
-		}))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	stats, err := rs.GetStats(context.Background())
-	require.NoError(t, err)
-	require.NotNil(t, stats)
-	assert.Equal(t, int64(5), stats.TotalSecrets)
-	assert.Equal(t, int64(3), stats.TotalUsers)
-	assert.Equal(t, int64(2), stats.TotalRoles)
-}
+// GetStats is a permanent stub as of the #1511/G80 deletion pass — see
+// TestRemoteCov_GetStats_Unsupported (remote_coverage_test.go).
 
 func TestRemoteStorage_SaveStatsSnapshot_NoOp(t *testing.T) {
 	// SaveStatsSnapshot is a no-op in remote mode — no HTTP call is made.

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -134,22 +134,19 @@ func (rs *RemoteStorage) ListRoles(ctx context.Context) ([]*models.Role, error) 
 
 // --- RBAC assignment ---
 
-// AssignRole assigns a role to a user at scope via remote API.
-func (rs *RemoteStorage) AssignRole(ctx context.Context, userID, roleID uint, scope storage.Scope) error {
-	payload := map[string]uint{
-		"user_id":        userID,
-		"role_id":        roleID,
-		"project_id":     scope.ProjectID,
-		"environment_id": scope.EnvironmentID,
-	}
-	resp, err := rs.client.Post(ctx, "/api/v1/rbac/assign-role", payload)
-	if err != nil {
-		return fmt.Errorf("failed to assign role: %w", err)
-	}
-	if !resp.Success {
-		return fmt.Errorf("assign role failed: %s", resp.Error.Error())
-	}
-	return nil
+// AssignRole: #1511/G80 deletion pass — POST /api/v1/rbac/assign-role has no
+// matching route. Every unguarded CLI path into this method (via
+// core.AssignUserRole/AssignUserRoleScoped, reached from
+// rbac/assign_role.go, user/create.go, and request/review.go's access-request
+// approval flow) is dead today: request/review.go's own requireReviewAuthority
+// AND core.ApproveAccessRequestWithExpiry's own requireAuthorityForRole both
+// independently fail closed against the SAME three RBAC primitives
+// (GetUserRoleIDsAt/GetUserGroupRoleIDsAt/RoleSetHasPermission) ADR-086 keeps
+// permanently stubbed — so this is dead via two independent barriers on a
+// permanent stub chain, not merely "guarded by a CLI dual-path check" as
+// originally recorded. See docs/adr-087-remote-storage-deletion-pass.md.
+func (rs *RemoteStorage) AssignRole(_ context.Context, _, _ uint, _ storage.Scope) error {
+	return remoteUnsupported("AssignRole")
 }
 
 // GetGroupRoleGrants is a thin passthrough onto GET
@@ -262,22 +259,13 @@ func (rs *RemoteStorage) DeleteExpiredRoleGrants(ctx context.Context, before tim
 	return result.Removed, nil
 }
 
-// RemoveRole removes a role from a user at scope via remote API.
-func (rs *RemoteStorage) RemoveRole(ctx context.Context, userID, roleID uint, scope storage.Scope) error {
-	payload := map[string]uint{
-		"user_id":        userID,
-		"role_id":        roleID,
-		"project_id":     scope.ProjectID,
-		"environment_id": scope.EnvironmentID,
-	}
-	resp, err := rs.client.Post(ctx, "/api/v1/rbac/remove-role", payload)
-	if err != nil {
-		return fmt.Errorf("failed to remove role: %w", err)
-	}
-	if !resp.Success {
-		return fmt.Errorf("remove role failed: %s", resp.Error.Error())
-	}
-	return nil
+// RemoveRole: #1511/G80 deletion pass — same DEAD verdict and evidence as
+// AssignRole above (POST /api/v1/rbac/remove-role has no matching route; the
+// one unguarded caller path, the access-request-approval race-revert branch
+// in core.finalizeAccessRequestApproval, is blocked by the same permanent
+// RBAC stub chain). See docs/adr-087-remote-storage-deletion-pass.md.
+func (rs *RemoteStorage) RemoveRole(_ context.Context, _, _ uint, _ storage.Scope) error {
+	return remoteUnsupported("RemoveRole")
 }
 
 // RemoveAllProjectRoleGrants proxies onto POST

--- a/internal/storage/store/remote_rbac_test.go
+++ b/internal/storage/store/remote_rbac_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -122,34 +123,26 @@ func TestRemoteStorage_ListRoles(t *testing.T) {
 
 // --- RBAC assignment ---
 
-func TestRemoteStorage_AssignRole(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/rbac/assign-role", r.URL.Path)
-		_, _ = w.Write(apiOK(nil))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+// TestRemoteStorage_AssignRole_Unsupported: #1511/G80 deletion pass — no
+// matching route; see docs/adr-087-remote-storage-deletion-pass.md.
+func TestRemoteStorage_AssignRole_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.AssignRole(context.Background(), 10, 1, corestorage.Scope{ProjectID: 0, EnvironmentID: 0})
-	require.NoError(t, err)
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
 }
 
-func TestRemoteStorage_RemoveRole(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/rbac/remove-role", r.URL.Path)
-		_, _ = w.Write(apiOK(nil))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+// TestRemoteStorage_RemoveRole_Unsupported: #1511/G80 deletion pass — no
+// matching route; see docs/adr-087-remote-storage-deletion-pass.md.
+func TestRemoteStorage_RemoveRole_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.RemoveRole(context.Background(), 10, 1, corestorage.Scope{ProjectID: 0, EnvironmentID: 0})
-	require.NoError(t, err)
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
 }
 
 func TestRemoteStorage_GetGroupRoleGrants(t *testing.T) {

--- a/internal/storage/store/remote_risk_exceptions.go
+++ b/internal/storage/store/remote_risk_exceptions.go
@@ -176,20 +176,15 @@ func (rs *RemoteStorage) GetRiskException(ctx context.Context, id uint) (*models
 	return decodeRiskExceptionResponse(resp.Data)
 }
 
-// UpdateRiskException persists the full exception row (revoke/approve
-// bookkeeping) via PUT /api/v1/system/risk-exceptions/{id}. Matches
-// LocalStorage's own unconditional full-row Save semantics exactly — see the
-// package doc for why no conditional write is needed here.
-func (rs *RemoteStorage) UpdateRiskException(ctx context.Context, e *models.RiskException) error {
-	path := fmt.Sprintf("/api/v1/system/risk-exceptions/%d", e.ID)
-	resp, err := rs.client.Put(ctx, path, newRiskExceptionWire(e))
-	if err != nil {
-		return fmt.Errorf("failed to update risk exception: %w", err)
-	}
-	if !resp.Success {
-		return fmt.Errorf("update risk exception failed: %s", resp.Error.Error())
-	}
-	return nil
+// UpdateRiskException: #1511/G80 deletion pass — PUT
+// /api/v1/system/risk-exceptions/{id} has no matching route. UpdateRiskExceptionProxy
+// was deliberately never registered (#G79, server/http/handlers/risk_exceptions_proxy.go) —
+// a repo-wide search found no caller of it anywhere, local or remote. This
+// entry in #1511's list was already stale (the route removal already
+// happened server-side); this pass closes it client-side too. See
+// docs/adr-087-remote-storage-deletion-pass.md.
+func (rs *RemoteStorage) UpdateRiskException(_ context.Context, _ *models.RiskException) error {
+	return remoteUnsupported("UpdateRiskException")
 }
 
 // RevokeRiskExceptionIfNotRevoked persists e's full row via a single conditional

--- a/internal/storage/store/remote_secrets.go
+++ b/internal/storage/store/remote_secrets.go
@@ -514,38 +514,13 @@ func buildSecretFilterPath(filter *storage.SecretFilter) string {
 
 // --- Version operations ---
 
-// CreateSecretVersion creates a new version of a secret via remote API.
-func (rs *RemoteStorage) CreateSecretVersion(ctx context.Context, version *models.SecretVersion) (*models.SecretVersion, error) {
-	path := fmt.Sprintf("/api/v1/secrets/%d/versions", version.SecretNodeID)
-	resp, err := rs.client.Post(ctx, path, version)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create secret version: %w", err)
-	}
-	if !resp.Success {
-		return nil, fmt.Errorf("create secret version failed: %s", resp.Error.Error())
-	}
-	var result models.SecretVersion
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return &result, nil
-}
-
-// GetSecretVersion retrieves a specific version of a secret via remote API.
-func (rs *RemoteStorage) GetSecretVersion(ctx context.Context, secretID uint, version int) (*models.SecretVersion, error) {
-	path := fmt.Sprintf("/api/v1/secrets/%d/versions/%d", secretID, version)
-	resp, err := rs.client.Get(ctx, path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get secret version: %w", err)
-	}
-	if !resp.Success {
-		return nil, fmt.Errorf("get secret version failed: %s", resp.Error.Error())
-	}
-	var result models.SecretVersion
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return &result, nil
+// CreateSecretVersion: #1511/G80 deletion pass — POST /api/v1/secrets/*/versions
+// has no matching route (confirmed absent, router.go); every core caller
+// (storeSecretVersion/storeNextSecretVersion, reached via CreateSecret/
+// UpdateSecret/CopySecret/RotateSecret) is either behind a NewRemoteClient()
+// CLI guard or server-only. See docs/adr-087-remote-storage-deletion-pass.md.
+func (rs *RemoteStorage) CreateSecretVersion(_ context.Context, _ *models.SecretVersion) (*models.SecretVersion, error) {
+	return nil, remoteUnsupported("CreateSecretVersion")
 }
 
 // ListSecretVersions lists all versions of a secret via remote API.
@@ -570,40 +545,30 @@ func (rs *RemoteStorage) GetSecretVersions(ctx context.Context, secretID uint) (
 	return rs.ListSecretVersions(ctx, secretID)
 }
 
-// GetLatestSecretVersion retrieves the most recent version of a secret via remote API.
 // SetSecretCertNotAfter is a server-side concern (the certificate scan runs on the
 // server); the remote client never invokes it.
 func (rs *RemoteStorage) SetSecretCertNotAfter(_ context.Context, _ uint, _ *time.Time) error {
 	return remoteUnsupported("SetSecretCertNotAfter")
 }
 
-func (rs *RemoteStorage) GetLatestSecretVersion(ctx context.Context, secretID uint) (*models.SecretVersion, error) {
-	path := fmt.Sprintf("/api/v1/secrets/%d/versions/latest", secretID)
-	resp, err := rs.client.Get(ctx, path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get latest secret version: %w", err)
-	}
-	if !resp.Success {
-		return nil, fmt.Errorf("get latest secret version failed: %s", resp.Error.Error())
-	}
-	var result models.SecretVersion
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return &result, nil
+// GetLatestSecretVersion: #1511/G80 deletion pass — GET
+// /api/v1/secrets/*/versions/latest has no matching route. The one CLI path
+// that looked unguarded (run/run.go) is not: run.go:102 calls
+// common.ResolveRemote() directly (Wave 0c correction), so it never reaches
+// this method under any complete storage.type: remote config. Every other
+// caller is behind a NewRemoteClient() guard or server-only. See
+// docs/adr-087-remote-storage-deletion-pass.md.
+func (rs *RemoteStorage) GetLatestSecretVersion(_ context.Context, _ uint) (*models.SecretVersion, error) {
+	return nil, remoteUnsupported("GetLatestSecretVersion")
 }
 
-// IncrementSecretReadCount increments the read counter for a secret version via remote API.
-func (rs *RemoteStorage) IncrementSecretReadCount(ctx context.Context, versionID uint) error {
-	path := fmt.Sprintf("/api/v1/secret-versions/%d/increment-read-count", versionID)
-	resp, err := rs.client.Post(ctx, path, nil)
-	if err != nil {
-		return fmt.Errorf("failed to increment read count: %w", err)
-	}
-	if !resp.Success {
-		return fmt.Errorf("increment read count failed: %s", resp.Error.Error())
-	}
-	return nil
+// IncrementSecretReadCount: #1511/G80 deletion pass — POST
+// /api/v1/secret-versions/*/increment-read-count has no matching route and
+// zero callers anywhere in internal/core (distinct from the separate,
+// already-classified TryIncrementSecretReadCount below). See
+// docs/adr-087-remote-storage-deletion-pass.md.
+func (rs *RemoteStorage) IncrementSecretReadCount(_ context.Context, _ uint) error {
+	return remoteUnsupported("IncrementSecretReadCount")
 }
 
 // TryIncrementSecretReadCount is the max-reads burn-after-N-reads gate

--- a/internal/storage/store/remote_secrets_test.go
+++ b/internal/storage/store/remote_secrets_test.go
@@ -3,6 +3,7 @@ package store_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -291,44 +292,17 @@ func TestRemoteStorage_TryIncrementSecretNodeReadCount_Unsupported(t *testing.T)
 
 // --- Secret version operations ---
 
-func TestRemoteStorage_CreateSecretVersion(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/secrets/42/versions", r.URL.Path)
-		_, _ = w.Write(apiOK(map[string]interface{}{
-			"ID": 100, "SecretNodeID": 42, "VersionNumber": 1, "ReadCount": 0,
-		}))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+// TestRemoteStorage_CreateSecretVersion_Unsupported: #1511/G80 deletion pass
+// — POST /api/v1/secrets/*/versions has no matching route (confirmed DEAD,
+// see docs/adr-087-remote-storage-deletion-pass.md); the method is now a
+// permanent stub, no HTTP server needed.
+func TestRemoteStorage_CreateSecretVersion_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
-	version, err := rs.CreateSecretVersion(context.Background(), &models.SecretVersion{
-		SecretNodeID:  42,
-		VersionNumber: 1,
-	})
-	require.NoError(t, err)
-	assert.Equal(t, 1, version.VersionNumber)
-}
-
-func TestRemoteStorage_GetSecretVersion(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/secrets/42/versions/2", r.URL.Path)
-		_, _ = w.Write(apiOK(map[string]interface{}{
-			"ID": 200, "SecretNodeID": 42, "VersionNumber": 2, "ReadCount": 3,
-		}))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	version, err := rs.GetSecretVersion(context.Background(), 42, 2)
-	require.NoError(t, err)
-	assert.Equal(t, 2, version.VersionNumber)
-	assert.Equal(t, 3, version.ReadCount)
+	_, err = rs.CreateSecretVersion(context.Background(), &models.SecretVersion{SecretNodeID: 42})
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
 }
 
 func TestRemoteStorage_ListSecretVersions(t *testing.T) {
@@ -404,36 +378,29 @@ func TestRemoteStorage_GetSecretVersions(t *testing.T) {
 	require.Len(t, versions, 1)
 }
 
-func TestRemoteStorage_GetLatestSecretVersion(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/v1/secrets/42/versions/latest", r.URL.Path)
-		_, _ = w.Write(apiOK(map[string]interface{}{
-			"ID": 300, "SecretNodeID": 42, "VersionNumber": 3, "ReadCount": 5,
-		}))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+// TestRemoteStorage_GetLatestSecretVersion_Unsupported: #1511/G80 deletion
+// pass — GET /api/v1/secrets/*/versions/latest has no matching route
+// (confirmed DEAD, Wave 0c's run.go/ResolveRemote() correction re-verified
+// intact; see docs/adr-087-remote-storage-deletion-pass.md); the method is
+// now a permanent stub.
+func TestRemoteStorage_GetLatestSecretVersion_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
-	version, err := rs.GetLatestSecretVersion(context.Background(), 42)
-	require.NoError(t, err)
-	assert.Equal(t, 3, version.VersionNumber)
-	assert.Equal(t, 5, version.ReadCount)
+	_, err = rs.GetLatestSecretVersion(context.Background(), 42)
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
 }
 
-func TestRemoteStorage_IncrementSecretReadCount(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/api/v1/secret-versions/100/increment-read-count", r.URL.Path)
-		_, _ = w.Write(apiOK(nil))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+// TestRemoteStorage_IncrementSecretReadCount_Unsupported: #1511/G80 deletion
+// pass — POST /api/v1/secret-versions/*/increment-read-count has no matching
+// route and zero callers anywhere in internal/core; see
+// docs/adr-087-remote-storage-deletion-pass.md.
+func TestRemoteStorage_IncrementSecretReadCount_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.IncrementSecretReadCount(context.Background(), 100)
-	require.NoError(t, err)
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
 }

--- a/internal/storage/store/remote_sharing.go
+++ b/internal/storage/store/remote_sharing.go
@@ -17,37 +17,21 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-// CreateShareRecord creates a new share record via remote API.
-func (rs *RemoteStorage) CreateShareRecord(ctx context.Context, share *models.ShareRecord) (*models.ShareRecord, error) {
-	resp, err := rs.client.Post(ctx, "/api/v1/shares", share)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create share record: %w", err)
-	}
-	if !resp.Success {
-		return nil, fmt.Errorf("create share record failed: %s", resp.Error.Error())
-	}
-	var result models.ShareRecord
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return &result, nil
+// CreateShareRecord: #1511/G80 deletion pass — POST /api/v1/shares has no
+// matching route (confirmed real: the /shares group has no POST). Every
+// caller (ShareSecret/ShareSecretWithGroup) is behind share/create.go's
+// NewRemoteClient() guard. See docs/adr-087-remote-storage-deletion-pass.md.
+func (rs *RemoteStorage) CreateShareRecord(_ context.Context, _ *models.ShareRecord) (*models.ShareRecord, error) {
+	return nil, remoteUnsupported("CreateShareRecord")
 }
 
-// GetShareRecord retrieves a share record by ID via remote API.
-func (rs *RemoteStorage) GetShareRecord(ctx context.Context, shareID uint) (*models.ShareRecord, error) {
-	path := fmt.Sprintf("/api/v1/shares/%d", shareID)
-	resp, err := rs.client.Get(ctx, path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get share record: %w", err)
-	}
-	if !resp.Success {
-		return nil, fmt.Errorf("get share record failed: %s", resp.Error.Error())
-	}
-	var result models.ShareRecord
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return &result, nil
+// GetShareRecord: #1511/G80 deletion pass — GET /api/v1/shares/{id} has no
+// matching route (confirmed real: the /shares group has no GET/{id}). Every
+// caller (UpdateSharePermission, RevokeShare) is behind a NewRemoteClient()
+// guard in share/update.go, share/revoke.go. See
+// docs/adr-087-remote-storage-deletion-pass.md.
+func (rs *RemoteStorage) GetShareRecord(_ context.Context, _ uint) (*models.ShareRecord, error) {
+	return nil, remoteUnsupported("GetShareRecord")
 }
 
 // UpdateShareRecord updates an existing share record via remote API.
@@ -192,40 +176,22 @@ func (rs *RemoteStorage) ListSharesByGroup(ctx context.Context, groupID uint) ([
 	return result, nil
 }
 
-// ListSharedSecrets lists all secrets shared with userID via remote API.
-func (rs *RemoteStorage) ListSharedSecrets(ctx context.Context, userID uint) ([]*models.SecretNode, error) {
-	path := fmt.Sprintf("/api/v1/users/%d/shared-secrets", userID)
-	resp, err := rs.client.Get(ctx, path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list shared secrets: %w", err)
-	}
-	if !resp.Success {
-		return nil, fmt.Errorf("list shared secrets failed: %s", resp.Error.Error())
-	}
-	var result []*models.SecretNode
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return result, nil
+// ListSharedSecrets: #1511/G80 deletion pass — GET
+// /api/v1/users/*/shared-secrets has no matching route (confirmed real: only
+// GET /shared-secrets, the caller's own, exists). Sole CLI caller
+// (share/shared_secrets.go) is behind a NewRemoteClient() guard. See
+// docs/adr-087-remote-storage-deletion-pass.md.
+func (rs *RemoteStorage) ListSharedSecrets(_ context.Context, _ uint) ([]*models.SecretNode, error) {
+	return nil, remoteUnsupported("ListSharedSecrets")
 }
 
-// CheckSharePermission returns the permission level a user has on a secret via remote API.
-func (rs *RemoteStorage) CheckSharePermission(ctx context.Context, secretID, userID uint) (string, error) {
-	path := fmt.Sprintf("/api/v1/secrets/%d/permissions?user_id=%d", secretID, userID)
-	resp, err := rs.client.Get(ctx, path)
-	if err != nil {
-		return "", fmt.Errorf("failed to check share permission: %w", err)
-	}
-	if !resp.Success {
-		return "", fmt.Errorf("check share permission failed: %s", resp.Error.Error())
-	}
-	var result struct {
-		Permission string `json:"permission"`
-	}
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return "", fmt.Errorf("failed to parse response: %w", err)
-	}
-	return result.Permission, nil
+// CheckSharePermission: #1511/G80 deletion pass — GET
+// /api/v1/secrets/*/permissions has no matching route, and core.CheckSharePermission
+// itself has zero callers anywhere (no HTTP handler, no gRPC service, no CLI)
+// — orphaned server-side, not just under storage.type: remote. See
+// docs/adr-087-remote-storage-deletion-pass.md.
+func (rs *RemoteStorage) CheckSharePermission(_ context.Context, _, _ uint) (string, error) {
+	return "", remoteUnsupported("CheckSharePermission")
 }
 
 // DeleteExpiredShareRecords proxies onto POST

--- a/internal/storage/store/remote_sharing_test.go
+++ b/internal/storage/store/remote_sharing_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -41,41 +42,28 @@ func shareRecordData(id, secretID, ownerID, recipientID uint) map[string]interfa
 
 // --- CreateShareRecord ---
 
-func TestRemoteStorage_CreateShareRecord(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v1/shares", r.URL.Path)
-		_, _ = w.Write(apiOK(shareRecordData(1, 10, 2, 3)))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+// TestRemoteStorage_CreateShareRecord_Unsupported: #1511/G80 deletion pass —
+// no matching route; see docs/adr-087-remote-storage-deletion-pass.md.
+func TestRemoteStorage_CreateShareRecord_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
-	result, err := rs.CreateShareRecord(context.Background(), testShareRecord(0, 10, 2, 3))
-	require.NoError(t, err)
-	assert.Equal(t, uint(1), result.ID)
-	assert.Equal(t, uint(10), result.SecretID)
-	assert.Equal(t, uint(3), result.RecipientID)
+	_, err = rs.CreateShareRecord(context.Background(), testShareRecord(0, 10, 2, 3))
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
 }
 
 // --- GetShareRecord ---
 
-func TestRemoteStorage_GetShareRecord(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/shares/1", r.URL.Path)
-		_, _ = w.Write(apiOK(shareRecordData(1, 10, 2, 3)))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+// TestRemoteStorage_GetShareRecord_Unsupported: #1511/G80 deletion pass — no
+// matching route; see docs/adr-087-remote-storage-deletion-pass.md.
+func TestRemoteStorage_GetShareRecord_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
-	result, err := rs.GetShareRecord(context.Background(), 1)
-	require.NoError(t, err)
-	assert.Equal(t, uint(1), result.ID)
-	assert.Equal(t, uint(10), result.SecretID)
+	_, err = rs.GetShareRecord(context.Background(), 1)
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
 }
 
 // --- UpdateShareRecord ---
@@ -233,44 +221,29 @@ func TestRemoteStorage_ListSharesByGroup(t *testing.T) {
 
 // --- ListSharedSecrets ---
 
-func TestRemoteStorage_ListSharedSecrets(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/users/3/shared-secrets", r.URL.Path)
-		_, _ = w.Write(apiOK([]map[string]interface{}{
-			{"id": 10, "name": "db-password", "type": "password"},
-		}))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+// TestRemoteStorage_ListSharedSecrets_Unsupported: #1511/G80 deletion pass —
+// no matching route; see docs/adr-087-remote-storage-deletion-pass.md.
+func TestRemoteStorage_ListSharedSecrets_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
-	results, err := rs.ListSharedSecrets(context.Background(), 3)
-	require.NoError(t, err)
-	assert.Len(t, results, 1)
-	assert.Equal(t, "db-password", results[0].Name)
+	_, err = rs.ListSharedSecrets(context.Background(), 3)
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
 }
 
 // --- CheckSharePermission ---
 
-func TestRemoteStorage_CheckSharePermission(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/secrets/10/permissions", r.URL.Path)
-		assert.Equal(t, "3", r.URL.Query().Get("user_id"))
-		_, _ = w.Write(apiOK(map[string]interface{}{
-			"permission": "write",
-		}))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+// TestRemoteStorage_CheckSharePermission_Unsupported: #1511/G80 deletion pass
+// — no matching route, and core.CheckSharePermission itself has zero callers
+// anywhere; see docs/adr-087-remote-storage-deletion-pass.md.
+func TestRemoteStorage_CheckSharePermission_Unsupported(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
-	perm, err := rs.CheckSharePermission(context.Background(), 10, 3)
-	require.NoError(t, err)
-	assert.Equal(t, "write", perm)
+	_, err = rs.CheckSharePermission(context.Background(), 10, 3)
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported),
+		"expected ErrRemoteUnsupported, got %v", err)
 }
 
 // --- DeleteExpiredShareRecords ---

--- a/internal/storage/store/remote_stats.go
+++ b/internal/storage/store/remote_stats.go
@@ -10,27 +10,18 @@ package store
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
-// GetStats retrieves storage statistics via remote API.
-func (rs *RemoteStorage) GetStats(ctx context.Context) (*storage.StorageStats, error) {
-	resp, err := rs.client.Get(ctx, "/api/v1/stats")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get stats: %w", err)
-	}
-	if !resp.Success {
-		return nil, fmt.Errorf("get stats failed: %s", resp.Error.Error())
-	}
-	var result storage.StorageStats
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return &result, nil
+// GetStats: #1511/G80 deletion pass — GET /api/v1/stats has no matching
+// route (confirmed real: only scoped */stats variants exist). Sole caller
+// GetDashboardStats is server-only (server/http/handlers/dashboard.go) — no
+// CLI path at all. See docs/adr-087-remote-storage-deletion-pass.md.
+func (rs *RemoteStorage) GetStats(_ context.Context) (*storage.StorageStats, error) {
+	return nil, remoteUnsupported("GetStats")
 }
 
 // SaveStatsSnapshot is a no-op in remote mode — snapshots are managed server-side.

--- a/internal/storage/store/remote_wire_route_coverage_test.go
+++ b/internal/storage/store/remote_wire_route_coverage_test.go
@@ -915,7 +915,7 @@ var knownUnresolvedWireCalls = map[string]wireCallExclusion{
 	"remote_access_review_campaigns.go:210": urlValuesEntry(),
 	"remote_access_review_campaigns.go:237": urlValuesEntry(),
 	"remote_access_review_campaigns.go:263": urlValuesEntry(),
-	"remote_auth.go:362":                    urlValuesEntry(),
+	"remote_auth.go:359":                    urlValuesEntry(),
 	"remote_break_glass.go:135":             urlValuesEntry(),
 	"remote_dynamic.go:260":                 urlValuesEntry(),
 	"remote_dynamic.go:348":                 urlValuesEntry(),
@@ -949,9 +949,9 @@ var knownUnresolvedWireCalls = map[string]wireCallExclusion{
 	// escaped segment as a wildcard "*" the way normalizeChiPath already does
 	// for a chi {param}), just a different one than the query-string case.
 	"remote_connector_project_bindings.go:63": pathEscapeEntry("url.PathEscape(connector) path-segment concatenation"),
-	"remote_rbac.go:497":                      pathEscapeEntry("url.PathEscape(connector) path-segment concatenation"),
-	"remote_rbac.go:810":                      pathEscapeEntry("url.PathEscape(name) path-segment concatenation"),
-	"remote_rbac.go:1088":                     pathEscapeEntry("joinUintsCSV(adminRoleIDs) query-string concatenation (a local helper, not url.Values)"),
+	"remote_rbac.go:485":                      pathEscapeEntry("url.PathEscape(connector) path-segment concatenation"),
+	"remote_rbac.go:798":                      pathEscapeEntry("url.PathEscape(name) path-segment concatenation"),
+	"remote_rbac.go:1076":                     pathEscapeEntry("joinUintsCSV(adminRoleIDs) query-string concatenation (a local helper, not url.Values)"),
 	"remote_users.go:978":                     pathEscapeEntry("url.QueryEscape(strings.Join(ids, \",\")) query-string concatenation"),
 
 	// Category: the ENTIRE path is a bare call to a locally-defined helper
@@ -1030,18 +1030,11 @@ func constRefEntry(constRef string) wireCallExclusion {
 // HaveMatchingRoute fails on any entry that no longer reproduces, so this can't silently
 // go stale. Do not add a new entry here to silence a genuinely new gap — file it as its
 // own issue-1511 item first.
-var knownMissingRoutes = map[routeKey]bool{
-	{Method: "POST", Path: "/api/v1/secrets/*/versions"}:                     true, // CreateSecretVersion — the G80 Phase 0 discovery
-	{Method: "POST", Path: "/api/v1/sessions/cleanup"}:                       true,
-	{Method: "POST", Path: "/api/v1/rbac/assign-role"}:                       true,
-	{Method: "POST", Path: "/api/v1/rbac/remove-role"}:                       true,
-	{Method: "PUT", Path: "/api/v1/system/risk-exceptions/*"}:                true,
-	{Method: "POST", Path: "/api/v1/shares"}:                                 true, // confirmed real: /shares group has no POST
-	{Method: "GET", Path: "/api/v1/shares/*"}:                                true, // confirmed real: /shares group has no GET/{id}
-	{Method: "GET", Path: "/api/v1/stats"}:                                   true, // confirmed real: only scoped */stats variants exist
-	{Method: "GET", Path: "/api/v1/secrets/*/versions/*"}:                    true,
-	{Method: "GET", Path: "/api/v1/secrets/*/versions/latest"}:               true,
-	{Method: "POST", Path: "/api/v1/secret-versions/*/increment-read-count"}: true,
-	{Method: "GET", Path: "/api/v1/users/*/shared-secrets"}:                  true, // confirmed real: only GET /shared-secrets (caller's own) exists
-	{Method: "GET", Path: "/api/v1/secrets/*/permissions"}:                   true,
-}
+//
+// Empty as of the G80 deletion pass (docs/adr-087-remote-storage-deletion-pass.md):
+// all 13 entries this map ever held (#1511's full list) were converted from a live,
+// permanently-404ing wire call to a remoteUnsupported() stub — see
+// remote_deletion_pass_completeness_test.go's addRemoteUnsupported
+// entries for the per-method DEAD evidence. A future genuinely-new gap gets a
+// fresh entry here, triaged the same way, not by resurrecting these.
+var knownMissingRoutes = map[routeKey]bool{}

--- a/internal/storage/store/store_s28_test.go
+++ b/internal/storage/store/store_s28_test.go
@@ -252,25 +252,9 @@ func TestRemoteStorage_S28_ListRoles_BadJSON(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestRemoteStorage_S28_AssignRole_APIError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(apiErrResp("CONFLICT", "already assigned"))
-	}))
-	defer srv.Close()
-	rs := newS28Remote(t, srv.URL)
-	err := rs.AssignRole(context.Background(), 1, 1, coreScope())
-	assert.Error(t, err)
-}
-
-func TestRemoteStorage_S28_RemoveRole_APIError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(apiErrResp("NOT_FOUND", "assignment not found"))
-	}))
-	defer srv.Close()
-	rs := newS28Remote(t, srv.URL)
-	err := rs.RemoveRole(context.Background(), 1, 1, coreScope())
-	assert.Error(t, err)
-}
+// AssignRole/RemoveRole are permanent stubs as of the #1511/G80 deletion
+// pass — see TestRemoteStorage_AssignRole_Unsupported/
+// TestRemoteStorage_RemoveRole_Unsupported (remote_rbac_test.go).
 
 func TestRemoteStorage_S28_GetGroupRoleGrants_APIError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/http/remote_storage_risk_exceptions_test.go
+++ b/server/http/remote_storage_risk_exceptions_test.go
@@ -87,7 +87,7 @@ func buildRiskException(now time.Time, createdBy uint, title, category string, e
 // see docs/adr-087-remote-storage-deletion-pass.md), not something this suite
 // exercises anymore.
 func TestRemoteStorageRiskExceptions_CreateGetList_RealServer(t *testing.T) {
-	t.Skip("#1511/G80 deletion pass fixed the original blocker (UpdateRiskException now a client-side stub, not a real 405) but un-skipping surfaced a SECOND, previously-invisible one: this harness's default credential (createNodeToken, a machine/node principal) cannot create a risk exception at all — CreateRiskExceptionProxy requires a human principal ('only a human principal may create a risk exception'). This has been true since before this pass; the original t.Skip() short-circuited before the Create call ever ran, so it was never actually observed. Out of scope for a dead-wire-call deletion pass — filed as its own follow-up, not fixed here.")
+	t.Skip("#1511/G80 deletion pass fixed the original blocker (UpdateRiskException now a client-side stub, not a real 405) but un-skipping surfaced a SECOND, previously-invisible one: this harness's default credential (createNodeToken, a machine/node principal) cannot create a risk exception at all — CreateRiskExceptionProxy requires a human principal ('only a human principal may create a risk exception'). This has been true since before this pass; the original t.Skip() short-circuited before the Create call ever ran, so it was never actually observed. Out of scope for a dead-wire-call deletion pass — filed as #1584, not fixed here.")
 	upstream, downstream := newUpstreamDownstreamForRiskExceptions(t)
 	ctx := context.Background()
 	now := time.Now()
@@ -199,7 +199,7 @@ func TestRemoteStorageRiskExceptions_Approve_DeniesNodeCredential(t *testing.T) 
 // expired-but-not-revoked row is still returned here — core is what drops it
 // from an "active" view).
 func TestRemoteStorageRiskExceptions_ActiveOnlyExcludesRevoked_RealServer(t *testing.T) {
-	t.Skip("Same second blocker as TestRemoteStorageRiskExceptions_CreateGetList_RealServer above: this harness's node/machine credential cannot create a risk exception at all ('only a human principal may create a risk exception'), unrelated to and not fixed by the #1511/G80 deletion pass. Quarantined here, not fixed.")
+	t.Skip("Same second blocker as TestRemoteStorageRiskExceptions_CreateGetList_RealServer above: this harness's node/machine credential cannot create a risk exception at all ('only a human principal may create a risk exception'), unrelated to and not fixed by the #1511/G80 deletion pass. Filed as #1584. Quarantined here, not fixed.")
 	upstream, downstream := newUpstreamDownstreamForRiskExceptions(t)
 	ctx := context.Background()
 	now := time.Now()

--- a/server/http/remote_storage_risk_exceptions_test.go
+++ b/server/http/remote_storage_risk_exceptions_test.go
@@ -73,14 +73,21 @@ func buildRiskException(now time.Time, createdBy uint, title, category string, e
 	}
 }
 
-// TestRemoteStorageRiskExceptions_CreateGetListUpdate_RealServer proves the #519
-// fix for CreateRiskException/GetRiskException/ListRiskExceptions/
-// UpdateRiskException: an exception is genuinely persisted on the upstream
-// server via the DOWNSTREAM's RemoteStorage, fetchable by ID, listed, and
-// updatable (revoke/approve bookkeeping) — all via storage.type: remote against
-// a real router, not a protocol mock.
-func TestRemoteStorageRiskExceptions_CreateGetListUpdate_RealServer(t *testing.T) {
-	t.Skip("PUT /api/v1/system/risk-exceptions/{id} (UpdateRiskExceptionProxy) is deliberately not registered (#G79 hardening — see router.go's comment at the risk-exceptions proxy group) and this test's Update call hits a real 405. Tracked in #1511; quarantined here, not fixed — do not re-register the route to make this pass.")
+// TestRemoteStorageRiskExceptions_CreateGetList_RealServer proves the #519 fix
+// for CreateRiskException/GetRiskException/ListRiskExceptions: an exception is
+// genuinely persisted on the upstream server via the DOWNSTREAM's
+// RemoteStorage, fetchable by ID, and listed — all via storage.type: remote
+// against a real router, not a protocol mock. The approve/revoke bookkeeping
+// this test used to also cover via UpdateRiskException is now proved by
+// TestRemoteStorageRiskExceptions_Approve_DeniesNodeCredential (approve, via
+// the dedicated conditional-write proxy) and
+// TestRemoteStorageRiskExceptions_ActiveOnlyExcludesRevoked_RealServer
+// (revoke, same) below — UpdateRiskException itself is a permanent stub as of
+// the #1511/G80 deletion pass (#G79 already removed its route server-side;
+// see docs/adr-087-remote-storage-deletion-pass.md), not something this suite
+// exercises anymore.
+func TestRemoteStorageRiskExceptions_CreateGetList_RealServer(t *testing.T) {
+	t.Skip("#1511/G80 deletion pass fixed the original blocker (UpdateRiskException now a client-side stub, not a real 405) but un-skipping surfaced a SECOND, previously-invisible one: this harness's default credential (createNodeToken, a machine/node principal) cannot create a risk exception at all — CreateRiskExceptionProxy requires a human principal ('only a human principal may create a risk exception'). This has been true since before this pass; the original t.Skip() short-circuited before the Create call ever ran, so it was never actually observed. Out of scope for a dead-wire-call deletion pass — filed as its own follow-up, not fixed here.")
 	upstream, downstream := newUpstreamDownstreamForRiskExceptions(t)
 	ctx := context.Background()
 	now := time.Now()
@@ -125,21 +132,18 @@ func TestRemoteStorageRiskExceptions_CreateGetListUpdate_RealServer(t *testing.T
 	}
 	assert.True(t, titles["MFA rollout delay"])
 	assert.True(t, titles["Dormant service account"])
+}
 
-	// UpdateRiskException: approve the first exception (dual control — a
-	// DIFFERENT actor than the creator) via the downstream, confirm the
-	// transition is visible directly on the upstream.
-	approvedAt := time.Now()
-	fetched.Approved = true
-	fetched.ApprovedBy = 2
-	fetched.ApprovedAt = &approvedAt
-	require.NoError(t, downstream.Storage().UpdateRiskException(ctx, fetched))
+// TestRemoteStorage_UpdateRiskException_Unsupported proves UpdateRiskException
+// fails client-side (a stub, never reaching the network) rather than hitting a
+// real 405 from the deliberately-unregistered route — the #1511/G80 deletion
+// pass's actual fix, replacing this suite's prior quarantined-Skip coverage.
+func TestRemoteStorage_UpdateRiskException_Unsupported(t *testing.T) {
+	_, downstream := newUpstreamDownstreamForRiskExceptions(t)
+	ctx := context.Background()
 
-	reFetched, err := upstream.Storage().GetRiskException(ctx, exc.ID)
-	require.NoError(t, err)
-	assert.True(t, reFetched.Approved, "the approval must be visible directly on the upstream's own storage")
-	assert.Equal(t, uint(2), reFetched.ApprovedBy)
-	require.NotNil(t, reFetched.ApprovedAt)
+	err := downstream.Storage().UpdateRiskException(ctx, &models.RiskException{ID: 1})
+	require.Error(t, err)
 }
 
 // TestRemoteStorageRiskExceptions_GetNotFound_RealServer proves a clean
@@ -195,7 +199,7 @@ func TestRemoteStorageRiskExceptions_Approve_DeniesNodeCredential(t *testing.T) 
 // expired-but-not-revoked row is still returned here — core is what drops it
 // from an "active" view).
 func TestRemoteStorageRiskExceptions_ActiveOnlyExcludesRevoked_RealServer(t *testing.T) {
-	t.Skip("Same #1511/#G79 cause as TestRemoteStorageRiskExceptions_CreateGetListUpdate_RealServer above: this test also calls the deliberately-unregistered UpdateRiskExceptionProxy route and hits a real 405. Quarantined here, not fixed.")
+	t.Skip("Same second blocker as TestRemoteStorageRiskExceptions_CreateGetList_RealServer above: this harness's node/machine credential cannot create a risk exception at all ('only a human principal may create a risk exception'), unrelated to and not fixed by the #1511/G80 deletion pass. Quarantined here, not fixed.")
 	upstream, downstream := newUpstreamDownstreamForRiskExceptions(t)
 	ctx := context.Background()
 	now := time.Now()
@@ -206,11 +210,16 @@ func TestRemoteStorageRiskExceptions_ActiveOnlyExcludesRevoked_RealServer(t *tes
 	revoked, err := downstream.Storage().CreateRiskException(ctx, buildRiskException(now, 1, "Revoked exception", "other", expiresAt))
 	require.NoError(t, err)
 
+	// Revoked via the dedicated conditional-write proxy (RevokeRiskExceptionIfNotRevoked),
+	// not UpdateRiskException — the latter is a permanent stub as of the
+	// #1511/G80 deletion pass (#G79 already removed its route server-side).
 	revokedAt := time.Now()
 	revoked.Revoked = true
 	revoked.RevokedBy = 1
 	revoked.RevokedAt = &revokedAt
-	require.NoError(t, downstream.Storage().UpdateRiskException(ctx, revoked))
+	matched, err := downstream.Storage().RevokeRiskExceptionIfNotRevoked(ctx, revoked)
+	require.NoError(t, err)
+	require.True(t, matched)
 
 	rows, err := downstream.Storage().ListRiskExceptions(ctx, true)
 	require.NoError(t, err)

--- a/server/http/role_grant_authority_guard_test.go
+++ b/server/http/role_grant_authority_guard_test.go
@@ -1,0 +1,160 @@
+// role_grant_authority_guard_test.go — a guard for the pattern named in #1582
+// (G80): three /system handlers were each found, one at a time, by a
+// different method, to persist a Role grant directly via storage with no
+// authority check at all — CreateInvitationProxy (found first, fixed in the
+// documented-exception re-verification sweep), then CreateMembershipProxy and
+// UpdateMembershipProxy (found by #1578, fixed alongside it). Three
+// independent discoveries of the same missing call is a signal that there is
+// an invariant to assert, not a list to maintain: every /system handler that
+// persists a Role grant DIRECTLY via storage (bypassing core) must call
+// core.RequireAuthorityForRole before doing so.
+//
+// Scope, deliberately narrow: this guard only covers the raw-storage-bypass
+// shape #1578/#1582 fixed — a handler that decodes a wire body carrying a
+// Role-shaped field and calls h.coreService.Storage().Create*/Update*
+// directly. A handler that instead routes through a core business-logic
+// function (e.g. AssignRoleWithExpiryProxy -> core.AssignUserRoleWithExpiry,
+// whose OWN body calls requireAuthorityForRole internally) is a different,
+// already-correct shape — core.AssignGroupRoleWithExpiry's own doc comment
+// names this explicitly. This guard would not, and should not, flag it: the
+// ceiling is enforced, just one hop further down, which the existing
+// raw_storage_bypass_guard_test.go already accounts for when classifying a
+// handler as calling core vs. calling storage directly. Detecting "the
+// ceiling is enforced SOMEWHERE in the full call graph" for every possible
+// handler shape would require the same interprocedural AST walk
+// raw_storage_bypass_guard_test.go's exportedCoreStorageWrappers already
+// does for a different question; duplicating that here was assessed and
+// rejected as growing this pass beyond a small check (per the G80 standing
+// guardrail) — the raw-storage-bypass shape is where all three real
+// instances were actually found, and is what this guard targets.
+package http
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// roleFieldRe matches a Role-shaped wire field reference: `body.Role`,
+// `.Role:` in a struct literal, `a.Role` in an assignments-loop variable
+// (CreateInvitationProxy's per-assignment loop), or `SystemRole` (the
+// substring match is deliberate — "SystemRole" is one identifier, not a
+// separate word-bounded "Role", but is exactly the field
+// RequireAuthorityForRole is also called for in CreateInvitationProxy).
+var roleFieldRe = regexp.MustCompile(`\.Role\b|\bRole:|SystemRole`)
+
+// directStorageWriteRe matches a direct, unmediated
+// h.coreService.Storage().Create*/Update* call — the raw-storage-bypass
+// shape, as opposed to routing through a core.KeyorixCore business-logic
+// method (core.AssignUserRoleWithExpiry and similar never appear as
+// `.Storage().Create`/`.Storage().Update` in a handler body).
+var directStorageWriteRe = regexp.MustCompile(`\.Storage\(\)\.(Create|Update)[A-Za-z]*\(`)
+
+// persistsRoleGrantDirectly reports whether the named handler's body both
+// references a Role-shaped field and calls storage directly to persist it —
+// the exact shape #1578/#1582 fixed.
+func persistsRoleGrantDirectly(t *testing.T, handlerName string) bool {
+	t.Helper()
+	text := handlerBodyText(t, handlerName)
+	return roleFieldRe.MatchString(text) && directStorageWriteRe.MatchString(text)
+}
+
+// callsRequireAuthorityForRole reports whether the named handler's body
+// calls RequireAuthorityForRole anywhere (this guard does not check ordering
+// relative to the storage write — a handler decoding, checking, THEN
+// persisting is the only sane shape in practice, and ordering bugs are a
+// different, more targeted review question than this guard's population
+// check).
+func callsRequireAuthorityForRole(t *testing.T, handlerName string) bool {
+	t.Helper()
+	return strings.Contains(handlerBodyText(t, handlerName), "RequireAuthorityForRole(")
+}
+
+// roleGrantAuthorityAllowlist is the exhaustive, reasoned inventory of every
+// /system handler this guard's scan flags as persisting a Role grant
+// directly via storage WITHOUT calling RequireAuthorityForRole, reviewed as
+// safe for a stated reason (e.g. the Role field is never admin-tier by
+// construction, or a different, equivalent ceiling already runs first).
+// TestEveryDirectRoleGrantChecksAuthority fails if a flagged handler is
+// missing from both this list and knownUnfixedRoleGrantAuthorityGaps, or if
+// a listed entry stops reproducing.
+var roleGrantAuthorityAllowlist = map[string]string{}
+
+// knownUnfixedRoleGrantAuthorityGaps is the set of /system handlers
+// confirmed, by individual review, to persist a Role grant directly with no
+// authority check, not yet fixed. Grandfathered so this guard can go live
+// immediately; each entry is a tracked gap, not a claim of safety. Empty as
+// of this guard's introduction (G80 deletion pass) — all three known
+// instances were fixed before this guard was written.
+var knownUnfixedRoleGrantAuthorityGaps = map[string]string{}
+
+// TestEveryDirectRoleGrantChecksAuthority is the guard: for every /system
+// handler that persists a Role-shaped field directly via storage, that
+// handler must call RequireAuthorityForRole, or have a reasoned entry in
+// roleGrantAuthorityAllowlist or knownUnfixedRoleGrantAuthorityGaps. RED
+// without #1582's fix: CreateMembershipProxy and UpdateMembershipProxy would
+// both have been flagged here.
+func TestEveryDirectRoleGrantChecksAuthority(t *testing.T) {
+	routerPath := "router.go"
+	actual := extractSystemGroupRoutes(t, routerPath)
+
+	handlerFlagged := map[string]bool{}
+	seenHandlers := map[string]bool{}
+	var flagged []string
+	for _, r := range actual {
+		if r.Handler == "" || seenHandlers[r.Handler] {
+			continue
+		}
+		seenHandlers[r.Handler] = true
+		if !persistsRoleGrantDirectly(t, r.Handler) {
+			continue
+		}
+		if callsRequireAuthorityForRole(t, r.Handler) {
+			continue
+		}
+		handlerFlagged[r.Handler] = true
+		_, safe := roleGrantAuthorityAllowlist[r.Handler]
+		_, unfixed := knownUnfixedRoleGrantAuthorityGaps[r.Handler]
+		if !safe && !unfixed {
+			flagged = append(flagged, r.Handler+" persists a Role-shaped field directly via storage with no "+
+				"RequireAuthorityForRole call")
+		}
+	}
+	sort.Strings(flagged)
+
+	if len(flagged) > 0 {
+		t.Errorf("found %d /system handler(s) persisting a Role grant directly via storage with no authority "+
+			"check (the #1578/#1582 shape): %v\nEither call h.coreService.RequireAuthorityForRole(r.Context(), "+
+			"actorID(r), projectID, role) before persisting, or add a reasoned entry to "+
+			"roleGrantAuthorityAllowlist (if genuinely safe) or knownUnfixedRoleGrantAuthorityGaps (if it's a "+
+			"real, tracked, not-yet-fixed gap) in this file.", len(flagged), flagged)
+	}
+
+	checkStale := func(listName string, m map[string]string) {
+		var stale []string
+		for handler := range m {
+			found := false
+			for _, r := range actual {
+				if r.Handler == handler {
+					found = true
+					break
+				}
+			}
+			if !found {
+				stale = append(stale, handler+" (no longer registered under /system)")
+				continue
+			}
+			if !handlerFlagged[handler] {
+				stale = append(stale, handler+" (no longer persists an unchecked Role grant)")
+			}
+		}
+		sort.Strings(stale)
+		if len(stale) > 0 {
+			t.Errorf("%s entr(y/ies) no longer reproduce: %v\nRemove the entry, or move it to the other list if "+
+				"its status changed (e.g. a real gap just got fixed).", listName, stale)
+		}
+	}
+	checkStale("roleGrantAuthorityAllowlist", roleGrantAuthorityAllowlist)
+	checkStale("knownUnfixedRoleGrantAuthorityGaps", knownUnfixedRoleGrantAuthorityGaps)
+}


### PR DESCRIPTION
## Summary

Executes the deletion Wave 0 sized but explicitly held pending review (`docs/g80-wave0-remote-storage-partition.md`). Full criterion, re-verification, and accounting in **`docs/adr-087-remote-storage-deletion-pass.md`**.

Converts 12 `RemoteStorage` methods from a live-but-permanently-404ing wire call to a `remoteUnsupported()` stub, and removes a 13th outright (`GetSecretVersion` — never part of the `storage.Storage` interface):

`CreateSecretVersion`, `CleanupExpiredSessions`, `AssignRole`, `RemoveRole`, `UpdateRiskException`, `CreateShareRecord`, `GetShareRecord`, `GetStats`, `GetSecretVersion` (removed), `GetLatestSecretVersion`, `IncrementSecretReadCount`, `ListSharedSecrets`, `CheckSharePermission`

## What this is, and isn't

- **Is**: removal of a *verified-dead subset* — issue #1511's full 13-item orphaned-wire-call list, each individually re-traced against current `origin/main` (post-#1576/#1581, post-#1582).
- **Isn't**: "the dead RemoteStorage surface is now removed." Wave 1's #1576 found 171 structurally-stub `RemoteStorage` methods. Wave 0's own LIVE/DEAD/UNRESOLVED partition individually examined exactly 13 of them (this deletion set) — **158 of 171 have never been examined for deletion-worthiness at all**, and this pass doesn't touch them.

## One correction to Wave 0's evidence

`AssignRole`/`RemoveRole`'s stated guard (`NewRemoteClient()` on `rbac/assign_role.go` et al.) was incomplete — `request/review.go`'s access-request-approval path reaches them with no such guard. They're still DEAD, confirmed, but via a more durable mechanism: two independent barriers on the RBAC stub chain (`GetUserRoleIDsAt`/`GetUserGroupRoleIDsAt`/`RoleSetHasPermission`) ADR-086 keeps permanently stubbed by design — not merely a CLI dual-path guard.

## Not deleted

- 3 LIVE methods (ADR-086) and 7 UNRESOLVED methods (Wave 0) — untouched. Unresolved means kept, not "probably fine."
- 3 of Wave 0's originally-sized "raw stub" candidates (`CreatePermission`, `CreateProject`, `CreateEnvironment`) needed no action — Wave 1's #1576 widening already absorbed and correctly classified them as permanent stubs before this pass started.

## Findability

Annotated tag `pre-remote-topology-deletion` at the commit immediately before this one preserves every removed method's original wire-call body (`git show pre-remote-topology-deletion:<path>`).

## The invariant, not just the list

`server/http/role_grant_authority_guard_test.go` (`TestEveryDirectRoleGrantChecksAuthority`): three `/system` handlers (`CreateInvitationProxy`, `CreateMembershipProxy`, `UpdateMembershipProxy`, #1582) were each found missing a `RequireAuthorityForRole` call by a different method, one at a time. This guard asserts the invariant directly. Verified red (a deliberately-reintroduced gap in `CreateMembershipProxy`) and green (all three intact).

## A second finding, surfaced not fixed

Un-skipping two risk-exceptions tests (to confirm `UpdateRiskException`'s fix) surfaced a second, unrelated, pre-existing blocker: both tests' harness authenticates as a machine/node credential, but `CreateRiskExceptionProxy` requires a human principal. Invisible until now because the original `t.Skip()` short-circuited before `Create` ever ran. Re-skipped with an accurate reason; out of scope here — filed as its own follow-up (#TBD, opening separately).

## Test plan

- [x] All 13 methods' guard-population accounting verified: `remoteUnsupportedAllowlist` 171 → 183 (12 newly-stub methods), predicted and actual match exactly.
- [x] `TestRemoteUnsupportedStubsAreAllowlisted`, `TestRemoteStorageWireCalls_HaveMatchingRoute`, `TestKnownUnresolvedWireCallsAreDisciplined` all green.
- [x] Full sweep of every guard-shaped test across `server/http`, `internal/storage/store`, `server/proto/pb` — all pass, including `TestNoUnjustifiedRawStorageBypass`, `TestNoUnjustifiedActorIdentityForgery`, `TestEveryDirectRoleGrantChecksAuthority` (new), every `SystemWriteCeiling`/`MachinePrivilegeCeiling` test, `TestEveryFileIsGenerated`.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean; `golangci-lint run` 0 issues; `gosec -severity medium -exclude-generated` 0 issues (both touched packages).
- [x] Full suites green: `internal/core`, `internal/storage/store` (2 pre-existing, unrelated failures — `TestListShares_ExcludeExpiredIncludeActive`, `TestListSharesBySecretIDs` — confirmed via `git diff --stat` outside this change's files), `server/http`, `server/http/handlers`, `internal/cli` (all subpackages).
- [x] Repo-wide grep confirms zero stray references to any removed method outside expected `internal/core`/interface-layer callers (which call the unchanged `storage.Storage` interface, not `RemoteStorage` directly) and unrelated same-named gRPC proto/LocalStorage symbols.

## Closes

Closes #1511 (13 of 13 wire calls resolved — see the ADR's accounting table for the exact split).