### PR TITLE
fix(storage): #1632 -- MFA/WebAuthn consumption trusts wall clock

### DIFF
--- a/internal/storage/store/consume_clock_regression_test.go
+++ b/internal/storage/store/consume_clock_regression_test.go
@@ -1,0 +1,172 @@
+// consume_clock_regression_test.go — #1632: exploit-shaped tests for
+// ConsumeMFAChallenge and ConsumeWebAuthnSession's defense against a
+// backward-stepped host clock. Both methods bind `now` directly into a SQL
+// `expires_at > ?` bound with no seam and, before this fix, no defense
+// against that comparison being fooled by an operator or NTP-less clock
+// correction stepping the host clock backward past a challenge/session's
+// real expiration — letting it be consumed for the first time past its real
+// window. This cannot enable literal replay of an ALREADY-consumed row (the
+// `used_at IS NULL` predicate is clock-independent), so these tests target
+// the narrower, still-security-relevant hazard: a never-consumed-but-expired
+// row being consumed for the first time after the clock steps back.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func newConsumeClockRegressionStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	return newS27bStore(t, &models.MFAChallenge{}, &models.WebAuthnSession{})
+}
+
+// TestConsumeMFAChallenge_ClockSteppedBackwardPastExpiry_StillRefused is the
+// exploit-shaped test: establishes a genuinely-expired-by-baseline challenge,
+// then steps the clock backward to before both the baseline and the
+// challenge's own expiry, and asserts consumption is still refused.
+//
+// Before the fix: the backward-stepped now reads as "not yet expired"
+// (expires_at > now) and the challenge is consumed — this assertion fails,
+// red. After the fix: consumeClockLooksRegressed detects the second call's
+// now is earlier than the watermark the first call already established and
+// refuses regardless of what expires_at says — green.
+func TestConsumeMFAChallenge_ClockSteppedBackwardPastExpiry_StillRefused(t *testing.T) {
+	ls := newConsumeClockRegressionStore(t)
+	ctx := context.Background()
+
+	baseline := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	realExpiry := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)  // expired by baseline
+	steppedBack := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC) // before BOTH baseline and realExpiry
+
+	require.NoError(t, ls.db.Create(&models.MFAChallenge{
+		UserID: 1, TokenHash: "mfa-clock-regression-target",
+		ExpiresAt: realExpiry, CreatedAt: realExpiry.Add(-time.Hour),
+	}).Error)
+
+	// Step 1: at the baseline, already expired — correctly refused, and this
+	// warms the shared consume-clock watermark to baseline.
+	_, err := ls.ConsumeMFAChallenge(ctx, "mfa-clock-regression-target", baseline)
+	require.Error(t, err, "sanity: the challenge must read as expired at the baseline time before the clock ever moves")
+
+	// Step 2: the exploit. Step the clock BACKWARD past both the watermark
+	// and the challenge's own expiry.
+	_, err = ls.ConsumeMFAChallenge(ctx, "mfa-clock-regression-target", steppedBack)
+	require.Error(t, err, "consumption must still be refused after the clock steps backward past the challenge's expiry")
+}
+
+// TestConsumeMFAChallenge_ClockSteppedBackward_LegitimatelyActiveChallengeStillConsumes
+// is the positive control: a challenge that has never expired, consumed
+// after the SAME kind of backward clock step (still within tolerance or
+// after a fresh watermark), must still succeed.
+func TestConsumeMFAChallenge_ClockSteppedBackward_LegitimatelyActiveChallengeStillConsumes(t *testing.T) {
+	ls := newConsumeClockRegressionStore(t)
+	ctx := context.Background()
+
+	baseline := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	farFuture := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	require.NoError(t, ls.db.Create(&models.MFAChallenge{
+		UserID: 1, TokenHash: "mfa-clock-regression-control",
+		ExpiresAt: farFuture, CreatedAt: baseline,
+	}).Error)
+
+	// A small, in-tolerance backward step (well under
+	// consumeClockRegressionTolerance) must not trip the guard on the very
+	// first call — ordinary NTP slew must not become a false-positive refusal
+	// even before any watermark has been established.
+	_, err := ls.ConsumeMFAChallenge(ctx, "mfa-clock-regression-control", baseline.Add(-5*time.Second))
+	require.NoError(t, err, "a small in-tolerance backward step must not refuse a legitimately unexpired, never-consumed challenge")
+}
+
+// TestConsumeWebAuthnSession_ClockSteppedBackwardPastExpiry_StillRefused is
+// ConsumeMFAChallenge's exploit test, repeated for the structurally
+// identical ConsumeWebAuthnSession (same `used_at IS NULL AND expires_at >
+// ?` predicate).
+func TestConsumeWebAuthnSession_ClockSteppedBackwardPastExpiry_StillRefused(t *testing.T) {
+	ls := newConsumeClockRegressionStore(t)
+	ctx := context.Background()
+
+	baseline := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	realExpiry := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	steppedBack := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	require.NoError(t, ls.db.Create(&models.WebAuthnSession{
+		UserID: 1, TokenHash: "wa-clock-regression-target", Purpose: "login",
+		ExpiresAt: realExpiry, CreatedAt: realExpiry.Add(-time.Hour),
+	}).Error)
+
+	_, err := ls.ConsumeWebAuthnSession(ctx, "wa-clock-regression-target", baseline)
+	require.Error(t, err, "sanity: the session must read as expired at the baseline time before the clock ever moves")
+
+	_, err = ls.ConsumeWebAuthnSession(ctx, "wa-clock-regression-target", steppedBack)
+	require.Error(t, err, "consumption must still be refused after the clock steps backward past the session's expiry")
+}
+
+// TestConsumeWebAuthnSession_ClockSteppedBackward_LegitimatelyActiveSessionStillConsumes
+// is ConsumeMFAChallenge's positive control, repeated for ConsumeWebAuthnSession.
+func TestConsumeWebAuthnSession_ClockSteppedBackward_LegitimatelyActiveSessionStillConsumes(t *testing.T) {
+	ls := newConsumeClockRegressionStore(t)
+	ctx := context.Background()
+
+	baseline := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	farFuture := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	require.NoError(t, ls.db.Create(&models.WebAuthnSession{
+		UserID: 1, TokenHash: "wa-clock-regression-control", Purpose: "login",
+		ExpiresAt: farFuture, CreatedAt: baseline,
+	}).Error)
+
+	_, err := ls.ConsumeWebAuthnSession(ctx, "wa-clock-regression-control", baseline.Add(-5*time.Second))
+	require.NoError(t, err, "a small in-tolerance backward step must not refuse a legitimately unexpired, never-consumed session")
+}
+
+// TestConsumeClockWatermark_SharedAcrossMFAAndWebAuthn proves the design
+// choice stated in consumeClockLooksRegressed's doc comment: the watermark
+// is ONE process-wide fact ("has this LocalStorage's clock been stepped
+// backward"), not kept per-method. Warming it via an MFA challenge
+// consumption must also protect a WebAuthn session consumption on the same
+// LocalStorage instance.
+func TestConsumeClockWatermark_SharedAcrossMFAAndWebAuthn(t *testing.T) {
+	ls := newConsumeClockRegressionStore(t)
+	ctx := context.Background()
+
+	baseline := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	steppedBack := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	farFuture := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Warm the watermark to baseline via an MFA challenge consumption
+	// (succeeds — never expired).
+	require.NoError(t, ls.db.Create(&models.MFAChallenge{
+		UserID: 1, TokenHash: "shared-watermark-mfa", ExpiresAt: farFuture, CreatedAt: baseline,
+	}).Error)
+	_, err := ls.ConsumeMFAChallenge(ctx, "shared-watermark-mfa", baseline)
+	require.NoError(t, err)
+
+	// A WebAuthn session that would otherwise still be genuinely unexpired
+	// relative to steppedBack must nonetheless be refused, because the clock
+	// now looks regressed relative to what the MFA consumption above already
+	// observed.
+	require.NoError(t, ls.db.Create(&models.WebAuthnSession{
+		UserID: 1, TokenHash: "shared-watermark-webauthn", Purpose: "login",
+		ExpiresAt: farFuture, CreatedAt: steppedBack,
+	}).Error)
+	_, err = ls.ConsumeWebAuthnSession(ctx, "shared-watermark-webauthn", steppedBack)
+	require.Error(t, err, "a backward step observed via ConsumeMFAChallenge must also refuse a subsequent ConsumeWebAuthnSession on the same store")
+}
+
+// TestConsumeClockLooksRegressed_FreshWatermarkNeverRefuses covers the
+// zero-value watermark case directly: a fresh LocalStorage (no prior
+// consumption has ever established a baseline) must never refuse solely
+// because the watermark is unset.
+func TestConsumeClockLooksRegressed_FreshWatermarkNeverRefuses(t *testing.T) {
+	ls := newConsumeClockRegressionStore(t)
+	assert.False(t, ls.consumeClockLooksRegressed(time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC)),
+		"an unset watermark must never itself cause a refusal")
+}

