### PR TITLE
fix(cli,http): #1648 -- invite list authority check; DeleteEnvironmentProxy scoping

### DIFF
--- a/internal/cli/invite/invite_s26_test.go
+++ b/internal/cli/invite/invite_s26_test.go
@@ -105,10 +105,11 @@ func TestRunList_ListInvitationsFails(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sqlDB.Close())
 
-	origProject, origStale := listProject, listStaleDays
-	defer func() { listProject = origProject; listStaleDays = origStale }()
+	origProject, origStale, origBy := listProject, listStaleDays, listBy
+	defer func() { listProject = origProject; listStaleDays = origStale; listBy = origBy }()
 	listProject = ""
 	listStaleDays = 0
+	listBy = "admin@example.com"
 
 	err = runList(nil, nil)
 	require.Error(t, err)
@@ -138,10 +139,11 @@ func TestRunList_StaleInvitationsFails(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sqlDB.Close())
 
-	origProject, origStale := listProject, listStaleDays
-	defer func() { listProject = origProject; listStaleDays = origStale }()
+	origProject, origStale, origBy := listProject, listStaleDays, listBy
+	defer func() { listProject = origProject; listStaleDays = origStale; listBy = origBy }()
 	listProject = ""
 	listStaleDays = 7
+	listBy = "admin@example.com"
 
 	err = runList(nil, nil)
 	require.Error(t, err)

--- a/internal/cli/invite/invite_s2_test.go
+++ b/internal/cli/invite/invite_s2_test.go
@@ -109,12 +109,13 @@ func TestRunList_StaleDays(t *testing.T) {
 
 	_, _ = seedInviteDB(t)
 
-	origProject, origStale := listProject, listStaleDays
-	defer func() { listProject = origProject; listStaleDays = origStale }()
+	origProject, origStale, origBy := listProject, listStaleDays, listBy
+	defer func() { listProject = origProject; listStaleDays = origStale; listBy = origBy }()
 	listProject = ""
 	listStaleDays = 7 // trigger the stale-days branch (StaleInvitations call)
+	listBy = "admin@example.com"
 
-	_ = runList(nil, nil)
+	require.NoError(t, runList(nil, nil))
 }
 
 // TestRunList_EmptyResult seeds a project but filters with an extremely large
@@ -129,12 +130,13 @@ func TestRunList_EmptyResult(t *testing.T) {
 
 	_, _ = seedInviteDB(t)
 
-	origProject, origStale := listProject, listStaleDays
-	defer func() { listProject = origProject; listStaleDays = origStale }()
+	origProject, origStale, origBy := listProject, listStaleDays, listBy
+	defer func() { listProject = origProject; listStaleDays = origStale; listBy = origBy }()
 	listProject = ""
 	listStaleDays = 36500 // 100 years — nothing is that old → empty result
+	listBy = "admin@example.com"
 
-	_ = runList(nil, nil)
+	require.NoError(t, runList(nil, nil))
 }
 
 // TestRunList_WithInvitations seeds a project with an invitation and lists with
@@ -148,12 +150,13 @@ func TestRunList_WithInvitations(t *testing.T) {
 
 	_, _ = seedInviteDB(t)
 
-	origProject, origStale := listProject, listStaleDays
-	defer func() { listProject = origProject; listStaleDays = origStale }()
+	origProject, origStale, origBy := listProject, listStaleDays, listBy
+	defer func() { listProject = origProject; listStaleDays = origStale; listBy = origBy }()
 	listProject = ""
 	listStaleDays = 0 // normal list — returns all invitations for the project
+	listBy = "admin@example.com"
 
-	_ = runList(nil, nil)
+	require.NoError(t, runList(nil, nil))
 }
 
 // ──────────────────────────── runRevoke ──────────────────────────────────────

--- a/internal/cli/invite/invite_test.go
+++ b/internal/cli/invite/invite_test.go
@@ -37,8 +37,13 @@ func TestInviteRevokeRequiredFlags(t *testing.T) {
 }
 
 func TestInviteListFlags(t *testing.T) {
-	assert.NotNil(t, listCmd.Flags().Lookup("project"))
-	assert.NotNil(t, listCmd.Flags().Lookup("stale-days"))
+	for _, name := range []string{"project", "stale-days", "by"} {
+		assert.NotNil(t, listCmd.Flags().Lookup(name), "list should have --%s", name)
+	}
+	// #1648: --by must be required -- without it, list had no authorization check
+	// at all (any embedded-CLI invoker could read any project's invitations).
+	byFlag := listCmd.Flags().Lookup("by")
+	assert.NotEmpty(t, byFlag.Annotations[cobraRequired], "--by should be marked required")
 }
 
 // cobraRequired is the annotation key cobra uses to mark required flags.

