### PR TITLE
fix(core): #1660 -- CreateRole/UpdateRole now route through internal/core

### DIFF
--- a/internal/core/rbac_roles.go
+++ b/internal/core/rbac_roles.go
@@ -1,0 +1,103 @@
+// rbac_roles.go — role DEFINITION CRUD (CreateRole, UpdateRole), distinct from
+// assigning a role to a principal (rbac_management.go/rbac.go).
+//
+// #1660: server/http/handlers/rbac.go's RBACHandler and server/grpc/services/
+// role_service.go's RoleGRPCService both used to call storage.Storage.CreateRole/
+// UpdateRole directly, bypassing internal/core entirely — the only two transports
+// that create/update roles had no shared validation layer, unlike every other
+// resource (users, groups, secrets, projects), each of which routes through a
+// core-layer function. #1642's identity.FoldedName constructor closed the
+// worst of this as a side effect (charset/length validation on the name), but
+// that was incidental to a different fix, not a deliberate one for this shape,
+// and left the reserved-builtin-name check and audit logging duplicated
+// per-transport rather than defined once. This file is that single definition;
+// both transports now call CreateRole/UpdateRole here instead of the storage
+// layer directly.
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// Role Name/Description length bounds — the single source of truth both
+// transports' own early-reject validation (server/http/handlers/rbac.go's
+// CreateRoleRequest/UpdateRoleRequest struct tags, server/grpc/services/
+// role_service.go's validateRoleName/validateRoleDescription) must mirror,
+// closing the #191/#1660 duplication where gRPC previously defined its own
+// copy of these numbers with no shared layer to inherit them from. Roles get
+// their own bounds rather than reusing the generic validateNameLength/
+// validateDescription (maxResourceNameLen=255, maxSecretDescriptionLen=1024,
+// neither with a minimum) — tighter and minimum-enforcing on purpose, since a
+// role name is a short, human-typed identifier, not free text.
+const (
+	RoleNameMinLen        = 3
+	RoleNameMaxLen        = 50
+	RoleDescriptionMinLen = 1
+	RoleDescriptionMaxLen = 200
+)
+
+func validateRoleNameLength(name string) error {
+	if len(name) < RoleNameMinLen || len(name) > RoleNameMaxLen {
+		return fmt.Errorf("role name must be between %d and %d characters", RoleNameMinLen, RoleNameMaxLen)
+	}
+	return nil
+}
+
+// CreateRole creates a new role definition. name is the raw, caller-supplied
+// role name — this is the ONLY point that constructs the identity.FoldedName
+// storage.CreateRole requires, so no future call site can reach storage with
+// an unfolded/unvalidated name (mirrors CreateGroup's identical treatment,
+// groups.go). Rejects reserved built-in role names (#294) before ever writing
+// anything: roleSetContainsAdmin (authz.go) grants a full admin bypass by name
+// match alone, so a caller-created row named e.g. "super_admin" would function
+// as a complete admin-bypass switch the moment it's assigned, even with zero
+// permissions of its own. actorID is the admin performing the create (0 = no
+// authenticated principal).
+func (c *KeyorixCore) CreateRole(ctx context.Context, actorID uint, name, description string) (*models.Role, error) {
+	if err := validateRoleNameLength(name); err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
+	foldedName, ferr := identity.NewFoldedName(name)
+	if ferr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+	}
+	if IsBuiltinRole(foldedName.Folded()) {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this role name is reserved and cannot be created")
+	}
+	role, err := c.storage.CreateRole(ctx, foldedName, description)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.LogRoleCreated(ctx, actorID, role.ID, role.Name)
+	return role, nil
+}
+
+// UpdateRole updates an existing role's description (role names are immutable —
+// #1494's closure rests on this: neither transport's UpdateRoleRequest carries
+// a field mapping to models.Role.Name, verified by AST inspection in
+// server/http/role_rename_unreachable_guard_test.go's
+// TestUpdateRoleRequest_CarriesNoNameField, so there is no rename call site
+// here to guard). Rejects mutating a built-in role (mirrors CreateRole's
+// reserved-name guard — an
+// admin/system_admin role's permission set must not be alterable through this
+// path). Callers that also need to replace the role's permission set do so via
+// AssignPermissionToRole/RemovePermissionFromRole around this call, matching
+// the existing per-transport sequencing — this function only persists the
+// role row itself and audits that change.
+func (c *KeyorixCore) UpdateRole(ctx context.Context, actorID uint, role *models.Role) (*models.Role, error) {
+	if IsBuiltinRole(role.Name) {
+		c.LogRoleUpdateDenied(ctx, actorID, role.ID, role.Name, "target is a built-in role")
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "cannot update built-in role: "+role.Name)
+	}
+	updated, err := c.storage.UpdateRole(ctx, role)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.LogRoleUpdated(ctx, actorID, updated.ID, updated.Name)
+	return updated, nil
+}

