### PR TITLE
fix(core): #1653 -- remaining absolute-ceiling checks trust wall clock

### DIFF
--- a/internal/core/access_request_approval_clock_regression_test.go
+++ b/internal/core/access_request_approval_clock_regression_test.go
@@ -1,0 +1,93 @@
+// access_request_approval_clock_regression_test.go — #1653 (follow-up to
+// #1632): exploit-shaped test for the access-request-approval lazy-expire-
+// and-refuse check, shared between ApproveSecretAccessRequest
+// (classification_gate.go) and ApproveAccessRequestWithExpiry
+// (invitations.go). Both bind a fresh c.now() directly against a DB-loaded
+// ExpiresAt with no seam — this exercises ApproveSecretAccessRequest, the
+// same fix applies identically to ApproveAccessRequestWithExpiry via the
+// shared checkAccessRequestApprovalClockNotRegressed watermark.
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestApproveSecretAccessRequest_ClockSteppedBackward_ExpiredRequestStaysRefused
+// is the exploit-shaped test. Uses TWO separate requests, not one reused
+// across both steps: ApproveSecretAccessRequest's pre-existing expiry check
+// persists AccessRequestExpired on a genuinely-expired request as a side
+// effect, which would make a second approval attempt on the SAME request
+// fail via "only a pending request can be approved" regardless of the new
+// guard — masking whether the guard itself did anything. Using an untouched
+// second request for the actual exploit attempt isolates the guard's effect.
+//
+//  1. Create warmupReq and exploitReq at the same base time (identical
+//     ExpiresAt).
+//  2. Approve warmupReq at a baseline c.now() two hours past ExpiresAt —
+//     correctly refused ("access request has expired"), and this warms
+//     checkAccessRequestApprovalClockNotRegressed's watermark to that
+//     baseline. exploitReq is untouched so far, still Pending.
+//  3. Step c.now() BACKWARD to 10 minutes BEFORE ExpiresAt (i.e., if trusted
+//     naively, exploitReq would look not-yet-expired) and approve
+//     exploitReq. Before this fix, the approver could approve a request
+//     that has genuinely already expired. After the fix, the regression
+//     guard refuses before the expiry check is ever reached.
+func TestApproveSecretAccessRequest_ClockSteppedBackward_ExpiredRequestStaysRefused(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, requesterID, approverID, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+
+	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return base }
+	warmupReq, err := c.RequestSecretAccess(ctx, secretID, requesterID, "warmup")
+	require.NoError(t, err)
+	exploitReq, err := c.RequestSecretAccess(ctx, secretID, requesterID, "exploit")
+	require.NoError(t, err)
+	expiresAt := base.Add(accessRequestTTL)
+	require.Equal(t, expiresAt, *warmupReq.ExpiresAt)
+	require.Equal(t, expiresAt, *exploitReq.ExpiresAt)
+
+	// Step 1: baseline, clearly past expiry — correctly refused, warms the
+	// watermark. Only warmupReq is touched.
+	c.now = func() time.Time { return expiresAt.Add(2 * time.Hour) }
+	_, err = c.ApproveSecretAccessRequest(ctx, warmupReq.ID, approverID)
+	require.Error(t, err, "sanity: approval must be refused at the baseline time before the clock ever moves")
+	require.Contains(t, err.Error(), "expired")
+
+	// Step 2: the exploit. Step c.now() BACKWARD to before expiry, and
+	// attempt exploitReq -- still Pending, never touched until now.
+	c.now = func() time.Time { return expiresAt.Add(-10 * time.Minute) }
+	_, err = c.ApproveSecretAccessRequest(ctx, exploitReq.ID, approverID)
+	require.Error(t, err, "approval must still be refused after the clock steps backward to before the request's expiry")
+	require.Contains(t, err.Error(), "expired")
+}
+
+// TestApproveSecretAccessRequest_ClockSteppedBackward_LegitimatelyLiveRequestStillApproves
+// is the positive control: a request well within its TTL, approved after a
+// SMALL in-tolerance backward step, must still succeed.
+func TestApproveSecretAccessRequest_ClockSteppedBackward_LegitimatelyLiveRequestStillApproves(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	secretID, requesterID, approverID, _ := seedClassificationGateFixture(t, st, ClassificationRestricted)
+	ctx := context.Background()
+
+	base := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	c.now = func() time.Time { return base }
+	req, err := c.RequestSecretAccess(ctx, secretID, requesterID, "")
+	require.NoError(t, err)
+
+	c.now = func() time.Time { return base.Add(-1 * time.Second) }
+	_, err = c.ApproveSecretAccessRequest(ctx, req.ID, approverID)
+	require.NoError(t, err, "a small in-tolerance backward step must not refuse approval of a request well within its TTL")
+}
+
+// TestCheckAccessRequestApprovalClockNotRegressed_FreshWatermarkNeverRefuses
+// covers the zero-value watermark case directly.
+func TestCheckAccessRequestApprovalClockNotRegressed_FreshWatermarkNeverRefuses(t *testing.T) {
+	c := &KeyorixCore{}
+	err := c.checkAccessRequestApprovalClockNotRegressed(time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err, "an unset watermark must never itself cause a refusal")
+}

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -361,6 +361,19 @@ func (c *KeyorixCore) RefreshSession(ctx context.Context, token string) (*models
 		c.handleSessionReuse(ctx, old)
 		return nil, fmt.Errorf("session not found or expired")
 	}
