### PR TITLE
feat(storage): add schema-epoch startup guard against silent downgrade (ADR-097)

### DIFF
--- a/docs/adr-097-schema-epoch-downgrade-guard.md
+++ b/docs/adr-097-schema-epoch-downgrade-guard.md
@@ -1,0 +1,137 @@
+# ADR-097: Schema-epoch startup guard against silent downgrade
+
+## Status
+
+**Accepted (2026-09-02).** Follow-up to the 2026-09 security review
+(`docs/security-review-2026-09.md`), which named migration downgrade safety
+as explicitly out of scope. This ADR closes that gap.
+
+## Summary
+
+`migrateDatabase` (`internal/storage/factory.go`) is a single, monotonic,
+always-forward migration function: GORM `AutoMigrate` plus a long sequence of
+idempotent `ALTER TABLE ... ADD COLUMN` statements, each gated on
+`columnExists`/`tableExists`. It has no notion of schema version, and nothing
+anywhere in the boot path checks whether the database it's about to run
+against was already migrated by a *newer* binary than the one currently
+starting. If an operator rolls back to an older release while pointing at
+the same database — a plausible operational action during a bad deploy, not
+a hypothetical — the older binary boots and runs normally against a schema
+it doesn't fully understand.
+
+Investigating this directly (tracing `roles.bypasses_permission_checks`,
+`user_roles.environment_id`/`group_roles.environment_id`, and
+`secret_nodes.classification` and its siblings through their actual
+authorization call sites — `GetUserRoleIDsAt`'s scope filter in
+`internal/storage/store/local_rbac.go`, `classification_gate.go`'s gate
+check, `verifyBatchEvents`'s audit-hash-chain walk) found that every
+column added by `migrateDatabase` to date happens to default in the safe
+direction: an old binary's `INSERT` that doesn't know a column exists gets
+that column's DB-level `DEFAULT`, and in every case checked, that default
+reproduces the pre-migration semantics rather than widening them
+(`bypasses_permission_checks DEFAULT false` = no bypass;
+`environment_id DEFAULT 0` = the old, pre-environment-scoping "applies to
+the whole project" behavior, not a wildcard grant; `classification DEFAULT
+''` = unclassified, the same no-extra-gate state a pre-classification
+binary always produced; an empty audit `entry_hash` appearing after the
+chain has started is already caught by `verifyBatchEvents`'s "missing entry
+hash on a chained event" check, not silently tolerated).
+
+That is a real, verified-safe result — but it holds only because every
+migration author so far independently made the correct default-direction
+choice. Nothing enforces that this stays true for the next one. A future
+migration that adds, say, a `require_step_up BOOLEAN NOT NULL DEFAULT
+false` where `false` is the *permissive* direction would reproduce exactly
+the silent-regression shape this review looked for and didn't find —
+individually undetectable without re-doing this same trace for every future
+column, by hand, forever.
+
+**Decision: add a structural startup guard, not a documentation convention.**
+This matches the review's own stated taste (`docs/security-review-2026-09.md`:
+"the raw-storage-bypass class is closed by a guard, not by a fixed list";
+"the 404-vs-403 finding produced a house convention... not a single patch")
+— close the *class* of problem (an old binary silently running against
+unknown schema) rather than re-auditing each instance of it.
+
+## The mechanism
+
+A monotonically increasing integer, `currentSchemaEpoch`, compiled into the
+binary next to `migrateDatabase` itself. Every PR that changes
+`migrateDatabase` in a way that adds or alters schema must bump it by one —
+a single `const` at the top of `factory.go`, impossible to miss when editing
+the function directly below it.
+
+- **Write**: after `migrateDatabase` completes successfully — not before,
+  and not on partial/failed completion — it upserts `currentSchemaEpoch`
+  into `system_metadata` under the key `schema_epoch`, using the same
+  `system_metadata` table and upsert idiom `SetSystemMetadata` already uses
+  (`internal/storage/store/local_system_metadata.go`), but written directly
+  against the `*gorm.DB` handle `migrateDatabase` already holds — the
+  `storage.Storage` wrapper doesn't exist yet at this point in
+  `createLocalStorage`/`createPostgresStorage`.
+- **Check**: as the very first thing `migrateDatabase` does, before any
+  `ALTER TABLE`/`AutoMigrate` call. If `system_metadata` doesn't exist yet,
+  this is a fresh install (or a database from before `system_metadata`
+  itself existed, i.e. pre-ADR-029 — in practice indistinguishable from
+  fresh at this point) — proceed unconditionally, nothing to compare
+  against. If the table exists but the `schema_epoch` key was never written
+  (an older binary that predates this guard), proceed unconditionally too —
+  absence of a recorded epoch cannot itself justify refusing to start. If
+  the key exists and parses to a value **greater than** `currentSchemaEpoch`,
+  refuse: return an error before any migration step runs, with a message
+  naming both epochs and telling the operator this binary is older than the
+  database it's pointed at.
+- **Corrupt value**: if the key exists but doesn't parse as an integer,
+  fail closed (refuse to start) rather than silently proceeding — matching
+  `migrateDatabase`'s existing `#G54` fail-closed discipline for a failed
+  `ALTER` (a silently-skipped check is worse than a loud one an operator
+  has to clear manually).
+
+## What this does not solve
+
+- **The legacy `migrations/*.down.sql` files** (`migrations/README.md`)
+  remain what they always were: unused by any code path in this repo,
+  runnable only via a manually-invoked external `golang-migrate` binary.
+  This guard has no interaction with them and doesn't make them any more or
+  less safe than before.
+- **It doesn't replace tracing a new migration's default-direction safety.**
+  A migration author still has to reason about which direction is safe for
+  a new column — this guard only stops an *old* binary from running against
+  a schema that already has an unsafe-if-ignored column; it says nothing
+  about whether a *new* binary's own migration chose the right default in
+  the first place. That reasoning is still a human judgment call at
+  migration-authoring time, the same as it always was.
+- **No automated check enforces bumping `currentSchemaEpoch`.** A test that
+  tries to infer "did this diff change something that requires an epoch
+  bump" would have to distinguish semantically-relevant schema changes from
+  comment/refactor-only changes inside a 250+ cyclomatic-complexity
+  function — not reliably automatable. This is a convention backed by
+  proximity (the constant sits directly above the function) and this ADR,
+  not a machine-checked gate. Stated here as a known limitation, not an
+  implied "and therefore machine-enforced."
+- **This is not a replacement for testing an actual downgrade.** The guard
+  makes a downgrade fail loudly instead of silently; it doesn't test that
+  every application code path behaves correctly on the *older* binary's own
+  side once it refuses (i.e., that refusing to start is itself clean —
+  which the test suite added alongside this ADR does cover for the
+  `migrateDatabase`/`createLocalStorage`/`createPostgresStorage` boundary,
+  but not for process-manager or orchestrator-level restart-loop behavior).
+
+## Alternatives considered
+
+- **Warn-and-continue instead of refuse-to-start.** Rejected: the whole
+  point is that the failure mode this guards against is silent. A warning
+  that isn't tied to actual startup failure will be missed in exactly the
+  incident-response scenario (a bad deploy, someone rolling back fast) where
+  it matters most.
+- **A full versioned migration framework (numbered up/down files, a
+  `schema_migrations` table tracking every individual step).** Rejected as
+  disproportionate: `migrateDatabase`'s existing idempotent-additive design
+  already handles forward migration correctly and has for a long time; the
+  actual gap this ADR closes is narrow (no downgrade detection), and a full
+  reframe of the migration system is a much larger, riskier change than the
+  problem warrants.
+- **Per-column safety documentation instead of a version gate.** Rejected
+  per the "guard, not a fixed list" reasoning above — a checklist a future
+  PR author has to remember to consult doesn't survive the same way a
+  compile-time-adjacent constant and a startup check does.

--- a/docs/security-review-2026-09.md
+++ b/docs/security-review-2026-09.md
@@ -65,7 +65,7 @@ are recorded as such. A review that only lists hits reads identically to one tha
 | Existence-oracle consistency (404-vs-403) | **1 issue, fixed** (#1645) — a house convention (ADR-096) plus an incremental, independently-testable migration, not a single patch. |
 | Role-creation core-bypass | **1 issue, fixed** (#1660). |
 | Multi-replica safety (mutex-only invariants) | **1 issue, fixed** (#1646), covering 6 named invariants. |
-| RBAC admin-detection structural integrity | **1 issue investigated, decision recorded (ADR-084), implementation deliberately deferred** (#1494) — see "What remains open." |
+| RBAC admin-detection structural integrity | **1 issue, fixed** (#1494) — decision recorded in ADR-084, implemented 2026-09-02. See "Update, 2026-09-02" below; deferred at the time this table was first written. |
 | Identity normalisation (Unicode NFC/NFD collision) | **1 issue, fixed** (#1642). |
 | File-creation permissions (umask inheritance) | **1 issue, fixed** (#1647). |
 | Request-context lifecycle (audit durability across client disconnect) | **1 issue, fixed** (#1650). |
@@ -104,18 +104,11 @@ being one-offs:
 
 ## What remains open
 
-Two items, both **deliberately deferred** — a decision was made in each case, and the reason still holds. Neither
-is scheduled-but-undone, and neither was found to be missed.
+One item, **deliberately deferred** — a decision was made and the reason still holds. Not scheduled-but-undone,
+and not found to be missed. (#1494/ADR-084 was also listed here at the time this section was first written; it has
+since been implemented — see "Update, 2026-09-02" below. Left here only as a pointer, not re-described, so this
+section states current reality rather than repeating a now-superseded claim.)
 
-- **#1494 / ADR-084 — replace name-based admin-role detection with a structural `bypasses_permission_checks`
-  column.** The live exploit surface this issue originally worried about (creating or renaming a role to acquire
-  the four reserved admin names) is closed today by an independent, structural guard
-  (`TestUpdateRoleRequest_CarriesNoNameField` — neither transport's update path can rename a role at all, so
-  there is no rename-based bypass to begin with). ADR-084 records the decision on the more resilient
-  long-term mechanism, with alternatives considered and rejected, and explicitly defers implementation as
-  not-urgent follow-up work — correctly so, since there is no live gap forcing an earlier timeline. This issue
-  was closed once, contrary to its own investigation's recommendation, with a corrupted closing comment; it has
-  been reopened, retitled to name ADR-084 directly, and the record corrected.
 - **#1653 — six wall-clock ceiling sites named, one (`break_glass.go`'s activation listing) left unfixed.** The
   fixing commit disclosed this omission explicitly rather than silently claiming full coverage, with the
   reasoning that the actual access grant a break-glass activation represents is a role assignment, and role
@@ -125,8 +118,8 @@ is scheduled-but-undone, and neither was found to be missed.
   grant, not an independent access-control decision point.
 
 No item in this review's scope was found to be *believed closed and isn't* with no available explanation, and
-none was found *filed and then lost track of* with no resolution at all — the two items above both have a stated,
-current, defensible reason, which is the difference between "deliberately deferred" and "missed."
+none was found *filed and then lost track of* with no resolution at all — every deferred item, past and present,
+had a stated, current, defensible reason, which is the difference between "deliberately deferred" and "missed."
 
 ## What was deliberately not examined
 
@@ -138,10 +131,6 @@ named here so that omission reads as a stated boundary rather than an implied "c
   garbage collector, or a swapped page, to eventually reclaim) was not examined. Go's runtime and garbage collector
   make this a substantially harder guarantee to make than it is in a language with manual memory management, and
   doing it properly is a distinct piece of work with its own design tradeoffs, not a fix-sized finding.
-- **Migration downgrade paths.** This review's wall-clock and path-resolution findings touch storage and config
-  loading, but whether a downgrade (running an older binary against a database a newer version has migrated)
-  fails safely was not tested. The existing migration system's `down` migrations were touched by an earlier,
-  separate piece of work (adding pre-drop backups) that predates this review and is not re-verified here.
 - **Availability and denial-of-service resistance**, beyond the specific multi-replica-mutex finding recorded
   above. Rate limiting, resource-exhaustion bounds on individual endpoints, and general load-shedding behavior
   were not swept as their own class in this pass.
@@ -151,9 +140,33 @@ named here so that omission reads as a stated boundary rather than an implied "c
 - **The frontend (`web/`) beyond its CSP configuration**, which surfaced incidentally via the accepted-risk CSP
   finding above and was not otherwise part of this pass's sweep.
 
+## Update, 2026-09-02
+
+Two changes since this document was first written, recorded here rather than silently folded into the sections
+above, for the same reason #1494's original mis-closure is narrated rather than quietly fixed: a review document
+that edits its own past claims without a visible trail is exactly the failure mode this document exists to avoid.
+
+- **#1494 / ADR-084 implemented.** `models.Role.BypassesPermissionChecks`, resolved by role ID via
+  `storage.RoleSetBypassesPermissionChecks`, now replaces `roleSetContainsAdmin`'s old fixed-name lookup at all
+  8 call sites (`authz.go` ×5, `dynamic_secrets.go`, `invitations.go`, `scim_groups.go`). Written only by role
+  seeding (`defaultRoles`/`BootstrapSystem`) and a one-time migration snapshot for existing installs;
+  `CreateRole`/`UpdateRole` never accept it from a request DTO on any transport, matching the ADR's decision.
+  `installAdminRoleIDSet` and `isAdminRoleName`/`adminRoleNames` remain unchanged, per the ADR's explicit scope.
+  This is no longer an open item.
+- **Migration downgrade paths, examined (ADR-097).** Tracing the security-relevant columns `migrateDatabase`
+  has added to date (`roles.bypasses_permission_checks`, `user_roles`/`group_roles.environment_id`,
+  `secret_nodes.classification` and its siblings, `audit_events.prev_hash`/`entry_hash`) through their actual
+  authorization/verification call sites found every one of them defaults in the safe direction if an older
+  binary — one that doesn't know the column exists — writes a new row. That holds only because each migration's
+  author independently chose the correct default; nothing enforced it. ADR-097 adds a schema-epoch startup guard
+  (`checkSchemaEpoch`/`recordSchemaEpoch`, `internal/storage/factory.go`) so a binary older than the database
+  it's pointed at refuses to start rather than silently running against unknown state — closing the class,
+  matching this review's own stated preference for a guard over a per-instance audit.
+
 ## Governing ADRs
 
-ADR-084 (admin-bypass structural marker, deferred implementation), ADR-087 (RemoteStorage deletion pass),
+ADR-084 (admin-bypass structural marker, implemented 2026-09-02), ADR-087 (RemoteStorage deletion pass),
 ADR-088 (system proxy layer design), ADR-091 (machine `CreatedBy` attribution classification), ADR-092 (audit
 event `UserID` for a machine principal), ADR-093 (remote `--by`-authority check), ADR-094 (time handling: UTC
-internally, wall-clock distrust), ADR-095 (database path resolution), ADR-096 (anti-enumeration, 403-for-both).
+internally, wall-clock distrust), ADR-095 (database path resolution), ADR-096 (anti-enumeration, 403-for-both),
+ADR-097 (schema-epoch downgrade guard).

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1,10 +1,12 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -25,6 +28,22 @@ const (
 	sqlCreateUniqueIdx = "CREATE UNIQUE INDEX IF NOT EXISTS "
 	sqlWhereNotDeleted = "deleted_at IS NULL"
 )
+
+// currentSchemaEpoch (ADR-097) is this binary's compiled-in schema version.
+// Bump it by exactly one in the SAME PR as any change to migrateDatabase
+// below that adds or alters schema (a new ALTER TABLE, a new AutoMigrate
+// model, a new column) -- checkSchemaEpoch uses it to refuse startup if the
+// database was already migrated by a newer binary, closing the class of
+// silent-downgrade regression this ADR documents (an old binary writing new
+// rows via a migrated-in column's DEFAULT, blind to whatever invariant that
+// column encodes). NOT bumped for pure comment/refactor changes that don't
+// touch what gets written to the database.
+const currentSchemaEpoch = 1
+
+// schemaEpochMetadataKey is the system_metadata (see models.SystemMetadata)
+// key checkSchemaEpoch/recordSchemaEpoch read and write. #nosec G101 --
+// metadata key name, not a credential.
+const schemaEpochMetadataKey = "schema_epoch"
 
 // migrationMu serializes migrateDatabase across goroutines IN THIS PROCESS (#266).
 // startHTTPServer and startGRPCServer each independently call CreateStorage →
@@ -451,6 +470,63 @@ func tableExists(db *gorm.DB, table string) bool {
 	return count > 0
 }
 
+// checkSchemaEpoch (ADR-097) refuses to let an older binary run migrateDatabase
+// against a database a newer binary already migrated. Called BEFORE any other
+// migration step. system_metadata not existing yet means a fresh install (or a
+// database old enough to predate system_metadata itself, i.e. pre-ADR-029) --
+// either way, there is nothing recorded to compare against, so this proceeds.
+// A missing schema_epoch key means an older binary that predates this guard
+// wrote to this database last -- absence of a recorded epoch cannot itself
+// justify refusing to start, so this proceeds too. Only an explicit, parsed
+// epoch GREATER than currentSchemaEpoch, or a value that fails to parse at
+// all (fail-closed, matching this file's #G54 discipline: a corrupted marker
+// is worse to silently ignore than to loudly refuse), blocks startup.
+func checkSchemaEpoch(db *gorm.DB) error {
+	if !tableExists(db, "system_metadata") {
+		return nil
+	}
+	var m models.SystemMetadata
+	err := db.Where("key = ?", schemaEpochMetadataKey).Take(&m).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		return fmt.Errorf("failed to read schema epoch: %w", err)
+	}
+	dbEpoch, parseErr := strconv.Atoi(m.Value)
+	if parseErr != nil {
+		return fmt.Errorf("stored schema epoch %q is not a valid integer -- refusing to start rather than guess whether this database is ahead of this binary (ADR-097)", m.Value)
+	}
+	if dbEpoch > currentSchemaEpoch {
+		return fmt.Errorf(
+			"database schema epoch %d is newer than this binary's schema epoch %d -- "+
+				"this database was migrated by a newer version of Keyorix; running an "+
+				"older binary against it risks silent, undetected regressions in any "+
+				"security invariant a column added since epoch %d encodes. Upgrade this "+
+				"binary to match, or restore a backup taken before the newer version ran (ADR-097)",
+			dbEpoch, currentSchemaEpoch, currentSchemaEpoch)
+	}
+	return nil
+}
+
+// recordSchemaEpoch (ADR-097) upserts currentSchemaEpoch into system_metadata.
+// Called only after migrateDatabase's other steps all succeed -- never on a
+// partial/failed migration, so a crash mid-migration can't advance the
+// recorded epoch past what was actually, successfully applied.
+func recordSchemaEpoch(db *gorm.DB) error {
+	if err := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"value", "updated_at"}),
+	}).Create(&models.SystemMetadata{
+		Key:       schemaEpochMetadataKey,
+		Value:     strconv.Itoa(currentSchemaEpoch),
+		UpdatedAt: time.Now(),
+	}).Error; err != nil {
+		return fmt.Errorf("failed to record schema epoch: %w", err)
+	}
+	return nil
+}
+
 // indexExists reports whether a database index with the given name already
 // exists. The ensure*Index helpers below gate their one-time, pre-existing-
 // duplicate-row scan (#490) on this: once the target unique index is in place,
@@ -726,6 +802,11 @@ func rebuildRolePKPostgres(db *gorm.DB, table, idCol, pkCols, oldConstraint stri
 // On a fresh DB, AutoMigrate creates all tables. On an existing DB,
 // it adds missing columns and indexes without dropping anything.
 func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR -- cognitive complexity 266, suppress go:S3776
+	// ADR-097: refuse before touching anything if this binary is older than
+	// the database it's pointed at -- must run before every other step below.
+	if err := checkSchemaEpoch(db); err != nil {
+		return err
+	}
 	// #G54: every additive column/index migration below is now checked and
 	// propagated (fail-closed) via this helper, instead of the bare
 	// db.Exec(...) each previously used — which discarded the result
@@ -1693,7 +1774,13 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	if err := ensureShareRecordUniqueIndex(db); err != nil {
 		return err
 	}
-	return ensureSecretVersionIndex(db)
+	if err := ensureSecretVersionIndex(db); err != nil {
+		return err
+	}
+	// ADR-097: only after every migration step above has succeeded -- a crash
+	// or error partway through must not advance the recorded epoch past what
+	// was actually, successfully applied.
+	return recordSchemaEpoch(db)
 }
 
 // ensureRoleNameIndex replaces Role.Name's original plain `unique` gorm tag

--- a/internal/storage/factory_schema_epoch_test.go
+++ b/internal/storage/factory_schema_epoch_test.go
@@ -1,0 +1,161 @@
+// factory_schema_epoch_test.go — coverage for ADR-097's schema-epoch startup
+// guard (checkSchemaEpoch/recordSchemaEpoch), which refuses to let an older
+// binary run migrateDatabase against a database a newer binary already
+// migrated.
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSchemaEpoch_FreshInstall_RecordsCurrentEpoch: a brand-new, empty
+// database has nothing to compare against -- migrateDatabase must succeed
+// and, having finished, record currentSchemaEpoch for the next run.
+func TestSchemaEpoch_FreshInstall_RecordsCurrentEpoch(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "epoch-fresh.db"))
+	require.NoError(t, err)
+
+	f := &DefaultStorageFactory{}
+	require.NoError(t, f.migrateDatabase(db))
+
+	var m models.SystemMetadata
+	require.NoError(t, db.Where("key = ?", schemaEpochMetadataKey).Take(&m).Error)
+	assert.Equal(t, "1", m.Value)
+}
+
+// TestSchemaEpoch_OlderRecordedEpoch_UpgradesSucceed: the normal upgrade
+// case -- the database was last migrated by an OLDER binary (lower epoch).
+// migrateDatabase must succeed and advance the recorded epoch.
+func TestSchemaEpoch_OlderRecordedEpoch_UpgradeSucceeds(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "epoch-older.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SystemMetadata{}))
+	require.NoError(t, db.Create(&models.SystemMetadata{Key: schemaEpochMetadataKey, Value: "0"}).Error)
+
+	f := &DefaultStorageFactory{}
+	require.NoError(t, f.migrateDatabase(db))
+
+	var m models.SystemMetadata
+	require.NoError(t, db.Where("key = ?", schemaEpochMetadataKey).Take(&m).Error)
+	assert.Equal(t, "1", m.Value, "epoch must advance to the current binary's epoch")
+}
+
+// TestSchemaEpoch_SameRecordedEpoch_Succeeds: re-running the same binary
+// version (epoch already matches) must succeed -- this is the common case
+// on every ordinary restart.
+func TestSchemaEpoch_SameRecordedEpoch_Succeeds(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "epoch-same.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SystemMetadata{}))
+	require.NoError(t, db.Create(&models.SystemMetadata{Key: schemaEpochMetadataKey, Value: "1"}).Error)
+
+	f := &DefaultStorageFactory{}
+	require.NoError(t, f.migrateDatabase(db))
+}
+
+// TestSchemaEpoch_NoRecordedEpoch_PredatesGuard_Succeeds: system_metadata
+// exists (this is an established database) but the schema_epoch key was
+// never written -- an older binary that predates this guard entirely wrote
+// here last. Absence of a recorded epoch cannot itself justify refusing to
+// start.
+func TestSchemaEpoch_NoRecordedEpoch_PredatesGuard_Succeeds(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "epoch-none.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SystemMetadata{}))
+	// system_metadata table exists (via AutoMigrate above) but no schema_epoch row.
+
+	f := &DefaultStorageFactory{}
+	require.NoError(t, f.migrateDatabase(db))
+
+	var m models.SystemMetadata
+	require.NoError(t, db.Where("key = ?", schemaEpochMetadataKey).Take(&m).Error)
+	assert.Equal(t, "1", m.Value, "the epoch must be recorded going forward even though none was found")
+}
+
+// TestSchemaEpoch_NewerRecordedEpoch_RefusesToStart is the core regression
+// this ADR closes: a database already migrated by a NEWER binary (higher
+// epoch) must cause migrateDatabase to refuse, not silently proceed.
+func TestSchemaEpoch_NewerRecordedEpoch_RefusesToStart(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "epoch-newer.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SystemMetadata{}))
+	require.NoError(t, db.Create(&models.SystemMetadata{Key: schemaEpochMetadataKey, Value: "2"}).Error)
+
+	f := &DefaultStorageFactory{}
+	err = f.migrateDatabase(db)
+	require.Error(t, err, "an older binary must refuse to run against a database migrated by a newer one")
+	assert.Contains(t, err.Error(), "newer than this binary's schema epoch")
+
+	// The refusal must be BEFORE any other migration step -- confirm the
+	// unrelated additive migration (users.account_state) never ran, i.e. this
+	// genuinely short-circuited rather than merely erroring out partway.
+	assert.False(t, columnExists(db, "users", "account_state"),
+		"checkSchemaEpoch must refuse before any other migration step runs")
+}
+
+// TestSchemaEpoch_CorruptRecordedEpoch_FailsClosed: a schema_epoch value that
+// doesn't parse as an integer must refuse to start (fail closed), not be
+// silently treated as absent or as zero.
+func TestSchemaEpoch_CorruptRecordedEpoch_FailsClosed(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "epoch-corrupt.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SystemMetadata{}))
+	require.NoError(t, db.Create(&models.SystemMetadata{Key: schemaEpochMetadataKey, Value: "not-a-number"}).Error)
+
+	f := &DefaultStorageFactory{}
+	err = f.migrateDatabase(db)
+	require.Error(t, err, "a corrupt schema_epoch value must fail closed, not be silently ignored")
+	assert.Contains(t, err.Error(), "not a valid integer")
+}
+
+// TestSchemaEpoch_FailedMigration_DoesNotAdvanceEpoch: if a later migration
+// step fails, the epoch must NOT be recorded -- recordSchemaEpoch only runs
+// after every other step succeeds, so a crash mid-migration can't advance
+// the recorded epoch past what was actually, successfully applied.
+func TestSchemaEpoch_FailedMigration_DoesNotAdvanceEpoch(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "epoch-failed-migration.db"))
+	require.NoError(t, err)
+	// An incompatible users table (missing columns ensureUserNameIndex needs)
+	// reproduces the same failure TestMigrateDatabase_S28_UsersTableIncompatibleSchema
+	// exercises, but this test asserts the epoch-specific consequence: no
+	// schema_epoch row must exist afterward.
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, display_name TEXT)`).Error)
+
+	f := &DefaultStorageFactory{}
+	err = f.migrateDatabase(db)
+	require.Error(t, err)
+
+	if !tableExists(db, "system_metadata") {
+		return // never got far enough to create the table at all -- also correct
+	}
+	var count int64
+	require.NoError(t, db.Model(&models.SystemMetadata{}).Where("key = ?", schemaEpochMetadataKey).Count(&count).Error)
+	assert.Zero(t, count, "a failed migration must not record a schema epoch")
+}


### PR DESCRIPTION
## Summary
- Closes the "migration downgrade paths" gap docs/security-review-2026-09.md named as explicitly out of scope: nothing in `migrateDatabase` (`internal/storage/factory.go`) checks whether an older binary is running against a database a newer binary already migrated.
- Traced every security-relevant column `migrateDatabase` has added to date through its real authorization/verification call site (`roles.bypasses_permission_checks` -> `GetUserRoleIDsAt`'s scope filter, `secret_nodes.classification`+siblings -> `classification_gate.go`, `audit_events.prev_hash`/`entry_hash` -> `verifyBatchEvents`'s hash-chain walk, `user_roles`/`group_roles.environment_id` -> the same scope filter). Every one defaults in the safe direction for an old binary's INSERT -- but only by consistent, deliberate per-migration choice, not by any structural guarantee.
- Adds ADR-097: a schema-epoch startup guard. `currentSchemaEpoch` is a compiled-in constant; `checkSchemaEpoch` refuses to run any migration step if the database's recorded epoch (`system_metadata.schema_epoch`) is ahead of the running binary's; `recordSchemaEpoch` only advances it after every other migration step succeeds.
- Updates `docs/security-review-2026-09.md` with a dated addendum recording this and ADR-084's implementation, rather than silently rewriting the document's original point-in-time claims.

## Test plan
- [x] New `internal/storage/factory_schema_epoch_test.go`: fresh install, normal upgrade, same-epoch restart, no-recorded-epoch (predates guard), newer-epoch-refuses, corrupt-value-fails-closed, failed-migration-does-not-advance-epoch
- [x] Mutation check: temporarily disabled the guard call and confirmed exactly the two tests asserting its effect (refusal, fail-closed-on-corrupt) go red -- not a vacuous pass
- [x] `go build ./...`, `go test ./...` -- full repo green
- [x] `go vet ./...`, `gofmt -l`, `gosec -severity medium ./internal/storage/...` (0 issues), `golangci-lint run ./internal/storage/...` -- all clean
- [x] `scripts/check-adr-numbers.sh` -- passes