### PR TITLE
test(encryption): strengthen KEK-derived key wipe tests to memory-scan style

### DIFF
--- a/docs/security-review-2026-09.md
+++ b/docs/security-review-2026-09.md
@@ -127,10 +127,6 @@ This review's scope was defined by the ambient-state and silent-falsification qu
 server, CLI, storage, RBAC, and CI/supply-chain surfaces. The following were explicitly out of scope, and are
 named here so that omission reads as a stated boundary rather than an implied "checked, fine":
 
-- **Memory zeroization.** Whether secret material is scrubbed from process memory after use (versus left for the
-  garbage collector, or a swapped page, to eventually reclaim) was not examined. Go's runtime and garbage collector
-  make this a substantially harder guarantee to make than it is in a language with manual memory management, and
-  doing it properly is a distinct piece of work with its own design tradeoffs, not a fix-sized finding.
 - **The frontend (`web/`) beyond its CSP configuration**, which surfaced incidentally via the accepted-risk CSP
   finding above and was not otherwise part of this pass's sweep.
 
@@ -176,6 +172,30 @@ that edits its own past claims without a visible trail is exactly the failure mo
   #422) were independently re-verified by running their dedicated tests rather than trusted at face value — both
   genuinely hold. The one real open item, cloud-KMS CMK rotation being entirely outside Keyorix's management, is
   already explicitly recorded as deferred in ADR-041's own scope — a stated boundary, not a gap this pass found.
