### PR TITLE
fix(config): #1636 -- resolve storage.database.path to absolute at load

### DIFF
--- a/docs/adr-095-database-path-resolution.md
+++ b/docs/adr-095-database-path-resolution.md
@@ -1,0 +1,199 @@
+# ADR-095: `storage.database.path` resolved against process cwd, not the config file — fixed at load time
+
+## Status
+
+**Accepted (2026-08-31).** #1636 (re-scoped from a migration-lock report to its
+actual root cause). Fix landed; the in-database migration-lock hardening and
+the create-vs-refuse behavior change are recommended, not built, in this pass.
+
+## What this is
+
+#1636 was originally filed as a migration-lock bug: `secrets.db.migration.lock`
+turned up untracked in several directories. The two-process reproduction that
+investigation ran found something larger — two servers started from different
+working directories didn't share a database at all. Each silently created its
+own, both succeeded, neither warned. The lock was a symptom.
+
+`internal/storage/factory.go:185-187` defaulted `database.path` to the
+relative `"./secrets.db"`, and the operator-facing template
+(`configs/keyorix.yaml.tpl:97`, formerly line 73 pre-#1637) ships `"keyorix.db"`
+— equally relative. Neither was ever resolved to an absolute path before being
+handed to `gorm.Open`. Reachable without anyone doing anything wrong: systemd
+with `WorkingDirectory=/`, a container with `WORKDIR /app`, or an operator
+running the binary from a different directory across two restarts.
+
+## Task 1 — does this reach bootstrap? No. Data-integrity, not escalation.
+
+Traced before anything else, since it decides the severity class:
+
+- Opening a missing SQLite path silently creates an empty schema (via
+  `gorm.Open` + `migrateDatabase`'s `AutoMigrate`) — no distinct gate on that
+  step. This is the actual "silent creation" finding.
+- Populating that empty schema with an admin identity, RBAC roles, or any
+  privileged material is a **separate, explicit, token-gated step**
+  (`BootstrapSystem`, reached only via `POST /system/init`). Nothing calls it
+  automatically at boot.
+- The token itself is generated fresh and logged **masked** (first 8 + last 4
+  characters only — `server/main.go:346`) whenever it wasn't operator-set via
+  `KEYORIX_BOOTSTRAP_TOKEN`; the comment is explicit that the full value is
+  otherwise unrecoverable by anyone, including the legitimate operator,
+  without rebooting with the env var pre-set. `BootstrapSystem` fails closed
+  outright on an empty token (`auth_bootstrap.go:250-251`).
+- The CLI's own remote-bootstrap path (`keyorix system init --server`) goes
+  through the identical HTTP-gated endpoint with the identical token
+  requirement — no local-access bypass. There is no gRPC bootstrap RPC.
+- A freshly-created, uninitialized instance IS externally indistinguishable
+  from a healthy one: both `/health` (`server/http/handlers/health.go`) and
+  `/readyz` (`readiness.go`, a bare `SELECT 1` reachability ping) report
+  healthy/ready regardless of bootstrap state.
+
+**Verdict: data-integrity, not privilege-escalation.** An actor able to
+influence the process's working directory gets a running-but-empty Keyorix
+that looks healthy — not one that bootstraps into their control. Claiming it
+still requires the actual bootstrap token, which the cwd bug itself does not
+grant. Per the investigation's own guardrail, this cleared the pass to fix
+rather than stop-and-report.
+
+## Task 2 — the class, not the instance
+
+Every filesystem path the process resolves at runtime, verdicted:
+
+| Path | Resolution | Consequence if cwd-relative |
+|---|---|---|
+| `storage.database.path` | Was cwd-relative | **Silent — a fresh, healthy-looking empty database.** Fixed here. |
+| SQLite migration lock (`*.migration.lock`) | Derived from `database.path` (same defect, same cause) | Silent — symptom of the above. Not independently fixed (see Task 4). |
+| `storage.encryption.dek_path` / `salt_path` | Cwd-relative (`server/main.go:252-254`'s own `baseDir = "."` fallback) | **Loud** — encryption init fails closed at boot if the key material can't be found; server refuses to start rather than serve plaintext. |
+| `key_provider.file_path` (file-type KMS) | Cwd-relative, no baseDir at all (`internal/crypto/raw_providers.go`) | Loud — `os.Stat` failure surfaces as an encryption-init error, same fail-closed boot refusal. |
+| `key_provider.wrapped_key_path` (TPM/KMS types) | Cwd-relative, but baseDir-aware like DEK/salt | Loud, same as above. |
+| `server.http.tls.cert_file` / `key_file` | Cwd-relative (`tls.LoadX509KeyPair`, `server/main.go:2043`) | Loud — missing file fails `ListenAndServeTLS` at boot. |
+| `tls.cert_cache_dir` (autocert/ACME cache) | Cwd-relative, defaults to `"certs"` (`server/main.go:2097-2099`) | Degraded, not silent-data-loss — a lost cache re-requests a cert from Let's Encrypt, risking their rate limit on repeated cwd drift. Opt-in feature (`auto_cert`), not in the default template. |
+| `audit_forwarding.siem.spool_dir` | Cwd-relative (`internal/audit/siem/spool.go`) | Low — opt-in, off by default; a misplaced backlog file, not data loss. |
+| `evidence_delivery.output_dir` | Cwd-relative (`server/main.go:1510`) | Low — opt-in, self-reporting (the resolved dir is logged on every scheduler tick). |
+| `notary.ca_cert_path` (audit-checkpoint RFC 3161 anchor) | Cwd-relative | Low — failure is logged and the feature best-effort-degrades; anchoring continues to fail loud in logs, not silent. |
+| `license.path` | Cwd-relative | Low — logged `WARNING`, degrades to community baseline. Not security-relevant. |
+| **Config file's own path** (`KEYORIX_CONFIG_PATH` / `keyorix.yaml`) | **Already correct** — `Load()`'s `baseDir`/`filepath.IsAbs` handling (`config.go:1767-1770`) roots an absolute path at its own directory. This IS the anchor the fix below reuses. | — |
+| Postgres client connection / migration lock | **Not applicable** — DSN/host/port fields, no filesystem path; `pg_advisory_lock` is a live-connection primitive with zero cwd dependency (`factory.go:73-80`, confirmed by reading the code, not assumed). | — |
+| Unix socket paths | **Not applicable** — no such feature exists in this codebase. | — |
+| Plugin/extension directories | **Not applicable** — no such feature exists in this codebase. | — |
+
+Only `database.path` (and its lock symptom) produces *silent* divergence.
+Every other cwd-relative path fails loud or degrades a specific, generally
+opt-in feature — annoying, not dangerous, and explicitly reported as such
+rather than left unstated.
+
+## Task 3 — absolute is not sufficient (recommended, not built)
+
+Resolving to absolute stops two processes from silently diverging onto two
+different files. It does not stop a single mistyped absolute path from
+producing a fresh, empty, healthy-looking store on its own.
+
+**The rule worth adopting:** opening a database expected to exist and finding
+nothing should refuse, not create. The codebase already has the exact marker
+this needs, without inventing a fourth mechanism: `keyorix system init
+--database` (`internal/cli/system/init.go:162-181`) already creates the
+database file as an **explicit, deliberate step** (`O_CREATE|O_EXCL`, atomic,
+no TOCTOU) — this is already the intended "yes, a fresh install belongs here"
+signal. `createLocalStorage` (the server's boot path) currently doesn't check
+for the file's prior existence at all before letting `gorm.Open` silently
+vivify it.
+
+**Recommended, not built this pass:** `createLocalStorage` should `os.Stat`
+the resolved path before `gorm.Open` and refuse (`"no database found at %s —
+run 'keyorix system init' to create one, or verify database.path/working
+directory"`) unless the file already exists. Cost: one stat call, one new
+error path; the compatibility risk is real (an existing fresh-install flow
+that never explicitly runs `system init --database` first would start
+failing) and is exactly the kind of behavior change that deserves a
+deliberate sign-off rather than landing inside a same-day investigation.
+
+## Task 4 — the fix, in the order that mattered
+
+Two independent pieces were on the table. What actually landed:
+
+1. **Built — `database.path` resolved to absolute at `Load()`, anchored to
+   the config file's own directory, not process cwd.**
+   `internal/config/config.go`: `resolveConfigRelativePath(baseDir, path)`,
+   called from `Load()` using the *same* `baseDir` the config file's own path
+   was already resolved against. An in-memory DSN (`:memory:`,
+   `mode=memory`) and any existing `?query` suffix are left untouched,
+   mirroring `acquireSQLiteMigrationLock`'s own detection of the same two
+   shapes. Lands first — it's the actual reported defect.
+
+   **Caught and fixed a regression this introduced before it shipped:**
+   `filepath.Abs`/`Join` silently collapses a `"../escapes.db"` traversal
+   attempt into a clean absolute path with no `".."` substring left to
+   detect — which would have defeated `internal/cli/system/init.go`'s own
+   `initializeDatabase` traversal guard (a check that, on inspection, only
+   ever ran on the CLI's `init --database` step in the first place, never on
+   the server's own boot path). Centralized the rejection into
+   `resolveConfigRelativePath` itself instead: a `database.path` containing
+   `".."` now fails `Load()` outright, covering both callers rather than
+   just the one that happened to remember to check.
+
+2. **Built — the startup log line, unconditionally, regardless of what else
+   landed.** `internal/storage/factory.go`'s `createLocalStorage` now logs,
+   before `gorm.Open`, whether it's opening an existing database or about to
+   create a new empty one, at the resolved absolute path. Pure diagnostics —
+   `dbPath` itself is untouched by this log line, no behavior change. This
+   directly answers "which database am I actually using," previously
+   unanswerable from the logs.
+
+3. **Recommended, not built — move the SQLite migration lock inside the
+   database**, matching Postgres's `pg_advisory_lock` and the scheduler
+   lease's `ON CONFLICT DO NOTHING`. On inspection, the scheduler-lease
+   pattern specifically does **not** transfer cleanly here: it requires a
+   pre-existing table, and the migration lock's whole purpose is guarding
+   the very first migration that creates that table — a chicken-and-egg
+   problem `pg_advisory_lock` (a server-level primitive, no schema
+   dependency) doesn't have. The correct SQLite analog is a `BEGIN
+   EXCLUSIVE` file-level lock, schema-independent and auto-released by the
+   OS on crash the same way `flock` already is — but wiring it correctly
+   through GORM's connection pooling (a dedicated `*sql.Conn`, careful
+   `busy_timeout` handling to preserve the current fail-fast-not-blocking
+   semantics) is real, correctness-sensitive plumbing. Left recommended
+   rather than risking a rushed, under-verified rewrite of a mechanism that
+   protects real migration integrity. Independent of (1) and (2) — this
+   piece is a hardening of the lock mechanism itself, valuable once the path
+   problem is fixed but not required to fix it.
+
+## Incidental finding, filed separately
+
+`configs/keyorix.yaml.tpl` sets `storage.type: sqlite`; `CreateStorage`'s
+switch and `Config.Validate()` only recognize `"local"`, `"postgres"`,
+`"postgresql"`, or `"remote"` — copying the shipped template verbatim and
+booting fails outright. Unrelated to path resolution; filed as its own issue
+rather than folded in here.
+
+## Verification
+
+- `TestLoad_DatabasePathResolvedAbsoluteRegardlessOfCwd`: the same config,
+  loaded via the same absolute path from two different process working
+  directories, resolves to the identical absolute `database.path` both
+  times. Red before the fix (asserted `keyorix.db`, unresolved), green after.
+- `TestResolveConfigRelativePath_*`: already-absolute passthrough, in-memory
+  DSN untouched, query-suffix preserved, empty passthrough, `".."` rejected
+  — each pinned individually.
+- `TestLoad_DatabasePathTraversal_Rejected` / updated
+  `TestRunInit_DatabasePathTraversal_RejectedAtConfigLoad`
+  (`internal/cli/system/system_s26_test.go`, renamed from
+  `TestRunInit_InitializeDatabaseErrorPropagates`): the traversal now fails
+  at `Load()`, verified through both the direct helper and the real CLI
+  entrypoint. `initializeDatabase`'s own defense-in-depth check remains
+  independently covered by `TestInitializeDatabase_InvalidPath`
+  (`system_s2_test.go`), which constructs its `*config.Config` by hand
+  rather than through `Load()`.
+- Two-process end-to-end re-demonstration, same absolute `KEYORIX_CONFIG_PATH`,
+  different working directories, through the real `config.Load()` →
+  `CreateStorage()` pipeline: process A logs "no database found... a NEW,
+  EMPTY database will be created here" and succeeds; process B logs "opening
+  existing SQLite database at [the same path]" and succeeds, genuinely
+  contending on the same file via the (now correctly co-located) migration
+  lock. Both processes' own working directories remain completely empty
+  afterward; only the config-anchored directory gains `secrets.db` +
+  `secrets.db-shm` + `secrets.db-wal` + `secrets.db.migration.lock`.
+- Postgres unaffected: confirmed by reading `withMigrationLock`'s Postgres
+  branch, which never reads `dbPath` at all, and by `database.path` legitimately
+  being empty for a Postgres deployment (the DSN/host/port fields are used
+  instead), which `resolveConfigRelativePath` passes through unchanged.
+- Full suites: `internal/storage`, `internal/config`, `internal/cli`,
+  `server/http` green.

--- a/internal/cli/system/system_s26_test.go
+++ b/internal/cli/system/system_s26_test.go
@@ -121,10 +121,18 @@ func TestRunInit_InitializeEncryptionErrorPropagates(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to initialize encryption")
 }
 
-// TestRunInit_InitializeDatabaseErrorPropagates exercises init.go:117-119: the
-// generated config's database path contains "..", which initializeDatabase
-// rejects, and runInit must wrap that error.
-func TestRunInit_InitializeDatabaseErrorPropagates(t *testing.T) {
+// TestRunInit_DatabasePathTraversal_RejectedAtConfigLoad exercises the same
+// "../escapes.db" traversal TestRunInit_InitializeDatabaseErrorPropagates
+// used to catch inside initializeDatabase (init.go's own "invalid path for
+// database" check) -- #1636 moved that rejection into config.Load() itself
+// (resolveConfigRelativePath, internal/config/config.go), since
+// initializeDatabase's check only ever ran on this CLI path, never on the
+// server's own boot path (createLocalStorage had no such check at all).
+// runInit now fails at the "failed to load config" step, before
+// initializeDatabase is ever reached -- initializeDatabase's own check is
+// still in place as defense-in-depth for a hand-constructed *config.Config
+// that didn't go through Load(), but is no longer what this test exercises.
+func TestRunInit_DatabasePathTraversal_RejectedAtConfigLoad(t *testing.T) {
 	dir := t.TempDir()
 	template := "storage:\n  type: local\n  database:\n    path: ../escapes.db\n"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "keyorix_template.yaml"), []byte(template), 0600))
@@ -142,7 +150,8 @@ func TestRunInit_InitializeDatabaseErrorPropagates(t *testing.T) {
 
 	err := runInit(InitCmd, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to initialize database")
+	assert.Contains(t, err.Error(), "failed to load config")
+	assert.Contains(t, err.Error(), "..")
 }
 
 // TestRunInit_InitializeLoggingErrorPropagates exercises init.go:123-125 (and,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1808,7 +1808,70 @@ func Load(path string) (*Config, error) {
 		cfg.Server.HTTP.AllowedOrigins[i] = expandEnvVars(origin)
 	}
 
+	// #1636: a relative storage.database.path was resolved against the PROCESS's
+	// cwd at the point internal/storage/factory.go happened to open it — not
+	// against baseDir, the directory THIS config file was actually read from.
+	// Two processes loading the identical config (e.g. via the same absolute
+	// KEYORIX_CONFIG_PATH, the documented container pattern above) but launched
+	// with different working directories silently opened two different SQLite
+	// files, each successfully, neither warning. Anchoring to baseDir here
+	// instead makes "same config" reliably mean "same database" regardless of
+	// launch directory — matching how baseDir already anchors the config file's
+	// OWN path resolution above. Anchoring to the config file's directory (not
+	// an unrelated fixed root) is deliberate: it's what "keyorix.db lives next
+	// to keyorix.yaml" (the template's own layout) actually means.
+	resolvedDBPath, derr := resolveConfigRelativePath(baseDir, cfg.Storage.Database.Path)
+	if derr != nil {
+		return nil, fmt.Errorf("invalid storage.database.path: %w", derr)
+	}
+	cfg.Storage.Database.Path = resolvedDBPath
+
 	return &cfg, nil
+}
+
+// resolveConfigRelativePath anchors a relative SQLite database path to
+// baseDir (the directory Load read the config file from) instead of leaving
+// it to resolve against the process's cwd wherever it's later opened. Two
+// shapes are deliberately left untouched, matching
+// acquireSQLiteMigrationLock's own detection of the same cases (see
+// internal/storage/factory_sqlite_migration_lock.go): an in-memory DSN
+// (":memory:" or a "mode=memory" query parameter) names no real file to
+// anchor, and any existing DSN query-string suffix (an operator-supplied
+// "?_pragma=...") is preserved verbatim, resolved around rather than through.
+// Already-absolute and empty paths pass through unchanged.
+//
+// Rejects (rather than silently resolving) a relative path containing "..":
+// filepath.Abs/Join would otherwise collapse it into a clean absolute path
+// OUTSIDE baseDir with no ".." substring left to detect afterward —
+// internal/cli/system/init.go's initializeDatabase used to catch this itself
+// (its own "invalid path for database" check), but only on the CLI's own
+// init --database step, never on the server's boot path (createLocalStorage
+// never ran any such check at all). Centralizing the rejection here, in
+// Load() itself, closes that gap for both callers at once, not just the one
+// that happened to remember to check.
+func resolveConfigRelativePath(baseDir, dbPath string) (string, error) {
+	if dbPath == "" || dbPath == ":memory:" || strings.Contains(dbPath, "mode=memory") {
+		return dbPath, nil
+	}
+	base, suffix := dbPath, ""
+	if idx := strings.IndexByte(dbPath, '?'); idx != -1 {
+		base, suffix = dbPath[:idx], dbPath[idx:]
+	}
+	if base == "" || filepath.IsAbs(base) {
+		return dbPath, nil
+	}
+	if strings.Contains(base, "..") {
+		return "", fmt.Errorf("database.path %q must not contain \"..\"", dbPath)
+	}
+	abs, err := filepath.Abs(filepath.Join(baseDir, base))
+	if err != nil {
+		// filepath.Abs only fails if os.Getwd() fails -- a more fundamental
+		// problem than this resolution step. Leave the path as Load found it
+		// rather than fail config loading over it; the pre-existing (relative)
+		// behavior is at least no worse than before this fix.
+		return dbPath, nil
+	}
+	return abs + suffix, nil
 }
 
 // envVarPattern matches shell-style ${VAR} and ${VAR:-default} references — the

--- a/internal/config/g1636_database_path_resolution_test.go
+++ b/internal/config/g1636_database_path_resolution_test.go
@@ -1,0 +1,125 @@
+// g1636_database_path_resolution_test.go — #1636: a relative
+// storage.database.path used to resolve against the process's cwd wherever
+// internal/storage/factory.go happened to open it, not against the directory
+// the config file itself was read from. Two processes loading the identical
+// config (same absolute KEYORIX_CONFIG_PATH) but launched from different
+// working directories silently opened two different SQLite files. These
+// tests pin Load()'s fix: cfg.Storage.Database.Path is now resolved to an
+// absolute path anchored at baseDir (the config file's own directory) before
+// Load returns, so "same config" reliably means "same database" regardless
+// of the caller's cwd.
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoad_DatabasePathResolvedAbsoluteRegardlessOfCwd is the core #1636
+// regression: the same config file, loaded via the same absolute
+// KEYORIX_CONFIG_PATH, from two different process working directories, must
+// resolve storage.database.path to the identical absolute path both times.
+// Before the fix, each call resolved "keyorix.db" against its OWN cwd,
+// producing two different (both non-absolute) values.
+func TestLoad_DatabasePathResolvedAbsoluteRegardlessOfCwd(t *testing.T) {
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("storage:\n  type: sqlite\n  database:\n    path: keyorix.db\n"), 0600))
+
+	cwdA := t.TempDir()
+	cwdB := t.TempDir()
+
+	loadFrom := func(t *testing.T, cwd string) string {
+		t.Helper()
+		orig, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(cwd))
+		defer func() { require.NoError(t, os.Chdir(orig)) }()
+
+		cfg, err := Load(configPath)
+		require.NoError(t, err)
+		return cfg.Storage.Database.Path
+	}
+
+	resolvedA := loadFrom(t, cwdA)
+	resolvedB := loadFrom(t, cwdB)
+
+	assert.True(t, filepath.IsAbs(resolvedA), "resolved database.path must be absolute, got %q", resolvedA)
+	assert.Equal(t, resolvedA, resolvedB, "the same config, loaded from two different working directories, must resolve to the same database file")
+	assert.Equal(t, filepath.Join(configDir, "keyorix.db"), resolvedA, "must anchor to the config file's own directory, not either process's cwd")
+}
+
+// TestResolveConfigRelativePath_AlreadyAbsolute_PassesThroughUnchanged confirms
+// an operator who already configured an absolute path is left alone -- no
+// double-joining, no surprise rewrite of a value they set deliberately.
+func TestResolveConfigRelativePath_AlreadyAbsolute_PassesThroughUnchanged(t *testing.T) {
+	got, err := resolveConfigRelativePath("/some/base", "/already/absolute/secrets.db")
+	require.NoError(t, err)
+	assert.Equal(t, "/already/absolute/secrets.db", got)
+}
+
+// TestResolveConfigRelativePath_InMemoryDSN_Untouched mirrors
+// acquireSQLiteMigrationLock's own in-memory detection (see
+// internal/storage/factory_sqlite_migration_lock.go) -- an in-memory
+// database names no real file to anchor, and joining it against baseDir
+// would corrupt the DSN into a garbage on-disk path.
+func TestResolveConfigRelativePath_InMemoryDSN_Untouched(t *testing.T) {
+	got, err := resolveConfigRelativePath("/some/base", ":memory:")
+	require.NoError(t, err)
+	assert.Equal(t, ":memory:", got)
+
+	got, err = resolveConfigRelativePath("/some/base", "file:foo?mode=memory&cache=shared")
+	require.NoError(t, err)
+	assert.Equal(t, "file:foo?mode=memory&cache=shared", got)
+}
+
+// TestResolveConfigRelativePath_QueryStringSuffixPreserved confirms an
+// operator-supplied DSN query suffix (e.g. a custom pragma) survives the
+// resolution unchanged, appended to the now-absolute path -- the file portion
+// is resolved, the suffix is not touched or reordered.
+func TestResolveConfigRelativePath_QueryStringSuffixPreserved(t *testing.T) {
+	got, err := resolveConfigRelativePath("/base/dir", "secrets.db?_pragma=foo(1)")
+	require.NoError(t, err)
+	assert.Equal(t, "/base/dir/secrets.db?_pragma=foo(1)", got)
+}
+
+// TestResolveConfigRelativePath_Empty_PassesThroughUnchanged confirms an
+// empty configured path (the "operator didn't set database.path at all"
+// case, defaulted later in internal/storage/factory.go) is left for that
+// caller to default -- Load() has no config-file-relative anchor to offer
+// when the field itself carries no value.
+func TestResolveConfigRelativePath_Empty_PassesThroughUnchanged(t *testing.T) {
+	got, err := resolveConfigRelativePath("/some/base", "")
+	require.NoError(t, err)
+	assert.Equal(t, "", got)
+}
+
+// TestResolveConfigRelativePath_DotDot_Rejected pins the traversal guard that
+// used to live only in internal/cli/system/init.go's initializeDatabase (a
+// CLI-only check, never run on the server's own boot path): filepath.Abs/Join
+// would otherwise silently collapse "../escapes.db" into a clean absolute
+// path outside baseDir with no ".." substring left to catch afterward.
+// Centralizing the rejection in Load() covers both callers, not just the CLI.
+func TestResolveConfigRelativePath_DotDot_Rejected(t *testing.T) {
+	_, err := resolveConfigRelativePath("/some/base", "../escapes.db")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "..")
+}
+
+// TestLoad_DatabasePathTraversal_Rejected confirms Load() itself fails loudly
+// (not silently escaping baseDir) when the config's database.path contains
+// "..", the same shape TestResolveConfigRelativePath_DotDot_Rejected pins at
+// the helper level, exercised through the real Load() entrypoint.
+func TestLoad_DatabasePathTraversal_Rejected(t *testing.T) {
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("storage:\n  type: local\n  database:\n    path: ../escapes.db\n"), 0600))
+
+	_, err := Load(configPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "..")
+}

--- a/internal/startup/validation_coverage_test.go
+++ b/internal/startup/validation_coverage_test.go
@@ -159,17 +159,22 @@ func TestValidateStartup_EncryptionEnabled_ValidKeys(t *testing.T) {
 	assert.True(t, result.EncryptionOK, "valid key files must set EncryptionOK=true")
 }
 
-// TestValidateStartup_DatabaseValidationFails exercises the path where
-// validateDatabase returns an error — for local storage with a relative DB path.
-// This covers lines 79-82 in ValidateStartup.
-func TestValidateStartup_DatabaseValidationFails(t *testing.T) {
+// TestValidateStartup_RelativeDatabasePath_ResolvedNotRejected replaces the
+// old TestValidateStartup_DatabaseValidationFails: #1636 made config.Load()
+// (called by ValidateStartup before validateDatabase ever runs) resolve a
+// relative storage.database.path to absolute, anchored at the config file's
+// own directory -- so by the time validateDatabase's own
+// !filepath.IsAbs(dbPath) check would fire, the path is already absolute,
+// and it doesn't. This is a deliberate behavior change, not a regression:
+// the path is now genuinely safe by construction rather than merely
+// flagged as unsafe while staying relative. validateDatabase's own
+// defense-in-depth rejection of a truly-relative path (for a
+// *config.Config built by hand, bypassing Load()) remains independently
+// covered by TestValidateDatabase_LocalStorageStillValidatesPath
+// (validation_test.go).
+func TestValidateStartup_RelativeDatabasePath_ResolvedNotRejected(t *testing.T) {
 	dir := t.TempDir()
-	// We need a config that passes schema validation but gives validateDatabase a
-	// relative (unsafe) path. Use a custom config struct path injection: write a
-	// config with a relative database path. Config.Validate() does not validate the
-	// path value itself, only that the field is non-empty for local storage.
 	configPath := filepath.Join(dir, "keyorix.yaml")
-	// Use a relative path that will be rejected by validateDatabase.
 	content := `
 storage:
   type: local
@@ -189,8 +194,48 @@ security:
 `
 	require.NoError(t, os.WriteFile(configPath, []byte(content), 0600))
 
+	result, err := ValidateStartup(configPath, false)
+	require.NoError(t, err, "a relative database path must now be resolved, not rejected")
+	assert.True(t, result.DatabaseOK)
+	assert.Contains(t, result.Warnings[len(result.Warnings)-1], filepath.Join(dir, "relative.db"),
+		"the resolved absolute path (anchored to the config file's directory) must be visible in the validation output")
+}
+
+// TestValidateStartup_DatabaseValidationFails_UnopenableFile keeps
+// ValidateStartup's lines 79-82 (the branch where validateDatabase returns
+// an error) covered via a trigger that still fails after #1636: an existing
+// database file this process cannot open, rather than a relative path
+// (which #1636 made config.Load() resolve instead of reject -- see
+// TestValidateStartup_RelativeDatabasePath_ResolvedNotRejected).
+func TestValidateStartup_DatabaseValidationFails_UnopenableFile(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "secrets.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("x"), 0600))
+	require.NoError(t, os.Chmod(dbPath, 0000))
+	t.Cleanup(func() { _ = os.Chmod(dbPath, 0600) })
+
+	configPath := filepath.Join(dir, "keyorix.yaml")
+	content := fmt.Sprintf(`
+storage:
+  type: local
+  database:
+    path: %q
+  encryption:
+    enabled: false
+
+server:
+  http:
+    enabled: false
+  grpc:
+    enabled: false
+
+security:
+  enable_file_permission_check: false
+`, dbPath)
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0600))
+
 	_, err := ValidateStartup(configPath, false)
-	require.Error(t, err, "a relative database path must cause database validation to fail")
+	require.Error(t, err, "an existing but unopenable database file must cause database validation to fail")
 	assert.Contains(t, err.Error(), "database")
 }
 

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -2,6 +2,9 @@ package storage
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -185,6 +188,24 @@ func (f *DefaultStorageFactory) createLocalStorage(cfg *config.Config) (storage.
 	dbPath := cfg.Storage.Database.Path
 	if dbPath == "" {
 		dbPath = "./secrets.db"
+	}
+
+	// #1636: log which file is actually about to be opened, and whether it
+	// already existed, BEFORE gorm.Open's implicit create-if-missing makes that
+	// distinction unrecoverable. dbPath itself is deliberately left untouched
+	// here (still cwd-relative if configured that way, still fed as-is into
+	// sqliteDSN/withMigrationLock below) -- this is diagnostics only, not a fix
+	// for the underlying resolution defect (tracked separately). Best-effort:
+	// filepath.Abs only fails if os.Getwd() fails, which would already be a
+	// more fundamental problem than this log line; never block startup on it.
+	logDbPath := dbPath
+	if abs, aerr := filepath.Abs(dbPath); aerr == nil {
+		logDbPath = abs
+	}
+	if _, statErr := os.Stat(dbPath); statErr == nil {
+		log.Printf("storage: opening existing SQLite database at %s (configured: %q)", logDbPath, cfg.Storage.Database.Path)
+	} else {
+		log.Printf("storage: no database found at %s (configured: %q) -- a NEW, EMPTY database will be created here", logDbPath, cfg.Storage.Database.Path)
 	}
 
 	// Hold migrationMu across gorm.Open too, not just the migration that follows


### PR DESCRIPTION
## Summary

Closes #1636 (re-scoped, retitled, and re-investigated from its original migration-lock filing to the actual root cause). Full report on the issue.

- **Task 1 (gates everything downstream): data-integrity, not privilege-escalation.** Opening a missing database silently creates an empty schema, but populating it with an admin identity requires `BootstrapSystem`'s separate, token-gated `POST /system/init` — the token is masked in logs (first 8 + last 4 chars) and otherwise unrecoverable without `KEYORIX_BOOTSTRAP_TOKEN` pre-set, no local-CLI or gRPC bypass. Confirmed by reading `BootstrapSystem`, `server/main.go`'s token wiring, and the CLI's remote-init path — not assumed. `/health` and `/readyz` both report healthy regardless of bootstrap state, which is the real hazard: a silently-fresh instance looks identical to a correctly-configured one.
- **Task 2**: full runtime-path sweep in `docs/adr-095-database-path-resolution.md` — TLS cert/key, DEK/salt paths, autocert cache, SIEM spool, evidence output, and the notary CA cert are all the *same class* of cwd-relative defect, but every one of them fails loud at boot or degrades an opt-in feature rather than silently fabricating fresh state. Only `database.path` (and its lock symptom) diverges silently.
- **Fix**: `config.Load()` resolves `database.path` to absolute, anchored to the config file's own directory (the same anchor `Load()` already uses for its own path) — not the process's cwd, wherever `gorm.Open` later happens to run from.
- **Caught and fixed a regression before it shipped**: naive absolute resolution silently defeated `internal/cli/system/init.go`'s own path-traversal guard (`filepath.Abs`/`Join` collapses `"../escapes.db"` into a clean absolute path with no `".."` left to detect). Centralized the rejection into the resolution helper itself — which also closes a real pre-existing gap, since the old check only ever ran on the CLI's `init --database` step, never on the server's own boot path.
- **Ships regardless**: a startup log line — `createLocalStorage` now logs whether it's opening an existing database or creating a new empty one, at the resolved absolute path, before `gorm.Open`.
- **Recommended, not built** (cost and reasoning in the ADR): refuse rather than silently create a missing database (the codebase already has the marker this needs — `keyorix system init --database`'s own explicit file creation); move the SQLite migration lock inside the database itself via `BEGIN EXCLUSIVE` (not the scheduler lease's `ON CONFLICT DO NOTHING` — that needs a pre-existing table, which the very first migration doesn't have yet).
- **Incidental finding, filed separately**: the shipped template sets `storage.type: sqlite`, but the code only recognizes `"local"` — copying the template verbatim and booting fails outright. Unrelated to path resolution.

## Test plan

- [x] `TestLoad_DatabasePathResolvedAbsoluteRegardlessOfCwd` — same config, two different process working directories, resolves to the identical absolute path both times. Verified red before the fix (asserted the unresolved relative value), green after.
- [x] `TestResolveConfigRelativePath_*` — already-absolute passthrough, in-memory DSN untouched, query-suffix preserved, empty passthrough, `".."` rejected.
- [x] `TestLoad_DatabasePathTraversal_Rejected` / renamed `TestRunInit_DatabasePathTraversal_RejectedAtConfigLoad` — traversal now fails at `Load()`; `initializeDatabase`'s own defense-in-depth check remains independently covered by the pre-existing `TestInitializeDatabase_InvalidPath` (constructs its config by hand, bypassing `Load()`).
- [x] Two-process end-to-end re-demonstration through the real `config.Load()` → `CreateStorage()` pipeline: process A creates, process B correctly recognizes and opens the same file instead of creating a second one, genuinely contending on the migration lock. Both processes' own working directories stay empty.
- [x] Postgres confirmed unaffected by reading `withMigrationLock`'s Postgres branch (never reads `dbPath`), not assumed.
- [x] Full suites (`internal/storage`, `internal/config`, `internal/cli`, `server/http`) green.