### PR TITLE
fix(http): #1645 -- ADR-096 (403-for-both anti-enumeration convention) + dynamic-secrets migration

### DIFF
--- a/docs/adr-096-anti-enumeration-403-for-both.md
+++ b/docs/adr-096-anti-enumeration-403-for-both.md
@@ -1,0 +1,201 @@
+# ADR-096: Anti-enumeration status-code convention — 403-for-both, not 404-for-both
+
+## Status
+
+**Accepted (2026-09-01).** #1645. This ADR documents the decision and the
+migration mechanism; see the tracking issue for which call sites have moved
+onto it as of any given date — the decision is final, the migration is
+incremental.
+
+## Summary
+
+#1645 found two incompatible, undocumented conventions coexisting for how a
+scoped-resource endpoint (a secret, project, user, role, dynamic-secret
+config, ...) responds when the caller either lacks the permission or the
+resource doesn't exist:
+
+- **Convention A (403-for-both)**: the primary GET-by-ID routes
+  (`server/middleware/auth.go`'s `handleScopeResolutionError`, used by
+  `RequireScopedPermission`/`RequireScopedSecretPermission`). An unauthorized
+  caller gets an identical 403 whether the target exists or not; only a
+  caller who holds the permission **globally** gets a real 404.
+- **Convention B (404-for-both)**: a separate, independently-invented idiom
+  (tagged `#G14`/`#G85`/`TMPL-002` at each site) used by dynamic-secret
+  config/lease routes, SCIM provisioning collision checks, secret rename, and
+  gRPC's `GetSecret`/dynamic-secret RPCs. Denied and nonexistent both
+  collapse to a uniform 404, **regardless of caller privilege** — there is no
+  privileged-caller exception at all in this convention.
+
+**Decision: Convention A (403-for-both) is the house standard.** Convention B
+sites migrate to it. Not because A is the majority (that would be a weak
+reason to standardize — if B were the better design it would be worth the
+larger migration the other direction) — because of the threat model.
+
+## Why 403, not 404
+
+404-for-denied is a deliberate lie to an authenticated user already inside
+the trust boundary. That's a reasonable trade for a product like GitHub,
+whose threat model is anonymous scraping of private repos. It is not a
+reasonable trade for an on-prem secrets tool used during incidents: an
+operator who lacks a permission and is told "not found" concludes the secret
+was deleted, or that they're pointed at the wrong server. That misdirection
+has a real operational cost, and it buys very little against an attacker who
+is already authenticated and knows the route shape.
+
+## The convention, precisely
+
+Four conditions. Without all four, "pick 403" is not actually a convention —
+it's a status code with no enforcement, which is exactly how this repo ended
+up with two conventions the first time.
+
+### 1. The real-404 exception is narrow, and must stay narrow
+
+A genuine 404 (not the collapsed one) is returned **only** when the caller
+holds, **at global scope**, the **same permission** that would have granted
+access to this specific resource had it existed. Not "any global
+permission." Not "global read on some other resource type." That sentence is
+the whole exception — a looser version (e.g. "any authenticated caller with
+some admin-tier role") re-opens the oracle for a broader population than
+intended.
+
+`handleScopeResolutionError` implements this exactly today:
+
+```go
+func handleScopeResolutionError(w http.ResponseWriter, r *http.Request, cs *core.KeyorixCore, userCtx *UserContext, permission string, err error) {
+	if errors.Is(err, errTargetNotFound) {
+		if ok, aerr := cs.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), permission, core.Scope{}); aerr == nil && ok {
+			notFoundResponse(w, "Resource not found")
+		} else {
+			forbiddenResponse(w, "Insufficient permissions")
+		}
+		return
+	}
+	badRequestResponse(w, "Invalid target")
+}
+```
+
+`core.Scope{}` here is the global scope — the check is literally "does this
+caller hold `permission` with no project/environment restriction," which is
+the precise exception, not an approximation of it.
+
+### 2. The convention is the whole response, not just the status code
+
+Identical body, identical error-code string, identical headers. Two handlers
+both returning 403 with `{"error":"forbidden"}` vs
+`{"error":"secret not found in project"}` leak exactly as much as
+403-vs-404 did — the caller learns which case they hit either way. Every
+site that adopts this convention must produce the SAME body shape
+`handleScopeResolutionError`/`finishScopedPermissionRequest` already produce
+for the "denied" branch (`forbiddenResponse(w, "Insufficient permissions")`)
+— not a resource-specific message that happens to also be a 403.
+
+### 3. Route through the shared mechanism, not a re-derived per-site check
+
+`handleScopeResolutionError` already exists and is exercised by every
+primary GET route today. The migration for a Convention-B site is "route
+this resource's scope resolution through `RequireScopedPermission`/a new
+`ScopeResolver`" — a mechanism fix, not writing the collapse logic again at
+each call site. See "Migration mechanism" below for the concrete shape.
+
+### 4. gRPC is specified here too, not left to be re-derived later
+
+`secret_service.go`'s `GetSecret` is one of the divergent (Convention B)
+sites, and gRPC has its own status codes (`PermissionDenied` vs `NotFound`,
+not HTTP 403/404). A convention written only in HTTP terms leaves gRPC to
+reinvent its own version later — which is how this repo ended up with two
+conventions the first time. The gRPC-side rule is the identical shape:
+
+- Denied or nonexistent, caller lacks the permission globally →
+  `codes.PermissionDenied`, with the same message text regardless of which
+  case actually happened.
+- Nonexistent, caller holds the permission globally → `codes.NotFound`.
+
+A shared Go function analogous to `handleScopeResolutionError` (gRPC has no
+middleware chain equivalent to chi's, so this is a plain function called
+from each RPC handler, not middleware) should back every gRPC RPC that
+resolves a scoped resource by ID, for the same "one mechanism, not
+per-RPC copies" reason.
+
+## Scope: this is a full rule, not just a GET-by-ID rule
+
+Two gaps the original recon didn't cover, closed here so the convention is
+complete:
+
+- **List endpoints** already comply by construction: they return 200 with
+  the filtered result set (an empty list leaks nothing — it's the honest
+  answer for "you have access to zero matching items," indistinguishable
+  from "zero items exist"). No change needed; noted so a future audit
+  doesn't have to re-derive this.
+- **Write verbs** (PUT/PATCH/DELETE) on a resource the caller can't see
+  follow the identical 403-for-both rule as GET. A write route that
+  resolves scope via `RequireScopedPermission`/`RequireScopedSecretPermission`
+  already gets this for free (the middleware doesn't distinguish HTTP
+  method). A write route with its own hand-rolled existence check (matching
+  the shape #1645 found on the read side) needs the same migration as any
+  other Convention-B site — otherwise existence gets probed through DELETE
+  instead of GET, which defeats the point.
+
+## Migration mechanism
+
+For an HTTP handler currently doing its own fetch-then-authorize-then-collapse
+(the `loadAuthorizedConfig`/`loadAuthorizedLease` shape in
+`server/http/handlers/dynamic_secrets.go` is the clearest example): write a
+`ScopeResolver` (`server/middleware/auth.go`'s existing type) for the
+resource, matching `ScopeFromSecretParam`'s shape —
+
+```go
+func ScopeFromDynamicSecretConfigParam(param string) ScopeResolver {
+	return func(r *http.Request, cs *core.KeyorixCore) (core.Scope, error) {
+		id, err := scopePathUint(r, param)
+		if err != nil {
+			return core.Scope{}, errInvalidTarget
+		}
+		cfg, err := cs.GetDynamicSecretConfig(r.Context(), id)
+		if err != nil {
+			return core.Scope{}, errTargetNotFound
+		}
+		return core.Scope{ProjectID: cfg.ProjectID, EnvironmentID: cfg.EnvironmentID}, nil
+	}
+}
+```
+
+— then wire the route through `RequireScopedPermission(perm,
+ScopeFromDynamicSecretConfigParam("id"))` in `router.go` instead of calling
+the handler-internal loader, and delete the handler-internal
+fetch/authorize/collapse logic (the handler now runs only once already
+authorized, and can fetch the row again cheaply, or the middleware can stash
+it on the request context the way `RequireScopedSecretRefPermission` already
+does for the by-ref read path, if avoiding a second fetch matters for that
+route).
+
+Where full middleware conversion is impractical for a specific call site
+(e.g. a check embedded in a larger multi-step operation like SCIM
+provisioning's collision check), the same decision must still be made by ONE
+shared, exported function callable from handler code — not re-derived
+inline. `handleScopeResolutionError` itself is unexported (package
+`server/middleware`); either export it or add a thin exported wrapper in
+that package so handler packages can call the identical logic without a
+full route restructure.
+
+## Guard
+
+An assertion that every handler touching a scoped resource returns denial
+through the shared mechanism, not a hand-rolled status code, is required
+once the migration lands — otherwise this drifts back to two conventions the
+same way it happened the first time. `handleScopeResolutionError`/
+`RequireScopedPermission` is the thing to grep for; a guard test enumerating
+every route registered against a `{id}`-shaped scoped-resource path and
+confirming it's wired through one of the shared resolvers (or is on an
+explicit, individually-justified exception list, mirroring
+`raw_storage_bypass_guard_test.go`'s own allowlist pattern) is the cheapest
+way to enforce this going forward.
+
+## Explicitly deferred: timing side-channel
+
+If the exists-but-denied path does a real lookup and the doesn't-exist path
+returns early (or vice versa), response time can distinguish the two cases
+regardless of what status code and body are returned. Routing every site
+through one shared mechanism helps structurally (a single code path means a
+single timing profile, rather than N independently-timed implementations),
+but actually measuring and closing that gap is a separate pass — not
+attempted as part of this ADR or its migration.

--- a/server/http/dynamic_secrets_403_convention_test.go
+++ b/server/http/dynamic_secrets_403_convention_test.go
@@ -1,0 +1,166 @@
+// dynamic_secrets_403_convention_test.go — #1645/ADR-096: live proof that
+// dynamic-secret config/lease routes now follow the house 403-for-both
+// anti-enumeration convention (via RequireScopedPermission +
+// ScopeFromDynamicSecretConfigParam/ScopeFromDynamicSecretLeaseParam,
+// router.go), not the old Convention B (uniform 404 regardless of caller
+// privilege) loadAuthorizedConfig/loadAuthorizedLease used to implement.
+//
+// This can only be demonstrated through the real router + middleware chain
+// -- the authorization decision no longer lives in the handler at all
+// (server/http/handlers/dynamic_secrets.go's loadConfig/loadLease just
+// re-fetch an already-authorized row), so a handler-level unit test cannot
+// exercise it.
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
+)
+
+type dynSecret403Fixture struct {
+	serverURL    string
+	core         *core.KeyorixCore
+	configID     uint
+	limitedToken string // secrets.read+write in a DIFFERENT project, zero access to configID
+	adminToken   string // global admin -- the narrow real-404 exception
+}
+
+func newDynSecret403Fixture(t *testing.T) *dynSecret403Fixture {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	cfg := &config.Config{}
+	testCore := newTestCore(t)
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+
+	ctx := context.Background()
+	adminToken := createTestToken(t, testCore) // bootstraps admin + project A + default env
+
+	admin, err := testCore.GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+	projects, err := testCore.Storage().ListProjects(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, projects)
+	projA := projects[0]
+	envsA, err := testCore.Storage().ListEnvironments(ctx)
+	require.NoError(t, err)
+	var envA uint
+	for _, e := range envsA {
+		if e.ProjectID == projA.ID {
+			envA = e.ID
+			break
+		}
+	}
+	require.NotZero(t, envA)
+
+	dsCfg, err := testCore.CreateDynamicSecretConfig(ctx, &core.CreateDynamicSecretConfigRequest{
+		Name: "probe-target", ProjectID: projA.ID, EnvironmentID: envA,
+		BackendType: "postgres", AdminDSN: "postgres://admin@db/x",
+		DefaultTTLSeconds: 300, MaxTTLSeconds: 3600, MaxActiveLeases: 10,
+		CreatedBy: "testadmin", ActorID: admin.ID,
+	})
+	require.NoError(t, err)
+
+	// Project B: the "limited" attacker's own turf -- entirely separate from
+	// project A, where the target config lives.
+	projB, err := testCore.CreateProject(ctx, "projB", "attacker project")
+	require.NoError(t, err)
+
+	perms, err := testCore.ListPermissions(ctx)
+	require.NoError(t, err)
+	var readID, writeID uint
+	for _, p := range perms {
+		if p.Name == "secrets.read" {
+			readID = p.ID
+		}
+		if p.Name == "secrets.write" {
+			writeID = p.ID
+		}
+	}
+	require.NotZero(t, readID)
+	require.NotZero(t, writeID)
+	foldedRoleName, err := identity.NewFoldedName("limited-403-conv-role")
+	require.NoError(t, err)
+	role, err := testCore.Storage().CreateRole(ctx, foldedRoleName, "limited")
+	require.NoError(t, err)
+	require.NoError(t, testCore.AssignPermissionToRole(ctx, admin.ID, role.ID, readID, false))
+	require.NoError(t, testCore.AssignPermissionToRole(ctx, admin.ID, role.ID, writeID, false))
+
+	limited, err := testCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "limited403", Email: "limited403@example.com", Password: "Xk9#mQ7zLp2!vR4t",
+	})
+	require.NoError(t, err)
+	require.NoError(t, testCore.Storage().AssignRole(ctx, limited.ID, role.ID, core.Scope{ProjectID: projB.ID}))
+
+	session, _, err := testCore.Login(ctx, &core.LoginRequest{Username: "limited403", Password: "Xk9#mQ7zLp2!vR4t"})
+	require.NoError(t, err)
+
+	return &dynSecret403Fixture{
+		serverURL:    server.URL,
+		core:         testCore,
+		configID:     dsCfg.ID,
+		limitedToken: session.SessionToken,
+		adminToken:   adminToken,
+	}
+}
+
+func (f *dynSecret403Fixture) get(t *testing.T, token string, id uint) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/dynamic-secrets/configs/%d", f.serverURL, id), nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(resp.Body)
+	return resp.StatusCode, buf.String()
+}
+
+// TestDynamicSecretConfig_403ForBoth_UnprivilegedCallerCannotDistinguish is the
+// core property #1645/ADR-096 requires: a caller with no access anywhere near
+// the target config gets the IDENTICAL response for a real config they can't
+// see and a config ID that doesn't exist at all.
+func TestDynamicSecretConfig_403ForBoth_UnprivilegedCallerCannotDistinguish(t *testing.T) {
+	f := newDynSecret403Fixture(t)
+
+	statusReal, bodyReal := f.get(t, f.limitedToken, f.configID)
+	statusFake, bodyFake := f.get(t, f.limitedToken, f.configID+999999)
+
+	require.Equal(t, http.StatusForbidden, statusReal, "real config, no access: %s", bodyReal)
+	require.Equal(t, http.StatusForbidden, statusFake, "nonexistent config: %s", bodyFake)
+	require.JSONEq(t, bodyReal, bodyFake, "the two cases must be byte-identical, not just same status")
+}
+
+// TestDynamicSecretConfig_403ForBoth_GloballyPrivilegedCallerGetsRealNotFound
+// is the narrow exception ADR-096 specifies: a caller who holds
+// secrets.read/write GLOBALLY gets a genuine 404 for an ID that truly
+// doesn't exist -- distinct from the 403 an unprivileged caller sees for the
+// same nonexistent ID.
+func TestDynamicSecretConfig_403ForBoth_GloballyPrivilegedCallerGetsRealNotFound(t *testing.T) {
+	f := newDynSecret403Fixture(t)
+
+	status, body := f.get(t, f.adminToken, f.configID+999999)
+	require.Equal(t, http.StatusNotFound, status, "admin, nonexistent config: %s", body)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(body), &parsed))
+}

