### PR TITLE
fix(storage): #1650 -- audit writes detach from the triggering request's cancellation

### DIFF
--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -529,6 +529,13 @@ func (c *KeyorixCore) emitAudit(ctx context.Context, event *models.AuditEvent) {
 	}
 	event.Description = truncateAuditField(event.Description, auditDescriptionMaxLen)
 	event.Diff = truncateAuditField(event.Diff, auditDiffMaxLen)
+	// #1650: the request-cancellation-immunity fix lives at the storage layer
+	// (LocalStorage.LogAuditEvent / RemoteStorage.LogAuditEvent detach their own ctx
+	// before doing I/O), not here — this is one of four call sites into LogAuditEvent
+	// in the codebase (the other three bypass emitAudit entirely: server/main.go,
+	// audit_ingest_proxy.go, anomaly.go), so fixing it at emitAudit alone would leave
+	// those three still vulnerable. See store.auditWriteContext's doc comment for the
+	// full rationale.
 	if err := c.storage.LogAuditEvent(ctx, event); err != nil {
 		// A failed chain-write is an audit gap that VerifyAuditChain cannot detect — a
 		// never-written event leaves no hole. Surface it loudly instead of swallowing,

--- a/internal/storage/store/audit_write_context.go
+++ b/internal/storage/store/audit_write_context.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// auditWriteTimeout bounds an audit write once it's detached from its caller's own
+// cancellation/deadline (see auditWriteContext) — generous on purpose (an audit insert,
+// local or forwarded, is normally single-digit milliseconds; this is a safety net
+// against a wedged storage backend or unreachable hub, not a performance budget), per
+// this repo's own stated timeout philosophy: timeouts detect hangs, they don't enforce
+// speed.
+const auditWriteTimeout = 10 * time.Second
+
+// auditWriteContext detaches parent from its own cancellation and deadline, keeping
+// every value on it (actor/impersonation/machine-actor tags an audit write may still
+// need to read), and bounds the result with auditWriteTimeout instead (#1650).
+//
+// Every LogAuditEvent implementation calls this before doing any I/O. Four call sites
+// across the codebase reach LogAuditEvent: core.KeyorixCore.emitAudit (the shared choke
+// point for ~190 Log*/writeAuditEvent* helpers), server/main.go's shutdown-audit write,
+// server/http/handlers/audit_ingest_proxy.go's remote-event ingestion, and
+// internal/core/anomaly.go's business-hours-config audit. All four pass a context that
+// traces back to an inbound HTTP/gRPC request (or, for two of them, that request's
+// cancellation propagated through several layers) — so without this, any of them can
+// turn "the mutation/event committed" into "committed with zero audit record" purely
+// because the triggering client disconnected in the window between the two writes
+// completing. Fixing this ONCE here, at the two concrete LogAuditEvent implementations
+// (LocalStorage's and RemoteStorage's) rather than at each of those four call sites (or
+// the ~190 sites emitAudit itself fans out to), closes the gap for all of them by
+// construction, including any future caller that reaches either implementation a fifth
+// way.
+func auditWriteContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), auditWriteTimeout)
+}

