### PR TITLE
chore: gitignore secrets.db.migration.lock, .pnpm-store/, nested .scratch/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,12 @@ keyorix.db
 test-keyorix.db
 data/*.db
 
+# SQLite cross-process migration lock sidecar (factory_sqlite_migration_lock.go)
+# -- named "<configured database.path>.migration.lock", cwd-relative by
+# default (#1636), so it appears wherever a CLI command or test happened to
+# run from, not just next to a real database file.
+*.migration.lock
+
 # --- Log Files ---
 *.log
 *.log.*
@@ -82,6 +88,7 @@ web/.nuxt/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-store/
 
 # --- Test Artifacts ---
 test-results/
@@ -201,8 +208,10 @@ certs/
 # compiled binary debris (use bin/ via make build)
 /main
 
-# throwaway binaries / test artifacts
-/.scratch/
+# throwaway binaries / test artifacts -- unanchored (not /.scratch/ alone) so
+# a nested module's own .scratch/ (e.g. operator/.scratch/) is covered too;
+# found leaking into `git status` at the repo root during #1636's investigation.
+.scratch/
 
 # Claude Code internal state and local tooling
 /.claire/


### PR DESCRIPTION
## Summary

Investigation into where `secrets.db.migration.lock` resolves from (it turned up untracked in the primary checkout and several worktrees). Full findings and the demonstrated defect filed separately as #1636 — this PR is just the litter cleanup Task 4 asked for regardless of that finding's disposition:

- `*.migration.lock` — the sidecar migration-lock file (`internal/storage/factory_sqlite_migration_lock.go`) is cwd-relative by default (`internal/storage/factory.go:187`, `configs/keyorix.yaml.tpl:73`), so it appears wherever a CLI command or test happened to run from, not just next to a real database file. Expected fixture/dev noise regardless of how #1636 gets resolved.
- `.pnpm-store/` — untracked package-manager cache in the primary checkout, not previously ignored anywhere.
- `.scratch/` — was anchored `/.scratch/` (repo root only), so a nested module's own scratch dir (`operator/.scratch/` was untracked in the primary checkout) leaked into `git status`. Unanchored to cover any depth.

## Test plan

- [x] `git check-ignore -v` confirmed all three new patterns match their target paths.
- [x] Full suites (`internal/core`, `internal/storage`, `server/http`, `server/grpc`) green — the change is inert, nothing depended on any of these being tracked.