### PR TITLE
THROWAWAY: verify required-check reporting on a docs-only PR (will not merge)

### DIFF
--- a/docs/TESTING_FRAMEWORK.md
+++ b/docs/TESTING_FRAMEWORK.md
@@ -474,3 +474,4 @@ func TestRBACPermissions(t *testing.T) {
 ```
 
 This framework provides a solid foundation for writing maintainable, reliable tests across the Keyorix project. The key is to use the appropriate helper for your test type and follow the established patterns for consistency.
+<!-- throwaway CI-verification edit, PR closed without merging -->


### PR DESCRIPTION
Verification-only PR for branch-protection investigation. Confirms exclusion-freshness/assert-leg-completeness (path-filtered, skip on docs-only) report a satisfying conclusion rather than never appearing. Will be closed without merging.