### PR TITLE
fix(storage): #1632 -- RBAC permission resolution trusts wall clock

### DIFF
--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -196,16 +196,26 @@ type LocalStorage struct {
 	// same reason as auditChainMu/auditCheckpointMu — a transaction-scoped
 	// LocalStorage must share its parent's mutex.
 	bootstrapMu *sync.Mutex
-	// consumeClockWatermark backs checkConsumeClockNotRegressed (#1632): an
+	// consumeClockWatermark backs consumeClockLooksRegressed (#1632): an
 	// in-memory monotonic high-water mark of the latest wall-clock instant a
 	// single-use-token consumption (ConsumeMFAChallenge, ConsumeWebAuthnSession)
 	// has legitimately observed, in this process's lifetime. A pointer for the
 	// same reason as the mutexes above — ConsumeMFAChallenge and
 	// ConsumeWebAuthnSession are two distinct call paths (one via the core
 	// layer's c.now(), one via a raw storage call from an HTTP handler; see
-	// checkConsumeClockNotRegressed's doc comment) that must share ONE
+	// consumeClockLooksRegressed's doc comment) that must share ONE
 	// watermark, not warm two independent ones.
 	consumeClockWatermark *clockWatermark
+	// rbacClockWatermark backs rbacEffectiveNow (#1632): an in-memory monotonic
+	// high-water mark of the latest wall-clock instant any RBAC permission-
+	// resolution query in local_rbac.go has legitimately observed. Unlike
+	// consumeClockWatermark (which backs a REFUSAL of a single, discrete
+	// action), this backs a CLAMP applied to a pervasive, high-volume read
+	// path reached on every authorized request — see rbacEffectiveNow's doc
+	// comment for why the two sites need different response shapes to the
+	// same underlying fact. A pointer for the same sharing reason as every
+	// other watermark/mutex field on this struct.
+	rbacClockWatermark *clockWatermark
 }
 
 // clockWatermark pairs a mutex with the time.Time it guards, so a single