--- a/internal/core/rbac_roles_test.go
+++ b/internal/core/rbac_roles_test.go
@@ -1,0 +1,123 @@
+// rbac_roles_test.go — #1660: CreateRole/UpdateRole are now internal/core
+// functions, not something each transport reimplements against storage
+// directly. These tests exercise the core layer alone (no HTTP/gRPC), to
+// prove the validation genuinely lives here and isn't just something both
+// transports happen to still do for themselves.
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+func newRoleCRUDTestCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	require.NoError(t, i18n.Initialize(&config.Config{
+		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+	}))
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Role{}, &models.AuditEvent{}))
+	return &KeyorixCore{storage: store.NewLocalStorage(db)}, db
+}
+
+func TestCreateRole_RejectsReservedBuiltinName(t *testing.T) {
+	c, _ := newRoleCRUDTestCore(t)
+	_, err := c.CreateRole(context.Background(), 1, "super_admin", "d")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reserved")
+}
+
+// TestCreateRole_RejectsReservedBuiltinName_CaseVariant is #294/#1642's own
+// closed gap: IsBuiltinRole's exact map lookup only matches the folded form,
+// so the reserved check must run AFTER folding, not against the raw name.
+func TestCreateRole_RejectsReservedBuiltinName_CaseVariant(t *testing.T) {
+	c, _ := newRoleCRUDTestCore(t)
+	_, err := c.CreateRole(context.Background(), 1, "Super_Admin", "d")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reserved")
+}
+
+func TestCreateRole_RejectsControlCharacters(t *testing.T) {
+	c, _ := newRoleCRUDTestCore(t)
+	_, err := c.CreateRole(context.Background(), 1, "readonly\n[AUDIT] granted admin", "d")
+	require.Error(t, err)
+}
+
+func TestCreateRole_RejectsTooShortName(t *testing.T) {
+	c, _ := newRoleCRUDTestCore(t)
+	_, err := c.CreateRole(context.Background(), 1, "ab", "d")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "between")
+}
+
+func TestCreateRole_RejectsTooLongName(t *testing.T) {
+	c, _ := newRoleCRUDTestCore(t)
+	_, err := c.CreateRole(context.Background(), 1, strings.Repeat("a", RoleNameMaxLen+1), "d")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "between")
+}
+
+func TestCreateRole_HappyPathAudited(t *testing.T) {
+	c, db := newRoleCRUDTestCore(t)
+	role, err := c.CreateRole(context.Background(), 7, "custom-role", "a custom role")
+	require.NoError(t, err)
+	assert.Equal(t, "custom-role", role.Name)
+	assert.NotZero(t, role.ID)
+
+	var n int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", EventRoleCreated).Count(&n).Error)
+	assert.Equal(t, int64(1), n, "CreateRole must audit exactly once")
+}
+
+func TestCreateRole_DuplicateNameRejected(t *testing.T) {
+	c, db := newRoleCRUDTestCore(t)
+	// Mirrors factory.go's ensureRoleNameIndex, which AutoMigrate alone does
+	// not create -- without it, this test's own duplicate-create wouldn't hit
+	// a real constraint and would silently "succeed" twice.
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX uniq_roles_name_folded ON roles (name_folded)").Error)
+	ctx := context.Background()
+	_, err := c.CreateRole(ctx, 1, "dup-role", "d")
+	require.NoError(t, err)
+	_, err = c.CreateRole(ctx, 1, "dup-role", "d")
+	require.Error(t, err)
+}
+
+func TestUpdateRole_RejectsBuiltin(t *testing.T) {
+	c, db := newRoleCRUDTestCore(t)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "super_admin", NameFolded: "super_admin"}).Error)
+
+	_, err := c.UpdateRole(context.Background(), 1, &models.Role{ID: 1, Name: "super_admin", Description: "hijacked"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "built-in")
+
+	var role models.Role
+	require.NoError(t, db.First(&role, 1).Error)
+	assert.NotEqual(t, "hijacked", role.Description, "a rejected update must not persist")
+}
+
+func TestUpdateRole_HappyPathAudited(t *testing.T) {
+	c, db := newRoleCRUDTestCore(t)
+	created, err := c.CreateRole(context.Background(), 1, "editable-role", "old")
+	require.NoError(t, err)
+
+	created.Description = "new"
+	updated, err := c.UpdateRole(context.Background(), 9, created)
+	require.NoError(t, err)
+	assert.Equal(t, "new", updated.Description)
+
+	var n int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", EventRoleUpdated).Count(&n).Error)
+	assert.Equal(t, int64(1), n, "UpdateRole must audit exactly once")
+}

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	pb "github.com/keyorixhq/keyorix/server/proto/pb"
 	"google.golang.org/grpc/codes"
