### PR TITLE
fix(storage): suppress false-positive SQL-injection findings in factory.go

### DIFF
--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1839,7 +1839,7 @@ func ensureGroupNameIndex(db *gorm.DB) error {
 	// Drop the legacy plain unique index from the old `unique` tag, and the
 	// raw-name (exact-match, pre-#1642) partial index this replaces.
 	for _, idx := range []string{"uni_groups_name", "uniq_groups_name_active"} {
-		if err := db.Exec("DROP INDEX IF EXISTS " + idx).Error; err != nil {
+		if err := db.Exec("DROP INDEX IF EXISTS " + idx).Error; err != nil { // nosemgrep: go.lang.security.audit.database.string-formatted-query.string-formatted-query -- idx ranges over the two-element hardcoded literal above, never external input
 			return fmt.Errorf("failed to drop legacy groups name index %q: %w", idx, err)
 		}
 	}
@@ -1934,7 +1934,7 @@ func ensureUserNameIndex(db *gorm.DB) error {
 	// Drop the legacy plain unique index. GORM's `uniqueIndex` tag names it
 	// idx_users_username; the older `unique` tag would be uni_users_username. Drop both.
 	for _, idx := range []string{"idx_users_username", "uni_users_username", "uniq_users_username_active"} {
-		if err := db.Exec("DROP INDEX IF EXISTS " + idx).Error; err != nil {
+		if err := db.Exec("DROP INDEX IF EXISTS " + idx).Error; err != nil { // nosemgrep: go.lang.security.audit.database.string-formatted-query.string-formatted-query -- idx ranges over the hardcoded literal above, never external input
 			return fmt.Errorf("failed to drop legacy users username index %q: %w", idx, err)
 		}
 	}


### PR DESCRIPTION
## Summary
- Code-scanning alert #803 (Semgrep `go.lang.security.audit.database.string-formatted-query`, LOW CONFIDENCE) flags `db.Exec("DROP INDEX IF EXISTS " + idx)` in `ensureGroupNameIndex` (internal/storage/factory.go) as a string-formatted SQL query.
- `idx` only ever ranges over a hardcoded two-element literal slice declared on the same `for` line -- never external/client-controlled input -- so there is no injection surface here.
- `ensureUserNameIndex` has the structurally identical pattern (hardcoded literal slice, same `DROP INDEX IF EXISTS " + idx` shape) a few functions down. It wasn't independently flagged yet, but a repo-wide grep confirms these are the only two call sites of this shape, and the sibling would trip the same rule the moment cross-file/cross-function analysis catches up -- so both got the same suppression comment now rather than waiting for a second alert.
- Verified locally with the exact flagged Semgrep rule: 1 finding before, 0 findings in `factory.go` after adding both justification comments.

## Test plan
- [x] `go build ./internal/storage/...` succeeds
- [x] `go test ./internal/storage/...` passes
- [x] `semgrep --config r/go.lang.security.audit.database.string-formatted-query.string-formatted-query internal/storage/factory.go` reports 0 findings