### PR TITLE
Wave 2 (ADR-088): #1546 full delegation, #1551 tenant-scoped revoke, #1572 credential-revocation bolt-on

### DIFF
--- a/internal/core/machine_token.go
+++ b/internal/core/machine_token.go
@@ -151,7 +151,7 @@ func (c *KeyorixCore) IssueMachineToken(ctx context.Context, projectID, machineI
 	// PAT-006: revoke the replaced credential after the new one is safely stored so
 	// the machine is never left without a valid credential during the rotation.
 	if params.ReplaceCredentialID != 0 {
-		if err := c.storage.RevokeMachineIdentityCredential(ctx, params.ReplaceCredentialID); err != nil {
+		if err := c.storage.RevokeMachineIdentityCredential(ctx, projectID, params.ReplaceCredentialID); err != nil {
 			return nil, fmt.Errorf("new token issued but failed to revoke old credential %d: %w", params.ReplaceCredentialID, err)
 		}
 		c.logMachineEvent(ctx, "machine_identity.token_rotated", m, actorID)
@@ -184,7 +184,7 @@ func (c *KeyorixCore) RevokeMachineToken(ctx context.Context, projectID, machine
 	if err != nil || cred.MachineIdentityID != machineID {
 		return "", fmt.Errorf("token not found")
 	}
-	if err := c.storage.RevokeMachineIdentityCredential(ctx, credentialID); err != nil {
+	if err := c.storage.RevokeMachineIdentityCredential(ctx, projectID, credentialID); err != nil {
 		return "", err
 	}
 	c.logMachineEvent(ctx, "machine_identity.token_revoked", m, actorID)

--- a/internal/core/machine_token_test.go
+++ b/internal/core/machine_token_test.go
@@ -64,7 +64,7 @@ func TestRevokeMachineToken_ReturnsHashForCacheEviction(t *testing.T) {
 	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
 	store.On("GetMachineIdentityCredentialByID", mock.Anything, uint(5)).
 		Return(&models.MachineIdentityCredential{ID: 5, MachineIdentityID: 1, TokenHash: "hash-5"}, nil)
-	store.On("RevokeMachineIdentityCredential", mock.Anything, uint(5)).Return(nil)
+	store.On("RevokeMachineIdentityCredential", mock.Anything, uint(2), uint(5)).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
 	hash, err := c.RevokeMachineToken(context.Background(), 2, 1, 5, 9)

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1939,8 +1939,8 @@ func (m *MockStorage) CountMachineIdentityCredentialsByClassification(ctx contex
 	return v, a.Error(1)
 }
 
-func (m *MockStorage) RevokeMachineIdentityCredential(ctx context.Context, id uint) error {
-	return m.Called(ctx, id).Error(0)
+func (m *MockStorage) RevokeMachineIdentityCredential(ctx context.Context, projectID, id uint) error {
+	return m.Called(ctx, projectID, id).Error(0)
 }
 
 func (m *MockStorage) TouchMachineIdentityCredential(ctx context.Context, id uint, usedAt time.Time, staleness time.Duration) error {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -504,7 +504,20 @@ type Storage interface {
 	// auditing (stale / expired-but-active).
 	ListActiveMachineIdentityCredentials(ctx context.Context) ([]*models.MachineIdentityCredential, error)
 	UpdateMachineIdentityCredential(ctx context.Context, c *models.MachineIdentityCredential) error
-	RevokeMachineIdentityCredential(ctx context.Context, id uint) error
+	// RevokeMachineIdentityCredential revokes credentialID, but only if it
+	// belongs to a machine identity owned by projectID (#1551) — the same
+	// ownership check core.machineInProject already applies for every other
+	// machine-token operation, now enforced at the storage boundary too so a
+	// caller that reaches this primitive directly (bypassing core, e.g. the
+	// /system RevokeMachineIdentityCredentialProxy relay) can't revoke a
+	// credential cross-tenant by supplying a project_id it doesn't actually
+	// own for a credential that belongs to a different one. Returns
+	// ErrNotFound (via the same not-found path as an unknown ID) when the
+	// credential exists but its machine's project doesn't match — the two
+	// cases are indistinguishable to the caller by design, matching how a
+	// non-existent row and a row a caller wasn't allowed to see already read
+	// the same "not found" elsewhere in this codebase.
+	RevokeMachineIdentityCredential(ctx context.Context, projectID, credentialID uint) error
 	// CountMachineIdentityCredentialsByClassification returns install-wide counts
 	// keyed by classification label ("" = unclassified) for the compliance posture.
 	CountMachineIdentityCredentialsByClassification(ctx context.Context) (map[string]int, error)

--- a/internal/storage/store/local_machine_credentials.go
+++ b/internal/storage/store/local_machine_credentials.go
@@ -89,9 +89,15 @@ func (ls *LocalStorage) CountMachineIdentityCredentialsByClassification(ctx cont
 	return countByClassification(ctx, ls.db, &models.MachineIdentityCredential{})
 }
 
-func (ls *LocalStorage) RevokeMachineIdentityCredential(ctx context.Context, id uint) error {
+// RevokeMachineIdentityCredential's project_id filter (#1551) is enforced via
+// a subquery against machine_identities rather than a join, matching this
+// package's existing UpdateColumn-conditional-write idiom (single statement,
+// no separate read).
+func (ls *LocalStorage) RevokeMachineIdentityCredential(ctx context.Context, projectID, credentialID uint) error {
 	result := ls.db.WithContext(ctx).Model(&models.MachineIdentityCredential{}).
-		Where("id = ?", id).UpdateColumn("revoked", true)
+		Where("id = ? AND machine_identity_id IN (?)", credentialID,
+			ls.db.Model(&models.MachineIdentity{}).Select("id").Where("project_id = ?", projectID)).
+		UpdateColumn("revoked", true)
 	if result.Error != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
 	}

--- a/internal/storage/store/local_machine_credentials_test.go
+++ b/internal/storage/store/local_machine_credentials_test.go
@@ -19,7 +19,7 @@ func newMachineCredTestStore(t *testing.T) *LocalStorage {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
-		&models.MachineIdentityCredential{}, &models.MachineIdentityRole{}, &models.Role{},
+		&models.MachineIdentity{}, &models.MachineIdentityCredential{}, &models.MachineIdentityRole{}, &models.Role{},
 		&models.Project{}, &models.Environment{},
 	))
 	return NewLocalStorage(db)
@@ -29,8 +29,13 @@ func TestMachineCredentialLifecycle(t *testing.T) {
 	ls := newMachineCredTestStore(t)
 	ctx := context.Background()
 
+	mi, err := ls.CreateMachineIdentity(ctx, &models.MachineIdentity{
+		ProjectID: 1, Name: "ci-machine", IdentityType: "ci", State: "active", CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
 	cred, err := ls.CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{
-		MachineIdentityID: 1, Name: "ci", TokenHash: "hash-abc", TokenPrefix: "kx_machine_ab12cd", CreatedAt: time.Now(),
+		MachineIdentityID: mi.ID, Name: "ci", TokenHash: "hash-abc", TokenPrefix: "kx_machine_ab12cd", CreatedAt: time.Now(),
 	})
 	require.NoError(t, err)
 	require.NotZero(t, cred.ID)
@@ -40,11 +45,11 @@ func TestMachineCredentialLifecycle(t *testing.T) {
 	assert.Equal(t, cred.ID, got.ID)
 	assert.False(t, got.Revoked)
 
-	list, err := ls.ListMachineIdentityCredentials(ctx, 1)
+	list, err := ls.ListMachineIdentityCredentials(ctx, mi.ID)
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 
-	require.NoError(t, ls.RevokeMachineIdentityCredential(ctx, cred.ID))
+	require.NoError(t, ls.RevokeMachineIdentityCredential(ctx, mi.ProjectID, cred.ID))
 	got, err = ls.GetMachineIdentityCredentialByHash(ctx, "hash-abc")
 	require.NoError(t, err)
 	assert.True(t, got.Revoked, "revoke flips the flag, row preserved for audit")

--- a/internal/storage/store/remote_machine_identities.go
+++ b/internal/storage/store/remote_machine_identities.go
@@ -532,10 +532,15 @@ func (rs *RemoteStorage) CountMachineIdentityCredentialsByClassification(ctx con
 
 // RevokeMachineIdentityCredential revokes a credential via POST
 // /api/v1/system/machine-credentials/{id}/revoke — the server applies the SAME
-// atomic conditional UPDATE local_machine_credentials.go does.
-func (rs *RemoteStorage) RevokeMachineIdentityCredential(ctx context.Context, id uint) error {
+// atomic conditional UPDATE local_machine_credentials.go does, now scoped by
+// project_id (#1551) so the server can verify the credential actually belongs
+// to the project this call claims, rather than trusting the ID alone.
+func (rs *RemoteStorage) RevokeMachineIdentityCredential(ctx context.Context, projectID, id uint) error {
 	path := fmt.Sprintf("/api/v1/system/machine-credentials/%d/revoke", id)
-	resp, err := rs.client.Post(ctx, path, nil)
+	body := struct {
+		ProjectID uint `json:"project_id"`
+	}{ProjectID: projectID}
+	resp, err := rs.client.Post(ctx, path, body)
 	if err != nil {
 		return fmt.Errorf("failed to revoke machine credential: %w", err)
 	}

--- a/internal/storage/store/remote_machine_identities_test.go
+++ b/internal/storage/store/remote_machine_identities_test.go
@@ -388,7 +388,7 @@ func TestRemoteStorage_RevokeMachineIdentityCredential(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	err = rs.RevokeMachineIdentityCredential(context.Background(), 12)
+	err = rs.RevokeMachineIdentityCredential(context.Background(), 7, 12)
 	require.NoError(t, err)
 }
 

--- a/internal/storage/store/remote_wire_route_coverage_test.go
+++ b/internal/storage/store/remote_wire_route_coverage_test.go
@@ -923,7 +923,7 @@ var knownUnresolvedWireCalls = map[string]wireCallExclusion{
 	"remote_invitations.go:396":             urlValuesEntry(),
 	"remote_login_attempts.go:52":           urlValuesEntry(),
 	"remote_machine_identities.go:337":      urlValuesEntry(),
-	"remote_machine_identities.go:681":      urlValuesEntry(),
+	"remote_machine_identities.go:686":      urlValuesEntry(),
 	"remote_memberships.go:206":             urlValuesEntry(),
 	"remote_memberships.go:225":             urlValuesEntry(),
 	"remote_memberships.go:242":             urlValuesEntry(),

--- a/internal/storage/store/store_s25_test.go
+++ b/internal/storage/store/store_s25_test.go
@@ -580,14 +580,14 @@ func TestListActiveMachineIdentityCredentials_S25_BrokenDB(t *testing.T) {
 // TestRevokeMachineIdentityCredential_S25_NotFound verifies the
 // RowsAffected == 0 branch: revoking a non-existent credential returns an error.
 func TestRevokeMachineIdentityCredential_S25_NotFound(t *testing.T) {
-	ls := newS25Store(t, &models.MachineIdentityCredential{})
-	err := ls.RevokeMachineIdentityCredential(context.Background(), 9999)
+	ls := newS25Store(t, &models.MachineIdentity{}, &models.MachineIdentityCredential{})
+	err := ls.RevokeMachineIdentityCredential(context.Background(), 1, 9999)
 	require.Error(t, err, "revoking a non-existent credential must return an error")
 }
 
 func TestRevokeMachineIdentityCredential_S25_BrokenDB(t *testing.T) {
 	ls := newBrokenDB(t)
-	err := ls.RevokeMachineIdentityCredential(context.Background(), 1)
+	err := ls.RevokeMachineIdentityCredential(context.Background(), 1, 1)
 	require.Error(t, err)
 }
 

--- a/internal/storage/store/store_s28_test.go
+++ b/internal/storage/store/store_s28_test.go
@@ -816,7 +816,7 @@ func TestRemoteStorage_S28_RevokeMachineIdentityCredential_APIError(t *testing.T
 	}))
 	defer srv.Close()
 	rs := newS28Remote(t, srv.URL)
-	err := rs.RevokeMachineIdentityCredential(context.Background(), 99)
+	err := rs.RevokeMachineIdentityCredential(context.Background(), 1, 99)
 	assert.Error(t, err)
 }
 

--- a/internal/storage/store/store_s3_local2_test.go
+++ b/internal/storage/store/store_s3_local2_test.go
@@ -272,13 +272,13 @@ func TestMachineIdentityCredential_CRUD(t *testing.T) {
 	assert.NotNil(t, got3.LastUsedAt)
 
 	// Revoke.
-	require.NoError(t, ls.RevokeMachineIdentityCredential(ctx, cred.ID))
+	require.NoError(t, ls.RevokeMachineIdentityCredential(ctx, m.ProjectID, cred.ID))
 	got4, err := ls.GetMachineIdentityCredentialByID(ctx, cred.ID)
 	require.NoError(t, err)
 	assert.True(t, got4.Revoked)
 
 	// Revoke non-existent credential → not found error.
-	err = ls.RevokeMachineIdentityCredential(ctx, 99999)
+	err = ls.RevokeMachineIdentityCredential(ctx, m.ProjectID, 99999)
 	require.Error(t, err)
 
 	// ListActive → now empty.

--- a/server/http/handlers/handlers_s21_machine_proxy_test.go
+++ b/server/http/handlers/handlers_s21_machine_proxy_test.go
@@ -712,7 +712,7 @@ func TestRevokeMachineIdentityCredentialProxy_BadID_S21(t *testing.T) {
 func TestRevokeMachineIdentityCredentialProxy_NotFound_S21(t *testing.T) {
 	h := freshCatalogHandlerS21(t)
 	req := withChiParam(
-		httptest.NewRequest(http.MethodPost, "/system/machine-credentials/9999/revoke", nil),
+		httptest.NewRequest(http.MethodPost, "/system/machine-credentials/9999/revoke", proxyBodyS21(map[string]interface{}{"project_id": 1})),
 		"id", "9999",
 	)
 	w := httptest.NewRecorder()
@@ -754,7 +754,7 @@ func TestRevokeMachineIdentityCredentialProxy_HappyPath_S21(t *testing.T) {
 	_ = credResp
 
 	req := withChiParam(
-		httptest.NewRequest(http.MethodPost, "/system/machine-credentials/"+credID+"/revoke", nil),
+		httptest.NewRequest(http.MethodPost, "/system/machine-credentials/"+credID+"/revoke", proxyBodyS21(map[string]interface{}{"project_id": 40})),
 		"id", credID,
 	)
 	w := httptest.NewRecorder()

--- a/server/http/handlers/handlers_s28_test.go
+++ b/server/http/handlers/handlers_s28_test.go
@@ -1114,7 +1114,7 @@ func TestRevokeMachineIdentityCredentialProxy_NotFound_S28(t *testing.T) {
 	cs := freshCoreS28(t)
 	h := NewCatalogHandler(cs)
 
-	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", nil), "id", "9999")
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(`{"project_id":1}`))), "id", "9999")
 	w := httptest.NewRecorder()
 	h.RevokeMachineIdentityCredentialProxy(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -1138,7 +1138,7 @@ func TestRevokeMachineIdentityCredentialProxy_HappyPath_S28(t *testing.T) {
 	require.NoError(t, err)
 
 	h := NewCatalogHandler(cs)
-	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", nil), "id", uintStrS28(cred.ID))
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(fmt.Sprintf(`{"project_id":%d}`, mi.ProjectID)))), "id", uintStrS28(cred.ID))
 	w := httptest.NewRecorder()
 	h.RevokeMachineIdentityCredentialProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/server/http/handlers/handlers_s33_test.go
+++ b/server/http/handlers/handlers_s33_test.go
@@ -87,7 +87,8 @@ func TestUpdateMachineIdentityCredentialProxy_DBError_S33(t *testing.T) {
 func TestRevokeMachineIdentityCredentialProxy_DBError_S33(t *testing.T) {
 	t.Parallel()
 	h := NewCatalogHandler(freshCoreBrokenS33(t))
-	r := withChiParamS7(httptest.NewRequest(http.MethodPost, "/api/v1/system/machine-credentials/1/revoke", nil), "id", "1")
+	body := bytes.NewBufferString(`{"project_id":1}`)
+	r := withChiParamS7(httptest.NewRequest(http.MethodPost, "/api/v1/system/machine-credentials/1/revoke", body), "id", "1")
 	w := httptest.NewRecorder()
 	h.RevokeMachineIdentityCredentialProxy(w, r)
 	// RevokeMachineIdentityCredential fails with "ErrorStorageFailed" (not "not found") → 500

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -11677,7 +11677,7 @@ func TestAuthHandler_AdvanceWebAuthnCredentialCounterProxy_MissingRequiredFields
 
 func TestCatalogHandler_RevokeMachineIdentityCredentialProxy_HappyPath(t *testing.T) {
 	h := newCatalogHandlerS4(t)
-	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", nil), "id", "1")
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"project_id":1}`)), "id", "1")
 	w := httptest.NewRecorder()
 	h.RevokeMachineIdentityCredentialProxy(w, req)
 	assert.NotEqual(t, http.StatusBadRequest, w.Code)

--- a/server/http/handlers/handlers_s5_test.go
+++ b/server/http/handlers/handlers_s5_test.go
@@ -3679,7 +3679,7 @@ func TestListGroupMembersByIDsProxy_HappyPathS5(t *testing.T) {
 
 func TestRevokeMachineIdentityCredentialProxy_HappyPath(t *testing.T) {
 	h := newCatalogHandlerS4(t)
-	req := withChiParam(httptest.NewRequest("POST", "/", nil), "id", "1")
+	req := withChiParam(httptest.NewRequest("POST", "/", strings.NewReader(`{"project_id":1}`)), "id", "1")
 	w := httptest.NewRecorder()
 	h.RevokeMachineIdentityCredentialProxy(w, req)
 	// Row may not exist → 404, but not bad-request.

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -757,18 +757,56 @@ func (h *CatalogHandler) CountMachineIdentityCredentialsByClassificationProxy(w 
 	writeRemoteAPISuccess(w, map[string]interface{}{"counts": counts})
 }
 
+// revokeMachineIdentityCredentialProxyBody is
+// RevokeMachineIdentityCredentialProxy's request body — see #1551 below.
+type revokeMachineIdentityCredentialProxyBody struct {
+	ProjectID uint `json:"project_id"`
+}
+
 // RevokeMachineIdentityCredentialProxy handles POST
 // /api/v1/system/machine-credentials/{id}/revoke. storage.Storage.
 // RevokeMachineIdentityCredential is itself an atomic conditional UPDATE
 // (local_machine_credentials.go: `UpdateColumn("revoked", true)` gated on
-// `id = ?`), so a single passthrough call here preserves that guarantee exactly.
+// `id = ? AND machine_identity_id IN (project's machines)`), so a single
+// passthrough call here preserves that guarantee exactly.
+//
+// #1551: project_id is now part of the wire request (previously this route
+// took only the credential id, with no tenant check at all). The
+// legitimate spoke topology (a CLI running under storage.type: remote calls
+// core.RevokeMachineToken, which already runs core.machineInProject's
+// ownership check client-side against its own RemoteStorage-backed read
+// before ever reaching this route) never depended on this route enforcing
+// tenancy itself. A caller reaching this route directly (holding the
+// blanket system.write raw-storage capability every /system proxy in this
+// package trusts, but not going through core.RevokeMachineToken) had no
+// such check at all: any credential ID could be revoked by naming any
+// project, since neither ID was ever cross-checked against the other. The
+// fix pushes the ownership check into the storage primitive itself
+// (RevokeMachineIdentityCredential's own project_id parameter, enforced in
+// its WHERE clause) rather than adding a second, parallel authorization
+// primitive at this handler — deriving from the existing
+// core.machineInProject check's *shape*, not inventing a new one: a
+// caller-claimed tenant is now verified against the credential's real
+// owning project before the write, the same "claim vs. ground truth"
+// pattern already applied to wire-supplied actors elsewhere in this
+// package (e.g. CreateMembershipProxy's #1578 fix), just for a tenant
+// field instead of an actor field.
 func (h *CatalogHandler) RevokeMachineIdentityCredentialProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", errInvalidCredentialID)
 		return
 	}
-	if err := h.coreService.Storage().RevokeMachineIdentityCredential(r.Context(), uint(id)); err != nil {
+	var body revokeMachineIdentityCredentialProxyBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
+		return
+	}
+	if body.ProjectID == 0 {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id is required")
+		return
+	}
+	if err := h.coreService.Storage().RevokeMachineIdentityCredential(r.Context(), body.ProjectID, uint(id)); err != nil {
 		if isNotFoundErr(err) {
 			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errMachineCredentialNotFound)
 			return

--- a/server/http/handlers/machine_identities_s13_test.go
+++ b/server/http/handlers/machine_identities_s13_test.go
@@ -807,8 +807,9 @@ func TestRevokeMachineIdentityCredentialProxy_BadID_S13(t *testing.T) {
 
 func TestRevokeMachineIdentityCredentialProxy_NotFound_S13(t *testing.T) {
 	h := machineHandlerS13(t)
+	body, _ := json.Marshal(map[string]interface{}{"project_id": 1})
 	req := withChiParam(
-		httptest.NewRequest(http.MethodPost, "/api/v1/system/machine-credentials/9999/revoke", nil),
+		httptest.NewRequest(http.MethodPost, "/api/v1/system/machine-credentials/9999/revoke", bytes.NewReader(body)),
 		"id", "9999",
 	)
 	w := httptest.NewRecorder()

--- a/server/http/handlers/project_memberships_proxy.go
+++ b/server/http/handlers/project_memberships_proxy.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -174,11 +175,58 @@ func (h *CatalogHandler) GetMembershipProxy(w http.ResponseWriter, r *http.Reque
 // TransitionMembershipProxy handles PUT
 // /api/v1/system/project-memberships/{id}/transition — the server-side
 // endpoint backing RemoteStorage.TransitionProjectMembershipState (#G42).
-// Persists the membership's full row via a single conditional UPDATE, gated
-// on the row's CURRENT state still matching the request's from_state, so a
-// concurrent transition on the same membership can't be silently reverted
-// (or silently revert this one) across the HTTP hop the way UpdateMembershipProxy
-// could.
+//
+// #1546: routes through core.TransitionMembership (FULL delegation) rather
+// than the narrow-primitive bolt-on ADR-088 costed for this handler
+// (docs/adr-088-system-proxy-layer-design.md, "Costing the rule against
+// #1546/#1551/#1572"). That costing assumed a live spoke already runs
+// core.TransitionMembership locally before relaying here, so full
+// delegation would duplicate the role-grant side effect
+// (AddProjectMember/RemoveProjectMember) the spoke already applied.
+// Liveness tracing for #1546 found no such spoke: core.TransitionMembership
+// has exactly one caller repo-wide (server/http/handlers/project_memberships.go,
+// the human-facing route, reachable only inside a booted HTTP server) and no
+// server process can ever run storage.type: remote
+// (validateRemoteStorageNotServer, internal/config/config.go, unconditional
+// since #1549) — so no spoke server can exist. No CLI command calls
+// core.TransitionMembership either (no project-membership CLI surface
+// exists at all). ADR-088's rule is explicitly conditional on that spoke
+// executing core locally ("Precondition this rule depends on" section); the
+// precondition does not hold for this specific handler, so the rule's
+// conclusion (bolt-on beats delegation) does not transfer to it either —
+// re-derived here, not inherited.
+//
+// Full delegation closes more than the ceiling+side-effect gap #1546 named:
+// the OLD raw-write version persisted the wire's ENTIRE membership row
+// verbatim (role, user_id, invited_by, ...) via body.Membership.toModel(),
+// so a caller could rewrite a membership's role while nominally just
+// "transitioning" it. core.TransitionMembership reads its OWN authoritative
+// row and only accepts (projectID, membershipID, to, actorID) from the
+// caller -- every other field is now ignored on the wire, closing that
+// forgery surface too. It also applies canTransition's state-machine
+// legality check, which the raw write never did (any from_state/to pair the
+// wire claimed would persist as long as the CAS condition matched).
+//
+// actorID is resolved from the authenticated caller (actorID(r)), never the
+// wire body — same convention CreateMembershipProxy's own #1578 fix uses
+// immediately above.
+//
+// Wire-shape note: from_state is still accepted (unchanged request shape
+// for whatever, if anything, sends it) but deliberately unused --
+// core.TransitionMembership re-derives the current state itself from a
+// fresh read rather than trusting the wire's claim, so a stale or forged
+// from_state can no longer influence the outcome the way it could in the
+// raw-write version (there, it was the ENTIRE CAS gate).
+//
+// Not replicated: core.TransitionMembership's own best-effort
+// revertFailedActivation (reverting the state row if the role-grant side
+// effect fails AFTER the CAS write already committed) is unexported and
+// internal to internal/core -- exporting it to reach it from this handler
+// would grow this fix past a single handler's worth of change. That failure
+// mode surfaces to the caller as a genuine error (STORAGE_ERROR) either
+// way; the row is left in its new state with the role grant not applied,
+// same residual risk core's own local callers already accept, just without
+// the auto-revert. Stated here as a residual gap, not silently dropped.
 func (h *CatalogHandler) TransitionMembershipProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
@@ -193,18 +241,24 @@ func (h *CatalogHandler) TransitionMembershipProxy(w http.ResponseWriter, r *htt
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
-	if body.FromState == "" {
-		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "from_state is required")
+	if body.Membership.State == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "membership.state (the target state) is required")
 		return
 	}
-	body.Membership.ID = uint(id)
-	matched, err := h.coreService.Storage().TransitionProjectMembershipState(r.Context(), body.Membership.toModel(), body.FromState)
+	_, err = h.coreService.TransitionMembership(r.Context(), body.Membership.ProjectID, uint(id), body.Membership.State, actorID(r))
 	if err != nil {
+		// #G42: a lost CAS race is a normal outcome on this wire contract
+		// (matched=false), not a server error -- matches every other
+		// conditional-transition wire method in this package.
+		if errors.Is(err, core.ErrMembershipStateConflict) {
+			writeRemoteAPISuccess(w, map[string]bool{"matched": false})
+			return
+		}
 		log.Printf("project-memberships proxy: transition failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
 	}
-	writeRemoteAPISuccess(w, map[string]bool{"matched": matched})
+	writeRemoteAPISuccess(w, map[string]bool{"matched": true})
 }
 
 // ListMembershipsProxy handles GET /api/v1/system/project-memberships?project_id=X.

--- a/server/http/handlers/project_memberships_proxy_transition_test.go
+++ b/server/http/handlers/project_memberships_proxy_transition_test.go
@@ -1,0 +1,131 @@
+// project_memberships_proxy_transition_test.go — G80 Wave 2 (#1546, ADR-088).
+// TransitionMembershipProxy used to persist the wire body's ENTIRE membership
+// row via a raw conditional write with no authority check and no role-grant
+// side effect — a caller reaching this route directly could activate an
+// admin-tier membership (bypassing RequireAuthorityForRole entirely) and the
+// role grant the legitimate path (core.TransitionMembership) applies as a
+// side effect of activation would never be created. Fixed by full delegation
+// to core.TransitionMembership, which applies both.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTransitionMembershipFixture seeds a project, a target member, and a
+// PROVISIONED membership carrying an admin-tier role ("project_admin") ready
+// to transition to "active" — the one transition core.TransitionMembership
+// gates with RequireAuthorityForRole. Returns the core service, the
+// membership, and the seeded admin (for building authorized requests).
+func setupTransitionMembershipFixture(t *testing.T) (cs *core.KeyorixCore, membership *models.ProjectMembership, admin *models.User) {
+	t.Helper()
+	cs, _ = freshCoreS12WithAdmin(t)
+	ctx := context.Background()
+
+	var err error
+	admin, err = cs.GetUserByUsername(ctx, "testuser_s12")
+	require.NoError(t, err)
+
+	project, err := cs.Storage().CreateProject(ctx, &models.Project{Name: "g80-1546-project"})
+	require.NoError(t, err)
+
+	if _, err := cs.Storage().GetRoleByName(ctx, "project_admin"); err != nil {
+		_, err := cs.Storage().CreateRole(ctx, &models.Role{Name: "project_admin", Description: "test"})
+		require.NoError(t, err)
+	}
+
+	target, err := cs.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "g80-1546-target", Email: "g80-1546-target@example.com",
+		DisplayName: "G80 1546 Target", Password: "NotArealpassword123!",
+	})
+	require.NoError(t, err)
+
+	membership, err = cs.Storage().CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: project.ID, UserID: target.ID, Role: "project_admin", State: core.MembershipProvisioned,
+	})
+	require.NoError(t, err)
+	return cs, membership, admin
+}
+
+// TestTransitionMembershipProxy_ActivatingAdminRoleRequiresAuthority_RealServer
+// is #1546's ceiling half: an actor with NO admin authority at the project
+// attempts to activate an admin-tier ("project_admin") membership directly
+// through the raw proxy. Must be refused, and the membership must remain
+// provisioned (not silently activated).
+func TestTransitionMembershipProxy_ActivatingAdminRoleRequiresAuthority_RealServer(t *testing.T) {
+	cs, membership, _ := setupTransitionMembershipFixture(t)
+	h := NewCatalogHandler(cs)
+	ctx := context.Background()
+
+	nobody, err := cs.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "g80-1546-nobody", Email: "g80-1546-nobody@example.com",
+		DisplayName: "G80 1546 Nobody", Password: "NotArealpassword123!",
+	})
+	require.NoError(t, err)
+
+	body, err := json.Marshal(map[string]interface{}{
+		"membership": map[string]interface{}{"id": membership.ID, "project_id": membership.ProjectID, "state": core.MembershipActive},
+		"from_state": core.MembershipProvisioned,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest("PUT", "/", bytes.NewReader(body))
+	uc := &middleware.UserContext{UserID: nobody.ID}
+	req = req.WithContext(context.WithValue(req.Context(), middleware.GetUserContextKey(), uc))
+	req = withChiParams(req, map[string]string{"id": machineUintToStr(membership.ID)})
+	w := httptest.NewRecorder()
+	h.TransitionMembershipProxy(w, req)
+	assert.NotEqual(t, 200, w.Code, "activating an admin-tier membership without authority must be refused: %s", w.Body.String())
+
+	reloaded, err := cs.Storage().GetProjectMembership(ctx, membership.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.MembershipProvisioned, reloaded.State, "the membership must remain provisioned, not silently activated")
+
+	ids, err := cs.Storage().GetUserRoleIDsExact(ctx, membership.UserID, core.Scope{ProjectID: membership.ProjectID})
+	require.NoError(t, err)
+	assert.Empty(t, ids, "no role grant may exist for a rejected activation")
+}
+
+// TestTransitionMembershipProxy_ActivationGrantsRole_RealServer is #1546's
+// side-effect half and the positive control: an actor WITH admin authority at
+// the project activates the same admin-tier membership, and the role grant
+// core.TransitionMembership applies as a side effect of activation must
+// actually be created — not just the membership row flipped to active.
+func TestTransitionMembershipProxy_ActivationGrantsRole_RealServer(t *testing.T) {
+	cs, membership, admin := setupTransitionMembershipFixture(t)
+	h := NewCatalogHandler(cs)
+	ctx := context.Background()
+
+	body, err := json.Marshal(map[string]interface{}{
+		"membership": map[string]interface{}{"id": membership.ID, "project_id": membership.ProjectID, "state": core.MembershipActive},
+		"from_state": core.MembershipProvisioned,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest("PUT", "/", bytes.NewReader(body))
+	uc := &middleware.UserContext{UserID: admin.ID}
+	req = req.WithContext(context.WithValue(req.Context(), middleware.GetUserContextKey(), uc))
+	req = withChiParams(req, map[string]string{"id": machineUintToStr(membership.ID)})
+	w := httptest.NewRecorder()
+	h.TransitionMembershipProxy(w, req)
+	require.Equal(t, 200, w.Code, "an authorized admin activating the membership must succeed: %s", w.Body.String())
+
+	reloaded, err := cs.Storage().GetProjectMembership(ctx, membership.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.MembershipActive, reloaded.State)
+	require.NotNil(t, reloaded.ActivatedAt)
+
+	role, err := cs.Storage().GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	ids, err := cs.Storage().GetUserRoleIDsExact(ctx, membership.UserID, core.Scope{ProjectID: membership.ProjectID})
+	require.NoError(t, err)
+	assert.Contains(t, ids, role.ID, "activation must grant the membership's role, not just flip the membership's own state")
+}

--- a/server/http/handlers/users_active_transition_proxy.go
+++ b/server/http/handlers/users_active_transition_proxy.go
@@ -117,14 +117,9 @@ func (h *UserHandler) UpdateUserIfActiveStateMatchesProxy(w http.ResponseWriter,
 	// depends only on the target user ID (a target-state invariant, not a
 	// caller-authority check -- see its doc), which is already the route's own
 	// path parameter, so this closes the gap with no RemoteStorage wire-protocol
-	// change. Deliberately NOT addressed here: PAT/session revocation on
-	// deactivation, which core.UpdateUser also performs -- that's a separate,
-	// pre-existing defect (RemoteStorage.RevokeAllPersonalAccessTokensForUser and
-	// DeleteSessionsForUserExcept are both stubbed to errUnsupportedRemote,
-	// meaning the "correct" full deactivation flow already fails outright over
-	// RemoteStorage today, independent of this proxy) -- tracked separately, not
-	// fixed as part of this change.
-	if body.FromActive && !body.Active {
+	// change.
+	deactivating := body.FromActive && !body.Active
+	if deactivating {
 		if err := h.coreService.GuardLastAdminDeactivation(r.Context(), uint(id)); err != nil {
 			writeRemoteAPIError(w, http.StatusForbidden, "LAST_ADMIN", clientSafe(err))
 			return
@@ -147,6 +142,37 @@ func (h *UserHandler) UpdateUserIfActiveStateMatchesProxy(w http.ResponseWriter,
 		log.Printf("users proxy: active-state transition failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
+	}
+	// #1572: replicate core.UpdateUser's deactivating-branch side effect --
+	// PAT/session revocation -- which a caller reaching this route directly
+	// (bypassing core.UpdateUser, e.g. holding raw system.write without going
+	// through the CLI's own core.UpdateUser call) would otherwise skip
+	// entirely, leaving the deactivated user's PATs/sessions live. The two
+	// core-level operations this calls (RevokeAllPersonalAccessTokensForUser/
+	// DeleteSessionsForUserExcept, server/http/handlers/users_credentials_proxy.go)
+	// already exist as safe, authorized, audited routes for exactly this
+	// purpose (ADR-088's own costing for #1572: "the fix is calling those same
+	// two already-safe internal/core operations directly, in sequence... no new
+	// primitive needed") -- reused here as in-process calls, not a second HTTP
+	// hop, since this handler already runs on the hub. Best-effort and
+	// non-fatal, matching core.UpdateUser's own posture toward the identical
+	// failure mode (internal/core/users.go's deactivating branch, lines
+	// ~419-463): the deactivation itself already committed via the conditional
+	// write above, and ValidateSessionToken/ValidatePATToken independently
+	// re-check the live is_active flag on every use regardless of whether
+	// revocation ran, so a failed best-effort revocation here leaves no live
+	// credential, only a stale row. Only fires when matched is true (this
+	// call's own CAS write actually won the race) and only on a real
+	// true->false transition -- calling it on every request would revoke
+	// credentials on no-op or reactivating calls too.
+	if matched && deactivating {
+		actorType, actorID := requestActorKindAndID(r)
+		if _, err := h.coreService.RevokeAllPersonalAccessTokensForUser(r.Context(), actorType, actorID, uint(id)); err != nil {
+			log.Printf("users proxy: active-state transition: best-effort PAT revocation failed for user %d: %v", id, err)
+		}
+		if err := h.coreService.DeleteSessionsForUserExcept(r.Context(), actorType, actorID, uint(id), 0); err != nil {
+			log.Printf("users proxy: active-state transition: best-effort session revocation failed for user %d: %v", id, err)
+		}
 	}
 	writeRemoteAPISuccess(w, map[string]bool{"matched": matched})
 }

--- a/server/http/handlers/users_active_transition_proxy_credential_revoke_test.go
+++ b/server/http/handlers/users_active_transition_proxy_credential_revoke_test.go
@@ -1,0 +1,148 @@
+// users_active_transition_proxy_credential_revoke_test.go — G80 Wave 2
+// (#1572, ADR-088). UpdateUserIfActiveStateMatchesProxy could deactivate a
+// user (flip is_active to false) without ever revoking their live personal
+// access tokens or sessions — a caller reaching this raw /system proxy
+// directly (bypassing core.UpdateUser, which performs both as part of the
+// same deactivating transaction) got a deactivated account with fully live
+// credentials. Fixed by calling core.RevokeAllPersonalAccessTokensForUser/
+// core.DeleteSessionsForUserExcept in-process immediately after a matched
+// true->false transition, best-effort and non-fatal like core.UpdateUser's
+// own deactivating branch.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateUserIfActiveStateMatchesProxy_DeactivationRevokesCredentials_RealServer
+// is the #1572 exploit shape: a target user holds a live PAT and a live
+// session. A caller with real users.write authority deactivates them through
+// the raw proxy alone (never touching core.UpdateUser or the two dedicated
+// credential-revocation proxies). Both credentials must come back revoked —
+// before the fix, neither would have.
+func TestUpdateUserIfActiveStateMatchesProxy_DeactivationRevokesCredentials_RealServer(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	admin, err := cs.GetUserByUsername(ctx, "testuser_s12")
+	require.NoError(t, err)
+
+	target, err := cs.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "g80-1572-target", Email: "g80-1572-target@example.com",
+		DisplayName: "G80 1572 Target", Password: "NotArealpassword123!",
+	})
+	require.NoError(t, err)
+
+	pat, err := cs.Storage().CreatePersonalAccessToken(ctx, &models.PersonalAccessToken{
+		UserID: target.ID, Name: "ci", TokenHash: "hash-1572-pat", TokenPrefix: "kx_pat_1572",
+	})
+	require.NoError(t, err)
+
+	session, err := cs.Storage().CreateSession(ctx, &models.Session{
+		UserID: target.ID, SessionToken: "hash-1572-session", CreatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Sanity: both are live before deactivation.
+	pats, err := cs.Storage().ListPersonalAccessTokensByUser(ctx, target.ID)
+	require.NoError(t, err)
+	require.Len(t, pats, 1)
+	require.False(t, pats[0].Revoked)
+
+	hashes, err := cs.Storage().ListSessionTokenHashesForUser(ctx, target.ID)
+	require.NoError(t, err)
+	require.Len(t, hashes, 1, "target must have exactly one live session before deactivation")
+
+	body, err := json.Marshal(map[string]interface{}{
+		"username":    target.Username,
+		"email":       target.Email,
+		"active":      false,
+		"updated_at":  time.Now(),
+		"from_active": true,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest("PUT", "/", bytes.NewReader(body))
+	uc := &middleware.UserContext{UserID: admin.ID, Username: admin.Username, Email: admin.Email}
+	req = req.WithContext(context.WithValue(req.Context(), middleware.GetUserContextKey(), uc))
+	req = withChiParams(req, map[string]string{"id": machineUintToStr(target.ID)})
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	require.Equal(t, 200, w.Code, "deactivation itself must still succeed: %s", w.Body.String())
+
+	reloaded, err := cs.Storage().GetUser(ctx, target.ID)
+	require.NoError(t, err)
+	assert.False(t, reloaded.IsActive)
+
+	patAfter, err := cs.Storage().GetPersonalAccessTokenByHash(ctx, "hash-1572-pat")
+	require.NoError(t, err)
+	assert.True(t, patAfter.Revoked, "the target's PAT must be revoked as a side effect of deactivation via this route")
+	assert.Equal(t, pat.ID, patAfter.ID)
+
+	hashesAfter, err := cs.Storage().ListSessionTokenHashesForUser(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Empty(t, hashesAfter, "the target's session must be deleted as a side effect of deactivation via this route")
+	_ = session
+}
+
+// TestUpdateUserIfActiveStateMatchesProxy_ReactivationDoesNotRevoke_RealServer
+// is the control: flipping IsActive from false->true (or any non-deactivating
+// call) must never trigger a revocation attempt -- only a real true->false
+// transition should.
+func TestUpdateUserIfActiveStateMatchesProxy_ReactivationDoesNotRevoke_RealServer(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	admin, err := cs.GetUserByUsername(ctx, "testuser_s12")
+	require.NoError(t, err)
+
+	target, err := cs.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "g80-1572-reactivate", Email: "g80-1572-reactivate@example.com",
+		DisplayName: "G80 1572 Reactivate", Password: "NotArealpassword123!",
+	})
+	require.NoError(t, err)
+	target.IsActive = false
+	target.UpdatedAt = time.Now()
+	_, err = cs.Storage().UpdateUser(ctx, target)
+	require.NoError(t, err)
+
+	pat, err := cs.Storage().CreatePersonalAccessToken(ctx, &models.PersonalAccessToken{
+		UserID: target.ID, Name: "ci", TokenHash: "hash-1572-reactivate-pat", TokenPrefix: "kx_pat_reac",
+	})
+	require.NoError(t, err)
+
+	body, err := json.Marshal(map[string]interface{}{
+		"username":    target.Username,
+		"email":       target.Email,
+		"active":      true,
+		"updated_at":  time.Now(),
+		"from_active": false,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest("PUT", "/", bytes.NewReader(body))
+	uc := &middleware.UserContext{UserID: admin.ID, Username: admin.Username, Email: admin.Email}
+	req = req.WithContext(context.WithValue(req.Context(), middleware.GetUserContextKey(), uc))
+	req = withChiParams(req, map[string]string{"id": machineUintToStr(target.ID)})
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	require.Equal(t, 200, w.Code, "reactivation must still succeed: %s", w.Body.String())
+
+	patAfter, err := cs.Storage().GetPersonalAccessTokenByHash(ctx, "hash-1572-reactivate-pat")
+	require.NoError(t, err)
+	assert.False(t, patAfter.Revoked, "reactivating a user must not revoke their PAT")
+	assert.Equal(t, pat.ID, patAfter.ID)
+}

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -632,6 +632,26 @@ func isReadShapedStorageMethod(method string) bool {
 // found calling a wrapped storage method (the #1542 shape recurring), or if a
 // listed entry no longer applies (fixed and forgotten).
 var rawStorageBypassAllowlist = map[string]string{
+	// G80 Wave 2 (#1572, ADR-088): the raw Storage().UpdateUserIfActiveStateMatches
+	// call is the deliberate CAS-conditional write this route exists to
+	// provide (same "conditional write, not full delegation" shape ADR-088
+	// costs for every /system proxy) -- what made it unjustified was that it
+	// skipped two of the three things core.UpdateUser's deactivating branch
+	// does around that same write: the last-admin guard (fixed 2026-08-24,
+	// core.GuardLastAdminDeactivation) and PAT/session revocation (fixed here
+	// via core.RevokeAllPersonalAccessTokensForUser/core.DeleteSessionsForUserExcept,
+	// called in-process immediately after a matched true->false transition).
+	// With both bolted on, this handler now performs every check and side
+	// effect core.UpdateUser's deactivating branch does, in the same order,
+	// around the same conditional write -- it just doesn't re-derive the row
+	// from a fresh GetUser/diff the way full delegation to core.UpdateUser
+	// would (which ADR-088 rejects for this route: full delegation would lose
+	// the FromActive CAS precondition the route exists to provide). Verified
+	// red/green in users_active_transition_proxy_credential_revoke_test.go.
+	"UpdateUserIfActiveStateMatchesProxy": "no-independent-ceiling once both bolt-ons are in place: " +
+		"GuardLastAdminDeactivation (fixed 2026-08-24) and RevokeAllPersonalAccessTokensForUser/" +
+		"DeleteSessionsForUserExcept (fixed here, #1572) replicate every check and side effect " +
+		"core.UpdateUser's deactivating branch applies around the same conditional write.",
 	// G80 Wave 1 (#1547): the one new candidate the repo-wide extension found,
 	// outside /system. VERIFIED 2026-08-25 (G80 documented-exception
 	// re-verification sweep, escalation-delta test), docs/g80-raw-storage-
@@ -1251,41 +1271,80 @@ var knownUnfixedRawStorageBypasses = map[string]string{
 	// on "is this a node credential" would LOWER the effective bar, not raise
 	// it, for an account-takeover primitive.
 	//
-	"TransitionMembershipProxy": "UNRESOLVED, not confirmed real or safe -- filed as #1546. The exported wrapper " +
-		"(TransitionMembership) gates activation with requireAuthorityForRole and grants/revokes the underlying " +
-		"role grant as a side effect neither of which this raw call performs; whether that's covered by a " +
-		"separate relayed call from the downstream's own core.TransitionMembership, or a real gap, is undetermined.",
+	// TransitionMembershipProxy is FIXED (#1546, Wave 2, ADR-088) -- entry
+	// removed. Liveness re-trace found the "undetermined" question above (did a
+	// spoke already relay the role-grant separately?) resolves to "no spoke
+	// exists at all": core.TransitionMembership's only caller repo-wide is the
+	// human-facing HTTP route (unreachable from any process with
+	// storage.type: remote, since validateRemoteStorageNotServer rejects that
+	// for every server), and no CLI command calls it either. With no live
+	// spoke, ADR-088's duplication concern for full delegation is moot, so the
+	// handler now fully delegates to core.TransitionMembership instead of the
+	// narrow bolt-on ADR-088 costed -- it no longer makes any raw
+	// wrapped-storage call at all (moved to actorID(r)-derived,
+	// core.TransitionMembership-routed logic;
+	// server/http/handlers/project_memberships_proxy.go).
 	// UpdateLoginLockoutStateProxy's route was deleted (G80 23-handler no-caller
 	// deletion) -- entry removed, no longer applicable.
 	// CreateMachineIdentityProxy is FIXED (moved to rawStorageBypassAllowlist);
 	// CreateMachineIdentityCredentialProxy is HALF-FIXED (see its entry below) --
 	// neither belongs here with its original pre-fix text.
-	"RevokeMachineIdentityCredentialProxy": "REAL, human-reachable, narrower: revokes by bare credential ID with " +
-		"no project-membership check, skips audit + cache-eviction hand-off. Mirrors this file's own " +
-		"already-fixed RemoveMachineRoleProxy pattern; impact is cross-tenant DoS/tampering, not escalation. " +
-		"Deferred (not a wire-compatible fix like its siblings): the wire contract carries no project/scope " +
-		"parameter at all, so closing it needs a RemoteStorage client-side change first -- filed as #1551. " +
+	// #1551 cross-tenant half FIXED 2026-08-29 (Wave 2, ADR-088):
+	// storage.Storage.RevokeMachineIdentityCredential now takes a projectID
+	// parameter, enforced in the WHERE clause (LocalStorage) and carried on
+	// the wire (RemoteStorage/RevokeMachineIdentityCredentialProxy) --
+	// deriving the existing core.machineInProject ownership-check *shape*
+	// rather than inventing a new authorization primitive: a caller-claimed
+	// project_id is now verified against the credential's real owning
+	// project before the write, the same claim-vs-ground-truth pattern
+	// already used for wire-supplied actors elsewhere in this package.
+	// Verified red/green via a real upstream/downstream integration test
+	// (server/http/remote_storage_machine_identities_test.go,
+	// TestRemoteStorageMachineIdentities_RevokeCredential_CrossTenantRejected_RealServer).
+	// Audit + cache-eviction hand-off remain a SEPARATE, still-open residual
+	// (unchanged by this fix, not silently dropped): this raw call still
+	// doesn't log an audit event or return the token hash for auth-cache
+	// eviction the way core.RevokeMachineToken's caller-side eviction
+	// contract expects -- and unlike the tenant check, that gap isn't closed
+	// by a wire parameter alone (it needs either an audit call here or a
+	// wire-carried hash in the response), so still belongs in this list under
+	// its own remaining half.
+	"RevokeMachineIdentityCredentialProxy": "PARTIALLY FIXED 2026-08-29 (#1551, Wave 2): cross-tenant revoke is " +
+		"now rejected (project_id required on the wire, enforced in the storage layer's WHERE clause). Still " +
+		"open: no audit event, no token-hash returned for auth-cache eviction (core.RevokeMachineToken's own " +
+		"caller-side eviction contract is unmet by this raw passthrough) -- narrower residual, not an " +
+		"escalation, not part of #1551's stated cross-tenant scope. " +
 		"ADR-085 (Accepted, 2026-08-25) closed the node-credential axis specifically: the /system group's own " +
 		"gate now requires system.write for every caller (see " +
 		"TestSystemWriteCeiling_RevokeMachineIdentityCredentialProxy_NodeCredential_DeniedAtGate, " +
-		"system_write_ceiling_table_test.go), so a bare node credential can no longer reach this handler at all -- " +
-		"#1551's real gap (cross-tenant revoke by any system.write holder, human or machine) is unchanged.",
+		"system_write_ceiling_table_test.go) -- irrelevant to the tenant check either way, since that check now " +
+		"runs for every caller regardless of credential class.",
 	// UpsertMFASecretProxy, CreateMFAStepUpGrantProxy, UpdateProjectProxy,
 	// RestoreProjectProxy, DeleteAnomalyAlertsBeforeProxy,
 	// DeleteClosedAccessReviewsBeforeProxy, DeleteExpiredBreakGlassBeforeProxy,
 	// DeleteResolvedAccessRequestsBeforeProxy, DeleteSecretDependencyProxy: all
 	// deleted (G80 23-handler no-caller deletion) -- entries removed, no longer
 	// applicable.
-	"UpdateUserIfActiveStateMatchesProxy": "PARTIALLY FIXED 2026-08-24 (G80 overnight campaign, Tier 1 Group A " +
-		"#3): the last-admin-lockout half is fixed -- core.GuardLastAdminDeactivation now runs before any " +
-		"deactivating transition (FromActive:true, Active:false), a target-state check needing only the target " +
-		"user ID, no RemoteStorage wire-protocol change required. The PAT/session revocation half (RemoteStorage." +
-		"RevokeAllPersonalAccessTokensForUser/DeleteSessionsForUserExcept were both hard-stubbed to " +
-		"errUnsupportedRemote, so the 'correct' full deactivation flow failed outright over RemoteStorage) is now " +
-		"fixed 2026-08-25 via two new proxy routes -- see the RevokeAllPersonalAccessTokensForUserProxy/ " +
-		"DeleteSessionsForUserExceptProxy entries below (this handler itself still makes no PAT/session call; the " +
-		"fix lives in the two new routes core.UpdateUser's deactivating branch now succeeds against, and in the " +
-		"RemoteStorage client methods themselves).",
+	// UpdateUserIfActiveStateMatchesProxy is FIXED (#1572, Wave 2, ADR-088) --
+	// entry removed. Recap: the last-admin-lockout half was fixed 2026-08-24
+	// (core.GuardLastAdminDeactivation). RemoteStorage.RevokeAllPersonalAccessTokensForUser/
+	// DeleteSessionsForUserExcept were un-stubbed 2026-08-25 via two new proxy
+	// routes (RevokeAllPersonalAccessTokensForUserProxy/DeleteSessionsForUserExceptProxy),
+	// which closed the gap for the LEGITIMATE flow (a CLI running
+	// core.UpdateUser under storage.type: remote, whose deactivating branch
+	// calls those two operations as separate HTTP round-trips). What remained
+	// open: a caller reaching THIS route directly, bypassing core.UpdateUser
+	// entirely, could deactivate a user via this route alone without ever
+	// triggering the other two -- PAT/session revocation was skippable, not a
+	// guaranteed side effect of deactivation the way it is for the legitimate
+	// path. Per ADR-088's own costing for #1572 ("the fix is calling those
+	// same two already-safe internal/core operations directly, in sequence...
+	// no new primitive needed"), this handler now calls
+	// core.RevokeAllPersonalAccessTokensForUser/core.DeleteSessionsForUserExcept
+	// itself (in-process, not a second HTTP hop) immediately after a matched
+	// true->false transition, best-effort and non-fatal like core.UpdateUser's
+	// own deactivating branch. Verified red before / green after in
+	// server/http/handlers/users_active_transition_proxy_credential_revoke_test.go.
 	// G80 Wave 2 (tx.X() blind-spot fix, ADR-088): the 9 MFA-management
 	// (ActivateMFASecretProxy/SetUserMFAEnabledProxy/CreateMFARecoveryCodesProxy/
 	// DeleteMFAForUserProxy/DeleteMFARecoveryCodesProxy) and retention-purge

--- a/server/http/remote_storage_machine_identities_test.go
+++ b/server/http/remote_storage_machine_identities_test.go
@@ -329,7 +329,7 @@ func TestRemoteStorageMachineIdentities_CredentialCreateGetHashListRevokeTouch_R
 
 	// RevokeMachineIdentityCredential flips Revoked and is visible directly on
 	// the upstream.
-	require.NoError(t, downstream.Storage().RevokeMachineIdentityCredential(ctx, cred.ID))
+	require.NoError(t, downstream.Storage().RevokeMachineIdentityCredential(ctx, projectID, cred.ID))
 	revoked, err := upstream.Storage().GetMachineIdentityCredentialByID(ctx, cred.ID)
 	require.NoError(t, err)
 	assert.True(t, revoked.Revoked)
@@ -340,6 +340,45 @@ func TestRemoteStorageMachineIdentities_CredentialCreateGetHashListRevokeTouch_R
 	for _, c := range activeAfter {
 		assert.NotEqual(t, cred.ID, c.ID, "a revoked credential must not appear in the active list")
 	}
+}
+
+// TestRemoteStorageMachineIdentities_RevokeCredential_CrossTenantRejected_RealServer
+// proves the #1551 fix: a caller reaching RevokeMachineIdentityCredentialProxy
+// directly (as this test does, exactly like a caller holding raw system.write
+// but not going through core.RevokeMachineToken's own client-side ownership
+// check) cannot revoke a credential by naming a project it doesn't actually
+// belong to. Before the fix, the wire carried no project_id at all and the
+// upstream revoked by credential ID alone — this scenario would have
+// succeeded. A positive control at the end proves the SAME credential is
+// still revocable when the caller names its real project, so this isn't
+// coincidentally rejecting every revoke.
+func TestRemoteStorageMachineIdentities_RevokeCredential_CrossTenantRejected_RealServer(t *testing.T) {
+	upstream, downstream, projectID := newUpstreamDownstreamForMachineIdentities(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	m, err := downstream.Storage().CreateMachineIdentity(ctx, buildMachineIdentity(now, projectID, "cross-tenant-test"))
+	require.NoError(t, err)
+
+	const hash = "cafef00d00112233445566778899aabbccddeeff0011223344556677889900"
+	cred, err := downstream.Storage().CreateMachineIdentityCredential(ctx, buildMachineIdentityCredential(now, m.ID, hash))
+	require.NoError(t, err)
+
+	wrongProjectID := projectID + 999
+	err = downstream.Storage().RevokeMachineIdentityCredential(ctx, wrongProjectID, cred.ID)
+	require.Error(t, err, "revoking with a project_id the credential's machine doesn't belong to must be rejected")
+
+	// The credential must still be live on the upstream — the rejected call
+	// must not have revoked it anyway.
+	stillLive, err := upstream.Storage().GetMachineIdentityCredentialByID(ctx, cred.ID)
+	require.NoError(t, err)
+	assert.False(t, stillLive.Revoked, "a cross-tenant revoke attempt must not revoke the credential")
+
+	// Positive control: the same credential, same caller, correct project_id.
+	require.NoError(t, downstream.Storage().RevokeMachineIdentityCredential(ctx, projectID, cred.ID))
+	revoked, err := upstream.Storage().GetMachineIdentityCredentialByID(ctx, cred.ID)
+	require.NoError(t, err)
+	assert.True(t, revoked.Revoked, "revoking with the credential's real project_id must still succeed")
 }
 
 // TestRemoteStorageMachineIdentities_RoleGrantAssignRemoveListIDs_RealServer

--- a/server/http/system_write_ceiling_table_test.go
+++ b/server/http/system_write_ceiling_table_test.go
@@ -26,11 +26,14 @@
 // later DELETED outright -- #1585, docs/adr-090-stale-fork-proxy-deletion.md
 // -- no live caller). Its
 // RevokeMachineIdentityCredentialProxy coverage
-// (RevokeMachineIdentityCredentialProxy_NodeCredential_DeniedAtGate below) is
-// gate-level only: the current wire contract (DELETE-by-bare-credential-ID, no
-// project/scope parameter at all) can't express a per-grant scope check
-// without a RemoteStorage client-side change first — a different, harder fix
-// shape than the other rows here; filed as #1551, not closed by this table.
+// (RevokeMachineIdentityCredentialProxy_NodeCredential_DeniedAtGate below) was
+// originally gate-level only, since the wire contract (POST-by-bare-
+// credential-ID, no project/scope parameter at all) couldn't express a
+// per-grant scope check without a RemoteStorage client-side change first —
+// filed as #1551. That wire change landed (Wave 2, 2026-08-29): the route now
+// requires project_id and rejects a cross-tenant claim in the storage layer's
+// own WHERE clause (see raw_storage_bypass_guard_test.go's entry for this
+// handler for the still-open residual, audit + cache-eviction hand-off).
 //
 // A second dimension: "Node-credential-path rows" below exercise the
 // human-caller rows' SAME write routes again, but with a bare node-type
@@ -747,15 +750,17 @@ func TestSystemWriteCeiling_AssignRoleWithExpiryProxy_NodeCredential_DeniedAtGat
 }
 
 // TestSystemWriteCeiling_RevokeMachineIdentityCredentialProxy_NodeCredential_DeniedAtGate
-// closes #1551's node-credential axis: RevokeMachineIdentityCredentialProxy
-// itself is STILL an unconditional raw storage.RevokeMachineIdentityCredential
-// passthrough with no caller-authority or project-scope check at all — that
-// deeper gap (any system.write holder can revoke any credential cross-tenant)
-// is unchanged and remains filed as #1551 (the wire contract, a bare
-// credential ID with no scope parameter, can't express a scope check without
-// a RemoteStorage client-side change first). What ADR-085 closes is narrower
-// but real: a bare node credential can no longer reach the handler AT ALL,
-// refused at the /system group's own system.write gate.
+// closes #1551's node-credential axis: a bare node credential can no longer
+// reach RevokeMachineIdentityCredentialProxy at all, refused at the /system
+// group's own system.write gate (ADR-085) — before the request body is ever
+// read, so this holds regardless of the handler's own body shape. #1551's
+// deeper cross-tenant gap (any system.write holder could revoke any
+// credential by naming any project) is now FIXED separately (Wave 2,
+// 2026-08-29): RevokeMachineIdentityCredentialProxy requires project_id on
+// the wire and storage.Storage.RevokeMachineIdentityCredential enforces it in
+// its WHERE clause. Audit + cache-eviction hand-off remain a separate, still-
+// open residual (raw_storage_bypass_guard_test.go's own entry for this
+// handler).
 func TestSystemWriteCeiling_RevokeMachineIdentityCredentialProxy_NodeCredential_DeniedAtGate(t *testing.T) {
 	f := setupCeilingTableFixtures(t)
 	status, body := doCeilingRequestAs(t, f, f.nodeToken, http.MethodPost, fmt.Sprintf("/api/v1/system/machine-credentials/%d/revoke", f.plainCredID), nil)


### PR DESCRIPTION
## Summary
- #1546 (`TransitionMembershipProxy`): full delegation to `core.TransitionMembership` -- no live spoke exists, so ADR-088's duplication concern for full delegation doesn't apply; closes the ceiling gap, the role-grant side-effect gap, plus two previously-unnamed gaps (wire-forgery of Role/UserID, missing state-machine legality check).
- #1572 (`UpdateUserIfActiveStateMatchesProxy`): calls `core.RevokeAllPersonalAccessTokensForUser`/`core.DeleteSessionsForUserExcept` in-process after a matched true->false transition -- live CLI spoke confirmed (`internal/cli/user/update.go`).
- #1551 (`RevokeMachineIdentityCredentialProxy`): `RevokeMachineIdentityCredential` now takes a `projectID`, enforced in `LocalStorage`'s WHERE clause and carried on the wire -- live CLI spoke confirmed (`internal/cli/machine/token.go`), whose ownership check previously ran client-side only.
- #1575 (11 CLI commands): re-confirmed still live and unfixed; issue reopened with a wire-change assessment. Not implemented in this pass -- the CLI's remote connection authenticates with a single static credential, so closing this needs a client-asserted-actor delegation-trust primitive, not a same-shape bolt-on.

Guard registry: `knownUnfixedRawStorageBypasses` 7->5, `rawStorageBypassAllowlist` 41->42.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./server/http/...` (includes `TestNoUnjustifiedRawStorageBypass` and real upstream/downstream integration tests)
- [x] `go test ./server/http/handlers/...`
- [x] `go test ./internal/core/...`
- [x] `go test ./internal/storage/...`
- [x] `go test ./internal/config/...`
- [x] Each fix verified red-before/green-after by temporarily reverting the subject and re-running its exploit-shaped test, plus a positive control confirming the legitimate caller still succeeds.