### PR TITLE
fix(rbac): close AssignPermissionToRole's machine-actor #169 bypass (#1545)

### DIFF
--- a/internal/core/actor_sentinel_completeness_test.go
+++ b/internal/core/actor_sentinel_completeness_test.go
@@ -63,6 +63,15 @@ const (
 	// today and the per-actor ceiling is skipped -- a confirmed, live,
 	// tracked gap, not fixed by this table. See note for the issue.
 	statusOpenGap
+	// statusReasonedSafe: a machine actor can reach this branch with
+	// actorID==0 and the per-actor ceiling IS skipped, same mechanism as
+	// statusOpenGap -- but tracing what the skipped check would have added
+	// shows it is fully subsumed by an earlier, coarser gate the caller
+	// already had to clear to reach this code at all, so skipping it confers
+	// no extra reach. Not the same claim as statusEnforced (nothing here
+	// denies the machine actor); the note must show the escalation-delta
+	// derivation, not just assert safety.
+	statusReasonedSafe
 )
 
 type actorSentinelEntry struct {
@@ -97,8 +106,8 @@ var actorSentinelAllowlist = map[string]actorSentinelEntry{
 		note: "#1542: actorIsMachine parameter added, denies a machine actor instead of exempting it. AssignRoleWithExpiryProxy's non-node-relay path now passes isMachineActor(r); a genuine node relay skips this function entirely (still calls raw storage, by design -- see rbac_role_grants_proxy.go). Other callers (AssignUserRole's OWN callers -- AddProjectMember, the AssignRole gRPC/HTTP endpoint, access-request approval) still pass actorIsMachine=false unconditionally -- sibling gap, not fixed here.",
 	},
 	"bulk_delete.go:BulkDeleteSecrets": {
-		class: classPerActorCeiling, status: statusOpenGap,
-		note: "actorID==0 skips GetSecretWithPermissionCheck/DeleteSecretWithPermissionCheck's per-secret ACL/ownership check (2 occurrences, same function). Live gap: reachable by any machine identity holding project-scoped secrets.delete. #1545, not fixed here.",
+		class: classPerActorCeiling, status: statusReasonedSafe,
+		note: "#1545 escalation-delta analysis: actorID==0 skips GetSecretWithPermissionCheck/DeleteSecretWithPermissionCheck's per-secret ACL/ownership check (2 occurrences, same function), but the route (POST /projects/{id}/secrets/bulk-delete) is gated by RequireScopedPermission(secrets.delete, projectScope) -- Scope{ProjectID, EnvironmentID:0}. GetUserRoleIDsAt/GetMachineRoleIDsAt only match a stored grant whose environment_id is 0 (global) or the scope's environment_id against a project-level (env=0) query, so ONLY a project-wide secrets.delete grant clears that gate; an environment-scoped-only grant is refused before the handler ever runs. Every skipped per-secret check (isLiveOwner, share, ACL-for-humans, RBAC fallback) is purely additive -- it can only grant MORE access, never less -- and the RBAC fallback resolves to the identical AuthorizePrincipal(secrets.delete, {ProjectID, EnvironmentID: secret's env}) call, which a project-wide grant always satisfies (broader scope covers narrower). So the exemption confers no reach a project-wide secrets.delete holder didn't already have by clearing the router gate. Not a vulnerability; issue closed on this reasoning, not fixed.",
 	},
 	"compliance_digest.go:SendComplianceDigest": {
 		class: classAuditOnly,
@@ -113,8 +122,8 @@ var actorSentinelAllowlist = map[string]actorSentinelEntry{
 		note:  "attribution-only: whether to attach a non-nil actor pointer to the prune audit record.",
 	},
 	"rbac_management.go:AssignPermissionToRole": {
-		class: classPerActorCeiling, status: statusOpenGap,
-		note: "actorID==0 skips the #169 self-permission-bundling check. Live gap: reachable by any machine identity holding roles.write globally. #1545, not fixed here.",
+		class: classPerActorCeiling, status: statusEnforced,
+		note: "#1545: actorIsMachine parameter added (matching P1's AddUserToGroup/ApproveRiskException shape); a machine actor is now denied instead of exempted from the #169 self-permission-bundling check. Only server/http/handlers/rbac.go's direct AssignPermissionToRole handler needed the real isMachineActor(r) value threaded in -- CreateRole/UpdateRole already pre-authorize every permission via Authorize(ctx, userCtx.UserID, ...) before ever reaching this function, which already denied a machine actor (userID 0 has no roles), so those two callers keep actorIsMachine=false unchanged.",
 	},
 	"secret_acl.go:GrantSecretACL": {
 		class: classPerActorCeiling, status: statusEnforced,
@@ -253,7 +262,8 @@ func TestActorSentinelOpenGapsAreTracked(t *testing.T) {
 		}
 	}
 	sort.Strings(open)
-	const knownOpen = 2 // bulk_delete.go:BulkDeleteSecrets, rbac_management.go:AssignPermissionToRole -- #1545
+	const knownOpen = 0 // #1545's two entries are resolved: AssignPermissionToRole fixed (statusEnforced),
+	// BulkDeleteSecrets reasoned safe (statusReasonedSafe) -- see their notes above.
 	if len(open) != knownOpen {
 		t.Errorf("expected exactly %d statusOpenGap classPerActorCeiling entries (tracked via #1545), found %d: %v\n"+
 			"A new open gap needs its own issue filed (see #1545's shape) before this count changes; a closed "+

--- a/internal/core/rbac_audit_test.go
+++ b/internal/core/rbac_audit_test.go
@@ -146,7 +146,7 @@ func TestRBACAuditTrail_PermissionToRole(t *testing.T) {
 	c := NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
 
-	require.NoError(t, c.AssignPermissionToRole(ctx, 5, 2, 8))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 5, 2, 8, false))
 	require.NoError(t, c.RemovePermissionFromRole(ctx, 5, 2, 8))
 
 	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -72,7 +72,19 @@ func (c *KeyorixCore) GetRoleWithPermissions(ctx context.Context, roleID uint) (
 // considered and declined. What changes is visibility: the audit event and
 // log warning below let an operator/reviewer SEE that a built-in role's
 // authorization baseline moved, without blocking the move.
-func (c *KeyorixCore) AssignPermissionToRole(ctx context.Context, actorID, roleID, permissionID uint) error {
+//
+// #1545: actorIsMachine distinguishes a machine-credential-authenticated caller
+// (UserID==0 by construction, ADR-030) from the true "no authenticated principal"
+// case the actorID==0 exemption below was written for (system/background callers
+// like ReconcileRBACPermissions). Both present as actorID==0; only the latter is
+// exempt. A machine identity holding nothing but roles.write reached this
+// unguarded — server/http/handlers/rbac.go's AssignPermissionToRole handler
+// passes userCtx.UserID directly, unlike CreateRole/UpdateRole which already
+// pre-authorize every permission via Authorize(ctx, userCtx.UserID, ...) before
+// ever reaching here (and so already denied a machine actor there — Authorize
+// has no user ID 0 to find roles for). actorID==0 with actorIsMachine==true now
+// falls into the check below, which correctly fails closed the same way.
+func (c *KeyorixCore) AssignPermissionToRole(ctx context.Context, actorID, roleID, permissionID uint, actorIsMachine bool) error {
 	role, err := c.storage.GetRole(ctx, roleID)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
@@ -86,8 +98,8 @@ func (c *KeyorixCore) AssignPermissionToRole(ctx context.Context, actorID, roleI
 	// additive, non-clobbering, once-per-boot top-up of newly-added canonical
 	// permissions — #293). Those callers have no role of their own to hold the
 	// permission being bundled, so the #169 self-permission check only applies to a
-	// real (non-zero) actor.
-	if actorID != 0 {
+	// real (non-zero) actor OR a machine-credential-authenticated one (#1545).
+	if actorID != 0 || actorIsMachine {
 		if ok, aerr := c.Authorize(ctx, actorID, perm.Name, Scope{}); aerr != nil {
 			return fmt.Errorf("failed to resolve actor authority: %w", aerr)
 		} else if !ok {

--- a/internal/core/rbac_management_test.go
+++ b/internal/core/rbac_management_test.go
@@ -38,13 +38,58 @@ func TestAssignPermissionToRole_RequiresActorHoldPermission(t *testing.T) {
 	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "system.write", Resource: "system", Action: "write"}).Error)
 
 	const attacker = uint(9) // holds ONLY roles.write in the real exploit scenario, no roles at all here
-	err := c.AssignPermissionToRole(ctx, attacker, 1, 1)
+	err := c.AssignPermissionToRole(ctx, attacker, 1, 1, false)
 	require.Error(t, err, "an actor who doesn't hold system.write must not be able to bundle it into a role")
 	assert.Contains(t, err.Error(), "do not hold it yourself")
 
 	var count int64
 	require.NoError(t, db.Model(&models.RolePermission{}).Count(&count).Error)
 	assert.Zero(t, count, "the permission must not have been assigned")
+}
+
+// #1545: a machine identity presents actorID==0 by construction (ADR-030, no
+// UserID), the same value the actorID==0 exemption was written for a true
+// "no authenticated principal" system caller (ReconcileRBACPermissions).
+// Before this fix, AssignPermissionToRole's `if actorID != 0` gate silently
+// exempted a machine caller from the #169 self-permission check right
+// alongside that trusted system caller — a machine identity holding nothing
+// but roles.write (a legitimate, grantable, non-admin permission) could
+// bundle system.write into ANY role's definition without holding it itself.
+// Exploit-shaped: this is the exact attacker shape (actorID==0, actorIsMachine
+// true, no roles at all) — must be denied, not silently trusted. Verified red
+// before the actorIsMachine fix (temporarily reverted the `|| actorIsMachine`
+// clause locally and confirmed this test failed with the assignment
+// succeeding), green after.
+func TestAssignPermissionToRole_MachineActorRequiresHoldPermission(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "custom"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "system.write", Resource: "system", Action: "write"}).Error)
+
+	err := c.AssignPermissionToRole(ctx, 0, 1, 1, true)
+	require.Error(t, err, "a machine actor (actorID==0, actorIsMachine=true) who doesn't hold system.write must not be able to bundle it into a role")
+	assert.Contains(t, err.Error(), "do not hold it yourself")
+
+	var count int64
+	require.NoError(t, db.Model(&models.RolePermission{}).Count(&count).Error)
+	assert.Zero(t, count, "the permission must not have been assigned")
+}
+
+// Positive control: the true "no authenticated principal" system caller
+// (actorID==0, actorIsMachine=false — e.g. ReconcileRBACPermissions's startup
+// top-up, #293) must remain exempt from the #169 check exactly as before —
+// the fix narrows the exemption to that genuine case, it does not remove it.
+func TestAssignPermissionToRole_SystemPseudoActorStillExempt(t *testing.T) {
+	c, db := newRBACManagementCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "custom"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "system.write", Resource: "system", Action: "write"}).Error)
+
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, 1, 1, false))
+
+	var count int64
+	require.NoError(t, db.Model(&models.RolePermission{}).Where("role_id = ? AND permission_id = ?", 1, 1).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
 }
 
 // The escalation path the finding describes: attacker holds roles.write (only)
