### PR TITLE
fix(identity): #1642 -- constructor-enforced Unicode/case normalization for identity fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,15 @@ Reasoning and incidents behind these: `docs/g80-remediation-notes.md`.
     5 handlers orphaned by that same scheduler fix stayed classified "uncertain," not
     "safe," until the fix's actual effect on the scheduler path was confirmed — only
     then reclassified to no-caller/delete.
+  - A demonstration proves reachability only at the layer actually demonstrated, not
+    the whole path to it: #1642's recon called `storage.NewStorageFactory().CreateStorage(cfg)`
+    directly and genuinely demonstrated an NFC/NFD project-name collision at the storage
+    layer — real demonstration, done correctly. It wasn't reachable through any live
+    caller: `internal/core`'s `validateProjectName` rejects non-ASCII before any real
+    request reaches storage. The demonstration wasn't wrong; treating it as proof the
+    *application* was reachable was the gap. Pair every storage/DB-layer demonstration
+    with a trace of whether a live caller can drive that exact code path with that exact
+    input — don't infer application-level reachability from a lower-layer repro alone.
 - Ask of any mechanism: what does it silently skip, and does it say so?
 - **A ceiling that inspects only the target is not a ceiling.** A privilege-ceiling
   check must derive the ceiling from the ACTOR's own effective privileges as well as

--- a/docs/compliance/SECURITY-FAQ.md
+++ b/docs/compliance/SECURITY-FAQ.md
@@ -143,3 +143,11 @@ We would rather tell you these up front than have you find them:
   item.
 - **No independent certification yet** — NIS2/DORA/ISO mappings are informational;
   detailed reviewed reports are targeted for Q3 2026.
+- **`keyorix run`'s injected secrets are readable via OS process-environment
+  introspection** — for the lifetime of the child process, any process able to
+  read this OS user's process environment (e.g. another local process, or an
+  operator with shell access to the host) can read an injected secret value.
+  This is inherent to how OS environment variables work, not unique to
+  Keyorix (direnv/dotenv share it), and not fixable at the application layer
+  — `--clean-env` isolates the child from the invoking shell's leftover
+  variables, not from external process-environment readers.

--- a/internal/cli/rbac/rbac_s17_test.go
+++ b/internal/cli/rbac/rbac_s17_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
@@ -74,9 +75,13 @@ func TestListRoles_EmbeddedMode_WithRoles(t *testing.T) {
 	_, st := initEmbeddedDB(t)
 
 	ctx := context.Background()
-	_, err := st.CreateRole(ctx, &models.Role{Name: "s17_admin", Description: "S17 Admin"})
+	s17AdminName, err := identity.NewFoldedName("s17_admin")
 	require.NoError(t, err)
-	_, err = st.CreateRole(ctx, &models.Role{Name: "s17_viewer", Description: "S17 Viewer"})
+	_, err = st.CreateRole(ctx, s17AdminName, "S17 Admin")
+	require.NoError(t, err)
+	s17ViewerName, err := identity.NewFoldedName("s17_viewer")
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, s17ViewerName, "S17 Viewer")
 	require.NoError(t, err)
 
 	errRun := runListRoles(nil, nil)
@@ -99,7 +104,9 @@ func TestListUserRoles_EmbeddedMode_UserWithRoles(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	role, err := st.CreateRole(ctx, &models.Role{Name: "s17_editor", Description: "S17 Editor"})
+	s17EditorName, err := identity.NewFoldedName("s17_editor")
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, s17EditorName, "S17 Editor")
 	require.NoError(t, err)
 
 	require.NoError(t, st.AssignRole(ctx, user.ID, role.ID, corestorage.Scope{}))
@@ -150,7 +157,9 @@ func TestListPermissions_EmbeddedMode_UserWithPermissions(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	role, err := st.CreateRole(ctx, &models.Role{Name: "s17_permrole", Description: "S17 perm role"})
+	s17PermRoleName, err := identity.NewFoldedName("s17_permrole")
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, s17PermRoleName, "S17 perm role")
 	require.NoError(t, err)
 
 	perm, err := st.CreatePermission(ctx, &models.Permission{

--- a/internal/cli/rbac/rbac_scope_cov_test.go
+++ b/internal/cli/rbac/rbac_scope_cov_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -110,7 +111,9 @@ func TestRunAssignRole_Embedded_GlobalScope(t *testing.T) {
 
 	_, err := st.CreateUser(ctx, &models.User{Username: "assign-global", Email: "assign-global@example.com"})
 	require.NoError(t, err)
-	_, err = st.CreateRole(ctx, &models.Role{Name: "assign-global-role", Description: "test"})
+	assignGlobalRoleName, err := identity.NewFoldedName("assign-global-role")
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, assignGlobalRoleName, "test")
 	require.NoError(t, err)
 
 	orig, origR, origP, origE := userEmail, roleName, assignProjectFlag, assignEnvFlag
@@ -133,7 +136,9 @@ func TestRunAssignRole_Embedded_WithProject(t *testing.T) {
 
 	_, err := st.CreateUser(ctx, &models.User{Username: "assign-proj", Email: "assign-proj@example.com"})
 	require.NoError(t, err)
-	_, err = st.CreateRole(ctx, &models.Role{Name: "assign-proj-role", Description: "test"})
+	assignProjRoleName, err := identity.NewFoldedName("assign-proj-role")
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, assignProjRoleName, "test")
 	require.NoError(t, err)
 	_, err = st.CreateProject(ctx, &models.Project{Name: "assign-proj-project"})
 	require.NoError(t, err)
@@ -178,7 +183,9 @@ func TestRunRemoveRole_Embedded_GlobalScope(t *testing.T) {
 
 	user, err := st.CreateUser(ctx, &models.User{Username: "remove-global", Email: "remove-global@example.com"})
 	require.NoError(t, err)
-	role, err := st.CreateRole(ctx, &models.Role{Name: "remove-global-role", Description: "test"})
+	removeGlobalRoleName, err := identity.NewFoldedName("remove-global-role")
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, removeGlobalRoleName, "test")
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRole(ctx, user.ID, role.ID, corestorage.Scope{}))
 
@@ -207,7 +214,9 @@ func TestRunRemoveRole_Embedded_WithProjectAndEnv(t *testing.T) {
 
 	user, err := st.CreateUser(ctx, &models.User{Username: "remove-scoped", Email: "remove-scoped@example.com"})
 	require.NoError(t, err)
-	role, err := st.CreateRole(ctx, &models.Role{Name: "remove-scoped-role", Description: "test"})
+	removeScopedRoleName, err := identity.NewFoldedName("remove-scoped-role")
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, removeScopedRoleName, "test")
 	require.NoError(t, err)
 	proj, err := st.CreateProject(ctx, &models.Project{Name: "remove-scoped-proj"})
 	require.NoError(t, err)
@@ -264,7 +273,9 @@ func TestRunAssignRoleToGroup_Embedded_GlobalScope(t *testing.T) {
 
 	_, err := st.CreateGroup(ctx, &models.Group{Name: "embed-group-assign", Description: ""})
 	require.NoError(t, err)
-	_, err = st.CreateRole(ctx, &models.Role{Name: "embed-group-role-assign", Description: "test"})
+	embedGroupRoleAssignName, err := identity.NewFoldedName("embed-group-role-assign")
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, embedGroupRoleAssignName, "test")
 	require.NoError(t, err)
 
 	origG, origR, origP, origE, origT := groupRoleGroupFlag, groupRoleName, groupRoleProjectFlag, groupRoleEnvFlag, groupRoleTTL
@@ -293,7 +304,9 @@ func TestRunAssignRoleToGroup_Embedded_WithProject(t *testing.T) {
 
 	_, err := st.CreateGroup(ctx, &models.Group{Name: "embed-group-proj", Description: ""})
 	require.NoError(t, err)
-	_, err = st.CreateRole(ctx, &models.Role{Name: "embed-group-role-proj", Description: "test"})
+	embedGroupRoleProjName, err := identity.NewFoldedName("embed-group-role-proj")
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, embedGroupRoleProjName, "test")
 	require.NoError(t, err)
 	_, err = st.CreateProject(ctx, &models.Project{Name: "embed-group-project"})
 	require.NoError(t, err)
@@ -355,7 +368,9 @@ func TestRunRemoveRoleFromGroup_Embedded_Success(t *testing.T) {
 
 	grp, err := st.CreateGroup(ctx, &models.Group{Name: "embed-grp-remove", Description: ""})
 	require.NoError(t, err)
-	role, err := st.CreateRole(ctx, &models.Role{Name: "embed-grp-role-remove", Description: "test"})
+	embedGrpRoleRemoveName, err := identity.NewFoldedName("embed-grp-role-remove")
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, embedGrpRoleRemoveName, "test")
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRoleToGroup(ctx, grp.ID, role.ID, corestorage.Scope{}))
 
@@ -385,7 +400,9 @@ func TestRunListGroupRoles_Embedded_WithRoles(t *testing.T) {
 
 	grp, err := st.CreateGroup(ctx, &models.Group{Name: "embed-grp-list", Description: ""})
 	require.NoError(t, err)
-	role, err := st.CreateRole(ctx, &models.Role{Name: "embed-grp-list-role", Description: "test"})
+	embedGrpListRoleName, err := identity.NewFoldedName("embed-grp-list-role")
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, embedGrpListRoleName, "test")
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRoleToGroup(ctx, grp.ID, role.ID, corestorage.Scope{}))
 
@@ -422,7 +439,9 @@ func TestResolveRoleIDEmbedded_Success(t *testing.T) {
 	_, st := initEmbeddedDB(t)
 	ctx := context.Background()
 
-	role, err := st.CreateRole(ctx, &models.Role{Name: "embed-resolve-role", Description: "test"})
+	embedResolveRoleName, err := identity.NewFoldedName("embed-resolve-role")
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, embedResolveRoleName, "test")
 	require.NoError(t, err)
 
 	id, err := resolveRoleIDEmbedded(ctx, st, "embed-resolve-role")
@@ -720,7 +739,9 @@ func TestRunAssignRoleToGroup_GroupNotFound(t *testing.T) {
 	ctx := context.Background()
 
 	// Seed a role so resolveRoleIDEmbedded would succeed if we got that far.
-	_, err := st.CreateRole(ctx, &models.Role{Name: "g-grp-nf-role", Description: "test"})
+	gGrpNfRoleName, err := identity.NewFoldedName("g-grp-nf-role")
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, gGrpNfRoleName, "test")
 	require.NoError(t, err)
 
 	origG, origR, origP, origE, origT := groupRoleGroupFlag, groupRoleName, groupRoleProjectFlag, groupRoleEnvFlag, groupRoleTTL
@@ -752,7 +773,9 @@ func TestRunAssignRoleToGroup_ScopeError(t *testing.T) {
 
 	_, err := st.CreateGroup(ctx, &models.Group{Name: "grp-scope-err", Description: ""})
 	require.NoError(t, err)
-	_, err = st.CreateRole(ctx, &models.Role{Name: "grp-scope-err-role", Description: "test"})
+	grpScopeErrRoleName, err := identity.NewFoldedName("grp-scope-err-role")
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, grpScopeErrRoleName, "test")
 	require.NoError(t, err)
 
 	origG, origR, origP, origE, origT := groupRoleGroupFlag, groupRoleName, groupRoleProjectFlag, groupRoleEnvFlag, groupRoleTTL