--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -54,6 +54,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
 	"gorm.io/gorm"
@@ -195,11 +196,36 @@ type LocalStorage struct {
 	// same reason as auditChainMu/auditCheckpointMu — a transaction-scoped
 	// LocalStorage must share its parent's mutex.
 	bootstrapMu *sync.Mutex
+	// consumeClockWatermark backs checkConsumeClockNotRegressed (#1632): an
+	// in-memory monotonic high-water mark of the latest wall-clock instant a
+	// single-use-token consumption (ConsumeMFAChallenge, ConsumeWebAuthnSession)
+	// has legitimately observed, in this process's lifetime. A pointer for the
+	// same reason as the mutexes above — ConsumeMFAChallenge and
+	// ConsumeWebAuthnSession are two distinct call paths (one via the core
+	// layer's c.now(), one via a raw storage call from an HTTP handler; see
+	// checkConsumeClockNotRegressed's doc comment) that must share ONE
+	// watermark, not warm two independent ones.
+	consumeClockWatermark *clockWatermark
+}
+
+// clockWatermark pairs a mutex with the time.Time it guards, so a single
+// pointer field on LocalStorage can be shared across transaction-scoped
+// copies (see WithTransaction) without copying the mutex and the time value
+// out of sync with each other.
+type clockWatermark struct {
+	mu   sync.Mutex
+	time time.Time
 }
 
 // NewLocalStorage creates a LocalStorage backed by the given *gorm.DB.
 func NewLocalStorage(db *gorm.DB) *LocalStorage {
-	return &LocalStorage{db: db, auditChainMu: &sync.Mutex{}, auditCheckpointMu: &sync.Mutex{}, bootstrapMu: &sync.Mutex{}}
+	return &LocalStorage{
+		db:                    db,
+		auditChainMu:          &sync.Mutex{},
+		auditCheckpointMu:     &sync.Mutex{},
+		bootstrapMu:           &sync.Mutex{},
+		consumeClockWatermark: &clockWatermark{},
+	}
 }
 
 // DB returns the underlying *gorm.DB. Exposed for test helpers that need direct