@@ -13,16 +12,18 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-// Role Name/Description length bounds. gRPC has no shared internal/core
-// validation layer to inherit these from (unlike other resources), so they
-// are mirrored here exactly from the HTTP-side struct tags in
-// server/http/handlers/rbac.go (CreateRoleRequest/UpdateRoleRequest) to keep
-// the two transports' accepted input identical (#191).
+// Role Name/Description length bounds. #1660: these now alias
+// internal/core.RoleName{Min,Max}Len/RoleDescription{Min,Max}Len — the
+// shared validation layer gRPC previously had none of (this comment used to
+// say so, #191) — rather than independently duplicating the numbers. Kept as
+// local names since the gRPC-side error messages ("name must be between %d
+// and %d characters") predate and differ in wording from HTTP's validator-
+// library message, and callers below reference these short names throughout.
 const (
-	roleNameMinLen        = 3
-	roleNameMaxLen        = 50
-	roleDescriptionMinLen = 1
-	roleDescriptionMaxLen = 200
+	roleNameMinLen        = core.RoleNameMinLen
+	roleNameMaxLen        = core.RoleNameMaxLen
+	roleDescriptionMinLen = core.RoleDescriptionMinLen
+	roleDescriptionMaxLen = core.RoleDescriptionMaxLen
 )
 
 // RoleGRPCService implements pb.RoleServiceServer, backing each RPC with the
@@ -59,28 +60,20 @@ func (s *RoleGRPCService) CreateRole(ctx context.Context, req *pb.CreateRoleRequ
 	if err := validateRoleDescription(req.GetDescription()); err != nil {
 		return nil, err
 	}
-	// #1642: fold once here, use for both the reserved-name check below and
-	// the CreateRole call — see the identical HTTP-side treatment
-	// (RBACHandler.CreateRole) for the full rationale, including why folding
-	// before IsBuiltinRole closes a case-variant gap that check's own exact
-	// map lookup otherwise leaves open.
-	foldedName, ferr := identity.NewFoldedName(req.GetName())
-	if ferr != nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid role name: "+ferr.Error())
-	}
-	// #294: reserved role names must never be creatable — see the identical guard (with
-	// full rationale) in the HTTP RBACHandler.CreateRole. This closes the same gap over
-	// gRPC, which has its own independent CreateRole path.
-	if core.IsBuiltinRole(foldedName.Folded()) {
-		return nil, status.Error(codes.AlreadyExists, "this role name is reserved and cannot be created")
-	}
-
 	permIDs, err := s.resolvePermissionIDs(ctx, actor.UserID, req.GetPermissions())
 	if err != nil {
 		return nil, err
 	}
 