@@ -63,7 +108,7 @@ func TestAssignPermissionToRole_ScopedHolderCannotBundleGlobally(t *testing.T) {
 	// attacker holds "system.write" only at project 3, not globally.
 	require.NoError(t, db.Create(&models.UserRole{UserID: attacker, RoleID: 2, ProjectID: 3}).Error)
 
-	err := c.AssignPermissionToRole(ctx, attacker, 1, 1)
+	err := c.AssignPermissionToRole(ctx, attacker, 1, 1, false)
 	require.Error(t, err, "a project-scoped holder of system.write must not bundle it into a role, which is a global object")
 }
 
@@ -80,7 +125,7 @@ func TestAssignPermissionToRole_HolderMaySelfBundle(t *testing.T) {
 	const holder = uint(9)
 	require.NoError(t, db.Create(&models.UserRole{UserID: holder, RoleID: 2}).Error) // global grant
 
-	require.NoError(t, c.AssignPermissionToRole(ctx, holder, 1, 1))
+	require.NoError(t, c.AssignPermissionToRole(ctx, holder, 1, 1, false))
 
 	var count int64
 	require.NoError(t, db.Model(&models.RolePermission{}).Where("role_id = ? AND permission_id = ?", 1, 1).Count(&count).Error)
@@ -99,7 +144,7 @@ func TestAssignPermissionToRole_AdminBypasses(t *testing.T) {
 	const admin = uint(9)
 	require.NoError(t, db.Create(&models.UserRole{UserID: admin, RoleID: 2}).Error)
 
-	require.NoError(t, c.AssignPermissionToRole(ctx, admin, 1, 1))
+	require.NoError(t, c.AssignPermissionToRole(ctx, admin, 1, 1, false))
 }
 
 // RemovePermissionFromRole is purely subtractive (weakens a role) — it must NOT
@@ -188,7 +233,7 @@ func TestAssignPermissionToRole_BuiltinRoleTarget_SignalsInAudit(t *testing.T) {
 	require.NoError(t, db.Create(&models.UserRole{UserID: actor, RoleID: 1}).Error)
 
 	logOutput := captureLog(t, func() {
-		require.NoError(t, c.AssignPermissionToRole(ctx, actor, 1, 1))
+		require.NoError(t, c.AssignPermissionToRole(ctx, actor, 1, 1, false))
 	})
 
 	event, detail := lastRBACEventDetail(t, c, EventPermissionAdded)
@@ -212,7 +257,7 @@ func TestAssignPermissionToRole_NonBuiltinRole_NoSignal(t *testing.T) {
 	require.NoError(t, db.Create(&models.UserRole{UserID: holder, RoleID: 2}).Error)
 
 	logOutput := captureLog(t, func() {
-		require.NoError(t, c.AssignPermissionToRole(ctx, holder, 1, 1))
+		require.NoError(t, c.AssignPermissionToRole(ctx, holder, 1, 1, false))
 	})
 
 	event, detail := lastRBACEventDetail(t, c, EventPermissionAdded)

--- a/internal/core/rbac_reconcile.go
+++ b/internal/core/rbac_reconcile.go
@@ -79,7 +79,7 @@ func (c *KeyorixCore) ReconcileRBACPermissions(ctx context.Context) error { // N
 			// convention every other system-initiated grant uses) so this startup
 			// top-up emits permission.assigned like every other permission grant
 			// path, instead of leaving the tamper-evident audit chain silent (#293).
-			if err := c.AssignPermissionToRole(ctx, 0, role.ID, id); err != nil {
+			if err := c.AssignPermissionToRole(ctx, 0, role.ID, id, false); err != nil {
 				log.Printf("rbac reconcile: grant %s to role %s: %v", permName, rdef.Name, err)
 			}
 		}

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -75,7 +75,7 @@ func (s *RoleGRPCService) CreateRole(ctx context.Context, req *pb.CreateRoleRequ
 		return nil, mapRoleError(err)
 	}
 	for _, pid := range permIDs {
-		if err := s.core.AssignPermissionToRole(ctx, actor.UserID, role.ID, pid); err != nil {
+		if err := s.core.AssignPermissionToRole(ctx, actor.UserID, role.ID, pid, false); err != nil {
 			return nil, status.Error(codes.Internal, "failed to assign permissions to role")
 		}
 	}
@@ -151,7 +151,7 @@ func (s *RoleGRPCService) UpdateRole(ctx context.Context, req *pb.UpdateRoleRequ
 			}
 		}
 		for _, pid := range permIDs {
-			if err := s.core.AssignPermissionToRole(ctx, actor.UserID, role.ID, pid); err != nil {
+			if err := s.core.AssignPermissionToRole(ctx, actor.UserID, role.ID, pid, false); err != nil {
 				return nil, status.Error(codes.Internal, "failed to update role permissions")
 			}
 		}

--- a/server/http/delete_project_proxy_scope_test.go
+++ b/server/http/delete_project_proxy_scope_test.go
@@ -70,8 +70,8 @@ func createSystemWriteAndProjectSecretsDeleteToken(t *testing.T, c *core.Keyorix
 	require.NotZero(t, systemWriteID, "system.write permission must already be seeded by bootstrap")
 	require.NotZero(t, secretsDeleteID, "secrets.delete permission must already be seeded by bootstrap")
 
-	require.NoError(t, c.AssignPermissionToRole(ctx, 0, globalRole.ID, systemWriteID))
-	require.NoError(t, c.AssignPermissionToRole(ctx, 0, scopedRole.ID, secretsDeleteID))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, globalRole.ID, systemWriteID, false))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, scopedRole.ID, secretsDeleteID, false))
 	require.NoError(t, c.Storage().AssignRole(ctx, user.ID, globalRole.ID, coreStorage.Scope{}))
 	require.NoError(t, c.Storage().AssignRole(ctx, user.ID, scopedRole.ID, coreStorage.Scope{ProjectID: projectID}))
 

--- a/server/http/g80_1530_machine_actor_attribution_test.go
+++ b/server/http/g80_1530_machine_actor_attribution_test.go
@@ -52,7 +52,7 @@ func TestG80_1530_MachineActorAttribution_NonNodeServiceIdentity(t *testing.T) {
 		}
 	}
 	require.NotZero(t, systemWriteID)
-	require.NoError(t, testCore.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID))
+	require.NoError(t, testCore.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID, false))
 	require.NoError(t, testCore.Storage().AssignMachineRole(ctx, mi.ID, role.ID, coreStorage.Scope{}))
 
 	result, err := testCore.IssueMachineToken(ctx, projects[0].ID, mi.ID, admin.ID, core.IssueMachineTokenParams{Name: "g80-1530-probe-token"})

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -179,7 +179,7 @@ func (h *RBACHandler) CreateRole(w http.ResponseWriter, r *http.Request) {
 
 	var assignedPerms []*models.Permission
 	for _, perm := range toAssign {
-		if err := h.coreService.AssignPermissionToRole(r.Context(), userCtx.UserID, role.ID, perm.ID); err != nil {
+		if err := h.coreService.AssignPermissionToRole(r.Context(), userCtx.UserID, role.ID, perm.ID, false); err != nil {
 			// Already authorized above; only a race (permission deleted concurrently) or
 			// storage error reaches here — log it, the role still exists with the rest.
 			log.Printf("Warning: could not assign permission %q to role %d: %v", perm.Name, role.ID, err)
@@ -397,7 +397,7 @@ func (h *RBACHandler) replaceRolePermissions(ctx context.Context, actorID, roleI
 		_ = h.coreService.RemovePermissionFromRole(ctx, actorID, roleID, ep.ID)
 	}
 	for _, perm := range toAssign {
-		if err := h.coreService.AssignPermissionToRole(ctx, actorID, roleID, perm.ID); err != nil {
+		if err := h.coreService.AssignPermissionToRole(ctx, actorID, roleID, perm.ID, false); err != nil {
 			log.Printf("Warning: could not assign permission %q to role %d: %v", perm.Name, roleID, err)
 		}
 	}
@@ -676,7 +676,7 @@ func (h *RBACHandler) AssignPermissionToRole(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if err := h.coreService.AssignPermissionToRole(r.Context(), userCtx.UserID, roleID, body.PermissionID); err != nil {
+	if err := h.coreService.AssignPermissionToRole(r.Context(), userCtx.UserID, roleID, body.PermissionID, isMachineActor(r)); err != nil {
 		log.Printf("Error assigning permission to role: %v", err)
 		switch {
 		case strings.Contains(err.Error(), errNotFound):

--- a/server/http/handlers/rbac_real_test.go
+++ b/server/http/handlers/rbac_real_test.go
@@ -165,6 +165,37 @@ func TestRBACReal_AssignPermissionToRole201(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, w.Code)
 }
 
+// #1545: the real reachable route — server/http/handlers/rbac.go's
+// AssignPermissionToRole passes userCtx.UserID straight through to
+// core.AssignPermissionToRole with no isMachineActor(r) indirection prior to
+// this fix, unlike CreateRole/UpdateRole which pre-authorize every permission
+// before ever reaching the core call. A machine identity presents UserID==0
+// (ADR-030) — the same value the #169 self-permission check's actorID==0
+// exemption was written for a trusted system caller — so a machine holding
+// nothing but the route's gating permission (roles.write) could bundle a
+// permission it does not hold into any role's definition. Exploit-shaped:
+// no role/permission grant exists for the machine at all.
+func TestRBACReal_AssignPermissionToRole_MachineActorDenied(t *testing.T) {
+	handler, _, db := setupRBACTestWithDB(t)
+	role := mustCreateRole(t, db, "victim-role")
+	perm := mustCreatePermission(t, db, "system.write", "system", "write")
+
+	body := fmt.Sprintf(`{"permission_id":%d}`, perm.ID)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/roles/%d/permissions", role.ID),
+		bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withMachineCtx(withChiParam(req, "id", fmt.Sprintf("%d", role.ID)))
+	w := httptest.NewRecorder()
+
+	handler.AssignPermissionToRole(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var count int64
+	require.NoError(t, db.Model(&models.RolePermission{}).Where("role_id = ? AND permission_id = ?", role.ID, perm.ID).Count(&count).Error)
+	assert.Zero(t, count, "the permission must not have been assigned")
+}
+
 func TestRBACReal_RemovePermissionFromRole204(t *testing.T) {
 	handler, _, db := setupRBACTestWithDB(t)
 	role := mustCreateRole(t, db, "operator")

--- a/server/http/remote_storage_access_request_test.go
+++ b/server/http/remote_storage_access_request_test.go
@@ -348,7 +348,7 @@ func grantSystemWrite(t *testing.T, upstream *core.KeyorixCore, userID uint) {
 			}
 		}
 		require.NotZero(t, systemWriteID, "system.write permission must already be seeded by bootstrap")
-		require.NoError(t, upstream.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID))
+		require.NoError(t, upstream.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID, false))
 	}
 	require.NoError(t, st.AssignRole(ctx, userID, role.ID, coreStorage.Scope{}))
 }

--- a/server/http/system_write_ceiling_table_test.go
+++ b/server/http/system_write_ceiling_table_test.go
@@ -122,8 +122,8 @@ func createSystemWriteAndRolesAssignToken(t *testing.T, c *core.KeyorixCore) str
 	require.NotZero(t, systemWriteID, "system.write permission must already be seeded by bootstrap")
 	require.NotZero(t, rolesAssignID, "roles.assign permission must already be seeded by bootstrap")
 
-	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID))
-	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, rolesAssignID))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID, false))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, rolesAssignID, false))
 	require.NoError(t, c.AssignRoleToUser(ctx, "sys_write_roles_assign@example.com", "ceiling_test_system_writer_roles_assign"))
 
 	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "sys_write_roles_assign", Password: "Qr7#Kp2$Lm5@Vn9!"})