--- a/internal/cli/invite/list.go
+++ b/internal/cli/invite/list.go
@@ -13,6 +13,7 @@ import (
 var (
 	listProject   string
 	listStaleDays int
+	listBy        string
 )
 
 var listCmd = &cobra.Command{
@@ -25,6 +26,8 @@ var listCmd = &cobra.Command{
 func init() {
 	listCmd.Flags().StringVar(&listProject, "project", "", "Project name (or use KEYORIX_PROJECT / active project)")
 	listCmd.Flags().IntVar(&listStaleDays, "stale-days", 0, "Show only pending invitations older than this many days")
+	listCmd.Flags().StringVar(&listBy, "by", "", "Viewer email address (required, for authorization)")
+	_ = listCmd.MarkFlagRequired("by")
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -40,6 +43,22 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 	projectID, err := common.LookupProjectIDByName(ctx, service.Storage(), projectName)
 	if err != nil {
+		return err
+	}
+
+	// #1648: mirrors send/revoke/resend's identical guard (requireInviteAuthority,
+	// invite.go) and the structurally identical request/list.go's requireListAuthority
+	// -- without it, --by resolving ANY email with zero authority check let an
+	// operator read an arbitrary project's pending invitations (invitee email,
+	// intended role, state) purely by naming an arbitrary or unprivileged account.
+	// ListProjectInvitations itself does not check permissions (the HTTP handler's
+	// job is done by router middleware), so this must be verified here, at the CLI
+	// entrypoint, before the list is returned.
+	viewerID, err := resolveUserID(ctx, service, listBy)
+	if err != nil {
+		return err
+	}
+	if err := requireInviteAuthority(ctx, service, viewerID, projectID); err != nil {
 		return err
 	}
 

--- a/internal/cli/invite/list_authority_test.go
+++ b/internal/cli/invite/list_authority_test.go
@@ -1,0 +1,98 @@
+package invite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunList_CrossProjectAttackerRejected is #1648's exact live-demonstrated
+// exploit, as a permanent regression test: an attacker who holds a role in a
+// DIFFERENT project (not merely no role at all) must not be able to list
+// project "default"'s invitations by naming themselves via --by. Before the
+// fix, runList performed no authorization check whatsoever, so any --by email
+// that resolved to a real user succeeded regardless of that user's actual
+// project membership.
+func TestRunList_CrossProjectAttackerRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_PROJECT", "default")
+
+	// Seed bootstrap DB: creates the "default" project (id=1) and an invitation
+	// on it -- this is the data the attacker must NOT be able to list.
+	_, invID := seedInviteDB(t)
+	require.NotZero(t, invID, "need a real invitation on the default project for this test to mean anything")
+
+	ctx := context.Background()
+	svc, svcErr := common.InitializeCoreService()
+	require.NoError(t, svcErr)
+
+	// A second, unrelated project the attacker DOES have a real role in --
+	// project_admin, not a placeholder: this proves the rejection is genuinely
+	// project-scoped, not just "has any role at all".
+	otherProject, err := svc.CreateProject(ctx, "attacker-owned-project", "")
+	require.NoError(t, err)
+
+	attackerEmail := "cross_project_attacker@example.com"
+	attacker, err := svc.Storage().CreateUser(ctx, &models.User{
+		Username: "crossprojectattacker", Email: attackerEmail, IsActive: true,
+	})
+	require.NoError(t, err)
+	adminRole, err := svc.Storage().GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	require.NoError(t, svc.Storage().AssignRole(ctx, attacker.ID, adminRole.ID, core.Scope{ProjectID: otherProject.ID}))
+
+	origProject, origStale, origBy := listProject, listStaleDays, listBy
+	defer func() { listProject = origProject; listStaleDays = origStale; listBy = origBy }()
+	listProject = "default"
+	listStaleDays = 0
+	listBy = attackerEmail
+
+	err = runList(nil, nil)
+	require.Error(t, err, "an attacker with a role in a DIFFERENT project must be refused, not shown the default project's invitations")
+	assert.Contains(t, err.Error(), "roles.assign")
+}
+
+// TestRunList_LegitimateProjectAdminAllowed is the positive control for the
+// test above: a user who genuinely holds roles.assign on the TARGET project
+// must still be able to list its invitations -- the fix must not have turned
+// this into a fully-broken command.
+func TestRunList_LegitimateProjectAdminAllowed(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_PROJECT", "default")
+
+	_, invID := seedInviteDB(t)
+	require.NotZero(t, invID)
+
+	ctx := context.Background()
+	svc, svcErr := common.InitializeCoreService()
+	require.NoError(t, svcErr)
+
+	legitEmail := "legit_default_project_admin@example.com"
+	legit, err := svc.Storage().CreateUser(ctx, &models.User{
+		Username: "legitdefaultprojectadmin", Email: legitEmail, IsActive: true,
+	})
+	require.NoError(t, err)
+	adminRole, err := svc.Storage().GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	// project_id=1 is the "default" project seedInviteDB/BootstrapSystem creates.
+	require.NoError(t, svc.Storage().AssignRole(ctx, legit.ID, adminRole.ID, core.Scope{ProjectID: 1}))
+
+	origProject, origStale, origBy := listProject, listStaleDays, listBy
+	defer func() { listProject = origProject; listStaleDays = origStale; listBy = origBy }()
+	listProject = "default"
+	listStaleDays = 0
+	listBy = legitEmail
+
+	require.NoError(t, runList(nil, nil), "a user holding roles.assign on the target project must still be able to list its invitations")
+}

--- a/server/http/delete_environment_proxy_scope_test.go
+++ b/server/http/delete_environment_proxy_scope_test.go
@@ -1,0 +1,145 @@
+// delete_environment_proxy_scope_test.go proves #1648's second finding: the
+// /system group's system.write gate alone let ANY holder of that permission
+// delete ANY environment on the hub, with no check that the caller is
+// authorized against the SPECIFIC environment's project — the same gap
+// DeleteProjectProxy's own fix (delete_project_proxy_scope_test.go) closed for
+// projects, never propagated to its structurally identical environment
+// sibling. The human-facing DELETE /api/v1/environments/{id} route requires
+// secrets.delete scoped via ScopeFromEnvParam("id"); DeleteEnvironmentProxy now
+// requires the same, layered on top of the group's existing system.write gate.
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// createSystemWriteAndProjectSecretsDeleteTokenForEnv is
+// createSystemWriteAndProjectSecretsDeleteToken's environment-route analog:
+// system.write GLOBALLY (clears the /system group's own gate) plus
+// secrets.delete SCOPED TO projectID only (clears DeleteEnvironmentProxy's new
+// per-environment check, since ScopeFromEnvParam resolves the environment's
+// OWNING project). A distinct role/username from the project-proxy test's
+// helper so the two tests' fixtures never collide within one test binary.
+func createSystemWriteAndProjectSecretsDeleteTokenForEnv(t *testing.T, c *core.KeyorixCore, projectID uint) string {
+	t.Helper()
+	ctx := context.Background()
+
+	user, err := c.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "sys_write_env_secrets_delete", Email: "sys_write_env_secrets_delete@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.RemoveRoleFromUser(ctx, "sys_write_env_secrets_delete@example.com", "system_viewer"))
+
+	globalRole, err := c.Storage().CreateRole(ctx, &models.Role{
+		Name: "ceiling_test_system_writer_delenv_global", Description: "test-only role: system.write only, granted globally",
+	})
+	require.NoError(t, err)
+	scopedRole, err := c.Storage().CreateRole(ctx, &models.Role{
+		Name: "ceiling_test_system_writer_delenv_scoped", Description: "test-only role: secrets.delete only, granted at one project's scope",
+	})
+	require.NoError(t, err)
+
+	perms, err := c.ListPermissions(ctx)
+	require.NoError(t, err)
+	var systemWriteID, secretsDeleteID uint
+	for _, p := range perms {
+		switch p.Name {
+		case "system.write":
+			systemWriteID = p.ID
+		case "secrets.delete":
+			secretsDeleteID = p.ID
+		}
+	}
+	require.NotZero(t, systemWriteID, "system.write permission must already be seeded by bootstrap")
+	require.NotZero(t, secretsDeleteID, "secrets.delete permission must already be seeded by bootstrap")
+
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, globalRole.ID, systemWriteID, false))
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, scopedRole.ID, secretsDeleteID, false))
+	require.NoError(t, c.Storage().AssignRole(ctx, user.ID, globalRole.ID, coreStorage.Scope{}))
+	require.NoError(t, c.Storage().AssignRole(ctx, user.ID, scopedRole.ID, coreStorage.Scope{ProjectID: projectID}))
+
+	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "sys_write_env_secrets_delete", Password: "Qr7#Kp2$Lm5@Vn9!"})
+	require.NoError(t, err)
+	return sess.SessionToken
+}
+
+// TestDeleteEnvironmentProxy_SystemWriteOnly_CannotDeleteEnvironment is the
+// fix's red case: a caller holding system.write but NOT secrets.delete on the
+// target environment's project must be refused — before the fix, the group's
+// system.write gate was the ONLY check, so this caller could delete any
+// environment on the hub. The scope predicate is asserted by querying storage
+// directly afterward (the environment must still exist), not just by reading
+// the handler's response.
+func TestDeleteEnvironmentProxy_SystemWriteOnly_CannotDeleteEnvironment(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	upstream := newTestCore(t)
+	ctx := context.Background()
+	createTestToken(t, upstream) // bootstrap admin + seed roles/permissions (incl. system.write, secrets.delete)
+	project, err := upstream.CreateProject(ctx, "Delete Env Scope Test Project", "")
+	require.NoError(t, err)
+	env, err := upstream.CreateEnvironment(ctx, project.ID, "scope-test-env")
+	require.NoError(t, err)
+
+	cfg := &config.Config{}
+	router, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	token := createSystemWriteOnlyToken(t, upstream)
+	rs := newDeleteProjectScopeRemoteClient(t, srv.URL, token)
+
+	err = rs.DeleteEnvironment(ctx, env.ID)
+	require.Error(t, err, "CEILING VIOLATED: system.write alone must not be sufficient to delete an environment in a project the caller holds no secrets.delete grant on")
+
+	// Scope predicate asserted at the query, not just the handler response.
+	_, getErr := upstream.Storage().GetEnvironment(ctx, env.ID)
+	assert.NoError(t, getErr, "the environment must still exist after a denied delete attempt")
+}
+
+// TestDeleteEnvironmentProxy_SystemWriteAndScopedSecretsDelete_Succeeds is the
+// fix's positive control: the legitimate caller the fix must keep working --
+// system.write (to clear the group's own gate) plus secrets.delete scoped to
+// the environment's project (to clear the new per-environment check) -- can
+// still delete it, exactly like the human-facing DeleteEnvironment route
+// already allows.
+func TestDeleteEnvironmentProxy_SystemWriteAndScopedSecretsDelete_Succeeds(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	upstream := newTestCore(t)
+	ctx := context.Background()
+	createTestToken(t, upstream)
+	project, err := upstream.CreateProject(ctx, "Delete Env Scope Allow Test Project", "")
+	require.NoError(t, err)
+	env, err := upstream.CreateEnvironment(ctx, project.ID, "scope-allow-test-env")
+	require.NoError(t, err)
+
+	cfg := &config.Config{}
+	router, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	token := createSystemWriteAndProjectSecretsDeleteTokenForEnv(t, upstream, project.ID)
+	rs := newDeleteProjectScopeRemoteClient(t, srv.URL, token)
+
+	require.NoError(t, rs.DeleteEnvironment(ctx, env.ID))
+
+	// Scope predicate asserted at the query, not just the handler response.
+	_, getErr := upstream.Storage().GetEnvironment(ctx, env.ID)
+	assert.Error(t, getErr, "the environment must actually be gone after an authorized delete")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -2014,7 +2014,22 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get(pathProjectEnvs, catalogHandler.ListEnvironmentsByProjectProxy)
 			r.Get("/environments", catalogHandler.ListEnvironmentsProxy)
 			r.Get(pathEnvironmentsID, catalogHandler.GetEnvironmentProxy)
-			r.Delete(pathEnvironmentsID, catalogHandler.DeleteEnvironmentProxy)
+			// DeleteEnvironmentProxy (#1648): the same gap DeleteProjectProxy's own
+			// fix above closed, for the same reason -- the group's system.write gate
+			// alone let ANY holder of that permission delete ANY environment on this
+			// hub, with no check that the caller is actually authorized against THIS
+			// environment's project. Deleting an environment is exactly as
+			// destructive/irreversible as deleting a project, so it gets the same
+			// treatment: mirrors the human-facing DeleteEnvironment route's own check
+			// (permSecretsDelete scoped via ScopeFromEnvParam, line ~583), layered on
+			// top of, not replacing, the group's system.write gate. This does NOT
+			// extend to the group's read routes above (ListProjectsProxy,
+			// GetProjectProxy, ListProjectMembersProxy, ListEnvironmentsByProjectProxy,
+			// GetEnvironmentProxy, etc.) -- this group's own doc comment already states
+			// those are deliberately flat-gated on system.write with no per-project
+			// scoping, "reads included," by design (see the group header comment
+			// above); only destructive/irreversible writes get this additional layer.
+			r.With(customMiddleware.RequireScopedPermission(permSecretsDelete, customMiddleware.ScopeFromEnvParam("id"))).Delete(pathEnvironmentsID, catalogHandler.DeleteEnvironmentProxy)
 
 			// Audit-event ingest proxy (#r122-A). Lets a downstream Keyorix server
 			// booted with storage.type: remote persist its emitAudit-emitted events


### PR DESCRIPTION
## Summary
- Closes #1648. Two findings, one narrowed after re-tracing before fixing (see correction comment posted on #1648 before this PR).
- **Finding 1 (confirmed, fixed as reported):** `internal/cli/invite/list.go`'s `runList` had zero authorization check -- no `--by`, no actor resolution. Fixed by adding the required `--by` flag and reusing `requireInviteAuthority` directly (the same check `send`/`revoke`/`resend` already use in the same package, not reimplemented).
- **Finding 2 (corrected -- significantly narrowed):** the original report characterized the entire `/system` proxy tree's flat `system.write` gate as under-scoped, based on `DeleteProjectProxy`'s own per-project scoping fix. Re-tracing found `router.go`'s own doc comment explicitly states the flat gate (reads included) is deliberate, documented design for this whole route group -- and `DeleteProjectProxy`'s fix is itself commented as a called-out *exception*, specific to destructive/irreversible operations. Of the 13 routes originally flagged, 12 are not defects (they match stated intent); only `DeleteEnvironmentProxy` was a genuine, undone analog to `DeleteProjectProxy`'s already-fixed gap, and is fixed here identically.

## Test plan
- [x] `TestRunList_CrossProjectAttackerRejected` / `TestRunList_LegitimateProjectAdminAllowed` -- exploit-shaped regression test: an attacker holding a REAL role in a DIFFERENT project (not just no role at all) is refused with the exact `roles.assign` error; positive control confirms a legitimately project-scoped caller still succeeds and sees the invitation. Confirmed red before the fix (temporarily neutralized the check in `list.go`, re-ran: the attacker's list actually printed to stdout -- the exact original leak).
- [x] `TestDeleteEnvironmentProxy_SystemWriteOnly_CannotDeleteEnvironment` / `TestDeleteEnvironmentProxy_SystemWriteAndScopedSecretsDelete_Succeeds` -- modeled directly on the existing `delete_project_proxy_scope_test.go`; scope predicate asserted via a direct storage query in both cases, not just the HTTP response. Confirmed red before the fix (temporarily reverted the router.go scoping, re-ran: system.write-only caller successfully deleted the environment).
- [x] Updated 5 pre-existing `internal/cli/invite` tests that call `runList` directly and would otherwise have silently stopped exercising their intended branches (list-formatting, stale-days filtering, empty-result) once `--by` became required -- set `listBy` to the seeded admin's email in each, matching this package's own established test convention for `sendBy`/`revokeBy`/`resendBy`.
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/cli/invite/... ./server/http/...` -- all green
- [x] `gosec -severity medium -exclude-generated` on touched packages -- 0 issues
- [x] `golangci-lint run` on touched packages -- 0 issues