-	role, err := s.core.Storage().CreateRole(ctx, foldedName, req.GetDescription())
+	// #1660: core.CreateRole is the single place that folds the name (identity.
+	// NewFoldedName — #1642), rejects reserved built-in names (#294:
+	// roleSetContainsAdmin in authz.go grants a full admin bypass by NAME
+	// match alone, so a caller-created row named e.g. "super_admin" would
+	// function as a complete admin-bypass switch the moment it's assigned,
+	// even with zero permissions of its own), and audits the creation —
+	// previously duplicated per-transport (the identical HTTP-side treatment
+	// in RBACHandler.CreateRole called storage.CreateRole directly too).
+	role, err := s.core.CreateRole(ctx, actor.UserID, req.GetName(), req.GetDescription())
 	if err != nil {
 		return nil, mapRoleError(err)
 	}
@@ -89,10 +82,8 @@ func (s *RoleGRPCService) CreateRole(ctx context.Context, req *pb.CreateRoleRequ
 			return nil, status.Error(codes.Internal, "failed to assign permissions to role")
 		}
 	}
-	// Audit the role creation, mirroring the HTTP handler — Storage().CreateRole does
-	// not audit internally, so without this a role created over gRPC left no trail.
-	// (Permission grants are audited by AssignPermissionToRole itself.)
-	s.core.LogRoleCreated(ctx, actor.UserID, role.ID, role.Name)
+	// core.CreateRole audits the role.created event itself now (permission
+	// grants are audited by AssignPermissionToRole).
 	return s.roleByID(ctx, role.ID)
 }
 
@@ -130,23 +121,24 @@ func (s *RoleGRPCService) UpdateRole(ctx context.Context, req *pb.UpdateRoleRequ
 	if err != nil {
 		return nil, mapRoleError(err)
 	}
-	// A built-in role must not be mutable over gRPC either — mirrors the CreateRole/
-	// DeleteRole guards above/below. UpdateRole unconditionally strips a role's entire
-	// current permission set before re-adding the caller-supplied one (see below), so
-	// without this check a roles.write holder could shrink e.g. admin/system_admin down
-	// to whatever subset they hold themselves, silently locking out every administrator
-	// who relies on that built-in role. The HTTP handler applies the identical guard
-	// (handlers/rbac.go); without it here the guard is bypassable by switching transport.
-	if core.IsBuiltinRole(role.Name) {
-		s.core.LogRoleUpdateDenied(ctx, actor.UserID, role.ID, role.Name, "target is a built-in role")
-		return nil, status.Errorf(codes.FailedPrecondition, "cannot update built-in role: %s", role.Name)
-	}
-
 	if req.Description != nil {
 		role.Description = req.GetDescription()
-		if _, err := s.core.Storage().UpdateRole(ctx, role); err != nil {
-			return nil, mapRoleError(err)
-		}
+	}
+	// #1660: core.UpdateRole is the single place that rejects mutating a
+	// built-in role (UpdateRole unconditionally strips a role's entire
+	// current permission set before re-adding the caller-supplied one below,
+	// so without this guard a roles.write holder could shrink e.g. admin/
+	// system_admin down to whatever subset they hold themselves, silently
+	// locking out every administrator who relies on that built-in role) and
+	// audits the update — previously duplicated per-transport (the identical
+	// HTTP-side treatment in RBACHandler.UpdateRole called storage.UpdateRole
+	// directly too). Called unconditionally, even when only Permissions is
+	// being replaced below, so a permission-only update to a built-in role is
+	// still rejected — the guard used to sit unconditionally right after the
+	// fetch for exactly this reason.
+	role, err = s.core.UpdateRole(ctx, actor.UserID, role)
+	if err != nil {
+		return nil, mapRoleError(err)
 	}
 
 	// A provided permission list replaces the entire set.
@@ -167,9 +159,8 @@ func (s *RoleGRPCService) UpdateRole(ctx context.Context, req *pb.UpdateRoleRequ
 		}
 	}
 
