### PR TITLE
Wave 4: correctness batch (#1521, #1507, #1503, #1531, #1584)

### DIFF
--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -202,19 +203,25 @@ func newHardenedRemoteClient(endpoint, token string) (*RemoteClient, bool) {
 	rc := &RemoteClient{
 		Endpoint: endpoint,
 		Token:    token,
-		// #315: the zero-value http.Client has an infinite Timeout. Only 3 CLI
-		// commands (status/connect/offline) wrap their own calls in
-		// context.WithTimeout; the 100+ other call sites across secret/rbac/
-		// machine/rotation/project/dynamic etc. use undecorated contexts — a hung
-		// or misconfigured KEYORIX_SERVER would otherwise hang the CLI forever
-		// with no way out. Mirrors the storage-layer remote client's default.
+		// #1521: a single total-round-trip http.Client.Timeout can't tell "the
+		// server is unreachable" from "a large transfer is slowly, genuinely
+		// progressing over a slow link" -- both look identical to a clock that
+		// only measures elapsed time since the request started. Split into two
+		// timeouts with different jobs instead (see newRemoteTransport):
+		// defaultConnectTimeout fails fast when the server can't be reached at
+		// all (no TCP handshake), and defaultIdleTransferTimeout only fires when
+		// NO bytes have moved for that long -- a slow-but-progressing transfer
+		// keeps resetting it and is never killed just for taking a while.
 		//
 		// CheckRedirect: without it, a 3xx response from the configured server
 		// (including a CWD-planted ./keyorix.yaml — see ResolveRemote's warning
 		// above) could bounce the bearer-token-bearing request to an internal
 		// host (e.g. cloud IMDS) at request time (CWE-918). This client backs
 		// essentially all CLI remote-mode traffic, so this one guard covers it.
-		hc: &http.Client{Timeout: defaultRemoteClientTimeout, CheckRedirect: refuseRemoteClientRedirect},
+		hc: &http.Client{
+			Transport:     newRemoteTransport(defaultConnectTimeout, defaultIdleTransferTimeout),
+			CheckRedirect: refuseRemoteClientRedirect,
+		},
 	}
 	// rc.Endpoint is a distinct field declaration from ClientConfig.Endpoint/
 	// RemoteConfig.BaseURL (already validated above in ResolveRemote) -- this direct
@@ -230,9 +237,95 @@ func refuseRemoteClientRedirect(req *http.Request, _ []*http.Request) error {
 	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
 }
 
-// defaultRemoteClientTimeout matches internal/storage/remote's default
-// (Config.GetTimeout's 30s fallback when TimeoutSeconds is unset).
-const defaultRemoteClientTimeout = 30 * time.Second
+// defaultConnectTimeout bounds only the TCP handshake (DNS + dial). A few
+// seconds is enough for any genuinely reachable server on a real network; an
+// unreachable or misconfigured KEYORIX_SERVER fails within this window
+// instead of the old 30s total-round-trip budget.
+const defaultConnectTimeout = 5 * time.Second
+
+// defaultIdleTransferTimeout bounds how long a connection may go without
+// producing or consuming a single byte, once connected. It is NOT a total
+// elapsed-time budget: idleConn (below) resets it on every successful
+// Read/Write, so a large secret import over a slow-but-working link can run
+// far longer than this value in total, as long as it keeps moving. Only a
+// genuine stall -- no progress at all for this long -- trips it. Matches the
+// old defaultRemoteClientTimeout value so an already-fast link's behavior is
+// unchanged; only the SHAPE of the timeout (idle vs. total) changes.
+const defaultIdleTransferTimeout = 30 * time.Second
+
+// newRemoteTransport builds an http.Transport whose dial phase is bounded by
+// connectTimeout and whose connection (once established) is bounded by
+// idleTimeout on a no-progress basis -- see defaultConnectTimeout/
+// defaultIdleTransferTimeout's doc comments for why these are split rather
+// than one flat http.Client.Timeout. Exposed (not inlined into
+// newHardenedRemoteClient) so tests can construct a transport with short
+// timeouts instead of waiting out the real 5s/30s defaults.
+func newRemoteTransport(connectTimeout, idleTimeout time.Duration) *http.Transport {
+	dialer := &net.Dialer{Timeout: connectTimeout}
+	return &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := dialer.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			return &idleConn{Conn: conn, idle: idleTimeout}, nil
+		},
+	}
+}
+
+// idleConn wraps a net.Conn so a read/write deadline resets on every
+// successful Read or Write, rather than the connection having a single fixed
+// deadline for its whole lifetime. This is what turns idleTimeout into a
+// no-progress timeout instead of a total-transfer-time timeout: TLS
+// handshake bytes, request-body upload bytes, and response-body download
+// bytes each push the deadline back out, so only a genuine stop in traffic
+// -- not merely a long transfer -- ever times out.
+type idleConn struct {
+	net.Conn
+	idle time.Duration
+}
+
+func (c *idleConn) Read(b []byte) (int, error) {
+	if err := c.Conn.SetReadDeadline(time.Now().Add(c.idle)); err != nil {
+		return 0, err
+	}
+	return c.Conn.Read(b)
+}
+
+func (c *idleConn) Write(b []byte) (int, error) {
+	if err := c.Conn.SetWriteDeadline(time.Now().Add(c.idle)); err != nil {
+		return 0, err
+	}
+	return c.Conn.Write(b)
+}
+
+// classifyTransportError turns a low-level dial/read/write network error
+// into a message that tells the caller WHICH kind of failure this was,
+// instead of the same generic wording for every case:
+//   - dial phase failed (connection refused, no route, DNS failure, or the
+//     connectTimeout itself expired): the server was never reachable at all.
+//   - a read or write on an established connection hit idleTimeout: the
+//     server WAS reachable and the transfer WAS progressing, then stopped.
+//
+// Any other error (HTTP-level, context cancellation, JSON decode) passes
+// through wrapped in the caller-supplied fallback wording unchanged -- this
+// only special-cases the two network-shaped failures the connect/idle split
+// above can actually distinguish.
+func (c *RemoteClient) classifyTransportError(err error, fallback string) error {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		switch opErr.Op {
+		case "dial":
+			return fmt.Errorf("could not reach server at %s: %w", c.Endpoint, err)
+		case "read", "write":
+			if ne, ok := opErr.Err.(net.Error); ok && ne.Timeout() {
+				return fmt.Errorf("transfer stalled after %s with no data sent or received (server: %s): %w",
+					defaultIdleTransferTimeout, c.Endpoint, err)
+			}
+		}
+	}
+	return fmt.Errorf("%s: %w", fallback, err)
+}
 
 // Get performs a GET to path, strips the {"data":…} envelope, and decodes into out.
 func (c *RemoteClient) Get(ctx context.Context, path string, out interface{}) error {
@@ -245,7 +338,7 @@ func (c *RemoteClient) Get(ctx context.Context, path string, out interface{}) er
 
 	resp, err := c.hc.Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return c.classifyTransportError(err, "request failed")
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
@@ -268,7 +361,7 @@ func (c *RemoteClient) GetRaw(ctx context.Context, path string) ([]byte, error) 
 
 	resp, err := c.hc.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return nil, c.classifyTransportError(err, "request failed")
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
@@ -277,7 +370,7 @@ func (c *RemoteClient) GetRaw(ctx context.Context, path string) ([]byte, error) 
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("read response from %s: %w", path, err)
+		return nil, c.classifyTransportError(err, fmt.Sprintf("read response from %s", path))
 	}
 	return body, nil
 }
