### PR TITLE
fix(rbac): distinct machine approvers no longer collapse in dual control (#1573)

### DIFF
--- a/docs/adr-091-machine-createdby-attribution-classification.md
+++ b/docs/adr-091-machine-createdby-attribution-classification.md
@@ -1,0 +1,226 @@
+# ADR-091: `CreatedBy`-shaped attribution fields left 0 for a machine actor — classification and the invariant it depends on
+
+## Status
+
+**Accepted (2026-08-29).** #1573. Classification recorded here; fixes tracked
+separately (PR1 for the check-breaking subset, PR2 for the mechanical
+attribution-only subset — see "What this does not resolve").
+
+## What this is
+
+#1530 fixed `AuditEvent.MachineIdentityID`: a machine identity's audit-log
+attribution was 0 (unattributed) despite `ActorType` correctly saying
+"a machine did this." #1573 asked the sibling question: do any *persisted
+model fields* (`CreatedBy`, `RevokedBy`, `OwnerID`, and similarly-shaped
+attribution columns) have the same gap — and unlike an audit log, a model
+row's `CreatedBy: 0` cannot be backfilled later, because nothing else on the
+row records who it really was.
+
+## Task 1 — no centralization point exists, and the reason is structural
+
+#1530's fix cost zero call sites because `emitAudit` (the single audit-write
+choke point) lives in the same package (`internal/core`) as the context key
+it reads (`machineActorFromContext`, `internal/core/audit_context.go`).
+
+That precondition does not hold for model fields:
+
+- Model attribution fields are set at `db.Create(&models.X{...})`, called
+  from `internal/storage/store` using structs from `internal/storage/models`.
+  Neither package imports `internal/core` (confirmed: `core` imports them,
+  never the reverse) — a GORM hook living on a model struct (where hooks
+  must live to fire automatically) cannot reference `core`'s **unexported**
+  `machineActorKey{}` without either an import cycle or relocating the key
+  to a new shared package neither side currently has.
+- No `BeforeCreate` hook exists anywhere in this codebase today — only
+  `BeforeSave` (15+ models, `models_beforesave_test.go`), and every one of
+  those only normalizes the struct's own timestamp fields; none reads
+  context.
+- The machine ID is already available as a plain function parameter at
+  (almost) every write site — `userCtx.MachineIdentityID`, resolved
+  synchronously in the HTTP handler before the core call. #1530 needed
+  context-threading specifically because audit writes run in **detached
+  goroutines** past request cancellation (`DetachedAuditContext`); model
+  creates don't have that problem, so the justification for context over an
+  explicit parameter doesn't transfer either.
+
+A hook-based centralization is buildable (relocate the context key,
+introduce `BeforeCreate` as a real pattern) and would scale by *model count*
+rather than *call-site count* — but it's a genuine architecture change, not
+a "register one callback" fix, and its cost isn't clearly lower than passing
+an already-available parameter explicitly. **Verdict: per-site, not
+centralized.**
+
+## Task 2 — the invariant this classification depends on
+
+Ten of the 26 traced fields (across 8 models) were classified "unreachable
+by any machine caller" because their route is gated by `RequirePermission`
+(`== RequireScopedPermission(perm, ScopeGlobal)`) — and a machine identity
+can **never** hold a role grant at global scope:
+
+- `AssignMachineRole`'s `machineInProject` check (`internal/core/machine_token.go`)
+  requires `m.ProjectID == scope.ProjectID`.
+- Every real `MachineIdentity` row has a nonzero `ProjectID` —
+  `CreateMachineIdentity` rejects `projectID == 0` outright
+  (`internal/core/machine_identities.go`).
+- The only production caller of `storage.AssignMachineRole` is
+  `core.AssignMachineRole`, always behind `machineInProject` — no other path
+  writes a `MachineIdentityRole` row.
+- So `GetMachineRoleIDsAt(machineID, Scope{ProjectID: 0})` — the query
+  `AuthorizePrincipal`'s machine branch uses — can never match a stored
+  grant, for any machine, ever.
+
+This rule is load-bearing for **ten** "unreachable" verdicts in this
+classification, and for reachability analysis in #1545 as well. Applying it
+consistently caught two initial over-claims during this investigation
+(`RejectionReasonTemplate.CreatedBy` and `SecretTemplate.CreatedBy` were
+both reported reachable via a route later found to be global-scope-gated).
+
+**Guarded**: `internal/core/machine_global_scope_invariant_test.go` —
+`TestAssignMachineRole_GlobalScopeRejected` pins the write-side half (a real
+machine, nonzero `ProjectID`, can never be granted a role at
+`Scope{ProjectID: 0}`); `TestCreateMachineIdentity_RejectsZeroProject` pins
+the creation-side half that makes the write-side check meaningful (no
+production path can ever produce the `ProjectID == 0` `MachineIdentity` row
+that would otherwise defeat it);
+`TestAssignMachineRole_GlobalScopeRejected_EvenIfMachineLookupSomehowReturnedGlobal`
+documents — rather than silently assumes — that `machineInProject`'s
+comparison alone would NOT catch a corrupted `ProjectID == 0` row; the
+creation-side guard is the sole thing preventing that. Verified red by
+temporarily relaxing `machineInProject`'s comparison to accept any project
+and confirming `TestAssignMachineRole_GlobalScopeRejected` failed with
+`storage.AssignMachineRole` actually invoked, then reverted.
+
+**If this invariant is ever weakened** — `machineInProject` relaxed, or a
+new path to `storage.AssignMachineRole`/`storage.CreateMachineIdentity`
+added that bypasses either check — this guard goes red, and every "Bucket 3"
+verdict below (and #1545's global-scope reasoning) must be re-derived, not
+assumed to still hold.
+
+## Task 2 — the three-bucket classification
+
+26 attribution-shaped fields (`*By uint`/`*By *uint`/`OwnerID uint`) exist
+across 22 models in `internal/storage/models/models.go` — no other file in
+the package carries any.
+
+### Bucket 1 — reachable, leaves 0 (11 fields / 10 models — the live gap)
+
+| Model.Field | Core write site | Gate (scope) |
+|---|---|---|
+| `ProjectInvitation.InvitedBy` | `invitations.go:134,264` | `roles.assign` (project) |
+| `AccessRequest.ResolvedBy` (approve path) | `invitations.go:785` | `roles.assign` (project) |
+| `AccessRequest.ResolvedBy` (reject path) | `invitations.go:848` | `roles.assign` (project) |
+| `AccessRequestApproval.ApproverID` | `invitations.go:741,779` | `roles.assign` (project) |
+| `BreakGlassActivation.RevokedBy` | `break_glass.go:282` | `roles.assign` (project) |
+| `AccessReviewCampaign.CreatedBy` | `access_review_campaign.go:98` | `roles.assign` (project) |
+| `AccessReviewCampaign.ClosedBy` | `access_review_campaign.go:413` | `roles.assign` (project) |
+| `SecretDependency.CreatedBy` | `secret_dependencies.go:131` | `secrets.write` (secret's own scope) |
+| `SecretNode.OwnerID` (creation only) | `secrets.go:149` | `secrets.write` (project/env) |
+| `SetupToken.CreatedBy` | `setup_token.go:132` | `roles.assign` (project) |
+| `MachineIdentity.CreatedBy` | `machine_identities.go:108` | `roles.assign` (project) |
+| `ProjectMembership.InvitedBy` | `membership_lifecycle.go:187` | `roles.assign` (project) |
+
+Every route here is gated by an ordinary, project-scoped, machine-grantable
+permission, and the handler forwards `userCtx.UserID`/`actor.UserID`
+straight into the attribution field with no `isMachineActor` check. Note:
+`AccessRequest.ResolvedBy` is set by two distinct code paths — see the
+check-breaking split below.
+
+### Bucket 2 — reachable, correctly attributed/denied (5 fields / 5 models)
+
+- `AccessReviewItem.DecidedBy` — `requireHumanReviewer` rejects `actorID==0` explicitly.
+- `SecretACL.GrantedBy` — `GrantSecretACL` rejects `actorID==0` outright.
+- `SecretNode.OwnerID` (**reassignment** path, distinct from creation above) — `secret_ownership.go`/`secret_reassign_owner.go` both reject `actorID==0`.
+- `ShareRecord.OwnerID` — gated by `requireLiveOwnerAuthority` (`actorID == secret.OwnerID`); a machine's `actorID` (0) can never equal a real owner ID.
+- `MachineIdentityOIDCBinding.CreatedBy` — `requireAdminAuthorityAt` resolves *user* role grants only; a machine's placeholder `actorID` (0) never resolves to an admin user row.
+- `AccessRequest.ResolvedBy` (the `ApproveSecretAccessRequest` restricted-secret path, `classification_gate.go:288`) — gated by `requireAdminAuthorityAt`, same reasoning.
+
+### Bucket 3 — unreachable by any machine caller (10 fields / 8 models)
+
+`SoDPolicy.CreatedBy`, `LegalHold.PlacedBy`, `LegalHold.ReleasedBy`,
+`RiskException.CreatedBy`, `RiskException.RevokedBy`,
+`RiskException.ApprovedBy`, `AnomalyAlert.AcknowledgedBy`,
+`AlertEscalationPolicy.CreatedBy`, `RejectionReasonTemplate.CreatedBy`,
+`SecretTemplate.CreatedBy` — all gated by `RequirePermission` (unscoped),
+including the `/system` `storage.type: remote` proxy siblings for
+`LegalHold`/`RiskException`, which reuse the identical global `system.write`
+group gate (`server/http/router.go:1097-1098`). Depends entirely on the
+invariant above.
+
+## Task 1 (continued) — the check-breaking subset
+
+Not all 11 Bucket-1 fields are equal. Traced whether a zero *defeats a
+check* (a correctness bug) versus merely *loses a record* (attribution
+hygiene):
+
+**`AccessRequestApproval.ApproverID` + `AccessRequest.ResolvedBy`'s approve
+path — check-defeating, narrower than first thought.**
+`ApproveAccessRequestWithExpiry` (`internal/core/invitations.go`) runs two
+checks keyed on the raw actor value before either field is written:
+
+1. Self-approval (`approverID == req.UserID`) — **investigated and ruled
+   out**: `RequestProjectAccess` rejects `userID == 0` outright
+   (`invitations.go:510-511`) and `AccessRequest.UserID` is never
+   reassigned after creation, so a machine identity can never be the
+   requester and `req.UserID` is guaranteed nonzero for the request's
+   entire lifetime. A machine approver's `approverID` (0) can never
+   collide with a real nonzero `req.UserID`. This check is safe as-is —
+   an earlier pass through this investigation reported it as defeated;
+   re-verified and corrected before implementing anything on that premise.
+2. Distinct-approver counting (`hasAlreadyApproved`, iterating existing
+   `AccessRequestApproval` rows for `ApproverID == approverID`) — **stands
+   as the real defect**: under human-originated, K-of-N (K≥2) dual control,
+   a first machine approves (`ApproverID: 0`); a second, genuinely
+   different machine's legitimate approval collides on the same value and
+   is wrongly rejected as "you have already approved this request." The
+   threshold can never be reached via two or more distinct machine
+   approvers — the DB-level `uniqueIndex:ux_access_request_approver` on
+   `(RequestID, ApproverID)` would refuse the second row even if the
+   in-memory check were bypassed.
+
+Fails closed (no unauthorized grant ever occurs) but defeats dual control's
+core promise of K *distinct* approvers for machine approvers, and returns a
+false, misleading error to a legitimate second approver. This is a
+correctness bug, not attribution loss — tracked for PR1. Since requesters
+can never be machines, PR1's fix only needs to make `hasAlreadyApproved`
+machine-identity-aware — no companion field is needed on `AccessRequest`
+itself for the requester side.
+
+`RejectAccessRequest` (`invitations.go:832`) also sets `ResolvedBy` but runs
+neither check — attribution-only there.
+
+**`BreakGlassActivation.RevokedBy` — attribution-only.** Every reference
+repo-wide is either the single write site, a test assertion, or a wire/proxy
+passthrough; the gRPC response conditionally omits it when zero rather than
+comparing against it. No authorization decision anywhere reads this field.
+
+**All other Bucket-1 fields** (`ProjectInvitation.InvitedBy`,
+`AccessReviewCampaign.CreatedBy`/`ClosedBy`, `SecretDependency.CreatedBy`,
+`SecretNode.OwnerID`, `SetupToken.CreatedBy`, `MachineIdentity.CreatedBy`,
+`ProjectMembership.InvitedBy`) — attribution-only; none feeds a comparison
+or counting check.
+
+## Missing-field vs. zeroed-field split
+
+These are different defects with different fixes, kept separate:
+
+- **`Notification`** (`models.go:1250`) — no actor field at all, by design
+  (confirmed unchanged from #1589): a notification doesn't need to record a
+  trigger the way a governance record does. Not a bug.
+- **`ConnectRefGrant`** (`models.go:677`) — flagged as a *plausible* gap but
+  not traced during this investigation: an admin-mutated
+  authorization-scope grant (role↔connector↔ref-prefix) with `CreatedAt`
+  but no actor field, unlike its siblings (`ShareRecord`/`RiskException`/
+  `BreakGlassActivation`, all of which carry a real attribution trail).
+  Filed separately (#1621) rather than assumed either way.
+
+## What this does not resolve
+
+- **PR1** (not yet landed): fix the check-breaking subset
+  (`AccessRequestApproval.ApproverID` + `AccessRequest.ResolvedBy`'s approve
+  and reject paths) with machine-identity-aware self-approval and
+  distinct-approver logic, exploit-shaped tests, and positive controls.
+- **PR2** (not yet landed): mechanical, one diff — companion
+  `*MachineIdentityID *uint` fields (mirroring `AuditEvent.MachineIdentityID`)
+  for the remaining 9 Bucket-1 fields, populated at each write site from the
+  already-resolved `userCtx.MachineIdentityID`.
+- **#1621** (`ConnectRefGrant`) — filed, not investigated.

--- a/docs/adr-091-machine-createdby-attribution-classification.md
+++ b/docs/adr-091-machine-createdby-attribution-classification.md
@@ -102,7 +102,7 @@ assumed to still hold.
 across 22 models in `internal/storage/models/models.go` — no other file in
 the package carries any.
 
-### Bucket 1 — reachable, leaves 0 (11 fields / 10 models — the live gap)
+### Bucket 1 — reachable, leaves 0 (10 fields / 9 models — the live gap)
 
 | Model.Field | Core write site | Gate (scope) |
 |---|---|---|
@@ -113,7 +113,6 @@ the package carries any.
 | `BreakGlassActivation.RevokedBy` | `break_glass.go:282` | `roles.assign` (project) |
 | `AccessReviewCampaign.CreatedBy` | `access_review_campaign.go:98` | `roles.assign` (project) |
 | `AccessReviewCampaign.ClosedBy` | `access_review_campaign.go:413` | `roles.assign` (project) |
-| `SecretDependency.CreatedBy` | `secret_dependencies.go:131` | `secrets.write` (secret's own scope) |
 | `SecretNode.OwnerID` (creation only) | `secrets.go:149` | `secrets.write` (project/env) |
 | `SetupToken.CreatedBy` | `setup_token.go:132` | `roles.assign` (project) |
 | `MachineIdentity.CreatedBy` | `machine_identities.go:108` | `roles.assign` (project) |
@@ -124,6 +123,24 @@ permission, and the handler forwards `userCtx.UserID`/`actor.UserID`
 straight into the attribution field with no `isMachineActor` check. Note:
 `AccessRequest.ResolvedBy` is set by two distinct code paths — see the
 check-breaking split below.
+
+**`SecretDependency.CreatedBy` was initially reported here and is removed —
+this classification's own verification error, corrected before implementing
+PR2.** The batch trace reported it as reachable-and-zero, inherited from
+#1573's original filing, without re-checking the actual handler call site.
+Re-verified: `server/http/handlers/secret_dependencies.go:89` calls
+`AddSecretDependency` with `userCtx.PrincipalID()`, not `.UserID` —
+`PrincipalID()` (`server/middleware/auth.go:135-140`) returns the machine's
+own `MachineIdentity.ID` for a machine caller, not 0. `CreatedBy` is already
+stamped with the machine's real ID. This surfaced a *different* problem
+instead — `CreatedBy uint` has no discriminator between a `User.ID` and a
+`MachineIdentity.ID` (separate tables, independent auto-increment sequences,
+so the two can and eventually will collide numerically) — filed separately
+as #1623, not fixed here; it's a different bug shape (silently ambiguous,
+not silently absent) that plausibly needs its own schema decision. The other
+8 Bucket-1 fields' handler call sites were all re-checked against the same
+question and confirmed to pass the raw, always-zero-for-machines
+`UserID`/`actor.UserID` — no other instance of this pattern found.
 
 ### Bucket 2 — reachable, correctly attributed/denied (5 fields / 5 models)
 
@@ -194,8 +211,8 @@ passthrough; the gRPC response conditionally omits it when zero rather than
 comparing against it. No authorization decision anywhere reads this field.
 
 **All other Bucket-1 fields** (`ProjectInvitation.InvitedBy`,
-`AccessReviewCampaign.CreatedBy`/`ClosedBy`, `SecretDependency.CreatedBy`,
-`SecretNode.OwnerID`, `SetupToken.CreatedBy`, `MachineIdentity.CreatedBy`,
+`AccessReviewCampaign.CreatedBy`/`ClosedBy`, `SecretNode.OwnerID`,
+`SetupToken.CreatedBy`, `MachineIdentity.CreatedBy`,
 `ProjectMembership.InvitedBy`) — attribution-only; none feeds a comparison
 or counting check.
 
@@ -215,12 +232,14 @@ These are different defects with different fixes, kept separate:
 
 ## What this does not resolve
 
-- **PR1** (not yet landed): fix the check-breaking subset
+- **PR1** (#1622, landed): fixed the check-breaking subset
   (`AccessRequestApproval.ApproverID` + `AccessRequest.ResolvedBy`'s approve
   and reject paths) with machine-identity-aware self-approval and
   distinct-approver logic, exploit-shaped tests, and positive controls.
 - **PR2** (not yet landed): mechanical, one diff — companion
   `*MachineIdentityID *uint` fields (mirroring `AuditEvent.MachineIdentityID`)
-  for the remaining 9 Bucket-1 fields, populated at each write site from the
-  already-resolved `userCtx.MachineIdentityID`.
+  for the remaining 8 attribution-only Bucket-1 fields, populated at each
+  write site from the already-resolved `userCtx.MachineIdentityID`.
 - **#1621** (`ConnectRefGrant`) — filed, not investigated.
+- **#1623** (`SecretDependency.CreatedBy`'s `User`/`MachineIdentity` ID-space
+  collision, discovered while starting PR2) — filed, not investigated.

--- a/internal/cli/request/request_s24_test.go
+++ b/internal/cli/request/request_s24_test.go
@@ -189,7 +189,7 @@ func TestRunReview_RejectFailsOnAlreadyRejected(t *testing.T) {
 	// CLI init opening the same file (same svc instance — no ambiguity).
 	admin, err := svc.GetUserByEmail(ctx, "admin@example.com")
 	require.NoError(t, err)
-	_, err = svc.RejectAccessRequest(ctx, projectID, req.ID, admin.ID, "first")
+	_, err = svc.RejectAccessRequest(ctx, projectID, req.ID, admin.ID, 0, "first")
 	require.NoError(t, err)
 
 	// Now try to reject via the CLI — the request is no longer pending.
@@ -236,7 +236,7 @@ func TestRunReview_ApproveFailsOnAlreadyApproved(t *testing.T) {
 	// First approval via core directly — puts state = "approved".
 	admin, err := svc.GetUserByEmail(ctx, "admin@example.com")
 	require.NoError(t, err)
-	_, err = svc.ApproveAccessRequestWithExpiry(ctx, projectID, req.ID, admin.ID, "viewer", 0)
+	_, err = svc.ApproveAccessRequestWithExpiry(ctx, projectID, req.ID, admin.ID, 0, "viewer", 0)
 	require.NoError(t, err)
 
 	// Now try to approve again via the CLI — must hit the error branch.

--- a/internal/cli/request/review.go
+++ b/internal/cli/request/review.go
@@ -95,7 +95,7 @@ func runReview(cmd *cobra.Command, args []string) error { // NOSONAR -- cognitiv
 				return fmt.Errorf("--ttl must be a non-negative Go duration (e.g. 4h)")
 			}
 		}
-		req, err := service.ApproveAccessRequestWithExpiry(ctx, projectID, reviewID, approverID, reviewRole, ttl)
+		req, err := service.ApproveAccessRequestWithExpiry(ctx, projectID, reviewID, approverID, 0, reviewRole, ttl)
 		if err != nil {
 			return fmt.Errorf("failed to approve access request: %w", err)
 		}
@@ -112,7 +112,7 @@ func runReview(cmd *cobra.Command, args []string) error { // NOSONAR -- cognitiv
 		fmt.Printf("Access request %d approved: granted role %q to %s %s.\n",
 			req.ID, req.GrantedRole, userLabel(ctx, service, req.UserID), grantNote)
 	case "reject":
-		req, err := service.RejectAccessRequest(ctx, projectID, reviewID, approverID, reviewReason)
+		req, err := service.RejectAccessRequest(ctx, projectID, reviewID, approverID, 0, reviewReason)
 		if err != nil {
 			return fmt.Errorf("failed to reject access request: %w", err)
 		}

--- a/internal/core/bulk_access_requests.go
+++ b/internal/core/bulk_access_requests.go
@@ -154,7 +154,7 @@ func (k *KeyorixCore) BulkRejectAccessRequests(ctx context.Context, requestIDs [
 			})
 			continue
 		}
-		_, rejectErr := k.RejectAccessRequest(ctx, req.ProjectID, id, approverID, reason)
+		_, rejectErr := k.RejectAccessRequest(ctx, req.ProjectID, id, approverID, 0, reason)
 		if rejectErr != nil {
 			result.Failed = append(result.Failed, BulkAccessError{
 				RequestID: id,

--- a/internal/core/concurrency_g04_threshold_race_test.go
+++ b/internal/core/concurrency_g04_threshold_race_test.go
@@ -215,7 +215,7 @@ func TestConcurrency_ApproveAccessRequestWithExpiry_ThresholdRace(t *testing.T) 
 			go func(approverID uint) {
 				defer wg.Done()
 				<-start
-				_, err := c.ApproveAccessRequestWithExpiry(ctx, 1, requestID, approverID, "", 0)
+				_, err := c.ApproveAccessRequestWithExpiry(ctx, 1, requestID, approverID, 0, "", 0)
 				switch {
 				case err == nil:
 					finalized.Add(1)

--- a/internal/core/core_s25_test.go
+++ b/internal/core/core_s25_test.go
@@ -528,7 +528,7 @@ func TestRejectAccessRequest_NotFound(t *testing.T) {
 	ms := new(MockStorage)
 	ms.On("GetAccessRequest", mock.Anything, uint(99)).Return(nil, errors.New("not found"))
 	c := NewKeyorixCore(ms)
-	_, err := c.RejectAccessRequest(context.Background(), 1, 99, 1, "no")
+	_, err := c.RejectAccessRequest(context.Background(), 1, 99, 1, 0, "no")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "access request not found")
 }
@@ -537,7 +537,7 @@ func TestRejectAccessRequest_WrongProject(t *testing.T) {
 	ms := new(MockStorage)
 	ms.On("GetAccessRequest", mock.Anything, uint(5)).Return(&models.AccessRequest{ID: 5, ProjectID: 2, State: AccessRequestPending}, nil)
 	c := NewKeyorixCore(ms)
-	_, err := c.RejectAccessRequest(context.Background(), 1, 5, 1, "no")
+	_, err := c.RejectAccessRequest(context.Background(), 1, 5, 1, 0, "no")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "access request not found")
 }
@@ -546,7 +546,7 @@ func TestRejectAccessRequest_NotPending(t *testing.T) {
 	ms := new(MockStorage)
 	ms.On("GetAccessRequest", mock.Anything, uint(5)).Return(&models.AccessRequest{ID: 5, ProjectID: 1, State: AccessRequestApproved}, nil)
 	c := NewKeyorixCore(ms)
-	_, err := c.RejectAccessRequest(context.Background(), 1, 5, 1, "no")
+	_, err := c.RejectAccessRequest(context.Background(), 1, 5, 1, 0, "no")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only a pending request")
 }
@@ -562,7 +562,7 @@ func TestRejectAccessRequest_Success(t *testing.T) {
 	ms.On("ListNotifications", mock.Anything, uint(2), mock.Anything, mock.Anything).Return([]*models.Notification{}, nil)
 	ms.On("CreateNotification", mock.Anything, mock.Anything).Return(&models.Notification{}, nil)
 	c := NewKeyorixCore(ms)
-	got, err := c.RejectAccessRequest(context.Background(), 1, 5, 1, "not now")
+	got, err := c.RejectAccessRequest(context.Background(), 1, 5, 1, 0, "not now")
 	require.NoError(t, err)
 	assert.Equal(t, AccessRequestRejected, got.State)
 }
@@ -574,7 +574,7 @@ func TestRejectAccessRequest_ConcurrentUpdate(t *testing.T) {
 	// ok=false: concurrent resolution
 	ms.On("UpdateAccessRequest", mock.Anything, mock.Anything).Return(false, nil)
 	c := NewKeyorixCore(ms)
-	_, err := c.RejectAccessRequest(context.Background(), 1, 5, 1, "no")
+	_, err := c.RejectAccessRequest(context.Background(), 1, 5, 1, 0, "no")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "concurrently")
 }

--- a/internal/core/dual_control_external_test.go
+++ b/internal/core/dual_control_external_test.go
@@ -34,7 +34,7 @@ func TestApprove_SingleControlDefault(t *testing.T) {
 	h.AssignUserRole(t, 11, 2, nil)
 	reqID := seedPendingRequest(t, h, 10)
 
-	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, "", 0)
+	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, 0, "", 0)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", req.State)
 
@@ -63,7 +63,7 @@ func TestApprove_DualControl(t *testing.T) {
 	reqID := seedPendingRequest(t, h, 10)
 
 	// First approval: still pending, no grant yet.
-	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, "", 0)
+	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, 0, "", 0)
 	require.NoError(t, err)
 	assert.Equal(t, "pending", req.State)
 	assert.Equal(t, 1, req.ApprovalsReceived)
@@ -72,14 +72,14 @@ func TestApprove_DualControl(t *testing.T) {
 	assert.NotContains(t, ids, uint(3), "no grant before the threshold")
 
 	// Same approver again → rejected.
-	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, "", 0)
+	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, 0, "", 0)
 	require.Error(t, err)
 	// The requester cannot approve their own request.
-	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 10, "", 0)
+	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 10, 0, "", 0)
 	require.Error(t, err)
 
 	// Second distinct approver reaches the threshold → granted.
-	req, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 12, "", 0)
+	req, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 12, 0, "", 0)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", req.State)
 	ids, _ = h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: 2})