@@ -166,8 +166,8 @@ func createSystemWriteAndUsersWriteToken(t *testing.T, c *core.KeyorixCore) stri
 	require.NotZero(t, systemWriteID, "system.write permission must already be seeded by bootstrap")
 	require.NotZero(t, usersWriteID, "users.write permission must already be seeded by bootstrap")
 
-	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID))
-	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, usersWriteID))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID, false))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, usersWriteID, false))
 	require.NoError(t, c.AssignRoleToUser(ctx, "sys_write_users_write@example.com", "ceiling_test_system_writer_users_write"))
 
 	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "sys_write_users_write", Password: "Qr7#Kp2$Lm5@Vn9!"})

--- a/server/http/system_write_ceiling_table_users_test.go
+++ b/server/http/system_write_ceiling_table_users_test.go
@@ -86,8 +86,8 @@ func createUsersWriteToken(t *testing.T, c *core.KeyorixCore) string {
 	require.NotZero(t, systemWriteID, "system.write permission must already be seeded by bootstrap")
 	require.NotZero(t, usersWriteID, "users.write permission must already be seeded by bootstrap")
 
-	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID))
-	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, usersWriteID))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID, false))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, usersWriteID, false))
 	require.NoError(t, c.AssignRoleToUser(ctx, "users_write_holder@example.com", "ceiling_test_users_and_system_writer"))
 
 	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "users_write_holder", Password: "Qr7#Kp2$Lm5@Vn9!"})