@@ -301,7 +394,7 @@ func (c *RemoteClient) Post(ctx context.Context, path string, body interface{}, 
 
 	resp, err := c.hc.Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return c.classifyTransportError(err, "request failed")
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
@@ -344,7 +437,7 @@ func (c *RemoteClient) Put(ctx context.Context, path string, body interface{}, o
 
 	resp, err := c.hc.Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return c.classifyTransportError(err, "request failed")
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
@@ -374,7 +467,7 @@ func (c *RemoteClient) Patch(ctx context.Context, path string, body interface{},
 
 	resp, err := c.hc.Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return c.classifyTransportError(err, "request failed")
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
@@ -404,7 +497,7 @@ func (c *RemoteClient) DeleteWithBody(ctx context.Context, path string, body int
 
 	resp, err := c.hc.Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return c.classifyTransportError(err, "request failed")
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
@@ -424,7 +517,7 @@ func (c *RemoteClient) Delete(ctx context.Context, path string) error {
 
 	resp, err := c.hc.Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return c.classifyTransportError(err, "request failed")
 	}
 	defer resp.Body.Close() //nolint:errcheck
 

--- a/internal/cli/common/remote_client_timeout_test.go
+++ b/internal/cli/common/remote_client_timeout_test.go
@@ -1,0 +1,218 @@
+// remote_client_timeout_test.go — #1521: the old defaultRemoteClientTimeout
+// was a single flat http.Client.Timeout bounding the ENTIRE round trip, so it
+// could not tell "the server is unreachable" from "a large transfer is
+// slowly, genuinely progressing over a slow link" -- both looked identical
+// to a clock that only measures elapsed time since the request started.
+//
+// Verified red against the pre-fix behaviour before writing the fix: with a
+// single http.Client{Timeout: X}, a handler that writes a byte every
+// interval < X but whose CUMULATIVE elapsed time exceeds X fails outright
+// (TestOldTimeoutShape_KillsASlowButProgressingTransfer, kept as a permanent
+// regression guard against reintroducing a flat timeout). The three tests
+// below exercise the fixed shape: a genuinely unreachable dial target fails
+// fast and says so, a genuine mid-transfer stall is cut off and says so, and
+// a slow-but-always-progressing transfer completes even though its total
+// duration would have tripped the old flat timeout.
+package common
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTimeoutTestTransport builds the real newRemoteTransport with short
+// timeouts so these tests run in milliseconds instead of waiting out
+// defaultConnectTimeout (5s) / defaultIdleTransferTimeout (30s).
+func newTimeoutTestClient(endpoint string, connectTimeout, idleTimeout time.Duration) *RemoteClient {
+	return &RemoteClient{
+		Endpoint: endpoint,
+		Token:    "tok",
+		hc:       &http.Client{Transport: newRemoteTransport(connectTimeout, idleTimeout)},
+	}
+}
+
+// TestOldTimeoutShape_KillsASlowButProgressingTransfer is the RED-BEFORE
+// control: it proves the bug this fix closes actually exists by reproducing
+// it directly against a bare http.Client{Timeout: ...} (the old shape), not
+// against RemoteClient. A handler writes 6 chunks, each after a 40ms sleep
+// (240ms total, always making progress, no single gap exceeds 40ms), against
+// a flat 150ms client timeout -- shorter than the total but longer than any
+// single gap. The old shape has no way to tell "slow but moving" from "one
+// long stall" and fails; kept permanently so the old shape can never be
+// silently reintroduced without this test going red again.
+func TestOldTimeoutShape_KillsASlowButProgressingTransfer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher := w.(http.Flusher)
+		for range 6 {
+			time.Sleep(40 * time.Millisecond)
+			_, _ = w.Write([]byte("x"))
+			flusher.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	oldShapeClient := &http.Client{Timeout: 150 * time.Millisecond}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	// Client.Timeout bounds header receipt AND body reading, but Do() only
+	// returns once headers arrive (after the first 40ms chunk) -- well inside
+	// the 150ms budget. The bug only shows up when the BODY is actually read,
+	// since the remaining chunks (200ms more) are what blows the budget.
+	resp, err := oldShapeClient.Do(req)
+	if err != nil {
+		t.Fatalf("expected headers to arrive within budget (only ~40ms elapsed by then), got: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	_, err = io.ReadAll(resp.Body)
+	if err == nil {
+		t.Fatal("expected reading the body of a transfer whose TOTAL duration exceeds Client.Timeout to fail, even though every individual gap is fine -- got no error")
+	}
+	if !strings.Contains(err.Error(), "Client.Timeout") && !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Errorf("expected a client-timeout-shaped error, got: %v", err)
+	}
+}
+
+// TestRemoteClient_Unreachable_FailsFastWithClearMessage: dialing a closed
+// port fails immediately (connection refused) at the dial phase, well within
+// the connect timeout, and the message says the server couldn't be reached
+// -- not a generic "request failed".
+func TestRemoteClient_Unreachable_FailsFastWithClearMessage(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close() // now nothing is listening on addr -- connection refused
+
+	rc := newTimeoutTestClient("http://"+addr, 2*time.Second, 2*time.Second)
+
+	start := time.Now()
+	err = rc.Get(context.Background(), "/whatever", &struct{}{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error against an unreachable server")
+	}
+	if !strings.Contains(err.Error(), "could not reach server") {
+		t.Errorf("error = %q, want it to say the server could not be reached", err.Error())
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("took %s to fail against a closed port -- should fail immediately (connection refused), not wait out any timeout", elapsed)
+	}
+}
+
+// TestRemoteClient_GenuineStall_CutOffWithClearMessage: the server accepts
+// the connection (so it IS reachable) but then never writes a single byte of
+// response. With a short idle timeout, the request is cut off once that
+// idle window elapses, and the message says the transfer stalled -- not a
+// generic "request failed".
+func TestRemoteClient_GenuineStall_CutOffWithClearMessage(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		// Read the request so the write side of the roundtrip completes, then go
+		// silent forever -- never write a response. Simulates a hung server.
+		buf := make([]byte, 4096)
+		_, _ = conn.Read(buf)
+		select {} //nolint:staticcheck // deliberately block until the test's idle timeout fires and the deferred Close runs
+	}()
+
+	const idleTimeout = 150 * time.Millisecond
+	rc := newTimeoutTestClient("http://"+ln.Addr().String(), 2*time.Second, idleTimeout)
+
+	start := time.Now()
+	err = rc.Get(context.Background(), "/whatever", &struct{}{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error against a server that never responds")
+	}
+	if !strings.Contains(err.Error(), "transfer stalled") {
+		t.Errorf("error = %q, want it to say the transfer stalled", err.Error())
+	}
+	if elapsed < idleTimeout {
+		t.Errorf("took only %s, shorter than the %s idle timeout -- cut off too early", elapsed, idleTimeout)
+	}
+	if elapsed > 2*idleTimeout {
+		t.Errorf("took %s, more than 2x the %s idle timeout -- not cut off promptly", elapsed, idleTimeout)
+	}
+}
+
+// TestRemoteClient_SlowButProgressing_Completes is the direct fix-in-action
+// counterpart to TestOldTimeoutShape_KillsASlowButProgressingTransfer above:
+// same shape (6 chunks, 40ms apart, 240ms total), but through RemoteClient's
+// real idle-timeout transport with a 100ms idle window. Every individual gap
+// (40ms) is well under the idle window (100ms), so the transfer completes
+// successfully even though its total duration (240ms) exceeds the idle
+// window more than twice over -- proving the timeout is genuinely no-progress-
+// shaped, not a disguised total-elapsed clock.
+func TestRemoteClient_SlowButProgressing_Completes(t *testing.T) {
+	const chunkGap = 40 * time.Millisecond
+	const chunks = 6
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(hdrContentType, mimeJSON)
+		flusher := w.(http.Flusher)
+		w.Write([]byte(`{"data":`)) //nolint:errcheck
+		flusher.Flush()
+		for range chunks {
+			time.Sleep(chunkGap)
+			w.Write([]byte("1")) //nolint:errcheck
+			flusher.Flush()
+		}
+		w.Write([]byte("}")) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	const idleTimeout = 100 * time.Millisecond // > chunkGap, < chunks*chunkGap
+	rc := newTimeoutTestClient(srv.URL, 2*time.Second, idleTimeout)
+
+	var out int
+	start := time.Now()
+	err := rc.Get(context.Background(), "/whatever", &out)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected the slow-but-always-progressing transfer to succeed, got: %v", err)
+	}
+	if elapsed < chunks*chunkGap {
+		t.Errorf("completed in %s, faster than the %d chunks could have produced -- test fixture problem", elapsed, chunks)
+	}
+	if elapsed <= idleTimeout {
+		t.Errorf("completed in %s, at or under the idle timeout (%s) -- this doesn't actually demonstrate surviving PAST the idle window", elapsed, idleTimeout)
+	}
+}
+
+// sanity check that classifyTransportError's dial/read/write branches don't
+// panic or misfire on a plain, non-network error (e.g. context cancellation
+// surfaced through http.Client.Do) -- it must fall through to the fallback
+// wording unchanged.
+func TestClassifyTransportError_NonNetworkErrorPassesThroughFallback(t *testing.T) {
+	rc := &RemoteClient{Endpoint: "http://example.invalid"}
+	plain := errors.New("boom")
+	got := rc.classifyTransportError(plain, "request failed")
+	if !strings.Contains(got.Error(), "request failed") || !strings.Contains(got.Error(), "boom") {
+		t.Errorf("got %q, want it to contain both the fallback wording and the original error", got.Error())
+	}
+	if strings.Contains(got.Error(), "could not reach") || strings.Contains(got.Error(), "stalled") {
+		t.Errorf("got %q, a non-network error should never be classified as a network failure", got.Error())
+	}
+}

--- a/internal/cli/run/run_fetch_test.go
+++ b/internal/cli/run/run_fetch_test.go
@@ -107,7 +107,8 @@ func TestFetchSecretsRemote_ProjectNotFound(t *testing.T) {
 // test: point fetchSecretsRemote at a server that accepts the TCP connection but
 // never writes a response, and assert the call fails with a bounded timeout error
 // rather than hanging indefinitely — matching common.RemoteClient's own
-// defaultRemoteClientTimeout (30s), since fetchSecretsRemote now goes through
+// idle-transfer timeout (#1521, 30s of no progress, not a flat total-round-trip
+// clock), since fetchSecretsRemote now goes through
 // common.NewRemoteClientWithCredentials instead of a homegrown *http.Client.
 func TestFetchSecretsRemote_HungServerTimesOut(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/cli/secret/rotate_test.go
+++ b/internal/cli/secret/rotate_test.go
@@ -77,8 +77,9 @@ func TestRunRotate_MissingValueFailsClosedWithoutATerminal(t *testing.T) {
 // point the configured server at a listener that accepts the TCP connection but
 // never writes a response, and assert runRotate fails with a bounded timeout
 // error rather than hanging indefinitely — matching common.RemoteClient's own
-// defaultRemoteClientTimeout (30s), since runRotate now goes through
-// common.NewRemoteClient instead of its own bypassing *http.Client.
+// idle-transfer timeout (#1521, 30s of no progress, not a flat total-round-trip
+// clock), since runRotate now goes through common.NewRemoteClient instead of
+// its own bypassing *http.Client.
 //
 // The endpoint is set BOTH via KEYORIX_SERVER/KEYORIX_TOKEN (what the current,
 // fixed runRotate reads via common.ResolveRemote) AND via a written cli.yaml

--- a/internal/cli/secret/source_vault.go
+++ b/internal/cli/secret/source_vault.go
@@ -18,8 +18,10 @@ import (
 )
 
 // vaultClientTimeout bounds every request this client makes to a configured Vault
-// server. Matches common.RemoteClient's own defaultRemoteClientTimeout (#G71
-// sibling fix): the caller's ctx (fetchFromVault ← cmd.Context(), which carries no
+// server. Matches common.RemoteClient's old flat 30s timeout value (#G71 sibling
+// fix) — deliberately NOT the connect/idle split #1521 gave common.RemoteClient,
+// since that fix's own scope was the Keyorix-server client specifically. The
+// caller's ctx (fetchFromVault ← cmd.Context(), which carries no
 // deadline anywhere in this CLI) previously left this client's requests with NO
 // bound at all — a hung/misconfigured/malicious VAULT_ADDR could stall 'secret
 // import --source vault' forever.

--- a/internal/core/audit.go
+++ b/internal/core/audit.go
@@ -178,6 +178,26 @@ func (c *KeyorixCore) LogRoleDeleted(ctx context.Context, actorID, roleID uint, 
 	c.logRoleDefinitionChange(ctx, EventRoleDeleted, "deleted", actorID, roleID, name)
 }
 
+// LogRoleUpdateDenied / LogRoleDeleteDenied record a DENIED attempt to update
+// or delete a role -- #1503: UpdateRole/DeleteRole refuse a built-in role
+// (core.IsBuiltinRole) on both transports (server/http/handlers/rbac.go,
+// server/grpc/services/role_service.go), but until now that refusal left no
+// audit trail at all, unlike every other RBAC/Connect deny path. Callable
+// from either handler package since writeAuditEventFailed itself is
+// unexported. Reuses EventRoleUpdated/EventRoleDeleted rather than minting a
+// "_denied" event type per action -- Success=false already distinguishes a
+// denied attempt from a completed one, the same convention CreateSoDPolicy/
+// PlaceLegalHold established (see sod.go's package-level comment).
+func (c *KeyorixCore) LogRoleUpdateDenied(ctx context.Context, actorID, roleID uint, name, reason string) {
+	c.writeAuditEventFailed(ctx, EventRoleUpdated, actorPtr(actorID), nil, "",
+		fmt.Sprintf("role update DENIED for %q (id %d): %s", name, roleID, reason))
+}
+
+func (c *KeyorixCore) LogRoleDeleteDenied(ctx context.Context, actorID, roleID uint, name, reason string) {
+	c.writeAuditEventFailed(ctx, EventRoleDeleted, actorPtr(actorID), nil, "",
+		fmt.Sprintf("role delete DENIED for %q (id %d): %s", name, roleID, reason))
+}
+
 func (c *KeyorixCore) logRoleDefinitionChange(ctx context.Context, eventType, verb string, actorID, roleID uint, name string) {
 	desc := fmt.Sprintf("role %q (id %d) %s", name, roleID, verb)
 	c.writeRBACAudit(ctx, eventType, desc, actorID, Scope{}, rbacAuditDetail{RoleID: roleID})

--- a/internal/core/risk_exceptions.go
+++ b/internal/core/risk_exceptions.go
@@ -9,6 +9,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -25,6 +26,36 @@ const (
 	EventRiskExceptionCreated  = "risk.exception_created"
 	EventRiskExceptionRevoked  = "risk.exception_revoked"
 	EventRiskExceptionApproved = "risk.exception_approved"
+)
+
+// #1531: RevokeRiskException/ApproveRiskException return a plain error for
+// every failure mode -- permission denial, validation, AND a lost CAS race
+// or an already-decided precondition. The local human-facing handler
+// (risk_exceptions.go) is fine with that (a human clicking revoke twice just
+// wants an error message either way), but RevokeRiskExceptionProxy/
+// ApproveRiskExceptionProxy back a wire contract where a lost race or an
+// already-decided precondition is a normal outcome (matched=false), not a
+// failure -- every sibling conditional-transition wire method in this
+// package (TransitionMachineIdentityState, TransitionSecretStatus, ...)
+// already makes that distinction. These sentinels let the proxy tell the
+// two apart via errors.Is without string-matching the message (the existing
+// local-handler precedent, kept working unchanged since these wrap the same
+// text via %w) and without a signature change that would touch the local
+// handler too.
+//
+// Scoped to exactly the preconditions RevokeRiskExceptionIfNotRevoked's
+// ("revoked = false") and ApproveRiskExceptionIfPending's ("revoked = false
+// AND approved = false") own WHERE clauses enforce -- the same invariant,
+// checked once eagerly here and once atomically at the storage layer.
+// ExceptionStatusExpired is deliberately NOT one of these: expiry is a
+// deterministic function of wall-clock time, not a concurrently-decided
+// precondition a CAS could lose a race on, so it stays a genuine error.
+var (
+	ErrRiskExceptionAlreadyRevoked       = errors.New("risk exception is already revoked")
+	ErrRiskExceptionConcurrentlyRevoked  = errors.New("risk exception was concurrently revoked by another request")
+	ErrRiskExceptionAlreadyApproved      = errors.New("risk exception is already approved")
+	ErrRiskExceptionRevokedNotApprovable = errors.New("cannot approve a revoked risk exception")
+	ErrRiskExceptionConcurrentlyDecided  = errors.New("risk exception was concurrently revoked or approved by another request")
 )
 
 // validExceptionCategories are the risk areas an exception may cover (aligned with
@@ -219,7 +250,7 @@ func (c *KeyorixCore) RevokeRiskException(ctx context.Context, actorID, id uint)
 			"only the creating admin or an admin-tier principal may revoke this risk exception")
 	}
 	if e.Revoked {
-		return fmt.Errorf("risk exception %d is already revoked", id)
+		return fmt.Errorf("risk exception %d is already revoked: %w", id, ErrRiskExceptionAlreadyRevoked)
 	}
 	now := c.now()
 	e.Revoked = true
@@ -235,7 +266,7 @@ func (c *KeyorixCore) RevokeRiskException(ctx context.Context, actorID, id uint)
 		// RevokeRiskException or ApproveRiskException call) — treat exactly like
 		// the already-revoked precondition failure above rather than silently
 		// overwriting the winner (StateTransitionMissingCAS.ql).
-		return fmt.Errorf("risk exception %d was concurrently revoked by another request", id)
+		return fmt.Errorf("risk exception %d was concurrently revoked by another request: %w", id, ErrRiskExceptionConcurrentlyRevoked)
 	}
 	c.writeAuditEvent(ctx, EventRiskExceptionRevoked, actorPtr(actorID), nil,
 		fmt.Sprintf("risk exception %d revoked: %q", id, e.Title))
@@ -262,13 +293,13 @@ func (c *KeyorixCore) ApproveRiskException(ctx context.Context, actorID uint, ac
 		return err
 	}
 	if e.Revoked {
-		return fmt.Errorf("cannot approve a revoked risk exception")
+		return fmt.Errorf("cannot approve a revoked risk exception: %w", ErrRiskExceptionRevokedNotApprovable)
 	}
 	if exceptionStatus(e, c.now()) == ExceptionStatusExpired {
 		return fmt.Errorf("cannot approve an expired risk exception")
 	}
 	if e.Approved {
-		return fmt.Errorf("risk exception %d is already approved", id)
+		return fmt.Errorf("risk exception %d is already approved: %w", id, ErrRiskExceptionAlreadyApproved)
 	}
 	if actorIsMachine {
 		c.writeAuditEventFailed(ctx, EventRiskExceptionApproved, actorPtr(actorID), nil, "",
@@ -304,7 +335,7 @@ func (c *KeyorixCore) ApproveRiskException(ctx context.Context, actorID uint, ac
 		// RevokeRiskException or ApproveRiskException call) — treat exactly like
 		// the already-revoked/already-approved precondition failures above rather
 		// than silently overwriting the winner (StateTransitionMissingCAS.ql).
-		return fmt.Errorf("risk exception %d was concurrently revoked or approved by another request", id)
+		return fmt.Errorf("risk exception %d was concurrently revoked or approved by another request: %w", id, ErrRiskExceptionConcurrentlyDecided)
 	}
 	c.writeAuditEvent(ctx, EventRiskExceptionApproved, actorPtr(actorID), nil,
 		fmt.Sprintf("risk exception %d approved by %d (created by %d): %q", id, actorID, e.CreatedBy, e.Title))

--- a/internal/storage/store/local_auth.go
+++ b/internal/storage/store/local_auth.go
@@ -213,6 +213,14 @@ func (ls *LocalStorage) ListSessionTokenHashesForUser(ctx context.Context, userI
 
 // TouchSession bumps last_seen_at only if the stored value is older than staleness
 // (or NULL), keeping the auth hot path from writing on every request.
+//
+// #1507: this UpdateColumn write bypasses model hooks too, but unlike
+// PersonalAccessToken.LastUsedAt/MachineIdentityCredential.LastUsedAt there is
+// no separate consumer to diverge from — the WHERE bound and the SET value
+// below both come from this function's own seenAt parameter, in the same
+// call. If a future range query on last_seen_at is ever added elsewhere
+// (there is none today — verified repo-wide), it would need the same
+// call-site normalization the other two #1507 fields document.
 func (ls *LocalStorage) TouchSession(ctx context.Context, id uint, seenAt time.Time, staleness time.Duration) error {
 	cutoff := seenAt.Add(-staleness)
 	return ls.db.WithContext(ctx).Model(&models.Session{}).
@@ -315,6 +323,15 @@ func (ls *LocalStorage) RevokeAllPersonalAccessTokensForUser(ctx context.Context
 
 // TouchPersonalAccessToken bumps last_used_at only when older than staleness (or NULL),
 // keeping the auth hot path from writing on every request (mirrors TouchSession).
+//
+// #1507: this UpdateColumn write bypasses model hooks, so last_used_at is
+// whatever Location usedAt itself carries (currently always c.now(), the same
+// accessor CountStalePATs (local_hygiene_counts.go) uses to derive its own
+// range-query bound) — safe ONLY as long as every last_used_at reader keeps
+// using that same source. If a future range query on this column is added
+// anywhere using a differently-sourced time (e.g. a raw time.Now().UTC()),
+// normalize explicitly at this call site (there is no BeforeSave hook that
+// can reach an UpdateColumn write) before trusting the comparison.
 func (ls *LocalStorage) TouchPersonalAccessToken(ctx context.Context, id uint, usedAt time.Time, staleness time.Duration) error {
 	cutoff := usedAt.Add(-staleness)
 	return ls.db.WithContext(ctx).Model(&models.PersonalAccessToken{}).

--- a/internal/storage/store/local_hygiene_counts.go
+++ b/internal/storage/store/local_hygiene_counts.go
@@ -74,6 +74,14 @@ func (ls *LocalStorage) CountExpiredPATs(ctx context.Context) (int, error) {
 // An active machine identity is "stale" when its most-recent credential
 // LastUsedAt is NULL or before threshold.
 func (ls *LocalStorage) CountStaleMachineCredentials(ctx context.Context, threshold time.Time) (int, error) {
+	// #1507 (MachineIdentityCredential.LastUsedAt): last_used_at's sole write
+	// path (TouchMachineIdentityCredential) bypasses model hooks via
+	// UpdateColumn, so this range query is safe only as long as threshold and
+	// the write both keep coming from the same c.now() accessor — see
+	// TouchMachineIdentityCredential's own #1507 comment (local_machine_credentials.go)
+	// for the normalization point if that ever stops being true. Same shape as
+	// CountStalePATs's #1507 comment just below for PersonalAccessToken.LastUsedAt.
+	//
 	// Subquery: machine identity IDs that have at least one credential used
 	// since threshold (i.e. NOT stale).
 	// We count active machine identities NOT in that set.

--- a/internal/storage/store/local_machine_credentials.go
+++ b/internal/storage/store/local_machine_credentials.go
@@ -101,6 +101,17 @@ func (ls *LocalStorage) RevokeMachineIdentityCredential(ctx context.Context, id 
 	return nil
 }
 
+// #1507: this UpdateColumn write bypasses model hooks, so last_used_at is
+// whatever Location usedAt itself carries (currently always c.now(), via
+// TouchMachineTokenLastUsed) — CountStaleMachineCredentials
+// (local_hygiene_counts.go), reachable today from GetHygieneTrends/
+// RecordHygieneTrendPoint (server/http/handlers/hygiene_trends.go), already
+// range-queries this same column with a bound derived from the SAME k.now()
+// accessor. Safe only as long as both stay on that one source. If either
+// side ever switches to a differently-sourced time (e.g. a raw
+// time.Now().UTC()), normalize explicitly at this call site (there is no
+// BeforeSave hook that can reach an UpdateColumn write) before trusting the
+// comparison.
 func (ls *LocalStorage) TouchMachineIdentityCredential(ctx context.Context, id uint, usedAt time.Time, staleness time.Duration) error {
 	cutoff := usedAt.Add(-staleness)
 	return ls.db.WithContext(ctx).Model(&models.MachineIdentityCredential{}).

--- a/internal/storage/store/local_scheduler_lock_lease.go
+++ b/internal/storage/store/local_scheduler_lock_lease.go
@@ -92,6 +92,16 @@ func (ls *LocalStorage) TryAcquireSchedulerLock(ctx context.Context, key int64, 
 		if existing.Holder != holder && existing.ExpiresAt.After(now) {
 			return nil // held by someone else and not yet expired — genuinely contended
 		}
+		// #1507: this raw-map Updates (like the Create above) bypasses model
+		// hooks entirely, so expires_at carries whatever Location expiresAt
+		// itself has (currently always local time.Now().Add(ttl), line 66-67).
+		// No SQL range query reads this column today (the only read is
+		// TryAcquireSchedulerLock's own Where("key = ?") equality Take above,
+		// compared in Go via .After() — Location-independent). If a future
+		// "clean up stale leases" sweep ever adds a SQL WHERE expires_at < ?
+		// query, normalize explicitly at BOTH write sites (the Create above and
+		// this Updates) before trusting that comparison — a hook can't reach
+		// either one.
 		if updErr := tx.Model(&models.SchedulerLockLease{}).Where("key = ?", key).
 			Updates(map[string]any{"holder": holder, "expires_at": expiresAt}).Error; updErr != nil {
 			return updErr

--- a/internal/storage/store/local_sharing_test.go
+++ b/internal/storage/store/local_sharing_test.go
@@ -289,7 +289,18 @@ func TestListShares_ExcludeExpiredIncludeActive(t *testing.T) {
 		ID: 100, Name: "s", ProjectID: 1, EnvironmentID: 1, OwnerID: 1, Status: "active", Type: "password",
 	}).Error)
 
-	past := time.Now().Add(-1 * time.Hour)
+	// past is UTC explicitly, not just time.Now().Add(...): the two db.Model(...).
+	// Update("expires_at", past) calls below write this raw value straight to the
+	// column, bypassing ShareRecord.BeforeSave's UTC normalization (BeforeSave only
+	// fires on a full-struct Save/Create — a raw column Update never touches the
+	// hook receiver's own field, so there's nothing for it to normalize). Without
+	// .UTC() here, "past" carries this machine's local offset while every listing
+	// query's bound (time.Now().UTC() in local_sharing.go) does not, and SQLite's
+	// plain string comparison between two differently-offset RFC3339 timestamps is
+	// not reliably chronological -- exactly the class of bug G81 fixed for
+	// production write paths (which all go through the hook-covered Save/Create,
+	// unlike this test's deliberately-raw "simulate a not-yet-swept expiry" update).
+	past := time.Now().UTC().Add(-1 * time.Hour)
 	future := time.Now().Add(1 * time.Hour)
 
 	// Active direct share (permanent, no expiry).

--- a/internal/storage/store/rotation_risk_batch_test.go
+++ b/internal/storage/store/rotation_risk_batch_test.go
@@ -94,7 +94,11 @@ func TestListSharesBySecretIDs(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ls.CreateShareRecord(ctx, &models.ShareRecord{SecretID: 2, OwnerID: 9, RecipientID: 3, IsGroup: false})
 	require.NoError(t, err)
-	past := time.Now().Add(-time.Hour)
+	// UTC explicitly: the raw db.Model(...).Update("expires_at", past) below bypasses
+	// ShareRecord.BeforeSave's UTC normalization (the hook only fires on a full-struct
+	// Save/Create, not a raw column Update) — see TestListShares_ExcludeExpiredIncludeActive's
+	// identical comment in local_sharing_test.go for the full reasoning.
+	past := time.Now().UTC().Add(-time.Hour)
 	expired, err := ls.CreateShareRecord(ctx, &models.ShareRecord{SecretID: 1, OwnerID: 9, RecipientID: 4, IsGroup: false})
 	require.NoError(t, err)
 	require.NoError(t, ls.db.Model(&models.ShareRecord{}).Where("id = ?", expired.ID).Update("expires_at", past).Error)

--- a/server/grpc/services/role_builtin_denial_audit_test.go
+++ b/server/grpc/services/role_builtin_denial_audit_test.go
@@ -1,0 +1,71 @@
+// role_builtin_denial_audit_test.go — #1503: UpdateRole/DeleteRole refuse a
+// built-in role (core.IsBuiltinRole) but, before this fix, wrote no audit
+// event for the refusal — unlike every other RBAC/Connect deny path. These
+// tests assert the audit event lands, not just that the request is refused
+// (the FailedPrecondition itself was already covered by
+// TestDeleteRole_BuiltinDenied_S21b in coverage_s21b_test.go).
+package services
+
+import (
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	pb "github.com/keyorixhq/keyorix/server/proto/pb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// findBuiltinRoleID looks up super_admin's ID via the service's own ListRoles
+// (mirrors TestDeleteRole_BuiltinDenied_S21b's own lookup approach) rather than
+// assuming a fixed seeded ID.
+func findBuiltinRoleID(t *testing.T, svc *RoleGRPCService) uint32 {
+	t.Helper()
+	roles, err := svc.ListRoles(roleAdminCtx(), &pb.ListRolesRequest{})
+	require.NoError(t, err)
+	for _, r := range roles.GetRoles() {
+		if r.GetName() == "super_admin" {
+			return r.GetId()
+		}
+	}
+	t.Skip("super_admin role not found in test rig; skipping builtin-denial audit test")
+	return 0
+}
+
+// TestUpdateRole_BuiltinDenied_AuditsTheDenial is the gRPC-transport half of
+// #1503: attempting to update a built-in role must both refuse
+// (FailedPrecondition, pre-existing behavior, unchanged) AND write a
+// Success=false audit event naming the role -- previously it did neither.
+func TestUpdateRole_BuiltinDenied_AuditsTheDenial(t *testing.T) {
+	svc, h := newRoleService(t)
+	require.NoError(t, h.DB.AutoMigrate(&models.AuditEvent{}))
+	builtinID := findBuiltinRoleID(t, svc)
+
+	_, err := svc.UpdateRole(roleAdminCtx(), &pb.UpdateRoleRequest{Id: builtinID})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+	var event models.AuditEvent
+	dberr := h.DB.Where("event_type = ? AND success = ?", core.EventRoleUpdated, false).First(&event).Error
+	require.NoError(t, dberr, "the denied update must write a Success=false audit event")
+	assert.Contains(t, event.Description, "super_admin", "the audit description must name the target role")
+}
+
+// TestDeleteRole_BuiltinDenied_AuditsTheDenial is the DeleteRole counterpart
+// -- see TestUpdateRole_BuiltinDenied_AuditsTheDenial's doc comment.
+func TestDeleteRole_BuiltinDenied_AuditsTheDenial(t *testing.T) {
+	svc, h := newRoleService(t)
+	require.NoError(t, h.DB.AutoMigrate(&models.AuditEvent{}))
+	builtinID := findBuiltinRoleID(t, svc)
+
+	_, err := svc.DeleteRole(roleAdminCtx(), &pb.DeleteRoleRequest{Id: builtinID})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+	var event models.AuditEvent
+	dberr := h.DB.Where("event_type = ? AND success = ?", core.EventRoleDeleted, false).First(&event).Error
+	require.NoError(t, dberr, "the denied delete must write a Success=false audit event")
+	assert.Contains(t, event.Description, "super_admin", "the audit description must name the target role")
+}

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -128,6 +128,7 @@ func (s *RoleGRPCService) UpdateRole(ctx context.Context, req *pb.UpdateRoleRequ
 	// who relies on that built-in role. The HTTP handler applies the identical guard
 	// (handlers/rbac.go); without it here the guard is bypassable by switching transport.
 	if core.IsBuiltinRole(role.Name) {
+		s.core.LogRoleUpdateDenied(ctx, actor.UserID, role.ID, role.Name, "target is a built-in role")
 		return nil, status.Errorf(codes.FailedPrecondition, "cannot update built-in role: %s", role.Name)
 	}
 
@@ -184,6 +185,7 @@ func (s *RoleGRPCService) DeleteRole(ctx context.Context, req *pb.DeleteRoleRequ
 	// invalidate live assignments and can lock every administrator out. Without
 	// this the guard is bypassable by switching transport.
 	if core.IsBuiltinRole(role.Name) {
+		s.core.LogRoleDeleteDenied(ctx, actor.UserID, role.ID, role.Name, "target is a built-in role")
 		return nil, status.Errorf(codes.FailedPrecondition, "cannot delete built-in role: %s", role.Name)
 	}
 	if err := s.core.Storage().DeleteRole(ctx, uint(req.GetId())); err != nil {

--- a/server/http/handlers/handlers_s13_proxy_test.go
+++ b/server/http/handlers/handlers_s13_proxy_test.go
@@ -730,12 +730,14 @@ func TestRevokeRiskExceptionProxy_BadID_S13(t *testing.T) {
 // TestRevokeRiskExceptionProxy_BadBody_S13 is gone with that body decode.
 
 // TestRevokeRiskExceptionProxy_LostRace_S13 — a second revoke attempt against
-// an already-revoked exception must be refused with an error (#G79:
-// RevokeRiskExceptionProxy now routes through
-// core.KeyorixCore.RevokeRiskException, which reports this precondition
-// failure as an error, not a matched:false success — see RevokeRiskException's
-// own doc comment), proving the CAS race still closes at the HTTP-proxy
-// boundary, just with a more specific error than the old raw matched bool.
+// an already-revoked exception is a normal outcome on this wire contract, not
+// a server error (#1531: RevokeRiskExceptionProxy used to turn
+// core.KeyorixCore.RevokeRiskException's already-revoked precondition error
+// into a 500 STORAGE_ERROR; it now recognizes
+// core.ErrRiskExceptionAlreadyRevoked via errors.Is and reports a clean
+// matched:false 200, matching every other conditional-transition wire method
+// in this package). Verified red against the pre-fix handler (500) before
+// this assertion was written to expect 200/matched:false.
 func TestRevokeRiskExceptionProxy_LostRace_S13(t *testing.T) {
 	h := freshDashboardHandlerS13(t)
 
@@ -768,7 +770,58 @@ func TestRevokeRiskExceptionProxy_LostRace_S13(t *testing.T) {
 	secondReq := withChiParam(httptest.NewRequest(http.MethodPut, "/system/risk-exceptions/"+idStr+"/revoke", nil), "id", idStr)
 	secondW := httptest.NewRecorder()
 	h.RevokeRiskExceptionProxy(secondW, secondReq)
-	assert.NotEqual(t, http.StatusOK, secondW.Code, "second (racing) revoke must be refused — already revoked")
+	assert.Equal(t, http.StatusOK, secondW.Code, "a lost race is a normal outcome, not a server error")
+	secondResp := decodeRemoteResp(t, secondW)
+	secondData, ok := secondResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, secondData["matched"], "second (racing) revoke must report matched:false, not win or error")
+}
+
+// TestApproveRiskExceptionProxy_LostRace_S13 is the ApproveRiskExceptionProxy
+// counterpart — see TestRevokeRiskExceptionProxy_LostRace_S13's doc comment.
+// A second approve attempt against an already-approved exception must report
+// matched:false, not a 500.
+func TestApproveRiskExceptionProxy_LostRace_S13(t *testing.T) {
+	h := freshDashboardHandlerS13(t)
+
+	createBody := proxyJSON(map[string]interface{}{
+		"title":         "Approve Race S13",
+		"category":      "other",
+		"justification": "Testing approve CAS",
+		"created_by":    1,
+		"expires_at":    time.Now().Add(30 * 24 * time.Hour),
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/system/risk-exceptions", createBody)
+	createW := httptest.NewRecorder()
+	h.CreateRiskExceptionProxy(createW, createReq)
+	require.Equal(t, http.StatusOK, createW.Code)
+	createResp := decodeRemoteResp(t, createW)
+	created, ok := createResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	id := uint(created["id"].(float64))
+	idStr := strconv.FormatUint(uint64(id), 10)
+
+	// CreateRiskExceptionProxy's create request above is a bare httptest
+	// request (no withUserCtx), so actorID(r)==0 makes creator 0 — approve as
+	// a DIFFERENT actor via withUserCtx (mirrors TestApproveRiskExceptionProxy_HappyPath_S13),
+	// satisfying dual control's self-approval check.
+	firstReq := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPut, "/system/risk-exceptions/"+idStr+"/approve", nil), "id", idStr))
+	firstW := httptest.NewRecorder()
+	h.ApproveRiskExceptionProxy(firstW, firstReq)
+	require.Equal(t, http.StatusOK, firstW.Code)
+	firstResp := decodeRemoteResp(t, firstW)
+	firstData, ok := firstResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, true, firstData["matched"], "first approve must win")
+
+	secondReq := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPut, "/system/risk-exceptions/"+idStr+"/approve", nil), "id", idStr))
+	secondW := httptest.NewRecorder()
+	h.ApproveRiskExceptionProxy(secondW, secondReq)
+	assert.Equal(t, http.StatusOK, secondW.Code, "a lost race is a normal outcome, not a server error")
+	secondResp := decodeRemoteResp(t, secondW)
+	secondData, ok := secondResp.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, secondData["matched"], "second (racing) approve must report matched:false, not win or error")
 }
 
 // TestApproveRiskExceptionProxy_BadID_S13 — non-numeric id → 400.

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -326,6 +326,7 @@ func (h *RBACHandler) UpdateRole(w http.ResponseWriter, r *http.Request) { // NO
 	// identical guard (server/grpc/services/role_service.go); without it here the guard
 	// is bypassable by switching transport.
 	if core.IsBuiltinRole(role.Name) {
+		h.coreService.LogRoleUpdateDenied(r.Context(), userCtx.UserID, role.ID, role.Name, "target is a built-in role")
 		sendError(w, "Forbidden", "Cannot update built-in role: "+role.Name, http.StatusForbidden, nil)
 		return
 	}
@@ -424,6 +425,7 @@ func (h *RBACHandler) DeleteRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if core.IsBuiltinRole(role.Name) {
+		h.coreService.LogRoleDeleteDenied(r.Context(), userCtx.UserID, role.ID, role.Name, "target is a built-in role")
 		sendError(w, "Forbidden", "Cannot delete built-in role: "+role.Name, http.StatusForbidden, nil)
 		return
 	}

--- a/server/http/handlers/rbac_builtin_denial_audit_test.go
+++ b/server/http/handlers/rbac_builtin_denial_audit_test.go
@@ -1,0 +1,67 @@
+// rbac_builtin_denial_audit_test.go — #1503: UpdateRole/DeleteRole refuse a
+// built-in role (core.IsBuiltinRole) but, before this fix, wrote no audit
+// event for the refusal — unlike every other RBAC/Connect deny path. These
+// tests assert the audit event lands, not just that the request is refused
+// (the 403 itself was already covered by TestDeleteRole_BuiltinRole_S26).
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateRole_BuiltinRole_AuditsTheDenial is the HTTP-transport half of
+// #1503: attempting to update a built-in role must both refuse (403,
+// pre-existing behavior, unchanged) AND write a Success=false audit event
+// naming the role -- previously it did neither.
+func TestUpdateRole_BuiltinRole_AuditsTheDenial(t *testing.T) {
+	cs, db := freshCoreS26WithAdmin(t)
+	h := NewRBACHandler(cs)
+
+	var adminRole models.Role
+	require.NoError(t, db.Where("name = ?", "system_admin").First(&adminRole).Error)
+
+	body := bytes.NewBufferString(`{"description":"attempted rename"}`)
+	req := withUserCtx(withChiParam_S25(
+		httptest.NewRequest(http.MethodPut, "/api/v1/roles/1", body),
+		"id", uintStrS26(adminRole.ID),
+	))
+	w := httptest.NewRecorder()
+	h.UpdateRole(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code, "the refusal itself must still happen")
+
+	var event models.AuditEvent
+	err := db.Where("event_type = ? AND success = ?", core.EventRoleUpdated, false).First(&event).Error
+	require.NoError(t, err, "the denied update must write a Success=false audit event")
+	assert.Contains(t, event.Description, adminRole.Name, "the audit description must name the target role")
+}
+
+// TestDeleteRole_BuiltinRole_AuditsTheDenial is the DeleteRole counterpart —
+// see TestUpdateRole_BuiltinRole_AuditsTheDenial's doc comment.
+func TestDeleteRole_BuiltinRole_AuditsTheDenial(t *testing.T) {
+	cs, db := freshCoreS26WithAdmin(t)
+	h := NewRBACHandler(cs)
+
+	var adminRole models.Role
+	require.NoError(t, db.Where("name = ?", "system_admin").First(&adminRole).Error)
+
+	req := withUserCtx(withChiParam_S25(
+		httptest.NewRequest(http.MethodDelete, "/api/v1/roles/1", nil),
+		"id", uintStrS26(adminRole.ID),
+	))
+	w := httptest.NewRecorder()
+	h.DeleteRole(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code, "the refusal itself must still happen")
+
+	var event models.AuditEvent
+	err := db.Where("event_type = ? AND success = ?", core.EventRoleDeleted, false).First(&event).Error
+	require.NoError(t, err, "the denied delete must write a Success=false audit event")
+	assert.Contains(t, event.Description, adminRole.Name, "the audit description must name the target role")
+}

--- a/server/http/handlers/rbac_role_audit_test.go
+++ b/server/http/handlers/rbac_role_audit_test.go
@@ -84,7 +84,14 @@ func TestRBACRoleDefinitionAudit(t *testing.T) {
 		assert.Equal(t, int64(1), countEvents(core.EventRoleDeleted))
 	})
 
-	t.Run("a refused built-in delete writes no event", func(t *testing.T) {
+	t.Run("a refused built-in delete writes a Success=false event", func(t *testing.T) {
+		// #1503: this used to assert the refusal audited NOTHING -- that was
+		// the bug the fix closes, not the intended behavior. A denied attempt
+		// to delete a built-in role is exactly the kind of event least-
+		// privilege evidence should capture; it now writes a second
+		// role.deleted row (Success=false) alongside the one earlier
+		// successful delete (Success=true), distinguished by the Success flag
+		// per this file's countEvents helper not filtering on it.
 		require.NoError(t, db.Create(&models.Role{Name: "admin", Description: "built-in"}).Error)
 		var adminID uint
 		require.NoError(t, db.Model(&models.Role{}).Where("name = ?", "admin").Select("id").Scan(&adminID).Error)
@@ -95,6 +102,10 @@ func TestRBACRoleDefinitionAudit(t *testing.T) {
 		handler.DeleteRole(w, req)
 
 		require.Equal(t, http.StatusForbidden, w.Code)
-		assert.Equal(t, int64(1), countEvents(core.EventRoleDeleted), "still just the one earlier delete — the refused built-in delete audits nothing")
+		assert.Equal(t, int64(2), countEvents(core.EventRoleDeleted), "the earlier successful delete plus this refused one")
+
+		var denied models.AuditEvent
+		require.NoError(t, db.Where("event_type = ? AND success = ?", core.EventRoleDeleted, false).First(&denied).Error)
+		assert.Contains(t, denied.Description, "admin", "the audit description must name the refused target role")
 	})
 }

--- a/server/http/handlers/risk_exceptions_proxy.go
+++ b/server/http/handlers/risk_exceptions_proxy.go
@@ -57,12 +57,14 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -201,6 +203,15 @@ func (h *DashboardHandler) RevokeRiskExceptionProxy(w http.ResponseWriter, r *ht
 		return
 	}
 	if err := h.coreService.RevokeRiskException(r.Context(), actorID(r), uint(id)); err != nil {
+		// #1531: a lost CAS race or an already-revoked precondition is a normal
+		// outcome on this wire contract (matched=false), not a server error --
+		// see core.ErrRiskExceptionAlreadyRevoked's doc comment for the exact
+		// scope. Every other failure (permission denial, not-found) is still a
+		// genuine error.
+		if errors.Is(err, core.ErrRiskExceptionAlreadyRevoked) || errors.Is(err, core.ErrRiskExceptionConcurrentlyRevoked) {
+			writeRemoteAPISuccess(w, map[string]bool{"matched": false})
+			return
+		}
 		log.Printf("risk-exceptions proxy: revoke failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
@@ -228,6 +239,17 @@ func (h *DashboardHandler) ApproveRiskExceptionProxy(w http.ResponseWriter, r *h
 		return
 	}
 	if err := h.coreService.ApproveRiskException(r.Context(), actorID(r), isMachineActor(r), uint(id)); err != nil {
+		// #1531: same treatment as RevokeRiskExceptionProxy above -- a lost CAS
+		// race or an already-decided precondition (already approved, or
+		// concurrently revoked out from under this approve) is matched=false,
+		// not a server error. Dual-control/machine-actor/expired/SoD-reference
+		// failures are unaffected and still return an error.
+		if errors.Is(err, core.ErrRiskExceptionAlreadyApproved) ||
+			errors.Is(err, core.ErrRiskExceptionRevokedNotApprovable) ||
+			errors.Is(err, core.ErrRiskExceptionConcurrentlyDecided) {
+			writeRemoteAPISuccess(w, map[string]bool{"matched": false})
+			return
+		}
 		log.Printf("risk-exceptions proxy: approve failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return

--- a/server/http/remote_storage_risk_exceptions_test.go
+++ b/server/http/remote_storage_risk_exceptions_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
@@ -52,6 +53,79 @@ func newUpstreamDownstreamForRiskExceptions(t *testing.T) (upstream *core.Keyori
 	downstream = core.NewKeyorixCore(rs)
 
 	return upstream, downstream
+}
+
+// newUpstreamHumanDownstreamForRiskExceptions is
+// newUpstreamDownstreamForRiskExceptions's counterpart for tests that need to
+// call CreateRiskException: CreateRiskExceptionProxy requires a human
+// principal ("only a human principal may create a risk exception", #1529) --
+// the node/machine credential newUpstreamDownstreamForRiskExceptions's shared
+// downstream uses can never satisfy that (see #1584, a deliberate product
+// constraint, not a bug — verified separately, not changed here). A SEPARATE
+// helper, not a change to the shared one: several other tests in this file
+// deliberately exercise the machine-credential path (or don't need Create at
+// all), and #1584 itself is verdict-only, not a fix — this only unblocks the
+// two conditional-race tests below, which need a working Create step to set
+// up their race and are otherwise unrelated to human-vs-machine identity.
+// Mirrors newUpstreamDownstreamForMemberships's own admin-session pattern
+// (TestMembershipProxy_CreateAllowsAdminRoleByGenuineAdmin). Also returns
+// baseURL so a caller needing a SECOND distinct human actor against the same
+// upstream (see humanRiskExceptionClient below — the approve-race test needs
+// one, since CreateRiskExceptionProxy makes the creator == this function's
+// own actor, and dual control forbids that actor from also approving) can
+// mint one without standing up a second server.
+func newUpstreamHumanDownstreamForRiskExceptions(t *testing.T) (upstream, downstream *core.KeyorixCore, baseURL string) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream = newTestCore(t)
+	_ = createTestToken(t, upstream) // SeedSystem: bootstraps admin user/roles/permissions/project — grantSystemWrite needs "system.write" to already exist
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"},
+		},
+	}
+	upstreamRouter, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	upstreamSrv := httptest.NewServer(upstreamRouter)
+	t.Cleanup(upstreamSrv.Close)
+	baseURL = upstreamSrv.URL
+
+	downstream, _ = humanRiskExceptionClient(t, upstream, baseURL, "riskexc1584-human")
+	return upstream, downstream, baseURL
+}
+
+// humanRiskExceptionClient creates a fresh human user against upstream,
+// grants it system.write (the permission /api/v1/system/risk-exceptions is
+// gated on), logs in, and returns a *core.KeyorixCore backed by that human's
+// session token against baseURL, plus the created user's ID — a distinct
+// principal each call, since username must be unique per upstream. The ID is
+// needed because RevokeRiskExceptionProxy/ApproveRiskExceptionProxy derive
+// RevokedBy/ApprovedBy from the AUTHENTICATED caller (actorID(r)), not from
+// anything the wire client sends — a caller distinguishing "the winning
+// writer's attribution" needs the real actor ID, not an arbitrary local value.
+func humanRiskExceptionClient(t *testing.T, upstream *core.KeyorixCore, baseURL, username string) (client *core.KeyorixCore, userID uint) {
+	t.Helper()
+	ctx := context.Background()
+	const pw = "Qr7#Kp2$Lm5@Vn9!"
+	human, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
+		Username: username, Email: username + "@example.com", Password: pw,
+	})
+	require.NoError(t, err)
+	grantSystemWrite(t, upstream, human.ID)
+	sess, _, err := upstream.Login(ctx, &core.LoginRequest{Username: username, Password: pw})
+	require.NoError(t, err)
+
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL:        baseURL,
+		APIKey:         sess.SessionToken,
+		TimeoutSeconds: 5,
+		RetryAttempts:  0,
+		TLSVerify:      true,
+	})
+	require.NoError(t, err)
+	return core.NewKeyorixCore(rs), human.ID
 }
 
 // buildRiskException mirrors what internal/core.CreateRiskException computes
@@ -244,8 +318,22 @@ func TestRemoteStorageRiskExceptions_ActiveOnlyExcludesRevoked_RealServer(t *tes
 // a row the first already moved to revoked=true, must be rejected
 // (matched=false) rather than silently re-applied over the winner.
 func TestRemoteStorageRiskExceptions_RevokeIfNotRevoked_ConditionalRace_RealServer(t *testing.T) {
-	t.Skip("CORRECTED (was misdiagnosed as an actorID(r)==0 cause — it is not): RemoteStorage.RevokeRiskExceptionIfNotRevoked (internal/storage/store/remote_risk_exceptions.go) is built on putConditionalTransition, whose documented wire contract — shared with TransitionMachineIdentityState/TransitionSecretStatus/TransitionDynamicSecretConfigDisabled/UpdateUserIfActiveStateMatches — is (matched=false, err=nil) on a lost race, mirroring the raw storage.Storage conditional-write primitive. But RevokeRiskExceptionProxy (risk_exceptions_proxy.go:203) does not proxy that raw primitive: it calls core.KeyorixCore.RevokeRiskException, the POLICY function, which converts both the already-revoked precondition and a lost race into a Go error (fmt.Errorf(...)) rather than returning matched=false. The proxy handler turns that error into a 500 STORAGE_ERROR, so the second (losing) caller in this test gets an error after retries exhaust, not the matched=false this test — and every other conditional-transition wire method in the package — expects. Verified directly: unskipping this test reproduces 'request failed after 3 attempts: STORAGE_ERROR: an internal error occurred' at the second RevokeRiskExceptionIfNotRevoked call, not a permission/authorization error. Filed as its own defect, unrelated to node-credential identity — see #1531. Quarantined here, not fixed — do not change core.RevokeRiskException's error-on-lost-race behavior to accommodate this without first deciding whether RevokeRiskExceptionProxy should instead proxy the raw conditional primitive directly, like its siblings do.")
-	upstream, downstream := newUpstreamDownstreamForRiskExceptions(t)
+	upstream, downstream, baseURL := newUpstreamHumanDownstreamForRiskExceptions(t)
+	// RevokeRiskExceptionProxy derives RevokedBy from the AUTHENTICATED caller
+	// (actorID(r)), not from anything the wire client sends (#G79) — a second,
+	// genuinely distinct admin session is what makes "the winner's attribution
+	// persists, not the loser's" a meaningful assertion below; reusing one
+	// session for both racing writes would make them indistinguishable by
+	// attribution regardless of which one actually won the CAS. Must be a
+	// genuine admin-tier role, not just system.write: RevokeRiskException's
+	// own authority check (internal/core/risk_exceptions.go) only allows the
+	// exception's creator OR an admin-tier principal to revoke — a second
+	// actor with system.write alone is neither, and would be denied outright
+	// before ever reaching the CAS this test means to race.
+	secondAdmin, secondAdminID := humanRiskExceptionClient(t, upstream, baseURL, "riskexc1584-second-revoker")
+	adminRole, err := upstream.Storage().GetRoleByName(context.Background(), "admin")
+	require.NoError(t, err)
+	require.NoError(t, upstream.Storage().AssignRole(context.Background(), secondAdminID, adminRole.ID, coreStorage.Scope{}))
 	ctx := context.Background()
 	now := time.Now()
 	expiresAt := now.Add(30 * 24 * time.Hour)
@@ -260,14 +348,12 @@ func TestRemoteStorageRiskExceptions_RevokeIfNotRevoked_ConditionalRace_RealServ
 	require.NoError(t, err)
 	firstRevokedAt := time.Now()
 	firstRead.Revoked = true
-	firstRead.RevokedBy = 1
 	firstRead.RevokedAt = &firstRevokedAt
 
-	secondRead, err := downstream.Storage().GetRiskException(ctx, exc.ID)
+	secondRead, err := secondAdmin.Storage().GetRiskException(ctx, exc.ID)
 	require.NoError(t, err)
 	secondRevokedAt := time.Now()
 	secondRead.Revoked = true
-	secondRead.RevokedBy = 2
 	secondRead.RevokedAt = &secondRevokedAt
 
 	// First admin's conditional revoke lands and wins.
@@ -277,9 +363,9 @@ func TestRemoteStorageRiskExceptions_RevokeIfNotRevoked_ConditionalRace_RealServ
 
 	// Second admin's conditional revoke, racing against a row the first write
 	// already moved to revoked=true, must be rejected — not silently
-	// re-applied (re-attributing the revoke away from admin 1 to admin 2, the
-	// exact clobber this fix closes).
-	matched, err = downstream.Storage().RevokeRiskExceptionIfNotRevoked(ctx, secondRead)
+	// re-applied (re-attributing the revoke away from the first admin to the
+	// second, the exact clobber this fix closes).
+	matched, err = secondAdmin.Storage().RevokeRiskExceptionIfNotRevoked(ctx, secondRead)
 	require.NoError(t, err)
 	assert.False(t, matched, "the second writer must lose, not clobber the first revoke")
 
@@ -288,7 +374,8 @@ func TestRemoteStorageRiskExceptions_RevokeIfNotRevoked_ConditionalRace_RealServ
 	final, err := upstream.Storage().GetRiskException(ctx, exc.ID)
 	require.NoError(t, err)
 	assert.True(t, final.Revoked)
-	assert.Equal(t, uint(1), final.RevokedBy, "the winning first admin's attribution must be the persisted state")
+	assert.NotEqual(t, secondAdminID, final.RevokedBy, "the losing second admin's attribution must not be the persisted state")
+	assert.Equal(t, exc.CreatedBy, final.RevokedBy, "the winning first admin's attribution must be the persisted state")
 }
 
 // TestRemoteStorageRiskExceptions_ApproveIfPending_ConditionalRace_RealServer
@@ -299,8 +386,12 @@ func TestRemoteStorageRiskExceptions_RevokeIfNotRevoked_ConditionalRace_RealServ
 // posture, so a revoked-then-approved exception would wrongly keep suppressing
 // it).
 func TestRemoteStorageRiskExceptions_ApproveIfPending_ConditionalRace_RealServer(t *testing.T) {
-	t.Skip("CORRECTED: same wire-contract mismatch as TestRemoteStorageRiskExceptions_RevokeIfNotRevoked_ConditionalRace_RealServer above (not an actorID(r)==0 cause) — ApproveRiskExceptionProxy also proxies the core.KeyorixCore.ApproveRiskException policy function instead of the raw ApproveRiskExceptionIfPending conditional primitive, so a losing/already-decided approve returns a 500 STORAGE_ERROR instead of putConditionalTransition's expected matched=false. Verified directly: unskipping reproduces 'request failed after 3 attempts: STORAGE_ERROR' at the ApproveRiskExceptionIfPending call. Quarantined here, not fixed.")
-	upstream, downstream := newUpstreamDownstreamForRiskExceptions(t)
+	upstream, downstream, baseURL := newUpstreamHumanDownstreamForRiskExceptions(t)
+	// Dual control (#170) forbids the creator from approving its own
+	// exception — downstream (this function's own actor) creates and revokes;
+	// a SECOND, distinct human actor approves, mirroring who would genuinely
+	// perform each step in production.
+	approver, _ := humanRiskExceptionClient(t, upstream, baseURL, "riskexc1584-approver")
 	ctx := context.Background()
 	now := time.Now()
 	expiresAt := now.Add(30 * 24 * time.Hour)
@@ -317,7 +408,7 @@ func TestRemoteStorageRiskExceptions_ApproveIfPending_ConditionalRace_RealServer
 	revokeRead.RevokedBy = 1
 	revokeRead.RevokedAt = &revokedAt
 
-	approveRead, err := downstream.Storage().GetRiskException(ctx, exc.ID)
+	approveRead, err := approver.Storage().GetRiskException(ctx, exc.ID)
 	require.NoError(t, err)
 	approvedAt := time.Now()
 	approveRead.Approved = true
@@ -331,7 +422,7 @@ func TestRemoteStorageRiskExceptions_ApproveIfPending_ConditionalRace_RealServer
 
 	// The approve, racing against a row that is no longer unrevoked, must be
 	// rejected.
-	matched, err = downstream.Storage().ApproveRiskExceptionIfPending(ctx, approveRead)
+	matched, err = approver.Storage().ApproveRiskExceptionIfPending(ctx, approveRead)
 	require.NoError(t, err)
 	assert.False(t, matched, "an approve racing a revoke must lose, not mark a revoked exception approved")
 


### PR DESCRIPTION
## Summary

Five independent, batchable correctness items from the live G80 plan, plus one sibling finding surfaced during verification. Own worktree, no shared state between items.

- **#1521** — CLI remote-client timeout was total-round-trip, not connect-only, so a slow-but-progressing bulk import (the primary Vault-migration workflow) was indistinguishable from an unreachable server. Split into a connect timeout (fails fast, unreachable) + an idle/no-progress timeout (resets on every byte moved, so a slow link survives). Distinguishing error messages: "could not reach server" vs "transfer stalled".
- **#1507** — Verdict: 2 of the 3 tracked `UpdateColumn`-only fields (`PersonalAccessToken.LastUsedAt`, `MachineIdentityCredential.LastUsedAt`) already ARE range-queried today, safe only because the write and the query bound share the same `c.now()`/`k.now()` accessor. Recorded the condition as a comment at each write site (not just the issue) so a future divergent range query is caught where someone is editing, not in an unread issue.
- **#1503** — `UpdateRole`/`DeleteRole`'s built-in-role refusal wrote no audit event on either transport. Added `LogRoleUpdateDenied`/`LogRoleDeleteDenied` (reusing `role.updated`/`role.deleted` with `Success=false`, matching the `CreateSoDPolicy`/`PlaceLegalHold` convention) and wired both HTTP and gRPC. Fixed a pre-existing test that had encoded the missing audit trail as the expected behavior.
- **#1531** — `RevokeRiskExceptionProxy`/`ApproveRiskExceptionProxy` returned a 500 instead of `matched:false` on a lost CAS race or an already-decided precondition. Added sentinel errors scoped to exactly the storage-layer CAS conditions, classified via `errors.Is` in the proxy. Un-broke a pre-existing test that had encoded the 500 as correct.
- **#1584** — Verdict: `CreateRiskExceptionProxy`'s human-only restriction is deliberate (#1529), not a harness bug. Closed with that reasoning. While verifying #1531, found two OTHER quarantined tests blocked by the exact #1531 bug plus a human-session-fixture gap — fixed the fixture and un-skipped both.
- **Bonus** — `TestListShares_ExcludeExpiredIncludeActive`/`TestListSharesBySecretIDs` were reported as isolation-dependent. Investigation found a different, more precise root cause: a test-only raw `Update("expires_at", ...)` bypassing `ShareRecord.BeforeSave`'s UTC normalization, deterministically broken on any non-UTC machine regardless of test grouping — not isolation/shared-state at all, and unrelated to #1509 (checked; different subsystem, different mechanism).

## Test plan

- [x] `go build ./...` — clean
- [x] `gosec -severity medium` on every touched package — 0 issues (470 files)
- [x] Full suites green: `internal/cli/...`, `internal/core/...`, `internal/storage/store/...`, `server/http/...`, `server/grpc/services/...`
- [x] Every fix independently verified RED before the wiring/fix, GREEN after (documented per-commit)
- [x] `internal/storage/store` full package re-run after the share-listing fix, plus `-shuffle=on -count=5` on the two previously-failing tests