+	if old.AbsoluteExpiresAt != nil {
+		// #1653: refuse a now that looks earlier than one this process has
+		// already legitimately observed for a session refresh -- see
+		// checkSessionRefreshClockNotRegressed's doc comment for what this
+		// defends against (a backward-stepped host clock letting the
+		// absolute-ceiling recheck below pass for a session that has
+		// actually exceeded its lifetime). Scoped to sessions that actually
+		// HAVE an absolute ceiling -- a session with none has nothing here
+		// for a clock regression to extend.
+		if err := c.checkSessionRefreshClockNotRegressed(now); err != nil {
+			return nil, err
+		}
+	}
 	if old.AbsoluteExpiresAt != nil && !now.Before(*old.AbsoluteExpiresAt) {
 		// Past the hard ceiling — re-authentication required, not another refresh.
 		_ = c.storage.DeleteSession(ctx, old.ID)
@@ -421,6 +434,38 @@ func (c *KeyorixCore) RefreshSession(ctx context.Context, token string) (*models
 		return nil, fmt.Errorf("session not found or expired")
 	}
 	return created, nil
+}
+
+// sessionRefreshClockRegressionTolerance bounds how far now may read EARLIER
+// than sessionRefreshWatermark before checkSessionRefreshClockNotRegressed
+// refuses a session refresh. Same value and rationale as
+// secretExpiryClockRegressionTolerance (versions.go, #1632): large enough not
+// to false-positive on ordinary NTP slew, small enough to still catch a
+// deliberate/NTP-less manual clock reset.
+const sessionRefreshClockRegressionTolerance = 30 * time.Second
+
+// checkSessionRefreshClockNotRegressed refuses to trust now for
+// RefreshSession's absolute-ceiling recheck if it looks EARLIER than a time
+// this process has already legitimately observed for a session refresh
+// (#1653, follow-up to #1632). RefreshSession's `!now.Before(*old.AbsoluteExpiresAt)`
+// comparison binds a fresh c.now() directly against a DB-loaded, non-renewable
+// ceiling — a host clock stepped backward past that ceiling would let a
+// session refresh past its true absolute lifetime. Reuses the exact same
+// refusal text RefreshSession's own ceiling check already returns
+// ("session lifetime exceeded; re-authentication required"), not a distinct
+// message, so a caller cannot use it as an oracle confirming clock
+// manipulation had an effect. On success, advances the watermark to now
+// (never backward).
+func (c *KeyorixCore) checkSessionRefreshClockNotRegressed(now time.Time) error {
+	c.sessionRefreshWatermarkMu.Lock()
+	defer c.sessionRefreshWatermarkMu.Unlock()
+	if !c.sessionRefreshWatermark.IsZero() && now.Before(c.sessionRefreshWatermark.Add(-sessionRefreshClockRegressionTolerance)) {
+		return fmt.Errorf("session lifetime exceeded; re-authentication required")
+	}
+	if now.After(c.sessionRefreshWatermark) {
+		c.sessionRefreshWatermark = now
+	}
+	return nil
 }
 
 // ensureFamilyID returns existing if non-empty, otherwise generates a new secure token.