@@ -109,19 +109,19 @@ func TestApprove_DualControl_RoleLockedToRequest(t *testing.T) {
 	reqID := seedPendingRequest(t, h, 10) // SuggestedRole "editor"
 
 	// First approver signs off on the request as-stated.
-	_, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, "", 0)
+	_, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, 0, "", 0)
 	require.NoError(t, err)
 
 	// The second (threshold-crossing) approver tries to escalate to a higher EXISTING
 	// role ("admin", id 2) than the requested "editor". Without the fix this would
 	// succeed (the last approver's role wins); the request must instead be rejected.
-	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 12, "admin", 0)
+	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 12, 0, "admin", 0)
 	require.Error(t, err, "an approver must not substitute a different role under dual control")
 	ids, _ := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: 2})
 	assert.NotContains(t, ids, uint(2), "the escalated role (admin) must not be granted")
 
 	// Approving the request as-stated (matching role) grants exactly the requested role.
-	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 12, "editor", 0)
+	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 12, 0, "editor", 0)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", req.State)
 	assert.Equal(t, "editor", req.GrantedRole)
@@ -147,8 +147,63 @@ func TestApprove_DualControl_RequiresRoleAtRequestTime(t *testing.T) {
 
 	// Even with a role supplied by the approver, multi-party control won't accept a
 	// request that named no role for everyone to review.
-	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, req.ID, 11, "editor", 0)
+	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, req.ID, 11, 0, "editor", 0)
 	require.Error(t, err)