--- a/server/http/system_write_ceiling_test.go
+++ b/server/http/system_write_ceiling_test.go
@@ -74,7 +74,7 @@ func createSystemWriteOnlyToken(t *testing.T, c *core.KeyorixCore) string {
 
 	// actorID 0 = the system pseudo-actor (skips AssignPermissionToRole's #169
 	// self-permission-holding check, which a fixture setup step has no actor for).
-	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, role.ID, systemWriteID, false))
 	require.NoError(t, c.AssignRoleToUser(ctx, "sys_write_only@example.com", "ceiling_test_system_writer"))
 
 	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "sys_write_only", Password: "Qr7#Kp2$Lm5@Vn9!"})


### PR DESCRIPTION
## Summary

- Closes the live half of #1545: a machine identity (actorID==0 by construction, ADR-030) holding only `roles.write` could bundle **any** permission into **any** role's definition via `POST /api/v1/roles/{id}/permissions`, bypassing the #169 self-permission-bundling check — the handler passes `userCtx.UserID` straight through with no `isMachineActor(r)` indirection, unlike `CreateRole`/`UpdateRole`, which already pre-authorize every permission before reaching `AssignPermissionToRole` (and so already deny a machine actor there).
- Fix mirrors #1524(b)/(c)'s `AddUserToGroup`/`ApproveRiskException` shape exactly: thread an `actorIsMachine bool` through, run the #169 check when `actorID != 0 || actorIsMachine`.
- #1545's *other* finding — `BulkDeleteSecrets`'s identical-looking `actorID==0` exemption — is **not fixed here**. Escalation-delta analysis (see commit message and `internal/core/actor_sentinel_completeness_test.go`) shows the route's coarse gate already requires PROJECT-WIDE `secrets.delete` to reach the handler at all, which strictly subsumes every per-secret check the exemption skips. No exploitable delta; reclassified `statusReasonedSafe`, not a vulnerability.

## Test plan

- [x] New exploit-shaped tests, verified red before the fix / green after (temporarily reverted the `|| actorIsMachine` clause and confirmed both fail):
  - `TestAssignPermissionToRole_MachineActorRequiresHoldPermission` (core layer)
  - `TestRBACReal_AssignPermissionToRole_MachineActorDenied` (HTTP layer, real route + real core, machine `UserContext`)
- [x] Positive controls unaffected: `TestAssignPermissionToRole_SystemPseudoActorStillExempt` (new — the true system pseudo-actor stays exempt), `TestAssignPermissionToRole_HolderMaySelfBundle`, `TestAssignPermissionToRole_AdminBypasses`, `TestRBACReal_AssignPermissionToRole201`
- [x] `internal/core/actor_sentinel_completeness_test.go`'s guard registry updated and green — tracked open-gap count for #1545 drops from 2 to 0 (predicted before running, confirmed after)
- [x] `TestNodeCredentialRoutes_MatchClassification`, `TestNodeCredentialRoutes_PerActorCeilingsAreEnforced`, `TestNoUnjustifiedRawStorageBypass` unaffected (this route isn't in the node-credential-gated group)
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/core/... ./server/http/... ./server/grpc/...` green