### PR TITLE
fix(core/grpc): confirm role validation errors via sentinel, not text-match

### DIFF
--- a/internal/core/rbac_roles.go
+++ b/internal/core/rbac_roles.go
@@ -17,12 +17,35 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// ErrRoleValidation marks a CreateRole failure as an application-generated
+// validation error (name length, folded-name charset/bidi rejection) rather
+// than a storage/driver failure, so a caller like mapRoleError
+// (server/grpc/services/role_service.go) can confirm via errors.Is that the
+// error's message is safe to echo to a client instead of guessing from its
+// text.
+var ErrRoleValidation = errors.New("role validation")
+
+// roleValidationError tags err as matching ErrRoleValidation for errors.Is,
+// without ErrRoleValidation's own text ever appearing in Error() -- the
+// displayed message stays exactly err's, unchanged from before this marker
+// existed.
+type roleValidationError struct{ err error }
+
+func (e *roleValidationError) Error() string        { return e.err.Error() }
+func (e *roleValidationError) Unwrap() error         { return e.err }
+func (e *roleValidationError) Is(target error) bool { return target == ErrRoleValidation }
+
+// WrapRoleValidation marks err as an ErrRoleValidation match for errors.Is,
+// without altering its Error() text.
+func WrapRoleValidation(err error) error { return &roleValidationError{err: err} }
 
 // Role Name/Description length bounds — the single source of truth both
 // transports' own early-reject validation (server/http/handlers/rbac.go's