@@ -207,4 +233,53 @@ func NewLocalStorage(db *gorm.DB) *LocalStorage {
 // code — all writes must go through the Storage interface methods.
 func (ls *LocalStorage) DB() *gorm.DB {
 	return ls.db
+}
+
+// consumeClockRegressionTolerance bounds how far now may read EARLIER than
+// consumeClockWatermark before checkConsumeClockNotRegressed refuses a
+// single-use-token consumption. Mirrors internal/core's
+// secretExpiryClockRegressionTolerance (#1632) -- same threat model (an
+// operator, or an NTP-less clock correction, stepping the host clock back by
+// an hour or more), same tolerance for ordinary NTP slew.
+const consumeClockRegressionTolerance = 30 * time.Second
+
+// consumeClockLooksRegressed reports whether now looks EARLIER than a time
+// this process has already legitimately observed for a single-use-token
+// consumption (ConsumeMFAChallenge, ConsumeWebAuthnSession) (#1632). Both
+// consumption methods bind now directly into a SQL `expires_at > ?` bound,
+// with no caching layer between the wall clock and the comparison -- a host
+// clock stepped backward past a challenge/session's real expiry would let it
+// be consumed for the first time past its real window (this cannot enable
+// replay of an ALREADY-consumed row: the `used_at IS NULL` predicate is
+// clock-independent).
+//
+// Returns a bool rather than an error so each caller can return its OWN
+// existing "invalid or expired X" text on a regression, matching the exact
+// wording its normal expiry path already uses -- a caller must not be able
+// to distinguish "genuinely expired" from "clock regression detected" by
+// the error text differing between the two refusal reasons.
+//
+// This watermark is shared by both methods rather than kept per-method,
+// because they have two genuinely distinct callers each (one via the core
+// layer's c.now(), one via a raw storage call from an HTTP handler that
+// passes a bare time.Now() -- see users_crud.go's ConsumeMFAChallenge and
+// webauthn_proxy.go's ConsumeWebAuthnSessionProxy) and the fact being
+// defended against -- "has this process's OS clock been stepped backward" --
+// is a single process-wide fact, not a per-method one.
+//
+// On a non-regressed reading, advances the watermark to now (never
+// backward, for the same reason as internal/core's
+// checkSecretExpiryClockNotRegressed: a second, slower backward step must
+// not walk the watermark down unnoticed).
+func (ls *LocalStorage) consumeClockLooksRegressed(now time.Time) bool {
+	wm := ls.consumeClockWatermark
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+	if !wm.time.IsZero() && now.Before(wm.time.Add(-consumeClockRegressionTolerance)) {
+		return true
+	}
+	if now.After(wm.time) {
+		wm.time = now
+	}
+	return false
 }

--- a/internal/storage/store/local_mfa.go
+++ b/internal/storage/store/local_mfa.go
@@ -123,6 +123,14 @@ func (ls *LocalStorage) GetActiveMFAChallenge(ctx context.Context, tokenHash str
 func (ls *LocalStorage) ConsumeMFAChallenge(ctx context.Context, tokenHash string, now time.Time) (*models.MFAChallenge, error) {
 	// G81 (MFAChallenge.ExpiresAt): normalize internally — see GetAuditLogs.
 	now = now.UTC()
+	// #1632: refuse a now that looks earlier than one this process has
+	// already legitimately observed -- see consumeClockLooksRegressed's doc
+	// comment for what this defends against (a backward-stepped host clock
+	// letting an expired-but-never-consumed challenge be consumed for the
+	// first time past its real window).
+	if ls.consumeClockLooksRegressed(now) {
+		return nil, fmt.Errorf("invalid or expired challenge")
+	}
 	var ch *models.MFAChallenge
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		res := tx.Model(&models.MFAChallenge{}).

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -423,7 +423,13 @@ func (ls *LocalStorage) ListGlobalAdminAssignmentsForUpdate(ctx context.Context,
 // when the caller drove both calls under its own WithTransaction.
 func (ls *LocalStorage) RemoveGlobalAdminRoleGuarded(ctx context.Context, userID, roleID uint, adminRoleIDs []uint) error {
 	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		txStorage := &LocalStorage{db: tx, auditChainMu: ls.auditChainMu, auditCheckpointMu: ls.auditCheckpointMu, bootstrapMu: ls.bootstrapMu}
+		txStorage := &LocalStorage{
+			db:                    tx,
+			auditChainMu:          ls.auditChainMu,
+			auditCheckpointMu:     ls.auditCheckpointMu,
+			bootstrapMu:           ls.bootstrapMu,
+			consumeClockWatermark: ls.consumeClockWatermark,
+		}
 		assignments, err := txStorage.ListGlobalAdminAssignmentsForUpdate(ctx, adminRoleIDs)
 		if err != nil {
 			return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/internal/storage/store/local_transaction.go
+++ b/internal/storage/store/local_transaction.go
@@ -16,6 +16,12 @@ import (
 // the transaction still serializes correctly (ADR-029/#339).
 func (ls *LocalStorage) WithTransaction(ctx context.Context, fn func(storage.Storage) error) error {
 	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		return fn(&LocalStorage{db: tx, auditChainMu: ls.auditChainMu, auditCheckpointMu: ls.auditCheckpointMu, bootstrapMu: ls.bootstrapMu})
+		return fn(&LocalStorage{
+			db:                    tx,
+			auditChainMu:          ls.auditChainMu,
+			auditCheckpointMu:     ls.auditCheckpointMu,
+			bootstrapMu:           ls.bootstrapMu,
+			consumeClockWatermark: ls.consumeClockWatermark,
+		})
 	})
 }

--- a/internal/storage/store/local_webauthn.go
+++ b/internal/storage/store/local_webauthn.go
@@ -161,6 +161,14 @@ func (ls *LocalStorage) CreateWebAuthnSession(ctx context.Context, s *models.Web
 func (ls *LocalStorage) ConsumeWebAuthnSession(ctx context.Context, tokenHash string, now time.Time) (*models.WebAuthnSession, error) {
 	// G81 (WebAuthnSession.ExpiresAt): normalize internally — see GetAuditLogs.
 	now = now.UTC()
+	// #1632: refuse a now that looks earlier than one this process has
+	// already legitimately observed -- see consumeClockLooksRegressed's doc
+	// comment (shared with ConsumeMFAChallenge) for what this defends
+	// against (a backward-stepped host clock letting an expired-but-never-
+	// consumed session be consumed for the first time past its real window).
+	if ls.consumeClockLooksRegressed(now) {
+		return nil, fmt.Errorf("invalid or expired webauthn session")
+	}
 	var sess *models.WebAuthnSession
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		res := tx.Model(&models.WebAuthnSession{}).

--- a/internal/storage/store/remote_wire_route_coverage_test.go
+++ b/internal/storage/store/remote_wire_route_coverage_test.go
@@ -831,7 +831,7 @@ const (
 	kindTemporary wireCallExclusionKind = iota
 	// kindPermanent means: this exact call site can never be made statically
 	// resolvable by construction (its path argument is a plain function
-	// PARAMETER — see entry.go:160's own entry below for the one case that
+	// PARAMETER — see entry.go:161's own entry below for the one case that
 	// currently qualifies), independent of whether router.go triage has
 	// happened. Exempt from the freshness check for the same reason C5's
 	// PERMANENT kind is: there is no fix to "land" that changes this.
@@ -890,7 +890,7 @@ var knownUnresolvedWireCalls = map[string]wireCallExclusion{
 	// router.go normally — this entry is only the wrapper definition itself,
 	// not a second copy of those two calls. kindPermanent: no code change
 	// makes a generic forwarding helper's own parameter a literal.
-	"entry.go:160": {kindPermanent, "path is a function parameter (putConditionalTransition's own signature) — " +
+	"entry.go:161": {kindPermanent, "path is a function parameter (putConditionalTransition's own signature) — " +
 		"genuinely caller-dependent by design; each real caller resolves independently via findWrapperMethods",
 		"#1511", "2026-08-28"},
 	// postRetentionBeforeCountResp (remote_secrets.go) -- the generic


### PR DESCRIPTION
## Summary

- `ConsumeMFAChallenge` (`local_mfa.go`) and `ConsumeWebAuthnSession` (`local_webauthn.go`) bind a caller-supplied `now` directly into a SQL `WHERE token_hash = ? AND used_at IS NULL AND expires_at > ?` bound, with no defense against that comparison being fooled by a backward-stepped host clock. An operator, or an NTP-less clock correction, stepping the clock back past a challenge/session's real expiry lets it be consumed for the first time past its real window.
- This is narrower than literal replay: `used_at IS NULL` is clock-independent, so an already-consumed row can never be replayed regardless of the clock. The hazard is specifically an expired-but-never-consumed row being consumed late.
- Both methods have two independent callers each — one via the core layer's `c.now()` (`internal/core/mfa.go`, `internal/core/webauthn.go`), one via a raw storage call from an HTTP handler that passes a bare `time.Now()` (`users_crud.go`'s `ConsumeMFAChallenge`, `webauthn_proxy.go`'s `ConsumeWebAuthnSessionProxy`) — so the fix lives in the storage layer, the single choke point both paths pass through, rather than at either caller.
- Adds `consumeClockWatermark` to `LocalStorage`: an in-memory monotonic high-water mark, modeled on `internal/core`'s `secretExpiryWatermark` (#1635, merged), shared by both methods since the fact being defended against — has this process's clock been stepped backward — is a single process-wide fact, not a per-method one. Each method's refusal reuses its own existing "invalid or expired X" error text, so a caller cannot distinguish a genuine expiry from a clock-regression refusal by wording differing between the two paths.
- Also updates `remote_wire_route_coverage_test.go`'s `knownUnresolvedWireCalls` key from `entry.go:160` to `entry.go:161` — purely a line-number-drift fix caused by the code added above it in the same file, not a change in what that allowlist entry documents.

This is #1632's second PR, following #1635 (secret-value disclosure guard, merged) and preceding the RBAC cluster's mechanical PR.

## Test plan

- [x] New tests (`consume_clock_regression_test.go`): exploit-shaped tests for both `ConsumeMFAChallenge` and `ConsumeWebAuthnSession` (establish an expired-but-never-consumed row, step the clock backward past its expiry, assert consumption is still refused).
- [x] Positive controls: legitimately unexpired rows still consume normally; a small in-tolerance backward step (well under the 30s tolerance) doesn't cause a false-positive refusal.
- [x] A test proving the watermark is genuinely shared: warming it via an MFA challenge consumption also protects a subsequent WebAuthn session consumption on the same store.
- [x] Red-before-green: disabled the watermark check, confirmed the three regression tests fail (challenge/session consumed despite the backward step); restored it, confirmed all pass.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` on touched files — all clean.
- [x] `gosec -severity medium -exclude-generated ./internal/storage/store/...` — 0 issues.
- [x] Full `internal/core`, `internal/storage`, `server/http`, `server/grpc` suites pass under UTC and `TZ=America/New_York`.