### PR TITLE
fix(core): bound transitiveDependents' BFS against resource exhaustion

### DIFF
--- a/internal/core/secret_dependencies.go
+++ b/internal/core/secret_dependencies.go
@@ -67,6 +67,10 @@ type SecretImpact struct {
 	SecretID   uint             `json:"secret_id"`
 	SecretName string           `json:"secret_name"`
 	Affected   []ImpactedSecret `json:"affected"`
+	// Truncated is true when the true affected set may extend beyond what
+	// Affected contains -- the underlying BFS hit maxDependencyBFSNodes or
+	// maxDependencyBFSDepth (see transitiveDependents).
+	Truncated bool `json:"truncated"`
 }
 
 // RotationOrder is a safe rotation sequence for a project's dependency graph: each
@@ -268,8 +272,8 @@ func (c *KeyorixCore) GetSecretImpact(ctx context.Context, actorKind string, act
 	}
 	info := c.resolveSecretInfo(ctx, edges)
 	edges = edgesWithinEnvironment(edges, info, secret.EnvironmentID) // defence-in-depth, as in ListSecretDependencies
-	affected := transitiveDependents(edges, secretID)
-	out := &SecretImpact{SecretID: secretID, SecretName: secret.Name, Affected: make([]ImpactedSecret, 0, len(affected))}
+	affected, truncated := transitiveDependents(edges, secretID)
+	out := &SecretImpact{SecretID: secretID, SecretName: secret.Name, Affected: make([]ImpactedSecret, 0, len(affected)), Truncated: truncated}
 	for _, a := range affected {
 		// #G32: the BFS traverses the full graph so a hop through an unauthorized peer
 		// still surfaces further, independently-authorized dependents — but a peer the
@@ -480,14 +484,32 @@ type impacted struct {
 	depth int
 }
 
+// maxDependencyBFSNodes bounds transitiveDependents' total node count — the
+// same resource-exhaustion vector blastBFS's maxBlastRadiusNodes guards
+// (#G44, blast_radius.go): both GetSecretImpact and GetSecretImpactPreview
+// do a per-node canReadSecret call over the result afterward, so an unbounded
+// node count is a per-request cost multiplier reachable via dependency-edge
+// fan-out within a single project (AddSecretDependency rejects cycles and
+// self-edges, but has no cap on total edge/node count). Independently
+// tunable from maxBlastRadiusNodes even though the value matches it today —
+// the two features may need different limits later.
+const maxDependencyBFSNodes = 2000
+
+// maxDependencyBFSDepth mirrors blastBFS's maxDepth, same reasoning.
+const maxDependencyBFSDepth = 10
+
 // transitiveDependents returns every secret that transitively depends on secretID, in
-// breadth-first order with the shortest hop-distance. Excludes secretID itself.
-func transitiveDependents(edges []*models.SecretDependency, secretID uint) []impacted {
+// breadth-first order with the shortest hop-distance, up to maxDependencyBFSNodes
+// total and maxDependencyBFSDepth deep. Excludes secretID itself. truncated is true
+// when either bound was hit — the true dependent set may extend further than what's
+// returned; callers must surface this rather than silently reporting a possibly
+// truncated result as complete (same discipline as blastBFS/#G24).
+func transitiveDependents(edges []*models.SecretDependency, secretID uint) (result []impacted, truncated bool) {
 	adj := dependentsAdjacency(edges)
 	seen := map[uint]bool{secretID: true}
 	out := []impacted{}
 	queue := []impacted{{id: secretID, depth: 0}}
-	for len(queue) > 0 {
+	for len(queue) > 0 && len(out) < maxDependencyBFSNodes {
 		cur := queue[0]
 		queue = queue[1:]
 		for _, dep := range adj[cur.id] {
@@ -495,11 +517,20 @@ func transitiveDependents(edges []*models.SecretDependency, secretID uint) []imp
 				continue
 			}
 			seen[dep] = true
-			out = append(out, impacted{id: dep, depth: cur.depth + 1})
-			queue = append(queue, impacted{id: dep, depth: cur.depth + 1})
+			next := impacted{id: dep, depth: cur.depth + 1}
+			out = append(out, next)
+			if next.depth < maxDependencyBFSDepth {
+				queue = append(queue, next)
+			} else {
+				truncated = true
+			}
+			if len(out) >= maxDependencyBFSNodes {
+				truncated = true
+				break
+			}
 		}
 	}
-	return out
+	return out, truncated
 }
 
 // topologicalRotationOrder returns the secrets in a project's dependency graph in a

--- a/internal/core/secret_dependencies_test.go
+++ b/internal/core/secret_dependencies_test.go
@@ -34,8 +34,9 @@ func TestDependencyReachable(t *testing.T) {
 func TestTransitiveDependents(t *testing.T) {
 	// 3 is depended on by 2 and 4; 2 is depended on by 1. So rotating 3 impacts 2,4 (depth1) then 1 (depth2).
 	edges := []*models.SecretDependency{edge(1, 2), edge(2, 3), edge(4, 3)}
-	got := transitiveDependents(edges, 3)
+	got, truncated := transitiveDependents(edges, 3)
 	require.Len(t, got, 3)
+	assert.False(t, truncated)
 	// BFS order: depth-1 dependents of 3 first (2,4 sorted), then 1.
 	assert.Equal(t, uint(2), got[0].id)
 	assert.Equal(t, 1, got[0].depth)
@@ -45,7 +46,55 @@ func TestTransitiveDependents(t *testing.T) {
 	assert.Equal(t, 2, got[2].depth)
 
 	// A leaf nobody depends on has no impact.
-	assert.Empty(t, transitiveDependents(edges, 1))
+	leaf, leafTruncated := transitiveDependents(edges, 1)
+	assert.Empty(t, leaf)
+	assert.False(t, leafTruncated)
+}
+
+// TestTransitiveDependents_DepthCapped is the resource-exhaustion regression:
+// a chain deeper than maxDependencyBFSDepth must stop at the cap and report
+// Truncated, not silently walk the entire graph.
+func TestTransitiveDependents_DepthCapped(t *testing.T) {
+	// Chain: 2 depends on 1, 3 depends on 2, ... 16 depends on 15 -- 15 hops
+	// deep, well past maxDependencyBFSDepth (10).
+	edges := make([]*models.SecretDependency, 0, 15)
+	for i := uint(1); i <= 15; i++ {
+		edges = append(edges, edge(i+1, i))
+	}
+	got, truncated := transitiveDependents(edges, 1)
+	assert.True(t, truncated, "a chain past maxDependencyBFSDepth must be flagged truncated")
+	require.Len(t, got, maxDependencyBFSDepth, "BFS must stop expanding at maxDependencyBFSDepth")
+	for _, n := range got {
+		assert.LessOrEqual(t, n.depth, maxDependencyBFSDepth)
+	}
+}
+
+// TestTransitiveDependents_NodeCapped is the breadth counterpart to the depth
+// cap: depth alone doesn't bound total node count (#G44's reasoning, shared
+// with blastBFS) -- a single secret with a very wide fan-out of direct
+// dependents must still be capped at maxDependencyBFSNodes.
+func TestTransitiveDependents_NodeCapped(t *testing.T) {
+	const fanOut = maxDependencyBFSNodes + 500
+	edges := make([]*models.SecretDependency, 0, fanOut)
+	for i := uint(0); i < fanOut; i++ {
+		// Each of these directly depends on secret 1 -- all at depth 1.
+		edges = append(edges, edge(i+2, 1))
+	}
+	got, truncated := transitiveDependents(edges, 1)
+	assert.True(t, truncated, "fan-out past maxDependencyBFSNodes must be flagged truncated")
+	assert.Len(t, got, maxDependencyBFSNodes, "BFS must stop at maxDependencyBFSNodes regardless of depth")
+}
+
+// TestTransitiveDependents_NotTruncatedWithinBounds is the negative
+// counterpart: a graph within both caps must not be flagged truncated.
+func TestTransitiveDependents_NotTruncatedWithinBounds(t *testing.T) {
+	edges := make([]*models.SecretDependency, 0, 5)
+	for i := uint(1); i <= 5; i++ {
+		edges = append(edges, edge(i+1, i))
+	}
+	got, truncated := transitiveDependents(edges, 1)
+	assert.False(t, truncated)
+	require.Len(t, got, 5)
 }
 
 func TestTopologicalRotationOrder(t *testing.T) {

--- a/internal/core/secret_impact_preview.go
+++ b/internal/core/secret_impact_preview.go
@@ -12,9 +12,14 @@ import "context"
 type ImpactPreviewResult struct {
 	SecretID             uint   `json:"secret_id"`
 	DirectDependents     int    `json:"direct_dependents"`     // secrets that directly depend on this one (depth=1)
-	TransitiveDependents int    `json:"transitive_dependents"` // full transitive-closure count (excludes root)
-	AffectedSecretIDs    []uint `json:"affected_secret_ids"`   // IDs of all transitively affected secrets
+	TransitiveDependents int    `json:"transitive_dependents"` // transitive-closure count (excludes root), up to maxDependencyBFSNodes
+	AffectedSecretIDs    []uint `json:"affected_secret_ids"`   // IDs of all transitively affected secrets found
 	MaxDepth             int    `json:"max_depth"`             // deepest dependency chain length found
+	// Truncated is true when the true cascade extends beyond what the counts
+	// above report -- the underlying BFS hit maxDependencyBFSNodes or
+	// maxDependencyBFSDepth (see transitiveDependents). When true, every
+	// count above is a LOWER BOUND, not the true cascade size.
+	Truncated bool `json:"truncated"`
 }
 
 // GetSecretImpactPreview computes the cascade-delete impact of removing secretID.
@@ -30,12 +35,17 @@ type ImpactPreviewResult struct {
 // GetSecretImpact returns.
 //
 // #G32: DirectDependents/TransitiveDependents/MaxDepth are computed over the FULL
-// graph — an operator deciding whether to delete secretID needs the true cascade size,
-// even if some affected secrets are outside their own visibility, and a bare count
-// discloses no peer identity. AffectedSecretIDs is the identifying part, though, so it
-// is filtered to only the peers the caller is independently authorized to read (same
-// reasoning as ListSecretDependencies/GetSecretImpact: same-environment membership
-// alone does not prove authorization on a peer).
+// graph (not filtered to what the caller can see) — an operator deciding whether to
+// delete secretID needs the true cascade size, even if some affected secrets are
+// outside their own visibility, and a bare count discloses no peer identity.
+// AffectedSecretIDs is the identifying part, though, so it is filtered to only the
+// peers the caller is independently authorized to read (same reasoning as
+// ListSecretDependencies/GetSecretImpact: same-environment membership alone does not
+// prove authorization on a peer). "Full graph" is itself bounded by
+// transitiveDependents' maxDependencyBFSNodes/maxDependencyBFSDepth (resource-
+// exhaustion guard, same as GetBlastRadius's maxBlastRadiusNodes) — Truncated
+// signals when a pathologically large dependency graph made these counts a lower
+// bound rather than the true cascade size.
 func (c *KeyorixCore) GetSecretImpactPreview(ctx context.Context, actorKind string, actorID, secretID uint) (*ImpactPreviewResult, error) {
 	secret, err := c.requireSecret(ctx, secretID)
 	if err != nil {
@@ -55,11 +65,12 @@ func (c *KeyorixCore) GetSecretImpactPreview(ctx context.Context, actorKind stri
 	// transitiveDependents walks the "dependents" direction (secrets that depend ON
 	// secretID), which is the correct direction for cascade-delete impact: if secretID
 	// is removed, every secret that depended on it is affected.
-	affected := transitiveDependents(edges, secretID)
+	affected, truncated := transitiveDependents(edges, secretID)
 
 	result := &ImpactPreviewResult{
 		SecretID:          secretID,
 		AffectedSecretIDs: make([]uint, 0, len(affected)),
+		Truncated:         truncated,
 	}
 
 	for _, a := range affected {

--- a/server/grpc/services/conversions.go
+++ b/server/grpc/services/conversions.go
@@ -291,7 +291,7 @@ func secretDependenciesToProto(d *core.SecretDependencies) *pb.SecretDependencie
 }
 
 func secretImpactToProto(im *core.SecretImpact) *pb.SecretImpact {
-	out := &pb.SecretImpact{SecretId: intToU32(int(im.SecretID)), SecretName: im.SecretName}
+	out := &pb.SecretImpact{SecretId: intToU32(int(im.SecretID)), SecretName: im.SecretName, Truncated: im.Truncated}
 	for _, a := range im.Affected {
 		out.Affected = append(out.Affected, &pb.ImpactedSecret{
 			SecretId:   intToU32(int(a.SecretID)),

--- a/server/proto/keyorix.proto
+++ b/server/proto/keyorix.proto
@@ -332,6 +332,11 @@ message SecretImpact {
   uint32 secret_id = 1;
   string secret_name = 2;
   repeated ImpactedSecret affected = 3; // transitive dependents
+  // truncated is true when the true affected set may extend beyond what
+  // affected contains -- the underlying dependency-graph BFS hit its
+  // resource-exhaustion node/depth cap (internal/core's maxDependencyBFSNodes
+  // / maxDependencyBFSDepth).
+  bool truncated = 4;
 }
 
 message RotationStep {

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -1237,10 +1237,15 @@ func (x *ImpactedSecret) GetDepth() int32 {
 }
 
 type SecretImpact struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SecretId      uint32                 `protobuf:"varint,1,opt,name=secret_id,json=secretId,proto3" json:"secret_id,omitempty"`
-	SecretName    string                 `protobuf:"bytes,2,opt,name=secret_name,json=secretName,proto3" json:"secret_name,omitempty"`
-	Affected      []*ImpactedSecret      `protobuf:"bytes,3,rep,name=affected,proto3" json:"affected,omitempty"` // transitive dependents
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	SecretId   uint32                 `protobuf:"varint,1,opt,name=secret_id,json=secretId,proto3" json:"secret_id,omitempty"`
+	SecretName string                 `protobuf:"bytes,2,opt,name=secret_name,json=secretName,proto3" json:"secret_name,omitempty"`
+	Affected   []*ImpactedSecret      `protobuf:"bytes,3,rep,name=affected,proto3" json:"affected,omitempty"` // transitive dependents
+	// truncated is true when the true affected set may extend beyond what
+	// affected contains -- the underlying dependency-graph BFS hit its
+	// resource-exhaustion node/depth cap (internal/core's maxDependencyBFSNodes
+	// / maxDependencyBFSDepth).
+	Truncated     bool `protobuf:"varint,4,opt,name=truncated,proto3" json:"truncated,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1294,6 +1299,13 @@ func (x *SecretImpact) GetAffected() []*ImpactedSecret {
 		return x.Affected
 	}
 	return nil
+}
+
+func (x *SecretImpact) GetTruncated() bool {
+	if x != nil {
+		return x.Truncated
+	}
+	return false
 }
 
 type RotationStep struct {
@@ -10815,12 +10827,13 @@ const file_keyorix_proto_rawDesc = "" +
 	"\tsecret_id\x18\x01 \x01(\rR\bsecretId\x12\x1f\n" +
 	"\vsecret_name\x18\x02 \x01(\tR\n" +
 	"secretName\x12\x14\n" +
-	"\x05depth\x18\x03 \x01(\x05R\x05depth\"\x84\x01\n" +
+	"\x05depth\x18\x03 \x01(\x05R\x05depth\"\xa2\x01\n" +
 	"\fSecretImpact\x12\x1b\n" +
 	"\tsecret_id\x18\x01 \x01(\rR\bsecretId\x12\x1f\n" +
 	"\vsecret_name\x18\x02 \x01(\tR\n" +
 	"secretName\x126\n" +
-	"\baffected\x18\x03 \x03(\v2\x1a.keyorix.v1.ImpactedSecretR\baffected\"L\n" +
+	"\baffected\x18\x03 \x03(\v2\x1a.keyorix.v1.ImpactedSecretR\baffected\x12\x1c\n" +
+	"\ttruncated\x18\x04 \x01(\bR\ttruncated\"L\n" +
 	"\fRotationStep\x12\x1b\n" +
 	"\tsecret_id\x18\x01 \x01(\rR\bsecretId\x12\x1f\n" +
 	"\vsecret_name\x18\x02 \x01(\tR\n" +


### PR DESCRIPTION
## Summary
- Availability/DoS-resistance investigation (docs/security-review-2026-09.md named this out of scope for the earlier pass). Recon found `transitiveDependents` (`internal/core/secret_dependencies.go`), the BFS backing `GetSecretImpact` and `GetSecretImpactPreview`, has no node or depth cap -- unlike its sibling `blastBFS` (`blast_radius.go`), which bounds both for exactly this reason (#G44): both callers do a per-node `canReadSecret` check afterward, so an unbounded node count is a per-request cost multiplier reachable via dependency-edge fan-out within a single project. `AddSecretDependency` rejects cycles/self-edges but has no cap on total edge/node count.
- Adds `maxDependencyBFSNodes`/`maxDependencyBFSDepth`, matching `blastBFS`'s values and shape exactly, and a `Truncated` flag on both `SecretImpact` and `ImpactPreviewResult` so a capped result is never silently reported as complete (same #G24 discipline `blastBFS` already follows). `GetSecretImpactPreview`'s counts are now explicitly a documented lower bound, not silently wrong, when the cap is hit.
- Adds the `truncated` field to the `SecretImpact` proto message (gRPC `GetSecretImpact`) for parity. `GetSecretImpactPreview` is HTTP-only, no proto change needed there.
- Other DoS-recon findings checked out clean or already-decided: the login/password-reset/SSO rate limiter is unconditional (not gated behind the general per-principal API budget's disabled-by-default flag); pagination, bulk-op batch sizes, HTTP/gRPC payload limits, and server timeouts are all already bounded; the per-process (not cluster-coordinated) general rate limiter is an explicit, documented ADR-040 trade-off, not a new finding.

## Test plan
- [x] New tests: `TestTransitiveDependents_DepthCapped`, `TestTransitiveDependents_NodeCapped`, `TestTransitiveDependents_NotTruncatedWithinBounds`
- [x] Mutation check: temporarily removed both bounds and confirmed exactly the two tests asserting the cap's effect go red -- not a vacuous pass
- [x] `server/proto/pb`'s `TestEveryFileIsGenerated` guard still passes (confirms the proto regen didn't reintroduce the hand-written-file-in-generated-dir issue `buf generate` transiently caused locally and was reverted before commit)
- [x] `go build ./...`, `go test ./...` -- full repo green
- [x] `go vet ./...`, `gofmt -l`, `gosec -severity medium` (0 issues), `golangci-lint run` -- all clean on touched packages