@@ -60,11 +83,11 @@ func validateRoleNameLength(name string) error {
 // authenticated principal).
 func (c *KeyorixCore) CreateRole(ctx context.Context, actorID uint, name, description string) (*models.Role, error) {
 	if err := validateRoleNameLength(name); err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+		return nil, WrapRoleValidation(fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err))
 	}
 	foldedName, ferr := identity.NewFoldedName(name)
 	if ferr != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+		return nil, WrapRoleValidation(fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr))
 	}
 	if IsBuiltinRole(foldedName.Folded()) {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this role name is reserved and cannot be created")

--- a/internal/core/rbac_roles.go
+++ b/internal/core/rbac_roles.go
@@ -40,7 +40,7 @@ var ErrRoleValidation = errors.New("role validation")
 type roleValidationError struct{ err error }
 
 func (e *roleValidationError) Error() string        { return e.err.Error() }
-func (e *roleValidationError) Unwrap() error         { return e.err }
+func (e *roleValidationError) Unwrap() error        { return e.err }
 func (e *roleValidationError) Is(target error) bool { return target == ErrRoleValidation }
 
 // WrapRoleValidation marks err as an ErrRoleValidation match for errors.Is,

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -414,11 +415,14 @@ func mapRoleError(err error) error {
 		return status.Error(codes.AlreadyExists, "this role name is reserved and cannot be created")
 	case strings.Contains(msg, "already exists"), strings.Contains(msg, "duplicate"), strings.Contains(msg, "unique"):
 		return status.Error(codes.AlreadyExists, "a role with that name already exists")
-	// #1660: core.CreateRole/UpdateRole's own validation (name fold rejects
-	// control/bidi characters, length bounds) surfaces here now that both
-	// RPCs route through them instead of storage directly.
-	case strings.Contains(msg, "validation"):
-		return status.Error(codes.InvalidArgument, err.Error())
+	// #1660: core.CreateRole's own validation (name fold rejects control/bidi
+	// characters, length bounds) surfaces here now that both RPCs route
+	// through it instead of storage directly. errors.Is against
+	// core.ErrRoleValidation confirms this err.Error() text is
+	// application-generated (never a storage/driver failure), so it's safe
+	// to echo instead of guessing from the message text.
+	case errors.Is(err, core.ErrRoleValidation):
+		return status.Error(codes.InvalidArgument, err.Error()) // nosemgrep: keyorix-raw-error-to-client -- confirmed via errors.Is(err, core.ErrRoleValidation) above; message is CreateRole's own fixed validation text, never storage/driver output
 	case strings.Contains(msg, "built-in"):
 		return status.Errorf(codes.FailedPrecondition, "%s", err.Error())
 	default:

--- a/server/grpc/services/services_s2_test.go
+++ b/server/grpc/services/services_s2_test.go
@@ -192,6 +192,39 @@ func TestMapRoleError_Default(t *testing.T) {
 	}
 }
 
+// core.ErrRoleValidation-wrapped errors (CreateRole's own length/charset
+// checks) map to InvalidArgument with their message intact -- safe to echo
+// since errors.Is confirms the text is application-generated, not a
+// storage/driver failure.
+func TestMapRoleError_Validation(t *testing.T) {
+	inner := errors.New("role name must be between 3 and 50 characters")
+	err := mapRoleError(core.WrapRoleValidation(inner))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", st.Code())
+	}
+	if st.Message() != "role name must be between 3 and 50 characters" {
+		t.Errorf("expected the validation message to be echoed verbatim, got %q", st.Message())
+	}
+}
+
+// A plain error whose text merely CONTAINS "validation" -- but isn't wrapped
+// in core.ErrRoleValidation -- must fall through to the generic Internal
+// bucket rather than being echoed to the client. This is the failure mode
+// the old strings.Contains(msg, "validation") check could not distinguish:
+// any storage/driver error mentioning the word "validation" would have had
+// its raw text sent straight to a gRPC client.
+func TestMapRoleError_ValidationTextWithoutSentinel_NotEchoed(t *testing.T) {
+	err := mapRoleError(errors.New("constraint chk_validation_xyz on table roles: internal driver detail"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Internal {
+		t.Errorf("expected Internal (no sentinel match), got %v", st.Code())
+	}
+	if st.Message() != "role operation failed" {
+		t.Errorf("expected the generic safe message, got %q (raw error text must not leak)", st.Message())
+	}
+}
+
 // --- breakGlassError ---
 
 func TestBreakGlassError_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary
- Follow-up to #1665 (fix(core): #1660 -- CreateRole/UpdateRole now route through internal/core), which merged with its `scan` CI check red (repo's own blocking custom Semgrep rule `keyorix-raw-error-to-client`). The original PR's branch was already merged before this fix was ready, so it landed on a now-orphaned branch and never reached `main` -- this PR re-applies the identical fix against current `main`.
- `mapRoleError` (server/grpc/services/role_service.go) is a general-purpose error translator shared by every role RPC. Its "is this safe to echo to the client" check for the `codes.InvalidArgument` branch was `strings.Contains(strings.ToLower(err.Error()), "validation")` -- true for `CreateRole`'s own safe validation text, but equally true for any unrelated storage/driver error that happens to contain the word "validation" (e.g. a constraint literally named `chk_validation_xyz`), which would leak raw internal error text to a gRPC client instead of falling through to the generic `Internal` bucket.
- Fixed by mirroring the existing `core.ErrMachinePrivilegeCeilingDenied` / `errors.Is` pattern already used in the same file (`TestMapMachineError_PrivilegeCeilingDenied`): `CreateRole` now wraps its two validation failures (name length, folded-name charset/bidi rejection) with a new `core.ErrRoleValidation` sentinel via a marker type whose `Error()` delegates entirely to the wrapped error -- wrapping changes nothing about the message a client sees, only what `errors.Is` can prove about its origin. `mapRoleError` now checks `errors.Is(err, core.ErrRoleValidation)` instead of guessing from text, with a `// nosemgrep` justification once that's confirmed.
- Added `TestMapRoleError_Validation` (message is echoed verbatim for a genuinely wrapped error -- confirms no behavior change) and `TestMapRoleError_ValidationTextWithoutSentinel_NotEchoed` (a plain error merely containing the word "validation" still falls through to the safe `Internal` default) -- this exact branch had zero prior test coverage, and the second test encodes the security property this fix establishes that the old substring check could not.

## Test plan
- [x] `go build ./internal/core/... ./server/grpc/services/...` succeeds
- [x] `go vet ./internal/core/... ./server/grpc/services/...` clean
- [x] `go test ./internal/core/... ./server/grpc/services/...` passes in full, including the two new tests and all pre-existing `TestCreateRole_*`/`TestUpdateRole_*`/`TestMapRoleError_*` cases (confirms client-visible error text is byte-for-byte unchanged)
- [x] `semgrep --config .semgrep/keyorix-rules.yml --severity WARNING --severity ERROR --error --quiet server/grpc/services/role_service.go internal/core/rbac_roles.go` -- the exact CI invocation -- exits 0