@@ -848,7 +871,9 @@ func TestRunRemoveRoleFromGroup_ScopeError(t *testing.T) {
 
 	_, err := st.CreateGroup(ctx, &models.Group{Name: "rrfg-scope-err", Description: ""})
 	require.NoError(t, err)
-	_, err = st.CreateRole(ctx, &models.Role{Name: "rrfg-scope-role", Description: "test"})
+	rrfgScopeRoleName, err := identity.NewFoldedName("rrfg-scope-role")
+	require.NoError(t, err)
+	_, err = st.CreateRole(ctx, rrfgScopeRoleName, "test")
 	require.NoError(t, err)
 
 	origG, origR, origP, origE := removeGroupRoleGroupFlag, removeGroupRoleName, removeGroupRoleProjectFlag, removeGroupRoleEnvFlag
@@ -1629,7 +1654,9 @@ func TestRunCheckPermission_Embedded_HasPermission(t *testing.T) {
 
 	user, err := st.CreateUser(ctx, &models.User{Username: "chkperm-yes", Email: "chkperm-yes@example.com"})
 	require.NoError(t, err)
-	role, err := st.CreateRole(ctx, &models.Role{Name: "chkperm-role", Description: "test"})
+	chkPermRoleName, err := identity.NewFoldedName("chkperm-role")
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, chkPermRoleName, "test")
 	require.NoError(t, err)
 	perm, err := st.CreatePermission(ctx, &models.Permission{
 		Name: "chkperm.read", Resource: "chkperm", Action: "read", Description: "test",

--- a/internal/cli/request/bulk_test.go
+++ b/internal/cli/request/bulk_test.go
@@ -50,7 +50,7 @@ func withUserSeededPartialService(t *testing.T, email string) {
 	// Migrate ONLY the users table so GetUserByEmail works.
 	require.NoError(t, db.AutoMigrate(&models.User{}))
 	require.NoError(t, db.Create(&models.User{
-		Username: "admin", Email: email, IsActive: true,
+		Username: "admin", UsernameFolded: "admin", Email: email, EmailFolded: email, IsActive: true,
 	}).Error)
 	svc := core.NewKeyorixCore(store.NewLocalStorage(db))
 	orig := bulkInitService

--- a/internal/cli/request/request_s2_test.go
+++ b/internal/cli/request/request_s2_test.go
@@ -38,7 +38,7 @@ func TestResolveUserID_ExistingEmail(t *testing.T) {
 	svc, st := newTestRequestCore(t)
 	ctx := context.Background()
 
-	u, err := st.CreateUser(ctx, &models.User{Username: "bob", Email: "bob@example.com", IsActive: true})
+	u, err := st.CreateUser(ctx, &models.User{Username: "bob", UsernameFolded: "bob", Email: "bob@example.com", EmailFolded: "bob@example.com", IsActive: true})
 	require.NoError(t, err)
 
 	id, err := resolveUserID(ctx, svc, "bob@example.com")

--- a/internal/cli/request/request_s3_test.go
+++ b/internal/cli/request/request_s3_test.go
@@ -440,7 +440,7 @@ func TestRunReview_RejectAuth_UnprivilegedUser(t *testing.T) {
 
 	// Create a plain viewer with no roles.assign.
 	viewer, err := svc.Storage().CreateUser(ctx, &models.User{
-		Username: "viewer-only", Email: "viewer@example.com", IsActive: true,
+		Username: "viewer-only", UsernameFolded: "viewer-only", Email: "viewer@example.com", EmailFolded: "viewer@example.com", IsActive: true,
 	})
 	require.NoError(t, err)
 

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -59,7 +59,14 @@ Environment isolation:
     (plus a minimal PATH/HOME baseline) instead — use this when you don't
     want the child to also see whatever else is already exported in the
     invoking shell (a leftover token from a prior 'keyorix run', an
-    unrelated CI secret, etc.).`,
+    unrelated CI secret, etc.).
+  • --clean-env isolates the child from the INVOKING SHELL's leftover
+    variables only. It does not isolate the secret from other observers: for
+    the lifetime of the child process, any process able to read this OS
+    user's process environment (e.g. another local process, or an operator
+    with shell access to the host) can read the injected values — the same
+    limitation every environment-variable-based secret injector shares, not
+    something Keyorix can close.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runRun,
 }

--- a/internal/core/auth_bootstrap.go
+++ b/internal/core/auth_bootstrap.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -289,10 +290,11 @@ func (c *KeyorixCore) bootstrapSystemLocked(ctx context.Context, req *BootstrapR
 
 	roleIDs := make(map[string]uint, len(defaultRoles))
 	for _, rdef := range defaultRoles {
-		role, err := c.storage.CreateRole(ctx, &models.Role{
-			Name:        rdef.Name,
-			Description: rdef.Description,
-		})
+		foldedName, ferr := identity.NewFoldedName(rdef.Name)
+		if ferr != nil {
+			return nil, fmt.Errorf("failed to normalize seed role name %s: %w", rdef.Name, ferr)
+		}
+		role, err := c.storage.CreateRole(ctx, foldedName, rdef.Description)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create role %s: %w", rdef.Name, err)
 		}

--- a/internal/core/break_glass_external_test.go
+++ b/internal/core/break_glass_external_test.go
@@ -499,8 +499,9 @@ func TestActivateBreakGlass_RejectsRoleAssignEmergencyRole(t *testing.T) {
 	makeProjectMember(t, h, 10, proj)
 
 	// A delegated, NON-admin role that nonetheless carries roles.assign (perm id 13).
-	h.ExecuteRawSQL(t, "INSERT OR IGNORE INTO roles (id, name, description) VALUES (?, ?, ?)",
-		50, "delegated_approver", "non-admin role that can assign roles")
+	// name_folded is NOT NULL (#1642); already pure-lowercase ASCII.
+	h.ExecuteRawSQL(t, "INSERT OR IGNORE INTO roles (id, name, name_folded, description) VALUES (?, ?, ?, ?)",
+		50, "delegated_approver", "delegated_approver", "non-admin role that can assign roles")
 	h.ExecuteRawSQL(t, "INSERT OR IGNORE INTO role_permissions (role_id, permission_id) VALUES (?, ?)", 50, 13)
 
 	enableBreakGlass(h, "delegated_approver", 4*time.Hour, 24*time.Hour)

--- a/internal/core/bulk_access_requests_integration_test.go
+++ b/internal/core/bulk_access_requests_integration_test.go
@@ -74,9 +74,10 @@ func setupBulkAccessDB(t *testing.T) (k *KeyorixCore, db *gorm.DB, approverID, r
 	require.NoError(t, err)
 	projectID = p.ID
 
-	// Seed roles: admin (id=1) and editor (id=2).
-	require.NoError(t, db.Exec("INSERT INTO roles (id,name,description) VALUES (1,'admin','Admin')").Error)
-	require.NoError(t, db.Exec("INSERT INTO roles (id,name,description) VALUES (2,'editor','Editor')").Error)
+	// Seed roles: admin (id=1) and editor (id=2). name_folded is NOT NULL
+	// (#1642); both names are already pure-lowercase ASCII.
+	require.NoError(t, db.Exec("INSERT INTO roles (id,name,name_folded,description) VALUES (1,'admin','admin','Admin')").Error)
+	require.NoError(t, db.Exec("INSERT INTO roles (id,name,name_folded,description) VALUES (2,'editor','editor','Editor')").Error)
 
 	// Permissions for admin so the ceiling check passes.
 	perms := []struct {
@@ -97,14 +98,16 @@ func setupBulkAccessDB(t *testing.T) (k *KeyorixCore, db *gorm.DB, approverID, r
 	db.Exec("INSERT OR IGNORE INTO role_permissions (role_id,permission_id) VALUES (2,2)") // secrets.write
 	db.Exec("INSERT OR IGNORE INTO role_permissions (role_id,permission_id) VALUES (2,5)") // users.read
 
-	// Approver user (holds global admin role).
-	require.NoError(t, db.Exec("INSERT INTO users (id,username,email) VALUES (10,'approver','approver@example.com')").Error)
+	// Approver user (holds global admin role). username_folded/email_folded
+	// are the columns GetUserByUsername/GetUserByEmail actually query (#1642);
+	// both values here are already pure-lowercase ASCII.
+	require.NoError(t, db.Exec("INSERT INTO users (id,username,username_folded,email,email_folded) VALUES (10,'approver','approver','approver@example.com','approver@example.com')").Error)
 	approverID = 10
 	// Grant approver the admin role at the project scope.
 	require.NoError(t, db.Exec("INSERT INTO user_roles (user_id,role_id,project_id) VALUES (10,1,?)", projectID).Error)
 
 	// Requester user (no role yet).
-	require.NoError(t, db.Exec("INSERT INTO users (id,username,email) VALUES (11,'requester','requester@example.com')").Error)
+	require.NoError(t, db.Exec("INSERT INTO users (id,username,username_folded,email,email_folded) VALUES (11,'requester','requester','requester@example.com','requester@example.com')").Error)
 	requesterID = 11
 
 	return
@@ -165,9 +168,11 @@ func TestBulkApproveAccessRequests_AtBatchLimit_RealApprovals(t *testing.T) {
 	ids := make([]uint, maxBulkAccessRequestBatchSize)
 	for i := range ids {
 		userID := uint(1000 + i)
+		username := fmt.Sprintf("requester%d", i)
+		email := fmt.Sprintf("requester%d@example.com", i)
 		require.NoError(t, db.Exec(
-			"INSERT INTO users (id,username,email) VALUES (?,?,?)",
-			userID, fmt.Sprintf("requester%d", i), fmt.Sprintf("requester%d@example.com", i),
+			"INSERT INTO users (id,username,username_folded,email,email_folded) VALUES (?,?,?,?,?)",
+			userID, username, username, email, email,
 		).Error)
 		ids[i] = seedPendingRequest(t, k, projectID, userID, "editor")
 	}

--- a/internal/core/classification_gate_test.go
+++ b/internal/core/classification_gate_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
@@ -211,7 +212,9 @@ func seedRestrictedPermissionFixture(t *testing.T, st *store.LocalStorage) (secr
 	perm, err := st.CreatePermission(ctx, &models.Permission{Name: PermSecretReadRestricted})
 	require.NoError(t, err)
 
-	role, err := st.CreateRole(ctx, &models.Role{Name: "restricted-reader"})
+	restrictedReaderName, err := identity.NewFoldedName("restricted-reader")
+	require.NoError(t, err)
+	role, err := st.CreateRole(ctx, restrictedReaderName, "")
 	require.NoError(t, err)
 
 	require.NoError(t, st.AssignPermissionToRole(ctx, role.ID, perm.ID))

--- a/internal/core/concurrency_create_user_test.go
+++ b/internal/core/concurrency_create_user_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -34,11 +35,13 @@ func TestConcurrency_CreateUser_NoDuplicateEmail(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.User{}))
-	// Mirror factory.go's ensureUserEmailIndex exactly: a partial, case-insensitive
-	// unique index on live rows, so this test exercises the same DB-level guard
-	// production installs get, not just the (removed) in-process check-then-act read.
-	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active "+
-		"ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error)
+	// Mirror factory.go's ensureUserEmailIndex exactly (#1642: on email_folded,
+	// not a SQL-side LOWER(email) expression -- see EmailFolded's doc comment
+	// for why): a partial, case-insensitive unique index on live rows, so this
+	// test exercises the same DB-level guard production installs get, not just
+	// the (removed) in-process check-then-act read.
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_folded_active "+
+		"ON users (email_folded) WHERE deleted_at IS NULL AND email <> ''").Error)
 
 	ls := store.NewLocalStorage(db)
 
@@ -58,9 +61,15 @@ func TestConcurrency_CreateUser_NoDuplicateEmail(t *testing.T) {
 			if i%2 == 1 {
 				email = "bob@example.com"
 			}
+			username := fmt.Sprintf("bob%d", i)
 			_, cerr := ls.CreateUser(context.Background(), &models.User{
-				Username: fmt.Sprintf("bob%d", i),
-				Email:    email,
+				Username:       username,
+				UsernameFolded: username,
+				Email:          email,
+				// #1642: fold here the same way core.buildUserForCreate does —
+				// this is the actual point of the test: two different-CASE
+				// emails must fold to the identical value and collide.
+				EmailFolded: strings.ToLower(email),
 			})
 			errs[i] = cerr
 		}(i)

--- a/internal/core/concurrency_login_lockout_test.go
+++ b/internal/core/concurrency_login_lockout_test.go
@@ -36,7 +36,7 @@ func TestConcurrency_LoginLockout_NoLostIncrements(t *testing.T) {
 	const password = "Secret#Pass123"
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost) // MinCost: keep the race tight
 	require.NoError(t, err)
-	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", PasswordHash: string(hash), AccountState: core.AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", UsernameFolded: "alice", PasswordHash: string(hash), AccountState: core.AccountActive}).Error)
 
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	const maxAttempts = 5

--- a/internal/core/concurrency_login_lockout_toctou_test.go
+++ b/internal/core/concurrency_login_lockout_toctou_test.go
@@ -75,7 +75,7 @@ func TestLogin_TOCTOU_ConcurrentLockTripBeforeMintIsRefused(t *testing.T) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&models.User{
-		ID: 1, Username: "alice", PasswordHash: string(hash), AccountState: core.AccountActive,
+		ID: 1, Username: "alice", UsernameFolded: "alice", PasswordHash: string(hash), AccountState: core.AccountActive,
 	}).Error)
 
 	wrapped := &raceInjectingStorage{
@@ -121,7 +121,7 @@ func TestConcurrency_LoginLockout_MixedBurstCorrectPasswordAmongLockedNeverMints
 	// attempt from the burst is enough to lock the account — maximizing the
 	// chance the burst genuinely races the correct-password attempt's recheck.
 	require.NoError(t, db.Create(&models.User{
-		ID: 1, Username: "alice", PasswordHash: string(hash), AccountState: core.AccountActive,
+		ID: 1, Username: "alice", UsernameFolded: "alice", PasswordHash: string(hash), AccountState: core.AccountActive,
 		FailedLoginAttempts: maxAttempts - 1,
 	}).Error)
 

--- a/internal/core/concurrency_password_reset_throttle_test.go
+++ b/internal/core/concurrency_password_reset_throttle_test.go
@@ -51,7 +51,7 @@ func TestConcurrency_RequestPasswordReset_BurstIsThrottled(t *testing.T) {
 
 	const email = "victim@acme.io"
 	require.NoError(t, db.Create(&models.User{
-		ID: 1, Username: "victim", Email: email, AccountState: core.AccountActive,
+		ID: 1, Username: "victim", UsernameFolded: "victim", Email: email, EmailFolded: email, AccountState: core.AccountActive,
 	}).Error)
 
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))

--- a/internal/core/concurrency_scim_update_email_test.go
+++ b/internal/core/concurrency_scim_update_email_test.go
@@ -39,19 +39,24 @@ func TestConcurrency_UpdateSCIMUser_NoDuplicateEmail(t *testing.T) {
 		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.Session{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{},
 	))
-	// Mirror factory.go's ensureUserEmailIndex exactly, so this test exercises the same
-	// DB-level guard production installs get (rather than only the in-process
-	// check-then-act read).
-	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active "+
-		"ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error)
+	// Mirror factory.go's ensureUserEmailIndex exactly (#1642: the folded-column
+	// index, not the old SQL-side LOWER() index this test used to create — SQL-side
+	// LOWER() is ASCII-only on modernc/SQLite and locale-dependent on Postgres, so it
+	// enforces different uniqueness per backend for the same login identity), so this
+	// test exercises the same DB-level guard production installs get (rather than
+	// only the in-process check-then-act read).
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_folded_active "+
+		"ON users (email_folded) WHERE deleted_at IS NULL AND email <> ''").Error)
 
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
 
 	const attackers = 20 // many concurrent SCIM updates racing to claim the same email
 	for i := 0; i < attackers; i++ {
+		username := fmt.Sprintf("user%d", i)
+		email := fmt.Sprintf("user%d@x.io", i)
 		require.NoError(t, db.Create(&models.User{
-			ID: uint(i + 1), Username: fmt.Sprintf("user%d", i), Email: fmt.Sprintf("user%d@x.io", i),
+			ID: uint(i + 1), Username: username, UsernameFolded: username, Email: email, EmailFolded: email,
 			IsActive: true, AccountState: core.AccountActive, ExternalID: fmt.Sprintf("okta|user%d", i),
 		}).Error)
 	}

--- a/internal/core/concurrency_sod_grant_postgres_test.go
+++ b/internal/core/concurrency_sod_grant_postgres_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	localstore "github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
@@ -70,10 +71,14 @@ func TestConcurrency_AssignUserRole_CrossReplicaPostgres_SoDBypass(t *testing.T)
 	require.NotZero(t, rolesAssignID, "roles.assign must be seeded")
 	require.NotZero(t, secretsDeleteID, "secrets.delete must be seeded")
 
-	roleA, err := setupCore.Storage().CreateRole(ctx, &models.Role{Name: "sod-race-role-a", Description: "grants roles.assign"})
+	roleAName, err := identity.NewFoldedName("sod-race-role-a")
+	require.NoError(t, err)
+	roleA, err := setupCore.Storage().CreateRole(ctx, roleAName, "grants roles.assign")
 	require.NoError(t, err)
 	require.NoError(t, setupCore.AssignPermissionToRole(ctx, 0, roleA.ID, rolesAssignID, false))
-	roleB, err := setupCore.Storage().CreateRole(ctx, &models.Role{Name: "sod-race-role-b", Description: "grants secrets.delete"})
+	roleBName, err := identity.NewFoldedName("sod-race-role-b")
+	require.NoError(t, err)
+	roleB, err := setupCore.Storage().CreateRole(ctx, roleBName, "grants secrets.delete")
 	require.NoError(t, err)
 	require.NoError(t, setupCore.AssignPermissionToRole(ctx, 0, roleB.ID, secretsDeleteID, false))
 

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -28,7 +29,15 @@ func (c *KeyorixCore) CreateGroup(ctx context.Context, actorID uint, req *Create
 	if err := c.validateCreateGroupRequest(req); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
-	group := &models.Group{Name: req.Name, Description: req.Description}
+	// #1642: fold once here — group names are identity (a human reads them to
+	// decide who's a member), so "Support Team"/"support team" and NFC/NFD
+	// forms of the same name must collide, not coexist as two indistinguishable
+	// groups.
+	foldedName, ferr := identity.NewFoldedName(req.Name)
+	if ferr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+	}
+	group := &models.Group{Name: req.Name, NameFolded: foldedName.Folded(), Description: req.Description}
 	created, err := c.storage.CreateGroup(ctx, group)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
@@ -60,7 +69,12 @@ func (c *KeyorixCore) UpdateGroup(ctx context.Context, actorID uint, req *Update
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	if req.Name != "" {
+		foldedName, ferr := identity.NewFoldedName(req.Name)
+		if ferr != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+		}
 		group.Name = req.Name
+		group.NameFolded = foldedName.Folded()
 	}
 	if req.Description != "" {
 		group.Description = req.Description

--- a/internal/core/login_lockout_test.go
+++ b/internal/core/login_lockout_test.go
@@ -27,7 +27,8 @@ func newLockoutTestCore(t *testing.T, enabled bool) (*KeyorixCore, *gorm.DB, *ti
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{}))
 	hash, err := bcrypt.GenerateFromPassword([]byte(lockoutTestPassword), bcrypt.DefaultCost)
 	require.NoError(t, err)
-	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", PasswordHash: string(hash), AccountState: AccountActive}).Error)
+	// UsernameFolded is what GetUserByUsername actually queries (#1642); "alice" is already its own folded form.
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", UsernameFolded: "alice", PasswordHash: string(hash), AccountState: AccountActive}).Error)
 
 	clock := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return clock }, passwordPolicy: DefaultPasswordPolicy()}

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -31,7 +31,7 @@ func newMFATestCore(t *testing.T) (*KeyorixCore, *gorm.DB, time.Time) {
 		&models.MFARecoveryCode{}, &models.MFAChallenge{}, &models.Session{}, &models.AuditEvent{},
 		&models.MFAStepupToken{}, &models.MFAStepUpGrant{}))
 	hash, _ := bcrypt.GenerateFromPassword([]byte(mfaTestPassword), bcrypt.DefaultCost)
-	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@b.com",
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", UsernameFolded: "alice", Email: "a@b.com", EmailFolded: "a@b.com",
 		PasswordHash: string(hash), AccountState: "active"}).Error)
 
 	enc := encryption.NewService(&config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}, t.TempDir())

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/mock"
 )
@@ -1113,8 +1114,8 @@ func (m *MockStorage) ListGroupMembersByGroupIDs(ctx context.Context, groupIDs [
 
 // Role Management
 
-func (m *MockStorage) CreateRole(ctx context.Context, role *models.Role) (*models.Role, error) {
-	args := m.Called(ctx, role)
+func (m *MockStorage) CreateRole(ctx context.Context, name identity.FoldedName, description string) (*models.Role, error) {
+	args := m.Called(ctx, name, description)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/core/rbac_reconcile_test.go
+++ b/internal/core/rbac_reconcile_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
@@ -37,7 +38,9 @@ func seedOldCatalog(t *testing.T, c *KeyorixCore, db *gorm.DB) {
 		require.NoError(t, err)
 	}
 	for _, rdef := range defaultRoles {
-		role, err := c.storage.CreateRole(ctx, &models.Role{Name: rdef.Name, Description: rdef.Description})
+		rdefFoldedName, err := identity.NewFoldedName(rdef.Name)
+		require.NoError(t, err)
+		role, err := c.storage.CreateRole(ctx, rdefFoldedName, rdef.Description)
 		require.NoError(t, err)
 		for _, permName := range rdef.Permissions {
 			if permName == "connect.read" {
@@ -97,7 +100,9 @@ func seedOldCatalogWithoutPlatformUse(t *testing.T, c *KeyorixCore, db *gorm.DB)
 		require.NoError(t, err)
 	}
 	for _, rdef := range defaultRoles {
-		role, err := c.storage.CreateRole(ctx, &models.Role{Name: rdef.Name, Description: rdef.Description})
+		rdefFoldedName, err := identity.NewFoldedName(rdef.Name)
+		require.NoError(t, err)
+		role, err := c.storage.CreateRole(ctx, rdefFoldedName, rdef.Description)
 		require.NoError(t, err)
 		for _, permName := range rdef.Permissions {
 			if permName == "connect.platform.use" {

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -174,8 +175,22 @@ func (c *KeyorixCore) ProvisionSCIMUser(ctx context.Context, actorID uint, userN
 	if !active {
 		state = AccountDeprovisioned
 	}
+	// #1642: SCIM-provisioned usernames/emails come from an external IdP and
+	// bypass buildUserForCreate entirely, so they need their own fold here —
+	// otherwise an IdP-asserted "Admin"/non-ASCII identity could collide with
+	// (or duplicate) an existing account in a way neither uniqueness check
+	// below would catch.
+	foldedUsername, ferr := identity.NewFoldedName(username)
+	if ferr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+	}
+	foldedEmail, ferr := identity.NewFoldedName(email)
+	if ferr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+	}
 	created, err := c.storage.CreateUser(ctx, &models.User{
-		Username: username, Email: email, DisplayName: displayName,
+		Username: username, UsernameFolded: foldedUsername.Folded(),
+		Email: email, EmailFolded: foldedEmail.Folded(), DisplayName: displayName,
 		PasswordHash: hash, IsActive: active, AccountState: state, ExternalID: externalID,
 		PasswordChangedAt: &now, CreatedAt: now, UpdatedAt: now,
 	})
@@ -341,7 +356,15 @@ func (c *KeyorixCore) scimUpdateUserTx(ctx context.Context, tx storage.Storage, 
 		user.DisplayName = *displayName
 	}
 	if email != nil && *email != "" {
+		// #1642: keep EmailFolded in lockstep with Email on every write path,
+		// not just core.UpdateUser's -- a stale EmailFolded here would make
+		// GetUserByEmail keep resolving to the user's OLD address forever.
+		folded, ferr := identity.NewFoldedName(*email)
+		if ferr != nil {
+			return nil, false, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+		}
 		user.Email = *email
+		user.EmailFolded = folded.Folded()
 	}
 	deactivated := false
 	applySCIMActiveState(user, active, &deactivated)

--- a/internal/core/scim_groups.go
+++ b/internal/core/scim_groups.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -116,9 +117,17 @@ func (c *KeyorixCore) ProvisionSCIMGroup(ctx context.Context, actorID uint, disp
 	if len(rejected) > 0 {
 		return nil, fmt.Errorf("%s: SCIM can only add SCIM-managed users to a group (rejected member id(s): %v)", i18n.T("ErrorNotAuthorized", nil), rejected)
 	}
+	// #1642: SCIM-provisioned group names come from an external IdP and
+	// bypass core.CreateGroup entirely (see the storage-direct note below),
+	// so they need their own fold — mirrors ProvisionSCIMUser's identical
+	// treatment (scim.go).
+	foldedName, ferr := identity.NewFoldedName(displayName)
+	if ferr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+	}
 	// Storage-direct: the SCIM path emits its own scim.group_provisioned event below,
 	// so it must not also fire the generic group.created from CreateGroup.
-	group, err := c.storage.CreateGroup(ctx, &models.Group{Name: displayName})
+	group, err := c.storage.CreateGroup(ctx, &models.Group{Name: displayName, NameFolded: foldedName.Folded()})
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +150,16 @@ func (c *KeyorixCore) ReplaceSCIMGroup(ctx context.Context, actorID, groupID uin
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
 	}
 	if displayName != "" && displayName != group.Name {
+		// #1642: keep NameFolded in lockstep with Name on every rename path,
+		// not just core.UpdateGroup's — a stale NameFolded here would leave
+		// the DB's uniqueness index checking a value that no longer matches
+		// the group's actual display name.
+		foldedName, ferr := identity.NewFoldedName(displayName)
+		if ferr != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+		}
 		group.Name = displayName
+		group.NameFolded = foldedName.Folded()
 		if _, err := c.storage.UpdateGroup(ctx, group); err != nil {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 		}
@@ -181,7 +199,12 @@ func (c *KeyorixCore) PatchSCIMGroup(ctx context.Context, actorID, groupID uint,
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
 	}
 	if newName != nil && *newName != "" && *newName != group.Name {
+		foldedName, ferr := identity.NewFoldedName(*newName)
+		if ferr != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+		}
 		group.Name = *newName
+		group.NameFolded = foldedName.Folded()
 		if _, err := c.storage.UpdateGroup(ctx, group); err != nil {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 		}

--- a/internal/core/scim_guards_test.go
+++ b/internal/core/scim_guards_test.go
@@ -33,8 +33,10 @@ func newSCIMGuardCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
 func TestUpdateSCIMUser_RejectsEmailCollision(t *testing.T) {
 	c, db := newSCIMGuardCore(t)
 	ctx := context.Background()
-	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "admin@x.io", IsActive: true, AccountState: AccountActive}).Error)
-	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", Email: "bob@x.io", IsActive: true, AccountState: AccountActive, ExternalID: "okta|bob"}).Error)
+	// EmailFolded is what the collision check's GetUserByEmail actually
+	// queries (#1642); both addresses are already their own folded form.
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", UsernameFolded: "admin", Email: "admin@x.io", EmailFolded: "admin@x.io", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", UsernameFolded: "bob", Email: "bob@x.io", EmailFolded: "bob@x.io", IsActive: true, AccountState: AccountActive, ExternalID: "okta|bob"}).Error)
 
 	adminEmail := "admin@x.io"
 	_, err := c.UpdateSCIMUser(ctx, 9, 2, nil, &adminEmail, nil)
@@ -247,18 +249,20 @@ func TestLocalStorage_UpdateUser_DuplicateEmailWrapsSentinel(t *testing.T) {
 	c, db := newSCIMGuardCore(t)
 	_ = c
 	// Install the same partial unique index production installs get (mirrors
-	// factory.go's ensureUserEmailIndex), since newSCIMGuardCore's in-memory AutoMigrate
-	// doesn't run the storage-factory migration path that creates it.
-	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active "+
-		"ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error)
+	// factory.go's ensureUserEmailIndex — #1642: on email_folded, not a
+	// SQL-side LOWER(email) expression), since newSCIMGuardCore's in-memory
+	// AutoMigrate doesn't run the storage-factory migration path that creates it.
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_folded_active "+
+		"ON users (email_folded) WHERE deleted_at IS NULL AND email <> ''").Error)
 	ctx := context.Background()
-	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "alice@x.io", IsActive: true, AccountState: AccountActive}).Error)
-	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", Email: "bob@x.io", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", UsernameFolded: "alice", Email: "alice@x.io", EmailFolded: "alice@x.io", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "bob", UsernameFolded: "bob", Email: "bob@x.io", EmailFolded: "bob@x.io", IsActive: true, AccountState: AccountActive}).Error)
 
 	ls := store.NewLocalStorage(db)
 	u2, err := ls.GetUser(ctx, 2)
 	require.NoError(t, err)
 	u2.Email = "alice@x.io" // collides with user 1
+	u2.EmailFolded = "alice@x.io"
 	_, err = ls.UpdateUser(ctx, u2)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, corestorage.ErrDuplicateEmail),

--- a/internal/core/secret_bulk_rename.go
+++ b/internal/core/secret_bulk_rename.go
@@ -14,6 +14,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/identity"
 )
 
 // Rename outcome statuses.
@@ -93,6 +95,18 @@ func (c *KeyorixCore) BulkRenameSecrets(ctx context.Context, projectID uint, ren
 			skip(rn.ID, "", "", "new name is empty")
 			continue
 		}
+		// #1642: normalize once here, use for the unchanged-check, the
+		// uniqueness check, and the stored value — GetSecretByName below
+		// already normalizes its own lookup key, but the pre-normalization
+		// newName must never be what actually gets written, or the stored
+		// row would end up in whatever form the caller happened to submit
+		// instead of the canonical NFC form CreateSecret always stores.
+		normalizedName, nerr := identity.NewAddressName(newName)
+		if nerr != nil {
+			skip(rn.ID, "", newName, "invalid name: "+nerr.Error())
+			continue
+		}
+		newName = normalizedName.String()
 
 		// #G14: "not found", "belongs to another project", and "not authorized" are
 		// collapsed into one uniform denial below — a distinct message per case

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -82,6 +83,15 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 	if err := c.validateSecretName(req.Name); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
+	// #1642: NFC-normalize once here, use everywhere below (the duplicate-name
+	// pre-check and the stored row) — secret names are addresses, not
+	// human-verified identity, so unlike username/role/group this does NOT
+	// fold case (PROD_KEY and prod_key must remain distinct); it only closes
+	// the NFC-vs-NFD collision gap.
+	normalizedName, nerr := identity.NewAddressName(req.Name)
+	if nerr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), nerr)
+	}
 	if len(strings.TrimSpace(req.Description)) > maxSecretDescriptionLen {
 		return nil, fmt.Errorf("%s: description exceeds %d characters", i18n.T("ErrorValidation", nil), maxSecretDescriptionLen)
 	}
@@ -103,7 +113,7 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 		return nil, fmt.Errorf("environment %d does not belong to project %d", req.EnvironmentID, req.ProjectID)
 	}
 
-	existing, err := c.storage.GetSecretByName(ctx, req.Name, req.ProjectID, req.EnvironmentID)
+	existing, err := c.storage.GetSecretByName(ctx, normalizedName.String(), req.ProjectID, req.EnvironmentID)
 	if err == nil && existing != nil {
 		return nil, fmt.Errorf("%s", i18n.T("ErrorSecretAlreadyExists", nil))
 	}
@@ -139,7 +149,7 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 	}
 
 	secret := &models.SecretNode{
-		Name:                   req.Name,
+		Name:                   normalizedName.String(),
 		ProjectID:              req.ProjectID,
 		EnvironmentID:          req.EnvironmentID,
 		Type:                   req.Type,
@@ -538,6 +548,15 @@ func (c *KeyorixCore) CreateFolder(
 	if name == "" {
 		return nil, fmt.Errorf("%s: folder name is required", i18n.T("ErrorValidation", nil))
 	}
+	// #1642: folders share secret_nodes' (project, environment, name) unique
+	// index with secrets, so they share the identical NFC-vs-NFD collision
+	// risk CreateSecret closes above — normalize here the same way, not
+	// case-folded (a folder name is an address/path segment, not identity).
+	normalizedFolderName, nerr := identity.NewAddressName(name)
+	if nerr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), nerr)
+	}
+	name = normalizedFolderName.String()
 	if projectID == 0 {
 		return nil, fmt.Errorf("%s: project_id is required", i18n.T("ErrorValidation", nil))
 	}

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	samlpkg "github.com/keyorixhq/keyorix/internal/saml"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -530,8 +531,20 @@ func (c *KeyorixCore) provisionSSOUser(ctx context.Context, p *SSOProvider, sub,
 		displayName = email
 	}
 	now := c.now()
+	// #1642: SSO JIT-provisioned usernames/emails come from the IdP's own
+	// claims and bypass buildUserForCreate entirely -- fold here, mirroring
+	// ProvisionSCIMUser's identical treatment (scim.go).
+	foldedUsername, ferr := identity.NewFoldedName(username)
+	if ferr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+	}
+	foldedEmail, ferr := identity.NewFoldedName(email)
+	if ferr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+	}
 	created, err := c.storage.CreateUser(ctx, &models.User{
-		Username: username, Email: email, DisplayName: displayName,
+		Username: username, UsernameFolded: foldedUsername.Folded(),
+		Email: email, EmailFolded: foldedEmail.Folded(), DisplayName: displayName,
 		PasswordHash: hash, IsActive: true, AccountState: AccountActive, ExternalID: ssoExternalID(p.Name, sub),
 		PasswordChangedAt: &now, CreatedAt: now, UpdatedAt: now,
 	})

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -983,7 +984,19 @@ type Storage interface {
 	AssignPermissionToRole(ctx context.Context, roleID, permissionID uint) error
 
 	// Role Management
-	CreateRole(ctx context.Context, role *models.Role) (*models.Role, error)
+	//
+	// CreateRole takes a typed identity.FoldedName, not a raw string or a
+	// pre-built *models.Role, deliberately (#1642): both server/http and
+	// server/grpc's role-creation handlers call this directly, bypassing
+	// internal/core entirely (no length cap, no charset check, no
+	// normalization of any kind existed before this). Patching each of those
+	// two known call sites to construct a FoldedName themselves would still
+	// let a third, future caller bypass it again by passing a raw string —
+	// putting the typed parameter in the signature makes every caller,
+	// present and future, go through identity.NewFoldedName's validation
+	// (which also rejects control characters and bidi-override characters as
+	// part of the PRECIS profile) or fail to compile.
+	CreateRole(ctx context.Context, name identity.FoldedName, description string) (*models.Role, error)
 	GetRole(ctx context.Context, id uint) (*models.Role, error)
 	GetRoleByName(ctx context.Context, name string) (*models.Role, error)
 	UpdateRole(ctx context.Context, role *models.Role) (*models.Role, error)

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -72,6 +73,18 @@ func (c *KeyorixCore) buildUserForCreate(ctx context.Context, req *CreateUserReq
 		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
 
+	// #1642: fold once here, use everywhere below — the constructor is the
+	// single point every username/email must pass through before it can reach
+	// a comparison or a write, so a raw string can never bypass normalization.
+	foldedUsername, err := identity.NewFoldedName(req.Username)
+	if err != nil {
+		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
+	foldedEmail, err := identity.NewFoldedName(req.Email)
+	if err != nil {
+		return nil, "", fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
+
 	displayName := req.DisplayName
 	if displayName == "" {
 		displayName = req.Username
@@ -120,7 +133,9 @@ func (c *KeyorixCore) buildUserForCreate(ctx context.Context, req *CreateUserReq
 	}
 	user := &models.User{
 		Username:          req.Username,
+		UsernameFolded:    foldedUsername.Folded(),
 		Email:             req.Email,
+		EmailFolded:       foldedEmail.Folded(),
 		DisplayName:       displayName,
 		PasswordHash:      string(hash),
 		IsActive:          active,
@@ -352,22 +367,42 @@ func (c *KeyorixCore) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
 	}
 	if req.Username != "" && req.Username != user.Username {
-		if _, err := c.storage.GetUserByUsername(ctx, req.Username); err == nil {
-			return nil, fmt.Errorf("%w: username already exists", ErrUserAlreadyExists)
-		} else if !storage.IsUserNotFound(err) {
-			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		foldedUsername, ferr := identity.NewFoldedName(req.Username)
+		if ferr != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+		}
+		// #1642: a rename that only changes display form/case (folds to the
+		// SAME identity the row already has, e.g. "Bob" -> "bob") must be a
+		// no-op for the uniqueness check -- otherwise GetUserByUsername would
+		// find this exact row under its own about-to-be-replaced folded value
+		// and reject the rename as "already exists" against itself. Only a
+		// genuine identity change needs the collision check.
+		if foldedUsername.Folded() != user.UsernameFolded {
+			if _, err := c.storage.GetUserByUsername(ctx, req.Username); err == nil {
+				return nil, fmt.Errorf("%w: username already exists", ErrUserAlreadyExists)
+			} else if !storage.IsUserNotFound(err) {
+				return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+			}
 		}
 		user.Username = req.Username
+		user.UsernameFolded = foldedUsername.Folded()
 	}
 	if req.Email != "" && req.Email != user.Email {
-		existing, err := c.storage.GetUserByEmail(ctx, req.Email)
-		if err == nil && existing != nil && existing.ID != user.ID {
-			return nil, fmt.Errorf("%w: user with email already exists", ErrUserAlreadyExists)
+		foldedEmail, ferr := identity.NewFoldedName(req.Email)
+		if ferr != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
 		}
-		if err != nil && !storage.IsUserNotFound(err) {
-			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+		if foldedEmail.Folded() != user.EmailFolded {
+			existing, err := c.storage.GetUserByEmail(ctx, req.Email)
+			if err == nil && existing != nil && existing.ID != user.ID {
+				return nil, fmt.Errorf("%w: user with email already exists", ErrUserAlreadyExists)
+			}
+			if err != nil && !storage.IsUserNotFound(err) {
+				return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+			}
 		}
 		user.Email = req.Email
+		user.EmailFolded = foldedEmail.Folded()
 	}
 	if req.DisplayName != "" {
 		user.DisplayName = req.DisplayName

--- a/internal/core/webauthn_test.go
+++ b/internal/core/webauthn_test.go
@@ -30,7 +30,7 @@ func newWebAuthnTestCore(t *testing.T, withRP bool) (*KeyorixCore, *gorm.DB) {
 		&models.MFAChallenge{}, &models.WebAuthnCredential{}, &models.WebAuthnSession{}, &models.Notification{},
 		&models.MFAStepupToken{}, &models.MFAStepUpGrant{}))
 	hash, _ := bcrypt.GenerateFromPassword([]byte(webauthnTestPassword), bcrypt.DefaultCost)
-	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", Email: "a@b.com",
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", UsernameFolded: "alice", Email: "a@b.com", EmailFolded: "a@b.com",
 		PasswordHash: string(hash), AccountState: "active"}).Error)
 
 	fixed := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -1,0 +1,111 @@
+// Package identity provides constructor-enforced Unicode normalization for
+// identity-bearing strings (#1642). A raw string cannot become a FoldedName or
+// AddressName except through NewFoldedName/NewAddressName — so any function
+// that takes one of these types as a parameter, rather than a plain string,
+// cannot be called with an un-normalized value. This is deliberately a
+// function-signature boundary, not a write-vs-read split: a "normalize on
+// write only" design turns a collision bug into a not-found bug the moment a
+// client submits the same identity in a different normalization form on a
+// lookup. Every entry point — INSERT or WHERE — must go through the same
+// constructor.
+//
+// Two profiles, matching two different real-world expectations:
+//
+//   - FoldedName folds case in addition to NFC-normalizing (via a custom
+//     precis Freeform profile: golang.org/x/text/secure/precis's own
+//     UsernameCaseMapped rejects spaces, which would break existing
+//     space-containing usernames/role/group/project names in this codebase —
+//     Freeform allows them). Use for identity a human reads to decide who has
+//     what: usernames, role names, group names, project names. "Admin" and
+//     "admin" coexisting as distinct principals is an impersonation risk
+//     exactly where an access review's value lives.
+//
+//   - AddressName NFC-normalizes only, via precis.OpaqueString, and does NOT
+//     fold case. Use for identity that functions as an address rather than a
+//     human-verified identity: secret names. Operators expect PROD_KEY and
+//     prod_key to remain distinct, the same way environment variables and
+//     filesystem paths are case-sensitive.
+//
+// Both profiles reject control characters and bidirectional-override
+// characters as part of the underlying PRECIS class restrictions (RFC 8264) —
+// this is the first character-set validation several of these fields have
+// ever had, independent of the normalization fix itself.
+package identity
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/text/secure/precis"
+	"golang.org/x/text/unicode/norm"
+)
+
+// ErrEmpty is returned when a name is empty after normalization.
+var ErrEmpty = errors.New("name must not be empty")
+
+// foldedProfile NFC-normalizes and case-folds, allowing spaces (unlike
+// precis.UsernameCaseMapped's Identifier class, which rejects them) since
+// usernames/role/group/project names in this codebase are permitted to
+// contain spaces today (see internal/core/catalog.go's validateIdentifier).
+var foldedProfile = precis.NewFreeform(precis.LowerCase(), precis.Norm(norm.NFC))
+
+// FoldedName is a case-folded, NFC-normalized identity string — the display
+// form as the user typed it, and the folded form used for storage-key
+// comparison/uniqueness. Construct only via NewFoldedName.
+type FoldedName struct {
+	display string
+	folded  string
+}
+
+// NewFoldedName normalizes raw into a FoldedName. Use for usernames, role
+// names, group names, and project names.
+func NewFoldedName(raw string) (FoldedName, error) {
+	folded, err := foldedProfile.String(raw)
+	if err != nil {
+		return FoldedName{}, fmt.Errorf("invalid name %q: %w", raw, err)
+	}
+	if folded == "" {
+		return FoldedName{}, ErrEmpty
+	}
+	return FoldedName{display: raw, folded: folded}, nil
+}
+
+// Display returns the name exactly as the caller supplied it — the form to
+// store in the display column and show in UI/audit output.
+func (n FoldedName) Display() string { return n.display }
+
+// Folded returns the case-folded, NFC-normalized form — the form to store in
+// the indexed/comparison column and use in every WHERE-clause lookup.
+func (n FoldedName) Folded() string { return n.folded }
+
+// String implements fmt.Stringer, returning the display form.
+func (n FoldedName) String() string { return n.display }
+
+// addressProfile NFC-normalizes without folding case, via RFC 8265's
+// OpaqueString profile (freeform class: allows spaces, maps Unicode
+// space-variant runes to plain space, rejects control/bidi characters).
+var addressProfile = precis.OpaqueString
+
+// AddressName is an NFC-normalized, case-preserved identity string.
+// Construct only via NewAddressName.
+type AddressName struct {
+	value string
+}
+
+// NewAddressName normalizes raw into an AddressName. Use for secret names —
+// addresses, not human-verified identity, so case is preserved rather than
+// folded (PROD_KEY and prod_key must remain distinct). precis.OpaqueString
+// itself rejects a raw or transformed-empty value (RFC 8265 DisallowEmpty),
+// so no separate empty check is needed here — contrast with NewFoldedName's
+// custom profile, which doesn't set that option and needs its own check.
+func NewAddressName(raw string) (AddressName, error) {
+	v, err := addressProfile.String(raw)
+	if err != nil {
+		return AddressName{}, fmt.Errorf("invalid name %q: %w", raw, err)
+	}
+	return AddressName{value: v}, nil
+}
+
+// String returns the NFC-normalized value — the single form to store and
+// compare, since this profile does not fold case.
+func (n AddressName) String() string { return n.value }

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -1,0 +1,116 @@
+package identity
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nfcCafe/nfdCafe reproduce #1642's exact live-demonstrated collision: two
+// byte-different, visually-identical representations of "cafe" + acute
+// accent. Built from \u escape sequences (pure ASCII source), not a literal
+// typed/pasted character -- an editor, terminal, or file-write layer can
+// silently re-normalize a literal combining-character sequence to NFC on
+// save, which would make this fixture worthless (the exact gotcha the
+// original #1642 recon itself called out).
+var (
+	nfcCafe = "café"  // e-acute precomposed (U+00E9), 5 bytes UTF-8
+	nfdCafe = "café" // e (U+0065) + combining acute accent (U+0301), 6 bytes UTF-8
+)
+
+func TestNewFoldedName_NFCCollisionResolved(t *testing.T) {
+	require.NotEqual(t, nfcCafe, nfdCafe, "test fixture must actually be byte-different")
+
+	a, err := NewFoldedName(nfcCafe)
+	require.NoError(t, err)
+	b, err := NewFoldedName(nfdCafe)
+	require.NoError(t, err)
+
+	assert.Equal(t, a.Folded(), b.Folded(), "NFC and NFD forms of the same identity must fold to the same key")
+}
+
+func TestNewFoldedName_CaseCollisionResolved(t *testing.T) {
+	a, err := NewFoldedName("Admin")
+	require.NoError(t, err)
+	b, err := NewFoldedName("admin")
+	require.NoError(t, err)
+
+	assert.Equal(t, a.Folded(), b.Folded())
+	// Display form is preserved exactly as typed.
+	assert.Equal(t, "Admin", a.Display())
+	assert.Equal(t, "admin", b.Display())
+}
+
+func TestNewFoldedName_PreservesSpaces(t *testing.T) {
+	n, err := NewFoldedName("Support Team")
+	require.NoError(t, err)
+	assert.Equal(t, "support team", n.Folded())
+	assert.Equal(t, "Support Team", n.Display())
+}
+
+func TestNewFoldedName_RejectsControlCharacters(t *testing.T) {
+	_, err := NewFoldedName("readonly\n[AUDIT] granted admin")
+	require.Error(t, err)
+}
+
+func TestNewFoldedName_RejectsBidiOverride(t *testing.T) {
+	_, err := NewFoldedName("read\u202eonly")
+	require.Error(t, err)
+}
+
+func TestNewFoldedName_RejectsEmpty(t *testing.T) {
+	_, err := NewFoldedName("")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrEmpty))
+}
+
+func TestNewAddressName_NFCCollisionResolved(t *testing.T) {
+	a, err := NewAddressName(nfcCafe)
+	require.NoError(t, err)
+	b, err := NewAddressName(nfdCafe)
+	require.NoError(t, err)
+
+	assert.Equal(t, a.String(), b.String(), "NFC and NFD forms must normalize to the same address")
+}
+
+func TestNewAddressName_DoesNotFoldCase(t *testing.T) {
+	a, err := NewAddressName("PROD_KEY")
+	require.NoError(t, err)
+	b, err := NewAddressName("prod_key")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, a.String(), b.String(), "secret names are addresses -- case must stay distinct")
+	assert.Equal(t, "PROD_KEY", a.String())
+	assert.Equal(t, "prod_key", b.String())
+}
+
+func TestNewAddressName_PreservesSpacesAndPunctuation(t *testing.T) {
+	for _, raw := range []string{"prod.database.url", "prod/database/url", "AWS:SECRET_KEY", "my key with spaces"} {
+		n, err := NewAddressName(raw)
+		require.NoError(t, err, "raw=%q", raw)
+		assert.Equal(t, raw, n.String())
+	}
+}
+
+func TestNewAddressName_RejectsControlCharacters(t *testing.T) {
+	_, err := NewAddressName("key\n[injected]")
+	require.Error(t, err)
+}
+
+func TestNewAddressName_RejectsBidiOverride(t *testing.T) {
+	_, err := NewAddressName("key\u202evalue")
+	require.Error(t, err)
+}
+
+func TestNewAddressName_RejectsEmpty(t *testing.T) {
+	_, err := NewAddressName("")
+	require.Error(t, err)
+}
+
+func TestFoldedName_StringImplementsStringer(t *testing.T) {
+	n, err := NewFoldedName("MyUser")
+	require.NoError(t, err)
+	assert.Equal(t, "MyUser", n.String())
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1661,10 +1661,62 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	if err := ensureProjectNameIndex(db); err != nil {
 		return err
 	}
+	if err := ensureRoleNameIndex(db); err != nil {
+		return err
+	}
+	if err := ensureSecretNodeNameNFC(db); err != nil {
+		return err
+	}
 	if err := ensureShareRecordUniqueIndex(db); err != nil {
 		return err
 	}
 	return ensureSecretVersionIndex(db)
+}
+
+// ensureRoleNameIndex replaces Role.Name's original plain `unique` gorm tag
+// (which only caught byte-identical duplicates) with a partial-free (roles
+// carry no soft-delete) unique index on name_folded — identity.NewFoldedName's
+// NFC+case-fold output, #1642 — so "Admin"/"admin" can't coexist as two
+// indistinguishable roles in an access review. Idempotent; works on both
+// SQLite and Postgres.
+func ensureRoleNameIndex(db *gorm.DB) error {
+	// Drop the unique constraint/index GORM's original `unique` tag on Name
+	// created. GORM names a plain `unique` tag's index uni_<table>_<column>.
+	if err := db.Exec("DROP INDEX IF EXISTS uni_roles_name").Error; err != nil {
+		return fmt.Errorf("failed to drop legacy roles name index: %w", err)
+	}
+	if err := backfillFoldedColumn(db, "roles", "id", "name", "name_folded", "", foldIdentity); err != nil {
+		return err
+	}
+	const idxName = "uniq_roles_name_folded"
+	// #490: other tables (RolePermission, UserRole, GroupRole) reference a
+	// role by ID, so auto-deleting one of two "duplicate name" roles would
+	// silently orphan any real permission grants tied to the deleted role's
+	// ID. Fail loud instead so an operator resolves the collision
+	// deliberately.
+	if !indexExists(db, idxName) {
+		if err := warnIfDuplicatesExist(db, "roles", "name_folded", "",
+			"rename or delete one of the conflicting roles via the application's role API before upgrading"); err != nil {
+			return err
+		}
+	}
+	if err := db.Exec(sqlCreateUniqueIdx + idxName + " ON roles (name_folded)").Error; err != nil {
+		return fmt.Errorf("failed to create roles name_folded index: %w", err)
+	}
+	return nil
+}
+
+// ensureSecretNodeNameNFC NFC-normalizes any pre-existing secret_nodes.name
+// value that isn't already in NFC form (#1642). Unlike the *_folded columns
+// elsewhere in this file, secret names are addresses, not human-verified
+// identity — they are NOT case-folded (PROD_KEY and prod_key must remain
+// distinct) — so there is no separate column: uniq_secret_nodes_project_env_name_active
+// (ensureSecretNodeNameIndex, already byte-exact/case-sensitive on both
+// backends) stays exactly as it is; this only ensures the name column itself
+// never holds two different Unicode representations of what a human reads as
+// the same address.
+func ensureSecretNodeNameNFC(db *gorm.DB) error {
+	return normalizeColumnInPlace(db, "secret_nodes", "id", "name", sqlWhereNotDeleted, normalizeAddress)
 }
 
 // ensureShareRecordUniqueIndex creates a partial unique index on share_records
@@ -1774,27 +1826,38 @@ func ensureDynamicSecretConfigNameIndex(db *gorm.DB) error {
 }
 
 // ensureGroupNameIndex replaces any plain unique index on groups.name with a
-// partial unique index scoped to non-deleted rows, so a soft-deleted group's name
-// is freed for reuse while the group stays restorable. Idempotent; works on both
+// partial unique index on name_folded (identity.NewFoldedName's NFC+case-fold
+// output, #1642), scoped to non-deleted rows so a soft-deleted group's name is
+// freed for reuse while the group stays restorable. Idempotent; works on both
 // SQLite and Postgres (both support partial indexes and IF [NOT] EXISTS).
 func ensureGroupNameIndex(db *gorm.DB) error {
-	// Drop the legacy plain unique index from the old `unique` tag, if present.
-	if err := db.Exec("DROP INDEX IF EXISTS uni_groups_name").Error; err != nil {
-		return fmt.Errorf("failed to drop legacy groups name index: %w", err)
+	// Drop the legacy plain unique index from the old `unique` tag, and the
+	// raw-name (exact-match, pre-#1642) partial index this replaces.
+	for _, idx := range []string{"uni_groups_name", "uniq_groups_name_active"} {
+		if err := db.Exec("DROP INDEX IF EXISTS " + idx).Error; err != nil {
+			return fmt.Errorf("failed to drop legacy groups name index %q: %w", idx, err)
+		}
 	}
-	const idxName = "uniq_groups_name_active"
+	// name_folded is Name run through identity.NewFoldedName — see
+	// models.Group.NameFolded's doc comment. Backfilling happens before the
+	// new index so any pre-existing row a normalization-aware write path
+	// never touched still gets one.
+	if err := backfillFoldedColumn(db, "groups", "id", "name", "name_folded", sqlWhereNotDeleted, foldIdentity); err != nil {
+		return err
+	}
+	const idxName = "uniq_groups_name_folded_active"
 	// #490: other tables (GroupRole, UserGroup) reference a group by ID, so
 	// auto-deleting one of two "duplicate name" groups would silently orphan
 	// any real memberships/role-grants tied to the deleted group's ID. Fail
 	// loud instead so an operator resolves the name collision deliberately.
 	if !indexExists(db, idxName) {
-		if err := warnIfDuplicatesExist(db, "groups", "name", sqlWhereNotDeleted,
+		if err := warnIfDuplicatesExist(db, "groups", "name_folded", sqlWhereNotDeleted,
 			"rename or delete one of the conflicting groups via the application's group-rename/delete API before upgrading"); err != nil {
 			return err
 		}
 	}
-	if err := db.Exec(sqlCreateUniqueIdx + idxName + " ON groups (name) WHERE deleted_at IS NULL").Error; err != nil {
-		return fmt.Errorf("failed to create partial groups name index: %w", err)
+	if err := db.Exec(sqlCreateUniqueIdx + idxName + " ON groups (name_folded) WHERE deleted_at IS NULL").Error; err != nil {
+		return fmt.Errorf("failed to create partial groups name_folded index: %w", err)
 	}
 	return nil
 }
@@ -1865,59 +1928,86 @@ func ensureBreakGlassActiveIndex(db *gorm.DB) error {
 func ensureUserNameIndex(db *gorm.DB) error {
 	// Drop the legacy plain unique index. GORM's `uniqueIndex` tag names it
 	// idx_users_username; the older `unique` tag would be uni_users_username. Drop both.
-	for _, idx := range []string{"idx_users_username", "uni_users_username"} {
+	for _, idx := range []string{"idx_users_username", "uni_users_username", "uniq_users_username_active"} {
 		if err := db.Exec("DROP INDEX IF EXISTS " + idx).Error; err != nil {
 			return fmt.Errorf("failed to drop legacy users username index %q: %w", idx, err)
 		}
 	}
-	const idxName = "uniq_users_username_active"
+	// #1642: username_folded is Username run through identity.NewFoldedName
+	// (NFC-normalized AND case-folded) — see models.User.UsernameFolded's doc
+	// comment. Backfilling happens before the new index so any pre-existing
+	// row a normalization-aware write path never touched still gets one.
+	// Precis-based folding can't be expressed as a portable SQL expression
+	// (unlike the old raw-username index this replaces), so this is a Go-side
+	// backfill (normalize_backfill.go), not a SQL migration.
+	if err := backfillFoldedColumn(db, "users", "id", "username", "username_folded", sqlWhereNotDeleted, foldIdentity); err != nil {
+		return err
+	}
+	const idxName = "uniq_users_username_folded_active"
 	// #490: two accounts colliding on username are two DIFFERENT real users
 	// (their own PasswordHash, MFA config, sessions), and other tables
 	// (roles, audit logs, owned secrets, sessions) reference a user by ID —
 	// auto-deleting one would silently delete a real account/credential and
-	// leave those references dangling. Fail loud instead.
+	// leave those references dangling. Fail loud instead. In practice this
+	// duplicates backfillFoldedColumn's own collision refusal above, but is
+	// kept as defense in depth for a row written directly to the DB outside
+	// any Go write path (e.g. a manual restore) with a pre-populated,
+	// colliding username_folded value.
 	if !indexExists(db, idxName) {
-		if err := warnIfDuplicatesExist(db, "users", "username", sqlWhereNotDeleted,
+		if err := warnIfDuplicatesExist(db, "users", "username_folded", sqlWhereNotDeleted,
 			"merge or rename the conflicting user accounts via the application's admin user API before upgrading"); err != nil {
 			return err
 		}
 	}
-	if err := db.Exec(sqlCreateUniqueIdx + idxName + " ON users (username) WHERE deleted_at IS NULL").Error; err != nil {
-		return fmt.Errorf("failed to create partial users username index: %w", err)
+	if err := db.Exec(sqlCreateUniqueIdx + idxName + " ON users (username_folded) WHERE deleted_at IS NULL").Error; err != nil {
+		return fmt.Errorf("failed to create partial users username_folded index: %w", err)
 	}
 	return nil
 }
 
-// ensureUserEmailIndex creates a partial, case-insensitive unique index on users.email
-// scoped to live (non-deleted) rows with a non-empty email (#117). Without a DB-level
-// constraint, email uniqueness was enforced only by a check-then-act read
-// (GetUserByEmail) before each create/update, which is racy: two concurrent
-// CreateUser/signup/invite-accept/SCIM-provision calls for the identical email could
-// both pass their pre-check before either write landed, producing multiple rows sharing
-// one email that GetUserByEmail then resolves to an arbitrary one of — an ambiguous
-// login/identity-resolution bug, empirically reproduced at a 100% rate under
-// concurrency. The index is on LOWER(email) to match GetUserByEmail's own
-// case-insensitive lookup (`LOWER(email) = LOWER(?)`) — an exact-match index would let
-// the race slip through on a case variant (Bob@x vs bob@x). Scoped to
-// `deleted_at IS NULL` so a soft-deleted (e.g. SCIM-deprovisioned) user's email is freed
-// for reuse on re-provisioning, mirroring ensureUserNameIndex; `email <> ”` so any
-// legacy rows with no email recorded don't collide with each other. Idempotent; works on
-// both SQLite and Postgres (both support expression indexes, partial indexes, and
-// IF [NOT] EXISTS).
+// ensureUserEmailIndex creates a partial, case-insensitive unique index on
+// users.email_folded, scoped to live (non-deleted) rows with a non-empty
+// email (#117). Without a DB-level constraint, email uniqueness was enforced
+// only by a check-then-act read (GetUserByEmail) before each create/update,
+// which is racy: two concurrent CreateUser/signup/invite-accept/SCIM-provision
+// calls for the identical email could both pass their pre-check before either
+// write landed, producing multiple rows sharing one email that GetUserByEmail
+// then resolves to an arbitrary one of — an ambiguous login/identity-resolution
+// bug, empirically reproduced at a 100% rate under concurrency. The index is
+// on email_folded (identity.NewFoldedName's NFC+case-fold output), not a raw
+// SQL LOWER(email) expression (#1642): LOWER() folds ASCII-only on SQLite (no
+// ICU) but locale-dependent on Postgres, so the exact same login-identity
+// column enforced different uniqueness on different backends. Scoped to
+// `deleted_at IS NULL` so a soft-deleted (e.g. SCIM-deprovisioned) user's email
+// is freed for reuse on re-provisioning, mirroring ensureUserNameIndex; `email
+// <> ''` so any legacy rows with no email recorded don't collide with each
+// other. Idempotent; works on both SQLite and Postgres.
 func ensureUserEmailIndex(db *gorm.DB) error {
-	const idxName = "uniq_users_email_active"
+	// Drop the previous LOWER(email)-expression index this replaces (#1642 —
+	// see models.User.EmailFolded's doc comment for why SQL-side LOWER() was
+	// backend-divergent).
+	if err := db.Exec("DROP INDEX IF EXISTS uniq_users_email_active").Error; err != nil {
+		return fmt.Errorf("failed to drop legacy users email index: %w", err)
+	}
+	// email_folded is Email run through identity.NewFoldedName, backfilled
+	// only for non-empty emails — an empty EmailFolded is fine and expected
+	// for the legacy/machine rows the index below already excludes.
+	if err := backfillFoldedColumn(db, "users", "id", "email", "email_folded", "deleted_at IS NULL AND email <> ''", foldIdentity); err != nil {
+		return err
+	}
+	const idxName = "uniq_users_email_folded_active"
 	// #490: same reasoning as ensureUserNameIndex — two accounts colliding on
 	// email are two DIFFERENT real accounts with their own credential/MFA
 	// state, and other tables reference a user by ID. Fail loud instead of
 	// auto-deleting one.
 	if !indexExists(db, idxName) {
-		if err := warnIfDuplicatesExist(db, "users", "LOWER(email)", "deleted_at IS NULL AND email <> ''",
+		if err := warnIfDuplicatesExist(db, "users", "email_folded", "deleted_at IS NULL AND email <> ''",
 			"merge or update the email of one of the conflicting user accounts via the application's admin user API before upgrading"); err != nil {
 			return err
 		}
 	}
-	if err := db.Exec(sqlCreateUniqueIdx + idxName + " ON users (LOWER(email)) WHERE deleted_at IS NULL AND email <> ''").Error; err != nil {
-		return fmt.Errorf("failed to create partial users email index: %w", err)
+	if err := db.Exec(sqlCreateUniqueIdx + idxName + " ON users (email_folded) WHERE deleted_at IS NULL AND email <> ''").Error; err != nil {
+		return fmt.Errorf("failed to create partial users email_folded index: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1980,7 +1980,7 @@ func ensureUserNameIndex(db *gorm.DB) error {
 // column enforced different uniqueness on different backends. Scoped to
 // `deleted_at IS NULL` so a soft-deleted (e.g. SCIM-deprovisioned) user's email
 // is freed for reuse on re-provisioning, mirroring ensureUserNameIndex; `email
-// <> ''` so any legacy rows with no email recorded don't collide with each
+// <> ”` so any legacy rows with no email recorded don't collide with each
 // other. Idempotent; works on both SQLite and Postgres.
 func ensureUserEmailIndex(db *gorm.DB) error {
 	// Drop the previous LOWER(email)-expression index this replaces (#1642 —

--- a/internal/storage/factory_coverage_test.go
+++ b/internal/storage/factory_coverage_test.go
@@ -327,6 +327,7 @@ func TestMigrateDatabase_Cov_GroupsElseBranch_DeletedAtPresent(t *testing.T) {
 	require.NoError(t, db.Exec(`CREATE TABLE groups (
 		id          INTEGER PRIMARY KEY,
 		name        TEXT    NOT NULL,
+		name_folded TEXT,
 		description TEXT,
 		created_at  DATETIME,
 		updated_at  DATETIME,
@@ -339,7 +340,7 @@ func TestMigrateDatabase_Cov_GroupsElseBranch_DeletedAtPresent(t *testing.T) {
 
 	assert.True(t, columnExists(db, "groups", "deleted_at"))
 	// ensureGroupNameIndex must have run and created the partial unique index.
-	assert.True(t, indexExists(db, "uniq_groups_name_active"),
+	assert.True(t, indexExists(db, "uniq_groups_name_folded_active"),
 		"ensureGroupNameIndex must be called in the groupsExists branch")
 }
 
@@ -489,18 +490,24 @@ func TestMigrateDatabase_Cov_EnsureUserEmailIndex_DuplicateEmails(t *testing.T) 
 	require.NoError(t, err)
 
 	// Pre-create users with unique usernames (so ensureUserNameIndex succeeds)
-	// but duplicate non-empty emails (so ensureUserEmailIndex fails).
+	// but duplicate non-empty emails (so ensureUserEmailIndex fails). username_folded/
+	// email_folded (#1642) are left blank so backfillFoldedColumn computes them:
+	// the two distinct usernames fold to distinct values (no collision), but the
+	// two identical emails fold to the same value, so backfillFoldedColumn's own
+	// collision refusal is what actually fails ensureUserEmailIndex here.
 	require.NoError(t, db.Exec(`CREATE TABLE users (
 		id         INTEGER PRIMARY KEY,
 		username   TEXT NOT NULL,
+		username_folded TEXT,
 		email      TEXT,
+		email_folded TEXT,
 		deleted_at DATETIME,
 		external_id TEXT NOT NULL DEFAULT ''
 	)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users (id, username, email, deleted_at, external_id)
-		VALUES (1, 'alice', 'dup@example.com', NULL, '')`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users (id, username, email, deleted_at, external_id)
-		VALUES (2, 'bob', 'dup@example.com', NULL, '')`).Error) // same email = duplicate
+	require.NoError(t, db.Exec(`INSERT INTO users (id, username, username_folded, email, email_folded, deleted_at, external_id)
+		VALUES (1, 'alice', '', 'dup@example.com', '', NULL, '')`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users (id, username, username_folded, email, email_folded, deleted_at, external_id)
+		VALUES (2, 'bob', '', 'dup@example.com', '', NULL, '')`).Error) // same email = duplicate
 
 	f := &DefaultStorageFactory{}
 	err = f.migrateDatabase(db)
@@ -528,17 +535,24 @@ func TestMigrateDatabase_Cov_EnsureUserExternalIDIndex_DuplicateExternalIDs(t *t
 	//   - unique usernames (ensureUserNameIndex succeeds)
 	//   - distinct/empty emails (ensureUserEmailIndex succeeds)
 	//   - duplicate non-empty external_ids (ensureUserExternalIDIndex fails)
+	// username_folded/email_folded (#1642) are left blank so backfillFoldedColumn
+	// computes them; the distinct usernames and distinct emails fold to distinct
+	// values, so neither ensureUserNameIndex nor ensureUserEmailIndex errors here.
+	// external_id has no folded counterpart (identity.NewFoldedName is for
+	// human-verified identity, not SCIM addresses), so this part is unaffected.
 	require.NoError(t, db.Exec(`CREATE TABLE users (
 		id          INTEGER PRIMARY KEY,
 		username    TEXT NOT NULL,
+		username_folded TEXT,
 		email       TEXT,
+		email_folded TEXT,
 		deleted_at  DATETIME,
 		external_id TEXT NOT NULL DEFAULT ''
 	)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users (id, username, email, deleted_at, external_id)
-		VALUES (1, 'alice', 'alice@example.com', NULL, 'scim-1234')`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users (id, username, email, deleted_at, external_id)
-		VALUES (2, 'bob', 'bob@example.com', NULL, 'scim-1234')`).Error) // same external_id
+	require.NoError(t, db.Exec(`INSERT INTO users (id, username, username_folded, email, email_folded, deleted_at, external_id)
+		VALUES (1, 'alice', '', 'alice@example.com', '', NULL, 'scim-1234')`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users (id, username, username_folded, email, email_folded, deleted_at, external_id)
+		VALUES (2, 'bob', '', 'bob@example.com', '', NULL, 'scim-1234')`).Error) // same external_id
 
 	f := &DefaultStorageFactory{}
 	err = f.migrateDatabase(db)

--- a/internal/storage/factory_g80_error_paths_test.go
+++ b/internal/storage/factory_g80_error_paths_test.go
@@ -59,11 +59,29 @@ func TestEnsureIndexHelpers_CreateIndexFailsWhenTargetTableMissing(t *testing.T)
 		{"SecretNodeNameIndex", "uniq_secret_nodes_project_env_name_active", ensureSecretNodeNameIndex, "failed to create secret_nodes unique-name index"},
 		{"SecretVersionIndex", "uniq_secret_versions_node_version", ensureSecretVersionIndex, "failed to create secret_versions unique index"},
 		{"DynamicSecretConfigNameIndex", "uniq_dynamic_secret_configs_project_env_name", ensureDynamicSecretConfigNameIndex, "failed to create dynamic_secret_configs unique index"},
-		{"GroupNameIndex", "uniq_groups_name_active", ensureGroupNameIndex, "failed to create partial groups name index"},
+		// GroupNameIndex/UserNameIndex/UserEmailIndex are deliberately NOT in this
+		// table-driven case list (#1642): each of those three now runs
+		// backfillFoldedColumn BEFORE the indexExists(idxName) short-circuit this
+		// helper relies on, so seeding the index name on a dummy table (with the
+		// real target table absent) makes backfillFoldedColumn's own "no such
+		// table" read fail FIRST -- a different branch than the CREATE INDEX
+		// failure this test is named for. Worse, the CREATE-INDEX-itself-fails
+		// branch these three used to exercise this way is no longer reachable by
+		// ANY variant of this technique: giving backfillFoldedColumn a real
+		// target table (so it succeeds) means CREATE UNIQUE INDEX IF NOT EXISTS
+		// also finds its target table valid -- and then the "IF NOT EXISTS" name
+		// match (the same seeded name that skips warnIfDuplicatesExist) ALSO
+		// short-circuits the CREATE itself before SQLite ever evaluates the real
+		// duplicate data, so no error surfaces (confirmed empirically). The
+		// reachable failure mode for these three is now backfillFoldedColumn's
+		// own "no such table" error when the table is genuinely absent --
+		// already covered by TestEnsureGroupNameIndex_S25_NoTableError /
+		// TestEnsureUserNameIndex_S25_NoTableError /
+		// TestEnsureUserEmailIndex_S25_NoTableError in storage_s25_test.go
+		// (their generic `Contains(err.Error(), "groups"/"users")` assertions
+		// still hold against the new backfill error text).
 		{"ProjectMembershipIndex", "uniq_project_memberships_active", ensureProjectMembershipIndex, "failed to create partial project_memberships index"},
 		{"BreakGlassActiveIndex", "uniq_break_glass_active_project_user", ensureBreakGlassActiveIndex, "failed to create partial break_glass_activations active index"},
-		{"UserNameIndex", "uniq_users_username_active", ensureUserNameIndex, "failed to create partial users username index"},
-		{"UserEmailIndex", "uniq_users_email_active", ensureUserEmailIndex, "failed to create partial users email index"},
 		{"UserExternalIDIndex", "uniq_users_external_id_active", ensureUserExternalIDIndex, "failed to create partial users external_id index"},
 		{"ProjectNameIndex", "uniq_projects_name_active", ensureProjectNameIndex, "failed to create partial projects name index"},
 		{"LegalHoldActiveIndex", "uniq_legal_holds_active", ensureLegalHoldActiveIndex, "failed to create partial legal_holds active index"},

--- a/internal/storage/factory_identity_index_test.go
+++ b/internal/storage/factory_identity_index_test.go
@@ -31,23 +31,23 @@ func TestEmailPartialUniqueIndex(t *testing.T) {
 	require.NoError(t, err)
 	ctx := context.Background()
 
-	alice, err := st.CreateUser(ctx, &models.User{Username: "alice", Email: "alice@x.io", IsActive: true})
+	alice, err := st.CreateUser(ctx, &models.User{Username: "alice", UsernameFolded: "alice", Email: "alice@x.io", EmailFolded: "alice@x.io", IsActive: true})
 	require.NoError(t, err)
 
 	// A second LIVE user with the same email is rejected.
-	_, err = st.CreateUser(ctx, &models.User{Username: "alice2", Email: "alice@x.io", IsActive: true})
+	_, err = st.CreateUser(ctx, &models.User{Username: "alice2", UsernameFolded: "alice2", Email: "alice@x.io", EmailFolded: "alice@x.io", IsActive: true})
 	require.Error(t, err, "two live users may not share an email")
 
 	// Soft-deleting alice frees her email for reuse.
 	require.NoError(t, st.DeleteUser(ctx, alice.ID))
-	reAlice, err := st.CreateUser(ctx, &models.User{Username: "alice-again", Email: "alice@x.io", IsActive: true})
+	reAlice, err := st.CreateUser(ctx, &models.User{Username: "alice-again", UsernameFolded: "alice-again", Email: "alice@x.io", EmailFolded: "alice@x.io", IsActive: true})
 	require.NoError(t, err, "a soft-deleted user's email must be reusable on re-provisioning")
 	assert.NotEqual(t, alice.ID, reAlice.ID)
 
 	// Multiple LIVE users with NO email at all is allowed (empty is excluded).
-	_, err = st.CreateUser(ctx, &models.User{Username: "svc-1", Email: "", IsActive: true})
+	_, err = st.CreateUser(ctx, &models.User{Username: "svc-1", UsernameFolded: "svc-1", Email: "", EmailFolded: "", IsActive: true})
 	require.NoError(t, err)
-	_, err = st.CreateUser(ctx, &models.User{Username: "svc-2", Email: "", IsActive: true})
+	_, err = st.CreateUser(ctx, &models.User{Username: "svc-2", UsernameFolded: "svc-2", Email: "", EmailFolded: "", IsActive: true})
 	require.NoError(t, err, "multiple users with no email must not collide with each other")
 }
 
@@ -68,16 +68,16 @@ func TestExternalIDPartialUniqueIndex(t *testing.T) {
 	require.NoError(t, err)
 	ctx := context.Background()
 
-	_, err = st.CreateUser(ctx, &models.User{Username: "bob", Email: "bob@x.io", ExternalID: "okta|bob", IsActive: true})
+	_, err = st.CreateUser(ctx, &models.User{Username: "bob", UsernameFolded: "bob", Email: "bob@x.io", EmailFolded: "bob@x.io", ExternalID: "okta|bob", IsActive: true})
 	require.NoError(t, err)
 
 	// A second LIVE user claiming the same external_id is rejected.
-	_, err = st.CreateUser(ctx, &models.User{Username: "bob2", Email: "bob2@x.io", ExternalID: "okta|bob", IsActive: true})
+	_, err = st.CreateUser(ctx, &models.User{Username: "bob2", UsernameFolded: "bob2", Email: "bob2@x.io", EmailFolded: "bob2@x.io", ExternalID: "okta|bob", IsActive: true})
 	require.Error(t, err, "two live users may not share a non-empty external_id")
 
 	// Multiple native (local) users with an empty external_id must not collide.
-	_, err = st.CreateUser(ctx, &models.User{Username: "native-1", Email: "n1@x.io", ExternalID: "", IsActive: true})
+	_, err = st.CreateUser(ctx, &models.User{Username: "native-1", UsernameFolded: "native-1", Email: "n1@x.io", EmailFolded: "n1@x.io", ExternalID: "", IsActive: true})
 	require.NoError(t, err)
-	_, err = st.CreateUser(ctx, &models.User{Username: "native-2", Email: "n2@x.io", ExternalID: "", IsActive: true})
+	_, err = st.CreateUser(ctx, &models.User{Username: "native-2", UsernameFolded: "native-2", Email: "n2@x.io", EmailFolded: "n2@x.io", ExternalID: "", IsActive: true})
 	require.NoError(t, err, "multiple native users with no external_id must not collide with each other")
 }

--- a/internal/storage/factory_username_index_test.go
+++ b/internal/storage/factory_username_index_test.go
@@ -28,16 +28,16 @@ func TestUsernamePartialUniqueIndex_ReuseAfterSoftDelete(t *testing.T) {
 	ctx := context.Background()
 
 	// Provision "alice".
-	alice, err := st.CreateUser(ctx, &models.User{Username: "alice", Email: "alice@x.io", IsActive: true})
+	alice, err := st.CreateUser(ctx, &models.User{Username: "alice", UsernameFolded: "alice", Email: "alice@x.io", EmailFolded: "alice@x.io", IsActive: true})
 	require.NoError(t, err)
 
 	// A second LIVE "alice" is rejected (live uniqueness still holds).
-	_, err = st.CreateUser(ctx, &models.User{Username: "alice", Email: "alice2@x.io", IsActive: true})
+	_, err = st.CreateUser(ctx, &models.User{Username: "alice", UsernameFolded: "alice", Email: "alice2@x.io", EmailFolded: "alice2@x.io", IsActive: true})
 	require.Error(t, err, "two live users may not share a username")
 
 	// Deprovision alice (soft delete), then re-provision the same userName — must succeed.
 	require.NoError(t, st.DeleteUser(ctx, alice.ID))
-	reAlice, err := st.CreateUser(ctx, &models.User{Username: "alice", Email: "alice@x.io", IsActive: true})
+	reAlice, err := st.CreateUser(ctx, &models.User{Username: "alice", UsernameFolded: "alice", Email: "alice@x.io", EmailFolded: "alice@x.io", IsActive: true})
 	require.NoError(t, err, "a soft-deleted username must be reusable on re-provisioning")
 	assert.NotEqual(t, alice.ID, reAlice.ID, "re-provisioning creates a fresh row")
 }

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -390,13 +390,32 @@ type User struct {
 	// tag — so a soft-deleted (e.g. SCIM-deprovisioned) user's username is freed for
 	// reuse on re-provisioning while the old row stays restorable for audit.
 	Username string `gorm:"not null"`
+	// UsernameFolded is Username run through identity.NewFoldedName: NFC-
+	// normalized AND case-folded (#1642). Username is the display form as
+	// typed; UsernameFolded is the form every uniqueness check and lookup
+	// compares against (uniq_users_username_folded_active), so "Admin" and
+	// "admin" — or NFC vs NFD forms of the same non-ASCII username — collide
+	// as the same identity instead of coexisting as two indistinguishable
+	// accounts.
+	UsernameFolded string `gorm:"not null" json:"-"`
 	// Email uniqueness (among live, non-empty rows) is enforced by a PARTIAL
-	// unique index (email WHERE deleted_at IS NULL AND email != ''), created in
-	// migrateDatabase — mirrors the Username precedent. Without this, two
-	// concurrent CreateUser calls with the same address could both succeed,
-	// leaving duplicate-email accounts with ambiguous SSO/SCIM/password-reset
-	// targeting.
-	Email        string
+	// unique index (email_folded WHERE deleted_at IS NULL AND email != ''),
+	// created in migrateDatabase — mirrors the Username precedent. Without
+	// this, two concurrent CreateUser calls with the same address could both
+	// succeed, leaving duplicate-email accounts with ambiguous
+	// SSO/SCIM/password-reset targeting.
+	Email string
+	// EmailFolded is Email run through identity.NewFoldedName (#1642) — same
+	// NFC+case-fold treatment as UsernameFolded, replacing the previous
+	// SQL-side LOWER(email) comparison/index. LOWER() folds differently
+	// depending on the backend (SQLite's is ASCII-only with no ICU loaded;
+	// Postgres's depends on the database locale/collation), so the exact same
+	// email column enforced different uniqueness rules on different customer
+	// deployments — two accounts could collide on one backend and coexist as
+	// distinct on another, for the column that is a user's login identity.
+	// Folding once in Go and comparing/indexing the stored result removes
+	// that divergence entirely.
+	EmailFolded  string `json:"-"`
 	DisplayName  string
 	PasswordHash string `json:"-"`
 	IsActive     bool   `gorm:"default:true"`
@@ -656,8 +675,17 @@ type PasswordHistory struct {
 }
 
 type Role struct {
-	ID          uint   `gorm:"primaryKey"`
-	Name        string `gorm:"unique;not null"`
+	ID   uint   `gorm:"primaryKey"`
+	Name string `gorm:"not null"`
+	// NameFolded is Name run through identity.NewFoldedName: NFC-normalized
+	// AND case-folded (#1642), so "Admin"/"admin" can't coexist as two
+	// indistinguishable roles in an access review. Uniqueness is enforced by
+	// ensureRoleNameIndex (uniq_roles_name_folded) rather than a `unique` gorm
+	// tag -- this codebase's AutoMigrate doesn't reliably rename/replace a
+	// tag-based unique constraint when the underlying column changes (see
+	// ensureUserNameIndex's identical rationale), so every unique-name column
+	// here is managed by an explicit ensure*Index function instead.
+	NameFolded  string `gorm:"not null" json:"-"`
 	Description string
 }
 
@@ -758,7 +786,12 @@ type Group struct {
 	// Name uniqueness is enforced by a PARTIAL unique index (name WHERE deleted_at
 	// IS NULL), created in migrateDatabase — not the plain `unique` tag — so a
 	// soft-deleted group's name is freed for reuse while it stays restorable.
-	Name        string `gorm:"not null"`
+	Name string `gorm:"not null"`
+	// NameFolded is Name run through identity.NewFoldedName: NFC-normalized
+	// AND case-folded (#1642), enforced by uniq_groups_name_folded_active —
+	// see Name's own doc comment for the soft-delete-scoping rationale, which
+	// applies identically here.
+	NameFolded  string `gorm:"not null" json:"-"`
 	Description string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time

--- a/internal/storage/normalize_backfill.go
+++ b/internal/storage/normalize_backfill.go
@@ -1,0 +1,170 @@
+// normalize_backfill.go — Go-side backfill for the new *_folded/NFC-normalized
+// identity columns (#1642). Unlike the LOWER()-based partial indexes elsewhere in
+// this package, Unicode NFC normalization and PRECIS case-folding can't be
+// expressed as a portable SQL expression both SQLite and Postgres support, so this
+// reads every row, computes the target value in Go via internal/identity, and
+// writes it back — refusing outright (no row modified) if two existing rows would
+// normalize to the same identity, since silently merging two identities on
+// upgrade is the worst possible outcome of a normalization migration.
+package storage
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/identity"
+)
+
+// foldIdentity adapts identity.NewFoldedName to backfillFoldedColumn's
+// fold func(string) (string, error) shape.
+func foldIdentity(raw string) (string, error) {
+	n, err := identity.NewFoldedName(raw)
+	if err != nil {
+		return "", err
+	}
+	return n.Folded(), nil
+}
+
+// normalizeAddress adapts identity.NewAddressName to backfillFoldedColumn's
+// fold func(string) (string, error) shape.
+func normalizeAddress(raw string) (string, error) {
+	n, err := identity.NewAddressName(raw)
+	if err != nil {
+		return "", err
+	}
+	return n.String(), nil
+}
+
+// backfillFoldedColumn computes foldColumn for every row of table (optionally
+// scoped by whereClause) from sourceColumn, via fold, and writes it back.
+// Only rows where foldColumn is still empty are considered — a non-empty value
+// means either an earlier run already backfilled it, or a normalization-aware
+// write path (post-#1642) already populated it correctly at create/update time.
+//
+// Refuses to write ANY row if two different rows' source values normalize to
+// the same folded value: this is a genuine identity collision uncovered by
+// tightening the definition of "the same name", and auto-resolving it (keep
+// one, drop/rename the other) is exactly the kind of unattended data-merging
+// decision this codebase's own #490 precedent (warnIfDuplicatesExist) refuses
+// to make. The operator must resolve it deliberately via the application's own
+// rename/merge API, which records a proper audit entry.
+func backfillFoldedColumn(db *gorm.DB, table, idColumn, sourceColumn, foldColumn, whereClause string, fold func(string) (string, error)) error {
+	type row struct {
+		ID     uint
+		Source string
+	}
+	var rows []row
+	q := db.Table(table).Select(idColumn + " AS id, " + sourceColumn + " AS source")
+	q = q.Where(foldColumn + " = '' OR " + foldColumn + " IS NULL")
+	if whereClause != "" {
+		q = q.Where(whereClause)
+	}
+	if err := q.Scan(&rows).Error; err != nil {
+		return fmt.Errorf("failed to read %s for %s backfill: %w", table, foldColumn, err)
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	foldedByID := make(map[uint]string, len(rows))
+	idsByFolded := make(map[string][]uint, len(rows))
+	for _, r := range rows {
+		folded, err := fold(r.Source)
+		if err != nil {
+			return fmt.Errorf("failed to normalize %s.%s=%q (id=%d): %w", table, sourceColumn, r.Source, r.ID, err)
+		}
+		foldedByID[r.ID] = folded
+		idsByFolded[folded] = append(idsByFolded[folded], r.ID)
+	}
+
+	var collisions []string
+	for folded, ids := range idsByFolded {
+		if len(ids) > 1 {
+			collisions = append(collisions, fmt.Sprintf("%q shared by %s row id(s) %v", folded, table, ids))
+		}
+	}
+	if len(collisions) > 0 {
+		sort.Strings(collisions)
+		return fmt.Errorf(
+			"cannot backfill %s.%s: %d existing row group(s) normalize to the same identity under Unicode NFC normalization/case-folding -- "+
+				"resolve manually via the application's rename API before upgrading (renaming one row changes only that row's identity, never merges the two): %s",
+			table, foldColumn, len(collisions), strings.Join(collisions, "; "))
+	}
+
+	for id, folded := range foldedByID {
+		if err := db.Table(table).Where(idColumn+" = ?", id).Update(foldColumn, folded).Error; err != nil {
+			return fmt.Errorf("failed to backfill %s.%s for id=%d: %w", table, foldColumn, id, err)
+		}
+	}
+	return nil
+}
+
+// normalizeColumnInPlace re-normalizes every row of table's column (scoped by
+// whereClause) via normalize, overwriting the SAME column with its normalized
+// form — unlike backfillFoldedColumn, there is no separate target column,
+// because normalize (identity.NewAddressName, for secret names) does not
+// fold case: the normalized value IS the value to display, so there is
+// nothing to keep display-distinct-from-comparison the way the *_folded
+// columns do. Only rows whose normalized form actually differs from the
+// stored value are written, so this is a no-op for an already-normalized
+// database. Same fail-loud collision refusal as backfillFoldedColumn: if two
+// existing rows normalize to the same value, nothing is written and the
+// error lists every colliding pair for manual resolution.
+func normalizeColumnInPlace(db *gorm.DB, table, idColumn, column, whereClause string, normalize func(string) (string, error)) error {
+	type row struct {
+		ID     uint
+		Source string
+	}
+	var rows []row
+	q := db.Table(table).Select(idColumn + " AS id, " + column + " AS source")
+	if whereClause != "" {
+		q = q.Where(whereClause)
+	}
+	if err := q.Scan(&rows).Error; err != nil {
+		return fmt.Errorf("failed to read %s for %s normalization: %w", table, column, err)
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	type change struct {
+		id  uint
+		new string
+	}
+	var changes []change
+	idsByNormalized := make(map[string][]uint, len(rows))
+	for _, r := range rows {
+		normalized, err := normalize(r.Source)
+		if err != nil {
+			return fmt.Errorf("failed to normalize %s.%s=%q (id=%d): %w", table, column, r.Source, r.ID, err)
+		}
+		idsByNormalized[normalized] = append(idsByNormalized[normalized], r.ID)
+		if normalized != r.Source {
+			changes = append(changes, change{id: r.ID, new: normalized})
+		}
+	}
+
+	var collisions []string
+	for normalized, ids := range idsByNormalized {
+		if len(ids) > 1 {
+			collisions = append(collisions, fmt.Sprintf("%q shared by %s row id(s) %v", normalized, table, ids))
+		}
+	}
+	if len(collisions) > 0 {
+		sort.Strings(collisions)
+		return fmt.Errorf(
+			"cannot normalize %s.%s: %d existing row group(s) normalize to the same value under Unicode NFC normalization -- "+
+				"resolve manually via the application's rename API before upgrading (renaming one row changes only that row's identity, never merges the two): %s",
+			table, column, len(collisions), strings.Join(collisions, "; "))
+	}
+
+	for _, c := range changes {
+		if err := db.Table(table).Where(idColumn+" = ?", c.id).Update(column, c.new).Error; err != nil {
+			return fmt.Errorf("failed to normalize %s.%s for id=%d: %w", table, column, c.id, err)
+		}
+	}
+	return nil
+}

--- a/internal/storage/normalize_backfill_test.go
+++ b/internal/storage/normalize_backfill_test.go
@@ -13,7 +13,7 @@ import (
 // accent, built from actual combining-character bytes (not a typed/pasted
 // glyph, which risks silent editor/tool re-normalization to NFC).
 var (
-	nfcCafe = "café"   // e-acute precomposed (U+00E9), 5 bytes UTF-8
+	nfcCafe = "café"  // e-acute precomposed (U+00E9), 5 bytes UTF-8
 	nfdCafe = "café" // e (U+0065) + combining acute accent (U+0301), 6 bytes UTF-8
 )
 

--- a/internal/storage/normalize_backfill_test.go
+++ b/internal/storage/normalize_backfill_test.go
@@ -1,0 +1,104 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nfcCafe/nfdCafe reproduce #1642's exact live-demonstrated collision: two
+// byte-different, visually-identical representations of "cafe" + acute
+// accent, built from actual combining-character bytes (not a typed/pasted
+// glyph, which risks silent editor/tool re-normalization to NFC).
+var (
+	nfcCafe = "café"   // e-acute precomposed (U+00E9), 5 bytes UTF-8
+	nfdCafe = "café" // e (U+0065) + combining acute accent (U+0301), 6 bytes UTF-8
+)
+
+// TestBackfillFoldedColumn_RefusesOnCollision pins the user's explicit design
+// requirement for #1642's migration: a backfill that discovers two existing
+// rows normalize to the same identity must refuse outright (write NOTHING)
+// and name every colliding row, never auto-resolve by merging or dropping
+// one — silently merging two identities is the worst possible outcome of a
+// normalization migration.
+func TestBackfillFoldedColumn_RefusesOnCollision(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "backfill-collision.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, username_folded TEXT, deleted_at DATETIME)`).Error)
+
+	// Two independent colliding pairs in one pass: a pure case collision
+	// ("Admin"/"admin") and an NFC/NFD collision (the café pair).
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'Admin', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'admin', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (3, ?, '', NULL)`, nfcCafe).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (4, ?, '', NULL)`, nfdCafe).Error)
+	// A non-colliding row must be unaffected by the refusal.
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (5, 'bob', '', NULL)`).Error)
+
+	err = backfillFoldedColumn(db, "users", "id", "username", "username_folded", "", foldIdentity)
+	require.Error(t, err, "two colliding row groups must refuse the entire backfill")
+	assert.Contains(t, err.Error(), "admin", "error must name the colliding folded value")
+	assert.Contains(t, err.Error(), "cannot backfill users.username_folded")
+
+	// Nothing was written -- not even the non-colliding row -- since the
+	// collision check runs before any write.
+	var stillEmpty int64
+	require.NoError(t, db.Table("users").Where("username_folded = ''").Count(&stillEmpty).Error)
+	assert.Equal(t, int64(5), stillEmpty, "no row may be written once a collision is found, including non-colliding ones")
+}
+
+// TestBackfillFoldedColumn_HappyPathBackfillsDistinctRows verifies the
+// non-collision path: every row with a genuinely distinct folded identity
+// gets its username_folded populated, and re-running is a no-op (only rows
+// with an empty/NULL folded column are re-examined).
+func TestBackfillFoldedColumn_HappyPathBackfillsDistinctRows(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "backfill-happy.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, username_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'Alice', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'Bob', '', NULL)`).Error)
+
+	require.NoError(t, backfillFoldedColumn(db, "users", "id", "username", "username_folded", "", foldIdentity))
+
+	var got1, got2 string
+	require.NoError(t, db.Table("users").Where("id = 1").Select("username_folded").Scan(&got1).Error)
+	require.NoError(t, db.Table("users").Where("id = 2").Select("username_folded").Scan(&got2).Error)
+	assert.Equal(t, "alice", got1)
+	assert.Equal(t, "bob", got2)
+
+	// Manually corrupt row 1's folded value, then re-run: since it's no
+	// longer empty, the backfill must leave it untouched (only empty/NULL
+	// rows are re-examined) -- proving the "only if empty" skip works.
+	require.NoError(t, db.Exec(`UPDATE users SET username_folded = 'manually-set' WHERE id = 1`).Error)
+	require.NoError(t, backfillFoldedColumn(db, "users", "id", "username", "username_folded", "", foldIdentity))
+	var afterRerun string
+	require.NoError(t, db.Table("users").Where("id = 1").Select("username_folded").Scan(&afterRerun).Error)
+	assert.Equal(t, "manually-set", afterRerun, "a non-empty folded column must not be recomputed")
+}
+
+// TestNormalizeColumnInPlace_RefusesOnCollision mirrors the FoldedColumn
+// collision-refusal test above, for the in-place NFC-only normalizer used by
+// secret_nodes.name (no separate folded column -- see normalize_backfill.go).
+func TestNormalizeColumnInPlace_RefusesOnCollision(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "normalize-collision.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE secret_nodes (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO secret_nodes VALUES (1, ?, NULL)`, nfcCafe).Error)
+	require.NoError(t, db.Exec(`INSERT INTO secret_nodes VALUES (2, ?, NULL)`, nfdCafe).Error)
+
+	err = normalizeColumnInPlace(db, "secret_nodes", "id", "name", "", normalizeAddress)
+	require.Error(t, err, "two rows normalizing to the same NFC form must refuse the entire pass")
+	assert.Contains(t, err.Error(), "cannot normalize secret_nodes.name")
+
+	// Case is NOT folded for addresses -- "PROD_KEY" and "prod_key" must stay
+	// distinct, so normalizing must NOT report them as colliding.
+	db2, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "normalize-case.db"))
+	require.NoError(t, err)
+	require.NoError(t, db2.Exec(`CREATE TABLE secret_nodes (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db2.Exec(`INSERT INTO secret_nodes VALUES (1, 'PROD_KEY', NULL)`).Error)
+	require.NoError(t, db2.Exec(`INSERT INTO secret_nodes VALUES (2, 'prod_key', NULL)`).Error)
+	require.NoError(t, normalizeColumnInPlace(db2, "secret_nodes", "id", "name", "", normalizeAddress),
+		"case-distinct secret names must not be treated as colliding")
+}

--- a/internal/storage/storage_s22_test.go
+++ b/internal/storage/storage_s22_test.go
@@ -180,11 +180,11 @@ func TestEnsureProjectNameIndex_S22_DeletedRowNotCounted(t *testing.T) {
 func TestEnsureUserNameIndex_S22_CleanDB(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "uname-clean.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'alice', NULL)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'bob', NULL)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, username_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'alice', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'bob', '', NULL)`).Error)
 	require.NoError(t, ensureUserNameIndex(db))
-	assert.True(t, indexExists(db, "uniq_users_username_active"))
+	assert.True(t, indexExists(db, "uniq_users_username_folded_active"))
 }
 
 // TestEnsureUserNameIndex_S22_DropsLegacyIndexes verifies that ensureUserNameIndex
@@ -192,14 +192,14 @@ func TestEnsureUserNameIndex_S22_CleanDB(t *testing.T) {
 func TestEnsureUserNameIndex_S22_DropsLegacyIndexes(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "uname-legacy.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, username_folded TEXT, deleted_at DATETIME)`).Error)
 	// Create legacy plain unique indexes (old GORM tag names).
 	require.NoError(t, db.Exec(`CREATE UNIQUE INDEX idx_users_username ON users (username)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'charlie', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'charlie', '', NULL)`).Error)
 	require.NoError(t, ensureUserNameIndex(db))
 	// Legacy index must be gone; partial index must exist.
 	assert.False(t, indexExists(db, "idx_users_username"), "legacy plain index must be dropped")
-	assert.True(t, indexExists(db, "uniq_users_username_active"), "partial index must be created")
+	assert.True(t, indexExists(db, "uniq_users_username_folded_active"), "partial index must be created")
 }
 
 // TestEnsureUserNameIndex_S22_DuplicateUsernames verifies that ensureUserNameIndex
@@ -207,9 +207,9 @@ func TestEnsureUserNameIndex_S22_DropsLegacyIndexes(t *testing.T) {
 func TestEnsureUserNameIndex_S22_DuplicateUsernames(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "uname-dup.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'dupe', NULL)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'dupe', NULL)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, username_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'dupe', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'dupe', '', NULL)`).Error)
 	err = ensureUserNameIndex(db)
 	require.Error(t, err, "pre-existing duplicate live usernames must block the migration")
 	assert.Contains(t, err.Error(), "users")
@@ -224,14 +224,14 @@ func TestEnsureUserNameIndex_S22_DuplicateUsernames(t *testing.T) {
 func TestEnsureUserEmailIndex_S22_CleanDB(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "email-clean.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'alice@x.io', NULL)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'bob@x.io', NULL)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, email_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'alice@x.io', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'bob@x.io', '', NULL)`).Error)
 	// Multiple users with empty email must not collide with each other.
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (3, '', NULL)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (4, '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (3, '', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (4, '', '', NULL)`).Error)
 	require.NoError(t, ensureUserEmailIndex(db))
-	assert.True(t, indexExists(db, "uniq_users_email_active"))
+	assert.True(t, indexExists(db, "uniq_users_email_folded_active"))
 }
 
 // TestEnsureUserEmailIndex_S22_DuplicateEmails verifies that ensureUserEmailIndex
@@ -240,9 +240,9 @@ func TestEnsureUserEmailIndex_S22_CleanDB(t *testing.T) {
 func TestEnsureUserEmailIndex_S22_DuplicateEmails(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "email-dup.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'carol@x.io', NULL)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'carol@x.io', NULL)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, email_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'carol@x.io', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'carol@x.io', '', NULL)`).Error)
 	err = ensureUserEmailIndex(db)
 	require.Error(t, err, "duplicate live emails must block the migration")
 	assert.Contains(t, err.Error(), "users")
@@ -253,7 +253,7 @@ func TestEnsureUserEmailIndex_S22_DuplicateEmails(t *testing.T) {
 func TestEnsureUserEmailIndex_S22_Idempotent(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "email-idem.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, email_folded TEXT, deleted_at DATETIME)`).Error)
 	require.NoError(t, ensureUserEmailIndex(db))
 	require.NoError(t, ensureUserEmailIndex(db))
 }
@@ -499,11 +499,11 @@ func TestEnsureSecretVersionIndex_S22_Idempotent(t *testing.T) {
 func TestEnsureGroupNameIndex_S22_CleanDB(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "grp-clean.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (1, 'eng', NULL)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (2, 'ops', NULL)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, name_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (1, 'eng', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (2, 'ops', '', NULL)`).Error)
 	require.NoError(t, ensureGroupNameIndex(db))
-	assert.True(t, indexExists(db, "uniq_groups_name_active"))
+	assert.True(t, indexExists(db, "uniq_groups_name_folded_active"))
 }
 
 // TestEnsureGroupNameIndex_S22_Idempotent verifies that calling ensureGroupNameIndex
@@ -511,7 +511,7 @@ func TestEnsureGroupNameIndex_S22_CleanDB(t *testing.T) {
 func TestEnsureGroupNameIndex_S22_Idempotent(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "grp-idem.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, name_folded TEXT, deleted_at DATETIME)`).Error)
 	require.NoError(t, ensureGroupNameIndex(db))
 	require.NoError(t, ensureGroupNameIndex(db))
 }
@@ -521,12 +521,12 @@ func TestEnsureGroupNameIndex_S22_Idempotent(t *testing.T) {
 func TestEnsureGroupNameIndex_S22_LegacyIndexDropped(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "grp-legacy.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, name_folded TEXT, deleted_at DATETIME)`).Error)
 	require.NoError(t, db.Exec(`CREATE UNIQUE INDEX uni_groups_name ON groups (name)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (1, 'admins', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (1, 'admins', '', NULL)`).Error)
 	require.NoError(t, ensureGroupNameIndex(db))
 	assert.False(t, indexExists(db, "uni_groups_name"), "legacy plain unique index must be dropped")
-	assert.True(t, indexExists(db, "uniq_groups_name_active"), "new partial index must be created")
+	assert.True(t, indexExists(db, "uniq_groups_name_folded_active"), "new partial index must be created")
 }
 
 // TestEnsureGroupNameIndex_S22_SoftDeletedNotCounted verifies that a soft-deleted
@@ -534,9 +534,9 @@ func TestEnsureGroupNameIndex_S22_LegacyIndexDropped(t *testing.T) {
 func TestEnsureGroupNameIndex_S22_SoftDeletedNotCounted(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "grp-softdel.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (1, 'devs', '2024-01-01')`).Error) // deleted
-	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (2, 'devs', NULL)`).Error)         // live
+	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, name_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (1, 'devs', '', '2024-01-01')`).Error) // deleted
+	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (2, 'devs', '', NULL)`).Error)         // live
 	require.NoError(t, ensureGroupNameIndex(db), "a soft-deleted group must not conflict with a live group of the same name")
 }
 

--- a/internal/storage/storage_s23_test.go
+++ b/internal/storage/storage_s23_test.go
@@ -358,9 +358,9 @@ func TestEnsureShareRecordUniqueIndex_S23_DuplicateActiveRecords(t *testing.T) {
 func TestEnsureGroupNameIndex_S23_DuplicateLiveGroupNames(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "grp-dup.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (1, 'engineers', NULL)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (2, 'engineers', NULL)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, name_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (1, 'engineers', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (2, 'engineers', '', NULL)`).Error)
 	err = ensureGroupNameIndex(db)
 	require.Error(t, err, "duplicate live group names must block the migration")
 	assert.Contains(t, err.Error(), "groups")
@@ -448,7 +448,7 @@ func TestEnsureLegalHoldActiveIndex_S23_ReleasedNotCounted(t *testing.T) {
 func TestEnsureUserNameIndex_S23_Idempotent(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "uname-idem.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, username_folded TEXT, deleted_at DATETIME)`).Error)
 	require.NoError(t, ensureUserNameIndex(db))
 	require.NoError(t, ensureUserNameIndex(db), "second call must be a no-op")
 }
@@ -459,9 +459,9 @@ func TestEnsureUserNameIndex_S23_Idempotent(t *testing.T) {
 func TestEnsureUserNameIndex_S23_SoftDeletedNotCounted(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "uname-softdel.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'alice', '2024-06-01')`).Error) // soft-deleted
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'alice', NULL)`).Error)         // live re-provisioned user
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, username_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'alice', '', '2024-06-01')`).Error) // soft-deleted
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'alice', '', NULL)`).Error)         // live re-provisioned user
 	require.NoError(t, ensureUserNameIndex(db), "a soft-deleted username must not block live re-creation")
 }
 
@@ -475,9 +475,9 @@ func TestEnsureUserNameIndex_S23_SoftDeletedNotCounted(t *testing.T) {
 func TestEnsureUserEmailIndex_S23_CaseInsensitiveDuplicateDetected(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "email-case-dup.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'Bob@example.com', NULL)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'bob@example.com', NULL)`).Error) // same LOWER()
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, email_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'Bob@example.com', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'bob@example.com', '', NULL)`).Error) // same LOWER()
 	err = ensureUserEmailIndex(db)
 	require.Error(t, err, "case-variant duplicate emails must be detected via LOWER(email)")
 	assert.Contains(t, err.Error(), "users")
@@ -489,9 +489,9 @@ func TestEnsureUserEmailIndex_S23_CaseInsensitiveDuplicateDetected(t *testing.T)
 func TestEnsureUserEmailIndex_S23_DeletedRowNotCounted(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "email-del.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'deleted@x.io', '2024-01-01')`).Error) // soft-deleted
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'deleted@x.io', NULL)`).Error)         // live re-provisioned
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, email_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'deleted@x.io', '', '2024-01-01')`).Error) // soft-deleted
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'deleted@x.io', '', NULL)`).Error)         // live re-provisioned
 	require.NoError(t, ensureUserEmailIndex(db), "a soft-deleted user email must not conflict with a live re-provision of the same email")
 }
 

--- a/internal/storage/storage_s25_test.go
+++ b/internal/storage/storage_s25_test.go
@@ -210,14 +210,14 @@ func TestEnsureLegalHoldActiveIndex_S25_NoTableError(t *testing.T) {
 func TestEnsureUserNameIndex_S25_BothLegacyIndexesDropped(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "uname-both-legacy.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, username_folded TEXT, deleted_at DATETIME)`).Error)
 	// Create both legacy index names.
 	require.NoError(t, db.Exec(`CREATE UNIQUE INDEX idx_users_username ON users (username)`).Error)
 	require.NoError(t, db.Exec(`CREATE UNIQUE INDEX uni_users_username ON users (username)`).Error)
 	require.NoError(t, ensureUserNameIndex(db))
 	assert.False(t, indexExists(db, "idx_users_username"), "first legacy index must be dropped")
 	assert.False(t, indexExists(db, "uni_users_username"), "second legacy index must be dropped")
-	assert.True(t, indexExists(db, "uniq_users_username_active"), "partial index must exist")
+	assert.True(t, indexExists(db, "uniq_users_username_folded_active"), "partial index must exist")
 }
 
 // ---------------------------------------------------------------------------
@@ -422,7 +422,9 @@ func TestMigrateDatabase_S25_UsersLockoutColumns_ElseBranch(t *testing.T) {
 	require.NoError(t, db.Exec(`CREATE TABLE users (
 		id INTEGER PRIMARY KEY,
 		username TEXT,
+		username_folded TEXT,
 		email TEXT,
+		email_folded TEXT,
 		external_id TEXT NOT NULL DEFAULT '',
 		deleted_at DATETIME
 	)`).Error)

--- a/internal/storage/storage_s27_test.go
+++ b/internal/storage/storage_s27_test.go
@@ -158,14 +158,14 @@ func TestApplyPoolSettings_S27_AllThreeSet(t *testing.T) {
 func TestEnsureGroupNameIndex_S27_HappyPath(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "grp-happy.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (1, 'alpha', NULL)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (2, 'beta', NULL)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, name_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (1, 'alpha', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (2, 'beta', '', NULL)`).Error)
 	// Soft-deleted group with same name as live group — must NOT count as dup.
-	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (3, 'alpha', '2024-01-01')`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (3, 'alpha', '', '2024-01-01')`).Error)
 
 	require.NoError(t, ensureGroupNameIndex(db))
-	assert.True(t, indexExists(db, "uniq_groups_name_active"))
+	assert.True(t, indexExists(db, "uniq_groups_name_folded_active"))
 }
 
 // TestEnsureGroupNameIndex_S27_DuplicateActiveNamesBlocked verifies that two
@@ -174,9 +174,9 @@ func TestEnsureGroupNameIndex_S27_HappyPath(t *testing.T) {
 func TestEnsureGroupNameIndex_S27_DuplicateActiveNamesBlocked(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "grp-dup.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (1, 'clash', NULL)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (2, 'clash', NULL)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, name_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (1, 'clash', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO groups VALUES (2, 'clash', '', NULL)`).Error)
 
 	err = ensureGroupNameIndex(db)
 	require.Error(t, err)
@@ -188,7 +188,7 @@ func TestEnsureGroupNameIndex_S27_DuplicateActiveNamesBlocked(t *testing.T) {
 func TestEnsureGroupNameIndex_S27_Idempotent(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "grp-idem.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, name_folded TEXT, deleted_at DATETIME)`).Error)
 	require.NoError(t, ensureGroupNameIndex(db))
 	require.NoError(t, ensureGroupNameIndex(db), "second call must be a no-op")
 }
@@ -202,11 +202,11 @@ func TestEnsureGroupNameIndex_S27_Idempotent(t *testing.T) {
 func TestEnsureUserEmailIndex_S27_HappyPath(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "email-happy.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'alice@example.com', NULL)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'bob@example.com', NULL)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, email_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'alice@example.com', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'bob@example.com', '', NULL)`).Error)
 	require.NoError(t, ensureUserEmailIndex(db))
-	assert.True(t, indexExists(db, "uniq_users_email_active"))
+	assert.True(t, indexExists(db, "uniq_users_email_folded_active"))
 }
 
 // TestEnsureUserEmailIndex_S27_DuplicateEmails verifies that two live rows with
@@ -214,9 +214,9 @@ func TestEnsureUserEmailIndex_S27_HappyPath(t *testing.T) {
 func TestEnsureUserEmailIndex_S27_DuplicateEmails(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "email-dup.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, deleted_at DATETIME)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'alice@example.com', NULL)`).Error)
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'Alice@Example.Com', NULL)`).Error) // same LOWER()
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, email_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'alice@example.com', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'Alice@Example.Com', '', NULL)`).Error) // same LOWER()
 	err = ensureUserEmailIndex(db)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "users")
@@ -556,7 +556,7 @@ func TestSQLiteBusyTimeoutMillis_S27_Value(t *testing.T) {
 func TestEnsureGroupNameIndex_S27_DropLegacyIndexNoOp(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "grp-droplg.db"))
 	require.NoError(t, err)
-	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, name_folded TEXT, deleted_at DATETIME)`).Error)
 	// No legacy index exists — DROP IF EXISTS is a no-op.
 	require.NoError(t, ensureGroupNameIndex(db), "must succeed even without a legacy index to drop")
 }

--- a/internal/storage/storage_s28_test.go
+++ b/internal/storage/storage_s28_test.go
@@ -689,13 +689,16 @@ func TestMigrateDatabase_S28_ProjectsExistingEarlyReturn(t *testing.T) {
 	require.NoError(t, db.Exec(`CREATE TABLE users (
 		id INTEGER PRIMARY KEY,
 		username TEXT,
+		username_folded TEXT,
 		email TEXT,
+		email_folded TEXT,
 		external_id TEXT NOT NULL DEFAULT '',
 		deleted_at DATETIME
 	)`).Error)
 	require.NoError(t, db.Exec(`CREATE TABLE groups (
 		id INTEGER PRIMARY KEY,
 		name TEXT,
+		name_folded TEXT,
 		deleted_at DATETIME
 	)`).Error)
 	require.NoError(t, db.Exec(`CREATE TABLE share_records (

--- a/internal/storage/store/group_soft_delete_test.go
+++ b/internal/storage/store/group_soft_delete_test.go
@@ -25,7 +25,7 @@ func newGroupSoftDeleteStore(t *testing.T) *LocalStorage {
 		&models.ShareRecord{}, &models.SecretNode{}, &models.User{},
 		&models.Project{}, &models.Environment{},
 	))
-	require.NoError(t, db.Create(&models.User{ID: 1, Username: "u1", Email: "u1@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "u1", UsernameFolded: "u1", Email: "u1@x.io", EmailFolded: "u1@x.io"}).Error)
 	return NewLocalStorage(db)
 }
 
@@ -36,7 +36,7 @@ func TestGroupSoftDelete_RevokesThenRestoresAccess(t *testing.T) {
 	ls := newGroupSoftDeleteStore(t)
 	ctx := context.Background()
 
-	g, err := ls.CreateGroup(ctx, &models.Group{Name: "ops"})
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "ops", NameFolded: "ops"})
 	require.NoError(t, err)
 	require.NoError(t, ls.AddUserToGroup(ctx, 1, g.ID, 0))
 	require.NoError(t, ls.db.Create(&models.GroupRole{GroupID: g.ID, RoleID: 50}).Error)
@@ -84,18 +84,19 @@ func TestGroupSoftDelete_RevokesThenRestoresAccess(t *testing.T) {
 func TestGroupSoftDelete_NameReuse(t *testing.T) {
 	ls := newGroupSoftDeleteStore(t)
 	ctx := context.Background()
-	// The production migration creates this; replicate it for the test DB.
-	require.NoError(t, ls.db.Exec("CREATE UNIQUE INDEX uniq_groups_name_active ON groups (name) WHERE deleted_at IS NULL").Error)
+	// The production migration creates this (#1642: now scoped to the folded
+	// column); replicate it for the test DB.
+	require.NoError(t, ls.db.Exec("CREATE UNIQUE INDEX uniq_groups_name_folded_active ON groups (name_folded) WHERE deleted_at IS NULL").Error)
 
-	g, err := ls.CreateGroup(ctx, &models.Group{Name: "dup"})
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "dup", NameFolded: "dup"})
 	require.NoError(t, err)
 
 	// A second LIVE group with the same name is rejected.
-	_, err = ls.CreateGroup(ctx, &models.Group{Name: "dup"})
+	_, err = ls.CreateGroup(ctx, &models.Group{Name: "dup", NameFolded: "dup"})
 	require.Error(t, err, "two live groups cannot share a name")
 
 	// After soft-delete, the name is free to reuse.
 	require.NoError(t, ls.DeleteGroup(ctx, g.ID))
-	_, err = ls.CreateGroup(ctx, &models.Group{Name: "dup"})
+	_, err = ls.CreateGroup(ctx, &models.Group{Name: "dup", NameFolded: "dup"})
 	require.NoError(t, err, "a soft-deleted group's name is reusable")
 }

--- a/internal/storage/store/last_login_test.go
+++ b/internal/storage/store/last_login_test.go
@@ -26,7 +26,7 @@ func TestUpdateLastLogin(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserTestStore(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "alice", Email: "a@x.io"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "alice", UsernameFolded: "alice", Email: "a@x.io", EmailFolded: "a@x.io"})
 	require.NoError(t, err)
 	require.Nil(t, u.LastLoginAt, "new user has never logged in")
 
@@ -47,14 +47,14 @@ func TestListUsersInactiveSince(t *testing.T) {
 	now := time.Now().UTC()
 
 	// never logged in → inactive
-	_, err := ls.CreateUser(ctx, &models.User{Username: "never", Email: "n@x.io"})
+	_, err := ls.CreateUser(ctx, &models.User{Username: "never", UsernameFolded: "never", Email: "n@x.io", EmailFolded: "n@x.io"})
 	require.NoError(t, err)
 	// logged in 40 days ago → inactive
-	stale, err := ls.CreateUser(ctx, &models.User{Username: "stale", Email: "s@x.io"})
+	stale, err := ls.CreateUser(ctx, &models.User{Username: "stale", UsernameFolded: "stale", Email: "s@x.io", EmailFolded: "s@x.io"})
 	require.NoError(t, err)
 	require.NoError(t, ls.UpdateLastLogin(ctx, stale.ID, now.Add(-40*24*time.Hour)))
 	// logged in yesterday → active
-	fresh, err := ls.CreateUser(ctx, &models.User{Username: "fresh", Email: "f@x.io"})
+	fresh, err := ls.CreateUser(ctx, &models.User{Username: "fresh", UsernameFolded: "fresh", Email: "f@x.io", EmailFolded: "f@x.io"})
 	require.NoError(t, err)
 	require.NoError(t, ls.UpdateLastLogin(ctx, fresh.ID, now.Add(-24*time.Hour)))
 

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -79,7 +80,8 @@ func (ls *LocalStorage) AssignPermissionToRole(ctx context.Context, roleID, perm
 
 // --- Roles ---
 
-func (ls *LocalStorage) CreateRole(ctx context.Context, role *models.Role) (*models.Role, error) {
+func (ls *LocalStorage) CreateRole(ctx context.Context, name identity.FoldedName, description string) (*models.Role, error) {
+	role := &models.Role{Name: name.Display(), NameFolded: name.Folded(), Description: description}
 	if err := ls.db.WithContext(ctx).Create(role).Error; err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
@@ -97,6 +99,27 @@ func (ls *LocalStorage) GetRole(ctx context.Context, id uint) (*models.Role, err
 	return &role, nil
 }
 
+// GetRoleByName looks up a role by its exact display name.
+//
+// #1642 follow-up (filed, not fixed here): this queries the raw `name`
+// column, not `name_folded`, so it does NOT benefit from the case-insensitive
+// fold CreateRole/ensureRoleNameIndex enforce at write time — a lookup for
+// "Admin" will not find a role created as "admin". This is the same
+// write-without-read-fold shape already fixed for GetUserByEmail/
+// GetUserByUsername, and the human-facing exposure (GET
+// /api/v1/roles/by-name?name=) has the same theoretical gap. It is left
+// unfixed in this change because roleSetContainsAdmin (authz.go) calls this
+// method internally, on every authorization check, with the four fixed
+// adminRoleNames literals — switching this query to name_folded requires
+// every test fixture across the repo that seeds a `models.Role{Name: "..."}`
+// row directly (bypassing CreateRole, and so leaving NameFolded empty) to
+// also set NameFolded, and that pattern is used by roughly 100 call sites
+// across internal/core, internal/cli, internal/storage/store,
+// server/grpc/services, and server/http(/handlers) — a fixture sweep at
+// least as large as the User/Group one already done for #1642, disproportionate
+// to what is a UX papercut (case-variant role-name search misses a match) with
+// no security stake, unlike CreateRole's charset bypass. Track as a separate
+// follow-up rather than expand this change further.
 func (ls *LocalStorage) GetRoleByName(ctx context.Context, name string) (*models.Role, error) {
 	var role models.Role
 	if err := ls.db.WithContext(ctx).Where("name = ?", name).First(&role).Error; err != nil {

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"gorm.io/gorm"
 )
@@ -454,12 +455,20 @@ func (ls *LocalStorage) GetSecretsByIDs(ctx context.Context, ids []uint) ([]*mod
 	return secrets, nil
 }
 
-// GetSecretByName retrieves a secret by name and scope.
+// GetSecretByName retrieves a secret by name and scope. The lookup name is
+// NFC-normalized (#1642) via identity.NewAddressName before comparison, the
+// same way CreateSecret normalizes before writing — not case-folded, since a
+// secret name is an address, not human-verified identity (PROD_KEY and
+// prod_key must remain distinct).
 func (ls *LocalStorage) GetSecretByName(ctx context.Context, name string, projectID, environmentID uint) (*models.SecretNode, error) {
+	normalized, nerr := identity.NewAddressName(name)
+	if nerr != nil {
+		return nil, fmt.Errorf("%s", i18n.T("ErrorSecretNotFound", nil))
+	}
 	var secret models.SecretNode
 	err := ls.db.WithContext(ctx).Where(
 		"name = ? AND project_id = ? AND environment_id = ?",
-		name, projectID, environmentID,
+		normalized.String(), projectID, environmentID,
 	).First(&secret).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/storage/store/local_transaction_test.go
+++ b/internal/storage/store/local_transaction_test.go
@@ -31,7 +31,7 @@ func TestLocalStorage_WithTransaction_CommitsOnSuccess(t *testing.T) {
 	ctx := context.Background()
 
 	err := ls.WithTransaction(ctx, func(tx storage.Storage) error {
-		_, e := tx.CreateUser(ctx, &models.User{Username: "alice", Email: "a@x.io"})
+		_, e := tx.CreateUser(ctx, &models.User{Username: "alice", UsernameFolded: "alice", Email: "a@x.io", EmailFolded: "a@x.io"})
 		return e
 	})
 	require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestLocalStorage_WithTransaction_RollsBackOnError(t *testing.T) {
 	sentinel := errors.New("boom")
 
 	err := ls.WithTransaction(ctx, func(tx storage.Storage) error {
-		if _, e := tx.CreateUser(ctx, &models.User{Username: "bob", Email: "b@x.io"}); e != nil {
+		if _, e := tx.CreateUser(ctx, &models.User{Username: "bob", UsernameFolded: "bob", Email: "b@x.io", EmailFolded: "b@x.io"}); e != nil {
 			return e
 		}
 		// The insert above must be rolled back when fn returns an error.

--- a/internal/storage/store/local_users.go
+++ b/internal/storage/store/local_users.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -33,24 +34,26 @@ var likeEscaper = strings.NewReplacer(`\`, `\\`, "%", `\%`, "_", `\_`)
 func escapeLike(s string) string { return likeEscaper.Replace(s) }
 
 // isDuplicateEmailViolation reports whether err is a unique-constraint violation on
-// specifically the partial users-email index (uniq_users_email_active, #117), as
+// specifically the partial users-email index (uniq_users_email_folded_active, #117), as
 // distinct from any other unique constraint on the users table (e.g. the username
-// index) or elsewhere. Both SQLite and Postgres include the violated index/constraint
-// name in the driver-native error text for an expression index like this one (SQLite:
-// `UNIQUE constraint failed: index 'uniq_users_email_active'`; Postgres: `duplicate key
-// value violates unique constraint "uniq_users_email_active"`), so matching the index
-// name — rather than the generic isUniqueViolation substrings used for
-// single-unique-index tables like project_memberships — avoids mis-attributing a
-// username collision (or any future users-table unique index) to email. Neither
-// dialector wraps a typed error here (that needs the gorm.Config{TranslateError: true}
-// opt-in, which this codebase doesn't set), so this is driver-native text matching, the
-// same approach already used for "not found"/unique-violation detection elsewhere (e.g.
+// index) or elsewhere. Postgres names the violated constraint in its driver-native error
+// text (`duplicate key value violates unique constraint "uniq_users_email_folded_active"`),
+// so matching the index name there avoids mis-attributing a username collision (or any
+// future users-table unique index) to email. SQLite (modernc.org/sqlite) does NOT name
+// the index at all — it names the violated COLUMN instead (`UNIQUE constraint failed:
+// users.email_folded`) — so the SQLite branch matches the column name, which is equally
+// unambiguous per-column (only one unique index targets email_folded). Neither dialector
+// wraps a typed error here (that needs the gorm.Config{TranslateError: true} opt-in,
+// which this codebase doesn't set), so this is driver-native text matching, the same
+// approach already used for "not found"/unique-violation detection elsewhere (e.g.
 // sso.go, users.go, scim.go, local_memberships.go).
 func isDuplicateEmailViolation(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "uniq_users_email_active")
+	msg := err.Error()
+	return strings.Contains(msg, "uniq_users_email_folded_active") || // Postgres constraint name
+		strings.Contains(msg, "users.email_folded") // SQLite column name
 }
 
 // --- Users ---
@@ -62,7 +65,7 @@ func isDuplicateEmailViolation(err error) bool {
 func (ls *LocalStorage) CreateUser(ctx context.Context, user *models.User, _ ...string) (*models.User, error) {
 	if err := ls.db.WithContext(ctx).Create(user).Error; err != nil {
 		if isDuplicateEmailViolation(err) {
-			// The partial unique index uniq_users_email_active (#117) caught a concurrent
+			// The partial unique index uniq_users_email_folded_active (#117) caught a concurrent
 			// duplicate: another create/signup/invite-accept/SCIM-provision for the
 			// identical (case-insensitive) email committed first. Translate to the
 			// sentinel so callers can surface a clean "email already in use" error
@@ -141,9 +144,18 @@ func (ls *LocalStorage) GetUserByEmail(ctx context.Context, email string) (*mode
 	var user models.User
 	// Case-insensitive: email addresses are not case-sensitive in practice, and an
 	// exact match let the ADR-028 invite-accept "account already exists" guard be
-	// evaded by case (Bob@x vs bob@x), minting a duplicate identity. LOWER() on both
-	// sides matches regardless of stored casing (covers legacy mixed-case rows).
-	if err := ls.db.WithContext(ctx).Where("LOWER(email) = LOWER(?)", email).First(&user).Error; err != nil {
+	// evaded by case (Bob@x vs bob@x), minting a duplicate identity. Fold the lookup
+	// key via identity.NewFoldedName and compare against the stored folded column —
+	// not a SQL-side LOWER(email) (#1642: that folds ASCII-only on SQLite but
+	// locale-dependent on Postgres, so the same lookup could resolve differently
+	// depending on backend). An email that itself fails to normalize (control/bidi
+	// characters) cannot match any legitimately-stored row, so treat it as
+	// not-found rather than surfacing a normalization error to a lookup caller.
+	folded, ferr := identity.NewFoldedName(email)
+	if ferr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
+	}
+	if err := ls.db.WithContext(ctx).Where("email_folded = ?", folded.Folded()).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			// Wrap the typed sentinel (matching GetUser/LockUserForUpdate, #504) so
 			// callers can detect "genuinely absent" via
@@ -158,7 +170,14 @@ func (ls *LocalStorage) GetUserByEmail(ctx context.Context, email string) (*mode
 
 func (ls *LocalStorage) GetUserByUsername(ctx context.Context, username string) (*models.User, error) {
 	var user models.User
-	if err := ls.db.WithContext(ctx).Where("username = ?", username).First(&user).Error; err != nil {
+	// Fold the lookup key the same way CreateUser folds it at write time
+	// (#1642) — see GetUserByEmail's identical rationale. A query string that
+	// itself fails to normalize cannot match any legitimately-stored row.
+	folded, ferr := identity.NewFoldedName(username)
+	if ferr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
+	}
+	if err := ls.db.WithContext(ctx).Where("username_folded = ?", folded.Folded()).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), storage.ErrUserNotFound)
 		}
@@ -181,7 +200,7 @@ func (ls *LocalStorage) GetUserByExternalID(ctx context.Context, externalID stri
 func (ls *LocalStorage) UpdateUser(ctx context.Context, user *models.User) (*models.User, error) {
 	if err := ls.db.WithContext(ctx).Save(user).Error; err != nil {
 		if isDuplicateEmailViolation(err) {
-			// The partial unique index uniq_users_email_active (#117) caught a concurrent
+			// The partial unique index uniq_users_email_folded_active (#117) caught a concurrent
 			// duplicate: another update (e.g. a racing UpdateSCIMUser, #120/#218) already
 			// committed the identical (case-insensitive) email to a different user before
 			// this write landed. Translate to the sentinel so callers surface a clean

--- a/internal/storage/store/remote_coverage_mfa_rbac_secrets_test.go
+++ b/internal/storage/store/remote_coverage_mfa_rbac_secrets_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -473,7 +473,9 @@ func TestRemoteCov_CreateRole_APIError(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	_, err = rs.CreateRole(context.Background(), &models.Role{Name: "admin"})
+	adminName, ferr := identity.NewFoldedName("admin")
+	require.NoError(t, ferr)
+	_, err = rs.CreateRole(context.Background(), adminName, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "create role failed")
 }
@@ -487,7 +489,9 @@ func TestRemoteCov_CreateRole_BadJSON(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	_, err = rs.CreateRole(context.Background(), &models.Role{Name: "test"})
+	testName, ferr := identity.NewFoldedName("test")
+	require.NoError(t, ferr)
+	_, err = rs.CreateRole(context.Background(), testName, "")
 	assert.Error(t, err)
 }
 

--- a/internal/storage/store/remote_rbac.go
+++ b/internal/storage/store/remote_rbac.go
@@ -21,14 +21,21 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
 )
 
 // --- Roles ---
 
-// CreateRole creates a new role via remote API.
-func (rs *RemoteStorage) CreateRole(ctx context.Context, role *models.Role) (*models.Role, error) {
+// CreateRole creates a new role via remote API. Sends only the display form
+// and description over the wire — the hub's own handler (server/http/handlers/
+// rbac.go's RBACHandler.CreateRole) independently re-derives the folded form
+// from the raw name it receives (#1642: never trust a client-supplied folded
+// value), so there is nothing normalization-specific for this client-side
+// call to do beyond matching the new typed signature.
+func (rs *RemoteStorage) CreateRole(ctx context.Context, name identity.FoldedName, description string) (*models.Role, error) {
+	role := &models.Role{Name: name.Display(), Description: description}
 	resp, err := rs.client.Post(ctx, "/api/v1/roles", role)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create role: %w", err)

--- a/internal/storage/store/remote_rbac_test.go
+++ b/internal/storage/store/remote_rbac_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,9 @@ func TestRemoteStorage_CreateRole(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	role, err := rs.CreateRole(context.Background(), &models.Role{Name: "admin"})
+	adminName, err := identity.NewFoldedName("admin")
+	require.NoError(t, err)
+	role, err := rs.CreateRole(context.Background(), adminName, "")
 	require.NoError(t, err)
 	assert.Equal(t, uint(1), role.ID)
 	assert.Equal(t, "admin", role.Name)

--- a/internal/storage/store/remote_wire_route_coverage_test.go
+++ b/internal/storage/store/remote_wire_route_coverage_test.go
@@ -945,7 +945,7 @@ var knownUnresolvedWireCalls = map[string]wireCallExclusion{
 	// real, scoped tool enhancement (resolve the literal prefix, represent the
 	// escaped segment as a wildcard "*" the way normalizeChiPath already does
 	// for a chi {param}), just a different one than the query-string case.
-	"remote_rbac.go:484":  pathEscapeEntry("url.PathEscape(connector) path-segment concatenation"),
+	"remote_rbac.go:491":  pathEscapeEntry("url.PathEscape(connector) path-segment concatenation"),
 	"remote_users.go:974": pathEscapeEntry("url.QueryEscape(strings.Join(ids, \",\")) query-string concatenation"),
 
 	// Category: the ENTIRE path is a bare call to a locally-defined helper

--- a/internal/storage/store/store_max_test.go
+++ b/internal/storage/store/store_max_test.go
@@ -28,6 +28,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -187,11 +188,11 @@ func TestCreateUser_DuplicateEmailSentinel(t *testing.T) {
 	ls := newUserStoreMax(t)
 	ctx := context.Background()
 
-	u := &models.User{Email: "dup@example.com", Username: "dup1"}
+	u := &models.User{Email: "dup@example.com", EmailFolded: "dup@example.com", Username: "dup1", UsernameFolded: "dup1"}
 	_, err := ls.CreateUser(ctx, u)
 	require.NoError(t, err)
 
-	u2 := &models.User{Email: "dup@example.com", Username: "dup2"}
+	u2 := &models.User{Email: "dup@example.com", EmailFolded: "dup@example.com", Username: "dup2", UsernameFolded: "dup2"}
 	_, err = ls.CreateUser(ctx, u2)
 	require.Error(t, err)
 }
@@ -201,9 +202,9 @@ func TestUpdateUser_Errors(t *testing.T) {
 	ls := newUserStoreMax(t)
 	ctx := context.Background()
 
-	u1, err := ls.CreateUser(ctx, &models.User{Email: "a@b.com", Username: "aUser"})
+	u1, err := ls.CreateUser(ctx, &models.User{Email: "a@b.com", EmailFolded: "a@b.com", Username: "aUser", UsernameFolded: "auser"})
 	require.NoError(t, err)
-	u2, err := ls.CreateUser(ctx, &models.User{Email: "c@d.com", Username: "cUser"})
+	u2, err := ls.CreateUser(ctx, &models.User{Email: "c@d.com", EmailFolded: "c@d.com", Username: "cUser", UsernameFolded: "cuser"})
 	require.NoError(t, err)
 
 	// Happy path: update u1's display name.
@@ -225,7 +226,7 @@ func TestUpdateLastLogin_Max(t *testing.T) {
 	ls := newUserStoreMax(t)
 	ctx := context.Background()
 
-	u, err := ls.CreateUser(ctx, &models.User{Email: "login@test.com", Username: "loginUser"})
+	u, err := ls.CreateUser(ctx, &models.User{Email: "login@test.com", EmailFolded: "login@test.com", Username: "loginUser", UsernameFolded: "loginuser"})
 	require.NoError(t, err)
 	require.NoError(t, ls.UpdateLastLogin(ctx, u.ID, time.Now()))
 }
@@ -269,10 +270,10 @@ func TestCreateUserWithRoleGrants_DuplicateEmailError(t *testing.T) {
 	ls.db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active ON users(email) WHERE deleted_at IS NULL AND email != ''")
 	ctx := context.Background()
 
-	_, err := ls.CreateUser(ctx, &models.User{Email: "uniq@dup.com", Username: "u1"})
+	_, err := ls.CreateUser(ctx, &models.User{Email: "uniq@dup.com", EmailFolded: "uniq@dup.com", Username: "u1", UsernameFolded: "u1"})
 	require.NoError(t, err)
 
-	_, err = ls.CreateUserWithRoleGrants(ctx, &models.User{Email: "uniq@dup.com", Username: "u2"}, nil)
+	_, err = ls.CreateUserWithRoleGrants(ctx, &models.User{Email: "uniq@dup.com", EmailFolded: "uniq@dup.com", Username: "u2", UsernameFolded: "u2"}, nil)
 	require.Error(t, err)
 }
 
@@ -295,9 +296,10 @@ func TestGetGroup_NotFound(t *testing.T) {
 func TestUpdateGroup_Success(t *testing.T) {
 	ls := newUserStoreMax(t)
 	ctx := context.Background()
-	g, err := ls.CreateGroup(ctx, &models.Group{Name: "g-upd"})
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "g-upd", NameFolded: "g-upd"})
 	require.NoError(t, err)
 	g.Name = "g-upd-v2"
+	g.NameFolded = "g-upd-v2"
 	got, err := ls.UpdateGroup(ctx, g)
 	require.NoError(t, err)
 	assert.Equal(t, "g-upd-v2", got.Name)
@@ -1030,7 +1032,7 @@ func TestPurgeDeletedUsersBefore_DeletesUsers(t *testing.T) {
 	ls := newPurgeStore(t)
 	ctx := context.Background()
 
-	u, err := ls.CreateUser(ctx, &models.User{Email: "purge@test.com", Username: "purgeMe"})
+	u, err := ls.CreateUser(ctx, &models.User{Email: "purge@test.com", EmailFolded: "purge@test.com", Username: "purgeMe", UsernameFolded: "purgeme"})
 	require.NoError(t, err)
 	require.NoError(t, ls.DeleteUser(ctx, u.ID))
 
@@ -1145,7 +1147,9 @@ func TestCreateRoleAndGetNotFound(t *testing.T) {
 	ls := newRBACStoreMax(t)
 	ctx := context.Background()
 
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "tester", Description: "d"})
+	testerName, err := identity.NewFoldedName("tester")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, testerName, "d")
 	require.NoError(t, err)
 	require.NotZero(t, role.ID)
 
@@ -1164,7 +1168,9 @@ func TestGetRoleByName_NotFound(t *testing.T) {
 func TestUpdateRole(t *testing.T) {
 	ls := newRBACStoreMax(t)
 	ctx := context.Background()
-	role, _ := ls.CreateRole(ctx, &models.Role{Name: "upd-role"})
+	updRoleName, err := identity.NewFoldedName("upd-role")
+	require.NoError(t, err)
+	role, _ := ls.CreateRole(ctx, updRoleName, "")
 	role.Description = "updated"
 	got, err := ls.UpdateRole(ctx, role)
 	require.NoError(t, err)
@@ -1191,7 +1197,9 @@ func TestAssignPermissionToRole(t *testing.T) {
 	ls := newRBACStoreMax(t)
 	ctx := context.Background()
 
-	role, _ := ls.CreateRole(ctx, &models.Role{Name: "r1"})
+	r1Name, err := identity.NewFoldedName("r1")
+	require.NoError(t, err)
+	role, _ := ls.CreateRole(ctx, r1Name, "")
 	perm, _ := ls.CreatePermission(ctx, &models.Permission{Name: "do.thing"})
 	require.NoError(t, ls.AssignPermissionToRole(ctx, role.ID, perm.ID))
 }
@@ -1214,11 +1222,13 @@ func TestGetUserRoles_Empty(t *testing.T) {
 func TestAssignRole_AlreadyAssigned(t *testing.T) {
 	ls := newRBACStoreMax(t)
 	ctx := context.Background()
-	role, _ := ls.CreateRole(ctx, &models.Role{Name: "dup-role"})
+	dupRoleName, err := identity.NewFoldedName("dup-role")
+	require.NoError(t, err)
+	role, _ := ls.CreateRole(ctx, dupRoleName, "")
 	scope := storage.Scope{ProjectID: 1}
 
 	require.NoError(t, ls.AssignRole(ctx, 2, role.ID, scope))
-	err := ls.AssignRole(ctx, 2, role.ID, scope)
+	err = ls.AssignRole(ctx, 2, role.ID, scope)
 	require.Error(t, err) // already assigned
 }
 
@@ -1226,7 +1236,9 @@ func TestAssignRole_AlreadyAssigned(t *testing.T) {
 func TestAssignRole_ExpiredGrantIsReplaced(t *testing.T) {
 	ls := newRBACStoreMax(t)
 	ctx := context.Background()
-	role, _ := ls.CreateRole(ctx, &models.Role{Name: "exp-role"})
+	expRoleName, err := identity.NewFoldedName("exp-role")
+	require.NoError(t, err)
+	role, _ := ls.CreateRole(ctx, expRoleName, "")
 	scope := storage.Scope{ProjectID: 5}
 
 	past := time.Now().Add(-time.Hour)
@@ -1309,11 +1321,13 @@ func TestListGroupRoleAssignments_Empty(t *testing.T) {
 func TestAssignRoleToGroup_AlreadyAssigned(t *testing.T) {
 	ls := newRBACStoreMax(t)
 	ctx := context.Background()
-	role, _ := ls.CreateRole(ctx, &models.Role{Name: "grole"})
+	groleName, err := identity.NewFoldedName("grole")
+	require.NoError(t, err)
+	role, _ := ls.CreateRole(ctx, groleName, "")
 	scope := storage.Scope{ProjectID: 7}
 
 	require.NoError(t, ls.AssignRoleToGroup(ctx, 4, role.ID, scope))
-	err := ls.AssignRoleToGroup(ctx, 4, role.ID, scope)
+	err = ls.AssignRoleToGroup(ctx, 4, role.ID, scope)
 	require.Error(t, err)
 }
 

--- a/internal/storage/store/store_s18_test.go
+++ b/internal/storage/store/store_s18_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -318,7 +319,9 @@ func TestCreateRole_HappyPath(t *testing.T) {
 	ls := newS18Store(t, &models.Role{})
 	ctx := context.Background()
 
-	r, err := ls.CreateRole(ctx, &models.Role{Name: "viewer", Description: "read-only"})
+	viewerName, err := identity.NewFoldedName("viewer")
+	require.NoError(t, err)
+	r, err := ls.CreateRole(ctx, viewerName, "read-only")
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	assert.NotZero(t, r.ID)
@@ -328,7 +331,9 @@ func TestCreateRole_BrokenDB(t *testing.T) {
 	ls := newS18Store(t, &models.Role{})
 	closeS18DB(t, ls)
 
-	_, err := ls.CreateRole(context.Background(), &models.Role{Name: "viewer"})
+	viewerName, err := identity.NewFoldedName("viewer")
+	require.NoError(t, err)
+	_, err = ls.CreateRole(context.Background(), viewerName, "")
 	require.Error(t, err)
 }
 

--- a/internal/storage/store/store_s26_test.go
+++ b/internal/storage/store/store_s26_test.go
@@ -420,7 +420,7 @@ func TestListGroupsPage_S26_HappyPath(t *testing.T) {
 	ctx := context.Background()
 
 	for _, name := range []string{"alpha", "beta", "gamma"} {
-		_, err := ls.CreateGroup(ctx, &models.Group{Name: name})
+		_, err := ls.CreateGroup(ctx, &models.Group{Name: name, NameFolded: name})
 		require.NoError(t, err)
 	}
 
@@ -436,7 +436,7 @@ func TestAddUserToGroup_S26_UserNotFound(t *testing.T) {
 	ls := newS26Store(t, &models.User{}, &models.Group{}, &models.UserGroup{})
 	ctx := context.Background()
 
-	grp, err := ls.CreateGroup(ctx, &models.Group{Name: "g1"})
+	grp, err := ls.CreateGroup(ctx, &models.Group{Name: "g1", NameFolded: "g1"})
 	require.NoError(t, err)
 
 	// User 9999 doesn't exist.
@@ -451,7 +451,7 @@ func TestAddUserToGroup_S26_GroupNotFound(t *testing.T) {
 	ctx := context.Background()
 
 	user, err := ls.CreateUser(ctx, &models.User{
-		Username: "u1", Email: "u1@test.com", PasswordHash: "x",
+		Username: "u1", UsernameFolded: "u1", Email: "u1@test.com", EmailFolded: "u1@test.com", PasswordHash: "x",
 	})
 	require.NoError(t, err)
 

--- a/internal/storage/store/store_s28_test.go
+++ b/internal/storage/store/store_s28_test.go
@@ -109,6 +109,7 @@ import (
 	"gorm.io/gorm"
 
 	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
@@ -168,7 +169,9 @@ func TestRemoteStorage_S28_CreateRole_APIError(t *testing.T) {
 	}))
 	defer srv.Close()
 	rs := newS28Remote(t, srv.URL)
-	_, err := rs.CreateRole(context.Background(), &models.Role{Name: "admin"})
+	adminName, ferr := identity.NewFoldedName("admin")
+	require.NoError(t, ferr)
+	_, err := rs.CreateRole(context.Background(), adminName, "")
 	assert.Error(t, err)
 }
 

--- a/internal/storage/store/store_s3_local2_test.go
+++ b/internal/storage/store/store_s3_local2_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -130,7 +131,7 @@ func TestMFA_SetUserMFAEnabled(t *testing.T) {
 	ls := newMFAStore(t)
 
 	// Create a user.
-	require.NoError(t, ls.db.Create(&models.User{Username: "mfa-user", Email: "mfa@example.com"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{Username: "mfa-user", UsernameFolded: "mfa-user", Email: "mfa@example.com", EmailFolded: "mfa@example.com"}).Error)
 	var u models.User
 	require.NoError(t, ls.db.Where("username = ?", "mfa-user").First(&u).Error)
 
@@ -586,7 +587,9 @@ func TestRBAC_RolesAndPermissions(t *testing.T) {
 	ls := newRBACStore(t)
 
 	// CreateRole.
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "viewer", Description: "read-only"})
+	viewerName, err := identity.NewFoldedName("viewer")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, viewerName, "read-only")
 	require.NoError(t, err)
 	assert.NotZero(t, role.ID)
 
@@ -650,11 +653,13 @@ func TestRBAC_UserRoles(t *testing.T) {
 	ls := newRBACStore(t)
 
 	// Create role.
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "editor", Description: "edit"})
+	editorName, err := identity.NewFoldedName("editor")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, editorName, "edit")
 	require.NoError(t, err)
 
 	// Create user.
-	require.NoError(t, ls.db.Create(&models.User{Username: "rbac-user", Email: "rbac@example.com"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{Username: "rbac-user", UsernameFolded: "rbac-user", Email: "rbac@example.com", EmailFolded: "rbac@example.com"}).Error)
 	var u models.User
 	require.NoError(t, ls.db.Where("username = ?", "rbac-user").First(&u).Error)
 
@@ -694,11 +699,13 @@ func TestRBAC_GroupRoles(t *testing.T) {
 	ctx := context.Background()
 	ls := newRBACStore(t)
 
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "member", Description: "member"})
+	memberName, err := identity.NewFoldedName("member")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, memberName, "member")
 	require.NoError(t, err)
 
 	// Create group.
-	group, err := ls.CreateGroup(ctx, &models.Group{Name: "eng-team"})
+	group, err := ls.CreateGroup(ctx, &models.Group{Name: "eng-team", NameFolded: "eng-team"})
 	require.NoError(t, err)
 	assert.NotZero(t, group.ID)
 
@@ -726,11 +733,11 @@ func TestRBAC_UserGroups(t *testing.T) {
 	ls := newRBACStore(t)
 
 	// Create group.
-	group, err := ls.CreateGroup(ctx, &models.Group{Name: "devs"})
+	group, err := ls.CreateGroup(ctx, &models.Group{Name: "devs", NameFolded: "devs"})
 	require.NoError(t, err)
 
 	// Create user.
-	require.NoError(t, ls.db.Create(&models.User{Username: "dev1", Email: "dev1@example.com"}).Error)
+	require.NoError(t, ls.db.Create(&models.User{Username: "dev1", UsernameFolded: "dev1", Email: "dev1@example.com", EmailFolded: "dev1@example.com"}).Error)
 	var u models.User
 	require.NoError(t, ls.db.Where("username = ?", "dev1").First(&u).Error)
 
@@ -758,7 +765,9 @@ func TestRBAC_DeleteRole(t *testing.T) {
 	ctx := context.Background()
 	ls := newRBACStore(t)
 
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "temp", Description: "temp"})
+	tempName, err := identity.NewFoldedName("temp")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, tempName, "temp")
 	require.NoError(t, err)
 
 	require.NoError(t, ls.DeleteRole(ctx, role.ID))

--- a/internal/storage/store/store_s3_local3_test.go
+++ b/internal/storage/store/store_s3_local3_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -231,7 +232,7 @@ func TestSecret_ListOrphanedAndCounts(t *testing.T) {
 	require.NoError(t, err)
 
 	// Active user.
-	u := &models.User{Username: "active-u", Email: "active@example.com"}
+	u := &models.User{Username: "active-u", UsernameFolded: "active-u", Email: "active@example.com", EmailFolded: "active@example.com"}
 	require.NoError(t, ls.db.Create(u).Error)
 
 	// Secret owned by live user → not orphaned.
@@ -319,7 +320,7 @@ func TestUser_GetByEmail(t *testing.T) {
 	ls := newUsersFullStore(t)
 
 	u, err := ls.CreateUser(ctx, &models.User{
-		Username: "alice", Email: "alice@example.com",
+		Username: "alice", UsernameFolded: "alice", Email: "alice@example.com", EmailFolded: "alice@example.com",
 	})
 	require.NoError(t, err)
 
@@ -343,7 +344,7 @@ func TestUser_GetByExternalID(t *testing.T) {
 	ls := newUsersFullStore(t)
 
 	u, err := ls.CreateUser(ctx, &models.User{
-		Username: "ext-user", Email: "ext@example.com", ExternalID: "ext-123",
+		Username: "ext-user", UsernameFolded: "ext-user", Email: "ext@example.com", EmailFolded: "ext@example.com", ExternalID: "ext-123",
 	})
 	require.NoError(t, err)
 
@@ -359,7 +360,7 @@ func TestUser_LockForUpdate(t *testing.T) {
 	ctx := context.Background()
 	ls := newUsersFullStore(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "lock-u", Email: "lock@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "lock-u", UsernameFolded: "lock-u", Email: "lock@example.com", EmailFolded: "lock@example.com"})
 	require.NoError(t, err)
 
 	got, err := ls.LockUserForUpdate(ctx, u.ID)
@@ -374,7 +375,7 @@ func TestUser_UpdateAndSetAccountState(t *testing.T) {
 	ctx := context.Background()
 	ls := newUsersFullStore(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "state-u", Email: "state@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "state-u", UsernameFolded: "state-u", Email: "state@example.com", EmailFolded: "state@example.com"})
 	require.NoError(t, err)
 
 	// UpdateUser.
@@ -398,7 +399,7 @@ func TestUser_SetPasswordHash(t *testing.T) {
 	ctx := context.Background()
 	ls := newUsersFullStore(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "pw-u", Email: "pw@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "pw-u", UsernameFolded: "pw-u", Email: "pw@example.com", EmailFolded: "pw@example.com"})
 	require.NoError(t, err)
 
 	require.NoError(t, ls.SetPasswordHash(ctx, u.ID, "$2a$bcrypt", time.Now()))
@@ -415,7 +416,7 @@ func TestUser_UpdateLoginLockoutState(t *testing.T) {
 	ctx := context.Background()
 	ls := newUsersFullStore(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "lock-state-u", Email: "lockstate@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "lock-state-u", UsernameFolded: "lock-state-u", Email: "lockstate@example.com", EmailFolded: "lockstate@example.com"})
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -430,7 +431,7 @@ func TestUser_DeleteAndRestore(t *testing.T) {
 	ctx := context.Background()
 	ls := newUsersFullStore(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "del-u", Email: "del@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "del-u", UsernameFolded: "del-u", Email: "del@example.com", EmailFolded: "del@example.com"})
 	require.NoError(t, err)
 
 	// DeleteUser (soft-delete).
@@ -463,7 +464,7 @@ func TestGroup_UpdateAndList(t *testing.T) {
 	ls := newUsersFullStore(t)
 
 	// CreateGroup (via RBAC in store_s3_local2_test.go already tests create).
-	g, err := ls.CreateGroup(ctx, &models.Group{Name: "list-group"})
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "list-group", NameFolded: "list-group"})
 	require.NoError(t, err)
 
 	// UpdateGroup.
@@ -506,10 +507,12 @@ func TestRBAC_RemoveAllProjectRoleGrants(t *testing.T) {
 	ctx := context.Background()
 	ls := newRBACAdvancedStore(t)
 
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "proj-role"})
+	projRoleName, err := identity.NewFoldedName("proj-role")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, projRoleName, "")
 	require.NoError(t, err)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "proj-user", Email: "pu@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "proj-user", UsernameFolded: "proj-user", Email: "pu@example.com", EmailFolded: "pu@example.com"})
 	require.NoError(t, err)
 
 	scope1 := coreStorage.Scope{ProjectID: 1, EnvironmentID: 0}
@@ -530,10 +533,12 @@ func TestRBAC_GetUserRoleScopes(t *testing.T) {
 	ctx := context.Background()
 	ls := newRBACAdvancedStore(t)
 
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "scope-role"})
+	scopeRoleName, err := identity.NewFoldedName("scope-role")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, scopeRoleName, "")
 	require.NoError(t, err)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "scope-user", Email: "su@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "scope-user", UsernameFolded: "scope-user", Email: "su@example.com", EmailFolded: "su@example.com"})
 	require.NoError(t, err)
 
 	require.NoError(t, ls.AssignRole(ctx, u.ID, role.ID, coreStorage.Scope{ProjectID: 5, EnvironmentID: 0}))
@@ -548,17 +553,19 @@ func TestRBAC_ListProjectRoleAssignments(t *testing.T) {
 	ctx := context.Background()
 	ls := newRBACAdvancedStore(t)
 
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "list-role"})
+	listRoleName, err := identity.NewFoldedName("list-role")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, listRoleName, "")
 	require.NoError(t, err)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "list-user", Email: "lu@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "list-user", UsernameFolded: "list-user", Email: "lu@example.com", EmailFolded: "lu@example.com"})
 	require.NoError(t, err)
 
 	scope := coreStorage.Scope{ProjectID: 10, EnvironmentID: 0}
 	require.NoError(t, ls.AssignRole(ctx, u.ID, role.ID, scope))
 
 	// Add a group grant too.
-	g, err := ls.CreateGroup(ctx, &models.Group{Name: "list-group2"})
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "list-group2", NameFolded: "list-group2"})
 	require.NoError(t, err)
 	require.NoError(t, ls.AssignRoleToGroup(ctx, g.ID, role.ID, scope))
 
@@ -576,7 +583,9 @@ func TestRBAC_ListProjectMachineRoleAssignments(t *testing.T) {
 	ctx := context.Background()
 	ls := newRBACAdvancedStore(t)
 
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "mach-role"})
+	machRoleName, err := identity.NewFoldedName("mach-role")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, machRoleName, "")
 	require.NoError(t, err)
 
 	m, err := ls.CreateMachineIdentity(ctx, &models.MachineIdentity{
@@ -602,10 +611,12 @@ func TestRBAC_IsProjectMember(t *testing.T) {
 	ctx := context.Background()
 	ls := newRBACAdvancedStore(t)
 
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "member-role"})
+	memberRoleName, err := identity.NewFoldedName("member-role")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, memberRoleName, "")
 	require.NoError(t, err)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "member-u", Email: "member@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "member-u", UsernameFolded: "member-u", Email: "member@example.com", EmailFolded: "member@example.com"})
 	require.NoError(t, err)
 
 	// Zero projectID → always false.
@@ -630,7 +641,9 @@ func TestRBAC_RoleSetHasPermission(t *testing.T) {
 	ctx := context.Background()
 	ls := newRBACAdvancedStore(t)
 
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "perm-role"})
+	permRoleName, err := identity.NewFoldedName("perm-role")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, permRoleName, "")
 	require.NoError(t, err)
 	perm, err := ls.CreatePermission(ctx, &models.Permission{Name: "secrets.read", Resource: "secrets", Action: "read"})
 	require.NoError(t, err)
@@ -678,9 +691,11 @@ func TestRBAC_GetGroupRoleGrants(t *testing.T) {
 	ctx := context.Background()
 	ls := newRBACAdvancedStore(t)
 
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "grp-grants-role"})
+	grpGrantsRoleName, err := identity.NewFoldedName("grp-grants-role")
 	require.NoError(t, err)
-	g, err := ls.CreateGroup(ctx, &models.Group{Name: "grants-group"})
+	role, err := ls.CreateRole(ctx, grpGrantsRoleName, "")
+	require.NoError(t, err)
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "grants-group", NameFolded: "grants-group"})
 	require.NoError(t, err)
 
 	scope := coreStorage.Scope{ProjectID: 40, EnvironmentID: 0}
@@ -701,10 +716,12 @@ func TestRBAC_DeleteExpiredRoleGrants(t *testing.T) {
 	ctx := context.Background()
 	ls := newRBACAdvancedStore(t)
 
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "exp-role"})
+	expRoleName, err := identity.NewFoldedName("exp-role")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, expRoleName, "")
 	require.NoError(t, err)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "exp-u", Email: "expu@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "exp-u", UsernameFolded: "exp-u", Email: "expu@example.com", EmailFolded: "expu@example.com"})
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -741,10 +758,12 @@ func TestRBAC_GlobalAdmin(t *testing.T) {
 	ctx := context.Background()
 	ls := newRBACAdvancedStore(t)
 
-	role, err := ls.CreateRole(ctx, &models.Role{Name: "global-admin"})
+	globalAdminName, err := identity.NewFoldedName("global-admin")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, globalAdminName, "")
 	require.NoError(t, err)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "gadmin", Email: "gadmin@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "gadmin", UsernameFolded: "gadmin", Email: "gadmin@example.com", EmailFolded: "gadmin@example.com"})
 	require.NoError(t, err)
 
 	// Assign global role (scope 0/0).
@@ -759,7 +778,7 @@ func TestRBAC_GlobalAdmin(t *testing.T) {
 	assert.Len(t, rows, 1)
 
 	// Add a second admin so we can remove one safely.
-	u2, err := ls.CreateUser(ctx, &models.User{Username: "gadmin2", Email: "gadmin2@example.com"})
+	u2, err := ls.CreateUser(ctx, &models.User{Username: "gadmin2", UsernameFolded: "gadmin2", Email: "gadmin2@example.com", EmailFolded: "gadmin2@example.com"})
 	require.NoError(t, err)
 	require.NoError(t, ls.AssignRole(ctx, u2.ID, role.ID, globalScope))
 
@@ -790,7 +809,7 @@ func TestWebAuthn_Credential_CRUD(t *testing.T) {
 	ctx := context.Background()
 	ls := newWebAuthnStore(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "wa-user", Email: "wa@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "wa-user", UsernameFolded: "wa-user", Email: "wa@example.com", EmailFolded: "wa@example.com"})
 	require.NoError(t, err)
 
 	blob := []byte(`{"authenticator":{"signCount":10}}`)
@@ -837,7 +856,7 @@ func TestWebAuthn_AdvanceCredentialCounter(t *testing.T) {
 	ctx := context.Background()
 	ls := newWebAuthnStore(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "wa-adv", Email: "wa-adv@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "wa-adv", UsernameFolded: "wa-adv", Email: "wa-adv@example.com", EmailFolded: "wa-adv@example.com"})
 	require.NoError(t, err)
 
 	type blobT struct {
@@ -1111,7 +1130,7 @@ func TestListProjectMemberships(t *testing.T) {
 
 	p, err := ls.CreateProject(ctx, &models.Project{Name: "memb-proj"})
 	require.NoError(t, err)
-	u, err := ls.CreateUser(ctx, &models.User{Username: "memb-user", Email: "memb@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "memb-user", UsernameFolded: "memb-user", Email: "memb@example.com", EmailFolded: "memb@example.com"})
 	require.NoError(t, err)
 
 	// Add membership.

--- a/internal/storage/store/store_s4_test.go
+++ b/internal/storage/store/store_s4_test.go
@@ -197,8 +197,8 @@ func TestListEnvironments(t *testing.T) {
 
 func TestIsDuplicateEmailViolation(t *testing.T) {
 	assert.False(t, isDuplicateEmailViolation(nil))
-	assert.True(t, isDuplicateEmailViolation(fmt.Errorf("uniq_users_email_active")))
-	assert.True(t, isDuplicateEmailViolation(fmt.Errorf("ERROR: violates unique constraint \"uniq_users_email_active\"")))
+	assert.True(t, isDuplicateEmailViolation(fmt.Errorf("uniq_users_email_folded_active")))
+	assert.True(t, isDuplicateEmailViolation(fmt.Errorf("ERROR: violates unique constraint \"uniq_users_email_folded_active\"")))
 	assert.False(t, isDuplicateEmailViolation(fmt.Errorf("some other error")))
 }
 
@@ -211,7 +211,7 @@ func TestCreateUser_Success(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "alice", Email: "alice@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "alice", UsernameFolded: "alice", Email: "alice@example.com", EmailFolded: "alice@example.com"})
 	require.NoError(t, err)
 	assert.NotZero(t, u.ID)
 }
@@ -220,7 +220,7 @@ func TestUpdateUser_Success(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "bob", Email: "bob@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "bob", UsernameFolded: "bob", Email: "bob@example.com", EmailFolded: "bob@example.com"})
 	require.NoError(t, err)
 
 	u.DisplayName = "Bobby"
@@ -236,7 +236,7 @@ func TestUpdateUserIfActiveStateMatches_Success(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "dave", Email: "dave@example.com", IsActive: true})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "dave", UsernameFolded: "dave", Email: "dave@example.com", EmailFolded: "dave@example.com", IsActive: true})
 	require.NoError(t, err)
 
 	u.IsActive = false
@@ -263,11 +263,11 @@ func TestUpdateUserIfActiveStateMatches_LostRaceReturnsFalse(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "eve", Email: "eve@example.com", IsActive: true})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "eve", UsernameFolded: "eve", Email: "eve@example.com", EmailFolded: "eve@example.com", IsActive: true})
 	require.NoError(t, err)
 
 	// First racing caller: observed IsActive=true, flips to false, wins.
-	first := &models.User{ID: u.ID, Username: u.Username, Email: u.Email, IsActive: false}
+	first := &models.User{ID: u.ID, Username: u.Username, UsernameFolded: u.UsernameFolded, Email: u.Email, EmailFolded: u.EmailFolded, IsActive: false}
 	matched, err := ls.UpdateUserIfActiveStateMatches(ctx, first, true)
 	require.NoError(t, err)
 	assert.True(t, matched, "first racing call must win")
@@ -276,7 +276,7 @@ func TestUpdateUserIfActiveStateMatches_LostRaceReturnsFalse(t *testing.T) {
 	// already committed false) and tries to persist its own unrelated field
 	// change plus a redundant IsActive=false assertion. Must lose the race, not
 	// silently re-apply its stale view over the winner's write.
-	second := &models.User{ID: u.ID, Username: u.Username, Email: u.Email, DisplayName: "Should Not Persist", IsActive: false}
+	second := &models.User{ID: u.ID, Username: u.Username, UsernameFolded: u.UsernameFolded, Email: u.Email, EmailFolded: u.EmailFolded, DisplayName: "Should Not Persist", IsActive: false}
 	matched, err = ls.UpdateUserIfActiveStateMatches(ctx, second, true)
 	require.NoError(t, err)
 	assert.False(t, matched, "second racing call must lose the race")
@@ -312,7 +312,7 @@ func TestRestoreUser_NotDeleted(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "carol", Email: "carol@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "carol", UsernameFolded: "carol", Email: "carol@example.com", EmailFolded: "carol@example.com"})
 	require.NoError(t, err)
 
 	// User not soft-deleted → returns not-found sentinel (RowsAffected == 0).
@@ -326,9 +326,9 @@ func TestListUsers_Filters(t *testing.T) {
 	ls := newUserS4Store(t)
 
 	active := true
-	u1, err := ls.CreateUser(ctx, &models.User{Username: "u1fil", Email: "u1fil@example.com", IsActive: true})
+	u1, err := ls.CreateUser(ctx, &models.User{Username: "u1fil", UsernameFolded: "u1fil", Email: "u1fil@example.com", EmailFolded: "u1fil@example.com", IsActive: true})
 	require.NoError(t, err)
-	u2, err := ls.CreateUser(ctx, &models.User{Username: "u2fil", Email: "u2fil@example.com", IsActive: true})
+	u2, err := ls.CreateUser(ctx, &models.User{Username: "u2fil", UsernameFolded: "u2fil", Email: "u2fil@example.com", EmailFolded: "u2fil@example.com", IsActive: true})
 	require.NoError(t, err)
 
 	// Deactivate u2 via direct DB update to avoid GORM zero-value issue.
@@ -353,9 +353,9 @@ func TestListUsers_UsernameEmailFilter(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)
 
-	_, err := ls.CreateUser(ctx, &models.User{Username: "dave", Email: "dave@example.com"})
+	_, err := ls.CreateUser(ctx, &models.User{Username: "dave", UsernameFolded: "dave", Email: "dave@example.com", EmailFolded: "dave@example.com"})
 	require.NoError(t, err)
-	_, err = ls.CreateUser(ctx, &models.User{Username: "eve", Email: "eve@example.com"})
+	_, err = ls.CreateUser(ctx, &models.User{Username: "eve", UsernameFolded: "eve", Email: "eve@example.com", EmailFolded: "eve@example.com"})
 	require.NoError(t, err)
 
 	uname := "dave"
@@ -375,7 +375,7 @@ func TestListUsers_CreatedAfterFilter(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)
 
-	_, err := ls.CreateUser(ctx, &models.User{Username: "frank", Email: "frank@example.com"})
+	_, err := ls.CreateUser(ctx, &models.User{Username: "frank", UsernameFolded: "frank", Email: "frank@example.com", EmailFolded: "frank@example.com"})
 	require.NoError(t, err)
 
 	past := time.Now().Add(-24 * time.Hour)
@@ -398,7 +398,7 @@ func TestListUsers_InactiveSinceFilter(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "grace", Email: "grace@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "grace", UsernameFolded: "grace", Email: "grace@example.com", EmailFolded: "grace@example.com"})
 	require.NoError(t, err)
 
 	// InactiveSince: never logged in (LastLoginAt = nil) → returned.
@@ -416,8 +416,10 @@ func TestListUsers_OffsetParam(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		_, err := ls.CreateUser(ctx, &models.User{
-			Username: fmt.Sprintf("puser%d", i),
-			Email:    fmt.Sprintf("puser%d@example.com", i),
+			Username:       fmt.Sprintf("puser%d", i),
+			UsernameFolded: fmt.Sprintf("puser%d", i),
+			Email:          fmt.Sprintf("puser%d@example.com", i),
+			EmailFolded:    fmt.Sprintf("puser%d@example.com", i),
 		})
 		require.NoError(t, err)
 	}
@@ -437,7 +439,7 @@ func TestGroup_CRUD(t *testing.T) {
 	ls := newUserS4Store(t)
 
 	// Create.
-	g, err := ls.CreateGroup(ctx, &models.Group{Name: "eng"})
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "eng", NameFolded: "eng"})
 	require.NoError(t, err)
 	assert.NotZero(t, g.ID)
 
@@ -505,9 +507,9 @@ func TestGroup_UserMembership(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "henry", Email: "henry@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "henry", UsernameFolded: "henry", Email: "henry@example.com", EmailFolded: "henry@example.com"})
 	require.NoError(t, err)
-	g, err := ls.CreateGroup(ctx, &models.Group{Name: "ops"})
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "ops", NameFolded: "ops"})
 	require.NoError(t, err)
 
 	// AddUserToGroup (global: projectID=0).
@@ -557,7 +559,7 @@ func TestListGroupsPage_Offset(t *testing.T) {
 	ls := newUserS4Store(t)
 
 	for i := 0; i < 3; i++ {
-		_, err := ls.CreateGroup(ctx, &models.Group{Name: fmt.Sprintf("g%d", i)})
+		_, err := ls.CreateGroup(ctx, &models.Group{Name: fmt.Sprintf("g%d", i), NameFolded: fmt.Sprintf("g%d", i)})
 		require.NoError(t, err)
 	}
 
@@ -572,7 +574,7 @@ func TestAddUserToGroup_UserNotFound(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)
 
-	g, err := ls.CreateGroup(ctx, &models.Group{Name: "admins"})
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "admins", NameFolded: "admins"})
 	require.NoError(t, err)
 
 	err = ls.AddUserToGroup(ctx, 99999, g.ID, 0)
@@ -583,7 +585,7 @@ func TestAddUserToGroup_GroupNotFound(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)
 
-	u, err := ls.CreateUser(ctx, &models.User{Username: "ivan", Email: "ivan@example.com"})
+	u, err := ls.CreateUser(ctx, &models.User{Username: "ivan", UsernameFolded: "ivan", Email: "ivan@example.com", EmailFolded: "ivan@example.com"})
 	require.NoError(t, err)
 
 	err = ls.AddUserToGroup(ctx, u.ID, 99999, 0)
@@ -598,13 +600,13 @@ func TestListGroupMembersByGroupIDsS4(t *testing.T) {
 	ctx := context.Background()
 	ls := newUserS4Store(t)
 
-	u1, err := ls.CreateUser(ctx, &models.User{Username: "jill", Email: "jill@example.com"})
+	u1, err := ls.CreateUser(ctx, &models.User{Username: "jill", UsernameFolded: "jill", Email: "jill@example.com", EmailFolded: "jill@example.com"})
 	require.NoError(t, err)
-	u2, err := ls.CreateUser(ctx, &models.User{Username: "jack", Email: "jack@example.com"})
+	u2, err := ls.CreateUser(ctx, &models.User{Username: "jack", UsernameFolded: "jack", Email: "jack@example.com", EmailFolded: "jack@example.com"})
 	require.NoError(t, err)
-	g1, err := ls.CreateGroup(ctx, &models.Group{Name: "g1"})
+	g1, err := ls.CreateGroup(ctx, &models.Group{Name: "g1", NameFolded: "g1"})
 	require.NoError(t, err)
-	g2, err := ls.CreateGroup(ctx, &models.Group{Name: "g2"})
+	g2, err := ls.CreateGroup(ctx, &models.Group{Name: "g2", NameFolded: "g2"})
 	require.NoError(t, err)
 
 	require.NoError(t, ls.AddUserToGroup(ctx, u1.ID, g1.ID, 0))

--- a/internal/testhelper/rbac_test_helper.go
+++ b/internal/testhelper/rbac_test_helper.go
@@ -3,6 +3,7 @@ package testhelper
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
@@ -148,8 +149,10 @@ func (h *RBACTestHelper) seedTestData(t *testing.T) {
 	}
 
 	for _, role := range roles {
-		_, _ = h.SqlDB.Exec("INSERT OR IGNORE INTO roles (id, name, description) VALUES (?, ?, ?)",
-			role.ID, role.Name, role.Description)
+		// name_folded is NOT NULL (#1642); every seeded role name here is
+		// already pure-lowercase ASCII, so it's its own folded form.
+		_, _ = h.SqlDB.Exec("INSERT OR IGNORE INTO roles (id, name, name_folded, description) VALUES (?, ?, ?, ?)",
+			role.ID, role.Name, role.Name, role.Description)
 	}
 
 	// Create default permissions using raw SQL
@@ -232,9 +235,11 @@ func (h *RBACTestHelper) seedTestData(t *testing.T) {
 // CreateTestUser creates a test user in the database
 func (h *RBACTestHelper) CreateTestUser(t *testing.T, username string, userID uint) *models.User {
 	user := &models.User{
-		ID:       userID,
-		Username: username,
-		Email:    username + "@test.com",
+		ID:             userID,
+		Username:       username,
+		UsernameFolded: strings.ToLower(username),
+		Email:          username + "@test.com",
+		EmailFolded:    strings.ToLower(username) + "@test.com",
 	}
 
 	result := h.DB.Create(user)
@@ -262,6 +267,7 @@ func (h *RBACTestHelper) CreateTestGroup(t *testing.T, name, description string,
 	group := &models.Group{
 		ID:          groupID,
 		Name:        name,
+		NameFolded:  strings.ToLower(name),
 		Description: description,
 	}
 

--- a/internal/testhelper/testhelper_extra_test.go
+++ b/internal/testhelper/testhelper_extra_test.go
@@ -34,8 +34,9 @@ func TestExecuteRawSQL_QueryRawSQL(t *testing.T) {
 	h := NewRBACTestHelper(t)
 	t.Cleanup(h.Cleanup)
 
-	h.ExecuteRawSQL(t, "INSERT INTO roles (id, name, description) VALUES (?, ?, ?)",
-		999, "raw_sql_role", "created via ExecuteRawSQL")
+	// name_folded is NOT NULL (#1642); already pure-lowercase ASCII.
+	h.ExecuteRawSQL(t, "INSERT INTO roles (id, name, name_folded, description) VALUES (?, ?, ?, ?)",
+		999, "raw_sql_role", "raw_sql_role", "created via ExecuteRawSQL")
 
 	rows := h.QueryRawSQL(t, "SELECT name, description FROM roles WHERE id = ?", 999)
 	defer rows.Close() //nolint:errcheck

--- a/server/grpc/services/coverage_g80_test.go
+++ b/server/grpc/services/coverage_g80_test.go
@@ -467,17 +467,21 @@ func TestMachineIdentityService_ListMachineIdentities_StorageErrorIsInternal(t *
 // role_service.go
 // ---------------------------------------------------------------------------
 
-// CreateRole's mapRoleError branch via a real storage failure: Role.Name
-// carries a `gorm:"unique"` tag (unlike Group.Name's partial index, this one
-// IS created by AutoMigrate), so creating two roles with the same name hits
-// a genuine UNIQUE constraint violation and mapRoleError's "unique" branch.
+// CreateRole's mapRoleError branch via a real storage failure: #1642 moved role-name
+// uniqueness off Role.Name's `gorm:"unique"` tag onto the explicit ensureRoleNameIndex
+// migration step (matching Group/User's folded-column pattern), so AutoMigrate alone no
+// longer creates any constraint here — replicate what the production migration creates
+// (uniq_roles_name_folded on the folded column) so this test still exercises a genuine
+// UNIQUE constraint violation and mapRoleError's "unique" branch.
 func TestRoleService_CreateRole_DuplicateName(t *testing.T) {
 	svc, h := newRoleService(t)
+	_, err := h.SqlDB.Exec("CREATE UNIQUE INDEX uniq_roles_name_folded ON roles (name_folded)")
+	require.NoError(t, err)
 	perm := somePermission(t, h)
 	ctx := roleAdminCtx()
 
 	req := &pb.CreateRoleRequest{Name: "duplicate-role", Description: "a role", Permissions: []string{perm}}
-	_, err := svc.CreateRole(ctx, req)
+	_, err = svc.CreateRole(ctx, req)
 	require.NoError(t, err)
 
 	_, err = svc.CreateRole(ctx, req)

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"google.golang.org/grpc/codes"
@@ -58,10 +59,19 @@ func (s *RoleGRPCService) CreateRole(ctx context.Context, req *pb.CreateRoleRequ
 	if err := validateRoleDescription(req.GetDescription()); err != nil {
 		return nil, err
 	}
+	// #1642: fold once here, use for both the reserved-name check below and
+	// the CreateRole call — see the identical HTTP-side treatment
+	// (RBACHandler.CreateRole) for the full rationale, including why folding
+	// before IsBuiltinRole closes a case-variant gap that check's own exact
+	// map lookup otherwise leaves open.
+	foldedName, ferr := identity.NewFoldedName(req.GetName())
+	if ferr != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid role name: "+ferr.Error())
+	}
 	// #294: reserved role names must never be creatable — see the identical guard (with
 	// full rationale) in the HTTP RBACHandler.CreateRole. This closes the same gap over
 	// gRPC, which has its own independent CreateRole path.
-	if core.IsBuiltinRole(req.GetName()) {
+	if core.IsBuiltinRole(foldedName.Folded()) {
 		return nil, status.Error(codes.AlreadyExists, "this role name is reserved and cannot be created")
 	}
 
@@ -70,7 +80,7 @@ func (s *RoleGRPCService) CreateRole(ctx context.Context, req *pb.CreateRoleRequ
 		return nil, err
 	}
 
-	role, err := s.core.Storage().CreateRole(ctx, &models.Role{Name: req.GetName(), Description: req.GetDescription()})
+	role, err := s.core.Storage().CreateRole(ctx, foldedName, req.GetDescription())
 	if err != nil {
 		return nil, mapRoleError(err)
 	}

--- a/server/http/delete_environment_proxy_scope_test.go
+++ b/server/http/delete_environment_proxy_scope_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core"
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/identity"
 )
 
 // createSystemWriteAndProjectSecretsDeleteTokenForEnv is
@@ -41,13 +41,13 @@ func createSystemWriteAndProjectSecretsDeleteTokenForEnv(t *testing.T, c *core.K
 	require.NoError(t, err)
 	require.NoError(t, c.RemoveRoleFromUser(ctx, "sys_write_env_secrets_delete@example.com", "system_viewer"))
 
-	globalRole, err := c.Storage().CreateRole(ctx, &models.Role{
-		Name: "ceiling_test_system_writer_delenv_global", Description: "test-only role: system.write only, granted globally",
-	})
+	globalRoleName, err := identity.NewFoldedName("ceiling_test_system_writer_delenv_global")
 	require.NoError(t, err)
-	scopedRole, err := c.Storage().CreateRole(ctx, &models.Role{
-		Name: "ceiling_test_system_writer_delenv_scoped", Description: "test-only role: secrets.delete only, granted at one project's scope",
-	})
+	globalRole, err := c.Storage().CreateRole(ctx, globalRoleName, "test-only role: system.write only, granted globally")
+	require.NoError(t, err)
+	scopedRoleName, err := identity.NewFoldedName("ceiling_test_system_writer_delenv_scoped")
+	require.NoError(t, err)
+	scopedRole, err := c.Storage().CreateRole(ctx, scopedRoleName, "test-only role: secrets.delete only, granted at one project's scope")
 	require.NoError(t, err)
 
 	perms, err := c.ListPermissions(ctx)

--- a/server/http/delete_project_proxy_scope_test.go
+++ b/server/http/delete_project_proxy_scope_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core"
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
@@ -47,13 +47,13 @@ func createSystemWriteAndProjectSecretsDeleteToken(t *testing.T, c *core.Keyorix
 	require.NoError(t, err)
 	require.NoError(t, c.RemoveRoleFromUser(ctx, "sys_write_proj_secrets_delete@example.com", "system_viewer"))
 
-	globalRole, err := c.Storage().CreateRole(ctx, &models.Role{
-		Name: "ceiling_test_system_writer_delproj_global", Description: "test-only role: system.write only, granted globally",
-	})
+	globalRoleName, err := identity.NewFoldedName("ceiling_test_system_writer_delproj_global")
 	require.NoError(t, err)
-	scopedRole, err := c.Storage().CreateRole(ctx, &models.Role{
-		Name: "ceiling_test_system_writer_delproj_scoped", Description: "test-only role: secrets.delete only, granted at one project's scope",
-	})
+	globalRole, err := c.Storage().CreateRole(ctx, globalRoleName, "test-only role: system.write only, granted globally")
+	require.NoError(t, err)
+	scopedRoleName, err := identity.NewFoldedName("ceiling_test_system_writer_delproj_scoped")
+	require.NoError(t, err)
+	scopedRole, err := c.Storage().CreateRole(ctx, scopedRoleName, "test-only role: secrets.delete only, granted at one project's scope")
 	require.NoError(t, err)
 
 	perms, err := c.ListPermissions(ctx)

--- a/server/http/g80_1530_machine_actor_attribution_test.go
+++ b/server/http/g80_1530_machine_actor_attribution_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core"
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/identity"
 )
 
 func TestG80_1530_MachineActorAttribution_NonNodeServiceIdentity(t *testing.T) {
@@ -41,7 +41,9 @@ func TestG80_1530_MachineActorAttribution_NonNodeServiceIdentity(t *testing.T) {
 	mi, err := testCore.CreateMachineIdentity(ctx, projects[0].ID, "attribution-probe-service", core.MachineTypeService, "", "", admin.ID, 0)
 	require.NoError(t, err)
 
-	role, err := testCore.Storage().CreateRole(ctx, &models.Role{Name: "g80_1530_system_writer"})
+	g801530SystemWriterName, err := identity.NewFoldedName("g80_1530_system_writer")
+	require.NoError(t, err)
+	role, err := testCore.Storage().CreateRole(ctx, g801530SystemWriterName, "")
 	require.NoError(t, err)
 	perms, err := testCore.ListPermissions(ctx)
 	require.NoError(t, err)

--- a/server/http/g80_final_sweep_test.go
+++ b/server/http/g80_final_sweep_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -533,7 +534,9 @@ func TestG80Sweep12_RevokeBreakGlassActivationProxy_RoleActuallyRemoved(t *testi
 	f := newG80SweepFixture(t)
 	ctx := context.Background()
 
-	role, err := f.core.Storage().CreateRole(ctx, &models.Role{Name: "g80sweep12-emergency-role"})
+	g80Sweep12EmergencyRoleName, err := identity.NewFoldedName("g80sweep12-emergency-role")
+	require.NoError(t, err)
+	role, err := f.core.Storage().CreateRole(ctx, g80Sweep12EmergencyRoleName, "")
 	require.NoError(t, err)
 	scope := core.Scope{ProjectID: f.projectID}
 	require.NoError(t, f.core.Storage().AssignRole(ctx, f.adminID, role.ID, scope))

--- a/server/http/handlers/handlers_s12_test.go
+++ b/server/http/handlers/handlers_s12_test.go
@@ -121,10 +121,10 @@ func freshCoreS12WithAdmin(t *testing.T) (*core.KeyorixCore, *gorm.DB) {
 	// Seed the user context user (UserID=1) as a global admin.
 	// The role name must be in adminRoleNames ("super_admin", "admin",
 	// "system_admin", "project_admin") for the admin bypass to fire.
-	adminRole := &models.Role{Name: "system_admin", Description: "Administrator"}
+	adminRole := &models.Role{Name: "system_admin", NameFolded: "system_admin", Description: "Administrator"}
 	require.NoError(t, db.Create(adminRole).Error)
 	// withUserCtx injects UserID=1 — seed a user with that implicit first ID.
-	testUser := &models.User{Username: "testuser_s12", Email: "testuser_s12@example.com", AccountState: "active"}
+	testUser := &models.User{Username: "testuser_s12", UsernameFolded: "testuser_s12", Email: "testuser_s12@example.com", EmailFolded: "testuser_s12@example.com", AccountState: "active"}
 	require.NoError(t, db.Create(testUser).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: testUser.ID, RoleID: adminRole.ID}).Error)
 
@@ -497,9 +497,11 @@ func TestCreateUserWithOTP_ConflictError_S12(t *testing.T) {
 	uh, _, db := freshUserHandlerS12(t)
 
 	existing := &models.User{
-		Username:     "otp-exists-s12",
-		Email:        "otp-exists-s12@x.com",
-		AccountState: "active",
+		Username:       "otp-exists-s12",
+		UsernameFolded: "otp-exists-s12",
+		Email:          "otp-exists-s12@x.com",
+		EmailFolded:    "otp-exists-s12@x.com",
+		AccountState:   "active",
 	}
 	require.NoError(t, db.Create(existing).Error)
 

--- a/server/http/handlers/handlers_s13_proxy_test.go
+++ b/server/http/handlers/handlers_s13_proxy_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1035,7 +1036,9 @@ func TestCreateSetupTokenProxy_HappyPath_S13(t *testing.T) {
 	require.NoError(t, err)
 	// Minting a setup token requires users.write (ADR-085); seed a caller who
 	// holds it via the system_admin adminRoleNames bypass (internal/core/authz.go).
-	adminRole, err := cs.Storage().CreateRole(context.Background(), &models.Role{Name: "system_admin", Description: "admin"})
+	systemAdminName, err := identity.NewFoldedName("system_admin")
+	require.NoError(t, err)
+	adminRole, err := cs.Storage().CreateRole(context.Background(), systemAdminName, "admin")
 	require.NoError(t, err)
 	admin, err := cs.Storage().CreateUser(context.Background(), &models.User{
 		Username: "admin_s13", Email: "admin_s13@example.com", PasswordHash: "x",
@@ -1084,7 +1087,9 @@ func TestCreateSetupTokenProxy_MachineCallerAttributionDistinguishable(t *testin
 	// bypass human callers can use (ADR-030's no-bypass property).
 	perm, err := cs.Storage().CreatePermission(ctx, &models.Permission{Name: "users.write", Resource: "users", Action: "write"})
 	require.NoError(t, err)
-	role, err := cs.Storage().CreateRole(ctx, &models.Role{Name: "setup-minter-role", Description: "test"})
+	setupMinterRoleName, err := identity.NewFoldedName("setup-minter-role")
+	require.NoError(t, err)
+	role, err := cs.Storage().CreateRole(ctx, setupMinterRoleName, "test")
 	require.NoError(t, err)
 	require.NoError(t, cs.Storage().AssignPermissionToRole(ctx, role.ID, perm.ID))
 	require.NoError(t, cs.Storage().AssignMachineRole(ctx, callerMachineID, role.ID, coreStorage.Scope{}))

--- a/server/http/handlers/handlers_s18_test.go
+++ b/server/http/handlers/handlers_s18_test.go
@@ -32,9 +32,11 @@ func TestCreateUserWithOTP_Conflict_S18(t *testing.T) {
 	uh, _, db := freshUserHandlerS12(t)
 
 	require.NoError(t, db.Create(&models.User{
-		Username:     "otp-conflict-s18",
-		Email:        "otp-conflict-s18@x.com",
-		AccountState: core.AccountActive,
+		Username:       "otp-conflict-s18",
+		UsernameFolded: "otp-conflict-s18",
+		Email:          "otp-conflict-s18@x.com",
+		EmailFolded:    "otp-conflict-s18@x.com",
+		AccountState:   core.AccountActive,
 	}).Error)
 
 	body, _ := json.Marshal(map[string]interface{}{

--- a/server/http/handlers/handlers_s21_machine_proxy_test.go
+++ b/server/http/handlers/handlers_s21_machine_proxy_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/core/storage"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/identity"
 )
 
 // freshCatalogHandlerS21 returns a CatalogHandler backed by a fresh in-memory DB.
@@ -59,7 +59,9 @@ func proxyBodyS21(v interface{}) *bytes.Buffer {
 func withOIDCAdminCtxS21(t *testing.T, h *CatalogHandler, r *http.Request) *http.Request {
 	t.Helper()
 	ctx := context.Background()
-	_, err := h.coreService.Storage().CreateRole(ctx, &models.Role{Name: "system_admin", Description: "Administrator"})
+	systemAdminName, err := identity.NewFoldedName("system_admin")
+	require.NoError(t, err)
+	_, err = h.coreService.Storage().CreateRole(ctx, systemAdminName, "Administrator")
 	if err != nil {
 		require.Contains(t, err.Error(), "UNIQUE", "unexpected CreateRole error: %v", err) // already exists from a prior call in this test
 	}
@@ -904,8 +906,9 @@ func TestAssignMachineRoleProxy_HappyPath_S21(t *testing.T) {
 	cs, db := freshCoreS12WithAdmin(t)
 	h2 := NewCatalogHandler(cs)
 
-	// Create a role via direct DB insert.
-	require.NoError(t, db.Exec("INSERT INTO roles (name, description) VALUES (?, ?)", "machine-test-role-s21", "test").Error)
+	// Create a role via direct DB insert. name_folded is NOT NULL (#1642);
+	// already pure-lowercase ASCII.
+	require.NoError(t, db.Exec("INSERT INTO roles (name, name_folded, description) VALUES (?, ?, ?)", "machine-test-role-s21", "machine-test-role-s21", "test").Error)
 
 	createMI := proxyBodyS21(map[string]interface{}{
 		"name": "assign-role-mi-s21", "project_id": 50, "state": "active",

--- a/server/http/handlers/handlers_s26_test.go
+++ b/server/http/handlers/handlers_s26_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
@@ -1149,7 +1150,9 @@ func TestRevokeBreakGlassActivationProxy_RemovesRoleGrant(t *testing.T) {
 	h := NewCatalogHandler(cs)
 	ctx := context.Background()
 
-	role, err := cs.Storage().CreateRole(ctx, &models.Role{Name: "s26_break_glass_emergency_role"})
+	breakGlassEmergencyRoleName, err := identity.NewFoldedName("s26_break_glass_emergency_role")
+	require.NoError(t, err)
+	role, err := cs.Storage().CreateRole(ctx, breakGlassEmergencyRoleName, "")
 	require.NoError(t, err)
 	scope := core.Scope{ProjectID: 1}
 	require.NoError(t, cs.Storage().AssignRole(ctx, 1, role.ID, scope))

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core"
 	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/keyorixhq/keyorix/server/middleware"
@@ -804,7 +805,11 @@ func seedS4AdminActor(t *testing.T, cs *core.KeyorixCore) {
 	t.Helper()
 	seedS4AdminActorOnce.Do(func() {
 		ctx := context.Background()
-		role, err := cs.Storage().CreateRole(ctx, &models.Role{Name: "system_admin", Description: "shared S4 admin fixture"})
+		systemAdminName, err := identity.NewFoldedName("system_admin")
+		if err != nil {
+			panic("seedS4AdminActor: NewFoldedName: " + err.Error())
+		}
+		role, err := cs.Storage().CreateRole(ctx, systemAdminName, "shared S4 admin fixture")
 		if err != nil {
 			panic("seedS4AdminActor: CreateRole: " + err.Error())
 		}
@@ -11288,7 +11293,9 @@ func TestCreateSoDPolicyProxy_WritesAuditEvent(t *testing.T) {
 	// DB is fresh per-run (openHandlerTestDB), so seed it directly rather than
 	// via the shared-DB seedS4AdminActor helper.
 	ctx := context.Background()
-	role, err := cs.Storage().CreateRole(ctx, &models.Role{Name: "system_admin", Description: "admin"})
+	systemAdminName, err := identity.NewFoldedName("system_admin")
+	require.NoError(t, err)
+	role, err := cs.Storage().CreateRole(ctx, systemAdminName, "admin")
 	require.NoError(t, err)
 	require.NoError(t, cs.Storage().AssignRole(ctx, 500, role.ID, corestorage.Scope{}))
 

--- a/server/http/handlers/machine_identities_migrate_test.go
+++ b/server/http/handlers/machine_identities_migrate_test.go
@@ -30,7 +30,7 @@ func newMigrateHandler(t *testing.T) (*CatalogHandler, *gorm.DB) {
 		&models.Role{}, &models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Environment{},
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 3, Name: "platform"}).Error)
-	require.NoError(t, db.Create(&models.User{ID: 7, Username: "ci-bot", Email: "ci-bot@x.io", AccountState: core.AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 7, Username: "ci-bot", UsernameFolded: "ci-bot", Email: "ci-bot@x.io", EmailFolded: "ci-bot@x.io", AccountState: core.AccountActive}).Error)
 	return NewCatalogHandler(core.NewKeyorixCore(store.NewLocalStorage(db))), db
 }
 

--- a/server/http/handlers/misc_remote_proxy.go
+++ b/server/http/handlers/misc_remote_proxy.go
@@ -56,6 +56,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -330,9 +331,26 @@ func (h *UserHandler) CreateUserWithRoleGrantsProxy(w http.ResponseWriter, r *ht
 		writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", clientSafe(err))
 		return
 	}
+	// #1642: this endpoint bypasses core.CreateUser/buildUserForCreate
+	// entirely (by design — see the doc comment above), so it needs its own
+	// fold, mirroring ValidateRoleGrantAuthority's own re-implementation of
+	// core's other checks for this wire path. Computed independently from
+	// body.Username/body.Email, never trusted from the wire.
+	foldedUsername, ferr := identity.NewFoldedName(body.Username)
+	if ferr != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid username: "+ferr.Error())
+		return
+	}
+	foldedEmail, ferr := identity.NewFoldedName(body.Email)
+	if ferr != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid email: "+ferr.Error())
+		return
+	}
 	user := &models.User{
 		Username:          body.Username,
+		UsernameFolded:    foldedUsername.Folded(),
 		Email:             body.Email,
+		EmailFolded:       foldedEmail.Folded(),
 		DisplayName:       body.DisplayName,
 		PasswordHash:      body.PasswordHash,
 		IsActive:          body.IsActive,

--- a/server/http/handlers/project_memberships_proxy_transition_test.go
+++ b/server/http/handlers/project_memberships_proxy_transition_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
 	"github.com/stretchr/testify/assert"
@@ -40,7 +41,9 @@ func setupTransitionMembershipFixture(t *testing.T) (cs *core.KeyorixCore, membe
 	require.NoError(t, err)
 
 	if _, err := cs.Storage().GetRoleByName(ctx, "project_admin"); err != nil {
-		_, err := cs.Storage().CreateRole(ctx, &models.Role{Name: "project_admin", Description: "test"})
+		projectAdminName, err := identity.NewFoldedName("project_admin")
+		require.NoError(t, err)
+		_, err = cs.Storage().CreateRole(ctx, projectAdminName, "test")
 		require.NoError(t, err)
 	}
 

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
 	"github.com/keyorixhq/keyorix/server/validation"
@@ -145,6 +146,17 @@ func (h *RBACHandler) CreateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// #1642: fold once here, use for both the reserved-name check below and
+	// the CreateRole call — a raw string can no longer reach either. This also
+	// closes a case-variant gap IsBuiltinRole's own exact map lookup left open
+	// ("Super_Admin"/"SUPER_ADMIN" never matched the reserved "super_admin"
+	// key), found while wiring this handler's identity boundary.
+	foldedName, ferr := identity.NewFoldedName(req.Name)
+	if ferr != nil {
+		sendError(w, "ValidationError", "invalid role name: "+ferr.Error(), http.StatusBadRequest, nil)
+		return
+	}
+
 	// #294: reserved role names (super_admin/admin/system_admin/project_admin/...) must
 	// never be creatable through the API. Bootstrap-seeded builtins (admin, system_admin,
 	// project_admin, ...) already collide with an existing row on the DB's unique(name)
@@ -155,7 +167,7 @@ func (h *RBACHandler) CreateRole(w http.ResponseWriter, r *http.Request) {
 	// by permission content, so that role — despite holding zero permissions and
 	// trivially satisfying #169's "must already hold every bundled permission" check —
 	// would function as a complete admin-bypass switch the moment it's assigned.
-	if core.IsBuiltinRole(req.Name) {
+	if core.IsBuiltinRole(foldedName.Folded()) {
 		sendError(w, "ConflictError", "this role name is reserved and cannot be created", http.StatusConflict, nil)
 		return
 	}
@@ -166,7 +178,7 @@ func (h *RBACHandler) CreateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	role, err := h.coreService.Storage().CreateRole(r.Context(), &models.Role{Name: req.Name, Description: req.Description})
+	role, err := h.coreService.Storage().CreateRole(r.Context(), foldedName, req.Description)
 	if err != nil {
 		log.Printf("Error creating role: %v", err)
 		if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "UNIQUE") {

--- a/server/http/handlers/sod_s13_test.go
+++ b/server/http/handlers/sod_s13_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -139,7 +139,9 @@ func TestCreateSoDPolicyProxy_MissingFields_S13(t *testing.T) {
 func TestCreateSoDPolicyProxy_HappyPath_S13(t *testing.T) {
 	h := newCatalogHandlerSoDSodS13(t)
 	ctx := context.Background()
-	adminRole, err := h.coreService.Storage().CreateRole(ctx, &models.Role{Name: "system_admin", Description: "Administrator"})
+	systemAdminName, err := identity.NewFoldedName("system_admin")
+	require.NoError(t, err)
+	adminRole, err := h.coreService.Storage().CreateRole(ctx, systemAdminName, "Administrator")
 	require.NoError(t, err)
 	require.NoError(t, h.coreService.Storage().AssignRole(ctx, 1, adminRole.ID, storage.Scope{}))
 

--- a/server/http/handlers/users_active_transition_proxy.go
+++ b/server/http/handlers/users_active_transition_proxy.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -125,13 +126,40 @@ func (h *UserHandler) UpdateUserIfActiveStateMatchesProxy(w http.ResponseWriter,
 			return
 		}
 	}
+	// #1642: this route bypasses core.UpdateUser's own fold entirely (it goes
+	// straight to storage.UpdateUserIfActiveStateMatches, a full-row replace —
+	// see its own doc comment), so a stale/empty UsernameFolded or
+	// EmailFolded here would silently break every future lookup for this user
+	// via GetUserByUsername/GetUserByEmail. Fold whatever the wire body
+	// carries; Email may legitimately be empty (some accounts have none,
+	// same as core.UpdateUser tolerates), in which case EmailFolded stays
+	// empty too, matching ensureUserEmailIndex's own empty-email exclusion.
+	var foldedUsername, foldedEmail identity.FoldedName
+	if body.Username != "" {
+		var ferr error
+		foldedUsername, ferr = identity.NewFoldedName(body.Username)
+		if ferr != nil {
+			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid username: "+ferr.Error())
+			return
+		}
+	}
+	if body.Email != "" {
+		var ferr error
+		foldedEmail, ferr = identity.NewFoldedName(body.Email)
+		if ferr != nil {
+			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid email: "+ferr.Error())
+			return
+		}
+	}
 	user := &models.User{
-		ID:          uint(id),
-		Username:    body.Username,
-		Email:       body.Email,
-		DisplayName: body.DisplayName,
-		IsActive:    body.Active,
-		UpdatedAt:   body.UpdatedAt,
+		ID:             uint(id),
+		Username:       body.Username,
+		UsernameFolded: foldedUsername.Folded(),
+		Email:          body.Email,
+		EmailFolded:    foldedEmail.Folded(),
+		DisplayName:    body.DisplayName,
+		IsActive:       body.Active,
+		UpdatedAt:      body.UpdatedAt,
 	}
 	matched, err := h.coreService.Storage().UpdateUserIfActiveStateMatches(r.Context(), user, body.FromActive)
 	if err != nil {

--- a/server/http/handlers/users_active_transition_proxy_test.go
+++ b/server/http/handlers/users_active_transition_proxy_test.go
@@ -169,7 +169,7 @@ func TestUpdateUserIfActiveStateMatchesProxy_DuplicateEmail(t *testing.T) {
 	db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_active ON users(email) WHERE deleted_at IS NULL AND email != ''")
 
 	require.NoError(t, db.Create(&models.User{
-		ID: 2, Username: "other_user", Email: "taken@example.com", IsActive: true,
+		ID: 2, Username: "other_user", UsernameFolded: "other_user", Email: "taken@example.com", EmailFolded: "taken@example.com", IsActive: true,
 	}).Error)
 
 	h, err := NewUserHandler(cs)
@@ -211,7 +211,7 @@ func TestUpdateUserIfActiveStateMatchesProxy_DuplicateEmail(t *testing.T) {
 func TestUpdateUserIfActiveStateMatchesProxy_DuplicateUsername(t *testing.T) {
 	cs, db := freshCoreS12WithAdmin(t)
 	require.NoError(t, db.Create(&models.User{
-		ID: 2, Username: "taken_username", Email: "user2@example.com", IsActive: true,
+		ID: 2, Username: "taken_username", UsernameFolded: "taken_username", Email: "user2@example.com", EmailFolded: "user2@example.com", IsActive: true,
 	}).Error)
 
 	h, err := NewUserHandler(cs)

--- a/server/http/handlers/users_crud_s13_test.go
+++ b/server/http/handlers/users_crud_s13_test.go
@@ -163,9 +163,11 @@ func TestCreateUserWithSetupLink_ConflictError_S13(t *testing.T) {
 	cs.SetCredentialDelivery(nil, "https://test.keyorix.example")
 
 	require.NoError(t, db.Create(&models.User{
-		Username:     "setup-conflict-s13",
-		Email:        "setup-conflict-s13@x.com",
-		AccountState: core.AccountActive,
+		Username:       "setup-conflict-s13",
+		UsernameFolded: "setup-conflict-s13",
+		Email:          "setup-conflict-s13@x.com",
+		EmailFolded:    "setup-conflict-s13@x.com",
+		AccountState:   core.AccountActive,
 	}).Error)
 
 	body, _ := json.Marshal(map[string]interface{}{
@@ -211,9 +213,11 @@ func TestGetUser_Found_S13(t *testing.T) {
 func TestGetUserByEmail_Found_S13(t *testing.T) {
 	uh, _, db := freshUserHandlerS12(t)
 	require.NoError(t, db.Create(&models.User{
-		Username:     "byemail-s13",
-		Email:        "byemail-s13@x.com",
-		AccountState: core.AccountActive,
+		Username:       "byemail-s13",
+		UsernameFolded: "byemail-s13",
+		Email:          "byemail-s13@x.com",
+		EmailFolded:    "byemail-s13@x.com",
+		AccountState:   core.AccountActive,
 	}).Error)
 
 	req := withUserCtx(httptest.NewRequest(
@@ -241,9 +245,11 @@ func TestGetUserByEmail_NotFound_S13(t *testing.T) {
 func TestGetUserByUsername_Found_S13(t *testing.T) {
 	uh, _, db := freshUserHandlerS12(t)
 	require.NoError(t, db.Create(&models.User{
-		Username:     "byusername-s13",
-		Email:        "byusername-s13@x.com",
-		AccountState: core.AccountActive,
+		Username:       "byusername-s13",
+		UsernameFolded: "byusername-s13",
+		Email:          "byusername-s13@x.com",
+		EmailFolded:    "byusername-s13@x.com",
+		AccountState:   core.AccountActive,
 	}).Error)
 
 	req := withUserCtx(httptest.NewRequest(
@@ -281,14 +287,18 @@ func TestUpdateUser_ConflictError_S13(t *testing.T) {
 	uh, _, db := freshUserHandlerS12(t)
 
 	require.NoError(t, db.Create(&models.User{
-		Username:     "existing-user-s13",
-		Email:        "existing-s13@x.com",
-		AccountState: core.AccountActive,
+		Username:       "existing-user-s13",
+		UsernameFolded: "existing-user-s13",
+		Email:          "existing-s13@x.com",
+		EmailFolded:    "existing-s13@x.com",
+		AccountState:   core.AccountActive,
 	}).Error)
 	require.NoError(t, db.Create(&models.User{
-		Username:     "target-user-s13",
-		Email:        "target-s13@x.com",
-		AccountState: core.AccountActive,
+		Username:       "target-user-s13",
+		UsernameFolded: "target-user-s13",
+		Email:          "target-s13@x.com",
+		EmailFolded:    "target-s13@x.com",
+		AccountState:   core.AccountActive,
 	}).Error)
 
 	var target models.User

--- a/server/http/remote_storage_access_request_test.go
+++ b/server/http/remote_storage_access_request_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core"
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -336,7 +337,9 @@ func grantSystemWrite(t *testing.T, upstream *core.KeyorixCore, userID uint) {
 
 	role, err := st.GetRoleByName(ctx, "ar_test_system_writer")
 	if err != nil {
-		role, err = st.CreateRole(ctx, &models.Role{Name: "ar_test_system_writer", Description: "test-only role: system.write and nothing else"})
+		arTestSystemWriterName, err := identity.NewFoldedName("ar_test_system_writer")
+		require.NoError(t, err)
+		role, err = st.CreateRole(ctx, arTestSystemWriterName, "test-only role: system.write and nothing else")
 		require.NoError(t, err)
 		perms, err := upstream.ListPermissions(ctx)
 		require.NoError(t, err)

--- a/server/http/remote_storage_connect_grants_test.go
+++ b/server/http/remote_storage_connect_grants_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -74,9 +75,13 @@ func TestRemoteStorageConnectGrants_ListByConnector_RealServer(t *testing.T) {
 	upstream, downstream := newUpstreamDownstreamForConnectGrants(t)
 	ctx := context.Background()
 
-	roleAWS, err := upstream.Storage().CreateRole(ctx, &models.Role{Name: "connect-grant-role-aws"})
+	connectGrantRoleAWSName, err := identity.NewFoldedName("connect-grant-role-aws")
 	require.NoError(t, err)
-	roleGCP, err := upstream.Storage().CreateRole(ctx, &models.Role{Name: "connect-grant-role-gcp"})
+	roleAWS, err := upstream.Storage().CreateRole(ctx, connectGrantRoleAWSName, "")
+	require.NoError(t, err)
+	connectGrantRoleGCPName, err := identity.NewFoldedName("connect-grant-role-gcp")
+	require.NoError(t, err)
+	roleGCP, err := upstream.Storage().CreateRole(ctx, connectGrantRoleGCPName, "")
 	require.NoError(t, err)
 
 	g1, err := upstream.Storage().CreateConnectRefGrant(ctx, &models.ConnectRefGrant{

--- a/server/http/remote_storage_machine_identities_test.go
+++ b/server/http/remote_storage_machine_identities_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core"
 	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/remote"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
@@ -392,7 +393,9 @@ func TestRemoteStorageMachineIdentities_RoleGrantAssignRemoveListIDs_RealServer(
 	m, err := downstream.Storage().CreateMachineIdentity(ctx, buildMachineIdentity(now, projectID, "role-test"))
 	require.NoError(t, err)
 
-	role, err := upstream.Storage().CreateRole(ctx, &models.Role{Name: "machine-role-test", Description: "test"})
+	machineRoleTestName, err := identity.NewFoldedName("machine-role-test")
+	require.NoError(t, err)
+	role, err := upstream.Storage().CreateRole(ctx, machineRoleTestName, "test")
 	require.NoError(t, err)
 
 	scope := corestorage.Scope{ProjectID: projectID, EnvironmentID: 0}

--- a/server/http/remote_storage_misc_proxy_test.go
+++ b/server/http/remote_storage_misc_proxy_test.go
@@ -332,6 +332,20 @@ func TestRemoteStorageCreateUserWithRoleGrants_DuplicateEmail_RealServer(t *test
 	upstream, downstream, _, _, _ := newUpstreamDownstreamForMiscProxy(t)
 	ctx := context.Background()
 
+	// newTestCore only creates the legacy uniq_users_email_active index (a
+	// LOWER(email) expression index, pre-#1642). Production's real partial
+	// unique index is on email_folded (internal/storage/factory.go's
+	// ensureUserEmailIndex) and isDuplicateEmailViolation
+	// (internal/storage/store/local_users.go) only recognizes that index's
+	// name/column text. Mirror production's index here, scoped to this test's
+	// own private in-memory DB only (newTestCore's DSN is unique per call, so
+	// this cannot affect any other test), so the DB-level collision this test
+	// exercises actually fires the sentinel-translation branch it asserts on.
+	realDB, ok := upstream.Storage().(*store.LocalStorage)
+	require.True(t, ok, "upstream storage must be *store.LocalStorage for this in-process index setup")
+	require.NoError(t, realDB.DB().Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_folded_active "+
+		"ON users (email_folded) WHERE deleted_at IS NULL AND email <> ''").Error)
+
 	_, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
 		Username:    "dup-email-owner",
 		Email:       "dup-email@example.com",
@@ -344,12 +358,14 @@ func TestRemoteStorageCreateUserWithRoleGrants_DuplicateEmail_RealServer(t *test
 	require.NoError(t, err)
 
 	_, err = downstream.Storage().CreateUserWithRoleGrants(ctx, &models.User{
-		Username:     "dup-email-newcomer",
-		Email:        "dup-email@example.com",
-		DisplayName:  "Dup Newcomer",
-		PasswordHash: "$2a$10$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0", // 60 chars: isPlausibleBcryptHash requires exactly 60
-		IsActive:     true,
-		AccountState: "active",
+		Username:       "dup-email-newcomer",
+		UsernameFolded: "dup-email-newcomer",
+		Email:          "dup-email@example.com",
+		EmailFolded:    "dup-email@example.com",
+		DisplayName:    "Dup Newcomer",
+		PasswordHash:   "$2a$10$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0", // 60 chars: isPlausibleBcryptHash requires exactly 60
+		IsActive:       true,
+		AccountState:   "active",
 	}, []corestorage.RoleGrant{{RoleID: viewerRole.ID}})
 	require.Error(t, err, "creating a user with an already-used email must fail, not silently succeed")
 	assert.True(t, errors.Is(err, corestorage.ErrDuplicateEmail),

--- a/server/http/remote_storage_rbac_role_grants_test.go
+++ b/server/http/remote_storage_rbac_role_grants_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,7 +62,9 @@ func TestRemoteStorageRBACRoleGrants_ReadsAndWrites_RealServer(t *testing.T) {
 
 	// Fixtures, created directly against the upstream's own storage (exactly what
 	// a real admin action would have produced).
-	role, err := upstream.Storage().CreateRole(ctx, &models.Role{Name: "rbac-grants-test-role", Description: "test role"})
+	rbacGrantsTestRoleName, err := identity.NewFoldedName("rbac-grants-test-role")
+	require.NoError(t, err)
+	role, err := upstream.Storage().CreateRole(ctx, rbacGrantsTestRoleName, "test role")
 	require.NoError(t, err)
 
 	group, err := upstream.Storage().CreateGroup(ctx, &models.Group{Name: "rbac-grants-test-group"})

--- a/server/http/system_write_ceiling_table_test.go
+++ b/server/http/system_write_ceiling_table_test.go
@@ -59,6 +59,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -103,9 +104,9 @@ func createSystemWriteAndRolesAssignToken(t *testing.T, c *core.KeyorixCore) str
 	require.NoError(t, err)
 	require.NoError(t, c.RemoveRoleFromUser(ctx, "sys_write_roles_assign@example.com", "system_viewer"))
 
-	role, err := c.Storage().CreateRole(ctx, &models.Role{
-		Name: "ceiling_test_system_writer_roles_assign", Description: "test-only role: system.write + roles.assign, nothing else",
-	})
+	ceilingTestSystemWriterRolesAssignName, err := identity.NewFoldedName("ceiling_test_system_writer_roles_assign")
+	require.NoError(t, err)
+	role, err := c.Storage().CreateRole(ctx, ceilingTestSystemWriterRolesAssignName, "test-only role: system.write + roles.assign, nothing else")
 	require.NoError(t, err)
 
 	perms, err := c.ListPermissions(ctx)
@@ -147,9 +148,9 @@ func createSystemWriteAndUsersWriteToken(t *testing.T, c *core.KeyorixCore) stri
 	require.NoError(t, err)
 	require.NoError(t, c.RemoveRoleFromUser(ctx, "sys_write_users_write@example.com", "system_viewer"))
 
-	role, err := c.Storage().CreateRole(ctx, &models.Role{
-		Name: "ceiling_test_system_writer_users_write", Description: "test-only role: system.write + users.write, nothing else",
-	})
+	ceilingTestSystemWriterUsersWriteName, err := identity.NewFoldedName("ceiling_test_system_writer_users_write")
+	require.NoError(t, err)
+	role, err := c.Storage().CreateRole(ctx, ceilingTestSystemWriterUsersWriteName, "test-only role: system.write + users.write, nothing else")
 	require.NoError(t, err)
 
 	perms, err := c.ListPermissions(ctx)
@@ -227,7 +228,9 @@ func setupCeilingTableFixtures(t *testing.T) ceilingTableFixtures {
 	})
 	require.NoError(t, err)
 
-	normalRole, err := testCore.Storage().CreateRole(ctx, &models.Role{Name: "ceiling_table_normal_role", Description: "non-admin"})
+	ceilingTableNormalRoleName, err := identity.NewFoldedName("ceiling_table_normal_role")
+	require.NoError(t, err)
+	normalRole, err := testCore.Storage().CreateRole(ctx, ceilingTableNormalRoleName, "non-admin")
 	require.NoError(t, err)
 
 	// A SECOND global admin, distinct from the bootstrap admin, so

--- a/server/http/system_write_ceiling_table_users_test.go
+++ b/server/http/system_write_ceiling_table_users_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/i18n"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/identity"
 )
 
 // userCredentialsCeilingFixtures holds every row this file's requests
@@ -67,9 +67,9 @@ func createUsersWriteToken(t *testing.T, c *core.KeyorixCore) string {
 	require.NoError(t, err)
 	require.NoError(t, c.RemoveRoleFromUser(ctx, "users_write_holder@example.com", "system_viewer"))
 
-	role, err := c.Storage().CreateRole(ctx, &models.Role{
-		Name: "ceiling_test_users_and_system_writer", Description: "test-only role: system.write + users.write",
-	})
+	ceilingTestUsersAndSystemWriterName, err := identity.NewFoldedName("ceiling_test_users_and_system_writer")
+	require.NoError(t, err)
+	role, err := c.Storage().CreateRole(ctx, ceilingTestUsersAndSystemWriterName, "test-only role: system.write + users.write")
 	require.NoError(t, err)
 
 	perms, err := c.ListPermissions(ctx)

--- a/server/http/system_write_ceiling_test.go
+++ b/server/http/system_write_ceiling_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/i18n"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/identity"
 )
 
 // createSystemWriteOnlyToken creates a human user holding ONLY the system.write
@@ -56,9 +56,9 @@ func createSystemWriteOnlyToken(t *testing.T, c *core.KeyorixCore) string {
 	require.NoError(t, err)
 	require.NoError(t, c.RemoveRoleFromUser(ctx, "sys_write_only@example.com", "system_viewer"))
 
-	role, err := c.Storage().CreateRole(ctx, &models.Role{
-		Name: "ceiling_test_system_writer", Description: "test-only role: system.write and nothing else",
-	})
+	ceilingTestSystemWriterName, err := identity.NewFoldedName("ceiling_test_system_writer")
+	require.NoError(t, err)
+	role, err := c.Storage().CreateRole(ctx, ceilingTestSystemWriterName, "test-only role: system.write and nothing else")
 	require.NoError(t, err)
 
 	perms, err := c.ListPermissions(ctx)

--- a/server/http/wire_actor_identity_forgery_test.go
+++ b/server/http/wire_actor_identity_forgery_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -304,7 +305,9 @@ func TestWireActorForgery_RevokeBreakGlassActivationProxy_RevokedByIsAlwaysCalle
 	f := newMachinePrivilegeCeilingFixture(t)
 	ctx := context.Background()
 
-	role, err := f.core.Storage().CreateRole(ctx, &models.Role{Name: "wire_forge_bg_emergency_role"})
+	wireForgeBgEmergencyRoleName, err := identity.NewFoldedName("wire_forge_bg_emergency_role")
+	require.NoError(t, err)
+	role, err := f.core.Storage().CreateRole(ctx, wireForgeBgEmergencyRoleName, "")
 	require.NoError(t, err)
 	require.NoError(t, f.core.Storage().AssignRole(ctx, f.adminID, role.ID, coreStorage.Scope{ProjectID: f.projectID}))
 	activation, err := f.core.Storage().CreateBreakGlassActivation(ctx, &models.BreakGlassActivation{

--- a/server/server_s27_test.go
+++ b/server/server_s27_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -1281,7 +1282,11 @@ func TestStartSchedulers_S27_JITExpiredGrantSwept(t *testing.T) {
 	ctx1 := context.Background()
 	store := coreService.Storage()
 
-	role, err := store.CreateRole(ctx1, &models.Role{Name: "s27-jit-role"})
+	s27JitRoleName, err := identity.NewFoldedName("s27-jit-role")
+	if err != nil {
+		t.Fatalf("NewFoldedName: %v", err)
+	}
+	role, err := store.CreateRole(ctx1, s27JitRoleName, "")
 	if err != nil {
 		t.Fatalf("CreateRole: %v", err)
 	}


### PR DESCRIPTION
## Summary

NFC/NFD representation differences and inconsistent case handling let visually-identical usernames, emails, role names, group names, and secret names coexist as distinct, indistinguishable rows. This adds `internal/identity` (`FoldedName`, `AddressName`) built on `golang.org/x/text/secure/precis`, so a raw string can never reach a query or a write without passing through a constructor that:

- folds **identity** fields (username, role name, group name) case-insensitively + NFC — a human reads these to identify a principal, so `Admin` and `admin` must resolve to the same row
- NFC-normalizes (does **not** fold case) **address** fields (secret names, which behave like env vars — `PROD_KEY` ≠ `prod_key`)
- rejects control characters and bidi-override characters as part of the character class

Project names keep their existing case-insensitive index (#490) unchanged — this is preserving existing behavior, not a fresh design choice.

## Scope

- **`internal/identity`**: `FoldedName`/`AddressName` types and their `precis` profiles.
- **Storage**: `users.username_folded`/`email_folded`, `groups.name_folded`, `roles.name_folded` columns; `ensureUserNameIndex`/`ensureUserEmailIndex`/`ensureGroupNameIndex` updated and a new `ensureRoleNameIndex`, all backed by `backfillFoldedColumn`/`normalizeColumnInPlace` migration helpers that **refuse and list every colliding pair** on collision rather than log-and-continue or silently merge. `secret_nodes.name` gets in-place NFC normalization only (no new column — its existing case-sensitive unique index is unchanged).
- **#117 gap closed**: `GetUserByEmail`'s uniqueness index moved off SQL-side `LOWER(email)`, which is ASCII-only on SQLite and locale-dependent on Postgres — enforcing *different* uniqueness per backend for the same login identity. Folding now happens in application code; the index is on the stored folded column.
- **`CreateRole` signature narrows** from `(*models.Role)` to `(identity.FoldedName, string)`, enforced at the constructing function itself rather than by convention at call sites. This closes a charset-validation bypass reachable from both the HTTP and gRPC transports (`RBACHandler.CreateRole` and `RoleGRPCService.CreateRole` each independently wrote `roles.Name` straight from the request with zero validation) — unvalidated role names enabled control-character log forgery and bidi-override rendering deception in the access-review UI. Sibling proxy-bypass sites found via the same sweep (`misc_remote_proxy.go`'s `CreateUserWithRoleGrantsProxy`, `users_active_transition_proxy.go`) fold independently before writing, since neither goes through `internal/core`. The broader shape — transports that reach storage directly, bypassing `internal/core` validation — is filed separately as **#1660** for a systemic sweep; this PR ships the normalization fix immediately rather than waiting on that redesign.
- **Read/write paths updated**: `GetUserByEmail`/`GetUserByUsername`/`GetSecretByName` fold or normalize the lookup key; `CreateUser`/`UpdateUser`/`ProvisionSCIMUser`/SSO JIT-provisioning/`CreateGroup`/`UpdateGroup`/SCIM group provisioning/`CreateSecret`/`CreateFolder`/secret bulk-rename all fold or normalize before writing. `UpdateUser`'s rename-collision check compares **folded** values so a pure case-only rename (`Bob` → `bob`) is a no-op, not a self-collision. Project rename (`UpdateProject`) already called `validateProjectName` alongside `CreateProject` — verified, no change needed.
- `concurrency_scim_update_email_test.go`: fixed a test fixture using the old SQL-side `LOWER(email)` index shape, which had silently stopped exercising the real duplicate-email path once `isDuplicateEmailViolation`'s driver-error matching moved to the folded-column index name/SQLite column text.

**Not fixed here** (follow-up, documented in `local_rbac.go`'s doc comment): `GetRoleByName` queries the raw `name` column, not `name_folded`, so it doesn't benefit from the same read-side fold as `GetUserByEmail`/`Username`. Left alone because `roleSetContainsAdmin` calls it internally on every authorization check with four fixed literal names, and fixing the read path requires populating `NameFolded` on every test fixture across the repo that constructs `models.Role{}` directly (~100 call sites) — a sweep disproportionate to what is a UX papercut (case-variant role-name search misses a match) with no security stake, unlike `CreateRole`'s charset bypass.

Also **#1649**: documents `keyorix run`'s `/proc`-readable child-environment limitation in `--clean-env`'s help text and the security FAQ's known gaps.

## Test plan

- [x] `internal/identity` unit tests: NFC/NFD collision (byte-verified fixtures), case-fold, space preservation, control-char/bidi rejection, empty rejection — both `FoldedName` and `AddressName`
- [x] Migration/backfill tests: refuse-and-list-collisions for both `backfillFoldedColumn` and `normalizeColumnInPlace`, happy-path backfill, re-run skip-if-non-empty
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `gosec -severity medium -exclude-generated` on all touched packages — 0 issues
- [x] `golangci-lint run` on all touched packages — 0 issues
- [x] Full suite green: `internal/core`, `internal/core/storage`, `internal/storage/...`, `internal/cli/...`, `server/grpc/services`, `server/http`, `server/http/handlers` (two consecutive full runs of `server/http`, after ruling out an initial flaky-under-load false alarm — 4 tests failed once, passed in isolation, passed clean on rerun; 3 of 4 in files untouched by this change)