### PR TITLE
chore(deps): bump google.golang.org/grpc to v1.83.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/text v0.41.0
 	golang.org/x/time v0.15.0
 	google.golang.org/api v0.293.0
-	google.golang.org/grpc v1.83.1
+	google.golang.org/grpc v1.83.2
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/postgres v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -390,8 +390,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260715232425-e75dac1f907d h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260715232425-e75dac1f907d/go.mod h1:WRrQ7/7N19PypuT0fxLOL5Lq0waoiRri4FbtHDEKrGE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260807164820-c8921c73eeea h1:kVhQEPTpKQahD5+JSBTfBB19wcgQTTjAIn45MBqnyHk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260807164820-c8921c73eeea/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
+google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.36.12 h1:pJOKDDOyeXErUroCihFAd5LQuwXBSpVnKGrj5o/fwxc=
 google.golang.org/protobuf v1.36.12/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary
- Bumps `google.golang.org/grpc` v1.83.1 -> v1.83.2 (latest stable release in the 1.83.x line).
- Related to Dependabot alert #10 (GHSA-vp52-pcj8-j9qc / CVE-2026-84304, gRPC-Go heap exhaustion via HTTP/2 DATA frame fragmentation, severity high) -- but note the repo was **never actually vulnerable**: v1.83.1 (already on `main` since PR #1602, 2026-08-28) is the exact version the advisory names as its fix. Verified across `go.mod`, `go.sum`, and the MVS-resolved build graph (`go list -m`) before this PR. The alert appears to be a false positive at generation time (advisory published 2026-09-01T21:32, alert created ~12h later, apparently without correctly checking this repo's already-patched pin).
- This bump to v1.83.2 is routine hygiene, not required to close the CVE.

## Test plan
- [x] `go build ./...` -- clean
- [x] `go test ./server/grpc/...` and `go test ./...` -- full repo green
- [x] `go vet ./...` -- clean