### PR TITLE
fix(rbac): emitAudit clears UserID for a machine principal (#1626)

### DIFF
--- a/docs/adr-092-audit-event-userid-machine-principal.md
+++ b/docs/adr-092-audit-event-userid-machine-principal.md
@@ -1,0 +1,149 @@
+# ADR-092: `AuditEvent.UserID` held a machine principal's raw ID at eight call sites — fixed at the choke point, not the call sites
+
+## Status
+
+**Accepted (2026-08-30).** #1626. Fix landed here; guard is the deliverable.
+
+## What this is
+
+#1530 added `AuditEvent.MachineIdentityID` alongside `UserID` specifically so a
+machine-actored audit row could record WHICH machine acted, not just that a
+machine did — and centralized the stamp at `emitAudit`, the single choke
+point every audit writer funnels through, so the fix cost zero call sites.
+
+#1626 is the same model's `UserID` column, the other direction: eight
+`internal/core` call sites built `userID` from a `PrincipalID()`-derived
+value (correct for `AuthorizePrincipal`, which needs the machine's real ID;
+wrong for `UserID`, a human-attribution column) and handed it to
+`writeAuditEventFull`/`writeAuditEventDiff`/`writeAuditEventFailed`. Found
+during #1623's `PrincipalID()` sweep (PR #1625) and deliberately filed
+separately — `AuditEvent` already has the discriminator #1623's persisted
+model columns lacked, so this is a narrower, differently-shaped bug: every
+affected row is still resolvable via `ActorType`/`MachineIdentityID`, just
+carries a corrupt `UserID`.
+
+## Task 1 — mechanism: pass-through, not bypass
+
+Verified directly, not assumed: `writeAuditEvent` → `writeAuditEventFull` →
+`writeAuditEventDiff` (and the parallel `writeAuditEventFailed`) all
+construct `&models.AuditEvent{UserID: userID, ..., ActorType:
+actorTypeFromContext(ctx)}` and call `c.emitAudit(ctx, event)` — every one of
+them, no exceptions. All eight go through this correctly; none bypass it.
+`TestDirectLogAuditEventCallersAreSafe` (#1530's existing guard) already
+confirms `emitAudit` is the sole legitimate caller of `storage.LogAuditEvent`
+repo-wide, with one unrelated allowlisted exception.
+
+This is not "eight independent mistakes" in the sense of needing eight
+independent fixes — it's the same mistake repeated eight times at the
+boundary where a `PrincipalID()`-derived authorization value gets reused as
+an attribution value, all funneling through one writer. That makes the fix
+belong at the writer.
+
+Confirmed safe to fix at `emitAudit` specifically (not just `writeAuditEvent*`)
+by checking all six `emitAudit` call sites repo-wide: the two
+`writeImpersonationEvent`/`writeImpersonationDeniedEvent` events
+(`impersonation.go`) never set `ActorType` at all (defaults to `""`), and
+`SetRetentionPolicy`/`AuditLicenseState` (`data_retention.go`, `service.go`)
+hardcode `ActorTypeSystem`/`"system"`. None of the four ever produce
+`ActorType == ActorTypeMachine`, so the fix's guard condition only ever fires
+for the real bug.
+
+## Task 2 — detectable, not silent, for all eight
+
+`writeAuditEventDiff`/`writeAuditEventFailed` set `ActorType:
+actorTypeFromContext(ctx)` — context-derived, independent of whatever
+`userID` the call site passed. `emitAudit`'s `MachineIdentityID` stamp fires
+on the identical `ActorType == ActorTypeMachine` condition, from the
+identical context. All eight are reached through ordinary HTTP/gRPC routes
+(real permission-gated requests, not an untagged background path), so
+`ActorType`/`MachineIdentityID` were always correctly populated even before
+this fix.
+
+**All eight land in the self-contradicting, detectable bucket**:
+`ActorType="machine_identity"` + `MachineIdentityID=<real machine ID>` +
+`UserID=<the same real machine ID, misplaced>`. A consumer that checks
+`ActorType` first — which any correct consumer must, `UserID` alone having
+always been nil-vs-set ambiguous — never mistakes one of these for a genuine
+human action. This is a materially different, better answer than #1623's:
+these rows are identifiable as machine-actored and the acting machine is
+still recoverable from `MachineIdentityID`. It is `UserID` specifically that
+was corrupt, not the row's overall attributability. Do not overstate this —
+identifying the row as bad is not the same claim as having a valid `UserID`.
+
+## Task 3 — the fix and the guard
+
+Fix: `emitAudit` (`internal/core/service.go`) now sets `event.UserID = nil`
+unconditionally whenever `event.ActorType == ActorTypeMachine`, right
+alongside the existing `MachineIdentityID` stamp. One correction, one place,
+covering all eight current call sites and any future one — not a second
+machine-actor field, not eight separate patches. This is the same "close the
+path, don't patch the habit" move #1530 made for `MachineIdentityID` itself.
+
+Guard: `internal/core/audit_userid_machine_principal_test.go`.
+- `TestEmitAudit_MachineActorNeverGetsUserID` pins the choke-point invariant
+  directly against `emitAudit`. Verified red by temporarily removing the
+  `event.UserID = nil` line and confirming the mocked `storage.LogAuditEvent`
+  call no longer matched (a raw machine ID surviving in `UserID`), then
+  restored.
+- `TestEmitAudit_HumanActorKeepsUserID` is the positive control: a
+  human-actored event's `UserID` is untouched, `MachineIdentityID` stays
+  nil — the fix is conditioned on `ActorType == machine`, not a blanket
+  UserID-clearing rule.
+- `TestAddSecretDependency_AuditEventUserIDNotMachinePrincipal` reproduces
+  the bug end-to-end against one of the real eight call sites (not just
+  `emitAudit` in isolation), with `ctx` tagged via `WithActorType`/
+  `WithMachineActor` exactly as the real HTTP auth middleware
+  (`buildRequestContext`) tags a machine-authenticated request — a bare
+  `context.Background()` would not reproduce the real bug, since
+  `AddSecretDependency`'s own `actorKind` parameter only drives
+  `AuthorizeSecretPrincipal`, not the audit writer's context-derived
+  `ActorType`/`MachineIdentityID`. Verified red the same way.
+
+This is this campaign's fifth instance of "guard the invariant, not the
+conclusion" (after #1494's DTO-shape guard, the `/system` proxy-layer sweep,
+#1573's machine-global-scope-invariant guard, and #1623's per-model
+discriminator pattern). It is the standing answer to "a completed fix with a
+per-caller hole in it": fix and guard the choke point every caller already
+funnels through, not the callers.
+
+## Task 4 — relationship to #1623 / PR #1624
+
+Same mechanism as #1623: `PrincipalID()` — correct for authorization, wrong
+when reused as a human-attribution value — feeding a column with no
+(#1623) or, here, an existing-but-bypassable (#1626) discriminator.
+
+The `PrincipalID()` sweep in PR #1625 did not miss these eight — it found
+them and deliberately filed them here rather than folding them into #1623,
+specifically because `AuditEvent` already carries `ActorType`/
+`MachineIdentityID` (landed by #1530), making this a narrower bug (a wrong
+value at an established choke point) than #1623's (no discriminator field
+existed at all, needing new columns and per-call-site threading). Confirmed
+by re-reading PR #1625's own description, not assumed. Nothing to flag about
+sweep coverage.
+
+Fix order, as scoped: this before any #1623-adjacent follow-up, since
+`AuditEvent` already has its target fields (`ActorType`/`MachineIdentityID`,
+#1530) and needed no schema change — unlike #1623's models, which needed a
+migration decision before any fix could land.
+
+## The data question
+
+Existing rows already conflate the two ID spaces on `AuditEvent.UserID` for
+every event these eight call sites wrote while the caller was a machine
+identity, and this cannot be disambiguated retroactively — the discriminating
+information was never recorded on `UserID` itself. No production installs
+exist yet; no backfill is possible or implied. Unlike #1623's persisted model
+rows, though, these rows ARE flaggable as suspect without any backfill: any
+row with `ActorType == "machine_identity"` and a non-nil `UserID` predates
+this fix and is known-wrong in that one column, even though which `User.ID`
+it accidentally collided with cannot be un-recorded.
+
+## Verification
+
+- `go build ./...`, `go vet ./...`, `gofmt -l .` clean.
+- Full suite: `internal/core`, `internal/storage`, `server/http`,
+  `server/grpc` green.
+- Guard registry: `TestDirectLogAuditEventCallersAreSafe` (#1530's existing
+  bypass guard) predicted unaffected (this fix doesn't add or remove any
+  `storage.LogAuditEvent` caller) — confirmed green, unchanged allowlist
+  (still 1 entry).

--- a/internal/core/audit_userid_machine_principal_test.go
+++ b/internal/core/audit_userid_machine_principal_test.go
@@ -1,0 +1,121 @@
+// audit_userid_machine_principal_test.go — guards #1626: emitAudit is the single
+// choke point (#1530) every audit writer funnels through, and it must never let
+// a machine principal's raw ID reach AuditEvent.UserID, a human-attribution
+// column that collides with the same User.ID space #1623 fixed for persisted
+// model columns. Eight callers (SetSecretAutoRotate, CreateConnectRefGrant/
+// DeleteConnectRefGrant, AddSecretDependency/RemoveSecretDependency,
+// transferOwnership, RevokeAllPersonalAccessTokensForUser/
+// DeleteSessionsForUserExcept) built userID from a PrincipalID()-derived value
+// and handed it to writeAuditEventFull/writeAuditEventDiff/writeAuditEventFailed
+// -- all of which funnel through emitAudit already (TestDirectLogAuditEventCallersAreSafe,
+// #1530's existing guard, confirms nothing else reaches storage.LogAuditEvent), so
+// the fix and the guard both belong at that one point, not at eight call sites.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmitAudit_MachineActorNeverGetsUserID pins the choke-point invariant
+// directly: any event already actor-typed "machine_identity" must have UserID
+// cleared by emitAudit, regardless of what the caller set it to -- the same
+// unconditional guarantee emitAudit already gives MachineIdentityID (#1530),
+// now given to UserID in the opposite direction.
+//
+// Verified red per standing practice: temporarily removed the `event.UserID =
+// nil` line from emitAudit (service.go), confirmed this test failed with
+// UserID still holding the machine's raw ID, then restored it.
+func TestEmitAudit_MachineActorNeverGetsUserID(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	ctx := WithMachineActor(context.Background(), 77)
+
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.UserID == nil && e.MachineIdentityID != nil && *e.MachineIdentityID == 77
+	})).Return(nil)
+
+	staleUserID := uint(42) // a machine's raw PrincipalID(), the exact #1626 mistake
+	c.emitAudit(ctx, &models.AuditEvent{
+		EventType: "test.probe",
+		ActorType: ActorTypeMachine,
+		UserID:    &staleUserID,
+	})
+
+	store.AssertExpectations(t)
+}
+
+// Positive control: a genuine human-actored event is untouched by the #1626
+// correction -- UserID survives exactly as the caller set it, and
+// MachineIdentityID stays nil. The fix must not widen into "always clear
+// UserID"; it is conditioned on ActorType == machine specifically.
+func TestEmitAudit_HumanActorKeepsUserID(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	ctx := context.Background()
+
+	store.On("LogAuditEvent", mock.Anything, mock.MatchedBy(func(e *models.AuditEvent) bool {
+		return e.UserID != nil && *e.UserID == 9 && e.MachineIdentityID == nil
+	})).Return(nil)
+
+	humanID := uint(9)
+	c.emitAudit(ctx, &models.AuditEvent{
+		EventType: "test.probe",
+		ActorType: ActorTypeUser,
+		UserID:    &humanID,
+	})
+
+	store.AssertExpectations(t)
+}
+
+// TestAddSecretDependency_AuditEventUserIDNotMachinePrincipal reproduces #1626
+// end-to-end against one of the eight real call sites (not just emitAudit in
+// isolation): a machine identity's own AddSecretDependency audit write
+// (EventSecretDependencyAdded, secret_dependencies.go) must not carry the
+// machine's raw PrincipalID in AuditEvent.UserID, even though
+// AddSecretDependency's OWN model-column attribution (CreatedBy/
+// CreatedByMachineIdentityID, #1623/#1625) is already correct -- this is the
+// audit trail for the same action, a separate write, previously not covered by
+// that fix. ctx is tagged with WithActorType/WithMachineActor exactly as the
+// real HTTP auth middleware tags a machine-authenticated request's context
+// (buildRequestContext, server/middleware/auth.go) -- AddSecretDependency's own
+// actorKind PARAMETER only drives AuthorizeSecretPrincipal, not the audit
+// writer's context-derived ActorType/MachineIdentityID stamp, so a bare
+// context.Background() here would not reproduce the real bug.
+func TestAddSecretDependency_AuditEventUserIDNotMachinePrincipal(t *testing.T) {
+	const machineID = uint(7)
+	ctx := WithMachineActor(WithActorType(context.Background(), ActorTypeMachine), machineID)
+	c, db := newDepCore(t)
+
+	perm := &models.Permission{Name: "secrets.write", Resource: "secrets", Action: "write"}
+	require.NoError(t, db.Create(perm).Error)
+	role := &models.Role{Name: "secret-writer-audit-probe"}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: role.ID, PermissionID: perm.ID}).Error)
+	require.NoError(t, db.AutoMigrate(&models.MachineIdentity{}))
+	require.NoError(t, db.Create(&models.MachineIdentity{ID: machineID, ProjectID: 1, Name: "ci", State: "active"}).Error)
+	require.NoError(t, db.Create(&models.MachineIdentityRole{MachineIdentityID: machineID, RoleID: role.ID, ProjectID: 1, EnvironmentID: 1}).Error)
+
+	dependent := mkSecret(t, db, 1, "audit-probe-app")
+	dependsOn := mkSecret(t, db, 1, "audit-probe-db")
+
+	_, err := c.AddSecretDependency(ctx, ActorTypeMachine, machineID, dependent, dependsOn, "machine-created", machineID)
+	require.NoError(t, err)
+
+	var events []*models.AuditEvent
+	require.NoError(t, db.Where("event_type = ?", EventSecretDependencyAdded).Find(&events).Error)
+	require.Len(t, events, 1, "AddSecretDependency must have produced exactly one audit event")
+	event := events[0]
+
+	assert.Equal(t, ActorTypeMachine, event.ActorType, "sanity: the event must be actor-typed as a machine")
+	assert.Nil(t, event.UserID,
+		"CEILING VIOLATED (#1626): a machine identity's AddSecretDependency produced an audit event "+
+			"with the machine's raw ID sitting in UserID, a human-attribution column")
+	require.NotNil(t, event.MachineIdentityID)
+	assert.Equal(t, machineID, *event.MachineIdentityID, "the attributed machine identity must be the one that actually made the call")
+}

