### PR TITLE
fix(storage): #1647 -- secrets database no longer inherits process umask

### DIFF
--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -2,6 +2,9 @@ package storage
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -180,11 +183,103 @@ func (f *DefaultStorageFactory) CreateStorage(cfg *config.Config) (storage.Stora
 	}
 }
 
+// secureLocalStoragePerm is the mode the SQLite database and its -wal/-shm sidecars must
+// never exceed: owner read/write only. See prepareLocalStorageFile / tightenSidecarPerms
+// and #1647.
+const secureLocalStoragePerm = 0o600
+
+// localStorageDBFile strips DSN query parameters from dbPath and reports whether the
+// result names a real on-disk file at all — false for an in-memory database ("file:
+// name?mode=memory[&cache=shared]" or ":memory:", both used throughout this package's own
+// test suite, per acquireSQLiteMigrationLock's identical check). Neither #1647 concern
+// (an insecure inherited mode, a mode left over from before this fix) applies to a
+// database that was never written to disk.
+func localStorageDBFile(dbPath string) (path string, isRealFile bool) {
+	base := dbPath
+	if idx := strings.IndexByte(base, '?'); idx != -1 {
+		base = base[:idx]
+	}
+	if base == "" || base == ":memory:" || strings.Contains(dbPath, "mode=memory") {
+		return "", false
+	}
+	return base, true
+}
+
+// prepareLocalStorageFile ensures dbPath's parent directory exists at a safe mode and, if
+// the database file does not already exist, pre-creates it at secureLocalStoragePerm
+// BEFORE gorm.Open ever touches it. modernc.org/sqlite's VFS creates a file it opens with
+// mode 0, which becomes SQLITE_DEFAULT_FILE_PERMISSIONS (0644) masked by the process's
+// (possibly lax) inherited umask -- main()'s explicit syscall.Umask(0o077) closes that for
+// every NEW file this process creates, but this pre-creation is a second, independent
+// layer: it means the database is born at 0600 even if that startup umask call is ever
+// missing, skipped, or reverted by something later in the process (#1647).
+//
+// If the file already exists from before this fix shipped, its mode is left untouched
+// here -- see tightenExistingLocalStorageFiles, which runs after Open and decides whether
+// to correct it, since that decision needs the file to exist first.
+func prepareLocalStorageFile(dbPath string) error {
+	path, isRealFile := localStorageDBFile(dbPath)
+	if !isRealFile {
+		return nil
+	}
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("failed to create database directory %q: %w", dir, err)
+		}
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, secureLocalStoragePerm) // #nosec G304 -- operator-configured storage.database.path, the same value gorm.Open uses immediately after
+	if err != nil {
+		if os.IsExist(err) {
+			return nil // pre-existing file — tightenExistingLocalStorageFiles handles it after Open
+		}
+		return fmt.Errorf("failed to pre-create database file %q: %w", path, err)
+	}
+	return f.Close()
+}
+
+// tightenExistingLocalStorageFiles corrects the mode of dbPath and its -wal/-shm sidecars
+// if any is more permissive than secureLocalStoragePerm — the case of a database created
+// before this fix shipped, which keeps whatever mode it was originally given (#1647). This
+// runs on every local-storage open (server boot AND every CLI invocation, since both share
+// this one factory function) rather than as an opt-in check: unlike most security
+// hardening, tightening a file's mode to 0600 can never break the owning process's own
+// access to it, so there is no operational reason to make correction conditional or to
+// refuse to start over it — only to make sure it is never SILENT. Each correction is
+// logged loudly so an operator relying on some other process (backup tooling running as a
+// different user, for instance) to read the file finds out immediately, not by that other
+// process mysteriously losing access.
+func tightenExistingLocalStorageFiles(dbPath string) {
+	dbPath, isRealFile := localStorageDBFile(dbPath)
+	if !isRealFile {
+		return
+	}
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		path := dbPath + suffix
+		info, err := os.Stat(path)
+		if err != nil {
+			continue // doesn't exist (yet, or ever, e.g. no -shm outside WAL mode) — nothing to tighten
+		}
+		if info.Mode().Perm() == secureLocalStoragePerm {
+			continue
+		}
+		oldMode := info.Mode().Perm()
+		if err := os.Chmod(path, secureLocalStoragePerm); err != nil {
+			log.Printf("SECURITY: failed to tighten permissions on %s (mode %04o, expected %04o): %v", path, oldMode, secureLocalStoragePerm, err)
+			continue
+		}
+		log.Printf("SECURITY: corrected %s permissions from %04o to %04o (see #1647 -- this file predates an explicit-mode fix and previously relied on the inherited process umask)", path, oldMode, secureLocalStoragePerm)
+	}
+}
+
 // createLocalStorage creates a SQLite-backed local storage instance
 func (f *DefaultStorageFactory) createLocalStorage(cfg *config.Config) (storage.Storage, error) {
 	dbPath := cfg.Storage.Database.Path
 	if dbPath == "" {
 		dbPath = "./secrets.db"
+	}
+	if err := prepareLocalStorageFile(dbPath); err != nil {
+		return nil, err
 	}
 
 	// Hold migrationMu across gorm.Open too, not just the migration that follows
@@ -210,6 +305,10 @@ func (f *DefaultStorageFactory) createLocalStorage(cfg *config.Config) (storage.
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
+	// The WAL pragma above (in sqliteDSN) creates -wal/-shm during Open, and a
+	// pre-existing database from before this fix shipped keeps whatever mode it
+	// originally had — tighten both cases here, after the file(s) are known to exist.
+	tightenExistingLocalStorageFiles(dbPath)
 
 	if err := applyPoolSettings(db, &cfg.Storage.Database); err != nil {
 		return nil, err

--- a/internal/storage/factory_local_storage_file_perms_test.go
+++ b/internal/storage/factory_local_storage_file_perms_test.go
@@ -1,0 +1,103 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// withUmask sets the process umask for the duration of fn and restores the prior value
+// afterward. #1647's whole point is that file mode depends on the process's inherited
+// umask, so this is the only way to exercise both a lax (022) and maximally lax (000)
+// inherited environment from a single test binary. Not safe to run with t.Parallel() in
+// this package (umask is process-global) — none of this package's other tests use it.
+func withUmask(t *testing.T, mask int, fn func()) {
+	t.Helper()
+	old := syscall.Umask(mask)
+	defer syscall.Umask(old)
+	fn()
+}
+
+// TestCreateLocalStorage_FreshDatabase_AlwaysSecureModeRegardlessOfUmask is the red-first
+// regression test for #1647: before the fix (no explicit mode passed anywhere in the
+// SQLite open path), this test fails under umask 022 with the database created at 0644.
+// After the fix (prepareLocalStorageFile pre-creates the file at 0600 before gorm.Open
+// ever touches it), the assertion holds regardless of the inherited umask.
+func TestCreateLocalStorage_FreshDatabase_AlwaysSecureModeRegardlessOfUmask(t *testing.T) {
+	for _, mask := range []int{0o022, 0o000} {
+		t.Run(modeLabel(mask), func(t *testing.T) {
+			dir := t.TempDir()
+			dbPath := filepath.Join(dir, "secrets.db")
+			cfg := &config.Config{Storage: config.StorageConfig{Database: config.DatabaseConfig{Path: dbPath}}}
+
+			withUmask(t, mask, func() {
+				f := &DefaultStorageFactory{}
+				storageInstance, err := f.createLocalStorage(cfg)
+				require.NoError(t, err)
+				if closer, ok := storageInstance.(interface{ Close() error }); ok {
+					defer func() { _ = closer.Close() }()
+				}
+			})
+
+			assertMode(t, dbPath, 0o600)
+			// -wal is created eagerly by the journal_mode=WAL pragma during Open; -shm may
+			// or may not exist yet depending on whether a read/write transaction has
+			// touched the shared cache — check it only if present, same as the production
+			// tightenExistingLocalStorageFiles logic does.
+			assertMode(t, dbPath+"-wal", 0o600)
+			if _, err := os.Stat(dbPath + "-shm"); err == nil {
+				assertMode(t, dbPath+"-shm", 0o600)
+			}
+		})
+	}
+}
+
+// TestCreateLocalStorage_PreExistingLaxPermissions_TightenedOnOpen covers the "what
+// happens to a database created before this fix shipped" question #1647 explicitly calls
+// out: the file keeps its original (possibly world-readable) mode until an operator
+// upgrades and restarts, at which point tightenExistingLocalStorageFiles corrects it —
+// loudly (a log line), not silently, and without refusing to start.
+func TestCreateLocalStorage_PreExistingLaxPermissions_TightenedOnOpen(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "secrets.db")
+
+	// Simulate a database that predates this fix: created directly at a lax mode, as the
+	// old code path (no explicit os.OpenFile mode) would have under umask 000.
+	require.NoError(t, os.WriteFile(dbPath, nil, 0o644))
+	require.NoError(t, os.WriteFile(dbPath+"-wal", nil, 0o644))
+	require.NoError(t, os.WriteFile(dbPath+"-shm", nil, 0o644))
+
+	cfg := &config.Config{Storage: config.StorageConfig{Database: config.DatabaseConfig{Path: dbPath}}}
+	f := &DefaultStorageFactory{}
+	storageInstance, err := f.createLocalStorage(cfg)
+	require.NoError(t, err)
+	if closer, ok := storageInstance.(interface{ Close() error }); ok {
+		defer func() { _ = closer.Close() }()
+	}
+
+	assertMode(t, dbPath, 0o600)
+	assertMode(t, dbPath+"-wal", 0o600)
+	assertMode(t, dbPath+"-shm", 0o600)
+}
+
+func assertMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err, "expected %s to exist", path)
+	require.Equalf(t, want, info.Mode().Perm(), "%s has mode %04o, want %04o", path, info.Mode().Perm(), want)
+}
+
+func modeLabel(mask int) string {
+	switch mask {
+	case 0o022:
+		return "umask_022"
+	case 0o000:
+		return "umask_000"
+	default:
+		return "umask_other"
+	}
+}