--- a/server/http/handlers/dynamic_secrets.go
+++ b/server/http/handlers/dynamic_secrets.go
@@ -160,7 +160,7 @@ func (h *DynamicSecretHandler) ListConfigs(w http.ResponseWriter, r *http.Reques
 
 // GetConfig handles GET /api/v1/dynamic-secrets/configs/{id}
 func (h *DynamicSecretHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
-	cfg, ok := h.loadAuthorizedConfig(w, r, permSecretsRead)
+	cfg, ok := h.loadConfig(w, r)
 	if !ok {
 		return
 	}
@@ -169,8 +169,11 @@ func (h *DynamicSecretHandler) GetConfig(w http.ResponseWriter, r *http.Request)
 
 // IssueLease handles POST /api/v1/dynamic-secrets/configs/{id}/issue
 func (h *DynamicSecretHandler) IssueLease(w http.ResponseWriter, r *http.Request) {
-	userCtx := middleware.GetUserFromContext(r.Context())
-	cfg, ok := h.loadAuthorizedConfig(w, r, permSecretsWrite)
+	userCtx, ok := mustGetUser(w, r)
+	if !ok {
+		return
+	}
+	cfg, ok := h.loadConfig(w, r)
 	if !ok {
 		return
 	}
@@ -195,7 +198,7 @@ func (h *DynamicSecretHandler) IssueLease(w http.ResponseWriter, r *http.Request
 
 // ListLeases handles GET /api/v1/dynamic-secrets/configs/{id}/leases
 func (h *DynamicSecretHandler) ListLeases(w http.ResponseWriter, r *http.Request) {
-	cfg, ok := h.loadAuthorizedConfig(w, r, permSecretsRead)
+	cfg, ok := h.loadConfig(w, r)
 	if !ok {
 		return
 	}
@@ -220,7 +223,7 @@ func (h *DynamicSecretHandler) RevokeLease(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	leaseID := chi.URLParam(r, "leaseID")
-	if _, ok := h.loadAuthorizedLease(w, r, leaseID, permSecretsWrite); !ok {
+	if _, ok := h.loadLease(w, r, leaseID); !ok {
 		return
 	}
 	if err := h.coreService.RevokeLease(r.Context(), leaseID, userCtx.UserID, "manual"); err != nil {
@@ -243,7 +246,7 @@ func (h *DynamicSecretHandler) RenewLease(w http.ResponseWriter, r *http.Request
 		return
 	}
 	leaseID := chi.URLParam(r, "leaseID")
-	if _, ok := h.loadAuthorizedLease(w, r, leaseID, permSecretsWrite); !ok {
+	if _, ok := h.loadLease(w, r, leaseID); !ok {
 		return
 	}
 	var body struct {
@@ -266,8 +269,11 @@ func (h *DynamicSecretHandler) RenewLease(w http.ResponseWriter, r *http.Request
 // RevokeAllLeases handles POST /api/v1/dynamic-secrets/configs/{id}/revoke-all —
 // the incident kill switch: revoke every active lease from a config at once.
 func (h *DynamicSecretHandler) RevokeAllLeases(w http.ResponseWriter, r *http.Request) {
-	userCtx := middleware.GetUserFromContext(r.Context())
-	cfg, ok := h.loadAuthorizedConfig(w, r, permSecretsWrite)
+	userCtx, ok := mustGetUser(w, r)
+	if !ok {
+		return
+	}
+	cfg, ok := h.loadConfig(w, r)
 	if !ok {
 		return
 	}
@@ -289,8 +295,11 @@ func (h *DynamicSecretHandler) RevokeAllLeases(w http.ResponseWriter, r *http.Re
 // ClassifyConfig handles PATCH /api/v1/dynamic-secrets/configs/{id}/classification —
 // sets (or clears) the config's data-classification label.
 func (h *DynamicSecretHandler) ClassifyConfig(w http.ResponseWriter, r *http.Request) {
-	userCtx := middleware.GetUserFromContext(r.Context())
-	cfg, ok := h.loadAuthorizedConfig(w, r, permSecretsWrite)
+	userCtx, ok := mustGetUser(w, r)
+	if !ok {
+		return
+	}
+	cfg, ok := h.loadConfig(w, r)
 	if !ok {
 		return
 	}
@@ -320,8 +329,11 @@ func (h *DynamicSecretHandler) ClassifyConfig(w http.ResponseWriter, r *http.Req
 // afterward (project restore deliberately does not do so on its own), or
 // disables one directly outside of a project delete.
 func (h *DynamicSecretHandler) SetConfigEnabled(w http.ResponseWriter, r *http.Request) {
-	userCtx := middleware.GetUserFromContext(r.Context())
-	cfg, ok := h.loadAuthorizedConfig(w, r, permSecretsWrite)
+	userCtx, ok := mustGetUser(w, r)
+	if !ok {
+		return
+	}
+	cfg, ok := h.loadConfig(w, r)
 	if !ok {
 		return
 	}
@@ -345,16 +357,17 @@ func (h *DynamicSecretHandler) SetConfigEnabled(w http.ResponseWriter, r *http.R
 	sendSuccess(w, sanitizeConfig(updated), "Config enabled state updated.")
 }
 
-// loadAuthorizedConfig loads the {id} config and authorizes the caller against
-// its scope. It writes the error response and returns ok=false on failure. A
-// missing config AND a found-but-unauthorized one both write the SAME NotFound
-// response (#G14) — a distinct Forbidden for the found-but-unauthorized branch
-// would let a caller distinguish "this ID doesn't exist" from "this ID exists
-// but you can't touch it". The MFA-blocked branch is deliberately NOT
-// collapsed: the caller is already known to be authorized at that point, just
-// missing a second factor, so hiding it behind a generic NotFound would mask
-// an actionable, legitimate error.
-func (h *DynamicSecretHandler) loadAuthorizedConfig(w http.ResponseWriter, r *http.Request, perm string) (*models.DynamicSecretConfig, bool) {
+// loadConfig fetches the {id} config. #1645/ADR-096: authorization against
+// the config's project/environment scope now runs as route-level
+// RequireScopedPermission middleware (router.go, ScopeFromDynamicSecretConfigParam)
+// before this handler is ever reached — a caller who lacks the permission or
+// whose target doesn't exist gets the shared 403-for-both collapse
+// (handleScopeResolutionError) there, not a second, independently-derived
+// collapse here. This function only re-fetches the already-authorized row;
+// a "not found" here means a benign TOCTOU race (deleted between the
+// middleware's check and this handler running), not an oracle — the caller
+// already passed authorization for this exact ID.
+func (h *DynamicSecretHandler) loadConfig(w http.ResponseWriter, r *http.Request) (*models.DynamicSecretConfig, bool) {
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseUint(idStr, 10, 32)
 	if err != nil {
@@ -366,34 +379,17 @@ func (h *DynamicSecretHandler) loadAuthorizedConfig(w http.ResponseWriter, r *ht
 		sendError(w, "NotFound", "Config not found", http.StatusNotFound, nil)
 		return nil, false
 	}
-	if ok, mfaBlocked := h.authorize(r, perm, core.Scope{ProjectID: cfg.ProjectID, EnvironmentID: cfg.EnvironmentID}); !ok {
-		if mfaBlocked {
-			h.denyAuthz(w, true)
-		} else {
-			sendError(w, "NotFound", "Config not found", http.StatusNotFound, nil)
-		}
-		return nil, false
-	}
 	return cfg, true
 }
 
-// loadAuthorizedLease loads the leaseID lease and authorizes the caller
-// against its scope, with the same #G14 uniform-NotFound treatment as
-// loadAuthorizedConfig above — see its doc comment for why the MFA branch is
-// deliberately excluded. Shared by RevokeLease/RenewLease so the pattern isn't
-// duplicated (and can't silently diverge) across call sites.
-func (h *DynamicSecretHandler) loadAuthorizedLease(w http.ResponseWriter, r *http.Request, leaseID string, perm string) (*models.DynamicSecretLease, bool) {
+// loadLease fetches the leaseID lease, mirroring loadConfig's #1645/ADR-096
+// treatment above (authorization already ran via RequireScopedPermission +
+// ScopeFromDynamicSecretLeaseParam before this handler runs). Shared by
+// RevokeLease/RenewLease so the fetch isn't duplicated.
+func (h *DynamicSecretHandler) loadLease(w http.ResponseWriter, r *http.Request, leaseID string) (*models.DynamicSecretLease, bool) {
 	lease, err := h.coreService.GetDynamicSecretLease(r.Context(), leaseID)
 	if err != nil {
 		sendError(w, "NotFound", "Lease not found", http.StatusNotFound, nil)
-		return nil, false
-	}
-	if ok, mfaBlocked := h.authorize(r, perm, core.Scope{ProjectID: lease.ProjectID, EnvironmentID: lease.EnvironmentID}); !ok {
-		if mfaBlocked {
-			h.denyAuthz(w, true)
-		} else {
-			sendError(w, "NotFound", "Lease not found", http.StatusNotFound, nil)
-		}
 		return nil, false
 	}
 	return lease, true

--- a/server/http/handlers/handlers_s17_test.go
+++ b/server/http/handlers/handlers_s17_test.go
@@ -261,15 +261,18 @@ func TestFinishWebAuthnPasswordlessLogin_CoreFailure_S17(t *testing.T) {
 func TestRevokeAllLeases_NoUserCtxLoadFails_S17(t *testing.T) {
 	t.Parallel()
 	h := NewDynamicSecretHandler(freshCoreS17(t))
-	req := withChiParam(
+	// #1645/ADR-096: RevokeAllLeases now checks mustGetUser BEFORE loadConfig
+	// (matching every sibling handler in this file, and closing a nil-userCtx
+	// panic loadConfig's removal of the old in-handler authorize() call
+	// otherwise left) -- a real user context is required to reach the bad-ID
+	// branch this test targets, or mustGetUser's own 401 fires first instead.
+	req := withUserCtx(withChiParam(
 		httptest.NewRequest(http.MethodPost, "/api/v1/dynamic-secrets/configs/notanid/revoke-all", nil),
 		"id", "notanid",
-	)
-	// No user context: authorize() returns false → loadAuthorizedConfig writes 403/400
-	// and returns ok=false, so the handler returns before touching userCtx.
+	))
 	w := httptest.NewRecorder()
 	h.RevokeAllLeases(w, req)
-	// Bad ID param is caught before auth check → 400.
+	// Bad ID param is caught after the user-ctx check → 400.
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 

--- a/server/http/handlers/handlers_s23_test.go
+++ b/server/http/handlers/handlers_s23_test.go
@@ -281,13 +281,14 @@ func TestDynamic_IssueLease_NoUserCtx_S23(t *testing.T) {
 	}
 	require.NoError(t, db.Create(cfg).Error)
 
-	// IssueLease calls loadAuthorizedConfig first, which calls authorize();
-	// authorize() returns false when userCtx is nil, so the guard fires before
-	// the core.IssueLease call. Because IssueLease's outer guard comes AFTER
-	// loadAuthorizedConfig (which has its own authorize inside), no user ctx
-	// means loadAuthorizedConfig returns false → NotFound (#G14: the
-	// found-but-unauthorized branch collapses to the same response a missing
-	// config ID would get, not a distinct Forbidden).
+	// #1645/ADR-096: authorization against the config's scope moved out of
+	// IssueLease's own body entirely (now route-level RequireScopedPermission
+	// middleware, router.go) -- the handler's only remaining pre-flight check
+	// is mustGetUser, matching every sibling handler in this file. No user
+	// context now fails fast with 401 here, before loadConfig ever runs
+	// (this test calls the handler directly, bypassing the router, so the
+	// middleware's own 403-for-both collapse is never exercised by this
+	// specific test -- see dynamic_secrets_403_convention_test.go for that).
 	req := withChiParam(
 		httptest.NewRequest(http.MethodPost, "/api/v1/dynamic-secrets/configs/1/issue", nil),
 		"id", uintStr(cfg.ID),
@@ -295,7 +296,7 @@ func TestDynamic_IssueLease_NoUserCtx_S23(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.IssueLease(w, req)
 
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 // TestDynamic_IssueLease_BadConfigID_S23 verifies that a non-numeric config id

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -2254,7 +2254,11 @@ func TestDynamicSecretHandler_GetConfig_BadID(t *testing.T) {
 
 func TestDynamicSecretHandler_IssueLease_BadID(t *testing.T) {
 	h := NewDynamicSecretHandler(newDynamicSecretHandlerS4(t).coreService)
-	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", nil), "id", "notanid")
+	// #1645/ADR-096: IssueLease now checks mustGetUser before loadConfig
+	// (matching every sibling handler in this file) -- a real user context
+	// is required to reach the bad-id branch this test targets, or mustGetUser's
+	// own 401 fires first instead.
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPost, "/", nil), "id", "notanid"))
 	w := httptest.NewRecorder()
 	h.IssueLease(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -2262,7 +2266,9 @@ func TestDynamicSecretHandler_IssueLease_BadID(t *testing.T) {
 
 func TestDynamicSecretHandler_IssueLease_NotFound(t *testing.T) {
 	h := NewDynamicSecretHandler(newDynamicSecretHandlerS4(t).coreService)
-	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", nil), "id", "999")
+	// #1645/ADR-096: a real user context is required to reach loadConfig's
+	// not-found branch this test targets -- see IssueLease_BadID's comment above.
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPost, "/", nil), "id", "999"))
 	w := httptest.NewRecorder()
 	h.IssueLease(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -2296,16 +2302,19 @@ func TestDynamicSecretHandler_RenewLease_Unauthorized(t *testing.T) {
 
 func TestDynamicSecretHandler_RevokeAllLeases_NotFound(t *testing.T) {
 	h := NewDynamicSecretHandler(newDynamicSecretHandlerS4(t).coreService)
-	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "999")
+	// #1645/ADR-096: RevokeAllLeases now checks mustGetUser before loadConfig
+	// (matching every sibling handler in this file) -- a real user context
+	// is required to reach loadConfig's not-found branch this test targets.
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "999"))
 	w := httptest.NewRecorder()
 	h.RevokeAllLeases(w, req)
-	// Config not found → 404 (loadAuthorizedConfig fails before user ctx check)
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestDynamicSecretHandler_ClassifyConfig_NotFound(t *testing.T) {
 	h := NewDynamicSecretHandler(newDynamicSecretHandlerS4(t).coreService)
-	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", nil), "id", "999")
+	// #1645/ADR-096: same mustGetUser-before-loadConfig ordering as above.
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPost, "/", nil), "id", "999"))
 	w := httptest.NewRecorder()
 	h.ClassifyConfig(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -2313,7 +2322,8 @@ func TestDynamicSecretHandler_ClassifyConfig_NotFound(t *testing.T) {
 
 func TestDynamicSecretHandler_SetConfigEnabled_NotFound(t *testing.T) {
 	h := NewDynamicSecretHandler(newDynamicSecretHandlerS4(t).coreService)
-	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", nil), "id", "999")
+	// #1645/ADR-096: same mustGetUser-before-loadConfig ordering as above.
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPost, "/", nil), "id", "999"))
 	w := httptest.NewRecorder()
 	h.SetConfigEnabled(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -779,20 +779,28 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequirePermission(permSecretsRead)).Post("/{id}/apply", secretTemplateHandler.Apply)
 		})
 
-		// Dynamic secrets (ADR-035). Authorization is in-handler against each
-		// config/lease's project/environment scope (reusing secrets.read/write),
-		// so these routes carry no scoped-permission middleware.
+		// Dynamic secrets (ADR-035). #1645/ADR-096: authorization against each
+		// config/lease's project/environment scope (reusing secrets.read/write)
+		// now runs as scoped-permission middleware, matching every other
+		// scoped resource -- it used to run in-handler
+		// (DynamicSecretHandler.loadAuthorizedConfig/loadAuthorizedLease),
+		// collapsing "doesn't exist" and "exists, denied" into a uniform 404
+		// regardless of caller privilege (Convention B) instead of the
+		// 403-for-both (narrow real-404-for-global-holders exception)
+		// every other scoped route gets from this same middleware.
 		r.Route("/dynamic-secrets", func(r chi.Router) {
+			configScope := customMiddleware.ScopeFromDynamicSecretConfigParam("id")
+			leaseScope := customMiddleware.ScopeFromDynamicSecretLeaseParam("leaseID")
 			r.Post("/configs", dynamicSecretHandler.CreateConfig)
 			r.Get("/configs", dynamicSecretHandler.ListConfigs)
-			r.Get("/configs/{id}", dynamicSecretHandler.GetConfig)
-			r.Patch("/configs/{id}/classification", dynamicSecretHandler.ClassifyConfig)
-			r.Patch("/configs/{id}/enabled", dynamicSecretHandler.SetConfigEnabled)
-			r.Post("/configs/{id}/issue", dynamicSecretHandler.IssueLease)
-			r.Get("/configs/{id}/leases", dynamicSecretHandler.ListLeases)
-			r.Post("/configs/{id}/revoke-all", dynamicSecretHandler.RevokeAllLeases)
-			r.Post("/leases/{leaseID}/renew", dynamicSecretHandler.RenewLease)
-			r.Post("/leases/{leaseID}/revoke", dynamicSecretHandler.RevokeLease)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, configScope)).Get("/configs/{id}", dynamicSecretHandler.GetConfig)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, configScope)).Patch("/configs/{id}/classification", dynamicSecretHandler.ClassifyConfig)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, configScope)).Patch("/configs/{id}/enabled", dynamicSecretHandler.SetConfigEnabled)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, configScope)).Post("/configs/{id}/issue", dynamicSecretHandler.IssueLease)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsRead, configScope)).Get("/configs/{id}/leases", dynamicSecretHandler.ListLeases)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, configScope)).Post("/configs/{id}/revoke-all", dynamicSecretHandler.RevokeAllLeases)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, leaseScope)).Post("/leases/{leaseID}/renew", dynamicSecretHandler.RenewLease)
+			r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, leaseScope)).Post("/leases/{leaseID}/revoke", dynamicSecretHandler.RevokeLease)
 		})
 
 		// Users endpoints (RBAC)

--- a/server/middleware/auth.go
+++ b/server/middleware/auth.go
@@ -864,6 +864,49 @@ func ScopeFromRotationPolicyParam(param string) ScopeResolver {
 	}
 }
 
+// ScopeFromDynamicSecretConfigParam treats the named path param as a
+// dynamic-secret config ID and resolves its project/environment scope.
+// #1645/ADR-096: replaces dynamic_secrets.go's handler-internal
+// loadAuthorizedConfig, which used to collapse "doesn't exist" and "exists,
+// denied" into a uniform 404 regardless of caller privilege (Convention B) --
+// routing through this resolver + RequireScopedPermission instead gives every
+// dynamic-secret config route the same 403-for-both behavior (with the
+// narrow real-404-for-global-holders exception) every other scoped resource
+// already has, via the one shared mechanism (handleScopeResolutionError)
+// rather than a second, independently-derived collapse implementation.
+func ScopeFromDynamicSecretConfigParam(param string) ScopeResolver {
+	return func(r *http.Request, cs *core.KeyorixCore) (core.Scope, error) {
+		id, err := scopePathUint(r, param)
+		if err != nil {
+			return core.Scope{}, errInvalidTarget
+		}
+		cfg, err := cs.GetDynamicSecretConfig(r.Context(), id)
+		if err != nil {
+			return core.Scope{}, errTargetNotFound
+		}
+		return core.Scope{ProjectID: cfg.ProjectID, EnvironmentID: cfg.EnvironmentID}, nil
+	}
+}
+
+// ScopeFromDynamicSecretLeaseParam treats the named path param as a
+// dynamic-secret lease ID (a string, unlike every other resolver's uint path
+// param -- lease IDs are opaque tokens, not row IDs) and resolves the scope
+// of the config that issued it. Same #1645/ADR-096 rationale as
+// ScopeFromDynamicSecretConfigParam above.
+func ScopeFromDynamicSecretLeaseParam(param string) ScopeResolver {
+	return func(r *http.Request, cs *core.KeyorixCore) (core.Scope, error) {
+		leaseID := chi.URLParam(r, param)
+		if leaseID == "" {
+			return core.Scope{}, errInvalidTarget
+		}
+		lease, err := cs.GetDynamicSecretLease(r.Context(), leaseID)
+		if err != nil {
+			return core.Scope{}, errTargetNotFound
+		}
+		return core.Scope{ProjectID: lease.ProjectID, EnvironmentID: lease.EnvironmentID}, nil
+	}
+}
+
 // roleAssignmentBodyScope is the subset of the user-roles assign/remove request
 // body (both share the same project_id/environment_id shape) needed to resolve
 // the target scope ahead of the handler's own decode.


### PR DESCRIPTION
## Summary

Adds **ADR-096**, documenting the house anti-enumeration convention decision for #1645: **403-for-both** (not 404-for-both) as the standard for any endpoint touching a scoped resource.

Decided on the threat-model argument, not majority-convention: 404-for-denied is a deliberate lie to an authenticated user already inside the trust boundary. That's a reasonable trade for GitHub, whose threat model is anonymous scraping of private repos. It's not a reasonable trade for an on-prem secrets tool used during incidents, where an operator told "not found" concludes the secret was deleted or they're on the wrong server -- real operational cost, for very little gained against an attacker who is already authenticated and knows the route shape.

The ADR specifies four binding conditions:
1. The real-404 exception is narrow: caller holds the **same permission**, at **global scope** -- not "any global permission," not looser.
2. The convention is the whole response (body + error-code string + headers), not just the status code.
3. Migrate through the shared mechanism (`handleScopeResolutionError`/`RequireScopedPermission`), not per-call-site logic.
4. gRPC gets the identical rule specified in the same document (its own codes, `PermissionDenied`/`NotFound`), so it isn't left to be re-derived later -- which is how this repo ended up with two conventions the first time.

Plus scope notes: list endpoints already comply (empty list leaks nothing), write verbs (PUT/PATCH/DELETE) must follow the same rule as GET. Timing side-channel is explicitly deferred as future work, not attempted here.

## Concrete migration: dynamic-secret config/lease routes

First application of the mechanism. Adds `ScopeFromDynamicSecretConfigParam`/`ScopeFromDynamicSecretLeaseParam` (`server/middleware/auth.go`) and wires all 8 config/lease routes through `RequireScopedPermission` instead of the handler-internal `loadAuthorizedConfig`/`loadAuthorizedLease`, which used to collapse "doesn't exist" and "exists, denied" into a uniform 404 regardless of caller privilege (the old Convention B).

Two new tests (`dynamic_secrets_403_convention_test.go`) prove the property live:
- An unprivileged caller gets a **byte-identical** 403 for a real config they can't see and a nonexistent config ID.
- A globally-privileged caller gets a genuine 404 only for the nonexistent one.

Verified red-first (temporarily reverted, confirmed the discriminating test failed against the old code, restored).

## Found and fixed along the way

Removing `loadAuthorizedConfig`'s inline `authorize()` call exposed a **latent nil-pointer-dereference panic** in 4 handlers (`IssueLease`/`RevokeAllLeases`/`ClassifyConfig`/`SetConfigEnabled`) that dereferenced `userCtx.UserID` without checking `userCtx` for nil -- they'd relied on the old `authorize()` call to also serve as the de facto user-context check. Added the same `mustGetUser` guard every sibling handler in the file already uses.

Six existing tests had encoded the old check ordering into their own premise and needed fixing, not loosening: `handlers_s4_test.go`'s `IssueLease`/`RevokeAllLeases`/`ClassifyConfig`/`SetConfigEnabled` NotFound+BadID tests now inject a real user context to reach the branch they're actually named for; `handlers_s17_test.go`/`handlers_s23_test.go`'s two NoUserCtx tests now expect 401 (`mustGetUser` fires first) instead of the old accidental 400/404.

## This is a partial migration

Remaining Convention-B sites, left for follow-up using the exact mechanism ADR-096 documents:
- HTTP: `scim.go`/`scim_groups.go`'s provisioning collision checks, `secret_render.go`
- gRPC: `secret_service.go`'s `GetSecret`, `dynamic_secret_service.go` -- gRPC needs its own shared collapse function, since it has no middleware chain equivalent to chi's

Issue #1645 stays open for the rest of this.

## Test plan

- [x] `go build ./...`, `gofmt -l .` -- clean
- [x] `gosec -severity medium -exclude-generated`, `golangci-lint run` on touched packages -- 0 issues
- [x] Full suite green: `server/http`, `server/http/handlers`, `server/http/handlers/contracttest` (full package, ~5.5 min)
- [x] New 403-for-both proof tests verified red-first