--- a/internal/core/classification_gate.go
+++ b/internal/core/classification_gate.go
@@ -266,10 +266,18 @@ func (c *KeyorixCore) ApproveSecretAccessRequest(ctx context.Context, requestID,
 	// Mirrors ApproveAccessRequestWithExpiry's own lazy-expire-and-refuse (#277):
 	// GetAccessRequest returns the row verbatim, so a request whose TTL already
 	// lapsed is still State==pending until something reconciles it.
-	if req.ExpiresAt != nil && c.now().After(*req.ExpiresAt) {
-		req.State = AccessRequestExpired
-		_, _ = c.storage.UpdateAccessRequest(ctx, req)
-		return nil, fmt.Errorf("access request has expired")
+	if req.ExpiresAt != nil {
+		// #1653: refuse a now that looks earlier than one this process has
+		// already legitimately observed for an access-request approval --
+		// see checkAccessRequestApprovalClockNotRegressed's doc comment.
+		if err := c.checkAccessRequestApprovalClockNotRegressed(c.now()); err != nil {
+			return nil, err
+		}
+		if c.now().After(*req.ExpiresAt) {
+			req.State = AccessRequestExpired
+			_, _ = c.storage.UpdateAccessRequest(ctx, req)
+			return nil, fmt.Errorf("access request has expired")
+		}
 	}
 	// Maker ≠ checker, same as the project/role flow.
 	if approverID == req.UserID {
@@ -303,6 +311,40 @@ func (c *KeyorixCore) ApproveSecretAccessRequest(ctx context.Context, requestID,
 		fmt.Sprintf("approved access request %d for user %d to read secret %d (%s)", req.ID, req.UserID, *req.SecretID, secret.Name))
 	c.notifySecretAccessResolved(ctx, req, secret, true)
 	return req, nil
+}
+
+// accessRequestApprovalClockRegressionTolerance bounds how far now may read
+// EARLIER than accessRequestApprovalWatermark before
+// checkAccessRequestApprovalClockNotRegressed refuses an approval. Same
+// value and rationale as secretExpiryClockRegressionTolerance (versions.go,
+// #1632).
+const accessRequestApprovalClockRegressionTolerance = 30 * time.Second
+
+// checkAccessRequestApprovalClockNotRegressed refuses to trust now for an
+// access-request approval's lazy-expire-and-refuse check if it looks
+// EARLIER than a time this process has already legitimately observed for
+// this same check (#1653, follow-up to #1632). Shared between
+// ApproveSecretAccessRequest (this file) and ApproveAccessRequestWithExpiry
+// (invitations.go) -- the same "is this access request's TTL still live"
+// question, reached via two entry points, mirroring #1638's
+// consumeClockWatermark being shared between ConsumeMFAChallenge and
+// ConsumeWebAuthnSession. Both callers' expiry check binds a fresh c.now()
+// directly against a DB-loaded ExpiresAt with no seam — a host clock
+// stepped backward past a request's real expiry would let an approver
+// approve a request that should have already lapsed. Reuses the exact same
+// refusal text both callers' own expiry check already returns
+// ("access request has expired"), not a distinct message, so a caller
+// cannot use it as an oracle confirming clock manipulation had an effect.
+func (c *KeyorixCore) checkAccessRequestApprovalClockNotRegressed(now time.Time) error {
+	c.accessRequestApprovalWatermarkMu.Lock()
+	defer c.accessRequestApprovalWatermarkMu.Unlock()
+	if !c.accessRequestApprovalWatermark.IsZero() && now.Before(c.accessRequestApprovalWatermark.Add(-accessRequestApprovalClockRegressionTolerance)) {
+		return fmt.Errorf("access request has expired")
+	}
+	if now.After(c.accessRequestApprovalWatermark) {
+		c.accessRequestApprovalWatermark = now
+	}
+	return nil
 }
 
 // notifySecretAccessRequested alerts the project's approvers of a new

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -20,6 +20,24 @@ import (
 // ConnectOwnershipReason and the deny-path reason constants below).
 const EventConnectSecretRead = "connect.secret_read"
 
+// connectEffectiveNow returns a wall-clock reading that never regresses
+// relative to what this KeyorixCore has already observed for Connect
+// ref-grant resolution (#1653, follow-up to #1632): max(now,
+// connectClockWatermark). connectRefAllowed/connectRefGrantDelegates/
+// connectorHasAnyDelegationForActor are reached on every federated read —
+// see rbacEffectiveNow's doc comment (internal/storage/store/local_rbac.go)
+// for why this clamps rather than refuses.
+func (c *KeyorixCore) connectEffectiveNow() time.Time {
+	c.connectClockWatermarkMu.Lock()
+	defer c.connectClockWatermarkMu.Unlock()
+	now := c.now()
+	if now.Before(c.connectClockWatermark) {
+		return c.connectClockWatermark
+	}
+	c.connectClockWatermark = now
+	return now
+}
+
 // Per-reference grant management events (ADR-045).
 const (
 	EventConnectRefGrantCreate = "connect.ref_grant_create"
@@ -474,7 +492,7 @@ func (c *KeyorixCore) connectRefAllowed(ctx context.Context, actorType string, p
 	if err != nil {
 		return false, err
 	}
-	now := time.Now()
+	now := c.connectEffectiveNow()
 	for _, g := range grants {
 		if roleSet[g.RoleID] && connectGrantActive(g, now) && refMatches(g.RefPrefix, ref) {
 			return true, nil
@@ -513,7 +531,7 @@ func (c *KeyorixCore) connectRefGrantDelegates(ctx context.Context, actorType st
 	if err != nil {
 		return false, true, err
 	}
-	now := time.Now()
+	now := c.connectEffectiveNow()
 	for _, g := range grants {
 		if roleSet[g.RoleID] && connectGrantActive(g, now) && refMatches(g.RefPrefix, ref) {
 			return true, true, nil
@@ -539,7 +557,7 @@ func (c *KeyorixCore) connectorHasAnyDelegationForActor(ctx context.Context, act
 	if err != nil {
 		return false, err
 	}
-	now := time.Now()
+	now := c.connectEffectiveNow()
 	for _, g := range grants {
 		if roleSet[g.RoleID] && connectGrantActive(g, now) {
 			return true, nil

--- a/internal/core/connect_clock_regression_test.go
+++ b/internal/core/connect_clock_regression_test.go
@@ -1,0 +1,77 @@
+// connect_clock_regression_test.go — #1653 (follow-up to #1632): exploit-shaped
+// tests for Connect ref-grant resolution's defense against a backward-stepped
+// host clock. connectRefAllowed/connectRefGrantDelegates/
+// connectorHasAnyDelegationForActor read time.Now() internally (via
+// connectEffectiveNow) rather than accepting it as a parameter, so — same
+// technique as the RBAC cluster's own regression test (#1651) — this seeds
+// connectClockWatermark directly (an unexported field, accessible from this
+// package) to simulate "this process has already observed a later real
+// time," then calls the real, unmodified connectRefAllowed.
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConnectRefAllowed_ClockSteppedBackward_ExpiredGrantStaysDenied is the
+// exploit-shaped test: a ConnectRefGrant whose ExpiresAt already elapsed
+// relative to a time this process has previously observed must not be
+// resurrected merely because the real time.Now() reading right now looks
+// earlier than that watermark.
+func TestConnectRefAllowed_ClockSteppedBackward_ExpiredGrantStaysDenied(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	seedRoleForUser(t, db, 1, 5, "temp-reader")
+	seedConnectPlatformUsePermission(t, db, 5)
+
+	future := time.Now().Add(24 * time.Hour)
+	c.connectClockWatermark = future
+
+	// Genuinely expired relative to the watermark, but NOT expired relative
+	// to the real, un-mocked time.Now() this test actually runs at.
+	expiry := time.Now().Add(time.Hour)
+	seedGrantExpiring(t, c, 5, "aws", "metrics/", expiry)
+
+	ok, err := c.connectRefAllowed(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
+	require.NoError(t, err)
+	assert.False(t, ok, "a grant already expired relative to a time this process has previously observed must not be resurrected by a real clock reading that looks earlier")
+}
+
+// TestConnectRefAllowed_ClockSteppedBackward_LegitimatelyLiveGrantStillAllowed
+// is the positive control: a grant genuinely still live even past the
+// watermark must still authorize normally.
+func TestConnectRefAllowed_ClockSteppedBackward_LegitimatelyLiveGrantStillAllowed(t *testing.T) {
+	c, db := connectRBACCore(t, fakeConnector{name: "aws", val: "v"})
+	seedRoleForUser(t, db, 1, 5, "temp-reader")
+	seedConnectPlatformUsePermission(t, db, 5)
+
+	future := time.Now().Add(24 * time.Hour)
+	c.connectClockWatermark = future
+
+	stillLive := future.Add(24 * time.Hour)
+	seedGrantExpiring(t, c, 5, "aws", "metrics/", stillLive)
+
+	ok, err := c.connectRefAllowed(context.Background(), ActorTypeUser, 1, "aws", "metrics/qps")
+	require.NoError(t, err)
+	assert.True(t, ok, "a grant genuinely live past the watermark must still authorize")
+}
+
+// TestConnectEffectiveNow_ClampsBackwardReadingToWatermark is a direct unit
+// test of the clamp itself.
+func TestConnectEffectiveNow_ClampsBackwardReadingToWatermark(t *testing.T) {
+	c := &KeyorixCore{now: time.Now}
+	watermark := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	c.connectClockWatermark = watermark
+
+	c.now = func() time.Time { return watermark.Add(-time.Hour) }
+	assert.Equal(t, watermark, c.connectEffectiveNow(), "a backward-looking reading must clamp up to the watermark")
+
+	forward := watermark.Add(time.Hour)
+	c.now = func() time.Time { return forward }
+	assert.Equal(t, forward, c.connectEffectiveNow(), "a forward reading must pass through unchanged and advance the watermark")
+	assert.Equal(t, forward, c.connectClockWatermark)
+}

--- a/internal/core/connect_rbac_test.go
+++ b/internal/core/connect_rbac_test.go
@@ -34,7 +34,11 @@ func connectRBACCore(t *testing.T, conns ...connect.Connector) (*KeyorixCore, *g
 		&models.ConnectorProjectBinding{},
 		&models.Permission{}, &models.RolePermission{},
 	))
-	c := &KeyorixCore{storage: store.NewLocalStorage(db)}
+	// #1653: connectRefAllowed/connectRefGrantDelegates/etc. now call
+	// c.connectEffectiveNow(), which calls c.now() -- needs the same default
+	// the NewKeyorixCore constructor sets, or every grant-resolution test
+	// through this helper panics on a nil c.now.
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	if len(conns) > 0 {
 		c.SetConnectManager(connect.NewManager(conns))
 		ownership := make(map[string]ConnectOwnership, len(conns))

--- a/internal/core/group_sharing.go
+++ b/internal/core/group_sharing.go
@@ -145,7 +145,12 @@ func (c *KeyorixCore) ListGroupSharedSecrets(ctx context.Context, actorKind stri
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 
-	now := c.now()
+	// #1653: shares the same clamp-based clock as shareActive/activeShares
+	// (permissions.go) rather than a bare c.now() — this is the same
+	// "share still authorizes" predicate, duplicated inline instead of
+	// calling shareActive, so it gets the same defense against a
+	// backward-stepped clock resurrecting an expired time-bound share.
+	now := c.shareEffectiveNow()
 	secrets := make([]*models.SecretNode, 0, len(shares))
 	seen := make(map[uint]bool, len(shares))
 	for _, s := range shares {

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -654,13 +654,23 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	// returns the stored record verbatim, so a request whose expiry has passed is still
 	// State==pending until something reconciles it — approving it would grant access on a
 	// stale request that should have lapsed. Expire it lazily and refuse.
-	if req.ExpiresAt != nil && c.now().After(*req.ExpiresAt) {
-		req.State = AccessRequestExpired
-		// Best-effort: if a concurrent approve/reject/withdraw already resolved this
-		// request, the "has expired" refusal below still stands — no role was
-		// granted on this path, so there's nothing to unwind either way.
-		_, _ = c.storage.UpdateAccessRequest(ctx, req)
-		return nil, fmt.Errorf("access request has expired")
+	if req.ExpiresAt != nil {
+		// #1653: refuse a now that looks earlier than one this process has
+		// already legitimately observed for an access-request approval --
+		// shared with ApproveSecretAccessRequest's identical check
+		// (classification_gate.go); see
+		// checkAccessRequestApprovalClockNotRegressed's doc comment there.
+		if err := c.checkAccessRequestApprovalClockNotRegressed(c.now()); err != nil {
+			return nil, err
+		}
+		if c.now().After(*req.ExpiresAt) {
+			req.State = AccessRequestExpired
+			// Best-effort: if a concurrent approve/reject/withdraw already resolved this
+			// request, the "has expired" refusal below still stands — no role was
+			// granted on this path, so there's nothing to unwind either way.
+			_, _ = c.storage.UpdateAccessRequest(ctx, req)
+			return nil, fmt.Errorf("access request has expired")
+		}
 	}
 	if grantTTL < 0 {
 		return nil, fmt.Errorf("grant TTL must not be negative")

--- a/internal/core/oidc.go
+++ b/internal/core/oidc.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -63,6 +64,34 @@ type OIDCVerifier struct {
 	jwks    JWKSResolver
 	leeway  time.Duration
 	now     func() time.Time
+	// clockWatermarkMu/clockWatermark back effectiveNow (#1653, follow-up to
+	// #1632): an in-memory monotonic high-water mark of the latest now()
+	// reading this verifier has legitimately observed. Verify's age check
+	// (v.now().Sub(claims.IssuedAt.Time)) is NOT monotonic-safe — claims.IssuedAt
+	// is parsed from the JWT (round-tripped, monotonic reading stripped), so a
+	// backward-stepped host clock makes a stale token's computed age look
+	// smaller, extending acceptance of it past its configured max-age. This
+	// CLAMPS rather than refuses — Verify runs on every OIDC-authenticated
+	// request (server/middleware/auth.go), a pervasive read path, not a single
+	// discrete action — see rbacEffectiveNow's doc comment
+	// (internal/storage/store/local_rbac.go) for why that shape calls for a
+	// clamp, not a refuse.
+	clockWatermarkMu sync.Mutex
+	clockWatermark   time.Time
+}
+
+// effectiveNow returns v.now() clamped so it never regresses relative to a
+// reading this verifier has already legitimately observed. See
+// clockWatermark's doc comment above for what this defends against.
+func (v *OIDCVerifier) effectiveNow() time.Time {
+	v.clockWatermarkMu.Lock()
+	defer v.clockWatermarkMu.Unlock()
+	now := v.now()
+	if now.Before(v.clockWatermark) {
+		return v.clockWatermark
+	}
+	v.clockWatermark = now
+	return now
 }
 
 // NewOIDCVerifier builds a verifier over the trusted issuers. An issuer with no
@@ -165,7 +194,7 @@ func (v *OIDCVerifier) Verify(ctx context.Context, raw string) (issuer, subject 
 	if claims.IssuedAt == nil {
 		return "", "", fmt.Errorf("oidc token has no iat claim")
 	}
-	if age := v.now().Sub(claims.IssuedAt.Time); age > trust.maxAge+v.leeway {
+	if age := v.effectiveNow().Sub(claims.IssuedAt.Time); age > trust.maxAge+v.leeway {
 		return "", "", fmt.Errorf("oidc token exceeds max age (issued %s ago)", age.Round(time.Second))
 	}
 	return claims.Issuer, claims.Subject, nil

--- a/internal/core/oidc_clock_regression_test.go
+++ b/internal/core/oidc_clock_regression_test.go
@@ -1,0 +1,113 @@
+// oidc_clock_regression_test.go — #1653 (follow-up to #1632): exploit-shaped
+// test for OIDCVerifier.Verify's max-age check. v.now().Sub(claims.IssuedAt.Time)
+// is NOT monotonic-safe (claims.IssuedAt is parsed from the JWT, round-tripped,
+// its monotonic reading stripped) -- a host clock stepped backward makes a
+// stale token's computed age look smaller, extending acceptance of it past its
+// configured max-age. Note: the JWT library's OWN exp/nbf validation uses the
+// real wall clock (no jwt.WithTimeFunc configured), independent of v.now -- so
+// this test keeps `exp` valid against real time throughout and controls only
+// v.now (via effectiveNow's clamp) to exercise the max-age check specifically.
+package core
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOIDCVerify_ClockSteppedBackward_StaleTokenStaysRejected is the
+// exploit-shaped test. Sequence:
+//
+//  1. At a baseline v.now() two hours after the token's iat (exceeding the
+//     issuer's 1-hour MaxTokenAge), Verify correctly refuses the token for
+//     being too old -- and this warms effectiveNow's watermark to that
+//     baseline.
+//  2. Step v.now() BACKWARD to only 10 minutes after iat (well within the
+//     1-hour budget if trusted naively) and Verify again with the SAME
+//     token. Before the fix, this age computes as ~10 minutes and the stale
+//     token is wrongly accepted. After the fix, effectiveNow clamps to the
+//     step-1 watermark, so age is still computed as ~2 hours and the token
+//     stays refused.
+func TestOIDCVerify_ClockSteppedBackward_StaleTokenStaysRejected(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	v, err := NewOIDCVerifier(
+		[]OIDCTrustedIssuer{{Issuer: "https://k8s.local", Audiences: []string{"keyorix"}, MaxTokenAge: time.Hour}},
+		staticResolver{kid: "kid-1", key: &key.PublicKey},
+	)
+	require.NoError(t, err)
+
+	realNow := time.Now()
+	iat := realNow.Add(-30 * time.Minute)
+	raw := signToken(t, key, "kid-1", jwt.MapClaims{
+		"iss": "https://k8s.local",
+		"sub": "system:serviceaccount:ci:deployer",
+		"aud": []string{"keyorix"},
+		"iat": iat.Unix(),
+		"exp": realNow.Add(time.Hour).Unix(), // valid against the JWT library's own real-clock exp check throughout
+	})
+
+	// Step 1: v.now() two hours ahead of iat -- exceeds the 1h MaxTokenAge,
+	// correctly refused, and warms effectiveNow's watermark.
+	baseline := realNow.Add(2 * time.Hour)
+	v.now = func() time.Time { return baseline }
+	_, _, err = v.Verify(context.Background(), raw)
+	require.ErrorContains(t, err, "exceeds max age", "sanity: the token must read as too old at the baseline time before the clock ever moves")
+
+	// Step 2: the exploit. Step v.now() BACKWARD to only 10 minutes after iat.
+	steppedBack := iat.Add(10 * time.Minute)
+	v.now = func() time.Time { return steppedBack }
+	_, _, err = v.Verify(context.Background(), raw)
+	require.ErrorContains(t, err, "exceeds max age", "a stale token must still be rejected after the clock steps backward to look freshly within the max-age budget")
+}
+
+// TestOIDCVerify_ClockSteppedBackward_FreshTokenStillAccepted is the positive
+// control: a genuinely fresh token, verified after a SMALL in-tolerance
+// backward step (well under the OIDC verifier's own leeway), must still be
+// accepted.
+func TestOIDCVerify_ClockSteppedBackward_FreshTokenStillAccepted(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	v, err := NewOIDCVerifier(
+		[]OIDCTrustedIssuer{{Issuer: "https://k8s.local", Audiences: []string{"keyorix"}, MaxTokenAge: time.Hour}},
+		staticResolver{kid: "kid-1", key: &key.PublicKey},
+	)
+	require.NoError(t, err)
+
+	realNow := time.Now()
+	raw := signToken(t, key, "kid-1", jwt.MapClaims{
+		"iss": "https://k8s.local",
+		"sub": "system:serviceaccount:ci:deployer",
+		"aud": []string{"keyorix"},
+		"iat": realNow.Unix(),
+		"exp": realNow.Add(time.Hour).Unix(),
+	})
+
+	v.now = func() time.Time { return realNow.Add(-1 * time.Second) }
+	_, _, err = v.Verify(context.Background(), raw)
+	require.NoError(t, err, "a fresh token must still verify after a small in-tolerance backward step")
+}
+
+// TestOIDCEffectiveNow_ClampsBackwardReadingToWatermark is a direct unit test
+// of the clamp itself.
+func TestOIDCEffectiveNow_ClampsBackwardReadingToWatermark(t *testing.T) {
+	v := &OIDCVerifier{}
+	watermark := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	v.clockWatermark = watermark
+
+	backward := watermark.Add(-time.Hour)
+	v.now = func() time.Time { return backward }
+	require.Equal(t, watermark, v.effectiveNow(), "a backward-looking reading must clamp up to the watermark")
+
+	forward := watermark.Add(time.Hour)
+	v.now = func() time.Time { return forward }
+	require.Equal(t, forward, v.effectiveNow(), "a forward reading must pass through unchanged and advance the watermark")
+	require.Equal(t, forward, v.clockWatermark)
+}

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -10,6 +10,24 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
+// shareEffectiveNow returns a wall-clock reading that never regresses
+// relative to what this KeyorixCore has already observed for share-active
+// resolution (#1653, follow-up to #1632): max(now, shareClockWatermark).
+// shareActive/activeShares are reached on every secret listing and
+// access-list resolution that involves shares — see rbacEffectiveNow's doc
+// comment (internal/storage/store/local_rbac.go) for why this clamps rather
+// than refuses.
+func (c *KeyorixCore) shareEffectiveNow() time.Time {
+	c.shareClockWatermarkMu.Lock()
+	defer c.shareClockWatermarkMu.Unlock()
+	now := c.now()
+	if now.Before(c.shareClockWatermark) {
+		return c.shareClockWatermark
+	}
+	c.shareClockWatermark = now
+	return now
+}
+
 // shareActive reports whether a share still authorizes at time now: a nil ExpiresAt
 // is permanent, otherwise the share stops authorizing the instant it passes (a
 // time-bound / JIT secret share, mirroring UserRole.ExpiresAt). The JIT sweeper later
@@ -113,7 +131,7 @@ func (c *KeyorixCore) CheckSecretPermission(ctx context.Context, secretID, userI
 	}
 	// Drop expired (time-bound) shares before any authorization: an expired share
 	// must never grant access, even though the sweep that reclaims its row runs later.
-	shares = activeShares(shares, c.now())
+	shares = activeShares(shares, c.shareEffectiveNow())
 
 	// Check direct shares.
 	for _, share := range shares {

--- a/internal/core/secret_access_list.go
+++ b/internal/core/secret_access_list.go
@@ -97,7 +97,7 @@ func (c *KeyorixCore) ListSecretAccessors(ctx context.Context, secretID, actorID
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
-	for _, sh := range activeShares(shares, c.now()) {
+	for _, sh := range activeShares(shares, c.shareEffectiveNow()) {
 		if sh.IsGroup {
 			gname := fmt.Sprintf("group %d", sh.RecipientID)
 			if g, err := c.storage.GetGroup(ctx, sh.RecipientID); err == nil && g != nil && g.Name != "" {

--- a/internal/core/secret_listing_sharing.go
+++ b/internal/core/secret_listing_sharing.go
@@ -83,7 +83,7 @@ func (c *KeyorixCore) GetSecretSharingStatusWithIndicators(ctx context.Context, 
 	}
 	// Expired (time-bound) shares no longer authorize, so the reported sharing
 	// status must not count or display them — keep it consistent with enforcement.
-	shares = activeShares(shares, c.now())
+	shares = activeShares(shares, c.shareEffectiveNow())
 
 	isOwner := secretOwnedBy(secret.OwnerID, userID)
 	userPermission := ""
@@ -159,7 +159,7 @@ func (c *KeyorixCore) GetUserSecretPermission(ctx context.Context, secretID, use
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	// An expired share grants no permission — match the authorization gate.
-	shares = activeShares(shares, c.now())
+	shares = activeShares(shares, c.shareEffectiveNow())
 
 	for _, share := range shares {
 		if !share.IsGroup && share.RecipientID == userID {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -392,6 +392,41 @@ type KeyorixCore struct {
 	// operational (not per-site code) mitigation.
 	secretExpiryWatermarkMu sync.Mutex
 	secretExpiryWatermark   time.Time
+	// connectClockWatermark, shareClockWatermark: in-memory monotonic high-water
+	// marks backing connectEffectiveNow (connect.go) and shareEffectiveNow
+	// (permissions.go) respectively (#1653, the follow-up to #1632). Both CLAMP
+	// rather than refuse — see rbacEffectiveNow's doc comment
+	// (internal/storage/store/local_rbac.go, #1651) for why: these are
+	// read-heavy permission-resolution paths (Connect ref-grant checks on every
+	// federated read; share-active checks on every secret listing/access-list
+	// resolution), not single discrete actions, so hard-refusing on a detected
+	// regression would trade a narrow clock-integrity concern for a broad
+	// denial-of-service. Kept as two separate fields, not one shared watermark,
+	// matching #1632's own precedent (consumeClockWatermark vs
+	// rbacClockWatermark) — Connect grants and shares are unrelated
+	// subsystems; sharing a watermark would only blur which mechanism actually
+	// warmed it, without protecting anything more.
+	connectClockWatermarkMu sync.Mutex
+	connectClockWatermark   time.Time
+	shareClockWatermarkMu   sync.Mutex
+	shareClockWatermark     time.Time
+	// sessionRefreshWatermark, accessRequestApprovalWatermark: in-memory
+	// monotonic high-water marks backing checkSessionRefreshClockNotRegressed
+	// (auth.go) and checkAccessRequestApprovalClockNotRegressed
+	// (classification_gate.go) respectively (#1653). Both REFUSE rather than
+	// clamp, matching secretExpiryWatermark's shape above — each guards a
+	// single, discrete, low-volume action (one session refresh per access
+	// window; one admin approval per request), not a pervasive read path, so
+	// refusing outright on a detected regression is proportionate. The
+	// access-request watermark is shared between
+	// ApproveSecretAccessRequest and ApproveAccessRequestWithExpiry
+	// (invitations.go) — the same "access request approval" action reached via
+	// two entry points, mirroring #1638's consumeClockWatermark being shared
+	// between ConsumeMFAChallenge and ConsumeWebAuthnSession.
+	sessionRefreshWatermarkMu        sync.Mutex
+	sessionRefreshWatermark          time.Time
+	accessRequestApprovalWatermarkMu sync.Mutex
+	accessRequestApprovalWatermark   time.Time
 }
 
 // AuditForwarder ships persisted audit events to an external sink (e.g. a SIEM).

--- a/internal/core/session_refresh_clock_regression_test.go
+++ b/internal/core/session_refresh_clock_regression_test.go
@@ -1,0 +1,81 @@
+// session_refresh_clock_regression_test.go — #1653 (follow-up to #1632):
+// exploit-shaped test for RefreshSession's absolute-ceiling recheck.
+// `!now.Before(*old.AbsoluteExpiresAt)` binds a fresh c.now() directly
+// against a DB-loaded, non-renewable ceiling with no defense against a
+// backward-stepped host clock — this reuses session_ttl_test.go's
+// newSessionCore fixed-clock pattern, swapping c.now between calls to
+// simulate the clock stepping backward mid-process.
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRefreshSession_ClockSteppedBackward_PastCeilingStaysRefused is the
+// exploit-shaped test. Sequence:
+//
+//  1. At a baseline c.now() two hours past the session's absolute ceiling,
+//     RefreshSession correctly refuses (the pre-existing ceiling check
+//     fires) — and this warms checkSessionRefreshClockNotRegressed's
+//     watermark to that baseline.
+//  2. Step c.now() BACKWARD to 10 minutes BEFORE the ceiling (i.e., if
+//     trusted naively, the pre-existing check `!now.Before(ceiling)` would
+//     evaluate false and ALLOW the refresh) and call RefreshSession again
+//     with the same session. Before this fix, the session refreshes past
+//     its real absolute lifetime. After the fix, the regression guard
+//     refuses before the ceiling check is ever reached.
+func TestRefreshSession_ClockSteppedBackward_PastCeilingStaysRefused(t *testing.T) {
+	store := new(MockStorage)
+	c := newSessionCore(store, 30*time.Minute, 12*time.Hour)
+
+	ceiling := sessionTestNow.Add(time.Hour)
+	old := &models.Session{ID: 7, UserID: 1, SessionToken: "old", AbsoluteExpiresAt: &ceiling}
+	store.On("GetSessionAny", mock.Anything, "old").Return(old, nil)
+	store.On("DeleteSession", mock.Anything, uint(7)).Return(nil)
+
+	// Step 1: baseline, clearly past the ceiling — correctly refused, warms
+	// the watermark.
+	c.now = func() time.Time { return ceiling.Add(2 * time.Hour) }
+	_, err := c.RefreshSession(context.Background(), "old")
+	require.Error(t, err, "sanity: refresh must be refused at the baseline time before the clock ever moves")
+	require.Contains(t, err.Error(), "re-authentication required")
+
+	// Step 2: the exploit. Step c.now() BACKWARD to before the ceiling.
+	c.now = func() time.Time { return ceiling.Add(-10 * time.Minute) }
+	_, err = c.RefreshSession(context.Background(), "old")
+	require.Error(t, err, "refresh must still be refused after the clock steps backward to before the ceiling")
+	require.Contains(t, err.Error(), "re-authentication required")
+}
+
+// TestRefreshSession_ClockSteppedBackward_LegitimatelyWithinCeilingStillRefreshes
+// is the positive control: a session well within its ceiling, refreshed
+// after a SMALL in-tolerance backward step, must still succeed.
+func TestRefreshSession_ClockSteppedBackward_LegitimatelyWithinCeilingStillRefreshes(t *testing.T) {
+	store := new(MockStorage)
+	captured := captureRotatedSession(store, 7)
+	c := newSessionCore(store, 30*time.Minute, 12*time.Hour)
+
+	ceiling := sessionTestNow.Add(8 * time.Hour)
+	old := &models.Session{ID: 7, UserID: 1, SessionToken: "old", FamilyID: "fam-1", AbsoluteExpiresAt: &ceiling}
+	store.On("GetSessionAny", mock.Anything, "old").Return(old, nil)
+	store.On("GetUser", mock.Anything, uint(1)).Return(&models.User{ID: 1, IsActive: true, AccountState: AccountActive}, nil)
+
+	c.now = func() time.Time { return sessionTestNow.Add(-1 * time.Second) }
+	_, err := c.RefreshSession(context.Background(), "old")
+	require.NoError(t, err, "a small in-tolerance backward step must not refuse a session well within its ceiling")
+	require.NotNil(t, captured.AbsoluteExpiresAt)
+}
+
+// TestCheckSessionRefreshClockNotRegressed_FreshWatermarkNeverRefuses covers
+// the zero-value watermark case directly.
+func TestCheckSessionRefreshClockNotRegressed_FreshWatermarkNeverRefuses(t *testing.T) {
+	c := &KeyorixCore{}
+	err := c.checkSessionRefreshClockNotRegressed(time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err, "an unset watermark must never itself cause a refusal")
+}

--- a/internal/core/share_clock_regression_test.go
+++ b/internal/core/share_clock_regression_test.go
@@ -1,0 +1,97 @@
+// share_clock_regression_test.go — #1653 (follow-up to #1632): exploit-shaped
+// tests for share-active resolution's (shareActive/activeShares,
+// permissions.go) defense against a backward-stepped host clock.
+// ListSecretShares/ListSharesByUser/etc. read time.Now() internally (via
+// shareEffectiveNow) rather than accepting it as a parameter, so — same
+// technique as the RBAC cluster's and Connect grant's own regression tests —
+// this seeds shareClockWatermark directly (an unexported field, accessible
+// from this package) to simulate "this process has already observed a later
+// real time," then calls the real, unmodified ListSecretShares.
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+func newShareClockRegressionCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretNode{}, &models.ShareRecord{}))
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
+	return c, db
+}
+
+// TestListSecretShares_ClockSteppedBackward_ExpiredShareStaysExcluded is the
+// exploit-shaped test: a ShareRecord whose ExpiresAt already elapsed
+// relative to a time this process has previously observed must not be
+// resurrected merely because the real time.Now() reading right now looks
+// earlier than that watermark.
+func TestListSecretShares_ClockSteppedBackward_ExpiredShareStaysExcluded(t *testing.T) {
+	c, db := newShareClockRegressionCore(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "s", Type: "generic"}).Error)
+
+	future := time.Now().Add(24 * time.Hour)
+	c.shareClockWatermark = future
+
+	// Genuinely expired relative to the watermark, but NOT expired relative
+	// to the real, un-mocked time.Now() this test actually runs at.
+	expiry := time.Now().Add(time.Hour)
+	require.NoError(t, db.Create(&models.ShareRecord{
+		SecretID: 1, OwnerID: 1, RecipientID: 2, Permission: "read", ExpiresAt: &expiry,
+	}).Error)
+
+	shares, err := c.ListSecretShares(ctx, 1)
+	require.NoError(t, err)
+	assert.Empty(t, shares, "a share already expired relative to a time this process has previously observed must not be resurrected by a real clock reading that looks earlier")
+}
+
+// TestListSecretShares_ClockSteppedBackward_LegitimatelyLiveShareStillResolves
+// is the positive control: a share genuinely still live even past the
+// watermark must still resolve normally.
+func TestListSecretShares_ClockSteppedBackward_LegitimatelyLiveShareStillResolves(t *testing.T) {
+	c, db := newShareClockRegressionCore(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, Name: "s", Type: "generic"}).Error)
+
+	future := time.Now().Add(24 * time.Hour)
+	c.shareClockWatermark = future
+
+	stillLive := future.Add(24 * time.Hour)
+	require.NoError(t, db.Create(&models.ShareRecord{
+		SecretID: 1, OwnerID: 1, RecipientID: 2, Permission: "read", ExpiresAt: &stillLive,
+	}).Error)
+
+	shares, err := c.ListSecretShares(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, shares, 1, "a share genuinely live past the watermark must still resolve")
+}
+
+// TestShareEffectiveNow_ClampsBackwardReadingToWatermark is a direct unit
+// test of the clamp itself.
+func TestShareEffectiveNow_ClampsBackwardReadingToWatermark(t *testing.T) {
+	c := &KeyorixCore{now: time.Now}
+	watermark := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	c.shareClockWatermark = watermark
+
+	c.now = func() time.Time { return watermark.Add(-time.Hour) }
+	assert.Equal(t, watermark, c.shareEffectiveNow(), "a backward-looking reading must clamp up to the watermark")
+
+	forward := watermark.Add(time.Hour)
+	c.now = func() time.Time { return forward }
+	assert.Equal(t, forward, c.shareEffectiveNow(), "a forward reading must pass through unchanged and advance the watermark")
+	assert.Equal(t, forward, c.shareClockWatermark)
+}

--- a/internal/core/sharing_query.go
+++ b/internal/core/sharing_query.go
@@ -43,7 +43,7 @@ func (c *KeyorixCore) ListSecretShares(ctx context.Context, secretID uint) ([]*m
 	}
 	// Drop expired time-bound shares so the list matches what actually authorizes
 	// (every enforcement path filters via activeShares); they're swept separately.
-	return activeShares(shares, c.now()), nil
+	return activeShares(shares, c.shareEffectiveNow()), nil
 }
 
 // ListSecretSharesWithPermissionCheck lists a secret's shares, but only for its
@@ -67,7 +67,7 @@ func (c *KeyorixCore) ListSecretSharesWithPermissionCheck(ctx context.Context, s
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	// Drop expired time-bound shares — see ListSecretShares.
-	return activeShares(shares, c.now()), nil
+	return activeShares(shares, c.shareEffectiveNow()), nil
 }
 
 // ListSharesByUser lists shares involving the user (received as recipient + outgoing as owner).


### PR DESCRIPTION
## Summary

Follow-up to #1632 (issue #1653). Fixes four of the six sites #1653 named, using two mechanisms depending on call shape — the same distinction #1651 (RBAC cluster) drew:

**Refuse** (single discrete action, own watermark, reuses each site's exact existing error text so a caller cannot distinguish "genuinely expired" from "clock regression detected"):
- `auth.go` `RefreshSession` — the absolute-ceiling recheck is now preceded by `checkSessionRefreshClockNotRegressed`, scoped to sessions that actually have a ceiling.
- `classification_gate.go` `ApproveSecretAccessRequest` / `invitations.go` `ApproveAccessRequestWithExpiry` — share ONE watermark (`checkAccessRequestApprovalClockNotRegressed`), same "is this request's TTL still live" question reached via two entry points, mirroring #1638's `consumeClockWatermark`.

**Clamp** (pervasive read path, reached on ordinary request volume — hard-refusing would be a denial-of-service, not a narrow fix; see `rbacEffectiveNow`'s doc comment, #1651):
- `oidc.go` `OIDCVerifier.Verify` — the JWT max-age check is not monotonic-safe (`claims.IssuedAt` is parsed from the token, round-tripped, its monotonic reading stripped). Reached on every OIDC-authenticated request. Own watermark on `OIDCVerifier` (a separate struct from `KeyorixCore`).
- `connect.go` — `connectRefAllowed`/`connectRefGrantDelegates`/`connectorHasAnyDelegationForActor`, reached on every federated read. Switched from a bare `time.Now()` to `c.connectEffectiveNow()`.
- `permissions.go` `shareActive`/`activeShares`, and `group_sharing.go`'s identical inline duplicate of the same predicate — reached on every secret listing/access-list resolution involving shares. Both now go through `c.shareEffectiveNow()`.

## Two sites reclassified, not fixed

Tracing every caller changed the verdict on two of #1653's originally-named sites — real corrections, not silent drops:

- **`break_glass.go` `ListBreakGlassActivations`**: its lazy-expire-on-read only updates a `BreakGlassActivation` row's own state/report label. The actual emergency-access grant is a `UserRole`/`GroupRole` row with its own `ExpiresAt`, already protected by #1651's RBAC cluster fix regardless of what this row's state says. `RevokeBreakGlass` calls `RemoveUserRole` directly and doesn't gate on this row's staleness either. No live access decision depends on it — hygiene, not security.
- **`risk_exceptions.go` `exceptionStatus`**: its only consumer is a compliance-posture snapshot counter. `DetectSoDViolations` never consults `RiskException` — an exception never suppresses violation detection, it's a separate reporting annotation. Hygiene, not security.

Also fixes `connect_rbac_test.go`'s `connectRBACCore` helper — a raw `KeyorixCore{}` literal with no `now` field, the same nil-`c.now` panic class from #1632's earlier fixes, exposed by `connectRefAllowed` now calling `c.connectEffectiveNow()` → `c.now()`.

## Test plan

- [x] Exploit-shaped test per fixed site (5 new test files), each with a positive control (legitimately live grant/share/session/request still resolves; small in-tolerance backward steps don't false-positive).
- [x] Red-before-green for all four mechanisms: disabled each guard/clamp individually, confirmed its exploit test fails, restored, confirmed green.
- [x] The access-request approval test uses two separate requests, not one reused across steps — the pre-existing expiry check's own side effect (persisting `AccessRequestExpired`) would otherwise mask whether the new guard mattered on a second call against the same row.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` on touched files — all clean.
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` — 0 issues.
- [x] Full `internal/core`, `internal/storage`, `server/http`, `server/grpc` suites pass under UTC and `TZ=America/New_York`.

Closes #1653.