### PR TITLE
test(core): #1626 verification — widen #1530's bypass guard to repo scope

### DIFF
--- a/docs/adr-092-audit-event-userid-machine-principal.md
+++ b/docs/adr-092-audit-event-userid-machine-principal.md
@@ -2,7 +2,14 @@
 
 ## Status
 
-**Accepted (2026-08-30).** #1626. Fix landed here; guard is the deliverable.
+**Closed (2026-08-30).** #1626, fixed in #1628, independently re-verified
+complete in a follow-up pass the same day (see "Verification pass" below) —
+#1628's title ("emitAudit clears UserID") undersold its own scope: it also
+correctly leaves `MachineIdentityID` populated and `ActorType` machine-typed,
+and it reaches all eight call sites structurally (through the choke point),
+not eight individual patches. Not an instance of #1573 (a cleared field with
+nothing recorded) — the actor ends up correctly attributed, just via
+`MachineIdentityID` instead of `UserID`.
 
 ## What this is
 
@@ -133,17 +140,117 @@ every event these eight call sites wrote while the caller was a machine
 identity, and this cannot be disambiguated retroactively — the discriminating
 information was never recorded on `UserID` itself. No production installs
 exist yet; no backfill is possible or implied. Unlike #1623's persisted model
-rows, though, these rows ARE flaggable as suspect without any backfill: any
-row with `ActorType == "machine_identity"` and a non-nil `UserID` predates
-this fix and is known-wrong in that one column, even though which `User.ID`
-it accidentally collided with cannot be un-recorded.
+rows, though, these rows ARE flaggable as suspect without any backfill, and
+better than merely flaggable: **the true actor is recoverable, not just the
+row's badness.** Directly verified (not assumed) against
+`server/middleware/auth.go`'s `buildRequestContext`: `WithActorType(ctx,
+ActorTypeMachine)` and `WithMachineActor(ctx, *userCtx.MachineIdentityID)`
+are set together, unconditionally, for every machine-authenticated request —
+so any pre-#1628 row from a real machine caller has all three of
+`ActorType="machine_identity"`, `MachineIdentityID=<the real machine>`, AND
+`UserID=<the same ID, misplaced>` simultaneously. Any row with
+`ActorType == "machine_identity"` and a non-nil `UserID` predates this fix,
+is known-wrong in that one column, and the correct actor is sitting right
+there in `MachineIdentityID` on the same row — "we can identify these rows
+AND recover the actor" is the accurate claim, stronger than "we can identify
+these rows but not recover the actor."
+
+**Detection query** (installs that ran between #1626's bug window and #1628's
+fix):
+
+```sql
+SELECT * FROM audit_events
+WHERE actor_type = 'machine_identity' AND user_id IS NOT NULL;
+```
+
+Every matching row's real actor is `machine_identity_id` on that same row;
+`user_id` on a matching row should be treated as garbage and ignored, never
+displayed as-is. This predicate is structurally unreachable for any row
+written after #1628 landed (`emitAudit` clears `UserID` unconditionally the
+instant `ActorType` is machine), so the query is self-limiting to the
+historical window without needing a cutoff timestamp.
+
+## Verification pass (2026-08-30) — is #1628 actually complete?
+
+A follow-up pass re-verified this ADR's claims from the merged diff, not the
+PR title or the closed issue, per standing practice. Three yes/no answers:
+
+1. **Does the machine principal end up in `MachineIdentityID`, or only out of
+   `UserID`? Both — populated into `MachineIdentityID` AND cleared from
+   `UserID`.** `git show 9f3adc42 -- internal/core/service.go` shows the
+   pre-existing #1530 `MachineIdentityID`-stamp logic untouched, now nested
+   alongside the new unconditional `event.UserID = nil`. Not a narrowing —
+   the original mechanism plus the new correction, in the same block.
+2. **Is `ActorType` set to machine on those events? Yes**, and independently
+   of the bug: `writeAuditEventDiff`/`writeAuditEventFailed`
+   (`internal/core/audit.go`) set `ActorType: actorTypeFromContext(ctx)` from
+   context, never from the call site's own (buggy) `userID` value.
+3. **Did the fix reach all eight call sites, or only the ones routed through
+   `emitAudit`? All eight — because all eight were already routed through
+   `emitAudit`.** Directly grepped each of the eight functions'
+   current bodies (`connect.go`, `rotation_executor.go`,
+   `secret_ownership.go`, `users.go`, `secret_dependencies.go`): every one
+   calls `writeAuditEvent`/`writeAuditEventFull`/`writeAuditEventDiff`/
+   `writeAuditEventFailed`, none constructs `models.AuditEvent{}` directly.
+
+**Task 2 — eight sites were wrong, not "the audit writer is optional."**
+Confirmed: none of the eight construct `AuditEvent` directly. The original
+diagnosis (a value-correctness bug at a converged choke point, not a bypass)
+holds. No structural closure needed for the eight themselves.
+
+**But the "audit writer is optional" question has a different answer at repo
+scope, found during this pass — not among the eight, a separate discovery.**
+`rg -n '\.LogAuditEvent\(' --type=go -g '!*_test.go'` across the whole repo
+(not just `internal/core`, which is all #1530's original guard scanned)
+found two direct callers the guard had never seen:
+`server/main.go:auditConnectorProjectBindingCreate` and
+`server/http/handlers/audit_ingest_proxy.go:IngestAuditEventProxy`. Both are
+safe on inspection (first hardcodes `ActorType: system`, never sets
+`UserID`; second is the `storage.type: remote` hub-side proxy, persisting an
+event a follower's own `emitAudit` already corrected before serializing it
+over the wire — a genuinely different trust boundary, `#G79`, already
+tracked and deferred, not something #1626/#1628 was scoped to close). But
+the OLD guard's own doc comment claimed "there is exactly one direct
+caller" — true for `internal/core`, false for the repository. Widened to
+walk the whole repo (see Guard, below) rather than leave a completeness
+claim that was accurate only by accident of where it looked.
+
+**One-sentence rule for #1573/#1623 to cite**: a machine principal's own ID
+belongs in `MachineIdentityID` (or a model's `*MachineIdentityID` companion
+field, #1573's shape) whenever it is being recorded as WHO acted, and must
+never occupy a `UserID`/`CreatedBy`-shaped human-attribution column, even
+though the identical `PrincipalID()` value is exactly what
+`AuthorizePrincipal` correctly needs for the SAME request's authorization
+decision — the two are different questions (who is allowed vs. who acted)
+that happen to share a source value, and conflating them is the single
+mistake #1573, #1623, and #1626 all trace back to.
+
+**Guard — widened, verified red-first, twice, in this pass.**
+`internal/core/g80_1530_machine_actor_attribution_guard_test.go`
+(`TestDirectLogAuditEventCallersAreSafe`, #1530's original guard) now walks
+the entire repository via `filepath.WalkDir` from repo root, not just
+`internal/core`'s own directory — the allowlist grew from 1 entry to 3
+(`anomaly.go`, `server/main.go`, `audit_ingest_proxy.go`), each with its own
+reasoning. Verified red twice, by actually breaking things, not by
+inspection:
+- Reverted `emitAudit`'s `event.UserID = nil` line locally; confirmed
+  `TestEmitAudit_MachineActorNeverGetsUserID` and
+  `TestAddSecretDependency_AuditEventUserIDNotMachinePrincipal` both failed
+  (a mocked `storage.LogAuditEvent` call no longer matched); restored;
+  confirmed green again.
+- Removed the new `audit_ingest_proxy.go` allowlist entry; confirmed
+  `TestDirectLogAuditEventCallersAreSafe` failed, naming that exact
+  `path:func`; restored; confirmed green again.
+
+Positive control: `TestEmitAudit_HumanActorKeepsUserID` — a human-actored
+event's `UserID` survives untouched and `MachineIdentityID` stays nil; the
+fix is conditioned on `ActorType == machine`, not a blanket clear.
 
 ## Verification
 
 - `go build ./...`, `go vet ./...`, `gofmt -l .` clean.
 - Full suite: `internal/core`, `internal/storage`, `server/http`,
   `server/grpc` green.
-- Guard registry: `TestDirectLogAuditEventCallersAreSafe` (#1530's existing
-  bypass guard) predicted unaffected (this fix doesn't add or remove any
-  `storage.LogAuditEvent` caller) — confirmed green, unchanged allowlist
-  (still 1 entry).
+- Guard registry: `TestDirectLogAuditEventCallersAreSafe` — predicted 3
+  entries after widening to repo scope (1 pre-existing + 2 newly discovered,
+  both safe); confirmed actual = 3, green.

--- a/internal/core/g80_1530_machine_actor_attribution_guard_test.go
+++ b/internal/core/g80_1530_machine_actor_attribution_guard_test.go
@@ -1,25 +1,34 @@
 // g80_1530_machine_actor_attribution_guard_test.go — #1530's guard: every
 // audit-emitting path funnels through emitAudit (service.go), the single
 // choke point that stamps MachineIdentityID from context when an event is
-// actor-typed "machine_identity". A call site that bypasses emitAudit and
-// writes storage.LogAuditEvent directly skips that stamp entirely -- if such
-// a site ever sets ActorType to "machine_identity" (or leaves it derivable
-// from a machine-authenticated context) without also setting
-// MachineIdentityID itself, it silently reintroduces #1530's exact gap.
+// actor-typed "machine_identity", and (#1626/#1628) unconditionally clears
+// UserID for the same events. A call site that bypasses emitAudit and writes
+// storage.LogAuditEvent directly skips BOTH corrections -- if such a site
+// ever sets ActorType to "machine_identity" (or leaves it derivable from a
+// machine-authenticated context) without also setting MachineIdentityID
+// itself and leaving UserID unset, it silently reintroduces #1530's and
+// #1626's gaps at once.
 //
-// This is a small, allowlist-shaped guard, not a repo-wide AST walk: as of
-// writing there is exactly one direct storage.LogAuditEvent caller outside
-// emitAudit itself (anomaly.go's auditBusinessHoursConfig), and it correctly
-// hardcodes ActorType: "system" -- a genuine no-actor event (a scheduler
-// config change), not a machine-identity one. Cheap to keep this way: a new
-// direct LogAuditEvent caller that constructs a "machine_identity"-typed
-// event without setting MachineIdentityID fails this test immediately.
+// Repo-wide, not internal/core-only (#1626 verification pass, 2026-08-30):
+// this guard used to scan only internal/core's own directory, and its own
+// doc comment claimed "there is exactly one direct storage.LogAuditEvent
+// caller outside emitAudit" -- true for that one package, false for the
+// repo. Two more direct callers exist outside internal/core entirely
+// (server/main.go's auditConnectorProjectBindingCreate,
+// server/http/handlers/audit_ingest_proxy.go's IngestAuditEventProxy), both
+// safe on inspection but invisible to the old package-scoped scan -- an
+// enumeration is only as complete as the directories it looks in. Still
+// allowlist-shaped, not a full AST walk (a `.LogAuditEvent(` substring match
+// per function, not real parsing), but now walks every non-test *.go file
+// in the repository.
 package core
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -27,38 +36,74 @@ import (
 // auditAttributionAllowlist is the exhaustive, reasoned inventory of every
 // direct storage.LogAuditEvent caller (bypassing emitAudit) reviewed as safe
 // -- either it never sets ActorType to "machine_identity" at all (a genuine
-// system/no-actor event), or it sets MachineIdentityID itself. Each entry
-// needs a reason; TestDirectLogAuditEventCallersAreSafe fails if a new
-// direct caller appears unlisted, or if a listed entry no longer matches
-// what it claims.
+// system/no-actor event), or it sets MachineIdentityID itself and leaves
+// UserID unset. Each entry needs a reason; TestDirectLogAuditEventCallersAreSafe
+// fails if a new direct caller appears unlisted, or if a listed entry no
+// longer matches what it claims. Keys are repo-root-relative "path:func".
 var auditAttributionAllowlist = map[string]string{
-	"anomaly.go:auditBusinessHoursConfig": "hardcodes ActorType: \"system\" -- a scheduler/config-change event " +
-		"with no human or machine actor, correctly using the system-actor marker rather than a null. Never " +
-		"machine-identity-typed, so emitAudit's MachineIdentityID stamp would never apply to it anyway.",
+	"internal/core/anomaly.go:auditBusinessHoursConfig": "hardcodes ActorType: \"system\" -- a " +
+		"scheduler/config-change event with no human or machine actor, correctly using the system-actor marker " +
+		"rather than a null. Never machine-identity-typed, so emitAudit's corrections would never apply to it " +
+		"anyway.",
+	"server/main.go:auditConnectorProjectBindingCreate": "hardcodes ActorType: core.ActorTypeSystem and never " +
+		"sets UserID (absent from the struct literal, so it's the zero value nil) -- an unattended boot-time " +
+		"binding-creation event with no actor, same shape as the anomaly.go entry above.",
+	"server/http/handlers/audit_ingest_proxy.go:IngestAuditEventProxy": "the hub side of the storage.type: " +
+		"remote LogAuditEvent proxy (#r122-A): persists an already-fully-formed AuditEvent a follower's own " +
+		"core.KeyorixCore already ran through emitAudit (correctly clearing UserID) before serializing it over " +
+		"the wire -- this endpoint is a raw passthrough, not a second policy decision. A malicious system.write " +
+		"holder submitting a forged event directly (bypassing the emitting server's emitAudit entirely) is a " +
+		"KNOWN, already-tracked, separately-scoped gap (#G79, this file's own auditIngestProxyMaxClockSkew doc " +
+		"comment) -- a distinct trust-boundary problem (attesting the submitter is a legitimate node) that " +
+		"#1626/#1628's single-process UserID-attribution fix was never going to close, deferred to Wave 4.",
 }
 
 var logAuditEventFuncRe = regexp.MustCompile(`^func\s+(?:\([^)]*\)\s*)?([A-Za-z0-9_]+)\(`)
 
-// findDirectLogAuditEventCallers scans every non-test *.go file in
-// internal/core for a `.LogAuditEvent(` call NOT inside emitAudit itself
+// repoRootG1626 locates the repository root relative to this file's own
+// location on disk (internal/core), so the guard works regardless of the
+// test runner's working directory.
+func repoRootG1626() string {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..")
+}
+
+// findDirectLogAuditEventCallers scans every non-test *.go file in the
+// repository for a `.LogAuditEvent(` call NOT inside emitAudit itself
 // (service.go's own funnel implementation is the one legitimate direct
-// caller of the storage interface method), returning "file:func" keys.
+// caller of the storage interface method), returning "path:func" keys
+// relative to the repo root.
 func findDirectLogAuditEventCallers(t *testing.T) map[string]bool {
 	t.Helper()
+	root := repoRootG1626()
 	found := map[string]bool{}
-	entries, err := os.ReadDir(".")
-	if err != nil {
-		t.Fatalf("reading internal/core: %v", err)
-	}
-	for _, e := range entries {
-		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
 		}
-		b, err := os.ReadFile(filepath.Join(".", name))
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", "web", ".scratch", ".task", ".semgrep":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		b, err := os.ReadFile(path)
 		if err != nil {
-			t.Fatalf("reading %s: %v", name, err)
+			t.Fatalf("reading %s: %v", path, err)
 		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			rel = path
+		}
+		rel = filepath.ToSlash(rel)
 		currentFunc := ""
 		for _, line := range strings.Split(string(b), "\n") {
 			if m := logAuditEventFuncRe.FindStringSubmatch(line); m != nil {
@@ -72,9 +117,13 @@ func findDirectLogAuditEventCallers(t *testing.T) map[string]bool {
 				continue
 			}
 			if strings.Contains(line, ".LogAuditEvent(") && currentFunc != "" {
-				found[name+":"+currentFunc] = true
+				found[rel+":"+currentFunc] = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking repo for direct LogAuditEvent callers: %v", err)
 	}
 	return found
 }


### PR DESCRIPTION
## Summary

Verification pass on #1626/#1628 (already merged, already closed) — read the merged diff directly rather than inferring completeness from the PR title or the closed issue, per standing practice. Full report posted to #1626.

- **#1628 is complete.** All three: `MachineIdentityID` gets populated (pre-existing #1530 logic, untouched) AND `UserID` gets cleared (the new fix) — not just cleared. `ActorType` is context-derived, independent of the bug. All eight named call sites route through `emitAudit` — confirmed by reading each function's current body in `connect.go`/`rotation_executor.go`/`secret_ownership.go`/`users.go`/`secret_dependencies.go`, not the commit message's claim.
- **No bypass among the eight.** The original diagnosis (a value-correctness bug at a converged choke point) holds.
- **But found a real, separate gap in #1530's existing guard**: `TestDirectLogAuditEventCallersAreSafe` claimed "exactly one direct `storage.LogAuditEvent` caller outside `emitAudit`" — true only because it scanned `internal/core`'s own directory. A repo-wide grep found two more direct callers (`server/main.go`, `server/http/handlers/audit_ingest_proxy.go`), both safe on inspection but invisible to the old scan. Widened the guard to walk the whole repository; allowlist grew from 1 entry to 3, each reasoned.
- **Historical rows**: self-contradicting and therefore identifiable — `ActorType=machine_identity` + `MachineIdentityID=<the real actor>` + `UserID=<the same ID, misplaced>`, all three set together by the auth middleware for every machine-authenticated request (verified directly against `buildRequestContext`). The true actor is recoverable, not just the row's badness — a detection query is in the ADR.
- ADR-092 updated with the three yes/no completeness answers, a one-sentence machine-attribution rule for #1573/#1623 to cite, and the detection query.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean.
- [x] Full suites (`internal/core`, `internal/storage`, `server/http`, `server/grpc`) green.
- [x] Guard verified red twice, by actually breaking things: reverted `emitAudit`'s `UserID = nil` line, confirmed the #1628 guards failed, restored; removed the new `audit_ingest_proxy.go` allowlist entry, confirmed the widened guard failed naming that exact site, restored.
- [x] Positive control (`TestEmitAudit_HumanActorKeepsUserID`): a genuine human action still records `UserID` and leaves `MachineIdentityID` unset.