+- **Memory zeroization, investigated — partial fix, one real gap remains open by design.** Traced where secret
+  material actually lives in process memory. What's genuinely protected: the master KEK (wiped in place
+  immediately after use) and the DEK plus its two KEK-derived siblings — the evidence-signing key and the
+  audit-checkpoint key — all wiped on graceful shutdown and DEK rotation via a real byte-by-byte overwrite
+  (confirmed empirically: the Go compiler lowers `for i := range b { b[i] = 0 }` to a genuine
+  `runtime.memclrNoHeapPointers` call, not eliminated — an initial hypothesis that this needed `runtime.KeepAlive`
+  protection against compiler dead-store elimination did not hold up under a direct compile-and-disassemble check,
+  and was dropped rather than "fixed" as cargo-culting). Two real test-coverage gaps were found and fixed:
+  `TestEvidenceSignKey_WipedOnShutdown`/`TestAuditCheckpointKey_WipedOnShutdown` only asserted the public getter
+  returned `ok=false` post-wipe — which only proves the field reference was nilled, since the getter always returns
+  a copy, not the real backing array. A `Wipe()` regression that dropped its `wipeBytes()` call but kept the
+  nil-assignment would have passed both tests unchanged. Rewritten to the same memory-scan style
+  `TestServiceShutdown_WipesEncryptionServiceDEK` already uses for the DEK (capture the real backing array before
+  wipe, assert all-zero after) and confirmed by mutation: reintroducing the exact dropped-`wipeBytes` regression
+  made both new tests fail as expected. **What remains genuinely unprotected, and why it's a design gap rather
+  than a fix-sized one** (confirming this document's original framing): every secret-VALUE plaintext accumulates
+  at least three unwiped heap copies between decryption and the wire (the `gcm.Open` output, a `string()`
+  conversion — Go strings are immutable and cannot be zeroed once created — and a JSON/protobuf serialization
+  buffer), by construction of `encoding/json`'s and Go strings' own APIs, not from a missed call site; closing it
+  would mean threading `[]byte`-only plaintext through the entire read path and abandoning string-based
+  serialization for secret fields. The master passphrase (`KEYORIX_MASTER_PASSWORD`) is string-shaped from
+  `os.Getenv` onward and, like any Go string, structurally cannot be wiped at all. Neither gap has a workable
+  fix within this pass's scope; both are recorded here as open, not silently left where "not examined" implied
+  no one had looked.
 
 ## Governing ADRs
 

--- a/internal/encryption/audit_checkpoint_key_test.go
+++ b/internal/encryption/audit_checkpoint_key_test.go
@@ -146,13 +146,34 @@ func TestAuditCheckpointKey_ChangesAcrossKEKMigration(t *testing.T) {
 
 // TestAuditCheckpointKey_WipedOnShutdown proves Wipe() zeroes the
 // audit-checkpoint key alongside the DEK, so neither lingers in memory after
-// shutdown.
+// shutdown. GetAuditCheckpointKey always returns a COPY (keymanager_io.go),
+// so asserting ok=false on it afterward only proves the field reference was
+// nilled -- a Wipe() that dropped its wipeBytes(km.auditCheckpointKey) call
+// but kept the nil-assignment would pass that check identically while
+// leaving the real key bytes live in memory. This test instead reaches the
+// unexported km.auditCheckpointKey field directly (same package as
+// keymanager_lifecycle.go) to capture the actual backing array before Wipe()
+// and assert every byte is zero afterward -- the same memory-scan style
+// TestServiceShutdown_WipesEncryptionServiceDEK (g62_dek_safety_test.go)
+// already uses for the DEK.
 func TestAuditCheckpointKey_WipedOnShutdown(t *testing.T) {
 	svc, _ := newTestService(t, "test-passphrase")
 	if _, _, ok := svc.AuditCheckpointKey(); !ok {
 		t.Fatal("AuditCheckpointKey unavailable before shutdown")
 	}
+
+	svc.keyManager.mu.RLock()
+	keyRef := svc.keyManager.auditCheckpointKey // same backing array wipeBytes must zero in place
+	svc.keyManager.mu.RUnlock()
+	if allZeroBytes(keyRef) {
+		t.Fatal("test setup bug: audit-checkpoint key was already all-zero before Wipe()")
+	}
+
 	svc.keyManager.Wipe()
+
+	if !allZeroBytes(keyRef) {
+		t.Fatal("audit-checkpoint key bytes were not wiped by Wipe() -- key remains live in process memory")
+	}
 	if _, _, ok := svc.keyManager.GetAuditCheckpointKey(); ok {
 		t.Fatal("expected the audit-checkpoint key to be gone after Wipe()")
 	}

--- a/internal/encryption/evidence_sign_key_test.go
+++ b/internal/encryption/evidence_sign_key_test.go
@@ -120,12 +120,35 @@ func TestEvidenceSignKey_UnavailableWhenUninitialized(t *testing.T) {
 
 // TestEvidenceSignKey_WipedOnShutdown proves Wipe() zeroes the evidence-signing
 // key alongside the DEK, so neither lingers in memory after shutdown.
+// GetEvidenceSignKey always returns a COPY (keymanager_io.go), so asserting
+// ok=false on it afterward only proves the field reference was nilled -- a
+// Wipe() that dropped its wipeBytes(km.evidenceSignKey) call but kept the
+// nil-assignment would pass that check identically while leaving the real key
+// bytes live in memory. This test instead reaches the unexported
+// km.evidenceSignKey field directly (same package as keymanager_lifecycle.go)
+// to capture the actual backing array before Wipe() and assert every byte is
+// zero afterward -- the same memory-scan style
+// TestServiceShutdown_WipesEncryptionServiceDEK (g62_dek_safety_test.go)
+// already uses for the DEK, and TestAuditCheckpointKey_WipedOnShutdown
+// (audit_checkpoint_key_test.go) now uses for its sibling key.
 func TestEvidenceSignKey_WipedOnShutdown(t *testing.T) {
 	svc, _ := newTestService(t, "test-passphrase")
 	if _, _, ok := svc.EvidenceSignKey(); !ok {
 		t.Fatal("EvidenceSignKey unavailable before shutdown")
 	}
+
+	svc.keyManager.mu.RLock()
+	keyRef := svc.keyManager.evidenceSignKey // same backing array wipeBytes must zero in place
+	svc.keyManager.mu.RUnlock()
+	if allZeroBytes(keyRef) {
+		t.Fatal("test setup bug: evidence-signing key was already all-zero before Wipe()")
+	}
+
 	svc.keyManager.Wipe()
+
+	if !allZeroBytes(keyRef) {
+		t.Fatal("evidence-signing key bytes were not wiped by Wipe() -- key remains live in process memory")
+	}
 	if _, _, ok := svc.keyManager.GetEvidenceSignKey(); ok {
 		t.Fatal("expected the evidence-signing key to be gone after Wipe()")
 	}


### PR DESCRIPTION
## Summary
- Memory-zeroization investigation (docs/security-review-2026-09.md named this out of scope for the earlier pass).
- `TestEvidenceSignKey_WipedOnShutdown`/`TestAuditCheckpointKey_WipedOnShutdown` only asserted the public getter returned `ok=false` post-`Wipe()` -- both getters always return a copy (`keymanager_io.go`), so this only proves the internal field reference was nilled, not that the real bytes were zeroed. A `Wipe()` regression that dropped its `wipeBytes()` call but kept the nil-assignment would have passed both tests unchanged.
- Rewritten to the same memory-scan style `TestServiceShutdown_WipesEncryptionServiceDEK` (`g62_dek_safety_test.go`) already uses for the DEK: capture the real backing array via the unexported field (same package) before `Wipe()`, assert every byte is zero afterward.
- Also checked whether `wipeBytes`' `for i := range b { b[i] = 0 }` loop needs `runtime.KeepAlive` protection against compiler dead-store elimination -- confirmed empirically via `go build -gcflags="-S"` that this pattern lowers to a real `runtime.memclrNoHeapPointers` call, not eliminated. Dropped as a non-finding rather than adding a no-op defensive call (would have been cargo-culting).
- Updates `docs/security-review-2026-09.md`: memory zeroization investigated. Records what's genuinely protected (KEK/DEK/derived keys, real wipes, now with stronger tests) and the two structural gaps that remain open by design -- secret-value plaintext accumulates unwiped copies by construction of `encoding/json` and Go string immutability, and the master passphrase is string-shaped from `os.Getenv` onward and cannot be wiped in Go's language model. Neither has a fix-sized closure within this pass's scope.

## Test plan
- [x] New assertions in `TestEvidenceSignKey_WipedOnShutdown`/`TestAuditCheckpointKey_WipedOnShutdown` pass
- [x] Mutation check: temporarily dropped each `wipeBytes()` call (kept the nil-assignment) and confirmed both strengthened tests fail as expected -- not a vacuous pass
- [x] `go build ./...` -- clean
- [x] `go test ./internal/encryption/...` -- green
- [x] `go vet`, `gofmt -l`, `golangci-lint run` on `internal/encryption/...` -- all clean