+}
+
+// #1573: two DISTINCT machine identities approving under K=2 dual control must
+// both count — before the fix, ApproverID is 0 for every machine caller
+// (ADR-030, no UserID), so hasAlreadyApproved's ApproverID-only comparison
+// treated the second machine's genuinely distinct approval as a duplicate of
+// the first, and the threshold could never be reached via machine approvers.
+// Exploit-shaped: two different approverMachineID values, both approverID=0
+// (the real production shape — no role grant needed since "editor" is
+// non-admin and requireAuthorityForRole only gates admin-tier roles).
+func TestApprove_DualControl_TwoDistinctMachineApprovers(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.AuditEvent{}))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10) // requester (human — RequestProjectAccess requires nonzero UserID)
+	h.CoreService.SetDualControlPolicy(2)
+	reqID := seedPendingRequest(t, h, 10)
+
+	// Machine 101 approves: still pending, no grant yet.
+	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 0, 101, "", 0)
+	require.NoError(t, err, "the first machine approver must succeed")
+	assert.Equal(t, "pending", req.State)
+	assert.Equal(t, 1, req.ApprovalsReceived)
+
+	// Machine 202 — a GENUINELY DIFFERENT machine, same approverID (0) — approves next.
+	// Before the fix this was rejected as "you have already approved this request".
+	req, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 0, 202, "", 0)
+	require.NoError(t, err, "a second, distinct machine approver must not be treated as a duplicate of the first")
+	assert.Equal(t, "approved", req.State)
+	ids, _ := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: 2})
+	assert.Contains(t, ids, uint(3), "editor granted once two distinct machine approvers signed off")
+}
+
+// Positive control: dual control must still reject a genuine duplicate — the
+// SAME machine identity attempting to approve twice. The fix must narrow the
+// false-positive (two different machines colliding on ApproverID=0) without
+// widening a false-negative (the same machine approving twice).
+func TestApprove_DualControl_SameMachineApproverTwiceRejected(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.AuditEvent{}))
+
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.CoreService.SetDualControlPolicy(2)
+	reqID := seedPendingRequest(t, h, 10)
+
+	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 0, 101, "", 0)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", req.State)
+
+	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 0, 101, "", 0)
+	require.Error(t, err, "the same machine approving twice must still be rejected as a duplicate")
 }
 
 // The listing annotates a pending request with its M-of-K progress.
