### PR TITLE
fix(core): #1632 -- secret-value disclosure guard trusts wall clock

### DIFF
--- a/internal/core/rollback_test.go
+++ b/internal/core/rollback_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,9 @@ func rollbackCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}))
-	return &KeyorixCore{storage: store.NewLocalStorage(db)}, db
+	// #1632: enforceSecretReadGuards (reached via RotateSecret) now calls
+	// c.now() -- see secret_schedule_test.go's newScheduleCore for the same fix.
+	return &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}, db
 }
 
 func TestRollbackSecret(t *testing.T) {

--- a/internal/core/secret_schedule_test.go
+++ b/internal/core/secret_schedule_test.go
@@ -103,7 +103,11 @@ func newScheduleCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 10, Name: "p"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 10, ProjectID: 10, Name: "e"}).Error)
-	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	// #1632: enforceSecretReadGuards now calls c.now() (previously a bare
+	// time.Now()), so this raw struct literal needs the same default the
+	// NewKeyorixCore constructor sets, or every value-read test through this
+	// helper panics on a nil c.now.
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	return c, db
 }
 

--- a/internal/core/secret_value_clock_regression_test.go
+++ b/internal/core/secret_value_clock_regression_test.go
@@ -1,0 +1,144 @@
+// secret_value_clock_regression_test.go — #1632: the worst site in the
+// time-handling sweep, its own test. enforceSecretReadGuards (versions.go)
+// is the actual secret-VALUE disclosure guard; before this fix, it compared
+// a bare time.Now() against secret.Expiration with no seam and no defense
+// against the comparison being fooled by a backward-stepped wall clock — an
+// operator, or an NTP-less clock correction, stepping the host clock back
+// past a secret's real expiration would disclose its plaintext value. This
+// is exploit-shaped, not unit-shaped: it establishes a genuinely-expired
+// secret, moves the clock backward past that expiration, and asserts the
+// value is still refused — plus a positive control proving a legitimately
+// unexpired secret still resolves normally.
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+func newClockRegressionCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	// Defensive, not relying solely on this package's TestMain: at least two
+	// other tests (secret_update_expiration_test.go, secret_value_crypto_test.go)
+	// call i18n.ResetForTesting() in their own cleanup, which de-initializes
+	// the package-level i18n singleton for whichever test runs next in the
+	// same binary -- a pre-existing test-isolation gap, not introduced here,
+	// that this test tripped over by being the first to reach an i18n.T()
+	// call path without its own defensive re-init.
+	require.NoError(t, i18n.InitializeForTesting())
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.SecretVersion{}, &models.AuditEvent{}, &models.SecretAccessSchedule{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	return c, db
+}
+
+// TestGetSecretValue_ClockSteppedBackwardPastExpiry_StillRefused is the
+// exploit-shaped test #1632 asks for. Sequence:
+//
+//  1. At a baseline "current" time, read the secret once — it is already
+//     genuinely expired relative to that baseline, so this both establishes
+//     the correct starting behavior AND warms the in-memory
+//     secretExpiryWatermark (service.go) to the baseline time.
+//  2. Step c.now() BACKWARD to a time before the secret's own Expiration
+//     (simulating an operator or NTP correction moving the host clock back
+//     by more than an hour — the #1632 threat model) and read again.
+//
+// Before the fix (a bare time.Now(), or c.now() with no regression check):
+// step 2's backward clock reads as "not yet expired" (now < Expiration) and
+// the plaintext value is disclosed — this assertion fails, red.
+//
+// After the fix: checkSecretExpiryClockNotRegressed (versions.go) detects
+// that step 2's c.now() is earlier than the watermark step 1 already
+// observed and refuses the read regardless of what Expiration says —
+// green.
+func TestGetSecretValue_ClockSteppedBackwardPastExpiry_StillRefused(t *testing.T) {
+	c, db := newClockRegressionCore(t)
+	ctx := context.Background()
+
+	baseline := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	realExpiration := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // genuinely expired by baseline
+	steppedBack := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)    // before BOTH baseline and realExpiration
+
+	secret := &models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: "clock-regression-target",
+		IsSecret: true, Status: "active", Type: "generic",
+		Expiration: &realExpiration,
+	}
+	require.NoError(t, db.Create(secret).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: secret.ID, VersionNumber: 1, EncryptedValue: []byte("top-secret-value"),
+	}).Error)
+
+	// Step 1: read at the baseline. Already expired relative to baseline —
+	// correctly refused, and warms the watermark to baseline.
+	c.now = func() time.Time { return baseline }
+	_, err := c.GetSecretValueByVersion(ctx, secret.ID, 1)
+	require.Error(t, err, "sanity: the secret must read as expired at the baseline time before the clock ever moves")
+
+	// Step 2: the exploit. Step the clock BACKWARD past both the watermark
+	// and the secret's own Expiration.
+	c.now = func() time.Time { return steppedBack }
+	_, err = c.GetSecretValueByVersion(ctx, secret.ID, 1)
+	require.Error(t, err, "a secret-value read must still be refused after the clock steps backward past the secret's expiration -- a backward clock step must never disclose an expired secret's value")
+}
+
+// TestGetSecretValue_ClockSteppedBackward_LegitimatelyUnexpiredSecretStillResolves
+// is the positive control: a secret that has never expired, read after the
+// SAME kind of backward clock step, must still resolve normally. The fix
+// must refuse a clock that looks regressed relative to what this process
+// has already seen -- it must not become a blanket refusal that breaks
+// ordinary reads whenever the clock is merely, legitimately, still early in
+// the process's lifetime (e.g. right after boot, before any watermark has
+// been established).
+func TestGetSecretValue_ClockSteppedBackward_LegitimatelyUnexpiredSecretStillResolves(t *testing.T) {
+	c, db := newClockRegressionCore(t)
+	ctx := context.Background()
+
+	baseline := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	farFuture := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC) // never expired, ever, in this test
+
+	secret := &models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: "clock-regression-control",
+		IsSecret: true, Status: "active", Type: "generic",
+		Expiration: &farFuture,
+	}
+	require.NoError(t, db.Create(secret).Error)
+	require.NoError(t, db.Create(&models.SecretVersion{
+		SecretNodeID: secret.ID, VersionNumber: 1, EncryptedValue: []byte("still-valid-value"),
+	}).Error)
+
+	c.now = func() time.Time { return baseline }
+	value, err := c.GetSecretValueByVersion(ctx, secret.ID, 1)
+	require.NoError(t, err, "positive control: a legitimately unexpired secret must resolve at the baseline time")
+	assert.Equal(t, []byte("still-valid-value"), value)
+
+	// A SMALL, in-tolerance backward step (well under
+	// secretExpiryClockRegressionTolerance) must not trip the guard --
+	// ordinary NTP slew must not become a false-positive refusal.
+	c.now = func() time.Time { return baseline.Add(-5 * time.Second) }
+	value, err = c.GetSecretValueByVersion(ctx, secret.ID, 1)
+	require.NoError(t, err, "a small in-tolerance backward step must not refuse a legitimately unexpired secret")
+	assert.Equal(t, []byte("still-valid-value"), value)
+}
+
+// TestCheckSecretExpiryClockNotRegressed_FreshWatermarkNeverRefuses covers
+// the zero-value watermark case directly (no prior call has ever
+// established a baseline -- e.g. the very first secret-value read after
+// process boot): it must never refuse solely because the watermark is
+// unset.
+func TestCheckSecretExpiryClockNotRegressed_FreshWatermarkNeverRefuses(t *testing.T) {
+	c := &KeyorixCore{}
+	err := c.checkSecretExpiryClockNotRegressed(time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err, "an unset watermark must never itself cause a refusal")
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -366,6 +366,32 @@ type KeyorixCore struct {
 	// by "actorID:targetID" to reduce per-request DB load on the auth hot path for
 	// impersonation sessions (IMP-001). Zero value is ready to use (sync.Map).
 	impersonationCeilingCache sync.Map
+	// secretExpiryWatermark is an in-memory monotonic high-water mark of the
+	// latest wall-clock instant enforceSecretReadGuards has ever observed via
+	// c.now(), in this process's lifetime (#1632). Mirrors auditMaxCertified's
+	// shape (an in-memory floor that never regresses) applied to wall-clock
+	// time instead of a chained-events count: the secret-value disclosure
+	// guard refuses to treat a c.now() reading as trustworthy if it is
+	// EARLIER than a time this process has already legitimately observed —
+	// the one deployment-realistic case this actually stops is an operator or
+	// NTP correction stepping the clock backward WHILE THE SERVER KEEPS
+	// RUNNING (the scenario ADR-094/#1632 named as the live one for this
+	// site), without requiring every other wall-clock site in #1632 to adopt
+	// the same mechanism. Deliberately NOT persisted (unlike auditMaxCertified,
+	// which backstops a SystemMetadata row): GetSystemMetadata/SetSystemMetadata
+	// are unconditionally unsupported on RemoteStorage
+	// (internal/storage/store/remote_audit.go), and this guard runs on every
+	// secret-value read including the CLI's embedded storage.type: remote
+	// path — persisting here would make every such read depend on a storage
+	// call that hard-fails under that backend, breaking secret reads entirely
+	// under remote mode to close a gap that mode is already reachable through.
+	// Residual risk, named rather than hidden: resets to zero on process
+	// restart, so an attacker who can also restart the process after
+	// stepping the clock back defeats it — a real limitation, not covered by
+	// this fix, of the same kind ADR-094 already flagged as calling for an
+	// operational (not per-site code) mitigation.
+	secretExpiryWatermarkMu sync.Mutex
+	secretExpiryWatermark   time.Time
 }
 
 // AuditForwarder ships persisted audit events to an external sink (e.g. a SIEM).

--- a/internal/core/versions.go
+++ b/internal/core/versions.go
@@ -9,6 +9,42 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
+// secretExpiryClockRegressionTolerance bounds how far c.now() may read
+// EARLIER than secretExpiryWatermark before checkSecretExpiryClockNotRegressed
+// refuses the read. Must be small enough to still catch a deliberate/
+// NTP-less manual clock reset (the #1632 threat model: an operator, or an
+// NTP correction, stepping the clock back by an hour or more) and large
+// enough not to false-positive on ordinary small backward NTP slew steps
+// (NTP step corrections, as opposed to gradual slewing, are typically
+// sub-second to low-single-digit seconds).
+const secretExpiryClockRegressionTolerance = 30 * time.Second
+
+// checkSecretExpiryClockNotRegressed refuses to trust now for the secret-value
+// disclosure guard if it looks EARLIER than a time this process has already
+// legitimately observed for this same check (more than
+// secretExpiryClockRegressionTolerance behind secretExpiryWatermark) — see
+// secretExpiryWatermark's doc comment (service.go) for what this does and
+// does not protect against. On success, advances the watermark to now (never
+// backward — the watermark itself must not regress, or a second, slower
+// backward step could walk it down unnoticed).
+func (c *KeyorixCore) checkSecretExpiryClockNotRegressed(now time.Time) error {
+	c.secretExpiryWatermarkMu.Lock()
+	defer c.secretExpiryWatermarkMu.Unlock()
+	if !c.secretExpiryWatermark.IsZero() && now.Before(c.secretExpiryWatermark.Add(-secretExpiryClockRegressionTolerance)) {
+		// Deliberately the SAME error i18n key and text as an ordinary expired
+		// secret, not a distinct "clock anomaly detected" message: telling a
+		// caller specifically that clock regression was detected is itself an
+		// oracle (it confirms the manipulation had an effect worth reacting
+		// to). A uniform refusal reveals nothing beyond "this read did not
+		// succeed," matching how every other guard in this bundle refuses.
+		return fmt.Errorf("%s", i18n.T("ErrorSecretExpired", nil))
+	}
+	if now.After(c.secretExpiryWatermark) {
+		c.secretExpiryWatermark = now
+	}
+	return nil
+}
+
 // GetSecretVersions retrieves all versions of a secret.
 func (c *KeyorixCore) GetSecretVersions(ctx context.Context, secretID uint) ([]*models.SecretVersion, error) {
 	if secretID == 0 {
@@ -121,7 +157,28 @@ func (c *KeyorixCore) GetSecretValue(ctx context.Context, secretID uint) ([]byte
 // the same secret correctly refused. Route every value-disclosing function
 // through this one guard bundle instead of re-implementing a subset of it.
 func (c *KeyorixCore) enforceSecretReadGuards(ctx context.Context, secret *models.SecretNode, userID uint) error {
-	if secret.Expiration != nil && time.Now().After(*secret.Expiration) {
+	// #1632: c.now(), not a bare time.Now() -- the injected/test-controllable
+	// clock every other security-relevant expiry check in this package uses
+	// (service.go's `now func() time.Time` field). This is the actual
+	// secret-VALUE disclosure guard (see the #G09 comment above), so it must
+	// be seam-testable the same way ValidateSessionToken/ValidateMachineToken
+	// etc. already are -- a bare time.Now() here could not be moved
+	// backward in a test at all, which is itself part of what made this the
+	// worst site in the #1632 sweep: there was no way to even exercise the
+	// hazard without actually changing the OS clock.
+	//
+	// The seam alone does not close the hazard -- it only makes it testable.
+	// checkSecretExpiryClockNotRegressed is the actual fix: it refuses this
+	// read outright if c.now() looks EARLIER than a time this process has
+	// already legitimately observed, rather than trusting a wall clock that
+	// may have just been stepped backward past this secret's real
+	// Expiration. See secretExpiryWatermark's doc comment (service.go) for
+	// why this is in-memory only, and named there as a residual limitation.
+	now := c.now()
+	if err := c.checkSecretExpiryClockNotRegressed(now); err != nil {
+		return err
+	}
+	if secret.Expiration != nil && now.After(*secret.Expiration) {
 		return fmt.Errorf("%s", i18n.T("ErrorSecretExpired", nil))
 	}
 	if secret.Status == SecretStatusSuspended {


### PR DESCRIPTION
## Summary

- `enforceSecretReadGuards` (`internal/core/versions.go`) gates plaintext secret-value disclosure on `time.Now().After(secret.Expiration)` with a bare, un-seamed wall-clock read -- an operator (or an NTP-less clock correction) stepping the host clock backward past a secret's real expiration discloses its value. This is the worst site found in the #1632 time-handling sweep: it's reachable by any on-prem/air-gapped customer's own operator, not just an internal actor.
- Switches the comparison to the existing `c.now()` clock seam (`internal/core/service.go`) already used by every other security-relevant expiry check in this package, and adds `secretExpiryWatermark`: an in-memory monotonic high-water mark (modeled on this codebase's existing `auditMaxCertified` pattern) that refuses a reading more than 30s earlier than the latest one this process has legitimately observed for this guard, with a small tolerance for ordinary NTP slew.
- The refusal reuses the exact same error text as an ordinary expired-secret refusal, so it isn't an oracle telling a caller their clock manipulation had an effect.
- Deliberately in-memory only, not persisted via `SystemMetadata`: that store is unconditionally unsupported on `RemoteStorage`, and this guard runs on every secret-value read including the CLI's embedded `storage.type: remote` path. The reset-on-restart limitation this leaves is named in the code as a residual risk, not hidden.
- Fixes two pre-existing test helpers (`secret_schedule_test.go`, `rollback_test.go`) that built `KeyorixCore` via a raw struct literal with no `now` field, which the new `c.now()` call exposed as a nil-pointer panic.

This is its own PR, landed first, per #1632's explicit ranking instruction -- not bundled with the RBAC cluster or MFA/WebAuthn work that follow it.

## Test plan

- [x] New exploit-shaped test (`secret_value_clock_regression_test.go`): establishes a genuinely-expired secret, steps `c.now()` backward past its expiration, asserts the value is still refused.
- [x] Positive control: a legitimately unexpired secret still resolves at baseline, and a small in-tolerance backward step (well under the 30s tolerance) does not cause a false-positive refusal.
- [x] Red-before-green: reverted the watermark check to a no-op, confirmed the exploit test fails (secret discloses); restored the fix, confirmed both tests pass.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` on touched files -- all clean.
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` -- 0 issues.
- [x] Full `internal/core`, `internal/storage`, `server/http`, `server/grpc` suites pass under default (UTC) environment.
- [x] Same four suites re-run under `TZ=America/New_York` (per ADR-094's finding that a UTC-only run can't see this class of bug).