--- a/main.go
+++ b/main.go
@@ -19,9 +19,20 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 package main
 
 import (
+	"syscall"
+
 	"github.com/keyorixhq/keyorix/internal/cli"
 )
 
 func main() {
+	// #1647: the CLI shares internal/storage/factory.go's local-SQLite path with the
+	// server, and without an explicit mode the driver creates the database (and its
+	// -wal/-shm sidecars) at SQLITE_DEFAULT_FILE_PERMISSIONS (0644) masked only by
+	// whatever umask this process inherited from its parent shell/supervisor -- a
+	// systemd unit with no UMask= commonly leaves that at 022, shipping the live
+	// secrets database world-readable with no error or log line. Setting an explicit,
+	// restrictive process umask here means every file this binary EVER creates -- not
+	// just the ones a call site remembers to pass 0600 to -- is born correct.
+	syscall.Umask(0o077)
 	cli.Execute()
 }

--- a/server/main.go
+++ b/server/main.go
@@ -64,6 +64,12 @@ import (
 )
 
 func main() { // NOSONAR -- cognitive complexity 22, suppress go:S3776
+	// #1647: see main.go's identical call for the full rationale -- an explicit,
+	// restrictive process umask means the SQLite database and its -wal/-shm sidecars
+	// (created deep inside the driver, with no mode this process's Go code controls
+	// directly) are born at 0600 regardless of what umask this process inherited.
+	syscall.Umask(0o077)
+
 	// Load configuration
 	cfg, err := config.LoadConfig()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Closes #1647 (CRITICAL): the SQLite database and its -wal/-shm sidecars were created at 0644 (world-readable) under a common inherited umask (e.g. a systemd unit with no `UMask=`), silently, with no log line either way.
- Two complementary layers: an explicit `syscall.Umask(0o077)` at process startup (both the server and CLI binaries, which share this storage path) so every future file is born correct, and explicit pre-creation/tightening in `internal/storage/factory.go` so the database file itself is never dependent on that umask call alone.
- Existing deployments: a database already created at a lax mode is corrected to 0600 on the next boot/CLI invocation, with a loud log line -- not silently, and without refusing to start (a mode correction can never break the owning process's own access to the file).

## What was checked (per Task 1's ask)
- Fresh-database creation under real umask 022 and 000 -- both now create the db/-wal/-shm at 0600 (red before the fix, green after -- verified by temporarily stashing the fix and re-running the same test).
- Pre-existing lax-mode files (simulating an install that predates this fix) are tightened on open, logged, and the process still starts.
- In-memory SQLite DSNs (used throughout this package's test suite) are explicitly excluded from both new code paths, reusing the exact detection logic already established for the migration lock -- an earlier draft of this fix created a stray on-disk file for one such DSN string before this exclusion was added; caught by running the full package suite and checking `git status` for stray files.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] New tests: `TestCreateLocalStorage_FreshDatabase_AlwaysSecureModeRegardlessOfUmask` (umask 022 + 000), `TestCreateLocalStorage_PreExistingLaxPermissions_TightenedOnOpen` -- both red before the fix (stashed and re-ran), green after
- [x] `go test ./internal/storage/...` (full package, all green, no stray files)
- [x] `go test ./server/...` (full package, all green)
- [x] `gosec -severity medium -exclude-generated` on touched packages -- 0 issues
- [x] `golangci-lint run` on touched packages -- 0 issues