@@ -225,6 +235,7 @@ func NewLocalStorage(db *gorm.DB) *LocalStorage {
 		auditCheckpointMu:     &sync.Mutex{},
 		bootstrapMu:           &sync.Mutex{},
 		consumeClockWatermark: &clockWatermark{},
+		rbacClockWatermark:    &clockWatermark{},
 	}
 }
 

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -22,6 +22,44 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// rbacEffectiveNow returns a wall-clock reading that never regresses relative
+// to what this LocalStorage has already observed for RBAC permission-
+// resolution queries (#1632): max(now, rbacClockWatermark), always advancing
+// the watermark forward. Every expiry check in this file binds a fresh
+// time.Now().UTC() directly into a SQL `expires_at > ?` bound (or an in-Go
+// ExpiresAt.After comparison) with no caching layer in between — a host
+// clock stepped backward past a grant's real expiry would compute that grant
+// as still live, extending a permission/role assignment's validity past its
+// real window.
+//
+// Unlike consumeClockLooksRegressed (which REFUSES a single, discrete
+// action outright), this CLAMPS rather than errors. These ~14+ call sites are
+// read-heavy permission-resolution queries reached on every authorized
+// request across the whole application; hard-refusing all of them the moment
+// a regression is detected would turn a narrow clock-integrity concern into
+// a total authorization outage (every permission check failing, for every
+// user, until the tolerance window passes) — a strictly worse outcome than
+// the hazard being defended against. Clamping achieves the same security
+// property (a backward-stepped clock can never compute a grant as MORE valid
+// than the highest wall-clock time this process has already legitimately
+// observed) without that availability blast radius. The two in-Go
+// ExpiresAt.After checks in this file (assignUserRole, assignGroupRole) are
+// already safe-direction on a regression — a backward clock makes an
+// EXPIRED existing grant look live, which blocks a fresh assignment rather
+// than granting anything — but are clamped too for mechanical consistency
+// with every other wall-clock read in this file, not because they are
+// themselves a security finding.
+func (ls *LocalStorage) rbacEffectiveNow(now time.Time) time.Time {
+	wm := ls.rbacClockWatermark
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+	if now.Before(wm.time) {
+		return wm.time
+	}
+	wm.time = now
+	return now
+}
+
 // --- Permissions ---
 
 func (ls *LocalStorage) CreatePermission(ctx context.Context, permission *models.Permission) (*models.Permission, error) {
@@ -149,7 +187,7 @@ func (ls *LocalStorage) assignUserRole(ctx context.Context, userID, roleID uint,
 			// so the composite primary key (user_id, role_id, project_id, environment_id) is
 			// free for the fresh Create below, mirroring how live-authorization queries
 			// elsewhere (e.g. GetUserRoles) already exclude expired grants.
-			if existing.ExpiresAt == nil || existing.ExpiresAt.After(time.Now()) {
+			if existing.ExpiresAt == nil || existing.ExpiresAt.After(ls.rbacEffectiveNow(time.Now().UTC())) {
 				return fmt.Errorf("%s", i18n.T("ErrorRoleAlreadyAssigned", nil))
 			}
 			if derr := tx.Where(sqlWhereUserRoleEnv,
@@ -212,7 +250,7 @@ func (ls *LocalStorage) GetUserRoles(ctx context.Context, userID uint) ([]*model
 	err := ls.db.WithContext(ctx).Table("roles").
 		Joins("JOIN user_roles ON roles.id = user_roles.role_id").
 		Where(sqlWhereURUserID, userID).
-		Where(sqlWhereURNotExpired, time.Now().UTC()).
+		Where(sqlWhereURNotExpired, ls.rbacEffectiveNow(time.Now().UTC())).
 		Find(&roles).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -244,7 +282,7 @@ func (ls *LocalStorage) GetUserRoleIDsAt(ctx context.Context, userID uint, scope
 		Where(sqlWhereURUserID, userID).
 		Where("user_roles.project_id = 0 OR (user_roles.project_id = ? AND projects.deleted_at IS NULL)", scope.ProjectID).
 		Where("user_roles.environment_id = 0 OR (user_roles.environment_id = ? AND environments.deleted_at IS NULL)", scope.EnvironmentID).
-		Where(sqlWhereURNotExpired, time.Now().UTC()).
+		Where(sqlWhereURNotExpired, ls.rbacEffectiveNow(time.Now().UTC())).
 		Distinct().Pluck("user_roles.role_id", &ids).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -267,7 +305,7 @@ func (ls *LocalStorage) GetUserRoleScopes(ctx context.Context, userID uint) ([]s
 	if err := ls.db.WithContext(ctx).Model(&models.UserRole{}).
 		Select("project_id, environment_id").
 		Where("user_id = ?", userID).
-		Where(sqlWhereURNotExpired, time.Now().UTC()).
+		Where(sqlWhereURNotExpired, ls.rbacEffectiveNow(time.Now().UTC())).
 		Group("project_id, environment_id").
 		Scan(&direct).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -282,7 +320,7 @@ func (ls *LocalStorage) GetUserRoleScopes(ctx context.Context, userID uint) ([]s
 		Joins(sqlJoinUserGroups).
 		Joins(sqlJoinGroups).
 		Where(sqlWhereUGUserID, userID).
-		Where(sqlWhereGRNotExpired, time.Now().UTC()).
+		Where(sqlWhereGRNotExpired, ls.rbacEffectiveNow(time.Now().UTC())).
 		Group("group_roles.project_id, group_roles.environment_id").
 		Scan(&viaGroups).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -306,7 +344,7 @@ func (ls *LocalStorage) GetUserRoleScopes(ctx context.Context, userID uint) ([]s
 func (ls *LocalStorage) ListProjectRoleAssignments(ctx context.Context, projectID uint) ([]storage.RoleAssignment, error) {
 	var out []storage.RoleAssignment
 
-	now := time.Now().UTC()
+	now := ls.rbacEffectiveNow(time.Now().UTC())
 	var userRows []models.UserRole
 	if err := ls.db.WithContext(ctx).
 		Where(sqlWhereProjectID, projectID).
@@ -382,7 +420,7 @@ func (ls *LocalStorage) ListGlobalAdminAssignmentsForUpdate(ctx context.Context,
 	}
 	var userRows []models.UserRole
 	if err := userQ.Where("project_id = 0 AND environment_id = 0 AND role_id IN ?", adminRoleIDs).
-		Where(sqlWhereURNotExpired, time.Now().UTC()).
+		Where(sqlWhereURNotExpired, ls.rbacEffectiveNow(time.Now().UTC())).
 		Find(&userRows).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
@@ -399,7 +437,7 @@ func (ls *LocalStorage) ListGlobalAdminAssignmentsForUpdate(ctx context.Context,
 	}
 	var groupRows []models.GroupRole
 	if err := groupQ.Where("project_id = 0 AND environment_id = 0 AND role_id IN ?", adminRoleIDs).
-		Where(sqlWhereGRNotExpired, time.Now().UTC()).
+		Where(sqlWhereGRNotExpired, ls.rbacEffectiveNow(time.Now().UTC())).
 		Find(&groupRows).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
@@ -429,6 +467,7 @@ func (ls *LocalStorage) RemoveGlobalAdminRoleGuarded(ctx context.Context, userID
 			auditCheckpointMu:     ls.auditCheckpointMu,
 			bootstrapMu:           ls.bootstrapMu,
 			consumeClockWatermark: ls.consumeClockWatermark,
+			rbacClockWatermark:    ls.rbacClockWatermark,
 		}
 		assignments, err := txStorage.ListGlobalAdminAssignmentsForUpdate(ctx, adminRoleIDs)
 		if err != nil {
@@ -459,7 +498,7 @@ func (ls *LocalStorage) GetUserRoleIDsExact(ctx context.Context, userID uint, sc
 	err := ls.db.WithContext(ctx).Model(&models.UserRole{}).
 		Where("user_id = ? AND project_id = ? AND environment_id = ?",
 			userID, scope.ProjectID, scope.EnvironmentID).
-		Where(sqlWhereURNotExpired, time.Now().UTC()).
+		Where(sqlWhereURNotExpired, ls.rbacEffectiveNow(time.Now().UTC())).
 		Distinct().Pluck("role_id", &ids).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -475,7 +514,7 @@ func (ls *LocalStorage) IsProjectMember(ctx context.Context, userID, projectID u
 	if projectID == 0 {
 		return false, nil
 	}
-	now := time.Now().UTC()
+	now := ls.rbacEffectiveNow(time.Now().UTC())
 	var direct int64
 	if err := ls.db.WithContext(ctx).Model(&models.UserRole{}).
 		Where("user_id = ? AND project_id = ?", userID, projectID).
@@ -507,7 +546,7 @@ func (ls *LocalStorage) IsGroupProjectScoped(ctx context.Context, groupID, proje
 	if projectID == 0 {
 		return false, nil
 	}
-	now := time.Now().UTC()
+	now := ls.rbacEffectiveNow(time.Now().UTC())
 	var count int64
 	if err := ls.db.WithContext(ctx).Table("group_roles").
 		Joins(sqlJoinGroups).
@@ -533,7 +572,7 @@ func (ls *LocalStorage) ListProjectMembers(ctx context.Context, projectID uint) 
 		Joins("JOIN users u ON u.id = ur.user_id").
 		Joins("JOIN roles r ON r.id = ur.role_id").
 		Where("ur.project_id = ? AND ur.environment_id = 0", projectID).
-		Where("ur.expires_at IS NULL OR ur.expires_at > ?", time.Now().UTC()).
+		Where("ur.expires_at IS NULL OR ur.expires_at > ?", ls.rbacEffectiveNow(time.Now().UTC())).
 		Where("u.deleted_at IS NULL").
 		Order("u.username").
 		Scan(&members).Error
@@ -571,7 +610,7 @@ func (ls *LocalStorage) GetUserGroupRoleIDsAt(ctx context.Context, userID uint, 
 		Where("user_groups.project_id = 0 OR user_groups.project_id = ?", scope.ProjectID).
 		Where("group_roles.project_id = 0 OR (group_roles.project_id = ? AND projects.deleted_at IS NULL)", scope.ProjectID).
 		Where("group_roles.environment_id = 0 OR (group_roles.environment_id = ? AND environments.deleted_at IS NULL)", scope.EnvironmentID).
-		Where(sqlWhereGRNotExpired, time.Now().UTC()).
+		Where(sqlWhereGRNotExpired, ls.rbacEffectiveNow(time.Now().UTC())).
 		Distinct().Pluck("group_roles.role_id", &ids).Error
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -683,7 +722,7 @@ func (ls *LocalStorage) ListGroupRoleAssignments(ctx context.Context, groupID ui
 	var rows []models.GroupRole
 	if err := ls.db.WithContext(ctx).
 		Where("group_id = ?", groupID).
-		Where(sqlWhereGRNotExpired, time.Now().UTC()).
+		Where(sqlWhereGRNotExpired, ls.rbacEffectiveNow(time.Now().UTC())).
 		Find(&rows).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
@@ -745,7 +784,7 @@ func (ls *LocalStorage) assignGroupRole(ctx context.Context, groupID, roleID uin
 			// though nothing live is actually being duplicated (#263/#471). Delete the stale
 			// row so the composite primary key (group_id, role_id, project_id, environment_id)
 			// is free for the fresh Create below, mirroring assignUserRole's identical fix.
-			if existing.ExpiresAt == nil || existing.ExpiresAt.After(time.Now()) {
+			if existing.ExpiresAt == nil || existing.ExpiresAt.After(ls.rbacEffectiveNow(time.Now().UTC())) {
 				return fmt.Errorf("%s", i18n.T("ErrorRoleAlreadyAssigned", nil))
 			}
 			if derr := tx.Where(sqlWhereGroupRoleEnv,
@@ -841,7 +880,7 @@ func (ls *LocalStorage) GetUserPermissions(ctx context.Context, userID uint) ([]
 		Joins(sqlJoinRolePerms).
 		Joins("JOIN user_roles ON role_permissions.role_id = user_roles.role_id").
 		Where(sqlWhereURUserID, userID).
-		Where(sqlWhereURNotExpired, time.Now().UTC()).
+		Where(sqlWhereURNotExpired, ls.rbacEffectiveNow(time.Now().UTC())).
 		Group("permissions.id").
 		Find(&permissions).Error
 	if err != nil {
@@ -864,7 +903,7 @@ func (ls *LocalStorage) GetUserGroupPermissions(ctx context.Context, userID uint
 		// A soft-deleted group confers no permissions (matches authz resolution).
 		Joins(sqlJoinGroups).
 		Where(sqlWhereUGUserID, userID).
-		Where(sqlWhereGRNotExpired, time.Now().UTC()).
+		Where(sqlWhereGRNotExpired, ls.rbacEffectiveNow(time.Now().UTC())).
 		Group("permissions.id").
 		Find(&permissions).Error
 	if err != nil {

--- a/internal/storage/store/local_transaction.go
+++ b/internal/storage/store/local_transaction.go
@@ -22,6 +22,7 @@ func (ls *LocalStorage) WithTransaction(ctx context.Context, fn func(storage.Sto
 			auditCheckpointMu:     ls.auditCheckpointMu,
 			bootstrapMu:           ls.bootstrapMu,
 			consumeClockWatermark: ls.consumeClockWatermark,
+			rbacClockWatermark:    ls.rbacClockWatermark,
 		})
 	})
 }

--- a/internal/storage/store/rbac_clock_regression_test.go
+++ b/internal/storage/store/rbac_clock_regression_test.go
@@ -1,0 +1,106 @@
+// rbac_clock_regression_test.go — #1632: exploit-shaped tests for the RBAC
+// permission-resolution cluster's defense against a backward-stepped host
+// clock. Unlike ConsumeMFAChallenge/ConsumeWebAuthnSession, the functions in
+// local_rbac.go do not take `now` as a parameter — they read the OS clock
+// directly via time.Now(), which a test cannot move backward. Instead, these
+// tests seed rbacClockWatermark directly (an unexported field, accessible
+// from this package) to simulate "this process has already legitimately
+// observed a later real time" — exactly the state a genuinely-running
+// process would be in right before an operator or NTP correction steps its
+// OS clock backward — then call the real, unmodified function (which still
+// reads the real, un-mocked time.Now()) and assert the clamp still refuses
+// to treat an already-expired-relative-to-that-later-time grant as live.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// TestGetUserRoles_ClockSteppedBackward_ExpiredGrantStaysExpired is the
+// exploit-shaped test: a UserRole grant whose ExpiresAt already elapsed
+// relative to a time this process has previously observed (the watermark)
+// must not be resurrected merely because the real time.Now() reading right
+// now looks earlier than that watermark — the actual backward-clock shape a
+// host clock rollback produces.
+//
+// Before the fix (bare time.Now(), no clamp): GetUserRoles would evaluate
+// expires_at > real-now, which is TRUE for a grant expiring between real-now
+// and the watermark — the role wrongly still resolves. After the fix:
+// rbacEffectiveNow clamps the comparison up to the watermark, correctly
+// excluding it.
+func TestGetUserRoles_ClockSteppedBackward_ExpiredGrantStaysExpired(t *testing.T) {
+	ls := newS27bStore(t, &models.Role{}, &models.UserRole{})
+	ctx := context.Background()
+
+	// Simulate this process having already legitimately observed a later
+	// real time (as it would have, running continuously, right before an
+	// operator/NTP correction stepped the host clock backward).
+	future := time.Now().UTC().Add(24 * time.Hour)
+	ls.rbacClockWatermark.time = future
+
+	// Genuinely expired relative to the watermark (future), but NOT expired
+	// relative to the real, un-mocked time.Now() this test actually runs at.
+	expiry := time.Now().UTC().Add(time.Hour)
+	require.NoError(t, ls.db.Create(&models.Role{ID: 1, Name: "rbac-clock-regression-role"}).Error)
+	require.NoError(t, ls.db.Create(&models.UserRole{UserID: 42, RoleID: 1, ExpiresAt: &expiry}).Error)
+
+	roles, err := ls.GetUserRoles(ctx, 42)
+	require.NoError(t, err)
+	assert.Empty(t, roles, "a grant already expired relative to a time this process has previously observed must not be resurrected by a real clock reading that looks earlier")
+}
+
+// TestGetUserRoles_ClockSteppedBackward_LegitimatelyLiveGrantStillResolves is
+// the positive control: a grant that is genuinely still live even relative
+// to the watermark (i.e., not exploiting anything) must still resolve
+// normally — the clamp must not become a blanket denial.
+func TestGetUserRoles_ClockSteppedBackward_LegitimatelyLiveGrantStillResolves(t *testing.T) {
+	ls := newS27bStore(t, &models.Role{}, &models.UserRole{})
+	ctx := context.Background()
+
+	future := time.Now().UTC().Add(24 * time.Hour)
+	ls.rbacClockWatermark.time = future
+
+	stillLive := future.Add(24 * time.Hour) // live even past the watermark
+	require.NoError(t, ls.db.Create(&models.Role{ID: 1, Name: "rbac-clock-regression-control"}).Error)
+	require.NoError(t, ls.db.Create(&models.UserRole{UserID: 43, RoleID: 1, ExpiresAt: &stillLive}).Error)
+
+	roles, err := ls.GetUserRoles(ctx, 43)
+	require.NoError(t, err)
+	require.Len(t, roles, 1, "a grant genuinely live past the watermark must still resolve")
+	assert.Equal(t, uint(1), roles[0].ID)
+}
+
+// TestRbacEffectiveNow_ClampsBackwardReadingToWatermark is a direct unit
+// test of the clamp itself: a now earlier than the watermark returns the
+// watermark, unchanged; a now at or after the watermark returns now and
+// advances the watermark.
+func TestRbacEffectiveNow_ClampsBackwardReadingToWatermark(t *testing.T) {
+	ls := newS27bStore(t)
+
+	watermark := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	ls.rbacClockWatermark.time = watermark
+
+	backward := watermark.Add(-time.Hour)
+	assert.Equal(t, watermark, ls.rbacEffectiveNow(backward), "a backward-looking reading must clamp up to the watermark, not pass through unchanged")
+
+	forward := watermark.Add(time.Hour)
+	assert.Equal(t, forward, ls.rbacEffectiveNow(forward), "a forward reading must pass through unchanged")
+	assert.Equal(t, forward, ls.rbacClockWatermark.time, "a forward reading must advance the watermark")
+}
+
+// TestRbacEffectiveNow_FreshWatermarkNeverClampsForward covers the
+// zero-value watermark case: a fresh LocalStorage (no prior RBAC query has
+// ever run) must let the very first real time.Now() reading through
+// unclamped.
+func TestRbacEffectiveNow_FreshWatermarkNeverClampsForward(t *testing.T) {
+	ls := newS27bStore(t)
+	now := time.Now().UTC()
+	assert.Equal(t, now, ls.rbacEffectiveNow(now), "an unset watermark must never clamp the first real reading")
+}


### PR DESCRIPTION
## Summary

- Every expiry check across `local_rbac.go`'s ~16 permission-resolution call sites binds a fresh `time.Now().UTC()` directly into either a SQL `expires_at > ?` bound (14 sites) or an in-Go `ExpiresAt.After` comparison (2 sites, `assignUserRole`/`assignGroupRole`), with no caching layer and no defense against the comparison being fooled by a backward-stepped host clock. This is the **primary** computation path for "is this role/group grant currently valid" — not behind any TTL-bounded cache — so a clock stepped backward past a grant's real expiry computes it as still live, extending a permission/role assignment's validity past its real window across every function in this file (`GetUserRoles`, `GetUserRoleIDsAt`, `GetUserRoleScopes`, `ListProjectRoleAssignments`, `ListGlobalAdminAssignmentsForUpdate`, `GetUserRoleIDsExact`, `IsProjectMember`, `IsGroupProjectScoped`, `ListProjectMembers`, `GetUserGroupRoleIDsAt`, `ListGroupRoleAssignments`, `GetUserPermissions`, `GetUserGroupPermissions`).
- Unlike `versions.go`'s `secretExpiryWatermark` (#1635, merged) and `local_mfa.go`/`local_webauthn.go`'s `consumeClockWatermark` (#1638, merged), which **refuse** a single discrete action on a detected regression, this fix **clamps** rather than errors. These sites are read-heavy queries reached on every authorized request across the whole application — hard-refusing all of them the moment a regression is detected would turn a narrow clock-integrity concern into a total authorization outage for every user, a strictly worse outcome than the hazard being defended against. `rbacEffectiveNow` returns `max(now, watermark)`, so a backward-stepped clock can never compute a grant as *more* valid than the highest wall-clock time this process has already legitimately observed, without that availability blast radius.
- The two in-Go `ExpiresAt.After` checks in `assignUserRole`/`assignGroupRole` are already safe-direction on a regression (a backward clock makes an expired existing grant look live, which *blocks* a fresh assignment rather than granting anything) but are clamped too for mechanical consistency with every other wall-clock read in this file, not because they are themselves a security finding.
- Adds `rbacClockWatermark` to `LocalStorage`, alongside the existing `consumeClockWatermark` — kept as a separate field/mechanism rather than merged into one, since the two have genuinely different response shapes (refuse vs. clamp) to the same underlying fact.

This is #1632's third and final security PR (following #1635 and #1638).

## Test plan

- [x] Since these functions read `time.Now()` internally rather than accepting it as a parameter, the exploit test seeds `rbacClockWatermark` directly (an unexported field, accessible from this package) to simulate "this process has already observed a later real time" — the actual state a long-running process would be in right before its OS clock is stepped backward — then calls the real, unmodified `GetUserRoles` (which still reads the real, un-mocked `time.Now()`) and asserts an already-expired-relative-to-that-later-time grant is not resurrected.
- [x] Positive control: a grant still live past the watermark resolves normally.
- [x] Direct unit tests of `rbacEffectiveNow` (clamps a backward reading, passes a forward reading through and advances the watermark, never clamps on a fresh/unset watermark).
- [x] Red-before-green: disabled the clamp, confirmed the exploit test and both unit tests fail; restored it, confirmed all pass.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` on touched files — all clean.
- [x] `gosec -severity medium -exclude-generated ./internal/storage/store/...` — 0 issues.
- [x] Full `internal/core`, `internal/storage`, `server/http`, `server/grpc` suites pass under UTC and `TZ=America/New_York`.