--- a/internal/core/connect_test.go
+++ b/internal/core/connect_test.go
@@ -144,6 +144,20 @@ func TestReadFederatedSecret_BackendErrorAudited(t *testing.T) {
 // context.Background() (i.e. WITHOUT the transport layer having already called
 // core.WithActorType). ReadFederatedSecret must stamp actorType itself rather than
 // trust that upstream middleware tagged the context.
+//
+// #1626: UserID must NOT hold principalID here — emitAudit clears UserID
+// unconditionally once ActorType is machine, since a machine's raw ID in a
+// human-attribution column is exactly the bug that issue fixed. This test
+// previously asserted the opposite (UserID == the machine's raw ID) as if it
+// were the correct, proven behavior; that assertion enshrined the bug rather
+// than testing for it. MachineIdentityID is correctly nil here too — but only
+// because THIS test deliberately uses a bare, untagged context.Background()
+// to probe ActorType's own defense-in-depth (see doc comment above); it does
+// not call WithMachineActor the way real HTTP/gRPC middleware does for an
+// actual machine-authenticated request. In production, MachineIdentityID
+// would be populated from that upstream tag regardless of what
+// ReadFederatedSecret does internally — this test's artificial premise (a
+// context nothing has ever tagged) is why it stays nil here specifically.
 func TestReadFederatedSecret_MachineIdentityAuditedAsMachine(t *testing.T) {
 	ms := new(MockStorage)
 	var got *models.AuditEvent
@@ -161,8 +175,7 @@ func TestReadFederatedSecret_MachineIdentityAuditedAsMachine(t *testing.T) {
 	assert.Equal(t, "v", val)
 	require.NotNil(t, got)
 	assert.Equal(t, ActorTypeMachine, got.ActorType, "machine-identity read must be actored as machine_identity, not default to user")
-	require.NotNil(t, got.UserID)
-	assert.EqualValues(t, 42, *got.UserID)
+	assert.Nil(t, got.UserID, "#1626: a machine's raw ID must never occupy UserID, a human-attribution column")
 }
 
 // TestReadFederatedSecret_UserAuditedAsUser is the counterpart: an ordinary user read

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -473,11 +473,33 @@ func truncateAuditField(s string, maxLen int) string {
 // identity's own ID is stamped here from context (WithMachineActor,
 // audit_context.go) whenever the event is already actor-typed "machine_identity"
 // and no caller explicitly set MachineIdentityID itself.
+//
+// #1626: the same guarantee, the other direction. Several writeAuditEventFull/
+// writeAuditEventDiff/writeAuditEventFailed callers (SetSecretAutoRotate,
+// CreateConnectRefGrant/DeleteConnectRefGrant, AddSecretDependency/
+// RemoveSecretDependency, transferOwnership, RevokeAllPersonalAccessTokensForUser/
+// DeleteSessionsForUserExcept) build userID from a PrincipalID()-derived value --
+// correct for AuthorizePrincipal, which needs the machine's real ID, but wrong
+// for UserID, a human-attribution column: it collides with the same User.ID
+// space #1623 fixed for persisted model columns. Every one of those callers
+// funnels through here already (confirmed: TestDirectLogAuditEventCallersAreSafe,
+// #1530's existing guard, allows no other path to storage.LogAuditEvent), so the
+// fix belongs here, not at each site -- one correction, not eight, and it closes
+// the same mistake at any future call site too. Do NOT add a second
+// machine-actor field to carry this; MachineIdentityID above is already the
+// mechanism. This is guard-the-invariant-not-the-conclusion's fifth instance in
+// this campaign -- see docs/adr-092-audit-event-userid-machine-principal.md.
 func (c *KeyorixCore) emitAudit(ctx context.Context, event *models.AuditEvent) {
-	if event.ActorType == ActorTypeMachine && event.MachineIdentityID == nil {
-		if machineID, ok := machineActorFromContext(ctx); ok {
-			event.MachineIdentityID = &machineID
+	if event.ActorType == ActorTypeMachine {
+		if event.MachineIdentityID == nil {
+			if machineID, ok := machineActorFromContext(ctx); ok {
+				event.MachineIdentityID = &machineID
+			}
 		}
+		// A machine principal's ID must never occupy UserID -- see the doc
+		// comment above. Unconditional: no caller has a legitimate reason to
+		// want a machine's raw ID there once ActorType says machine.
+		event.UserID = nil
 	}
 	event.Description = truncateAuditField(event.Description, auditDescriptionMaxLen)
 	event.Diff = truncateAuditField(event.Diff, auditDiffMaxLen)


### PR DESCRIPTION
## Summary

- Eight `internal/core` call sites (`SetSecretAutoRotate`, `CreateConnectRefGrant`/`DeleteConnectRefGrant`, `AddSecretDependency`/`RemoveSecretDependency`, `transferOwnership`, `RevokeAllPersonalAccessTokensForUser`/`DeleteSessionsForUserExcept`) built `AuditEvent.UserID` from a `PrincipalID()`-derived value — correct for `AuthorizePrincipal`, wrong for `UserID`, a human-attribution column that collides with the same `User.ID` space #1623 fixed for persisted model columns.
- **Mechanism (Task 1)**: none of the eight bypass `emitAudit` — all funnel through `writeAuditEventFull`/`writeAuditEventDiff`/`writeAuditEventFailed`, confirmed the only path to `storage.LogAuditEvent` by `TestDirectLogAuditEventCallersAreSafe` (#1530's existing guard). Fix belongs at the one choke point, not eight call sites.
- **Detectable, not silent (Task 2)**: `ActorType` is set from context independently of the call site's own `userID` mistake, so every affected row already carried `ActorType="machine_identity"` alongside the wrong `UserID` — self-contradicting and identifiable without needing to know which machine. Materially better than #1623's shape, though not the same as having a valid `UserID`.
- **Fix (Task 3)**: `emitAudit` now clears `event.UserID` unconditionally whenever `ActorType == machine`, right alongside the existing `MachineIdentityID` stamp — one correction, no second machine-actor field, covers all eight plus any future call site. Full reasoning in `docs/adr-092-audit-event-userid-machine-principal.md`.
- **#1623/#1624 relationship (Task 4)**: same `PrincipalID()` mechanism in both. PR #1625's sweep found these eight and deliberately filed them separately, since `AuditEvent` already had the discriminator #1623's models lacked — not a sweep miss.

## Test plan

- [x] `TestEmitAudit_MachineActorNeverGetsUserID` — pins the choke point directly, verified red by temporarily removing the fix line
- [x] `TestEmitAudit_HumanActorKeepsUserID` — positive control, proves the fix is conditioned on `ActorType == machine`, not a blanket clear
- [x] `TestAddSecretDependency_AuditEventUserIDNotMachinePrincipal` — end-to-end reproduction against a real one of the eight call sites, context tagged the way real HTTP/gRPC middleware tags a machine-authenticated request, verified red first
- [x] Corrected `TestReadFederatedSecret_MachineIdentityAuditedAsMachine` (`connect_test.go`), a pre-existing test whose own assertion enshrined the bug (asserted `UserID` equaled the machine's raw `PrincipalID`)
- [x] `TestDirectLogAuditEventCallersAreSafe` — predicted unaffected (no new `storage.LogAuditEvent` caller added), confirmed green, allowlist unchanged at 1 entry
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] Full suites green: `internal/core`, `internal/storage`, `server/http`, `server/grpc`