### PR TITLE
fix(cli/invite): suppress false-positive nil-deref finding in invite send

### DIFF
--- a/internal/cli/invite/send.go
+++ b/internal/cli/invite/send.go
@@ -61,7 +61,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	inv, prov, err := service.InviteToProjectWithLink(ctx, projectID, sendEmail, sendRole, invitedBy, 0)
+	inv, prov, err := service.InviteToProjectWithLink(ctx, projectID, sendEmail, sendRole, invitedBy, 0) // nosemgrep: trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable -- inv is nil-checked below before any field is dereferenced; the non-nil branch is the intentional partial-result path (invite created, link delivery failed)
 	if err != nil {
 		if inv == nil {
 			return fmt.Errorf("failed to send invitation: %w", err)


### PR DESCRIPTION
## Summary
- Code-scanning alert #802 (Semgrep `trailofbits.go.invalid-usage-of-modified-variable`) flags `inv` in `internal/cli/invite/send.go` as used after `InviteToProjectWithLink` returns an error.
- The code already guards this: `if inv == nil { return ... }` runs before any field on `inv` is dereferenced. The non-nil branch is the intentional partial-result path (invitation row created, setup-link delivery failed) added in #759.
- Verified locally with the same Semgrep rule (`trailofbits.go.invalid-usage-of-modified-variable`) that this specific case is a false positive, then added a `// nosemgrep` justification comment matching this repo's existing convention so CI stops re-flagging it.
- Dismissed alert #802 on GitHub as a false positive with this analysis recorded in the dismissal comment.

## Test plan
- [x] `go build ./internal/cli/invite/...` succeeds
- [x] `semgrep --config r/trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable internal/cli/invite/send.go` now reports 0 findings