-	// Audit the role update, mirroring the HTTP handler — Storage().UpdateRole and the
-	// permission swap above do not emit a role.updated event on their own.
-	s.core.LogRoleUpdated(ctx, actor.UserID, role.ID, role.Name)
+	// core.UpdateRole already audited the role.updated event above (permission
+	// grants/removals are audited by AssignPermissionToRole/RemovePermissionFromRole).
 	return s.roleByID(ctx, role.ID)
 }
 
@@ -419,8 +410,17 @@ func mapRoleError(err error) error {
 	switch {
 	case strings.Contains(msg, "not found"):
 		return status.Error(codes.NotFound, "role not found")
+	case strings.Contains(msg, "reserved"):
+		return status.Error(codes.AlreadyExists, "this role name is reserved and cannot be created")
 	case strings.Contains(msg, "already exists"), strings.Contains(msg, "duplicate"), strings.Contains(msg, "unique"):
 		return status.Error(codes.AlreadyExists, "a role with that name already exists")
+	// #1660: core.CreateRole/UpdateRole's own validation (name fold rejects
+	// control/bidi characters, length bounds) surfaces here now that both
+	// RPCs route through them instead of storage directly.
+	case strings.Contains(msg, "validation"):
+		return status.Error(codes.InvalidArgument, err.Error())
+	case strings.Contains(msg, "built-in"):
+		return status.Errorf(codes.FailedPrecondition, "%s", err.Error())
 	default:
 		return status.Error(codes.Internal, "role operation failed")
 	}

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
-	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
 	"github.com/keyorixhq/keyorix/server/validation"
@@ -146,44 +146,33 @@ func (h *RBACHandler) CreateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// #1642: fold once here, use for both the reserved-name check below and
-	// the CreateRole call — a raw string can no longer reach either. This also
-	// closes a case-variant gap IsBuiltinRole's own exact map lookup left open
-	// ("Super_Admin"/"SUPER_ADMIN" never matched the reserved "super_admin"
-	// key), found while wiring this handler's identity boundary.
-	foldedName, ferr := identity.NewFoldedName(req.Name)
-	if ferr != nil {
-		sendError(w, "ValidationError", "invalid role name: "+ferr.Error(), http.StatusBadRequest, nil)
-		return
-	}
-
-	// #294: reserved role names (super_admin/admin/system_admin/project_admin/...) must
-	// never be creatable through the API. Bootstrap-seeded builtins (admin, system_admin,
-	// project_admin, ...) already collide with an existing row on the DB's unique(name)
-	// constraint, but "super_admin" and "auditor" are pinned as builtin/reserved (see
-	// IsBuiltinRole) WITHOUT ever being seeded — nothing previously stopped a roles.write
-	// holder from creating an empty-permission role literally named "super_admin".
-	// roleSetContainsAdmin (authz.go) grants a full admin bypass by NAME match alone, not
-	// by permission content, so that role — despite holding zero permissions and
-	// trivially satisfying #169's "must already hold every bundled permission" check —
-	// would function as a complete admin-bypass switch the moment it's assigned.
-	if core.IsBuiltinRole(foldedName.Folded()) {
-		sendError(w, "ConflictError", "this role name is reserved and cannot be created", http.StatusConflict, nil)
-		return
-	}
-
 	// #169: resolve + authorize every requested permission BEFORE creating anything.
 	toAssign, handled := h.resolveAndAuthorizePermissions(w, r, userCtx.UserID, req.Permissions)
 	if handled {
 		return
 	}
 
-	role, err := h.coreService.Storage().CreateRole(r.Context(), foldedName, req.Description)
+	// #1660: core.CreateRole is the single place that folds the name (identity.
+	// NewFoldedName — #1642), rejects reserved built-in names (#294:
+	// roleSetContainsAdmin in authz.go grants a full admin bypass by NAME match
+	// alone, so a caller-created row named e.g. "super_admin" would function as
+	// a complete admin-bypass switch the moment it's assigned, even with zero
+	// permissions of its own), and audits the creation — previously duplicated
+	// per-transport (this handler and the gRPC RoleGRPCService each called
+	// storage.CreateRole directly, bypassing internal/core's validation layer
+	// entirely).
+	role, err := h.coreService.CreateRole(r.Context(), userCtx.UserID, req.Name, req.Description)
 	if err != nil {
 		log.Printf("Error creating role: %v", err)
-		if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "UNIQUE") {
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "reserved"):
+			sendError(w, "ConflictError", "this role name is reserved and cannot be created", http.StatusConflict, nil)
+		case strings.Contains(msg, "already exists"), strings.Contains(msg, "UNIQUE"):
 			sendError(w, "ConflictError", "Role with this name already exists", http.StatusConflict, nil)
-		} else {
+		case strings.Contains(msg, i18n.T("ErrorValidation", nil)):
+			sendError(w, "ValidationError", msg, http.StatusBadRequest, nil)
+		default:
 			sendError(w, "InternalError", "Failed to create role", http.StatusInternalServerError, nil)
 		}
 		return
