### PR TITLE
fix(http): #1645 -- surface real 403/404 denials instead of masking them as 500

### DIFF
--- a/server/http/handlers/catalog.go
+++ b/server/http/handlers/catalog.go
@@ -264,6 +264,8 @@ func (h *CatalogHandler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.Contains(msg, "name is required"), strings.Contains(msg, "exceeds"):
 			status = http.StatusBadRequest
+		case strings.Contains(msg, errNotFound):
+			status = http.StatusNotFound
 		default:
 			log.Printf("Error updating project %d: %v", id, err)
 			msg = clientSafe(err)

--- a/server/http/handlers/handlers_s13_gaps_test.go
+++ b/server/http/handlers/handlers_s13_gaps_test.go
@@ -208,14 +208,18 @@ func TestUpdateProject_ValidationError_S13(t *testing.T) {
 }
 
 // TestUpdateProject_NotFound_S13 — valid id but project doesn't exist → error from core.
+// TestUpdateProject_NotFound_S13 -- #1645: a nonexistent project ID must surface
+// 404, matching GetProject's sibling behavior on the identical underlying fact.
+// The handler's switch previously matched only "name is required"/"exceeds",
+// so a real "project not found" error from the core layer fell through to a
+// generic 500.
 func TestUpdateProject_NotFound_S13(t *testing.T) {
 	t.Parallel()
 	h := NewCatalogHandler(freshCoreS12(t))
 	r := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(`{"name":"newname"}`)), "id", "99999"))
 	w := httptest.NewRecorder()
 	h.UpdateProject(w, r)
-	// Either 400 (validation name error path) or 500 (internal storage fail).
-	assert.True(t, w.Code >= 400, "expected 4xx or 5xx, got %d", w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 // TestCreateProjectEnvironment_BadParam_S13 — non-numeric project id → 400.

--- a/server/http/handlers/handlers_s5_test.go
+++ b/server/http/handlers/handlers_s5_test.go
@@ -1117,8 +1117,8 @@ func TestCatalogHandler_UpdateProject_NotFound(t *testing.T) {
 	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body)), "id", "9999"))
 	w := httptest.NewRecorder()
 	h.UpdateProject(w, req)
-	// project 9999 doesn't exist → not 401
-	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
+	// #1645: project 9999 doesn't exist -> 404, matching GetProject's sibling behavior.
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestCatalogHandler_CreateProjectEnvironment_EmptyName(t *testing.T) {
@@ -4700,8 +4700,8 @@ func TestCatalogHandler_UpdateProject_NotFound_S5(t *testing.T) {
 	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body)), "id", "99999"))
 	w := httptest.NewRecorder()
 	h.UpdateProject(w, req)
