### PR TITLE
THROWAWAY: mis-based-merge-detector fire-in-anger test (will not land on main)

### DIFF
--- a/docs/TESTING_FRAMEWORK.md
+++ b/docs/TESTING_FRAMEWORK.md
@@ -475,3 +475,5 @@ func TestRBACPermissions(t *testing.T) {
 
 This framework provides a solid foundation for writing maintainable, reliable tests across the Keyorix project. The key is to use the appropriate helper for your test type and follow the established patterns for consistency.
 <!-- throwaway detector-base branch, mis-based-merge-detector fire-in-anger test -->
+
+<!-- throwaway detector-child commit, mis-based-merge-detector fire-in-anger test -->


### PR DESCRIPTION
Verification-only PR for the mis-based-merge-detector. Base is deliberately not main. Will be merged (into this non-main base, not main), then the detector will be run via workflow_dispatch to confirm it fires and files an issue with correct details.