### PR TITLE
THROWAWAY: verify base-branch-check trips and confirm merge-block reality (will not merge)

### DIFF
--- a/docs/TESTING_FRAMEWORK.md
+++ b/docs/TESTING_FRAMEWORK.md
@@ -475,3 +475,5 @@ func TestRBACPermissions(t *testing.T) {
 
 This framework provides a solid foundation for writing maintainable, reliable tests across the Keyorix project. The key is to use the appropriate helper for your test type and follow the established patterns for consistency.
 <!-- throwaway stack-base branch for CI base-branch-check verification -->
+
+<!-- throwaway child commit, PR base deliberately not main -->


### PR DESCRIPTION
Verification-only PR for branch-protection investigation. Base is deliberately NOT main (feat/throwaway-stack-base) and unlabeled (no stacked-pr label), so base-branch-check should fail. Purpose: confirm whether that failure actually blocks the merge button, given only main has branch protection configured in this repo. Will be closed without merging.