-	// Not found → not 401
-	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
+	// #1645: not found -> 404, matching GetProject's sibling behavior.
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestCatalogHandler_DeleteProject_NotFound_S5(t *testing.T) {

--- a/server/http/handlers/invitations.go
+++ b/server/http/handlers/invitations.go
@@ -343,8 +343,21 @@ func (h *CatalogHandler) ResolveAccessRequest(w http.ResponseWriter, r *http.Req
 		switch {
 		case strings.Contains(msg, errNotFound):
 			status = http.StatusNotFound
-		case strings.Contains(msg, errOnlyPending), strings.Contains(msg, errUnknownRole), strings.Contains(msg, "required"):
+		case strings.Contains(msg, errOnlyPending), strings.Contains(msg, errUnknownRole), strings.Contains(msg, "required"),
+			// #1645: ApproveAccessRequestWithExpiry/RejectAccessRequest's own
+			// state/timing-conflict business rules -- an approval racing a
+			// concurrent resolution, an approver double-approving, an expired
+			// request, or the request's project having been deleted underneath
+			// it. These previously fell through to a generic 500 alongside a
+			// real internal error, hiding a legitimate "the request can no
+			// longer be actioned" outcome as a server bug.
+			strings.Contains(msg, "already approved"), strings.Contains(msg, "no longer pending"),
+			strings.Contains(msg, "has expired"), strings.Contains(msg, "no longer exists"):
 			status = http.StatusConflict
+		// #1645: a requester approving their own request is a business RULE
+		// about who may act, not a state conflict -- 403, not 409.
+		case strings.Contains(msg, "cannot approve their own"):
+			status = http.StatusForbidden
 		default:
 			log.Printf("Error resolving access request %d for project %d: %v", reqID, projectID, resolveErr)
 			msg = clientSafe(resolveErr)

--- a/server/http/handlers/invitations_project_members_s13_test.go
+++ b/server/http/handlers/invitations_project_members_s13_test.go
@@ -319,6 +319,28 @@ func TestResolveAccessRequest_UnknownAction_S13(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "action must be approve or reject")
 }
 
+// TestResolveAccessRequest_SelfApproval_S13 -- #1645: ApproveAccessRequestWithExpiry's
+// "a requester cannot approve their own access request" business rule previously
+// fell through to a generic 500 (matched none of the handler's status branches),
+// misreporting a legitimate authorization-adjacent denial as a server bug.
+func TestResolveAccessRequest_SelfApproval_S13(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.AccessRequest{
+		ID: 1, ProjectID: 1, UserID: 1, SuggestedRole: "viewer", State: "pending",
+	}).Error)
+
+	req := withChiParams(
+		withUserCtx(jsonReq(t, http.MethodPut, "/api/v1/projects/1/access-requests/1", `{"action":"approve"}`)),
+		map[string]string{"id": "1", "requestId": "1"},
+	)
+	w := httptest.NewRecorder()
+	h.ResolveAccessRequest(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 func TestResolveAccessRequest_BadGrantTTL_S13(t *testing.T) {
 	cs := freshCoreS12(t)
 	h := NewCatalogHandler(cs)

--- a/server/http/handlers/secret_read_aggregation_handler.go
+++ b/server/http/handlers/secret_read_aggregation_handler.go
@@ -66,6 +66,16 @@ func (h *SecretHandler) GetSecretReadSummary(w http.ResponseWriter, r *http.Requ
 			h.sendError(w, "Forbidden", err.Error(), http.StatusForbidden, nil)
 			return
 		}
+		// #1645: AuthorizeSecretPrincipal resolves the secret before checking
+		// permission, so a nonexistent ID surfaces here as a wrapped "not found"
+		// error, not as ErrInvalidInput or a permission string -- without this
+		// branch it fell through to a generic 500, unlike every one of this
+		// endpoint's 7 sibling read-metadata endpoints (tags, versions,
+		// access-history/list/stats/audit-trail), which all map it to 404.
+		if strings.Contains(err.Error(), errNotFound) {
+			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
+			return
+		}
 		h.sendError(w, "InternalServerError", "failed to retrieve read summary", http.StatusInternalServerError, nil)
 		return
 	}

--- a/server/http/handlers/secret_read_aggregation_handler_test.go
+++ b/server/http/handlers/secret_read_aggregation_handler_test.go
@@ -157,6 +157,23 @@ func TestGetSecretReadSummary_HappyPath(t *testing.T) {
 	assert.Contains(t, body, `"secret_id":7`)
 }
 
+// TestGetSecretReadSummary_NotFound -- #1645: a nonexistent secret ID must
+// surface 404, matching this endpoint's 7 read-metadata siblings (tags,
+// versions, access-history/list/stats/audit-trail). AuthorizeSecretPrincipal
+// resolves the secret before checking permission, so the wrapped error text
+// is "not found", not "permission"/"not authorized" -- without the dedicated
+// branch it fell through to a generic 500.
+func TestGetSecretReadSummary_NotFound(t *testing.T) {
+	c, _ := newSecretReadAggCore(t)
+	h, err := NewSecretHandler(c)
+	require.NoError(t, err)
+
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodGet, "/", nil), "id", "999999"))
+	w := httptest.NewRecorder()
+	h.GetSecretReadSummary(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 // ── limit=60 is silently capped at 50 by core ────────────────────────────────
 
 func TestGetSecretReadSummary_LimitCappedAt50(t *testing.T) {

--- a/server/http/handlers/sod.go
+++ b/server/http/handlers/sod.go
@@ -49,9 +49,12 @@ func (h *CatalogHandler) CreateSoDPolicy(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()
-		if strings.Contains(msg, "required") || strings.Contains(msg, "must be different") {
+		switch {
+		case strings.Contains(msg, "required") || strings.Contains(msg, "must be different"):
 			status = http.StatusBadRequest
-		} else {
+		case strings.Contains(msg, "permission denied"):
+			status = http.StatusForbidden
+		default:
 			log.Printf("Error creating SoD policy: %v", err)
 			msg = clientSafe(err)
 		}
@@ -77,9 +80,12 @@ func (h *CatalogHandler) DeleteSoDPolicy(w http.ResponseWriter, r *http.Request)
 	if err := h.coreService.DeleteSoDPolicy(r.Context(), actor.UserID, uint(id)); err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()
-		if strings.Contains(msg, "not found") {
+		switch {
+		case strings.Contains(msg, "not found"):
 			status = http.StatusNotFound
-		} else {
+		case strings.Contains(msg, "permission denied"):
+			status = http.StatusForbidden
+		default:
 			log.Printf("Error deleting SoD policy %d: %v", id, err)
 			msg = clientSafe(err)
 		}

--- a/server/http/handlers/sod_s13_test.go
+++ b/server/http/handlers/sod_s13_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -77,6 +80,24 @@ func TestCreateSoDPolicy_SamePermissions_S13(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// TestCreateSoDPolicy_PermissionDenied_S13 -- #1645 item 3: a valid, well-formed
+// request from a non-admin actor must surface the core layer's "permission
+// denied" error as 403, not fall through to a generic 500 (the handler's
+// switch previously matched only "required"/"must be different"). withUserCtx's
+// hardcoded UserID=1 has no role assigned here (unlike
+// TestCreateSoDPolicyProxy_HappyPath_S13, which grants system_admin first), so
+// isGlobalAdminRoleName returns "" and CreateSoDPolicy's #1529 authority check
+// denies.
+func TestCreateSoDPolicy_PermissionDenied_S13(t *testing.T) {
+	h := newCatalogHandlerSoDSodS13(t)
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/api/v1/sod/policies",
+		strings.NewReader(`{"name":"unauth-pol","permission_a":"secrets.read","permission_b":"secrets.write"}`)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateSoDPolicy(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 // ── sod.go: DeleteSoDPolicy ───────────────────────────────────────────────────
 
 func TestDeleteSoDPolicy_NoUserCtx_S13(t *testing.T) {
@@ -101,6 +122,26 @@ func TestDeleteSoDPolicy_NotFound_S13(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.DeleteSoDPolicy(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestDeleteSoDPolicy_PermissionDenied_S13 -- #1645 item 3's DeleteSoDPolicy
+// sibling: an existing policy created by a DIFFERENT user, deleted by a
+// non-admin, non-creator actor (withUserCtx's UserID=1, no role assigned)
+// must surface 403, not the generic 500 the handler's old switch fell
+// through to for any error besides "not found".
+func TestDeleteSoDPolicy_PermissionDenied_S13(t *testing.T) {
+	h := newCatalogHandlerSoDSodS13(t)
+	ctx := context.Background()
+	policy, err := h.coreService.Storage().CreateSoDPolicy(ctx, &models.SoDPolicy{
+		Name: "someone-elses-policy", PermissionA: "secrets.read", PermissionB: "secrets.write",
+		CreatedBy: 2, CreatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", strconv.Itoa(int(policy.ID))))
+	w := httptest.NewRecorder()
+	h.DeleteSoDPolicy(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 // ── sod.go: ListSoDViolations ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Four handlers matched only some of the core layer's possible error strings in their error-to-status switch, so a legitimate 4xx denial silently fell through to a generic 500 -- masking a real authorization or not-found outcome as a server bug (independent of the separate 403-vs-404 existence-oracle question #1645 is mainly about).

- **`sod.go`**: `CreateSoDPolicy`/`DeleteSoDPolicy` dropped `#1529`'s admin-tier `ErrorPermissionDenied` to 500 -- now maps to 403.
- **`catalog.go` `UpdateProject`**: a nonexistent project ID fell through to 500 instead of 404, unlike its `GetProject`/`RestoreProject` siblings in the same file.
- **`secret_read_aggregation_handler.go`**: the one read-metadata sibling (of 7) that didn't map "not found" to 404 -- confirmed live, per the issue's own claim.
- **`invitations.go` `ResolveAccessRequest`**: several real business-rule denials (self-approval, double-approval, expired/concurrently-resolved request, project deleted underneath it) matched none of the switch's cases -- self-approval now 403, the state/timing conflicts now 409 (same bucket as the existing "only pending" case).

Several existing tests were literally named for these cases (`*_NotFound*`, etc.) but had deliberately loose assertions (`w.Code >= 400`, `!= 401`) instead of the specific status -- tightened all of them rather than leaving the ambiguity, and added new regression tests for the cases that had none. Every fix was verified red-first (stashed, confirmed the test fails against the old code, restored).

Three sub-claims from the tracking issue were traced and corrected rather than fixed as reported (posted to #1645 with the full detail):
- `DeleteProject`/`DeleteSessionByID`/gRPC `DeleteRefGrant`'s "missing 404 branch" turns out unreachable -- none of their storage-layer deletes check row-existence, so a delete of a nonexistent ID silently succeeds with no error to differentiate from.
- `secret_update_diff.go`'s write-path 403-for-everything is a deliberate (and safer) anti-oracle default, not a masked error.

This is a partial fix for #1645 -- item 2 (gRPC vs HTTP `GetSecret` convention divergence) and the overall recommendation (pick one house anti-enumeration convention and document it) remain open; the latter is a product/architecture decision, not something to decide unilaterally in this PR.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` -- all clean
- [x] `gosec -severity medium -exclude-generated` on touched packages -- 0 issues
- [x] `golangci-lint run` on touched packages -- 0 issues
- [x] Full suite green: `server/http/handlers`, `server/http` (full package, ~5 min)
- [x] Every fix verified red-first (temporarily reverted, confirmed the regression test failed, restored)