@@ -200,7 +189,7 @@ func (h *RBACHandler) CreateRole(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	h.coreService.LogRoleCreated(r.Context(), userCtx.UserID, role.ID, role.Name)
+	// core.CreateRole already audited the role.created event above.
 	w.WriteHeader(http.StatusCreated)
 	sendSuccess(w, map[string]any{"role": role, "permissions": assignedPerms}, "Role created successfully")
 }
@@ -329,20 +318,6 @@ func (h *RBACHandler) UpdateRole(w http.ResponseWriter, r *http.Request) { // NO
 		}
 		return
 	}
-	// A built-in role must not be mutable through the API — mirrors the CreateRole/
-	// DeleteRole guards below/above. replaceRolePermissions unconditionally strips a
-	// role's entire current permission set before re-adding the caller-supplied one, so
-	// without this check a roles.write holder could shrink e.g. admin/system_admin down
-	// to whatever subset they hold themselves, silently locking out every administrator
-	// who relies on that built-in role. The gRPC RoleGRPCService.UpdateRole applies the
-	// identical guard (server/grpc/services/role_service.go); without it here the guard
-	// is bypassable by switching transport.
-	if core.IsBuiltinRole(role.Name) {
-		h.coreService.LogRoleUpdateDenied(r.Context(), userCtx.UserID, role.ID, role.Name, "target is a built-in role")
-		sendError(w, "Forbidden", "Cannot update built-in role: "+role.Name, http.StatusForbidden, nil)
-		return
-	}
-
 	// #169: resolve + authorize every requested permission BEFORE touching the
 	// role's existing permission set — otherwise a request naming even one
 	// permission the actor doesn't hold would strip the role's current permissions
