### PR TITLE
docs(server/http): correct UpdateMachineIdentityProxy's false caller claim

### DIFF
--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -383,10 +383,19 @@ func (h *CatalogHandler) GetMachineIdentityProxy(w http.ResponseWriter, r *http.
 
 // UpdateMachineIdentityProxy handles PUT /api/v1/system/machine-identities/{id}.
 // A raw persist (storage.Storage.UpdateMachineIdentity is an unconditional
-// full-row Save, matching LocalStorage's own semantics exactly — used by
-// core.ClassifyMachineIdentity, which has no state-machine invariant to protect).
-// core.TransitionMachineIdentity does NOT use this path — see
-// TransitionMachineIdentityStateProxy below.
+// full-row Save, matching LocalStorage's own semantics exactly).
+//
+// CORRECTED (#1592 stale-fork sweep, #1585): this comment used to claim
+// core.ClassifyMachineIdentity backs this path. That was false when checked
+// directly — ClassifyMachineIdentity (machine_identities.go) was fixed under
+// G42 to call c.storage.TransitionMachineIdentityState instead, precisely to
+// avoid the blind-Save race this raw call still reproduces. A repo-wide
+// grep (excluding this file and comments) finds ZERO callers of
+// storage.UpdateMachineIdentity anywhere in internal/core — this raw
+// primitive currently has no known legitimate caller under any topology.
+// See #1585 for the finding and its resolution (pending as of this
+// correction). core.TransitionMachineIdentity does NOT use this path
+// either — see TransitionMachineIdentityStateProxy below.
 func (h *CatalogHandler) UpdateMachineIdentityProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `UpdateMachineIdentityProxy`'s doc comment claimed it backs `core.ClassifyMachineIdentity`. Checked directly: that function was fixed under G42 to call `c.storage.TransitionMachineIdentityState` instead, precisely to avoid the race this raw call still reproduces (#1585). The comment described a caller relationship that no longer exists.
- Found during the #1592 stale-fork sweep follow-up (full liveness check on #1585/#1586/#1587, reported separately). Corrected now, independent of whatever #1585 resolves to (fix or deletion), so the false claim doesn't sit uncorrected in history either way.

## Test plan
- [x] `go build ./...`: clean (comment-only change)