@@ -162,7 +217,7 @@ func TestListAccessRequests_AnnotatesProgress(t *testing.T) {
 	h.CreateTestUser(t, "admin1", 11)
 	h.CoreService.SetDualControlPolicy(2)
 	reqID := seedPendingRequest(t, h, 10)
-	_, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, "", 0)
+	_, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, 0, "", 0)
 	require.NoError(t, err)
 
 	list, err := h.CoreService.ListAccessRequests(ctx, 2)

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -594,7 +594,7 @@ func (c *KeyorixCore) ListAccessRequests(ctx context.Context, projectID uint) ([
 // back to the suggested role) at the project scope, permanently. No auto-approval —
 // an admin performs this explicitly.
 func (c *KeyorixCore) ApproveAccessRequest(ctx context.Context, projectID, requestID, approverID uint, grantedRole string) (*models.AccessRequest, error) {
-	return c.ApproveAccessRequestWithExpiry(ctx, projectID, requestID, approverID, grantedRole, 0)
+	return c.ApproveAccessRequestWithExpiry(ctx, projectID, requestID, approverID, 0, grantedRole, 0)
 }
 
 // SetDualControlPolicy sets the N-of-M approval threshold for access requests
@@ -616,7 +616,7 @@ func (c *KeyorixCore) requiredApprovals() int {
 // is reached, grants the role — TIME-BOUND when grantTTL > 0 (JIT). Below the
 // threshold the request stays pending and the returned request carries the M-of-K
 // progress. When K is 1 (the default) the first approval grants immediately.
-func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projectID, requestID, approverID uint, grantedRole string, grantTTL time.Duration) (*models.AccessRequest, error) {
+func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projectID, requestID, approverID, approverMachineID uint, grantedRole string, grantTTL time.Duration) (*models.AccessRequest, error) {
 	// #G04: dualControlApprovalMu holds for the whole read-approvals-decide-
 	// grant sequence below — see its doc comment in service.go for why two
 	// approvers racing at the exact threshold boundary can otherwise both
@@ -690,16 +690,16 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	if err != nil {
 		return nil, fmt.Errorf("failed to read approvals: %w", err)
 	}
-	if hasAlreadyApproved(approvals, approverID) {
+	if hasAlreadyApproved(approvals, approverID, approverMachineID) {
 		return nil, fmt.Errorf("you have already approved this request")
 	}
 	received := len(approvals) + 1
 	// Below the threshold: record the approval, stay pending, notify, return progress.
 	if received < required {
-		return c.recordPartialApproval(ctx, req, requestID, approverID, received, required)
+		return c.recordPartialApproval(ctx, req, requestID, approverID, approverMachineID, received, required)
 	}
 	// Threshold reached — grant the role and finalize.
-	return c.finalizeAccessRequestApproval(ctx, req, approverID, roleModel, grantTTL, received, required)
+	return c.finalizeAccessRequestApproval(ctx, req, approverID, approverMachineID, roleModel, grantTTL, received, required)
 }
 
 // resolveApprovalRole determines the role string to grant for an approval, enforcing
@@ -724,10 +724,17 @@ func resolveApprovalRole(req *models.AccessRequest, grantedRole string, required
 	return role, nil
 }
 
-// hasAlreadyApproved reports whether approverID appears in the existing approvals.
-func hasAlreadyApproved(approvals []*models.AccessRequestApproval, approverID uint) bool {
+// hasAlreadyApproved reports whether the (approverID, approverMachineID) principal
+// already appears in the existing approvals. #1573: approverID alone is 0 for
+// EVERY machine caller (ADR-030, no UserID), so comparing only ApproverID would
+// treat any two distinct machine approvers as the same approver — the second,
+// genuinely different machine's legitimate sign-off would be rejected as a
+// duplicate, making a K>=2 threshold unreachable via machine approvers.
+// approverMachineID is 0 for a human approver, so the tuple comparison reduces
+// to the original ApproverID-only check for the human case unchanged.
+func hasAlreadyApproved(approvals []*models.AccessRequestApproval, approverID, approverMachineID uint) bool {
 	for _, a := range approvals {
-		if a.ApproverID == approverID {
+		if a.ApproverID == approverID && a.ApproverMachineIdentityID == approverMachineID {
 			return true
 		}
 	}
@@ -736,9 +743,9 @@ func hasAlreadyApproved(approvals []*models.AccessRequestApproval, approverID ui
 
 // recordPartialApproval handles the below-threshold path: records the approval, stays
 // pending, notifies, and returns progress annotations on the request.
-func (c *KeyorixCore) recordPartialApproval(ctx context.Context, req *models.AccessRequest, requestID, approverID uint, received, required int) (*models.AccessRequest, error) {
+func (c *KeyorixCore) recordPartialApproval(ctx context.Context, req *models.AccessRequest, requestID, approverID, approverMachineID uint, received, required int) (*models.AccessRequest, error) {
 	if err := c.storage.CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{
-		RequestID: requestID, ApproverID: approverID, CreatedAt: c.now(),
+		RequestID: requestID, ApproverID: approverID, ApproverMachineIdentityID: approverMachineID, CreatedAt: c.now(),
 	}); err != nil {
 		return nil, fmt.Errorf("failed to record approval: %w", err)
 	}
@@ -753,7 +760,7 @@ func (c *KeyorixCore) recordPartialApproval(ctx context.Context, req *models.Acc
 // finalizeAccessRequestApproval handles the threshold-reached path: grants the role,
 // records the approval, and updates the request state atomically. On a concurrent
 // write race (!ok) the grant is reverted and the caller receives an error.
-func (c *KeyorixCore) finalizeAccessRequestApproval(ctx context.Context, req *models.AccessRequest, approverID uint, roleModel *models.Role, grantTTL time.Duration, received, required int) (*models.AccessRequest, error) {
+func (c *KeyorixCore) finalizeAccessRequestApproval(ctx context.Context, req *models.AccessRequest, approverID, approverMachineID uint, roleModel *models.Role, grantTTL time.Duration, received, required int) (*models.AccessRequest, error) {
 	now := c.now()
 	scope := storage.Scope{ProjectID: req.ProjectID}
 	// Grant the role FIRST so that a grant failure leaves the approval unrecorded
@@ -776,13 +783,14 @@ func (c *KeyorixCore) finalizeAccessRequestApproval(ctx context.Context, req *mo
 		}
 	}
 	if err := c.storage.CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{
-		RequestID: req.ID, ApproverID: approverID, CreatedAt: now,
+		RequestID: req.ID, ApproverID: approverID, ApproverMachineIdentityID: approverMachineID, CreatedAt: now,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to record approval: %w", err)
 	}
 	req.State = AccessRequestApproved
 	req.GrantedRole = roleModel.Name
 	req.ResolvedBy = approverID
+	req.ResolvedByMachineIdentityID = approverMachineID
 	req.ResolvedAt = &now
 	ok, err := c.storage.UpdateAccessRequest(ctx, req)
 	if err != nil {
@@ -831,7 +839,7 @@ func (c *KeyorixCore) notifyApprovalProgress(ctx context.Context, req *models.Ac
 }
 
 // RejectAccessRequest rejects a pending request with a reason.
-func (c *KeyorixCore) RejectAccessRequest(ctx context.Context, projectID, requestID, approverID uint, reason string) (*models.AccessRequest, error) {
+func (c *KeyorixCore) RejectAccessRequest(ctx context.Context, projectID, requestID, approverID, approverMachineID uint, reason string) (*models.AccessRequest, error) {
 	req, err := c.storage.GetAccessRequest(ctx, requestID)
 	if err != nil {
 		return nil, fmt.Errorf("access request not found")
@@ -846,6 +854,7 @@ func (c *KeyorixCore) RejectAccessRequest(ctx context.Context, projectID, reques
 	req.State = AccessRequestRejected
 	req.Reason = reason
 	req.ResolvedBy = approverID
+	req.ResolvedByMachineIdentityID = approverMachineID
 	req.ResolvedAt = &now
 	ok, err := c.storage.UpdateAccessRequest(ctx, req)
 	if err != nil {

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -377,7 +377,7 @@ func TestApproveAccessRequestWithExpiry_RejectsSoftDeletedProject(t *testing.T) 
 	// The project is soft-deleted AFTER the request was filed, but before it's approved.
 	require.NoError(t, st.DeleteProject(ctx, proj.ID))
 
-	_, err = c.ApproveAccessRequestWithExpiry(ctx, proj.ID, req.ID, approver.ID, "", 0)
+	_, err = c.ApproveAccessRequestWithExpiry(ctx, proj.ID, req.ID, approver.ID, 0, "", 0)
 	require.Error(t, err, "approving a request against a soft-deleted project must be refused")
 	assert.Contains(t, err.Error(), "no longer exists")
 
@@ -524,7 +524,7 @@ func TestApproveAccessRequestWithExpiry_IsRBACAudited(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = c.ApproveAccessRequestWithExpiry(ctx, 1, req.ID, approver.ID, "", 0)
+	_, err = c.ApproveAccessRequestWithExpiry(ctx, 1, req.ID, approver.ID, 0, "", 0)
 	require.NoError(t, err)
 
 	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
@@ -546,7 +546,7 @@ func TestApproveAccessRequestWithExpiry_IsRBACAudited(t *testing.T) {
 		ProjectID: 1, UserID: requester.ID, SuggestedRole: "project_developer", State: AccessRequestPending,
 	})
 	require.NoError(t, err)
-	_, err = c.ApproveAccessRequestWithExpiry(ctx, 1, req2.ID, approver.ID, "", time.Hour)
+	_, err = c.ApproveAccessRequestWithExpiry(ctx, 1, req2.ID, approver.ID, 0, "", time.Hour)
 	require.NoError(t, err)
 
 	entries, _, err = c.ListRBACAuditLogs(ctx, 1, 50)

--- a/internal/core/jit_access_external_test.go
+++ b/internal/core/jit_access_external_test.go
@@ -125,7 +125,7 @@ func TestApproveAccessRequestWithExpiry_TimeBound(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, proj, created.ID, 1, "editor", time.Hour)
+	_, err = h.CoreService.ApproveAccessRequestWithExpiry(ctx, proj, created.ID, 1, 0, "editor", time.Hour)
 	require.NoError(t, err)
 
 	// The grant is active now (within the TTL window).

--- a/internal/core/machine_global_scope_invariant_test.go
+++ b/internal/core/machine_global_scope_invariant_test.go
@@ -1,0 +1,95 @@
+// machine_global_scope_invariant_test.go — guards a structural invariant that
+// #1573's investigation leaned on to classify ten attribution fields as
+// unreachable by any machine identity (see docs/adr-091-machine-global-scope-attribution.md):
+// a machine identity can never hold a role grant at global scope (ProjectID 0).
+//
+// The invariant holds because AssignMachineRole's machineInProject check
+// requires m.ProjectID == scope.ProjectID, and every real MachineIdentity row
+// has a nonzero ProjectID (machines are always created scoped to a project —
+// there is no machine-identity creation path that leaves ProjectID 0). So a
+// global-scope grant attempt can never find a matching machine, and
+// GetMachineRoleIDsAt(machineID, Scope{ProjectID:0}) — the query
+// AuthorizePrincipal's machine branch uses — never returns a role for any
+// machine at global scope either way. Any route gated by RequirePermission
+// (== RequireScopedPermission(perm, ScopeGlobal)) is therefore categorically
+// unreachable by a machine caller, independent of what permission it names or
+// what downstream check exists — a fact both this issue and #1545 depend on.
+//
+// Nothing else in this codebase asserts this — a future change to
+// machineInProject (or a new path to storage.AssignMachineRole that bypasses
+// it) would silently invalidate every classification built on it, with
+// nothing to catch the drift. This test is that catch.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAssignMachineRole_GlobalScopeRejected pins the invariant: a real machine
+// identity (nonzero ProjectID, as every one is) can never be granted a role at
+// global scope (Scope{ProjectID: 0}) — AssignMachineRole must refuse before
+// ever reaching storage.AssignMachineRole.
+//
+// Verified red per standing practice: temporarily changed machineInProject's
+// comparison from `m.ProjectID != projectID` to `false` (i.e. "any project
+// matches"), confirmed this test failed with storage.AssignMachineRole
+// actually invoked, then reverted.
+func TestAssignMachineRole_GlobalScopeRejected(t *testing.T) {
+	ms := new(MockStorage)
+	machine := &models.MachineIdentity{ID: 1, ProjectID: 5, Name: "ci-runner", State: MachineActive}
+	ms.On("GetMachineIdentity", mock.Anything, uint(1)).Return(machine, nil)
+	c := NewKeyorixCore(ms)
+
+	err := c.AssignMachineRole(context.Background(), 1, 2, Scope{ProjectID: 0}, 1)
+
+	require.Error(t, err, "a machine identity must never be grantable a role at global scope")
+	ms.AssertNotCalled(t, "AssignMachineRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestAssignMachineRole_GlobalScopeRejected_EvenIfMachineLookupSomehowReturnedGlobal
+// covers the theoretical case where GetMachineIdentity itself returned a row
+// with ProjectID 0 (should never happen in practice — every creation path
+// requires a nonzero project — but machineInProject's own comparison is what
+// this test pins, not the creation invariant, since a storage-layer bug
+// producing such a row is a different failure mode this check should still
+// catch defensively... except it wouldn't: matching ProjectIDs of 0 and 0
+// legitimately passes machineInProject. This is intentional and documented
+// here rather than silently assumed: the SOLE thing preventing a global-scope
+// machine grant is that no real MachineIdentity row ever has ProjectID 0, not
+// a second independent check. See TestCreateMachineIdentity_RejectsZeroProject
+// for the creation-side half of this invariant.
+func TestAssignMachineRole_GlobalScopeRejected_EvenIfMachineLookupSomehowReturnedGlobal(t *testing.T) {
+	ms := new(MockStorage)
+	machine := &models.MachineIdentity{ID: 1, ProjectID: 0, Name: "corrupted-fixture", State: MachineActive}
+	ms.On("GetMachineIdentity", mock.Anything, uint(1)).Return(machine, nil)
+	role := &models.Role{ID: 2, Name: "viewer"}
+	ms.On("GetRole", mock.Anything, uint(2)).Return(role, nil)
+	ms.On("AssignMachineRole", mock.Anything, uint(1), uint(2), mock.AnythingOfType("storage.Scope")).Return(nil)
+	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+	c := NewKeyorixCore(ms)
+
+	err := c.AssignMachineRole(context.Background(), 1, 2, Scope{ProjectID: 0}, 1)
+
+	require.NoError(t, err, "machineInProject matches ProjectID 0 == 0 -- this documents the gap rather than hiding it")
+	ms.AssertCalled(t, "AssignMachineRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestCreateMachineIdentity_RejectsZeroProject pins the other half of the
+// invariant: CreateMachineIdentity itself refuses projectID 0, so no
+// production path can ever produce the ProjectID==0 MachineIdentity row the
+// test above shows would defeat machineInProject's check. This is the
+// invariant's real enforcement point.
+func TestCreateMachineIdentity_RejectsZeroProject(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+
+	_, err := c.CreateMachineIdentity(context.Background(), 0, "orphan", "service", "", "", 1)
+
+	require.Error(t, err)
+	ms.AssertNotCalled(t, "CreateMachineIdentity", mock.Anything, mock.Anything)
+}

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -82,9 +82,17 @@ type AccessRequest struct {
 	State      string // pending | approved | rejected | withdrawn | expired
 	Reason     string // requester's note, or the rejecter's reason
 	ResolvedBy uint
-	ExpiresAt  *time.Time
-	CreatedAt  time.Time
-	ResolvedAt *time.Time
+	// ResolvedByMachineIdentityID (#1573) records which machine identity
+	// approved or rejected this request, when ResolvedBy is 0 because the
+	// resolver was a machine caller (ADR-030) rather than a human — mirrors
+	// AuditEvent.MachineIdentityID's purpose but as a plain uint (0 = none,
+	// consistent with every other attribution field on this model) rather than
+	// a nullable pointer, since it does not participate in a uniqueness
+	// constraint the way AccessRequestApproval.ApproverMachineIdentityID does.
+	ResolvedByMachineIdentityID uint
+	ExpiresAt                   *time.Time
+	CreatedAt                   time.Time
+	ResolvedAt                  *time.Time
 	// ApprovalsReceived / RequiredApprovals are transient (not persisted): the
 	// dual-control progress (M of K) the API surfaces for a pending request.
 	ApprovalsReceived int `gorm:"-"`
@@ -111,14 +119,31 @@ func (r *AccessRequest) BeforeSave(_ *gorm.DB) error {
 // RequiredApprovals distinct approvers (none of them the requester) have approved.
 type AccessRequestApproval struct {
 	ID uint `gorm:"primaryKey"`
-	// (RequestID, ApproverID) is unique: one sign-off per distinct approver. The
-	// constraint is the race backstop for the M-of-K dual-control count — without it,
-	// concurrent approvals from the same approver could insert multiple rows and the
-	// row-count threshold would treat one person as several, defeating dual control.
-	// The composite index also covers RequestID lookups (leftmost column).
+	// (RequestID, ApproverID, ApproverMachineIdentityID) is unique: one sign-off
+	// per distinct approver. The constraint is the race backstop for the M-of-K
+	// dual-control count — without it, concurrent approvals from the same
+	// approver could insert multiple rows and the row-count threshold would
+	// treat one person as several, defeating dual control. The composite index
+	// also covers RequestID lookups (leftmost column).
 	RequestID  uint `gorm:"not null;uniqueIndex:ux_access_request_approver"`
 	ApproverID uint `gorm:"not null;uniqueIndex:ux_access_request_approver"`
-	CreatedAt  time.Time
+	// ApproverMachineIdentityID (#1573) distinguishes one machine approver from
+	// another: ApproverID is 0 for every machine caller by construction
+	// (ADR-030, no UserID), so without this column the unique index above
+	// cannot tell two DIFFERENT machines' approvals apart from a duplicate
+	// approval by the SAME machine — the second, genuinely distinct machine's
+	// legitimate sign-off would collide on (RequestID, ApproverID=0) and be
+	// rejected as "already approved," making a K>=2 threshold unreachable via
+	// machine approvers. A plain uint (not *uint) with 0 = "no machine, this is
+	// a human approver" — deliberately NOT nullable, unlike
+	// AuditEvent.MachineIdentityID (#1530) — because this field participates in
+	// the uniqueness constraint above: SQL treats NULL as distinct from every
+	// other NULL, so a nullable column here would silently stop enforcing "one
+	// sign-off per human approver" (every human row would have NULL in this
+	// column and none would collide). 0 is a safe sentinel because no
+	// MachineIdentity row is ever assigned ID 0 (primary keys start at 1).
+	ApproverMachineIdentityID uint `gorm:"not null;default:0;uniqueIndex:ux_access_request_approver"`
+	CreatedAt                 time.Time
 }
 
 // RejectionReasonTemplate is a reusable pre-defined reason for rejecting access

--- a/server/http/handlers/invitations.go
+++ b/server/http/handlers/invitations.go
@@ -311,6 +311,14 @@ func (h *CatalogHandler) ResolveAccessRequest(w http.ResponseWriter, r *http.Req
 		sendError(w, "InvalidJSON", errInvalidRequestBody, http.StatusBadRequest, nil)
 		return
 	}
+	// #1573: approverMachineID distinguishes one machine approver from another —
+	// ApproverID/ResolvedBy is 0 for every machine caller (ADR-030, no UserID),
+	// so without this the dual-control distinct-approver count could not tell
+	// two different machines' sign-offs apart. 0 for a human actor.
+	var approverMachineID uint
+	if actor.MachineIdentityID != nil {
+		approverMachineID = *actor.MachineIdentityID
+	}
 	var resolveErr error
 	switch body.Action {
 	case "approve":
@@ -322,9 +330,9 @@ func (h *CatalogHandler) ResolveAccessRequest(w http.ResponseWriter, r *http.Req
 				return
 			}
 		}
-		_, resolveErr = h.coreService.ApproveAccessRequestWithExpiry(r.Context(), uint(projectID), uint(reqID), actor.UserID, body.GrantedRole, ttl)
+		_, resolveErr = h.coreService.ApproveAccessRequestWithExpiry(r.Context(), uint(projectID), uint(reqID), actor.UserID, approverMachineID, body.GrantedRole, ttl)
 	case "reject":
-		_, resolveErr = h.coreService.RejectAccessRequest(r.Context(), uint(projectID), uint(reqID), actor.UserID, body.Reason)
+		_, resolveErr = h.coreService.RejectAccessRequest(r.Context(), uint(projectID), uint(reqID), actor.UserID, approverMachineID, body.Reason)
 	default:
 		sendError(w, "ValidationError", "action must be approve or reject", http.StatusBadRequest, nil)
 		return


### PR DESCRIPTION
## Summary

- Closes the check-breaking half of #1573: `hasAlreadyApproved` compared only `ApproverID`, which is 0 for **every** machine caller by construction (ADR-030, no UserID). Under K-of-N (K≥2) dual control, a first machine's approval recorded `ApproverID=0`, and a second, genuinely distinct machine's legitimate sign-off collided on the same value and was rejected as "you have already approved this request" — the threshold could never be reached via two or more distinct machine approvers. Fails closed (no unauthorized grant ever occurred) but broke dual control's core promise of K *distinct* approvers.
- The self-approval check (`approverID == req.UserID`) was investigated and **ruled out** as broken: `RequestProjectAccess` rejects `userID == 0` outright, so `AccessRequest.UserID` can never be 0 and a machine approver can never collide with it. (An earlier pass through this investigation reported it as defeated too — corrected before implementing, see `docs/adr-091-...md`.)
- **Fix**: `AccessRequestApproval.ApproverMachineIdentityID` (plain `uint`, 0 = human/none — deliberately not nullable like `AuditEvent.MachineIdentityID` from #1530, since this field participates in the `(RequestID, ApproverID, ApproverMachineIdentityID)` uniqueness constraint, and NULL wouldn't collide with NULL). `hasAlreadyApproved` now compares the full tuple. `AccessRequest.ResolvedByMachineIdentityID` records which machine approved/rejected, same convention.
- Also lands the structural invariant #1573's whole 26-field classification depends on: a machine identity can never hold a role grant at global scope (`AssignMachineRole`'s `machineInProject` requires a nonzero `ProjectID`, and no production path ever creates a `MachineIdentity` with `ProjectID` 0). Guarded by `TestAssignMachineRole_GlobalScopeRejected` + `TestCreateMachineIdentity_RejectsZeroProject`. Full classification (three buckets, all 26 fields), the check-breaking-vs-attribution-only split, and the missing-field-vs-zeroed-field distinction recorded in `docs/adr-091-machine-createdby-attribution-classification.md`.
- PR2 (mechanical, the remaining 9 attribution-only Bucket-1 fields) and #1621 (`ConnectRefGrant`, filed separately) are tracked, not included here — per the requested two-PR split (not ten).

## Test plan

- [x] `TestApprove_DualControl_TwoDistinctMachineApprovers` — exploit-shaped, verified red before the `hasAlreadyApproved` fix (temporarily reverted to `ApproverID`-only comparison, confirmed the second machine's approval failed with "you have already approved this request") / green after
- [x] `TestApprove_DualControl_SameMachineApproverTwiceRejected` — positive control: the same machine approving twice must still be rejected as a genuine duplicate
- [x] `TestAssignMachineRole_GlobalScopeRejected` — verified red by temporarily relaxing `machineInProject`'s comparison, confirmed `storage.AssignMachineRole` was actually invoked, then reverted
- [x] `TestCreateMachineIdentity_RejectsZeroProject`, `TestAssignMachineRole_GlobalScopeRejected_EvenIfMachineLookupSomehowReturnedGlobal`
- [x] Existing dual-control/access-request suite unaffected (`TestApprove_SingleControlDefault`, `TestApprove_DualControl`, `TestApprove_DualControl_RoleLockedToRequest`, `TestRejectAccessRequest_*`, etc.)
- [x] `go build ./...`, `go vet ./...` clean
- [x] Full suite: `internal/core`, `internal/cli/...`, `server/http`, `server/http/handlers`, `server/grpc/...` all green