### PR TITLE
fix(rbac): record which machine identity acted, for 8 attribution-only fields (#1573)

### DIFF
--- a/internal/cli/invite/invite_s2_test.go
+++ b/internal/cli/invite/invite_s2_test.go
@@ -43,11 +43,11 @@ func seedInviteDB(t *testing.T) (projectID uint, invitationID uint) {
 
 	// InviteToProjectWithLink may fail on delivery (out-of-band mode), but the
 	// invitation is still created; fall back to InviteToProject if needed.
-	inv, _, linkErr := svc.InviteToProjectWithLink(ctx, proj.ID, "invitee@example.com", "project_viewer", resp.User.ID)
+	inv, _, linkErr := svc.InviteToProjectWithLink(ctx, proj.ID, "invitee@example.com", "project_viewer", resp.User.ID, 0)
 	if linkErr == nil && inv != nil {
 		return proj.ID, inv.ID
 	}
-	inv2, err2 := svc.InviteToProject(ctx, proj.ID, "invitee@example.com", "project_viewer", resp.User.ID)
+	inv2, err2 := svc.InviteToProject(ctx, proj.ID, "invitee@example.com", "project_viewer", resp.User.ID, 0)
 	if err2 == nil {
 		return proj.ID, inv2.ID
 	}

--- a/internal/cli/invite/send.go
+++ b/internal/cli/invite/send.go
@@ -61,7 +61,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	inv, prov, err := service.InviteToProjectWithLink(ctx, projectID, sendEmail, sendRole, invitedBy)
+	inv, prov, err := service.InviteToProjectWithLink(ctx, projectID, sendEmail, sendRole, invitedBy, 0)
 	if err != nil {
 		if inv == nil {
 			return fmt.Errorf("failed to send invitation: %w", err)

--- a/internal/cli/machine/create.go
+++ b/internal/cli/machine/create.go
@@ -65,7 +65,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize service: %w", err)
 	}
 	// #G67: operator-asserted actor (KEYORIX_CLI_ACTOR), not a hardcoded placeholder.
-	m, err := svc.CreateMachineIdentity(ctx, projectID, createName, createType, createDescription, createClassification, common.ResolveActorID())
+	m, err := svc.CreateMachineIdentity(ctx, projectID, createName, createType, createDescription, createClassification, common.ResolveActorID(), 0)
 	if err != nil {
 		return fmt.Errorf("failed to create machine identity: %w", err)
 	}

--- a/internal/cli/machine/machine_s2_test.go
+++ b/internal/cli/machine/machine_s2_test.go
@@ -67,7 +67,7 @@ func setupMachineLocalDB(t *testing.T) (projectID uint, machineID uint, machineN
 	require.NoError(t, err)
 	projectID = proj.ID
 
-	m, err := svc.CreateMachineIdentity(ctx, projectID, "ci-bot", "ci", "CI runner", "", 0)
+	m, err := svc.CreateMachineIdentity(ctx, projectID, "ci-bot", "ci", "CI runner", "", 0, 0)
 	require.NoError(t, err)
 	machineID = m.ID
 	machineName = m.Name

--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -70,7 +70,7 @@ func tallyProgress(items []*models.AccessReviewItem) CampaignProgress {
 // OpenAccessReviewCampaign snapshots the project's current access review into a new
 // campaign's items (each pending) and returns the campaign with its (all-pending)
 // progress. actorID is the opener.
-func (c *KeyorixCore) OpenAccessReviewCampaign(ctx context.Context, actorID, projectID uint, name string) (*CampaignWithProgress, error) {
+func (c *KeyorixCore) OpenAccessReviewCampaign(ctx context.Context, actorID, actorMachineID, projectID uint, name string) (*CampaignWithProgress, error) {
 	// Note: opening is NOT gated on a human actor — the scheduler legitimately auto-opens
 	// overdue campaigns as a system action (actorID==0). Opening only generates review
 	// items; the attributable-human requirement is enforced on the DECISION (attest/
@@ -92,13 +92,14 @@ func (c *KeyorixCore) OpenAccessReviewCampaign(ctx context.Context, actorID, pro
 	// consumed — an ephemeral return value is not a durable record that this
 	// recertification cycle's evidence snapshot was incomplete.
 	campaign, err := c.storage.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
-		ProjectID:       projectID,
-		Name:            name,
-		State:           CampaignStateOpen,
-		CreatedBy:       actorID,
-		CreatedAt:       c.now(),
-		Degraded:        report.Degraded,
-		DegradedReasons: report.DegradedReasons,
+		ProjectID:                  projectID,
+		Name:                       name,
+		State:                      CampaignStateOpen,
+		CreatedBy:                  actorID,
+		CreatedByMachineIdentityID: actorMachineID,
+		CreatedAt:                  c.now(),
+		Degraded:                   report.Degraded,
+		DegradedReasons:            report.DegradedReasons,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
@@ -383,7 +384,7 @@ func (c *KeyorixCore) checkForceCloseIndependence(ctx context.Context, actorID u
 // CloseAccessReviewCampaign freezes a campaign as the evidence record. It refuses
 // while items remain pending unless force is set (so an auditor sees either a fully
 // decided cycle or an explicit early close). actorID is the closer.
-func (c *KeyorixCore) CloseAccessReviewCampaign(ctx context.Context, actorID, projectID, campaignID uint, force bool) (*CampaignWithProgress, error) {
+func (c *KeyorixCore) CloseAccessReviewCampaign(ctx context.Context, actorID, actorMachineID, projectID, campaignID uint, force bool) (*CampaignWithProgress, error) {
 	campaign, err := c.loadScopedCampaign(ctx, projectID, campaignID)
 	if err != nil {
 		return nil, err
@@ -411,6 +412,7 @@ func (c *KeyorixCore) CloseAccessReviewCampaign(ctx context.Context, actorID, pr
 	now := c.now()
 	campaign.State = CampaignStateClosed
 	campaign.ClosedBy = actorID
+	campaign.ClosedByMachineIdentityID = actorMachineID
 	campaign.ClosedAt = &now
 	// #237: a forced close with items still pending freezes the campaign as
 	// evidence, but it is NOT a genuine, fully-decided recertification cycle —

--- a/internal/core/access_review_campaign_external_test.go
+++ b/internal/core/access_review_campaign_external_test.go
@@ -26,7 +26,7 @@ func TestOpenAccessReviewCampaign_SnapshotsEntries(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)
 	h.AssignUserRole(t, 10, 3, uptr(proj)) // editor → one role entry
 
-	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "Q4 2026")
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 0, proj, "Q4 2026")
 	require.NoError(t, err)
 	assert.Equal(t, core.CampaignStateOpen, res.Campaign.State)
 	assert.Equal(t, "Q4 2026", res.Campaign.Name)
@@ -38,6 +38,30 @@ func TestOpenAccessReviewCampaign_SnapshotsEntries(t *testing.T) {
 	require.Len(t, detail.Items, 1)
 	assert.Equal(t, core.ReviewItemPending, detail.Items[0].Decision)
 	assert.Equal(t, "alice", detail.Items[0].PrincipalName)
+}
+
+// #1573: a machine identity holding project-scoped roles.assign can open and
+// close a campaign. actorID (0, ADR-030) alone loses which machine did it;
+// the *MachineIdentityID companion fields must carry it through.
+func TestAccessReviewCampaign_RecordsActingMachineIdentity(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateCampaignTables(t, h)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	h.AssignUserRole(t, 10, 3, uptr(proj))
+
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 0, 42, proj, "Machine-opened")
+	require.NoError(t, err)
+	assert.Zero(t, res.Campaign.CreatedBy)
+	assert.Equal(t, uint(42), res.Campaign.CreatedByMachineIdentityID)
+
+	closed, err := h.CoreService.CloseAccessReviewCampaign(ctx, 0, 77, proj, res.Campaign.ID, true)
+	require.NoError(t, err)
+	assert.Zero(t, closed.Campaign.ClosedBy)
+	assert.Equal(t, uint(77), closed.Campaign.ClosedByMachineIdentityID)
 }
 
 // Attesting an item marks it kept; revoking removes the underlying grant.
@@ -53,7 +77,7 @@ func TestDecideAccessReviewItem_AttestAndRevoke(t *testing.T) {
 	h.AssignUserRole(t, 10, 3, uptr(proj)) // alice editor
 	h.AssignUserRole(t, 11, 4, uptr(proj)) // bob viewer
 
-	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 0, proj, "review")
 	require.NoError(t, err)
 	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
 	require.NoError(t, err)
@@ -103,7 +127,7 @@ func TestDecideAccessReviewItem_RejectsSelfCertification(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)
 	h.AssignUserRole(t, 10, 3, uptr(proj))
 
-	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 0, proj, "review")
 	require.NoError(t, err)
 	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
 	require.NoError(t, err)
@@ -133,7 +157,7 @@ func TestDecideAccessReviewItem_RejectsNonHumanReviewer(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)
 	h.AssignUserRole(t, 10, 3, uptr(proj))
 
-	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 0, proj, "review")
 	require.NoError(t, err)
 	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
 	require.NoError(t, err)
@@ -165,7 +189,7 @@ func TestDecideAccessReviewItem_RejectsGroupSelfCertification(t *testing.T) {
 	h.AssignGroupRole(t, g.ID, 3, uptr(proj)) // the group holds a role in the project
 	h.AssignUserToGroup(t, 20, g.ID)          // carol is a member
 
-	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 0, proj, "review")
 	require.NoError(t, err)
 	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
 	require.NoError(t, err)
@@ -199,7 +223,7 @@ func TestDecideAccessReviewItem_RejectsDoubleDecision(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)
 	h.AssignUserRole(t, 10, 3, uptr(proj))
 
-	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 0, proj, "review")
 	require.NoError(t, err)
 	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
 	require.NoError(t, err)
@@ -228,15 +252,15 @@ func TestCloseAccessReviewCampaign_PendingGuardAndForce(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)
 	h.AssignUserRole(t, 10, 3, uptr(proj))
 
-	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 0, proj, "review")
 	require.NoError(t, err)
 
 	// One pending item → close without force fails.
-	_, err = h.CoreService.CloseAccessReviewCampaign(ctx, 1, proj, res.Campaign.ID, false)
+	_, err = h.CoreService.CloseAccessReviewCampaign(ctx, 1, 0, proj, res.Campaign.ID, false)
 	require.Error(t, err)
 
 	// Force-close succeeds and freezes the campaign.
-	closed, err := h.CoreService.CloseAccessReviewCampaign(ctx, 1, proj, res.Campaign.ID, true)
+	closed, err := h.CoreService.CloseAccessReviewCampaign(ctx, 1, 0, proj, res.Campaign.ID, true)
 	require.NoError(t, err)
 	assert.Equal(t, core.CampaignStateClosed, closed.Campaign.State)
 	// #237: a force-close performed while items are still pending must be marked
@@ -251,7 +275,7 @@ func TestCloseAccessReviewCampaign_PendingGuardAndForce(t *testing.T) {
 	require.Error(t, err)
 
 	// Re-closing is rejected.
-	_, err = h.CoreService.CloseAccessReviewCampaign(ctx, 1, proj, res.Campaign.ID, true)
+	_, err = h.CoreService.CloseAccessReviewCampaign(ctx, 1, 0, proj, res.Campaign.ID, true)
 	require.Error(t, err)
 }
 
@@ -269,7 +293,7 @@ func TestCloseAccessReviewCampaign_FullyDecidedIsNotForcedIncomplete(t *testing.
 	h.CreateTestUser(t, "alice", 10)
 	h.AssignUserRole(t, 10, 3, uptr(proj))
 
-	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "review")
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 0, proj, "review")
 	require.NoError(t, err)
 	detail, err := h.CoreService.GetAccessReviewCampaign(ctx, proj, res.Campaign.ID)
 	require.NoError(t, err)
@@ -278,7 +302,7 @@ func TestCloseAccessReviewCampaign_FullyDecidedIsNotForcedIncomplete(t *testing.
 
 	// Nothing pending, so this close (whether force is true or false) is a genuine
 	// completed review.
-	closed, err := h.CoreService.CloseAccessReviewCampaign(ctx, 1, proj, res.Campaign.ID, true)
+	closed, err := h.CoreService.CloseAccessReviewCampaign(ctx, 1, 0, proj, res.Campaign.ID, true)
 	require.NoError(t, err)
 	assert.Equal(t, core.CampaignStateClosed, closed.Campaign.State)
 	assert.False(t, closed.Campaign.ForcedIncomplete, "a fully-decided close must not be flagged incomplete")
@@ -294,7 +318,7 @@ func TestAccessReviewCampaign_CrossProjectGuard(t *testing.T) {
 	h.CreateTestUser(t, "alice", 10)
 	h.AssignUserRole(t, 10, 3, uptr(uint(2)))
 
-	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 2, "p2")
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 0, 2, "p2")
 	require.NoError(t, err)
 
 	// Reaching campaign (project 2) through project 3 must fail.
@@ -308,7 +332,7 @@ func TestOpenAccessReviewCampaign_RequiresProject(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)
 	defer h.Cleanup()
 	migrateCampaignTables(t, h)
-	_, err := h.CoreService.OpenAccessReviewCampaign(context.Background(), 1, 0, "x")
+	_, err := h.CoreService.OpenAccessReviewCampaign(context.Background(), 1, 0, 0, "x")
 	require.Error(t, err)
 }
 
@@ -336,7 +360,7 @@ func TestOpenAccessReviewCampaign_PersistsDegradedFromReport(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, report.Degraded, "sanity: the report itself must be degraded for this test to be meaningful")
 
-	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "degraded review")
+	res, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 0, proj, "degraded review")
 	require.NoError(t, err)
 	assert.True(t, res.Campaign.Degraded, "the campaign returned by Open must carry the degraded signal")
 	assert.NotEmpty(t, res.Campaign.DegradedReasons)

--- a/internal/core/authz_admin_ceiling_group_test.go
+++ b/internal/core/authz_admin_ceiling_group_test.go
@@ -99,7 +99,7 @@ func TestAssignMachineRole_EscalationByProxyBlocked(t *testing.T) {
 	c, st := newBootstrappedCore(t)
 	ctx := context.Background()
 	attacker := seedUserWithRole(t, st, "mr-attacker", "project_viewer", storage.Scope{ProjectID: 1})
-	m, err := c.CreateMachineIdentity(ctx, 1, "svc", MachineTypeService, "", "", attacker)
+	m, err := c.CreateMachineIdentity(ctx, 1, "svc", MachineTypeService, "", "", attacker, 0)
 	require.NoError(t, err)
 	adminRole, err := c.storage.GetRoleByName(ctx, "project_admin")
 	require.NoError(t, err)

--- a/internal/core/break_glass.go
+++ b/internal/core/break_glass.go
@@ -247,7 +247,7 @@ func (c *KeyorixCore) ListBreakGlassActivations(ctx context.Context, projectID u
 // RevokeBreakGlass ends an active emergency grant early: removes the role assignment
 // (best-effort — it may already have auto-expired) and marks the record revoked.
 // actorID is the admin performing the revoke.
-func (c *KeyorixCore) RevokeBreakGlass(ctx context.Context, actorID, projectID, activationID uint) error {
+func (c *KeyorixCore) RevokeBreakGlass(ctx context.Context, actorID, actorMachineID, projectID, activationID uint) error {
 	if projectID == 0 {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID is required")
 	}
@@ -279,7 +279,7 @@ func (c *KeyorixCore) RevokeBreakGlass(ctx context.Context, actorID, projectID, 
 	// concurrent caller's conditional update actually transitions state; the second
 	// gets ErrBreakGlassNotActive instead of silently overwriting RevokedBy/RevokedAt.
 	now := c.now()
-	if err := c.storage.RevokeBreakGlassActivation(ctx, activation.ID, actorID, now); err != nil {
+	if err := c.storage.RevokeBreakGlassActivation(ctx, activation.ID, actorID, actorMachineID, now); err != nil {
 		if errors.Is(err, storage.ErrBreakGlassNotActive) {
 			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "activation is not active")
 		}

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -171,7 +171,7 @@ func TestRevokeBreakGlass_RemovesGrant(t *testing.T) {
 	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "prod incident", "")
 	require.NoError(t, err)
 
-	require.NoError(t, h.CoreService.RevokeBreakGlass(ctx, 1, proj, act.ID))
+	require.NoError(t, h.CoreService.RevokeBreakGlass(ctx, 1, 0, proj, act.ID))
 
 	// The emergency role is gone.
 	ids, err := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: proj})
@@ -183,7 +183,33 @@ func TestRevokeBreakGlass_RemovesGrant(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 	assert.Equal(t, core.BreakGlassRevoked, list[0].State)
-	require.Error(t, h.CoreService.RevokeBreakGlass(ctx, 1, proj, act.ID))
+	require.Error(t, h.CoreService.RevokeBreakGlass(ctx, 1, 0, proj, act.ID))
+}
+
+// #1573: a machine identity holding project-scoped roles.assign can revoke a
+// break-glass activation. actorID (0, ADR-030) alone loses which machine did
+// it; RevokedByMachineIdentityID must carry it through to the persisted row.
+func TestRevokeBreakGlass_RecordsActingMachineIdentity(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	migrateBreakGlass(t, h)
+	enableBreakGlass(h, "editor", 4*time.Hour, 24*time.Hour)
+
+	const proj = uint(2)
+	ctx := context.Background()
+	h.CreateTestUser(t, "alice", 10)
+	makeProjectMember(t, h, 10, proj)
+
+	act, err := h.CoreService.ActivateBreakGlass(ctx, proj, 10, "prod incident", "")
+	require.NoError(t, err)
+
+	require.NoError(t, h.CoreService.RevokeBreakGlass(ctx, 0, 42, proj, act.ID))
+
+	list, err := h.CoreService.ListBreakGlassActivations(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Zero(t, list[0].RevokedBy)
+	assert.Equal(t, uint(42), list[0].RevokedByMachineIdentityID)
 }
 
 // #304: the storage-layer state transition is a single conditional UPDATE
@@ -207,10 +233,10 @@ func TestRevokeBreakGlassActivation_ConditionalUpdateOnlyFirstAttemptWins(t *tes
 	require.NoError(t, err)
 
 	firstRevokeAt := time.Now().Add(-time.Minute).UTC().Truncate(time.Second)
-	require.NoError(t, h.Storage.RevokeBreakGlassActivation(ctx, act.ID, 100, firstRevokeAt))
+	require.NoError(t, h.Storage.RevokeBreakGlassActivation(ctx, act.ID, 100, 0, firstRevokeAt))
 
 	secondRevokeAt := time.Now().UTC().Truncate(time.Second)
-	err = h.Storage.RevokeBreakGlassActivation(ctx, act.ID, 200, secondRevokeAt)
+	err = h.Storage.RevokeBreakGlassActivation(ctx, act.ID, 200, 0, secondRevokeAt)
 	require.Error(t, err, "a second conditional revoke of an already-revoked activation must fail")
 	assert.ErrorIs(t, err, storage.ErrBreakGlassNotActive)
 
@@ -250,7 +276,7 @@ func TestRevokeBreakGlass_ConcurrentRevokesOnlyOneWins(t *testing.T) {
 		wg.Add(1)
 		go func(i int, admin uint) {
 			defer wg.Done()
-			errs[i] = h.CoreService.RevokeBreakGlass(ctx, admin, proj, act.ID)
+			errs[i] = h.CoreService.RevokeBreakGlass(ctx, admin, 0, proj, act.ID)
 		}(i, admin)
 	}
 	wg.Wait()
@@ -390,7 +416,7 @@ func TestActivateBreakGlass_RejectsConcurrentReactivation(t *testing.T) {
 	require.Len(t, list, 1)
 
 	// Once the first is revoked, a fresh activation is allowed again.
-	require.NoError(t, h.CoreService.RevokeBreakGlass(ctx, 1, proj, list[0].ID))
+	require.NoError(t, h.CoreService.RevokeBreakGlass(ctx, 1, 0, proj, list[0].ID))
 	_, err = h.CoreService.ActivateBreakGlass(ctx, proj, 10, "new incident", "")
 	require.NoError(t, err)
 }

--- a/internal/core/break_glass_revoke_test.go
+++ b/internal/core/break_glass_revoke_test.go
@@ -45,14 +45,14 @@ func TestRevokeBreakGlass_GenuineRoleRemovalFailureAbortsRevoke(t *testing.T) {
 	dbErr := errors.New("connection reset by peer")
 	mockStorage.On("RemoveRole", mock.Anything, uint(10), uint(3), storage.Scope{ProjectID: 2}).Return(dbErr)
 
-	err := c.RevokeBreakGlass(ctx, 1, 2, 7)
+	err := c.RevokeBreakGlass(ctx, 1, 0, 2, 7)
 	require.Error(t, err, "a genuine RemoveUserRole failure must abort the revoke")
 
 	// The conditional state transition (and the audit write that follows it) must
 	// never be reached: no expectation was set for either, so RevokeBreakGlassActivation
 	// or LogAuditEvent being called would fail this test (mock panics on an
 	// unexpected call, or AssertExpectations below would report an extra call).
-	mockStorage.AssertNotCalled(t, "RevokeBreakGlassActivation", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockStorage.AssertNotCalled(t, "RevokeBreakGlassActivation", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	mockStorage.AssertExpectations(t)
 }
 
@@ -70,10 +70,10 @@ func TestRevokeBreakGlass_AlreadyGoneRoleRemovalIsNotAFailure(t *testing.T) {
 	mockStorage.On("GetBreakGlassActivation", mock.Anything, uint(7)).Return(activation, nil)
 	mockStorage.On("RemoveRole", mock.Anything, uint(10), uint(3), storage.Scope{ProjectID: 2}).
 		Return(storage.ErrRoleNotAssigned)
-	mockStorage.On("RevokeBreakGlassActivation", mock.Anything, uint(7), uint(1), now).Return(nil)
+	mockStorage.On("RevokeBreakGlassActivation", mock.Anything, uint(7), uint(1), uint(0), now).Return(nil)
 	mockStorage.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	err := c.RevokeBreakGlass(ctx, 1, 2, 7)
+	err := c.RevokeBreakGlass(ctx, 1, 0, 2, 7)
 	require.NoError(t, err, "an already-removed role assignment must not block the revoke")
 	mockStorage.AssertExpectations(t)
 }

--- a/internal/core/compliance_evidence_external_test.go
+++ b/internal/core/compliance_evidence_external_test.go
@@ -27,7 +27,7 @@ func TestGenerateComplianceEvidence_BundlesRecords(t *testing.T) {
 	h.AssignUserRole(t, 10, 3, uptr(proj))
 
 	// A campaign (the recertification record) and an active break-glass activation.
-	camp, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "Q4 review")
+	camp, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 0, proj, "Q4 review")
 	require.NoError(t, err)
 	future := time.Now().Add(time.Hour)
 	require.NoError(t, h.DB.Create(&models.BreakGlassActivation{

--- a/internal/core/compliance_posture_external_test.go
+++ b/internal/core/compliance_posture_external_test.go
@@ -30,7 +30,7 @@ func TestGetCompliancePosture_RollsUpControls(t *testing.T) {
 	// alice holds a role grant in project 2 with no secret activity → dormant.
 	h.AssignUserRole(t, 10, 3, uptr(proj))
 	// An open campaign on project 2.
-	_, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, proj, "Q4")
+	_, err := h.CoreService.OpenAccessReviewCampaign(ctx, 1, 0, proj, "Q4")
 	require.NoError(t, err)
 	// An active break-glass activation in project 2.
 	future := time.Now().Add(time.Hour)

--- a/internal/core/concurrency_access_review_campaign_close_test.go
+++ b/internal/core/concurrency_access_review_campaign_close_test.go
@@ -86,7 +86,7 @@ func TestConcurrency_DecideAccessReviewItem_RejectsWhenRacingClose(t *testing.T)
 	go func() {
 		defer wg.Done()
 		<-start
-		_, closeErr := c.CloseAccessReviewCampaign(ctx, 1, proj, campaign.ID, true)
+		_, closeErr := c.CloseAccessReviewCampaign(ctx, 1, 0, proj, campaign.ID, true)
 		switch {
 		case closeErr == nil:
 			closeSucceeded.Add(1)

--- a/internal/core/concurrency_invite_member_test.go
+++ b/internal/core/concurrency_invite_member_test.go
@@ -52,7 +52,7 @@ func TestConcurrency_InviteMember_NoDuplicateActiveMembership(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			_, err := c.InviteMember(context.Background(), 1, 2, "project_viewer", 9, false)
+			_, err := c.InviteMember(context.Background(), 1, 2, "project_viewer", 9, 0, false)
 			errs[i] = err
 		}(i)
 	}

--- a/internal/core/core_s27_test.go
+++ b/internal/core/core_s27_test.go
@@ -559,7 +559,7 @@ func TestGetSecretValueForUser_SuspendedSecret(t *testing.T) {
 func TestOpenAccessReviewCampaign_ZeroProjectID(t *testing.T) {
 	ms := new(MockStorage)
 	c := NewKeyorixCore(ms)
-	_, err := c.OpenAccessReviewCampaign(context.Background(), 1, 0, "test")
+	_, err := c.OpenAccessReviewCampaign(context.Background(), 1, 0, 0, "test")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "project ID is required")
 }

--- a/internal/core/core_s30_test.go
+++ b/internal/core/core_s30_test.go
@@ -332,7 +332,7 @@ func TestLogin_MFARequired(t *testing.T) {
 func TestOpenAccessReviewCampaign_ZeroProjectID_s30(t *testing.T) {
 	c := NewKeyorixCore(new(MockStorage))
 	// actorID=1, projectID=0 → returns "project ID is required" immediately.
-	_, err := c.OpenAccessReviewCampaign(context.Background(), 1, 0, "Campaign")
+	_, err := c.OpenAccessReviewCampaign(context.Background(), 1, 0, 0, "Campaign")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "project ID is required")
 }
@@ -343,7 +343,7 @@ func TestCloseAccessReviewCampaign_CampaignNotFound(t *testing.T) {
 	ms := new(MockStorage)
 	ms.On("GetAccessReviewCampaign", mock.Anything, uint(5)).Return(nil, errors.New("not found"))
 	c := NewKeyorixCore(ms)
-	_, err := c.CloseAccessReviewCampaign(context.Background(), 1, 1, 5, false)
+	_, err := c.CloseAccessReviewCampaign(context.Background(), 1, 0, 1, 5, false)
 	require.Error(t, err)
 }
 
@@ -353,7 +353,7 @@ func TestCloseAccessReviewCampaign_WrongProject(t *testing.T) {
 	ms.On("GetAccessReviewCampaign", mock.Anything, uint(5)).Return(campaign, nil)
 	c := NewKeyorixCore(ms)
 	// projectID=1 but campaign has ProjectID=99 → scoping error.
-	_, err := c.CloseAccessReviewCampaign(context.Background(), 1, 1, 5, false)
+	_, err := c.CloseAccessReviewCampaign(context.Background(), 1, 0, 1, 5, false)
 	require.Error(t, err)
 }
 

--- a/internal/core/invitation_global_test.go
+++ b/internal/core/invitation_global_test.go
@@ -41,7 +41,7 @@ func TestInviteGlobal_ValidatesAndSnapshotsAssignments(t *testing.T) {
 		{ProjectID: 1, Role: "project_developer"},
 		{ProjectID: 2, Role: "project_viewer"},
 		{ProjectID: 1, Role: "project_viewer"}, // duplicate project — deduped
-	}, 9)
+	}, 9, 0)
 
 	require.NoError(t, err)
 	assert.Equal(t, InvitationPending, inv.State)
@@ -58,7 +58,7 @@ func TestInviteGlobal_RejectsUnknownRole(t *testing.T) {
 
 	_, err := c.InviteGlobal(ctx, "carol@acme.io", "", []ProjectAssignment{
 		{ProjectID: 1, Role: "bogus_role"},
-	}, 9)
+	}, 9, 0)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown role")
@@ -74,7 +74,7 @@ func TestInviteGlobal_RejectsDisallowedDomain(t *testing.T) {
 	c.SetMembershipDomainAllowlist([]string{"acme.com"})
 	ctx := context.Background()
 
-	_, err := c.InviteGlobal(ctx, "carol@evil.example", "", nil, 9)
+	_, err := c.InviteGlobal(ctx, "carol@evil.example", "", nil, 9, 0)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not on the allowlist")
@@ -90,7 +90,7 @@ func TestInviteGlobal_RejectsAssignmentMissingRole(t *testing.T) {
 
 	_, err := c.InviteGlobal(ctx, "carol@acme.io", "", []ProjectAssignment{
 		{ProjectID: 1, Role: ""},
-	}, 9)
+	}, 9, 0)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "needs a project_id and a role")
@@ -109,7 +109,7 @@ func TestInviteGlobal_RejectsNonAdminGrantingGlobalAdminRole(t *testing.T) {
 	// no admin-tier role anywhere) must not be able to mint an "admin" invitation.
 	nonAdminID := seedUserWithRole(t, st, "non-admin-inviter", "project_developer", storage.Scope{})
 
-	_, err := c.InviteGlobal(ctx, "mallory@acme.io", "admin", nil, nonAdminID)
+	_, err := c.InviteGlobal(ctx, "mallory@acme.io", "admin", nil, nonAdminID, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only an administrator can grant")
 }
@@ -128,7 +128,7 @@ func TestInviteGlobal_RejectsNonAdminGrantingProjectAdminAssignment(t *testing.T
 
 	_, err = c.InviteGlobal(ctx, "mallory2@acme.io", "system_viewer", []ProjectAssignment{
 		{ProjectID: proj.ID, Role: "project_admin"},
-	}, nonAdminID)
+	}, nonAdminID, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only an administrator can grant")
 }
@@ -144,7 +144,7 @@ func TestInviteGlobal_DefaultsSystemViewer(t *testing.T) {
 	})).Return(&models.ProjectInvitation{ID: 13, State: InvitationPending}, nil)
 	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
 
-	_, err := c.InviteGlobal(ctx, "dave@acme.io", "", nil, 9)
+	_, err := c.InviteGlobal(ctx, "dave@acme.io", "", nil, 9, 0)
 	require.NoError(t, err)
 	store.AssertExpectations(t)
 }

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -109,7 +109,7 @@ func (c *KeyorixCore) requireAdminAuthorityAt(ctx context.Context, actorID, proj
 
 // InviteToProject creates a pending invitation for an email to a project with an
 // intended role. It snapshots the current validation mode and sets a 14-day TTL.
-func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email, role string, invitedBy uint) (*models.ProjectInvitation, error) {
+func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email, role string, invitedBy, invitedByMachineID uint) (*models.ProjectInvitation, error) {
 	if projectID == 0 || email == "" || role == "" {
 		return nil, fmt.Errorf("project ID, email, and role are required")
 	}
@@ -127,11 +127,12 @@ func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email
 	now := c.now()
 	expires := now.Add(invitationTTL)
 	inv := &models.ProjectInvitation{
-		ProjectID: projectID,
-		Email:     email,
-		Role:      role,
-		State:     InvitationPending,
-		InvitedBy: invitedBy,
+		ProjectID:                  projectID,
+		Email:                      email,
+		Role:                       role,
+		State:                      InvitationPending,
+		InvitedBy:                  invitedBy,
+		InvitedByMachineIdentityID: invitedByMachineID,
 		// Snapshot the install validation mode (ADR-022) so acceptance honours the
 		// mode in force at invite time, not whatever it changes to later.
 		ValidationModeAtInvite: c.validationMode(),
@@ -174,17 +175,18 @@ func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email
 // email) globally — see above) preserves the SMTP-abuse ceiling while eliminating that
 // cross-project side effect. A genuine same-project resend/re-invite still supersedes
 // the prior pending invite for that project, exactly as before.
-func (c *KeyorixCore) InviteToProjectWithLink(ctx context.Context, projectID uint, email, role string, invitedBy uint) (*models.ProjectInvitation, *ProvisionSetupResult, error) {
-	inv, err := c.InviteToProject(ctx, projectID, email, role, invitedBy)
+func (c *KeyorixCore) InviteToProjectWithLink(ctx context.Context, projectID uint, email, role string, invitedBy, invitedByMachineID uint) (*models.ProjectInvitation, *ProvisionSetupResult, error) {
+	inv, err := c.InviteToProject(ctx, projectID, email, role, invitedBy, invitedByMachineID)
 	if err != nil {
 		return nil, nil, err
 	}
 	prov, err := c.provisionSetupLinkThrottled(ctx, IssueSetupTokenRequest{
-		Purpose:            SetupPurposeInvitationAccept,
-		SubjectEmail:       email,
-		InvitationID:       &inv.ID,
-		CreatedBy:          invitedBy,
-		SupersedeProjectID: &projectID,
+		Purpose:                    SetupPurposeInvitationAccept,
+		SubjectEmail:               email,
+		InvitationID:               &inv.ID,
+		CreatedBy:                  invitedBy,
+		CreatedByMachineIdentityID: invitedByMachineID,
+		SupersedeProjectID:         &projectID,
 	}, "", fmt.Sprintf("%s on project %d", role, projectID))
 	if err != nil {
 		return inv, nil, err
@@ -198,7 +200,7 @@ func (c *KeyorixCore) InviteToProjectWithLink(ctx context.Context, projectID uin
 // and every assignment (project + role) are validated and deduped up front, so
 // acceptance can't later fail on an unknown role or project. The per-project
 // grants are snapshotted as JSON on the invitation.
-func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string, assignments []ProjectAssignment, invitedBy uint) (*models.ProjectInvitation, error) { // NOSONAR -- cognitive complexity 20, suppress go:S3776
+func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string, assignments []ProjectAssignment, invitedBy, invitedByMachineID uint) (*models.ProjectInvitation, error) { // NOSONAR -- cognitive complexity 20, suppress go:S3776
 	if email == "" {
 		return nil, fmt.Errorf("email is required")
 	}
@@ -257,16 +259,17 @@ func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string
 	now := c.now()
 	expires := now.Add(invitationTTL)
 	inv := &models.ProjectInvitation{
-		ProjectID:              0, // global
-		Email:                  email,
-		Role:                   "",
-		State:                  InvitationPending,
-		InvitedBy:              invitedBy,
-		SystemRole:             sysRole,
-		AssignmentsJSON:        assignJSON,
-		ValidationModeAtInvite: c.validationMode(),
-		ExpiresAt:              &expires,
-		CreatedAt:              now,
+		ProjectID:                  0, // global
+		Email:                      email,
+		Role:                       "",
+		State:                      InvitationPending,
+		InvitedBy:                  invitedBy,
+		InvitedByMachineIdentityID: invitedByMachineID,
+		SystemRole:                 sysRole,
+		AssignmentsJSON:            assignJSON,
+		ValidationModeAtInvite:     c.validationMode(),
+		ExpiresAt:                  &expires,
+		CreatedAt:                  now,
 	}
 	created, err := c.storage.CreateProjectInvitation(ctx, inv)
 	if err != nil {
@@ -291,16 +294,17 @@ func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string
 // supersedes a prior pending global invite to the same address, and, as before, a
 // prior PROJECT-scoped invite to that address (there is no narrower boundary to draw
 // here; CORE-INVITATIONS-003 is specifically about project-vs-project interference).
-func (c *KeyorixCore) InviteGlobalWithLink(ctx context.Context, email, systemRole string, assignments []ProjectAssignment, invitedBy uint) (*models.ProjectInvitation, *ProvisionSetupResult, error) {
-	inv, err := c.InviteGlobal(ctx, email, systemRole, assignments, invitedBy)
+func (c *KeyorixCore) InviteGlobalWithLink(ctx context.Context, email, systemRole string, assignments []ProjectAssignment, invitedBy, invitedByMachineID uint) (*models.ProjectInvitation, *ProvisionSetupResult, error) {
+	inv, err := c.InviteGlobal(ctx, email, systemRole, assignments, invitedBy, invitedByMachineID)
 	if err != nil {
 		return nil, nil, err
 	}
 	prov, err := c.provisionSetupLinkThrottled(ctx, IssueSetupTokenRequest{
-		Purpose:      SetupPurposeInvitationAccept,
-		SubjectEmail: email,
-		InvitationID: &inv.ID,
-		CreatedBy:    invitedBy,
+		Purpose:                    SetupPurposeInvitationAccept,
+		SubjectEmail:               email,
+		InvitationID:               &inv.ID,
+		CreatedBy:                  invitedBy,
+		CreatedByMachineIdentityID: invitedByMachineID,
 	}, "", fmt.Sprintf("%s + %d project assignment(s)", inv.SystemRole, len(assignments)))
 	if err != nil {
 		return inv, nil, err
@@ -335,7 +339,7 @@ func (c *KeyorixCore) applyInvitationGrants(ctx context.Context, inv *models.Pro
 				return fmt.Errorf("failed to decode assignments: %w", err)
 			}
 			for _, a := range assignments {
-				if _, err := c.inviteMemberWithMode(ctx, a.ProjectID, userID, a.Role, inv.InvitedBy, inv.ValidationModeAtInvite, false); err != nil {
+				if _, err := c.inviteMemberWithMode(ctx, a.ProjectID, userID, a.Role, inv.InvitedBy, inv.InvitedByMachineIdentityID, inv.ValidationModeAtInvite, false); err != nil {
 					return err
 				}
 			}
@@ -343,7 +347,7 @@ func (c *KeyorixCore) applyInvitationGrants(ctx context.Context, inv *models.Pro
 		return nil
 	}
 	// Project-scoped invite: single project membership.
-	_, err := c.inviteMemberWithMode(ctx, inv.ProjectID, userID, inv.Role, inv.InvitedBy, inv.ValidationModeAtInvite, false)
+	_, err := c.inviteMemberWithMode(ctx, inv.ProjectID, userID, inv.Role, inv.InvitedBy, inv.InvitedByMachineIdentityID, inv.ValidationModeAtInvite, false)
 	return err
 }
 

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -31,9 +31,27 @@ func TestInviteToProject(t *testing.T) {
 		return e.EventType == "invitation.created"
 	})).Return(nil)
 
-	inv, err := c.InviteToProject(ctx, 1, "a@b.com", "project_developer", 9)
+	inv, err := c.InviteToProject(ctx, 1, "a@b.com", "project_developer", 9, 0)
 	require.NoError(t, err)
 	assert.Equal(t, InvitationPending, inv.State)
+	store.AssertExpectations(t)
+}
+
+// #1573: a machine identity holding project-scoped roles.assign can invite a
+// project member. invitedBy (0, ADR-030) alone loses which machine did it;
+// InvitedByMachineIdentityID must carry it through to the persisted row.
+func TestInviteToProject_RecordsActingMachineIdentity(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	ctx := context.Background()
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5, Name: "project_developer"}, nil)
+	store.On("CreateProjectInvitation", ctx, mock.MatchedBy(func(inv *models.ProjectInvitation) bool {
+		return inv.InvitedBy == 0 && inv.InvitedByMachineIdentityID == 42
+	})).Return(&models.ProjectInvitation{ID: 8, State: InvitationPending}, nil)
+	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+	_, err := c.InviteToProject(ctx, 1, "a@b.com", "project_developer", 0, 42)
+	require.NoError(t, err)
 	store.AssertExpectations(t)
 }
 
@@ -47,7 +65,7 @@ func TestInviteToProject_RejectsDisallowedDomain(t *testing.T) {
 	c.SetMembershipDomainAllowlist([]string{"acme.com"})
 	ctx := context.Background()
 
-	_, err := c.InviteToProject(ctx, 1, "a@evil.example", "project_developer", 9)
+	_, err := c.InviteToProject(ctx, 1, "a@evil.example", "project_developer", 9, 0)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not on the allowlist")
@@ -67,7 +85,7 @@ func TestInviteToProject_AllowsAllowlistedDomain(t *testing.T) {
 		return e.EventType == "invitation.created"
 	})).Return(nil)
 
-	inv, err := c.InviteToProject(ctx, 1, "a@acme.com", "project_developer", 9)
+	inv, err := c.InviteToProject(ctx, 1, "a@acme.com", "project_developer", 9, 0)
 
 	require.NoError(t, err)
 	assert.Equal(t, InvitationPending, inv.State)
@@ -179,7 +197,7 @@ func TestInviteToProject_EnforcesAdminCeiling(t *testing.T) {
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{}, nil)
 
 	// Inviting as project_admin → refused before any invitation is created.
-	_, err := c.InviteToProject(ctx, 1, "a@b.io", "project_admin", 9)
+	_, err := c.InviteToProject(ctx, 1, "a@b.io", "project_admin", 9, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only an administrator can grant")
 	store.AssertNotCalled(t, "CreateProjectInvitation", mock.Anything, mock.Anything)
@@ -188,7 +206,7 @@ func TestInviteToProject_EnforcesAdminCeiling(t *testing.T) {
 	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 6, Name: "project_developer"}, nil)
 	store.On("CreateProjectInvitation", ctx, mock.Anything).Return(&models.ProjectInvitation{ID: 1}, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
-	_, err = c.InviteToProject(ctx, 1, "c@d.io", "project_developer", 9)
+	_, err = c.InviteToProject(ctx, 1, "c@d.io", "project_developer", 9, 0)
 	require.NoError(t, err)
 }
 
@@ -444,7 +462,7 @@ func TestInviteToProjectWithLink_ThrottlesRepeatedInitialInvites(t *testing.T) {
 	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "a@b.com", fixed.Add(-24*time.Hour)).Return(int64(0), nil).Once()
 	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "a@b.com", fixed.Add(-resendMinInterval)).Return(int64(0), nil).Once()
 
-	inv1, prov1, err := c.InviteToProjectWithLink(ctx, 1, "a@b.com", "project_developer", 9)
+	inv1, prov1, err := c.InviteToProjectWithLink(ctx, 1, "a@b.com", "project_developer", 9, 0)
 	require.NoError(t, err)
 	require.NotNil(t, inv1)
 	require.NotNil(t, prov1)
@@ -455,7 +473,7 @@ func TestInviteToProjectWithLink_ThrottlesRepeatedInitialInvites(t *testing.T) {
 	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "a@b.com", fixed.Add(-24*time.Hour)).Return(int64(1), nil).Once()
 	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "a@b.com", fixed.Add(-resendMinInterval)).Return(int64(1), nil).Once()
 
-	inv2, prov2, err := c.InviteToProjectWithLink(ctx, 1, "a@b.com", "project_developer", 9)
+	inv2, prov2, err := c.InviteToProjectWithLink(ctx, 1, "a@b.com", "project_developer", 9, 0)
 	require.Error(t, err, "the second same-email invite must be throttled, not delivered")
 	assert.Contains(t, err.Error(), "wait")
 	assert.Nil(t, prov2)
@@ -464,6 +482,34 @@ func TestInviteToProjectWithLink_ThrottlesRepeatedInitialInvites(t *testing.T) {
 	// the window passes rather than losing the invite.
 	require.NotNil(t, inv2)
 	store.AssertNumberOfCalls(t, "CreateSetupToken", 1)
+}
+
+// #1573: a machine identity inviting a project member also mints the setup
+// token via InviteToProjectWithLink. createdBy (0, ADR-030) alone loses which
+// machine did it; SetupToken.CreatedByMachineIdentityID must carry it through.
+func TestInviteToProjectWithLink_RecordsActingMachineIdentityOnSetupToken(t *testing.T) {
+	store := new(MockStorage)
+	c := newInviteCore(store)
+	c.SetCredentialDelivery(&fakeDeliverer{result: delivery.DeliveryResult{Channel: delivery.ChannelSMTP, Delivered: true}}, testBaseURL)
+	ctx := context.Background()
+	fixed := c.now()
+	anyAudit(store)
+
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5, Name: "project_developer"}, nil)
+	store.On("CreateProjectInvitation", ctx, mock.MatchedBy(func(inv *models.ProjectInvitation) bool {
+		return inv.InvitedBy == 0 && inv.InvitedByMachineIdentityID == 42
+	})).Return(&models.ProjectInvitation{ID: 7, State: InvitationPending}, nil)
+	store.On("SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "a@b.com", ptr(uint(1))).Return(nil)
+	store.On("CreateSetupToken", ctx, mock.MatchedBy(func(tok *models.SetupToken) bool {
+		return tok.CreatedBy == 0 && tok.CreatedByMachineIdentityID == 42
+	})).Return(&models.SetupToken{ID: 1}, nil)
+	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "a@b.com", fixed.Add(-24*time.Hour)).Return(int64(0), nil).Once()
+	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "a@b.com", fixed.Add(-resendMinInterval)).Return(int64(0), nil).Once()
+
+	_, prov, err := c.InviteToProjectWithLink(ctx, 1, "a@b.com", "project_developer", 0, 42)
+	require.NoError(t, err)
+	assert.True(t, prov.Delivered)
+	store.AssertExpectations(t)
 }
 
 // #345: InviteGlobalWithLink has the same unthrottled-initial-send shape as
@@ -485,7 +531,7 @@ func TestInviteGlobalWithLink_ThrottlesRepeatedInitialInvites(t *testing.T) {
 	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "c@d.com", fixed.Add(-24*time.Hour)).Return(int64(0), nil).Once()
 	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "c@d.com", fixed.Add(-resendMinInterval)).Return(int64(0), nil).Once()
 
-	inv1, prov1, err := c.InviteGlobalWithLink(ctx, "c@d.com", "", nil, 9)
+	inv1, prov1, err := c.InviteGlobalWithLink(ctx, "c@d.com", "", nil, 9, 0)
 	require.NoError(t, err)
 	require.NotNil(t, inv1)
 	require.NotNil(t, prov1)
@@ -493,7 +539,7 @@ func TestInviteGlobalWithLink_ThrottlesRepeatedInitialInvites(t *testing.T) {
 	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "c@d.com", fixed.Add(-24*time.Hour)).Return(int64(1), nil).Once()
 	store.On("CountSetupTokensSince", ctx, SetupPurposeInvitationAccept, "c@d.com", fixed.Add(-resendMinInterval)).Return(int64(1), nil).Once()
 
-	inv2, prov2, err := c.InviteGlobalWithLink(ctx, "c@d.com", "", nil, 9)
+	inv2, prov2, err := c.InviteGlobalWithLink(ctx, "c@d.com", "", nil, 9, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "wait")
 	assert.Nil(t, prov2)

--- a/internal/core/machine_global_scope_invariant_test.go
+++ b/internal/core/machine_global_scope_invariant_test.go
@@ -88,7 +88,7 @@ func TestCreateMachineIdentity_RejectsZeroProject(t *testing.T) {
 	ms := new(MockStorage)
 	c := NewKeyorixCore(ms)
 
-	_, err := c.CreateMachineIdentity(context.Background(), 0, "orphan", "service", "", "", 1)
+	_, err := c.CreateMachineIdentity(context.Background(), 0, "orphan", "service", "", "", 1, 0)
 
 	require.Error(t, err)
 	ms.AssertNotCalled(t, "CreateMachineIdentity", mock.Anything, mock.Anything)

--- a/internal/core/machine_identities.go
+++ b/internal/core/machine_identities.go
@@ -84,7 +84,7 @@ func IsValidMachineTransition(from, to string) bool {
 }
 
 // CreateMachineIdentity creates an active machine identity in a project.
-func (c *KeyorixCore) CreateMachineIdentity(ctx context.Context, projectID uint, name, identityType, description, classification string, createdBy uint) (*models.MachineIdentity, error) {
+func (c *KeyorixCore) CreateMachineIdentity(ctx context.Context, projectID uint, name, identityType, description, classification string, createdBy, createdByMachineID uint) (*models.MachineIdentity, error) {
 	if projectID == 0 || name == "" {
 		return nil, fmt.Errorf("project ID and name are required")
 	}
@@ -99,15 +99,16 @@ func (c *KeyorixCore) CreateMachineIdentity(ctx context.Context, projectID uint,
 	}
 	now := c.now()
 	m := &models.MachineIdentity{
-		ProjectID:      projectID,
-		Name:           name,
-		IdentityType:   identityType,
-		State:          MachineActive,
-		Description:    description,
-		Classification: classification,
-		CreatedBy:      createdBy,
-		CreatedAt:      now,
-		UpdatedAt:      now,
+		ProjectID:                  projectID,
+		Name:                       name,
+		IdentityType:               identityType,
+		State:                      MachineActive,
+		Description:                description,
+		Classification:             classification,
+		CreatedBy:                  createdBy,
+		CreatedByMachineIdentityID: createdByMachineID,
+		CreatedAt:                  now,
+		UpdatedAt:                  now,
 	}
 	created, err := c.storage.CreateMachineIdentity(ctx, m)
 	if err != nil {

--- a/internal/core/machine_identities_test.go
+++ b/internal/core/machine_identities_test.go
@@ -51,16 +51,34 @@ func TestCreateMachineIdentity(t *testing.T) {
 			return e.EventType == "machine_identity.created"
 		})).Return(nil)
 
-		m, err := c.CreateMachineIdentity(ctx, 1, "ci-runner", MachineTypeCI, "GitHub Actions", "", 9)
+		m, err := c.CreateMachineIdentity(ctx, 1, "ci-runner", MachineTypeCI, "GitHub Actions", "", 9, 0)
 		require.NoError(t, err)
 		assert.Equal(t, MachineActive, m.State)
+		store.AssertExpectations(t)
+	})
+
+	// #1573: a machine identity holding project-scoped roles.assign can create
+	// another machine identity (a machine-provisioning-machine chain). createdBy
+	// (0, ADR-030) alone loses which machine did it; createdByMachineID must
+	// carry it through to the persisted row.
+	t.Run("records the acting machine identity when created by a machine", func(t *testing.T) {
+		store := new(MockStorage)
+		c := newMachineCore(store)
+		ctx := context.Background()
+		store.On("CreateMachineIdentity", ctx, mock.MatchedBy(func(m *models.MachineIdentity) bool {
+			return m.CreatedBy == 0 && m.CreatedByMachineIdentityID == 42
+		})).Return(&models.MachineIdentity{ID: 11, ProjectID: 1, Name: "provisioner-created", State: MachineActive}, nil)
+		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+
+		_, err := c.CreateMachineIdentity(ctx, 1, "provisioner-created", MachineTypeCI, "", "", 0, 42)
+		require.NoError(t, err)
 		store.AssertExpectations(t)
 	})
 
 	t.Run("rejects an unknown identity type", func(t *testing.T) {
 		store := new(MockStorage)
 		c := newMachineCore(store)
-		_, err := c.CreateMachineIdentity(context.Background(), 1, "x", "robot", "", "", 9)
+		_, err := c.CreateMachineIdentity(context.Background(), 1, "x", "robot", "", "", 9, 0)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid identity_type")
 		store.AssertNotCalled(t, "CreateMachineIdentity", mock.Anything, mock.Anything)
@@ -75,7 +93,7 @@ func TestCreateMachineIdentity(t *testing.T) {
 		})).Return(&models.MachineIdentity{ID: 11, IdentityType: MachineTypeOther, State: MachineActive}, nil)
 		store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
 
-		_, err := c.CreateMachineIdentity(ctx, 1, "x", "", "", "", 9)
+		_, err := c.CreateMachineIdentity(ctx, 1, "x", "", "", "", 9, 0)
 		require.NoError(t, err)
 	})
 }

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -138,14 +138,14 @@ func (c *KeyorixCore) validationMode() string {
 // for idp, whether the user is IdP-resolved). Rejects a duplicate non-revoked
 // membership. When the mode lands the membership directly in `active`, the role
 // grant is applied immediately.
-func (c *KeyorixCore) InviteMember(ctx context.Context, projectID, userID uint, role string, invitedBy uint, idpResolved bool) (*models.ProjectMembership, error) {
-	return c.inviteMemberWithMode(ctx, projectID, userID, role, invitedBy, c.validationMode(), idpResolved)
+func (c *KeyorixCore) InviteMember(ctx context.Context, projectID, userID uint, role string, invitedBy, invitedByMachineID uint, idpResolved bool) (*models.ProjectMembership, error) {
+	return c.inviteMemberWithMode(ctx, projectID, userID, role, invitedBy, invitedByMachineID, c.validationMode(), idpResolved)
 }
 
 // inviteMemberWithMode is InviteMember with an explicit validation mode, so the
 // invitation-accept flow (ADR-024/ADR-028) can honour the mode snapshotted at invite
 // time rather than the install's current mode. InviteMember passes the current mode.
-func (c *KeyorixCore) inviteMemberWithMode(ctx context.Context, projectID, userID uint, role string, invitedBy uint, mode string, idpResolved bool) (*models.ProjectMembership, error) {
+func (c *KeyorixCore) inviteMemberWithMode(ctx context.Context, projectID, userID uint, role string, invitedBy, invitedByMachineID uint, mode string, idpResolved bool) (*models.ProjectMembership, error) {
 	if projectID == 0 || userID == 0 {
 		return nil, fmt.Errorf("project and user IDs are required")
 	}
@@ -180,13 +180,14 @@ func (c *KeyorixCore) inviteMemberWithMode(ctx context.Context, projectID, userI
 	now := c.now()
 	initial := initialMembershipStateForMode(mode, idpResolved)
 	m := &models.ProjectMembership{
-		ProjectID: projectID,
-		UserID:    userID,
-		Role:      role,
-		State:     initial,
-		InvitedBy: invitedBy,
-		InvitedAt: now,
-		UpdatedAt: now,
+		ProjectID:                  projectID,
+		UserID:                     userID,
+		Role:                       role,
+		State:                      initial,
+		InvitedBy:                  invitedBy,
+		InvitedByMachineIdentityID: invitedByMachineID,
+		InvitedAt:                  now,
+		UpdatedAt:                  now,
 	}
 	if initial == MembershipActive {
 		t := now

--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -63,11 +63,32 @@ func TestInviteMember_AllowlistStartsInvited(t *testing.T) {
 	})).Return(&models.ProjectMembership{ID: 50, ProjectID: 1, UserID: 2, State: MembershipInvited}, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	m, err := c.InviteMember(ctx, 1, 2, "project_developer", 9, false)
+	m, err := c.InviteMember(ctx, 1, 2, "project_developer", 9, 0, false)
 	require.NoError(t, err)
 	assert.Equal(t, MembershipInvited, m.State)
 	// No role granted yet in allowlist mode.
 	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// #1573: a machine identity holding project-scoped roles.assign can invite a
+// project member. invitedBy (0, ADR-030) alone loses which machine did it;
+// InvitedByMachineIdentityID must carry it through to the persisted row.
+func TestInviteMember_RecordsActingMachineIdentity(t *testing.T) {
+	store := new(MockStorage)
+	c := newMembershipCore(store)
+	c.membershipValidationMode = ValidationModeAllowlist
+	ctx := context.Background()
+
+	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5, Name: "project_developer"}, nil)
+	store.On("GetActiveProjectMembership", ctx, uint(1), uint(2)).Return(nil, fmt.Errorf("not found"))
+	store.On("CreateProjectMembership", ctx, mock.MatchedBy(func(m *models.ProjectMembership) bool {
+		return m.InvitedBy == 0 && m.InvitedByMachineIdentityID == 42
+	})).Return(&models.ProjectMembership{ID: 51, ProjectID: 1, UserID: 2, State: MembershipInvited}, nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	_, err := c.InviteMember(ctx, 1, 2, "project_developer", 0, 42, false)
+	require.NoError(t, err)
+	store.AssertExpectations(t)
 }
 
 func TestInviteMember_OpenGrantsRoleImmediately(t *testing.T) {
@@ -85,7 +106,7 @@ func TestInviteMember_OpenGrantsRoleImmediately(t *testing.T) {
 	store.On("AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1}).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	m, err := c.InviteMember(ctx, 1, 2, "project_developer", 9, false)
+	m, err := c.InviteMember(ctx, 1, 2, "project_developer", 9, 0, false)
 	require.NoError(t, err)
 	assert.Equal(t, MembershipActive, m.State)
 	store.AssertCalled(t, "AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1})
@@ -103,7 +124,7 @@ func TestInviteMember_RejectsDisallowedDomain(t *testing.T) {
 	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5, Name: "project_developer"}, nil)
 	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Email: "outsider@evil.com"}, nil)
 
-	_, err := c.InviteMember(ctx, 1, 2, "project_developer", 9, false)
+	_, err := c.InviteMember(ctx, 1, 2, "project_developer", 9, 0, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not on the allowlist")
 	store.AssertNotCalled(t, "CreateProjectMembership", mock.Anything, mock.Anything)
@@ -141,7 +162,7 @@ func TestInviteMember_RejectsDuplicate(t *testing.T) {
 	store.On("GetActiveProjectMembership", ctx, uint(1), uint(2)).
 		Return(&models.ProjectMembership{ID: 1, State: MembershipActive}, nil)
 
-	_, err := c.InviteMember(ctx, 1, 2, "project_viewer", 9, false)
+	_, err := c.InviteMember(ctx, 1, 2, "project_viewer", 9, 0, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already has")
 	store.AssertNotCalled(t, "CreateProjectMembership", mock.Anything, mock.Anything)
@@ -192,7 +213,7 @@ func TestInviteMember_OpenActivationFailure_RevertsOrphanedActiveMembership(t *t
 	}), MembershipActive).Return(true, nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	m, err := c.InviteMember(ctx, 1, 2, "project_viewer", 9, false)
+	m, err := c.InviteMember(ctx, 1, 2, "project_viewer", 9, 0, false)
 
 	// (a) the error still propagates to the caller.
 	require.Error(t, err)

--- a/internal/core/migrate_user_to_machine.go
+++ b/internal/core/migrate_user_to_machine.go
@@ -54,7 +54,7 @@ func (c *KeyorixCore) MigrateUserToMachine(ctx context.Context, username string,
 	// event below, which is gated behind audit.read.
 	desc := fmt.Sprintf("Migrated from user %q (id %d)", user.Username, user.ID)
 
-	m, err := c.CreateMachineIdentity(ctx, projectID, name, identityType, desc, "", actorID)
+	m, err := c.CreateMachineIdentity(ctx, projectID, name, identityType, desc, "", actorID, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -559,8 +559,8 @@ func (m *MockStorage) UpdateBreakGlassActivation(ctx context.Context, a *models.
 	return args.Error(0)
 }
 
-func (m *MockStorage) RevokeBreakGlassActivation(ctx context.Context, id, revokedBy uint, revokedAt time.Time) error {
-	args := m.Called(ctx, id, revokedBy, revokedAt)
+func (m *MockStorage) RevokeBreakGlassActivation(ctx context.Context, id, revokedBy, revokedByMachineID uint, revokedAt time.Time) error {
+	args := m.Called(ctx, id, revokedBy, revokedByMachineID, revokedAt)
 	return args.Error(0)
 }
 

--- a/internal/core/recertification.go
+++ b/internal/core/recertification.go
@@ -120,7 +120,7 @@ func (c *KeyorixCore) RunScheduledRecertification(ctx context.Context, cadenceDa
 
 		if autoOpen {
 			name := fmt.Sprintf("Scheduled recertification %s", c.now().Format("2006-01-02"))
-			if _, err := c.OpenAccessReviewCampaign(WithActorType(ctx, ActorTypeSystem), 0, pid, name); err != nil {
+			if _, err := c.OpenAccessReviewCampaign(WithActorType(ctx, ActorTypeSystem), 0, 0, pid, name); err != nil {
 				continue
 			}
 			res.Opened++

--- a/internal/core/secret_folder_test.go
+++ b/internal/core/secret_folder_test.go
@@ -91,6 +91,29 @@ func TestCreateSecret_ParentID_SetsParent(t *testing.T) {
 	assert.Equal(t, folder.ID, *got.ParentID)
 }
 
+// TestCreateSecret_RecordsActingMachineIdentity: #1573 -- a machine identity
+// holding project-scoped secrets.write can create a secret. OwnerID (0,
+// ADR-030) alone loses which machine did it; OwnerMachineIdentityID must
+// carry it through to the persisted row.
+func TestCreateSecret_RecordsActingMachineIdentity(t *testing.T) {
+	c, _ := newFolderCoreDB(t)
+
+	req := &CreateSecretRequest{
+		Name:                   "machine-created",
+		Value:                  []byte("s3cr3t"),
+		ProjectID:              1,
+		EnvironmentID:          10,
+		Type:                   "generic",
+		CreatedBy:              "machine",
+		OwnerID:                0,
+		OwnerMachineIdentityID: 42,
+	}
+	got, err := c.CreateSecret(context.Background(), req)
+	require.NoError(t, err)
+	assert.Zero(t, got.OwnerID)
+	assert.Equal(t, uint(42), got.OwnerMachineIdentityID)
+}
+
 // TestCreateSecret_ParentID_NotAFolder verifies that using a real secret as the
 // parent is rejected with a validation error.
 func TestCreateSecret_ParentID_NotAFolder(t *testing.T) {

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -32,6 +32,10 @@ type CreateSecretRequest struct {
 	Tags          []string          `json:"tags,omitempty"`
 	CreatedBy     string            `json:"created_by" validate:"required"`
 	OwnerID       uint              `json:"owner_id,omitempty"`
+	// OwnerMachineIdentityID (#1573) records which machine identity created this
+	// secret, when OwnerID is 0 because the creator was a machine caller
+	// (ADR-030) rather than a human. 0 = none.
+	OwnerMachineIdentityID uint `json:"-"`
 	// ParentID optionally places the new secret inside a folder node. When set,
 	// the parent must exist, belong to the same project/environment, and be a
 	// folder (IsSecret=false). A zero value means no parent (root level).
@@ -135,20 +139,21 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 	}
 
 	secret := &models.SecretNode{
-		Name:           req.Name,
-		ProjectID:      req.ProjectID,
-		EnvironmentID:  req.EnvironmentID,
-		Type:           req.Type,
-		Description:    strings.TrimSpace(req.Description),
-		MaxReads:       req.MaxReads,
-		Expiration:     req.Expiration,
-		Classification: req.Classification,
-		IsSecret:       true,
-		Status:         "active",
-		CreatedBy:      req.CreatedBy,
-		OwnerID:        req.OwnerID,
-		CreatedAt:      time.Now(),
-		UpdatedAt:      time.Now(),
+		Name:                   req.Name,
+		ProjectID:              req.ProjectID,
+		EnvironmentID:          req.EnvironmentID,
+		Type:                   req.Type,
+		Description:            strings.TrimSpace(req.Description),
+		MaxReads:               req.MaxReads,
+		Expiration:             req.Expiration,
+		Classification:         req.Classification,
+		IsSecret:               true,
+		Status:                 "active",
+		CreatedBy:              req.CreatedBy,
+		OwnerID:                req.OwnerID,
+		OwnerMachineIdentityID: req.OwnerMachineIdentityID,
+		CreatedAt:              time.Now(),
+		UpdatedAt:              time.Now(),
 	}
 	if req.ParentID != nil && *req.ParentID != 0 {
 		secret.ParentID = req.ParentID

--- a/internal/core/setup_token.go
+++ b/internal/core/setup_token.go
@@ -69,6 +69,10 @@ type IssueSetupTokenRequest struct {
 	SubjectUserID *uint  // nil until an account exists (e.g. invitation by email)
 	InvitationID  *uint  // set for purpose = invitation_accept
 	CreatedBy     uint   // issuing admin/inviter; 0 for self-service reset
+	// CreatedByMachineIdentityID (#1573) records which machine identity issued
+	// this token, when CreatedBy is 0 because the issuer was a machine caller
+	// (ADR-030) rather than a human. 0 = none.
+	CreatedByMachineIdentityID uint
 
 	// SupersedeProjectID additionally scopes the pre-issuance supersede (see
 	// IssueSetupToken below) to a single project's own invitations, instead of every
@@ -122,15 +126,16 @@ func (c *KeyorixCore) IssueSetupToken(ctx context.Context, req IssueSetupTokenRe
 	now := c.now()
 
 	tok := &models.SetupToken{
-		TokenHash:     sha256Hex(raw),
-		Purpose:       req.Purpose,
-		SubjectUserID: req.SubjectUserID,
-		SubjectEmail:  email,
-		InvitationID:  req.InvitationID,
-		State:         SetupTokenActive,
-		ExpiresAt:     now.Add(ttl),
-		CreatedBy:     req.CreatedBy,
-		CreatedAt:     now,
+		TokenHash:                  sha256Hex(raw),
+		Purpose:                    req.Purpose,
+		SubjectUserID:              req.SubjectUserID,
+		SubjectEmail:               email,
+		InvitationID:               req.InvitationID,
+		State:                      SetupTokenActive,
+		ExpiresAt:                  now.Add(ttl),
+		CreatedBy:                  req.CreatedBy,
+		CreatedByMachineIdentityID: req.CreatedByMachineIdentityID,
+		CreatedAt:                  now,
 	}
 	created, err := c.storage.CreateSetupToken(ctx, tok)
 	if err != nil {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -443,7 +443,7 @@ type Storage interface {
 	// revokes of the same activation cannot both "win": only the first transitions
 	// state, and the second gets ErrBreakGlassNotActive rather than silently
 	// overwriting the first revoker's attribution.
-	RevokeBreakGlassActivation(ctx context.Context, id, revokedBy uint, revokedAt time.Time) error
+	RevokeBreakGlassActivation(ctx context.Context, id, revokedBy, revokedByMachineID uint, revokedAt time.Time) error
 	// Machine identities (ADR-023) — non-human project members.
 	CreateMachineIdentity(ctx context.Context, m *models.MachineIdentity) (*models.MachineIdentity, error)
 	GetMachineIdentity(ctx context.Context, id uint) (*models.MachineIdentity, error)

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -41,13 +41,18 @@ type Environment struct {
 // internal/core/setup_consume.go (completeInvitationAccept); this record tracks
 // the pending invite so it can be listed, revoked, and aged out.
 type ProjectInvitation struct {
-	ID                     uint   `gorm:"primaryKey"`
-	ProjectID              uint   `gorm:"index"`
-	Email                  string `gorm:"index"`
-	Role                   string // intended project role (project-scoped invite)
-	State                  string // pending | accepted | revoked | expired
-	InvitedBy              uint
-	ValidationModeAtInvite string // snapshot of the install validation mode at invite time
+	ID        uint   `gorm:"primaryKey"`
+	ProjectID uint   `gorm:"index"`
+	Email     string `gorm:"index"`
+	Role      string // intended project role (project-scoped invite)
+	State     string // pending | accepted | revoked | expired
+	InvitedBy uint
+	// InvitedByMachineIdentityID (#1573) records which machine identity issued
+	// this invitation, when InvitedBy is 0 because the inviter was a machine
+	// caller (ADR-030) rather than a human. Plain uint, 0 = none, consistent
+	// with every other attribution field on this model.
+	InvitedByMachineIdentityID uint
+	ValidationModeAtInvite     string // snapshot of the install validation mode at invite time
 	// Global invite (ADR-024): a non-project-scoped invitation (ProjectID 0) that, on
 	// accept, grants a system role plus the per-project assignments below. Both empty
 	// for a project-scoped invite.
@@ -275,7 +280,11 @@ type BreakGlassActivation struct {
 	ExpiresAt     *time.Time `gorm:"index" json:"expires_at,omitempty"`
 	CreatedAt     time.Time  `json:"created_at"`
 	RevokedBy     uint       `json:"revoked_by,omitempty"` // set on early revoke
-	RevokedAt     *time.Time `json:"revoked_at,omitempty"`
+	// RevokedByMachineIdentityID (#1573) records which machine identity ended
+	// this emergency grant early, when RevokedBy is 0 because the revoker was a
+	// machine caller (ADR-030) rather than a human. Plain uint, 0 = none.
+	RevokedByMachineIdentityID uint       `json:"revoked_by_machine_identity_id,omitempty"`
+	RevokedAt                  *time.Time `json:"revoked_at,omitempty"`
 }
 
 // BeforeSave normalises CreatedAt to UTC so SQLite string comparisons are
@@ -304,6 +313,12 @@ type AccessReviewCampaign struct {
 	CreatedAt time.Time  `json:"created_at"`
 	ClosedBy  uint       `json:"closed_by,omitempty"`
 	ClosedAt  *time.Time `json:"closed_at,omitempty"`
+	// CreatedByMachineIdentityID/ClosedByMachineIdentityID (#1573) record which
+	// machine identity opened/closed this campaign, when the corresponding
+	// *By field is 0 because the actor was a machine caller (ADR-030) rather
+	// than a human. Plain uint, 0 = none.
+	CreatedByMachineIdentityID uint `json:"created_by_machine_identity_id,omitempty"`
+	ClosedByMachineIdentityID  uint `json:"closed_by_machine_identity_id,omitempty"`
 	// Degraded/DegradedReasons carry forward AccessReviewReport.Degraded/
 	// DegradedReasons (access_review.go) from the snapshot this campaign was
 	// opened from (#483). Without this, a transient storage error mid-snapshot
@@ -811,10 +826,16 @@ type SecretNode struct {
 	Status         string `gorm:"default:'active'"`
 	CreatedBy      string
 	OwnerID        uint `gorm:"index"`
-	IsShared       bool `gorm:"default:false"`
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	LastRotatedAt  *time.Time
+	// OwnerMachineIdentityID (#1573) records which machine identity created (and
+	// so owns) this secret, when OwnerID is 0 because the creator was a machine
+	// caller (ADR-030) rather than a human. Plain uint, 0 = none. Only set at
+	// creation time -- the reassignment path (secret_ownership.go/
+	// secret_reassign_owner.go) already rejects a machine actor outright.
+	OwnerMachineIdentityID uint `gorm:"index"`
+	IsShared               bool `gorm:"default:false"`
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+	LastRotatedAt          *time.Time
 	// AutoRotate opts this secret into automated rotation (ADR-046): when set, and the
 	// secret is covered by an active rotation policy it is overdue under, the rotation
 	// executor regenerates its value on schedule. Off by default — only secrets whose
@@ -1210,9 +1231,14 @@ type SetupToken struct {
 
 	ExpiresAt time.Time
 	// CreatedBy is the admin/inviter who minted the token; 0 for self-service reset.
-	CreatedBy  uint
-	CreatedAt  time.Time
-	ConsumedAt *time.Time // nil until consumed
+	CreatedBy uint
+	// CreatedByMachineIdentityID (#1573) records which machine identity minted
+	// this token, when CreatedBy is 0 because the inviter was a machine caller
+	// (ADR-030) rather than a human (or the token is genuinely self-service —
+	// both cases already collapse to CreatedBy 0, unchanged). Plain uint, 0 = none.
+	CreatedByMachineIdentityID uint
+	CreatedAt                  time.Time
+	ConsumedAt                 *time.Time // nil until consumed
 }
 
 // BeforeSave normalises CreatedAt to UTC so SQLite string comparisons are
@@ -1704,10 +1730,15 @@ type MachineIdentity struct {
 	State        string // pending | active | suspended | revoked
 	Description  string
 	CreatedBy    uint
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
-	LastSeenAt   *time.Time
-	RevokedAt    *time.Time
+	// CreatedByMachineIdentityID (#1573) records which machine identity created
+	// this machine identity (a machine provisioning another machine), when
+	// CreatedBy is 0 because the creator was a machine caller (ADR-030) rather
+	// than a human. Plain uint, 0 = none.
+	CreatedByMachineIdentityID uint
+	CreatedAt                  time.Time
+	UpdatedAt                  time.Time
+	LastSeenAt                 *time.Time
+	RevokedAt                  *time.Time
 	// Classification is the data-sensitivity tier this machine identity handles
 	// (ISO 27001 A.5.12): "" = unclassified, else public|internal|confidential|restricted.
 	// LABEL ONLY, NOT A CONTROL — see internal/core/classification.go.
@@ -1857,11 +1888,15 @@ type ProjectMembership struct {
 	// the user_roles grant a membership is supposed to carry once active; see
 	// KeyorixCore.revertFailedActivation for what happens when that grant fails
 	// after this row already committed as active.
-	InvitedBy   uint
-	InvitedAt   time.Time
-	ActivatedAt *time.Time
-	RevokedAt   *time.Time
-	UpdatedAt   time.Time
+	InvitedBy uint
+	// InvitedByMachineIdentityID (#1573) records which machine identity created
+	// this membership, when InvitedBy is 0 because the inviter was a machine
+	// caller (ADR-030) rather than a human. Plain uint, 0 = none.
+	InvitedByMachineIdentityID uint
+	InvitedAt                  time.Time
+	ActivatedAt                *time.Time
+	RevokedAt                  *time.Time
+	UpdatedAt                  time.Time
 }
 
 // BeforeSave normalises InvitedAt to UTC so SQLite string comparisons are

--- a/internal/storage/store/local_break_glass.go
+++ b/internal/storage/store/local_break_glass.go
@@ -86,13 +86,14 @@ func (ls *LocalStorage) UpdateBreakGlassActivation(ctx context.Context, a *model
 // so a concurrent revoke of the same activation cannot silently overwrite this
 // one's RevokedBy/RevokedAt. Returns storage.ErrBreakGlassNotActive (wrapped) if
 // the row was not active (already revoked, or absent).
-func (ls *LocalStorage) RevokeBreakGlassActivation(ctx context.Context, id, revokedBy uint, revokedAt time.Time) error {
+func (ls *LocalStorage) RevokeBreakGlassActivation(ctx context.Context, id, revokedBy, revokedByMachineID uint, revokedAt time.Time) error {
 	result := ls.db.WithContext(ctx).Model(&models.BreakGlassActivation{}).
 		Where("id = ? AND state = ?", id, breakGlassActiveState).
 		Updates(map[string]interface{}{
-			"state":      breakGlassRevokedState,
-			"revoked_by": revokedBy,
-			"revoked_at": revokedAt,
+			"state":                          breakGlassRevokedState,
+			"revoked_by":                     revokedBy,
+			"revoked_by_machine_identity_id": revokedByMachineID,
+			"revoked_at":                     revokedAt,
 		})
 	if result.Error != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)

--- a/internal/storage/store/remote_break_glass.go
+++ b/internal/storage/store/remote_break_glass.go
@@ -60,32 +60,34 @@ import (
 // models.ProjectInvitation before #507), so — matching membershipWire's/
 // invitationWire's reasoning — every field is named explicitly here.
 type breakGlassActivationWire struct {
-	ID            uint       `json:"id"`
-	ProjectID     uint       `json:"project_id"`
-	UserID        uint       `json:"user_id"`
-	RoleID        uint       `json:"role_id"`
-	RoleName      string     `json:"role_name"`
-	Justification string     `json:"justification"`
-	State         string     `json:"state"`
-	ExpiresAt     *time.Time `json:"expires_at,omitempty"`
-	CreatedAt     time.Time  `json:"created_at"`
-	RevokedBy     uint       `json:"revoked_by,omitempty"`
-	RevokedAt     *time.Time `json:"revoked_at,omitempty"`
+	ID                         uint       `json:"id"`
+	ProjectID                  uint       `json:"project_id"`
+	UserID                     uint       `json:"user_id"`
+	RoleID                     uint       `json:"role_id"`
+	RoleName                   string     `json:"role_name"`
+	Justification              string     `json:"justification"`
+	State                      string     `json:"state"`
+	ExpiresAt                  *time.Time `json:"expires_at,omitempty"`
+	CreatedAt                  time.Time  `json:"created_at"`
+	RevokedBy                  uint       `json:"revoked_by,omitempty"`
+	RevokedByMachineIdentityID uint       `json:"revoked_by_machine_identity_id,omitempty"`
+	RevokedAt                  *time.Time `json:"revoked_at,omitempty"`
 }
 
 func (w breakGlassActivationWire) toModel() *models.BreakGlassActivation {
 	return &models.BreakGlassActivation{
-		ID:            w.ID,
-		ProjectID:     w.ProjectID,
-		UserID:        w.UserID,
-		RoleID:        w.RoleID,
-		RoleName:      w.RoleName,
-		Justification: w.Justification,
-		State:         w.State,
-		ExpiresAt:     w.ExpiresAt,
-		CreatedAt:     w.CreatedAt,
-		RevokedBy:     w.RevokedBy,
-		RevokedAt:     w.RevokedAt,
+		ID:                         w.ID,
+		ProjectID:                  w.ProjectID,
+		UserID:                     w.UserID,
+		RoleID:                     w.RoleID,
+		RoleName:                   w.RoleName,
+		Justification:              w.Justification,
+		State:                      w.State,
+		ExpiresAt:                  w.ExpiresAt,
+		CreatedAt:                  w.CreatedAt,
+		RevokedBy:                  w.RevokedBy,
+		RevokedByMachineIdentityID: w.RevokedByMachineIdentityID,
+		RevokedAt:                  w.RevokedAt,
 	}
 }
 
@@ -164,8 +166,9 @@ func (rs *RemoteStorage) UpdateBreakGlassActivation(_ context.Context, _ *models
 // breakGlassRevokeRequest is RevokeBreakGlassActivation's request body, matching
 // server/http/handlers/break_glass_proxy.go's breakGlassRevokeProxyRequest.
 type breakGlassRevokeRequest struct {
-	RevokedBy uint      `json:"revoked_by"`
-	RevokedAt time.Time `json:"revoked_at"`
+	RevokedBy                  uint      `json:"revoked_by"`
+	RevokedByMachineIdentityID uint      `json:"revoked_by_machine_identity_id,omitempty"`
+	RevokedAt                  time.Time `json:"revoked_at"`
 }
 
 // RevokeBreakGlassActivation atomically transitions activation id from active to
@@ -177,9 +180,9 @@ type breakGlassRevokeRequest struct {
 // the exact double-revoke TOCTOU race this method exists to close (two
 // concurrent revoke requests both observing "active" before either writes). One
 // HTTP round trip maps to one atomic server-side conditional UPDATE.
-func (rs *RemoteStorage) RevokeBreakGlassActivation(ctx context.Context, id, revokedBy uint, revokedAt time.Time) error {
+func (rs *RemoteStorage) RevokeBreakGlassActivation(ctx context.Context, id, revokedBy, revokedByMachineID uint, revokedAt time.Time) error {
 	path := fmt.Sprintf("/api/v1/system/break-glass/%d/revoke", id)
-	resp, err := rs.client.Post(ctx, path, breakGlassRevokeRequest{RevokedBy: revokedBy, RevokedAt: revokedAt})
+	resp, err := rs.client.Post(ctx, path, breakGlassRevokeRequest{RevokedBy: revokedBy, RevokedByMachineIdentityID: revokedByMachineID, RevokedAt: revokedAt})
 	if err != nil {
 		// Same reasoning as CreateBreakGlassActivation above: makeRequest turns
 		// RevokeBreakGlassActivationProxy's 409 Conflict into a non-nil error

--- a/internal/storage/store/remote_misc_test.go
+++ b/internal/storage/store/remote_misc_test.go
@@ -202,7 +202,7 @@ func TestRemoteStorage_RevokeBreakGlassActivation(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	err = rs.RevokeBreakGlassActivation(context.Background(), 9, 1, now)
+	err = rs.RevokeBreakGlassActivation(context.Background(), 9, 1, 0, now)
 	assert.NoError(t, err)
 }
 
@@ -216,7 +216,7 @@ func TestRemoteStorage_RevokeBreakGlassActivation_NotActive(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	err = rs.RevokeBreakGlassActivation(context.Background(), 9, 1, time.Now())
+	err = rs.RevokeBreakGlassActivation(context.Background(), 9, 1, 0, time.Now())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, corestorage.ErrBreakGlassNotActive)
 }

--- a/internal/storage/store/remote_wire_route_coverage_test.go
+++ b/internal/storage/store/remote_wire_route_coverage_test.go
@@ -914,7 +914,7 @@ var knownUnresolvedWireCalls = map[string]wireCallExclusion{
 	"remote_access_review_campaigns.go:237": urlValuesEntry(),
 	"remote_access_review_campaigns.go:263": urlValuesEntry(),
 	"remote_auth.go:341":                    urlValuesEntry(),
-	"remote_break_glass.go:135":             urlValuesEntry(),
+	"remote_break_glass.go:137":             urlValuesEntry(),
 	"remote_dynamic.go:243":                 urlValuesEntry(),
 	"remote_dynamic.go:331":                 urlValuesEntry(),
 	"remote_dynamic.go:358":                 urlValuesEntry(),

--- a/internal/storage/store/store_max_test.go
+++ b/internal/storage/store/store_max_test.go
@@ -2061,7 +2061,7 @@ func TestUpdateBreakGlassActivation_UpsertPath(t *testing.T) {
 // RevokeBreakGlassActivation — not-found.
 func TestRevokeBreakGlassActivation_NotFound(t *testing.T) {
 	ls := newBGStoreMax(t)
-	err := ls.RevokeBreakGlassActivation(context.Background(), 9999, 1, time.Now())
+	err := ls.RevokeBreakGlassActivation(context.Background(), 9999, 1, 0, time.Now())
 	require.Error(t, err)
 }
 

--- a/internal/storage/store/store_s22_test.go
+++ b/internal/storage/store/store_s22_test.go
@@ -402,7 +402,7 @@ func TestBreakGlass_S22_CRUD(t *testing.T) {
 
 	// RevokeBreakGlassActivation — success path.
 	revokedAt := time.Now()
-	require.NoError(t, ls.RevokeBreakGlassActivation(ctx, a.ID, 1, revokedAt))
+	require.NoError(t, ls.RevokeBreakGlassActivation(ctx, a.ID, 1, 0, revokedAt))
 	revoked, err := ls.GetBreakGlassActivation(ctx, a.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "revoked", revoked.State)
@@ -421,10 +421,10 @@ func TestBreakGlass_S22_RevokeNotActive(t *testing.T) {
 	require.NoError(t, err)
 
 	// Revoke once successfully.
-	require.NoError(t, ls.RevokeBreakGlassActivation(ctx, a.ID, 1, time.Now()))
+	require.NoError(t, ls.RevokeBreakGlassActivation(ctx, a.ID, 1, 0, time.Now()))
 
 	// Second revoke on the already-revoked row must fail.
-	err = ls.RevokeBreakGlassActivation(ctx, a.ID, 1, time.Now())
+	err = ls.RevokeBreakGlassActivation(ctx, a.ID, 1, 0, time.Now())
 	require.Error(t, err)
 }
 

--- a/internal/storage/store/store_s27_test.go
+++ b/internal/storage/store/store_s27_test.go
@@ -443,14 +443,14 @@ func TestListBreakGlassActivations_S27_BrokenDB(t *testing.T) {
 
 func TestRevokeBreakGlassActivation_S27_NotActive(t *testing.T) {
 	ls := newS27Store(t, &models.BreakGlassActivation{})
-	err := ls.RevokeBreakGlassActivation(context.Background(), 9999, 1, time.Now())
+	err := ls.RevokeBreakGlassActivation(context.Background(), 9999, 1, 0, time.Now())
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, storage.ErrBreakGlassNotActive) || err != nil)
 }
 
 func TestRevokeBreakGlassActivation_S27_BrokenDB(t *testing.T) {
 	ls := brokenS27Store(t)
-	err := ls.RevokeBreakGlassActivation(context.Background(), 1, 1, time.Now())
+	err := ls.RevokeBreakGlassActivation(context.Background(), 1, 1, 0, time.Now())
 	require.Error(t, err)
 }
 

--- a/internal/storage/store/store_s27b_test.go
+++ b/internal/storage/store/store_s27b_test.go
@@ -406,7 +406,7 @@ func TestListBreakGlassActivations_S27b_HappyPath(t *testing.T) {
 // the table does not exist.
 func TestRevokeBreakGlassActivation_S27b_BrokenDB(t *testing.T) {
 	ls := newBrokenDB(t)
-	err := ls.RevokeBreakGlassActivation(context.Background(), 1, 1, time.Now())
+	err := ls.RevokeBreakGlassActivation(context.Background(), 1, 1, 0, time.Now())
 	require.Error(t, err)
 }
 

--- a/internal/storage/store/store_s3_test.go
+++ b/internal/storage/store/store_s3_test.go
@@ -1228,7 +1228,7 @@ func TestBreakGlass_GetListRevoke(t *testing.T) {
 
 	// Revoke.
 	revokedAt := time.Now()
-	require.NoError(t, ls.RevokeBreakGlassActivation(ctx, act.ID, 1, revokedAt))
+	require.NoError(t, ls.RevokeBreakGlassActivation(ctx, act.ID, 1, 0, revokedAt))
 
 	// Verify revoked.
 	got2, err := ls.GetBreakGlassActivation(ctx, act.ID)
@@ -1236,7 +1236,7 @@ func TestBreakGlass_GetListRevoke(t *testing.T) {
 	assert.Equal(t, "revoked", got2.State)
 
 	// Revoke again → ErrBreakGlassNotActive (wrapped).
-	err = ls.RevokeBreakGlassActivation(ctx, act.ID, 1, time.Now())
+	err = ls.RevokeBreakGlassActivation(ctx, act.ID, 1, 0, time.Now())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, storage.ErrBreakGlassNotActive)
 }

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -244,7 +244,7 @@ func TestAuthInterceptor_MachineTokenAuthenticatesAndUsesMachineRBAC(t *testing.
 	require.NoError(t, h.DB.AutoMigrate(
 		&models.MachineIdentity{}, &models.MachineIdentityCredential{}, &models.MachineIdentityRole{}))
 
-	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot", "service", "", "", 1)
+	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot", "service", "", "", 1, 0)
 	require.NoError(t, err)
 	// requireMachinePrivilegeCeiling now requires the calling actor (user 1) to
 	// hold roles.assign at the target project scope before it can mint a token —
@@ -345,7 +345,7 @@ func TestAuthInterceptor_MachineTokenNetworkAllowlistOverGRPC(t *testing.T) {
 	require.NoError(t, h.DB.AutoMigrate(
 		&models.MachineIdentity{}, &models.MachineIdentityCredential{}, &models.MachineIdentityRole{}))
 
-	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot-cidr", "service", "", "", 1)
+	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot-cidr", "service", "", "", 1, 0)
 	require.NoError(t, err)
 	// requireMachinePrivilegeCeiling now requires the calling actor (user 1) to
 	// hold roles.assign at the target project scope before it can mint a token —
@@ -445,7 +445,7 @@ func TestAuthInterceptor_MachineRequestStampsMachineActorInAudit(t *testing.T) {
 	require.NoError(t, h.DB.AutoMigrate(
 		&models.MachineIdentity{}, &models.MachineIdentityCredential{}, &models.MachineIdentityRole{}, &models.AuditEvent{}))
 
-	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot", "service", "", "", 1)
+	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "ci-bot", "service", "", "", 1, 0)
 	require.NoError(t, err)
 	// requireMachinePrivilegeCeiling now requires the calling actor (user 1) to
 	// hold roles.assign at the target project scope before it can mint a token —

--- a/server/grpc/interceptors/interceptors_s22_test.go
+++ b/server/grpc/interceptors/interceptors_s22_test.go
@@ -503,7 +503,7 @@ func TestStreamAuthInterceptor_S22_MachineTokenAuthenticates(t *testing.T) {
 	require.NoError(t, h.DB.AutoMigrate(
 		&models.MachineIdentity{}, &models.MachineIdentityCredential{}, &models.MachineIdentityRole{}))
 
-	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "stream-bot", "service", "", "", 1)
+	m, err := h.CoreService.CreateMachineIdentity(context.Background(), 2, "stream-bot", "service", "", "", 1, 0)
 	require.NoError(t, err)
 	// requireMachinePrivilegeCeiling now requires the calling actor (user 1) to
 	// hold roles.assign at the target project scope before it can mint a token —

--- a/server/grpc/services/break_glass_service.go
+++ b/server/grpc/services/break_glass_service.go
@@ -80,7 +80,7 @@ func (s *BreakGlassGRPCService) RevokeBreakGlass(ctx context.Context, req *pb.Re
 	if err := authorizeScoped(ctx, s.core, actor, "roles.assign", core.Scope{ProjectID: uint(req.GetProjectId())}); err != nil {
 		return nil, err
 	}
-	if err := s.core.RevokeBreakGlass(ctx, actor.UserID, uint(req.GetProjectId()), uint(req.GetActivationId())); err != nil {
+	if err := s.core.RevokeBreakGlass(ctx, actor.UserID, actor.MachineIdentityID, uint(req.GetProjectId()), uint(req.GetActivationId())); err != nil {
 		return nil, breakGlassError(err)
 	}
 	return &emptypb.Empty{}, nil

--- a/server/grpc/services/machine_identity_service.go
+++ b/server/grpc/services/machine_identity_service.go
@@ -103,7 +103,7 @@ func (s *MachineIdentityGRPCService) CreateMachineIdentity(ctx context.Context, 
 	if err := authorizeScoped(ctx, s.core, user, permRolesAssign, core.Scope{ProjectID: uint(req.GetProjectId())}); err != nil {
 		return nil, err
 	}
-	m, err := s.core.CreateMachineIdentity(ctx, uint(req.GetProjectId()), req.GetName(), req.GetIdentityType(), req.GetDescription(), req.GetClassification(), user.UserID)
+	m, err := s.core.CreateMachineIdentity(ctx, uint(req.GetProjectId()), req.GetName(), req.GetIdentityType(), req.GetDescription(), req.GetClassification(), user.UserID, user.MachineIdentityID)
 	if err != nil {
 		return nil, mapMachineError(err)
 	}

--- a/server/http/deployment_disclosure_family_test.go
+++ b/server/http/deployment_disclosure_family_test.go
@@ -125,7 +125,7 @@ func seedFamilyFixtures(t *testing.T, c *core.KeyorixCore) familyFixtures {
 
 	// An expired-but-active machine credential, so /machine-token-hygiene (#274) has a
 	// flagged entry.
-	mi, err := c.CreateMachineIdentity(ctx, project.ID, "family-ci-runner", "ci", "", "", admin.ID)
+	mi, err := c.CreateMachineIdentity(ctx, project.ID, "family-ci-runner", "ci", "", "", admin.ID, 0)
 	require.NoError(t, err)
 	_, err = c.IssueMachineToken(ctx, project.ID, mi.ID, admin.ID, core.IssueMachineTokenParams{Name: "family-ci-token", ExpiresAt: &pastExpiry})
 	require.NoError(t, err)

--- a/server/http/g80_1530_machine_actor_attribution_test.go
+++ b/server/http/g80_1530_machine_actor_attribution_test.go
@@ -38,7 +38,7 @@ func TestG80_1530_MachineActorAttribution_NonNodeServiceIdentity(t *testing.T) {
 	projects, err := testCore.Storage().ListProjects(ctx)
 	require.NoError(t, err)
 
-	mi, err := testCore.CreateMachineIdentity(ctx, projects[0].ID, "attribution-probe-service", core.MachineTypeService, "", "", admin.ID)
+	mi, err := testCore.CreateMachineIdentity(ctx, projects[0].ID, "attribution-probe-service", core.MachineTypeService, "", "", admin.ID, 0)
 	require.NoError(t, err)
 
 	role, err := testCore.Storage().CreateRole(ctx, &models.Role{Name: "g80_1530_system_writer"})

--- a/server/http/g80_final_sweep_test.go
+++ b/server/http/g80_final_sweep_test.go
@@ -370,7 +370,7 @@ func TestG80Sweep08_TransitionMachineIdentityStateProxy_LegalityAndCreatedBy(t *
 	f := newG80SweepFixture(t)
 	ctx := context.Background()
 
-	machine, err := f.core.CreateMachineIdentity(ctx, f.projectID, "g80sweep08-machine", core.MachineTypeService, "", "", f.adminID)
+	machine, err := f.core.CreateMachineIdentity(ctx, f.projectID, "g80sweep08-machine", core.MachineTypeService, "", "", f.adminID, 0)
 	require.NoError(t, err)
 	require.Equal(t, core.MachineActive, machine.State, "fixture assumption: CreateMachineIdentity starts a machine Active")
 
@@ -418,7 +418,7 @@ func TestG80Sweep09_UpdateMachineIdentityCredentialProxy_OnlyClassificationAppli
 	f := newG80SweepFixture(t)
 	ctx := context.Background()
 
-	machine, err := f.core.CreateMachineIdentity(ctx, f.projectID, "g80sweep09-machine", core.MachineTypeService, "", "", f.adminID)
+	machine, err := f.core.CreateMachineIdentity(ctx, f.projectID, "g80sweep09-machine", core.MachineTypeService, "", "", f.adminID, 0)
 	require.NoError(t, err)
 	originalExpiry := time.Now().Add(30 * 24 * time.Hour)
 	cred, err := f.core.Storage().CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{

--- a/server/http/handlers/access_review_campaigns.go
+++ b/server/http/handlers/access_review_campaigns.go
@@ -61,7 +61,7 @@ func (h *CatalogHandler) OpenAccessReviewCampaign(w http.ResponseWriter, r *http
 	}
 	// Body is optional; ignore decode errors on an empty body.
 	_ = json.NewDecoder(r.Body).Decode(&body)
-	result, err := h.coreService.OpenAccessReviewCampaign(r.Context(), userCtx.UserID, uint(projectID), body.Name)
+	result, err := h.coreService.OpenAccessReviewCampaign(r.Context(), userCtx.UserID, machineID(r), uint(projectID), body.Name)
 	if err != nil {
 		sendCampaignError(w, "opening access-review campaign", err)
 		return
@@ -172,7 +172,7 @@ func (h *CatalogHandler) CloseAccessReviewCampaign(w http.ResponseWriter, r *htt
 		Force bool `json:"force"`
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body)
-	result, err := h.coreService.CloseAccessReviewCampaign(r.Context(), userCtx.UserID, uint(projectID), uint(campaignID), body.Force)
+	result, err := h.coreService.CloseAccessReviewCampaign(r.Context(), userCtx.UserID, machineID(r), uint(projectID), uint(campaignID), body.Force)
 	if err != nil {
 		sendCampaignError(w, "closing access-review campaign", err)
 		return

--- a/server/http/handlers/break_glass.go
+++ b/server/http/handlers/break_glass.go
@@ -94,7 +94,7 @@ func (h *CatalogHandler) RevokeBreakGlass(w http.ResponseWriter, r *http.Request
 		sendError(w, "Unauthorized", "User context not found", http.StatusUnauthorized, nil)
 		return
 	}
-	if err := h.coreService.RevokeBreakGlass(r.Context(), actor.UserID, uint(id), uint(activationID)); err != nil {
+	if err := h.coreService.RevokeBreakGlass(r.Context(), actor.UserID, machineID(r), uint(id), uint(activationID)); err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()
 		switch {

--- a/server/http/handlers/break_glass_proxy.go
+++ b/server/http/handlers/break_glass_proxy.go
@@ -268,7 +268,9 @@ func (h *CatalogHandler) RevokeBreakGlassActivationProxy(w http.ResponseWriter, 
 		return
 	}
 
-	if err := h.coreService.Storage().RevokeBreakGlassActivation(r.Context(), uint(id), revokedBy, body.RevokedAt); err != nil {
+	// revokedBy is required nonzero human above (actorID(r)==0 denied) -- this
+	// route never represents a machine revoker, so 0 for the companion param.
+	if err := h.coreService.Storage().RevokeBreakGlassActivation(r.Context(), uint(id), revokedBy, 0, body.RevokedAt); err != nil {
 		if errors.Is(err, coreStorage.ErrBreakGlassNotActive) {
 			writeRemoteAPIError(w, http.StatusConflict, breakGlassNotActiveCode, coreStorage.ErrBreakGlassNotActive.Error())
 			return

--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -47,6 +47,19 @@ func isMachineActor(r *http.Request) bool {
 	return u != nil && u.ActorKind() == core.ActorTypeMachine
 }
 
+// machineID returns the acting machine identity's ID (0 for a human actor or
+// no request context), for threading into a *MachineIdentityID attribution
+// companion parameter (#1573) alongside actorID(r). Unlike actorID(r), which
+// is always 0 for a machine caller (ADR-030, no UserID), this carries WHICH
+// machine, so a model's actor-attribution field is not left unattributed.
+func machineID(r *http.Request) uint {
+	u := middleware.GetUserFromContext(r.Context())
+	if u != nil && u.MachineIdentityID != nil {
+		return *u.MachineIdentityID
+	}
+	return 0
+}
+
 // isNodeCredentialRequest is REMOVED (ADR-085, Accepted, 2026-08-25). It used
 // to report whether a request authenticated with a genuine MachineTypeNode
 // credential, so a handful of /system handlers could trust that call

--- a/server/http/handlers/invitations.go
+++ b/server/http/handlers/invitations.go
@@ -56,7 +56,7 @@ func (h *CatalogHandler) CreateInvitation(w http.ResponseWriter, r *http.Request
 		sendError(w, "ValidationError", "email and role are required", http.StatusBadRequest, nil)
 		return
 	}
-	inv, prov, err := h.coreService.InviteToProjectWithLink(r.Context(), id, body.Email, body.Role, actor.UserID)
+	inv, prov, err := h.coreService.InviteToProjectWithLink(r.Context(), id, body.Email, body.Role, actor.UserID, machineID(r))
 	if err != nil {
 		// A nil inv means the invitation was not created at all; a non-nil inv with an
 		// error means it was created but the link could not be provisioned (e.g.
@@ -130,7 +130,7 @@ func (h *CatalogHandler) CreateGlobalInvitation(w http.ResponseWriter, r *http.R
 	for _, a := range body.ProjectAssignments {
 		assignments = append(assignments, core.ProjectAssignment{ProjectID: a.ProjectID, Role: a.Role})
 	}
-	inv, prov, err := h.coreService.InviteGlobalWithLink(r.Context(), body.Email, body.Role, assignments, actor.UserID)
+	inv, prov, err := h.coreService.InviteGlobalWithLink(r.Context(), body.Email, body.Role, assignments, actor.UserID, machineID(r))
 	if err != nil {
 		// A nil inv means the invitation was not created at all (bad input); a non-nil
 		// inv with an error means it exists but the link couldn't be provisioned (e.g.

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -80,7 +80,7 @@ func (h *CatalogHandler) CreateMachineIdentity(w http.ResponseWriter, r *http.Re
 		sendError(w, "ValidationError", "name is required", http.StatusBadRequest, nil)
 		return
 	}
-	m, err := h.coreService.CreateMachineIdentity(r.Context(), id, body.Name, body.IdentityType, body.Description, body.Classification, actor.UserID)
+	m, err := h.coreService.CreateMachineIdentity(r.Context(), id, body.Name, body.IdentityType, body.Description, body.Classification, actor.UserID, machineID(r))
 	if err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -341,7 +341,12 @@ func (h *CatalogHandler) CreateMachineIdentityProxy(w http.ResponseWriter, r *ht
 	// this SAME function just ceiling-checked two lines above) already being
 	// available — force provenance to match the actor that was actually
 	// authorized to perform this create.
-	created, err := h.coreService.CreateMachineIdentity(r.Context(), body.ProjectID, body.Name, body.IdentityType, body.Description, body.Classification, principalID)
+	// #1573: this proxy already stamps CreatedBy from principalID (the machine's
+	// own ID for a machine relay caller), not 0 -- the same ID-namespace-collision
+	// shape as #1623 (SecretDependency.CreatedBy), not the "left at 0" shape PR2
+	// fixes elsewhere. Left unchanged here rather than silently fixed mid-PR; see
+	// #1623.
+	created, err := h.coreService.CreateMachineIdentity(r.Context(), body.ProjectID, body.Name, body.IdentityType, body.Description, body.Classification, principalID, 0)
 	if err != nil {
 		msg := err.Error()
 		status := http.StatusInternalServerError

--- a/server/http/handlers/machine_identities_proxy_credential_narrow_test.go
+++ b/server/http/handlers/machine_identities_proxy_credential_narrow_test.go
@@ -33,7 +33,7 @@ func TestUpdateMachineIdentityCredentialProxy_IgnoresTokenHashAndRevoked_RealSer
 
 	proj, err := cs.CreateProject(ctx, "g80-credential-narrow-proj", "")
 	require.NoError(t, err)
-	m, err := cs.CreateMachineIdentity(ctx, proj.ID, "g80-credential-narrow-machine", core.MachineTypeOther, "", "", 0)
+	m, err := cs.CreateMachineIdentity(ctx, proj.ID, "g80-credential-narrow-machine", core.MachineTypeOther, "", "", 0, 0)
 	require.NoError(t, err)
 	// actorID must belong to a real user holding admin/roles.assign authority
 	// now that IssueMachineToken enforces RequireMachinePrivilegeCeiling; user

--- a/server/http/handlers/machine_identities_proxy_transition_ceiling_test.go
+++ b/server/http/handlers/machine_identities_proxy_transition_ceiling_test.go
@@ -37,7 +37,7 @@ func TestTransitionMachineIdentityStateProxy_RejectsIllegalTransition_RealServer
 
 	proj, err := cs.CreateProject(ctx, "g80-transition-ceiling-proj", "")
 	require.NoError(t, err)
-	m, err := cs.CreateMachineIdentity(ctx, proj.ID, "g80-transition-ceiling-machine", core.MachineTypeOther, "", "", 0)
+	m, err := cs.CreateMachineIdentity(ctx, proj.ID, "g80-transition-ceiling-machine", core.MachineTypeOther, "", "", 0, 0)
 	require.NoError(t, err)
 	require.Equal(t, core.MachineActive, m.State)
 

--- a/server/http/handlers/project_memberships.go
+++ b/server/http/handlers/project_memberships.go
@@ -97,7 +97,7 @@ func (h *CatalogHandler) InviteMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	const idpResolvedNotAcceptedFromClient = false
-	m, err := h.coreService.InviteMember(r.Context(), uint(id), body.UserID, body.Role, actor.UserID, idpResolvedNotAcceptedFromClient)
+	m, err := h.coreService.InviteMember(r.Context(), uint(id), body.UserID, body.Role, actor.UserID, machineID(r), idpResolvedNotAcceptedFromClient)
 	if err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()

--- a/server/http/handlers/secret_update_diff.go
+++ b/server/http/handlers/secret_update_diff.go
@@ -103,10 +103,11 @@ var updateSecretAllowlist = map[string]secretUpdateFieldClass{
 	"RetentionOverrideDays": secretFieldRejected,
 
 	// -- rejected: gated by an authorization check this endpoint cannot run --
-	"OwnerID":        secretFieldRejected, // TransferSecretOwnership: current-owner + SoD check
-	"ParentID":       secretFieldRejected, // MoveSecret: cross-project/environment guard
-	"Name":           secretFieldRejected, // BulkRenameSecrets: uniqueness + validation
-	"Classification": secretFieldRejected, // ClassifySecret: G09 read-approval gate on downgrade
+	"OwnerID":                secretFieldRejected, // TransferSecretOwnership: current-owner + SoD check
+	"OwnerMachineIdentityID": secretFieldRejected, // set at creation only (#1573); reassignment is the same TransferSecretOwnership gate as OwnerID, which explicitly rejects a machine actor
+	"ParentID":               secretFieldRejected, // MoveSecret: cross-project/environment guard
+	"Name":                   secretFieldRejected, // BulkRenameSecrets: uniqueness + validation
+	"Classification":         secretFieldRejected, // ClassifySecret: G09 read-approval gate on downgrade
 	// AutoRotate/RotationLength/RotationCharset are set together with
 	// RotationBackend/RotationRef in the ONE SetSecretAutoRotate call (rotation_executor.go)
 	// as a single AutoRotateSpec. requireAdminAuthorityAt only fires when Backend/Ref
@@ -214,6 +215,9 @@ func diffSecretUpdate(authoritative, desired *models.SecretNode) secretUpdateDif
 	}
 	if authoritative.OwnerID != desired.OwnerID {
 		d.Rejected = append(d.Rejected, "owner_id")
+	}
+	if authoritative.OwnerMachineIdentityID != desired.OwnerMachineIdentityID {
+		d.Rejected = append(d.Rejected, "owner_machine_identity_id")
 	}
 	if authoritative.IsShared != desired.IsShared {
 		d.Rejected = append(d.Rejected, "is_shared")

--- a/server/http/handlers/secret_update_diff_test.go
+++ b/server/http/handlers/secret_update_diff_test.go
@@ -103,6 +103,7 @@ func TestDiffSecretUpdate_EveryFieldBehavesAsClassified(t *testing.T) {
 		{"Status", secretFieldRejected, func(s *models.SecretNode) { s.Status = "suspended" }},
 		{"CreatedBy", secretFieldRejected, func(s *models.SecretNode) { s.CreatedBy = "someone-else" }},
 		{"OwnerID", secretFieldRejected, func(s *models.SecretNode) { s.OwnerID = 999 }},
+		{"OwnerMachineIdentityID", secretFieldRejected, func(s *models.SecretNode) { s.OwnerMachineIdentityID = 999 }},
 		{"IsShared", secretFieldRejected, func(s *models.SecretNode) { s.IsShared = true }},
 		{"CreatedAt", secretFieldRejected, func(s *models.SecretNode) { s.CreatedAt = time.Unix(1, 0) }},
 		{"LastRotatedAt", secretFieldRejected, func(s *models.SecretNode) { now := time.Unix(3000, 0); s.LastRotatedAt = &now }},

--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -120,7 +120,7 @@ func createNodeIdentityAndAdmin(t *testing.T, c *core.KeyorixCore) (mi *models.M
 	projects, err := c.Storage().ListProjects(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, projects, "createTestToken must have seeded a default project")
-	mi, err = c.CreateMachineIdentity(ctx, projects[0].ID, "test-node", core.MachineTypeNode, "test node credential", "", admin.ID)
+	mi, err = c.CreateMachineIdentity(ctx, projects[0].ID, "test-node", core.MachineTypeNode, "test node credential", "", admin.ID, 0)
 	require.NoError(t, err)
 	return mi, admin, projects[0].ID
 }

--- a/server/http/machine_audit_handler_test.go
+++ b/server/http/machine_audit_handler_test.go
@@ -113,7 +113,7 @@ func TestMachineAuditReport_ContainsCreatedMachine(t *testing.T) {
 
 	// Create a project first (bootstrap already creates project ID=1).
 	ctx := context.Background()
-	machine, err := c.CreateMachineIdentity(ctx, 1, "audit-test-bot", "ci", "robot for audit test", "", 1)
+	machine, err := c.CreateMachineIdentity(ctx, 1, "audit-test-bot", "ci", "robot for audit test", "", 1, 0)
 	require.NoError(t, err)
 	require.NotNil(t, machine)
 
@@ -152,7 +152,7 @@ func TestMachineAuditReport_NeverUsedIsStale(t *testing.T) {
 	defer srv.Close()
 
 	ctx := context.Background()
-	machine, err := c.CreateMachineIdentity(ctx, 1, "stale-bot", "ci", "never used", "", 1)
+	machine, err := c.CreateMachineIdentity(ctx, 1, "stale-bot", "ci", "never used", "", 1, 0)
 	require.NoError(t, err)
 
 	resp := authGetMachineAudit(t, srv, token, "/api/v1/machine-identities/audit")

--- a/server/http/machine_privilege_ceiling_creation_test.go
+++ b/server/http/machine_privilege_ceiling_creation_test.go
@@ -120,7 +120,7 @@ func TestMachinePrivilegeCeiling_CreateMachineIdentityCredentialProxy_ZeroRoleTa
 	f := newMachinePrivilegeCeilingFixture(t)
 	ctx := context.Background()
 
-	zeroRoleMachine, err := f.core.CreateMachineIdentity(ctx, f.projectID, "zero-role-target", core.MachineTypeNode, "", "", f.adminID)
+	zeroRoleMachine, err := f.core.CreateMachineIdentity(ctx, f.projectID, "zero-role-target", core.MachineTypeNode, "", "", f.adminID, 0)
 	require.NoError(t, err)
 
 	status, body := f.do(t, f.swToken, http.MethodPost, "/api/v1/system/machine-credentials", map[string]any{
@@ -141,7 +141,7 @@ func TestMachinePrivilegeCeiling_CreateMachineIdentityCredentialProxy_RolesAssig
 	f := newMachinePrivilegeCeilingFixture(t)
 	ctx := context.Background()
 
-	zeroRoleMachine, err := f.core.CreateMachineIdentity(ctx, f.projectID, "zero-role-target-2", core.MachineTypeNode, "", "", f.adminID)
+	zeroRoleMachine, err := f.core.CreateMachineIdentity(ctx, f.projectID, "zero-role-target-2", core.MachineTypeNode, "", "", f.adminID, 0)
 	require.NoError(t, err)
 
 	status, body := f.do(t, f.assignToken, http.MethodPost, "/api/v1/system/machine-credentials", map[string]any{

--- a/server/http/remote_storage_break_glass_test.go
+++ b/server/http/remote_storage_break_glass_test.go
@@ -213,7 +213,7 @@ func TestRemoteStorageBreakGlass_RevokeActuallyRemovesTheRoleGrant(t *testing.T)
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, asRevoker.Storage().RevokeBreakGlassActivation(ctx, act.ID, revoker.ID, time.Now()))
+	require.NoError(t, asRevoker.Storage().RevokeBreakGlassActivation(ctx, act.ID, revoker.ID, 0, time.Now()))
 
 	final, err := upstream.Storage().GetBreakGlassActivation(ctx, act.ID)
 	require.NoError(t, err)
@@ -252,13 +252,13 @@ func TestRemoteStorageBreakGlass_RevokeThenRevokeAgainFails_RealServer(t *testin
 	act, err := upstream.Storage().CreateBreakGlassActivation(ctx, buildActiveBreakGlassActivation(now, projectID, 7))
 	require.NoError(t, err)
 
-	require.NoError(t, asRevoker.Storage().RevokeBreakGlassActivation(ctx, act.ID, revoker.ID, time.Now()))
+	require.NoError(t, asRevoker.Storage().RevokeBreakGlassActivation(ctx, act.ID, revoker.ID, 0, time.Now()))
 
 	final, err := downstream.Storage().GetBreakGlassActivation(ctx, act.ID)
 	require.NoError(t, err)
 	assert.Equal(t, core.BreakGlassRevoked, final.State)
 
-	err = asRevoker.Storage().RevokeBreakGlassActivation(ctx, act.ID, revoker.ID, time.Now())
+	err = asRevoker.Storage().RevokeBreakGlassActivation(ctx, act.ID, revoker.ID, 0, time.Now())
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, coreStorage.ErrBreakGlassNotActive), "got %v", err)
 }
@@ -307,7 +307,7 @@ func TestRemoteStorageBreakGlass_ConcurrentRevokeRace_RealServer(t *testing.T) {
 			// Conflict responses from losing racers can't trip a shared client's
 			// circuit breaker.
 			client := newBreakGlassRemoteClient(t, baseURL, apiKey)
-			err := client.Storage().RevokeBreakGlassActivation(context.Background(), act.ID, revokedBy, time.Now())
+			err := client.Storage().RevokeBreakGlassActivation(context.Background(), act.ID, revokedBy, 0, time.Now())
 			switch {
 			case err == nil:
 				successCount.Add(1)

--- a/server/http/system_write_ceiling_table_test.go
+++ b/server/http/system_write_ceiling_table_test.go
@@ -196,16 +196,16 @@ func setupCeilingTableFixtures(t *testing.T) ceilingTableFixtures {
 	require.NotEmpty(t, projects)
 	projectID := projects[0].ID
 
-	plainMachine, err := testCore.CreateMachineIdentity(ctx, projectID, "ceiling-table-plain", core.MachineTypeService, "", "", admin.ID)
+	plainMachine, err := testCore.CreateMachineIdentity(ctx, projectID, "ceiling-table-plain", core.MachineTypeService, "", "", admin.ID, 0)
 	require.NoError(t, err)
 
-	adminMachine, err := testCore.CreateMachineIdentity(ctx, projectID, "ceiling-table-admin-tier", core.MachineTypeService, "", "", admin.ID)
+	adminMachine, err := testCore.CreateMachineIdentity(ctx, projectID, "ceiling-table-admin-tier", core.MachineTypeService, "", "", admin.ID, 0)
 	require.NoError(t, err)
 	adminRole, err := testCore.Storage().GetRoleByName(ctx, "system_admin")
 	require.NoError(t, err)
 	require.NoError(t, testCore.AssignMachineRole(ctx, adminMachine.ID, adminRole.ID, core.Scope{ProjectID: projectID}, admin.ID))
 
-	revokedMachine, err := testCore.CreateMachineIdentity(ctx, projectID, "ceiling-table-revoked", core.MachineTypeService, "", "", admin.ID)
+	revokedMachine, err := testCore.CreateMachineIdentity(ctx, projectID, "ceiling-table-revoked", core.MachineTypeService, "", "", admin.ID, 0)
 	require.NoError(t, err)
 	revokedMachine.State = core.MachineRevoked
 	matched, err := testCore.Storage().TransitionMachineIdentityState(ctx, revokedMachine, core.MachineActive)

--- a/server/http/system_write_ceiling_test.go
+++ b/server/http/system_write_ceiling_test.go
@@ -104,7 +104,7 @@ func TestSystemWriteOnlyCeiling_RealServer(t *testing.T) {
 	// A real target machine identity for the proxy call to attach a credential to —
 	// created by the admin, exactly as a real deployment would have one.
 	targetMI, err := testCore.CreateMachineIdentity(ctx, projects[0].ID,
-		"ceiling-test-target", core.MachineTypeService, "target for the ceiling test", "", admin.ID)
+		"ceiling-test-target", core.MachineTypeService, "target for the ceiling test", "", admin.ID, 0)
 	require.NoError(t, err)
 
 	token := createSystemWriteOnlyToken(t, testCore)


### PR DESCRIPTION
## Summary

- PR2 of #1573's two-PR split (see #1622 for PR1, the check-breaking `AccessRequestApproval.ApproverID` fix). Mechanical: the remaining 8 Bucket-1 fields from #1573's classification (`docs/adr-091`, landed in #1622) whose zero-for-machine value loses attribution but doesn't defeat any check.
- Fields fixed: `ProjectInvitation.InvitedBy`, `SetupToken.CreatedBy`, `AccessReviewCampaign.CreatedBy`/`ClosedBy`, `SecretNode.OwnerID`, `MachineIdentity.CreatedBy`, `ProjectMembership.InvitedBy`, `BreakGlassActivation.RevokedBy`.
- Each gets a plain `uint *MachineIdentityID` companion field (0 = human/none — consistent with every existing attribution field on these models, not the nullable `*uint` `AuditEvent.MachineIdentityID` shape from #1530, since none of these participate in a uniqueness constraint the way #1622's `ApproverMachineIdentityID` does), populated from the handler's already-resolved machine identity via a new `machineID(r)` helper (`server/http/handlers/catalog.go`, alongside `actorID(r)`/`isMachineActor(r)`).

## Two deliberate exclusions — not silently folded in

- **`SecretDependency.CreatedBy`**, originally in scope, turned out to already be correctly attributed — `server/http/handlers/secret_dependencies.go` uses `PrincipalID()`, not `UserID`. This surfaced a *different* bug (no discriminator between a `User.ID` and a `MachineIdentity.ID` in the same `uint` column — separate tables, independent auto-increment sequences, can collide), filed separately as #1623 rather than fixed here.
- `machine_identities_proxy.go`'s `CreateMachineIdentityProxy` has the same #1623 shape (stamps `CreatedBy` from `principalID` already) — left unchanged, noted in a comment pointing to #1623.

## Test plan

- [x] New tests verify each of the 8 fields is populated for a machine actor: `TestInviteToProject_RecordsActingMachineIdentity`, `TestInviteToProjectWithLink_RecordsActingMachineIdentityOnSetupToken`, `TestAccessReviewCampaign_RecordsActingMachineIdentity` (both Created/Closed), `TestCreateSecret_RecordsActingMachineIdentity`, `TestCreateMachineIdentity`'s new subtest, `TestInviteMember_RecordsActingMachineIdentity`, `TestRevokeBreakGlass_RecordsActingMachineIdentity`
- [x] Fixed two completeness-guard breaks the new `SecretNode.OwnerMachineIdentityID` field tripped: `TestSecretUpdateAllowlist_CoversEveryPersistedField`/`TestDiffSecretUpdate_EveryFieldBehavesAsClassified` (needed an explicit classification + diff check) and `TestRemoteStorageWireCalls_HaveMatchingRoute` (a line-number-pinned registry entry shifted when `remote_break_glass.go` grew new lines)
- [x] ~50 pre-existing test call sites across the repo updated for the new function signatures (mechanical `0`-insertion, preserving original human-actor test behavior)
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] Full repo test suite (`go test ./...`) green