--- a/internal/storage/store/audit_write_context_completeness_test.go
+++ b/internal/storage/store/audit_write_context_completeness_test.go
@@ -1,0 +1,184 @@
+// audit_write_context_completeness_test.go — #1650 repo-wide structural guard.
+//
+// The fix for #1650 (a committed mutation can end up with zero audit record if the
+// triggering client disconnects between the mutation and the audit write, because the
+// audit write shares the request's cancellable context) lives at the lowest common
+// layer: every concrete LogAuditEvent implementation must detach from its caller's
+// context via auditWriteContext before doing any I/O, rather than relying on each of
+// the ~190 call sites that eventually reach one of them to remember to do so.
+//
+// This test verifies that invariant PROGRAMMATICALLY via go/ast, across the whole
+// repository — not just the two files known to implement LogAuditEvent today — so a
+// future third implementation (a new storage backend) that omits the fix is caught
+// automatically, and so a regression that strips the call out of an existing one is
+// caught too. It is deliberately NOT a hand-maintained list of "the two files we fixed".
+package store
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// auditWriteContextAllowlist names LogAuditEvent implementations that are
+// deliberately exempt from calling auditWriteContext, keyed
+// "<file basename>:<enclosing type name>", with the reason as the value. Empty on
+// purpose: every real implementation found so far needs the fix (test mocks in
+// _test.go files are already excluded by the walk below, not via this list).
+var auditWriteContextAllowlist = map[string]string{}
+
+func TestLogAuditEventImplementations_DetachFromCallerCancellation(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed — cannot locate the repo root relative to this test file")
+	}
+	// internal/storage/store -> repo root.
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+
+	fset := token.NewFileSet()
+	implementations := discoverLogAuditEventImplementations(t, fset, repoRoot)
+
+	if len(implementations) == 0 {
+		t.Fatal("discovered zero LogAuditEvent implementations across the repo — the AST walk is almost certainly broken (LocalStorage.LogAuditEvent and RemoteStorage.LogAuditEvent alone should match), not that both were removed")
+	}
+	if len(implementations) < 2 {
+		t.Fatalf("discovered only %d LogAuditEvent implementation(s); expected at least 2 (LocalStorage, RemoteStorage) — the AST walk may be skipping a file it shouldn't", len(implementations))
+	}
+
+	var violations []string
+	for _, impl := range implementations {
+		if impl.CallsAuditWriteContext {
+			continue
+		}
+		key := impl.key()
+		if reason, ok := auditWriteContextAllowlist[key]; ok {
+			t.Logf("allowlisted LogAuditEvent implementation %s (does not call auditWriteContext): %s", key, reason)
+			continue
+		}
+		violations = append(violations, impl.String()+
+			": does not call auditWriteContext(ctx) before doing I/O -- a canceled caller context (e.g. an HTTP client disconnecting) can silently turn a committed mutation into one with zero audit record (#1650)")
+	}
+	sort.Strings(violations)
+
+	if len(violations) > 0 {
+		t.Errorf("found %d LogAuditEvent implementation(s) not detached from caller cancellation, and not in auditWriteContextAllowlist:\n%s\n"+
+			"Fix: add `ctx, cancel := auditWriteContext(ctx); defer cancel()` as the first thing the method does (see LocalStorage.LogAuditEvent / RemoteStorage.LogAuditEvent for the pattern), or, if this really is a deliberate exception, add it to auditWriteContextAllowlist with a comment explaining why.",
+			len(violations), strings.Join(violations, "\n"))
+	}
+}
+
+type logAuditEventImpl struct {
+	File                   string // basename
+	TypeName               string // receiver type, e.g. "LocalStorage"
+	CallsAuditWriteContext bool
+}
+
+func (i logAuditEventImpl) key() string    { return i.File + ":" + i.TypeName }
+func (i logAuditEventImpl) String() string { return i.File + ":" + i.TypeName + ".LogAuditEvent" }
+
+// skipDir reports whether a directory should be excluded from the walk: VCS metadata,
+// dependency/build output, and the operator module (a separate Go module per its own
+// go.mod, kept out of this repo's go.work — see operator/README or go.work itself).
+func skipDir(name string) bool {
+	switch name {
+	case ".git", "node_modules", "dist", ".scratch", "vendor", "operator", "web":
+		return true
+	}
+	return false
+}
+
+// discoverLogAuditEventImplementations walks root for every non-test .go file,
+// parses it, and finds every method literally named LogAuditEvent — recording, for
+// each, whether its body contains a call to auditWriteContext anywhere (a shallow
+// syntactic check, not a full call-graph analysis: it would not catch a method that
+// calls a wrapper which itself calls auditWriteContext, but every implementation found
+// to date calls it directly, matching the pattern this test asks every implementation
+// to follow).
+func discoverLogAuditEventImplementations(t *testing.T, fset *token.FileSet, root string) []logAuditEventImpl {
+	t.Helper()
+	var out []logAuditEventImpl
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		file, perr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if perr != nil {
+			t.Fatalf("failed to parse %s: %v", path, perr)
+		}
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != "LogAuditEvent" || fn.Recv == nil || len(fn.Recv.List) == 0 {
+				continue
+			}
+			typeName := receiverTypeName(fn.Recv.List[0].Type)
+			if typeName == "" {
+				continue
+			}
+			out = append(out, logAuditEventImpl{
+				File:                   filepath.Base(path),
+				TypeName:               typeName,
+				CallsAuditWriteContext: bodyCallsFunction(fn.Body, "auditWriteContext"),
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk %s: %v", root, err)
+	}
+	return out
+}
+
+// receiverTypeName extracts the bare type name from a method receiver expression,
+// unwrapping a single leading pointer star (e.g. "*LocalStorage" -> "LocalStorage").
+func receiverTypeName(expr ast.Expr) string {
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	if ident, ok := expr.(*ast.Ident); ok {
+		return ident.Name
+	}
+	return ""
+}
+
+// bodyCallsFunction reports whether body contains a call expression whose function
+// name is exactly name, anywhere in its statement tree (including inside nested
+// blocks, closures, etc.).
+func bodyCallsFunction(body *ast.BlockStmt, name string) bool {
+	if body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/internal/storage/store/audit_write_context_test.go
+++ b/internal/storage/store/audit_write_context_test.go
@@ -1,0 +1,41 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogAuditEvent_SucceedsWithAlreadyCanceledCallerContext is the deterministic,
+// non-racy proof that #1650's mechanism fix actually works, not just that the source
+// code happens to call auditWriteContext syntactically (see
+// audit_write_context_completeness_test.go for that structural check). The original
+// bug report reproduced this by racing a client disconnect against a real HTTP
+// request's timing window — necessarily probabilistic and slow. Canceling the context
+// BEFORE the call even starts removes the timing dependency entirely while exercising
+// the identical failure mode: if LogAuditEvent used ctx directly, ls.db.WithContext(ctx)
+// would refuse to even begin the transaction, and this write would fail with "context
+// canceled" -- exactly the gap #1650 demonstrated live on a real mutation.
+func TestLogAuditEvent_SucceedsWithAlreadyCanceledCallerContext(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled before LogAuditEvent is ever called
+
+	tr := true
+	event := &models.AuditEvent{
+		EventType: "role.assigned", Description: "canceled-caller-context regression",
+		Success: &tr, EventTime: time.Now().UTC(), ActorType: "user",
+	}
+	err := ls.LogAuditEvent(ctx, event)
+	require.NoError(t, err, "an audit write must succeed even when its caller's context was already canceled (#1650) -- a committed mutation must never end up with zero audit record just because the triggering request disconnected")
+
+	logs, total, err := ls.GetAuditLogs(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	assert.Equal(t, "role.assigned", logs[0].EventType)
+}

--- a/internal/storage/store/local_audit_chain.go
+++ b/internal/storage/store/local_audit_chain.go
@@ -133,6 +133,11 @@ func computeAuditEntryHash(e *models.AuditEvent, prevHash string) string {
 // hash chain (ADR-029). The read-chain-head + insert is serialized so the chain
 // stays well-formed under concurrent writers.
 func (ls *LocalStorage) LogAuditEvent(ctx context.Context, event *models.AuditEvent) error {
+	// #1650: detach from the caller's cancellation before the transaction below runs —
+	// see auditWriteContext's doc comment for the full rationale.
+	ctx, cancel := auditWriteContext(ctx)
+	defer cancel()
+
 	// Truncate to microseconds before both hashing and storage so the stored
 	// timestamp equals the hashed one on every backend (Postgres timestamptz is
 	// µs-precision; an un-truncated nanosecond time would not round-trip).

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -25,6 +25,10 @@ import (
 // path for a remote-storage follower's emitAudit calls; the hub's /audit/logs
 // (GET) and /audit/rbac-logs (GET) routes only serve reads.
 func (rs *RemoteStorage) LogAuditEvent(ctx context.Context, event *models.AuditEvent) error {
+	// #1650: detach from the caller's cancellation before the outbound HTTP call --
+	// see auditWriteContext's doc comment for the full rationale.
+	ctx, cancel := auditWriteContext(ctx)
+	defer cancel()
 	resp, err := rs.client.Post(ctx, apiAuditIngestPath, event)
 	if err != nil {
 		return fmt.Errorf("failed to log audit event: %w", err)

--- a/internal/storage/store/remote_wire_route_coverage_test.go
+++ b/internal/storage/store/remote_wire_route_coverage_test.go
@@ -959,8 +959,8 @@ var knownUnresolvedWireCalls = map[string]wireCallExclusion{
 	// struct fields) — real, scoped, but more work than the BinaryExpr cases
 	// above, which is exactly why this campaign's own past attempts stopped at
 	// literal/Sprintf/local-var and never reached this category.
-	"remote_audit.go:53":    helperReturnEntry("buildAuditFilterPath(filter)"),
-	"remote_audit.go:95":    helperReturnEntry("buildRBACAuditFilterPath(filter)"),
+	"remote_audit.go:57":    helperReturnEntry("buildAuditFilterPath(filter)"),
+	"remote_audit.go:99":    helperReturnEntry("buildRBACAuditFilterPath(filter)"),
 	"remote_secrets.go:422": helperReturnEntry("buildSecretFilterPath(filter)"),
 	"remote_users.go:514":   helperReturnEntry("buildUserFilterPath(filter)"),
 
@@ -977,7 +977,7 @@ var knownUnresolvedWireCalls = map[string]wireCallExclusion{
 	// function for them. kindTemporary: a real, scoped, mechanical fix --
 	// give extractWireCalls a constants.go-scoped constPaths map, the same
 	// shape extractRouterRoutes already has for router.go.
-	"remote_audit.go:28":    constRefEntry("apiAuditIngestPath (internal/storage/store/constants.go), a package const declared outside this call's function body"),
+	"remote_audit.go:32":    constRefEntry("apiAuditIngestPath (internal/storage/store/constants.go), a package const declared outside this call's function body"),
 	"remote_secrets.go:148": constRefEntry("apiSecretsPath (internal/storage/store/constants.go), a package const declared outside this call's function body"),
 	"remote_users.go:225":   constRefEntry("apiUsersPath (internal/storage/store/constants.go), a package const declared outside this call's function body"),
 }


### PR DESCRIPTION
## Summary
- Closes #1650 (HIGH, bordering CRITICAL): a mutation could commit while its audit record silently never got written, because the audit write shared the mutation's request context -- a client disconnecting between the two committing turned "mutation succeeded" into "mutation succeeded, unaudited."
- Fixed at the lowest common layer instead of at the originally-reported call site: grepped every caller of `storage.LogAuditEvent` and found **four** direct entry points, not one -- `core.emitAudit` (the ~190-call-site choke point the original report focused on), plus three direct bypasses: `server/main.go`'s shutdown-audit write, `audit_ingest_proxy.go`'s remote-event ingestion, and `internal/core/anomaly.go`'s business-hours-config audit. Fixing `emitAudit` alone would have left the other three vulnerable -- fixing both concrete `LogAuditEvent` implementations (`LocalStorage`'s and `RemoteStorage`'s) covers all four, and any future fifth caller, by construction.
- `auditWriteContext` (`internal/storage/store/audit_write_context.go`) detaches from the caller's cancellation via `context.WithoutCancel` (preserving every value on it) and re-bounds the result with its own 10s timeout. Both implementations call it as the first thing they do.

## Test plan
- [x] `TestLogAuditEvent_SucceedsWithAlreadyCanceledCallerContext` -- deterministic (no timing race): cancels the caller's context before calling `LogAuditEvent`, asserts the write still succeeds and is queryable. Confirmed red before the fix (temporarily reverted just `LocalStorage`'s change, re-ran: got the exact original symptom, `context canceled`).
- [x] `TestLogAuditEventImplementations_DetachFromCallerCancellation` -- repo-wide `go/ast` structural guard: discovers every method literally named `LogAuditEvent` anywhere in the repo (excluding test mocks) and fails if any doesn't call `auditWriteContext`. Confirmed red before the fix (temporarily reverted both implementations, re-ran: both correctly flagged by file:type name).
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/storage/store/... ./internal/core/... ./internal/storage/... ./server/...` -- all green
- [x] `gosec -severity medium -exclude-generated` on touched packages -- 0 issues
- [x] `golangci-lint run` on touched packages -- 0 new issues (1 pre-existing, unrelated staticcheck finding in `oidc_jwks.go`, a file this PR never touches)
- [x] Fixed `remote_wire_route_coverage_test.go`'s line-number-keyed allowlist entries, shifted by the `auditWriteContext` insertion in `remote_audit.go` (no route/path semantics changed, confirmed by re-running that guard test)