@@ -368,12 +343,25 @@ func (h *RBACHandler) UpdateRole(w http.ResponseWriter, r *http.Request) { // NO
 	if req.Description != nil {
 		role.Description = *req.Description
 	}
-	if _, err := h.coreService.Storage().UpdateRole(r.Context(), role); err != nil {
+	// #1660: core.UpdateRole is the single place that rejects mutating a
+	// built-in role (replaceRolePermissions below unconditionally strips a
+	// role's entire current permission set before re-adding the caller-
+	// supplied one, so without this guard a roles.write holder could shrink
+	// e.g. admin/system_admin down to whatever subset they hold themselves,
+	// silently locking out every administrator who relies on that built-in
+	// role) and audits the update — previously duplicated per-transport, the
+	// same shape CreateRole had (see its own #1660 comment above).
+	updated, err := h.coreService.UpdateRole(r.Context(), userCtx.UserID, role)
+	if err != nil {
 		log.Printf("Error updating role: %v", err)
-		sendError(w, "InternalError", "Failed to update role", http.StatusInternalServerError, nil)
+		if strings.Contains(err.Error(), "built-in") {
+			sendError(w, "Forbidden", "Cannot update built-in role: "+role.Name, http.StatusForbidden, nil)
+		} else {
+			sendError(w, "InternalError", "Failed to update role", http.StatusInternalServerError, nil)
+		}
 		return
 	}
-	h.coreService.LogRoleUpdated(r.Context(), userCtx.UserID, role.ID, role.Name)
+	role = updated
 
 	// Replace permissions if provided.
 	if req.Permissions != nil {

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -692,11 +692,6 @@ var rawStorageBypassAllowlist = map[string]string{
 	"UpdateWebAuthnCredentialProxy": "no-independent-ceiling: the proxy's own doc comment establishes it backs " +
 		"rejectIfCloned's best-effort 'mark disabled' write -- a defensive, capability-REDUCING action (disabling " +
 		"a suspected-cloned credential), not an authorization gate to bypass.",
-	"CreateRole": "no-independent-ceiling: the exported wrapper reachable via one hop is bootstrapSystemLocked " +
-		"(internal/core/auth_bootstrap.go:226-292, called only from system-init bootstrap), which creates a FIXED, " +
-		"hardcoded set of default roles -- unrelated in content to this HTTP route's actual authorization gate " +
-		"(RequirePermission(permRolesWrite), router.go:962), which already independently governs arbitrary " +
-		"caller-supplied role creation.",
 	"ExpireSetupTokenProxy": "no-independent-ceiling: marking a setup token expired only REDUCES future capability " +
 		"(revokes an outstanding token early) -- there is no privilege to gain by skipping whatever ceiling " +
 		"inspectActiveSetupToken's lazy-expiry path would otherwise apply, since expiry is itself the safe " +
@@ -1115,24 +1110,22 @@ var rawStorageBypassAllowlist = map[string]string{
 	// ReleaseSchedulerLockProxy/DeleteMFAStepUpGrantsForProxy were removed
 	// outright under #1480, no live caller): verified individually below, not
 	// assumed safe by pattern-matching the shape.
-	// UpdateRole/DeleteRole are NOT /system proxies -- they're the original
-	// human-facing RBAC handlers (server/http/handlers/rbac.go, registered at
-	// PUT/DELETE /api/v1/roles/{id}, gated by RequirePermission(permRolesWrite),
-	// router.go:974-975), newly flagged by this guard's repo-wide scope now that
-	// "no wrapper" no longer means "not considered." internal/core has no
-	// exported wrapper for role update/delete at all -- there is no separate
-	// operation for this raw call to bypass, matching the existing "CreateRole"
-	// entry above exactly (same file, same absence of a core-level equivalent,
-	// same reasoning). Each handler carries its own built-in-role protection
-	// inline (core.IsBuiltinRole check, rbac.go:328/426) and, for UpdateRole,
-	// its own permission-bundling authorization (authorizeAndCollectPermissions,
-	// rbac.go:374-391) before ever reaching the raw call.
-	"UpdateRole": "no-independent-ceiling: internal/core has no exported wrapper for role update at all (same " +
-		"absence as the existing \"CreateRole\" entry above) -- this route (PUT /api/v1/roles/{id}, " +
-		"RequirePermission(permRolesWrite)) IS the authoritative implementation, with its own built-in-role guard " +
-		"(rbac.go:328) and permission-bundling authorization (rbac.go:374-391) already inline.",
-	"DeleteRole": "no-independent-ceiling: same reasoning as UpdateRole immediately above -- no core-level " +
-		"equivalent exists to bypass; this route's own built-in-role guard (rbac.go:426) already runs inline.",
+	// DeleteRole is NOT a /system proxy -- it's the original human-facing RBAC
+	// handler (server/http/handlers/rbac.go, registered at DELETE
+	// /api/v1/roles/{id}, gated by RequirePermission(permRolesWrite),
+	// router.go:975), flagged by this guard's repo-wide scope now that "no
+	// wrapper" no longer means "not considered." internal/core has no exported
+	// wrapper for role deletion at all -- there is no separate operation for
+	// this raw call to bypass. The handler carries its own built-in-role
+	// protection inline (core.IsBuiltinRole check, rbac.go:426) before ever
+	// reaching the raw call. (CreateRole/UpdateRole used to be listed here
+	// too, with the identical "no core wrapper" reasoning -- #1660 gave both
+	// a real internal/core.CreateRole/UpdateRole wrapper, so their raw
+	// storage calls are gone, not merely justified; removed from this list
+	// rather than re-justified.)
+	"DeleteRole": "no-independent-ceiling: internal/core has no exported wrapper for role deletion at all -- " +
+		"this route (DELETE /api/v1/roles/{id}, RequirePermission(permRolesWrite)) IS the authoritative " +
+		"implementation, with its own built-in-role guard (rbac.go:426) already inline.",
 }
 
 // knownUnfixedRawStorageBypasses is the set of /system handlers confirmed, by


### PR DESCRIPTION
## Summary

`server/http/handlers/rbac.go`'s `RBACHandler` and `server/grpc/services/role_service.go`'s `RoleGRPCService` both called `storage.Storage.CreateRole`/`UpdateRole` directly, bypassing `internal/core` entirely -- the only two transports that create/update roles had no shared validation layer, unlike every other resource (users, groups, secrets, projects), each of which routes through a core-layer function. `#1642`'s `identity.FoldedName` constructor closed the worst of this as a side effect (charset/length validation on the name via the fold), but that was incidental to a different fix, not a deliberate one for this shape, and left the reserved-builtin-name check and audit logging duplicated per-transport.

## What changed

`internal/core/rbac_roles.go` adds `CreateRole`/`UpdateRole` as the single definition of:
- fold the name (`identity.NewFoldedName`)
- reject reserved built-in names (`#294` -- `roleSetContainsAdmin` grants a full admin bypass by name match alone, so a caller-created row named e.g. `"super_admin"` would function as a complete admin-bypass switch the moment it's assigned, even with zero permissions of its own)
- reject a built-in role mutation
- audit the change

Both transports now call these instead of `.Storage().CreateRole`/`UpdateRole`.

Role-specific length bounds (`RoleNameMinLen=3`/`Max=50`/`DescriptionMin=1`/`Max=200`) are now defined once in `internal/core` and aliased by gRPC's local consts instead of independently duplicated -- gRPC's own comment used to say outright it had "no shared internal/core validation layer to inherit these from" (`#191`). HTTP's struct-tag validator can't reference a Go constant, so its literal min/max values still need to be kept in sync by hand, same as before this change.

## Sibling sweep

Per the issue's own recommendation, swept every other direct `.Storage().CreateXxx(`/`.Storage().UpdateXxx(` call site in `server/http/handlers` and `server/grpc/services`. All of them are in `*_proxy.go` files -- verified each is a documented G80/ADR-049 `storage.type: remote` wire proxy (`RemoteStorage` clients proxying to the hub's real storage layer), not a genuine validation bypass. None needed the same fix.

## Guard test update

`server/http/raw_storage_bypass_guard_test.go`'s allowlist tracked `CreateRole`/`UpdateRole` as known, individually-justified raw-storage-bypass call sites (the guard's own purpose: catch an *unjustified* bypass, not forbid bypasses outright). This change doesn't re-justify them -- it removes the underlying raw calls entirely, so the entries are gone rather than updated. `DeleteRole` is untouched (out of this issue's Create/Update scope, and takes no untrusted string input) and keeps its own entry with inlined reasoning, since the removed `UpdateRole` entry it used to cross-reference no longer exists.

## Test plan

- [x] `go build ./...`, `gofmt -l .` -- clean
- [x] `gosec -severity medium -exclude-generated`, `golangci-lint run` on touched packages -- 0 new issues
- [x] New core-layer tests (`internal/core/rbac_roles_test.go`) exercising `CreateRole`/`UpdateRole` directly -- reserved-name rejection (including the case-variant gap `#1642` already closed), control-character rejection, length bounds, duplicate-name rejection, built-in-role mutation rejection, and audit-event counts
- [x] Full suite green: `internal/core`, `server/http/handlers`, `server/grpc/services`, and `server/http` (full package, ~5 min)
- [x] `TestNoUnjustifiedRawStorageBypass` (the allowlist guard) passes with the updated allowlist