### PR TITLE
fix(config): #1640 -- accept "sqlite" as an alias for storage.type: local

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -460,7 +460,7 @@ type RateLimitConfig struct {
 }
 
 type StorageConfig struct {
-	Type       string           `yaml:"type"` // "local", "postgres", "postgresql", "remote"
+	Type       string           `yaml:"type"` // "local" (alias "sqlite"), "postgres", "postgresql", "remote"
 	Database   DatabaseConfig   `yaml:"database"`
 	Remote     *RemoteConfig    `yaml:"remote,omitempty"`
 	Encryption EncryptionConfig `yaml:"encryption"`
@@ -1969,7 +1969,9 @@ func (c *Config) Validate() error { // NOSONAR -- cognitive complexity 32, suppr
 		if db.DSN == "" && (db.Host == "" || db.Name == "" || db.User == "") {
 			return fmt.Errorf("postgres storage requires either database.dsn or all of host, name, and user to be set")
 		}
-	case "local", "":
+	// #1640: "sqlite" is an accepted alias for "local" -- see the matching
+	// comment in internal/storage/factory.go's CreateStorage switch.
+	case "local", "sqlite", "":
 		if c.Storage.Database.Path == "" {
 			return fmt.Errorf("database path is not specified")
 		}
@@ -1980,7 +1982,7 @@ func (c *Config) Validate() error { // NOSONAR -- cognitive complexity 32, suppr
 		// deployment intending shared Postgres/remote storage, that produced
 		// per-replica split-brain SQLite instances with no operator-visible
 		// signal. Fail fast at config-validation time instead.
-		return fmt.Errorf("invalid storage.type %q: must be one of \"local\", \"postgres\", \"postgresql\", or \"remote\"", c.Storage.Type)
+		return fmt.Errorf("invalid storage.type %q: must be one of \"local\", \"sqlite\", \"postgres\", \"postgresql\", or \"remote\"", c.Storage.Type)
 	}
 
 	if c.Locale.Language == "" {

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -259,16 +259,27 @@ func TestValidate_AcceptsValidStorageTypes(t *testing.T) {
 	// TestValidate_RejectsRemoteStorageWithNoServerEnabled's comment) and now rejects
 	// "remote" unconditionally, since it's the one storage type this validator's own
 	// caller (server/main.go) can never legitimately back a server process with.
-	for _, storageType := range []string{"", "local", "postgres", "postgresql"} {
+	for _, storageType := range []string{"", "local", "sqlite", "postgres", "postgresql"} {
 		c := &Config{}
 		c.Storage.Type = storageType
 		switch storageType {
 		case "postgres", "postgresql":
 			c.Storage.Database.DSN = "postgres://user:pass@localhost/db"
-		case "local", "":
+		case "local", "sqlite", "":
 			c.Storage.Database.Path = "/tmp/keyorix.db"
 		}
 		err := c.Validate()
 		require.NoErrorf(t, err, "storage.type %q should be accepted", storageType)
 	}
+}
+
+// TestValidate_SqliteAliasForLocal is #1640's regression: configs/keyorix.yaml.tpl
+// documents storage.type: sqlite, but until this fix only "local" validated —
+// copying the shipped template verbatim and leaving it as documented failed
+// outright at startup.
+func TestValidate_SqliteAliasForLocal(t *testing.T) {
+	c := &Config{}
+	c.Storage.Type = "sqlite"
+	c.Storage.Database.Path = "/tmp/keyorix.db"
+	require.NoError(t, c.Validate())
 }

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -169,7 +169,12 @@ func (f *DefaultStorageFactory) CreateStorage(cfg *config.Config) (storage.Stora
 		return f.createRemoteStorage(cfg)
 	case "postgres", "postgresql":
 		return f.createPostgresStorage(cfg)
-	case "local", "":
+	// #1640: "sqlite" is an accepted alias for "local" (the shipped
+	// configs/keyorix.yaml.tpl documents "sqlite" as the value to set,
+	// matching the "postgres"/"postgresql" dual-spelling precedent above --
+	// operators write the storage engine's name, not this codebase's
+	// internal term for it).
+	case "local", "sqlite", "":
 		return f.createLocalStorage(cfg)
 	default:
 		// #463: defense in depth. Config.Validate() rejects an unrecognized

--- a/internal/storage/factory_routing_test.go
+++ b/internal/storage/factory_routing_test.go
@@ -62,6 +62,23 @@ func TestCreateStorage_EmptyTypeIsLocal(t *testing.T) {
 	assert.NotNil(t, st)
 }
 
+// TestCreateStorage_SqliteAliasIsLocal validates that "sqlite" -- the value
+// configs/keyorix.yaml.tpl documents (#1640) -- is accepted as an alias for
+// "local", not rejected as an unrecognized type.
+func TestCreateStorage_SqliteAliasIsLocal(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Storage.Type = "sqlite"
+	cfg.Storage.Database.Path = filepath.Join(dir, "sqlite-alias.db")
+
+	st, err := NewStorageFactory().CreateStorage(cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, st)
+}
+
 // TestCreateStorage_InvalidType validates that any unrecognized type is
 // explicitly rejected rather than silently falling through to SQLite.
 func TestCreateStorage_InvalidType(t *testing.T) {
@@ -125,6 +142,21 @@ func TestOpenGormDB_LocalSQLite(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Storage.Type = "local"
 	cfg.Storage.Database.Path = filepath.Join(dir, "gormdb.db")
+
+	db, err := OpenGormDB(cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, db)
+}
+
+// TestOpenGormDB_SqliteAlias validates that OpenGormDB also accepts "sqlite"
+// as an alias for "local" (#1640) -- it runs without Config.Validate() first
+// (see its own doc comment), so it must not rely on Validate() to have
+// normalized the alias upstream.
+func TestOpenGormDB_SqliteAlias(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Storage.Type = "sqlite"
+	cfg.Storage.Database.Path = filepath.Join(dir, "gormdb-sqlite-alias.db")
 
 	db, err := OpenGormDB(cfg)
 	require.NoError(t, err)

--- a/internal/storage/gormdb.go
+++ b/internal/storage/gormdb.go
@@ -43,7 +43,12 @@ func OpenGormDB(cfg *config.Config) (*gorm.DB, error) {
 			return nil, err
 		}
 		return db, nil
-	case "local", "":
+	// #1640: "sqlite" is an accepted alias for "local" -- see the matching
+	// comment in internal/storage/factory.go's CreateStorage switch. This
+	// function's own doc comment already notes these CLI admin commands run
+	// without Config.Validate() first, so it must accept the alias
+	// independently, not rely on Validate() to have normalized it upstream.
+	case "local", "sqlite", "":
 		dbPath := cfg.Storage.Database.Path
 		if dbPath == "" {
 			dbPath = "./secrets.db"
@@ -61,6 +66,6 @@ func OpenGormDB(cfg *config.Config) (*gorm.DB, error) {
 		// CLI admin commands run without going through Config.Validate() first,
 		// so a typo'd storage.type must not silently open a local SQLite file
 		// disconnected from the operator's intended (e.g. shared Postgres) backend.
-		return nil, fmt.Errorf("invalid storage.type %q: must be one of \"local\", \"postgres\", \"postgresql\", or \"remote\"", cfg.Storage.Type)
+		return nil, fmt.Errorf("invalid storage.type %q: must be one of \"local\", \"sqlite\", \"postgres\", \"postgresql\", or \"remote\"", cfg.Storage.Type)
 	}
 }


### PR DESCRIPTION
## Summary

`configs/keyorix.yaml.tpl` (the template `keyorix system init` copies out for local setup) documents:

```yaml
storage:
  type: sqlite  # options: sqlite, postgres
```

But three separate switches only ever recognized `"local"`:

- `internal/storage/factory.go`'s `CreateStorage`
- `internal/config/config.go`'s `Validate()`
- `internal/storage/gormdb.go`'s `OpenGormDB` (used independently by CLI admin commands that run without `Validate()` first, per its own doc comment -- it needs the alias too, not just `Validate()`)

Copying the shipped template verbatim and leaving `storage.type` as documented failed outright at startup with `"invalid storage.type"`.

## Which way to fix it

The issue itself flagged this as worth a deliberate choice: fix the template to say `"local"`, or accept `"sqlite"` as an alias in the code. Went with the alias, for two reasons:

1. `internal/cli/common/common.go` already treats `"sqlite"` as equivalent to `"local"` in its own actor-attribution check -- one part of the codebase already made this call; this makes it consistent everywhere `storage.type` is switched on.
2. It matches the `"postgres"`/`"postgresql"` dual-spelling precedent already established in the same switches -- accepting the operator-legible name (`"sqlite"`) alongside the internal one (`"local"`) is the existing pattern, not a new one.

The template needed no change -- its `# options: sqlite, postgres` comment is now accurate.

## Scope check

Swept every other `cfg.Storage.Type`/`c.Storage.Type` switch in the repo. Two more (`internal/startup/validation.go`'s two callers, `internal/cli/auth/auth.go`, `internal/cli/status/status.go`) dispatch the local case via a bare `default:` branch rather than an explicit `case "local", "":` -- those already handled `"sqlite"` correctly and needed no change.

## Test plan

- [x] `go build ./...`, `gofmt -l .` -- clean
- [x] `gosec -severity medium -exclude-generated`, `golangci-lint run` on touched packages -- 0 new issues (one pre-existing staticcheck finding in `config.go`'s untouched `remote` branch, confirmed present on `origin/main` before this change too)
- [x] Full suite green: `internal/storage/...`, `internal/config/...`
- [x] Three new regression tests (`TestCreateStorage_SqliteAliasIsLocal`, `TestOpenGormDB_SqliteAlias`, `TestValidate_SqliteAliasForLocal`), each verified red-first (temporarily reverted the fix, confirmed failure, restored)