### PR TITLE
fix(config): #1644 -- a config parse error must never trigger a silent write

### DIFF
--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -67,7 +67,15 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	// Load current configuration
 	cfg, err := config.Load(configFilename)
 	if err != nil {
-		// Create default config if it doesn't exist
+		// #1644: a Load error means EITHER "no config file yet" (safe to proceed with
+		// defaults) OR "a config file is there and failed to parse" (must NOT proceed --
+		// falling through to the write below would silently replace an existing,
+		// merely-unparseable file, discarding whatever security-relevant settings it
+		// held, e.g. security.require_transport_tls: true). Only the first case may
+		// fall back to a fresh default config.
+		if !config.IsNotExist(err) {
+			return fmt.Errorf("failed to load existing configuration: %w", err)
+		}
 		cfg = &config.Config{
 			Storage: config.StorageConfig{
 				Type: "local",
@@ -114,19 +122,18 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	// since the token will be sent in cleartext on every subsequent request.
 	common.WarnIfInsecureEndpoint(server)
 
-	// Update configuration
-	cfg.Storage.Type = "remote"
-	if cfg.Storage.Remote == nil {
-		cfg.Storage.Remote = &config.RemoteConfig{}
-	}
-	cfg.Storage.Remote.BaseURL = server
-	cfg.Storage.Remote.APIKey = apiKey
-	cfg.Storage.Remote.TLSVerify = config.BoolPtr(true)
-	cfg.Storage.Remote.TimeoutSeconds = 30
-	cfg.Storage.Remote.RetryAttempts = 3
-
-	// Save configuration
-	if err := config.Save(configFilename, cfg); err != nil {
+	// Persist only the fields this command sets (#1644): SaveFields edits the on-disk
+	// YAML in place, so anything else already in the file -- security.*, other storage
+	// settings, comments, key order -- round-trips untouched, instead of being silently
+	// reconstituted from whatever this in-memory *Config happens to have (or not have) set.
+	if err := config.SaveFields(configFilename, map[string]any{
+		"storage.type":                   "remote",
+		"storage.remote.base_url":        server,
+		"storage.remote.api_key":         apiKey,
+		"storage.remote.tls_verify":      true,
+		"storage.remote.timeout_seconds": 30,
+		"storage.remote.retry_attempts":  3,
+	}); err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}
 
@@ -164,6 +171,12 @@ func runLogout(cmd *cobra.Command, args []string) error {
 func runStatus(cmd *cobra.Command, args []string) error {
 	cfg, err := config.Load(configFilename)
 	if err != nil {
+		// #1644: a Load error means EITHER "no config file yet" OR "a config file is
+		// there and failed to parse" -- reporting the latter as "no configuration
+		// found" is actively misleading, so surface the real error instead.
+		if !config.IsNotExist(err) {
+			return fmt.Errorf("failed to load existing configuration: %w", err)
+		}
 		fmt.Printf("❌ No configuration found\n")
 		return nil
 	}

--- a/internal/cli/auth/config_parse_error_test.go
+++ b/internal/cli/auth/config_parse_error_test.go
@@ -1,0 +1,44 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunLogin_ExistingConfigParseError_LeavesFileUnchangedAndFails is #1644's
+// exact reproduction: a config file with a security-relevant setting enabled
+// (security.require_transport_tls: true) plus one unrelated typo elsewhere
+// (tls_verfiy instead of tls_verify) fails config.Load's strict decode. Before
+// the #1644 fix, runLogin treated ANY Load error as "no config file yet",
+// silently built a fresh default *Config, and wrote it back — reverting
+// require_transport_tls to its false zero value and discarding every other
+// setting, with a plain "✅ Successfully authenticated" success message. This
+// test asserts the fixed contract: the command fails clearly, and the file on
+// disk is byte-for-byte unchanged.
+func TestRunLogin_ExistingConfigParseError_LeavesFileUnchangedAndFails(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	original := "security:\n  require_transport_tls: true\nstorage:\n  type: remote\n  remote:\n    base_url: https://original-trusted-server.example.com:8443\n    api_key: sk-original-production-api-key-do-not-lose\n    timeout_seconds: 90\n    retry_attempts: 7\n    tls_verfiy: false\n"
+	configPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(original), 0o600))
+
+	t.Setenv("KEYORIX_API_KEY", "kx_new_key")
+	require.NoError(t, loginCmd.Flags().Set("server", "https://new-server.example.com"))
+	t.Cleanup(func() {
+		_ = loginCmd.Flags().Set("server", "")
+		loginCmd.Flags().Lookup("server").Changed = false
+	})
+
+	err := runLogin(loginCmd, nil)
+	require.Error(t, err, "a config that exists but fails to parse must fail the command, not silently proceed")
+	assert.Contains(t, err.Error(), "failed to load existing configuration")
+
+	after, readErr := os.ReadFile(configPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, original, string(after), "the file must be byte-for-byte unchanged when Load fails for a reason other than \"does not exist\"")
+}

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -88,7 +88,14 @@ func InitializeCoreService() (*core.KeyorixCore, error) {
 	// Load configuration
 	cfg, err := config.Load("")
 	if err != nil {
-		// If no config file exists, use default local storage
+		// #1644: a Load error means EITHER "no config file yet" (safe to fall back to
+		// local storage) OR "a config file is there and failed to parse" (must NOT
+		// silently proceed as if unconfigured -- that would run against the wrong
+		// storage backend with no indication anything was wrong). Only the first case
+		// may fall back to a default.
+		if !config.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to load existing configuration: %w", err)
+		}
 		cfg = &config.Config{
 			Locale: config.LocaleConfig{
 				Language:         "en",

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -138,23 +138,25 @@ func runSetRemote(cmd *cobra.Command, args []string) error {
 	// optional here, so an unset value is left empty rather than prompted for.
 	apiKey := resolveAPIKey(cmd)
 
-	cfg, cerr := config.Load(configFilename)
-	if cerr != nil {
-		// Create default config if it doesn't exist
-		cfg = &config.Config{}
+	// #1644: check whether an existing config file fails to parse BEFORE writing anything
+	// -- distinguishes "no config file yet" (safe to proceed) from "a config file is there
+	// and failed to parse" (must NOT proceed; see auth.runLogin's identical guard for the
+	// full rationale). The loaded value itself isn't needed: SaveFields below only ever
+	// touches the specific fields this command sets, so there's nothing to carry over.
+	if _, cerr := config.Load(configFilename); cerr != nil && !config.IsNotExist(cerr) {
+		return fmt.Errorf("failed to load existing configuration: %w", cerr)
 	}
 
-	// Configure remote storage
-	cfg.Storage.Type = "remote"
-	if cfg.Storage.Remote == nil {
-		cfg.Storage.Remote = &config.RemoteConfig{}
-	}
-	cfg.Storage.Remote.BaseURL = remoteURL
-	cfg.Storage.Remote.APIKey = apiKey
-	cfg.Storage.Remote.TimeoutSeconds = timeout
-	cfg.Storage.Remote.TLSVerify = config.BoolPtr(true)
-
-	if err := config.Save(configFilename, cfg); err != nil {
+	// Persist only the fields this command sets (#1644): everything else already in the
+	// file round-trips untouched instead of being silently reconstituted from this
+	// in-memory *Config's zero values -- see SaveFields' doc comment.
+	if err := config.SaveFields(configFilename, map[string]any{
+		"storage.type":                   "remote",
+		"storage.remote.base_url":        remoteURL,
+		"storage.remote.api_key":         apiKey,
+		"storage.remote.timeout_seconds": timeout,
+		"storage.remote.tls_verify":      true,
+	}); err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}
 
@@ -170,22 +172,35 @@ func runSetRemote(cmd *cobra.Command, args []string) error {
 func runUseLocal(cmd *cobra.Command, args []string) error {
 	cfg, err := config.Load(configFilename)
 	if err != nil {
-		// Create default config if it doesn't exist
+		// #1644: distinguish "no config file yet" (safe to proceed with defaults) from
+		// "a config file is there and failed to parse" (must NOT proceed -- see
+		// auth.runLogin's identical guard for the full rationale).
+		if !config.IsNotExist(err) {
+			return fmt.Errorf("failed to load existing configuration: %w", err)
+		}
 		cfg = &config.Config{}
 	}
 
-	// Configure local storage
-	cfg.Storage.Type = "local"
-	if cfg.Storage.Database.Path == "" {
-		cfg.Storage.Database.Path = "./secrets.db" //nolint:goconst
+	// Configure local storage — read the existing path (if the config loaded
+	// successfully) to decide whether a default is needed; the write below only ever
+	// touches the two fields actually being set.
+	dbPath := cfg.Storage.Database.Path
+	if dbPath == "" {
+		dbPath = "./secrets.db" //nolint:goconst
 	}
 
-	if err := config.Save(configFilename, cfg); err != nil {
+	// Persist only the fields this command sets (#1644): everything else already in the
+	// file round-trips untouched instead of being silently reconstituted from this
+	// in-memory *Config's zero values -- see SaveFields' doc comment.
+	if err := config.SaveFields(configFilename, map[string]any{
+		"storage.type":          "local",
+		"storage.database.path": dbPath,
+	}); err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}
 
 	fmt.Printf("✅ Configuration updated successfully!\n")
-	fmt.Printf("💾 CLI now uses local database: %s\n", cfg.Storage.Database.Path)
+	fmt.Printf("💾 CLI now uses local database: %s\n", dbPath)
 
 	return nil
 }

--- a/internal/cli/config/config_g80_test.go
+++ b/internal/cli/config/config_g80_test.go
@@ -77,9 +77,13 @@ func TestRefuseConfigRedirect_ReturnsErrorNamingTarget(t *testing.T) {
 
 // ──────────────────────────── runSetRemote / runUseLocal gaps ────────────────
 
-// TestRunSetRemote_SaveConfigError exercises the config.Save error branch: a
-// directory already occupies the "keyorix.yaml" path in the CWD, so the
-// write fails instead of silently succeeding.
+// TestRunSetRemote_SaveConfigError: a directory already occupies the
+// "keyorix.yaml" path in the CWD, so config.Load fails to read it. #1644:
+// this is neither "no config file" (IsNotExist) nor a case Load should ever
+// silently paper over, so the command must fail at the LOAD step, before
+// ever attempting to write anything — not fail later at the save step, as it
+// did before that fix (proceed on any Load error, then fail trying to write
+// through the directory).
 func TestRunSetRemote_SaveConfigError(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -88,7 +92,7 @@ func TestRunSetRemote_SaveConfigError(t *testing.T) {
 	cmd := newSetRemoteCmd("https://keyorix.example.com", "")
 	err := runSetRemote(cmd, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to save configuration")
+	assert.Contains(t, err.Error(), "failed to load existing configuration")
 }
 
 func TestRunUseLocal_SaveConfigError(t *testing.T) {
@@ -99,7 +103,7 @@ func TestRunUseLocal_SaveConfigError(t *testing.T) {
 	cmd := &cobra.Command{}
 	err := runUseLocal(cmd, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to save configuration")
+	assert.Contains(t, err.Error(), "failed to load existing configuration")
 }
 
 // TestRunSetRemote_ReusesExistingRemoteConfig covers the case where

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -39,6 +39,13 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	// for the health check could silently disagree.
 	cfg, err := config.Load("")
 	if err != nil {
+		// #1644: a Load error means EITHER "no config file yet" OR "a config file is
+		// there and failed to parse" -- reporting the latter as "no configuration
+		// found, using defaults" is actively misleading (the file exists and is
+		// broken, not absent), so surface the real error instead of guessing wrong.
+		if !config.IsNotExist(err) {
+			return fmt.Errorf("failed to load existing configuration: %w", err)
+		}
 		fmt.Printf("⚠️  No configuration found, using defaults\n")
 		cfg = &config.Config{
 			Storage: config.StorageConfig{

--- a/internal/config/roundtrip.go
+++ b/internal/config/roundtrip.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/securefiles"
+	"gopkg.in/yaml.v3"
+)
+
+// IsNotExist reports whether err (as returned by Load) means the config file does not
+// exist at all, as opposed to existing but failing to read or parse. Load wraps the
+// underlying read/decode error, so the standard library's os.IsNotExist -- which predates
+// errors.Is and only recognizes a narrow set of unwrapped error shapes -- does NOT
+// reliably detect this through Load's wrapping; use this instead.
+//
+// Any caller that falls back to default values on a Load error MUST check IsNotExist
+// first. Without it, a config file that exists but fails to parse (a single typo, say) is
+// indistinguishable from one that was never created, and a caller that then re-Saves
+// silently destroys the existing file's content -- including any security-relevant
+// setting it held (#1644: a config with a stray typo plus security.require_transport_tls:
+// true, run through `keyorix auth login`, came back with that control silently reverted
+// to its false default and every other prior setting gone, with a plain success message).
+func IsNotExist(err error) bool {
+	return errors.Is(err, fs.ErrNotExist)
+}
+
+// SaveFields updates only the given dot-separated YAML key paths (e.g.
+// "storage.remote.base_url" -- YAML key names, not Go struct field names) in the config
+// file at path, leaving every other key, value, comment, and the existing ordering
+// untouched. This is the fix for the second half of #1644: Save re-marshals the entire
+// *Config struct, which silently reconstitutes the whole file from whatever that
+// in-memory value does or doesn't have set -- any field the caller didn't explicitly
+// carry over from a prior Load is written back at its Go zero value, and comments/
+// ordering are lost outright. SaveFields never touches a key the caller didn't name.
+//
+// If path does not exist yet, a new file containing only these fields is created
+// (mirroring Save's existing fresh-install behavior). If path exists but its content is
+// not valid YAML, SaveFields returns an error and writes nothing -- it applies the same
+// "a parse failure is not licence to replace the file" rule Load already follows, for the
+// write side. Values are marshaled via yaml.Node.Encode, so any YAML-marshalable Go value
+// (string, bool, int, ...) is accepted.
+func SaveFields(path string, fields map[string]any) error {
+	if path == "" {
+		path = filepath.Join(appRootDir, "keyorix.yaml")
+	}
+
+	baseDir, rwPath := appRootDir, path
+	if filepath.IsAbs(path) {
+		baseDir, rwPath = filepath.Dir(path), filepath.Base(path)
+	}
+
+	var doc yaml.Node
+	data, err := securefiles.SafeReadFile(baseDir, rwPath)
+	switch {
+	case err == nil:
+		if uerr := yaml.Unmarshal(data, &doc); uerr != nil {
+			return fmt.Errorf("failed to parse existing config file %q: %w", path, uerr)
+		}
+	case IsNotExist(err):
+		// No existing content — doc stays its zero value; filled in below.
+	default:
+		return fmt.Errorf("failed to read config file %q: %w", path, err)
+	}
+
+	if doc.Kind == 0 {
+		doc = yaml.Node{Kind: yaml.DocumentNode}
+	}
+	if len(doc.Content) == 0 {
+		doc.Content = append(doc.Content, &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"})
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return fmt.Errorf("config file %q does not contain a YAML mapping at its root", path)
+	}
+
+	for keyPath, value := range fields {
+		if err := yamlSetField(root, strings.Split(keyPath, "."), value); err != nil {
+			return fmt.Errorf("failed to set %q: %w", keyPath, err)
+		}
+	}
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	if err := securefiles.SecureWriteFileSync(baseDir, rwPath, out, 0o600); err != nil {
+		return fmt.Errorf("failed to write config file %q: %w", path, err)
+	}
+	return nil
+}
+
+// yamlSetField sets value at the given dot-path within a YAML mapping node, creating
+// intermediate mapping nodes as needed and overwriting (rather than merging into) any
+// existing non-mapping node found along an intermediate segment.
+func yamlSetField(mapping *yaml.Node, path []string, value any) error {
+	key := path[0]
+	idx := -1
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			idx = i
+			break
+		}
+	}
+
+	if len(path) == 1 {
+		valNode := &yaml.Node{}
+		if err := valNode.Encode(value); err != nil {
+			return err
+		}
+		if idx == -1 {
+			mapping.Content = append(mapping.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, valNode)
+		} else {
+			mapping.Content[idx+1] = valNode
+		}
+		return nil
+	}
+
+	var child *yaml.Node
+	if idx == -1 {
+		child = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		mapping.Content = append(mapping.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}, child)
+	} else {
+		child = mapping.Content[idx+1]
+		if child.Kind != yaml.MappingNode {
+			child.Kind, child.Tag, child.Content, child.Value = yaml.MappingNode, "!!map", nil, ""
+		}
+	}
+	return yamlSetField(child, path[1:], value)
+}


### PR DESCRIPTION
## Summary
- Closes #1644 (HIGH): `keyorix auth login` (and `config set-remote`/`config use-local`) treated ANY `config.Load()` error as "no config file yet," including a strict-decode parse failure from one typo anywhere in the file -- then silently built a fresh default config and wrote it back, reverting `security.require_transport_tls` to `false` and destroying every other setting, with a plain success message.
- Two separable defects, both fixed:
  1. **A parse error must never result in a write.** `config.IsNotExist(err)` distinguishes "file genuinely absent" from "file present but broken" through `Load`'s error-wrapping chain (the stdlib's `os.IsNotExist` does NOT reliably do this -- verified directly, see commit message). Every "any error = absent" call site (`auth login`, `auth status`, `config set-remote`, `config use-local`, `status`, `InitializeCoreService`) now checks this first; only genuine absence falls back to defaults.
  2. **A write that does happen must preserve everything it didn't touch.** `config.SaveFields(path, map[string]any{...})` edits the on-disk YAML as a node tree, touching only the specific dotted keys a command sets -- not a full-struct re-marshal from whatever the in-memory `*Config` happens to have. Applied to the three write call sites (`auth login`, `set-remote`, `use-local`).

## Scope note
`config logout` shares the same write mechanism (`config.Save`, full struct re-marshal) but already handles defect 1 correctly (returns the Load error directly, never falls back to defaults) -- left as-is, out of scope for this fix.

## Test plan
- [x] New red-first regression test (`TestRunLogin_ExistingConfigParseError_LeavesFileUnchangedAndFails`) reproduces #1644 exactly: `require_transport_tls: true` + a `tls_verfiy` typo, run through `auth login` -- confirmed red before the fix (stashed the fix, re-ran: silent success + file destroyed), green after (command fails clearly, file byte-for-byte unchanged).
- [x] Two pre-existing tests asserting on the old failure shape (`TestRunSetRemote_SaveConfigError`, `TestRunUseLocal_SaveConfigError`) updated to assert the new, earlier, more accurate failure point -- confirmed still exercise a real failure (a directory occupying the config path), just caught at Load instead of Save now.
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/cli/auth/... ./internal/cli/config/... ./internal/cli/status/... ./internal/cli/common/... ./internal/config/...` -- all green
- [x] `gosec -severity medium -exclude-generated` on touched packages -- 0 issues
- [x] `golangci-lint run` on touched packages -- 0 new issues (1 pre-existing, unrelated staticcheck finding in `config.go` confirmed present without this change too)