### PR TITLE
feat(hardening): lock secret memory against swap, disable core dumps (ADR-098)

### DIFF
--- a/docs/adr-098-process-memory-hardening.md
+++ b/docs/adr-098-process-memory-hardening.md
@@ -1,0 +1,190 @@
+# ADR-098: Process memory hardening — mlock and core dump suppression
+
+## Status
+
+**Accepted (2026-09-02).** Follow-up to the 2026-09 security review
+(`docs/security-review-2026-09.md`), specifically its memory-zeroization
+finding: `internal/crypto`'s wipe-after-use discipline closes the transient
+in-process exposure of decrypted secret values (three unwiped heap copies,
+fixed 2026-09-02), but that fix protects the process's own address space
+only. It says nothing about two durable ways the same plaintext can leave
+that address space and persist: swap, and a core dump. This ADR closes both.
+
+## Summary
+
+Two independent hardening steps are applied once, at server startup, before
+any key material or decrypted secret value is allocated
+(`internal/hardening.ApplyMemoryHardening`, called from `server/main.go`):
+
+1. **`mlockall(MCL_CURRENT | MCL_FUTURE)`** — locks the process's already-
+   mapped pages, and every page mapped for the rest of the process's
+   lifetime, into physical RAM. The kernel can never swap a locked page to
+   disk, so a decrypted secret value can no longer survive in a swap file or
+   partition across a reboot or hibernate. This is the same mechanism
+   HashiCorp Vault applies at Vault server startup, for the same reason.
+2. **`RLIMIT_CORE = {0, 0}`** — both the soft and hard limit are lowered to
+   zero, unconditionally, for every process. A core dump captures the
+   process's full resident memory at the moment of a crash; with the limit
+   at zero the kernel refuses to write one, regardless of what
+   `core_pattern` or an inherited shell `ulimit -c` would otherwise do.
+
+## Scope
+
+Applied to the server process (`server/main.go`) only. The CLI binary
+(`main.go` → `internal/cli`) is out of scope: it is short-lived (a single
+command invocation, not a long-running daemon holding decrypted secret
+material resident for extended periods), and Vault's own precedent — the
+model this ADR follows — is specifically the *server* daemon, not its CLI
+client. If the CLI grows a long-running mode that holds secret material for
+an extended period, this scoping decision should be revisited.
+
+## Design decisions
+
+**Core dump suppression is unconditional — no config switch.** Unlike
+mlockall, lowering RLIMIT_CORE has no operator prerequisite (no capability,
+no raised host limit) and cannot fail for a process operating on its own
+resource limits. There is no legitimate operational reason to want core
+dumps of a secrets-manager server enabled, so this is not gated behind
+config the way mlockall is.
+
+**`Max` is lowered to 0, not just `Cur`.** Setting only the soft limit
+(`Cur`) leaves the hard limit (`Max`) at whatever the process inherited,
+which would let a later unprivileged `setrlimit` call raise `Cur` back up
+within that ceiling. Lowering `Max` to 0 as well closes that — raising it
+back would require `CAP_SYS_RESOURCE`, which this process does not need or
+request for any other reason. A repo-wide check found no in-process crash
+handler, panic recovery path, or signal handler that calls `setrlimit` at
+all (`rg -n "Setrlimit|RLIMIT_CORE|debug\.SetTraceback|SIGQUIT|Mlockall"`
+across the repo, before this change, returned no matches outside an
+unrelated `RLIMIT_FSIZE` test fixture) — so nothing in this codebase
+re-enables core dumps after this call. An external supervisor (systemd,
+a container runtime) that explicitly sets `LimitCORE=` or `ulimit -c` before
+`exec`-ing the process could still raise the *inherited* starting limit
+before this code ever runs, and is out of this code's control — see
+Operator prerequisites below.
+
+**mlockall is opt-out (`security.mlock.disabled`, default false — attempted
+by default), and its failure mode is config-driven
+(`security.mlock.require_success`, default false — warn and continue).**
+`mlockall` requires `CAP_IPC_LOCK` or a raised `RLIMIT_MEMLOCK`, and many
+hosts — unprivileged containers particularly — grant neither by default.
+Defaulting to "attempt it, warn loudly on failure" (mirroring Vault's own
+default) gets the protection for free on hosts that support it, without
+turning an unrelated capability gap into a hard startup failure on hosts
+that don't. `security.mlock.require_success=true` is available for
+operators who need the guarantee to be enforced rather than best-effort —
+matching Vault's own configurable "refuse to start" mode.
+
+**Every outcome produces exactly one log line, unconditionally.** Success,
+skipped-by-config, and failure (both warn and fatal) each log a distinct,
+explicit message. Silent failure — mlockall silently not applying with no
+trace in the log — was called out as the one unacceptable outcome, and is
+structurally impossible here: every code path through
+`ApplyMemoryHardening` logs before returning.
+
+## What this does not protect against
+
+This narrows the memory-zeroization gap; it does not close it. Specifically,
+it does **not** protect against:
+
+- **Transient in-process exposure.** While the process is live and healthy,
+  a decrypted secret value is still present in heap memory for whatever
+  window exists between decryption and the wipe-after-use call — the exact
+  exposure documented and accepted in the memory-zeroization review entry
+  this ADR follows up on. `mlockall` keeps that memory off disk; it does not
+  make it inaccessible to something that can read the live process's address
+  space (`ptrace`, `/proc/[pid]/mem`, a hypervisor-level memory inspection).
+- **A privileged local attacker.** Anyone with the capability to attach a
+  debugger to the process, or root access to the host, can read locked
+  memory just as easily as unlocked memory — mlock defends against swap
+  persistence, not against process introspection.
+- **Memory captured before this code runs.** `mlockall(MCL_CURRENT | ...)`
+  only locks pages mapped *by the time the call executes*. It runs as early
+  as practical in `server/main.go` (immediately after config validation and
+  startup validation, before core-service/encryption initialization), but
+  anything hypothetically allocated earlier in the Go runtime's own startup
+  is outside this guarantee. In practice nothing secret-bearing is allocated
+  that early.
+- **A core dump explicitly forced by an external supervisor bypassing this
+  process's own limits**, or a kernel-level memory capture mechanism (e.g. a
+  hypervisor snapshot, `kdump`) that doesn't go through this process's
+  `RLIMIT_CORE` at all.
+- **The CLI process** (see Scope above).
+
+## Operator prerequisites
+
+`mlockall` needs one of:
+
+- The `CAP_IPC_LOCK` capability granted to the process (e.g. in a container:
+  `--cap-add=IPC_LOCK`; in Kubernetes: the `IPC_LOCK` capability in the
+  container's `securityContext.capabilities.add`), or
+- `RLIMIT_MEMLOCK` raised above the process's resident set size. Under
+  systemd, set `LimitMEMLOCK=infinity` (or a large explicit value) in the
+  unit file. Docker's default `--ulimit memlock` is often small or absent
+  and commonly needs to be raised explicitly for a non-root container user.
+
+Without either, `mlockall` fails with `EPERM`/`ENOMEM`, which is logged as a
+`WARNING` (or is fatal, if `security.mlock.require_success=true`) — it is
+never silent.
+
+## Verification
+
+Verified with a real Linux container (this repo's development host is
+macOS, which has no `mlockall`/`/proc` equivalent to test against directly),
+`golang:1.26-bookworm`, matching this repo's pinned Go version:
+
+- **mlockall success, quoting `/proc/self/status`:** run with
+  `--cap-add=IPC_LOCK`, unprivileged (`--user 1000:1000`, `--cap-drop=ALL`
+  otherwise):
+  ```
+  hardening: core dumps disabled (RLIMIT_CORE=0)
+  ApplyMemoryHardening returned nil
+  VmLck:	 1227348 kB
+  hardening: mlockall succeeded -- process memory locked against swap
+  ```
+  `VmLck` was `0` before this change; it is non-zero and reflects the
+  process's actual locked memory after.
+- **mlockall failure warns, does not fail startup:** run with
+  `--cap-drop=ALL --ulimit memlock=0:0` (no capability, no raised limit),
+  `security.mlock.require_success` unset:
+  ```
+  hardening: core dumps disabled (RLIMIT_CORE=0)
+  WARNING: hardening: mlockall failed (operation not permitted) -- decrypted
+  secret memory CAN be swapped to disk. Grant CAP_IPC_LOCK or raise
+  RLIMIT_MEMLOCK (systemd unit: LimitMEMLOCK=infinity) to fix, or set
+  security.mlock.disabled=true to silence this warning
+  ApplyMemoryHardening returned nil
+  ```
+- **mlockall failure is fatal with `require_success=true`:** same
+  no-capability container, `RequireSuccess: true` — process exits 1 with the
+  same message, prefixed "refusing to start: security.mlock.require_success=true".
+- **Core dump suppression, verified by triggering a real crash, not by
+  reading the rlimit back:** baseline (no hardening applied, `GOTRACEBACK=crash`,
+  shell `ulimit -c unlimited`) produces a 46 MB `core` file on a deliberate
+  nil-pointer dereference. The identical crash, in a process that called
+  `ApplyMemoryHardening` first, produces **no** core file — the shell
+  process reports `Aborted` (not `Aborted (core dumped)`), and the working
+  directory is empty afterward. This confirms the in-process `RLIMIT_CORE=0`
+  genuinely overrides the *inherited* shell limit, which is the case that
+  actually matters (a process is normally started by a supervisor whose own
+  ulimit posture this code cannot control any other way).
+
+Unit tests (`internal/hardening/memlock_test.go`) cover all four branches
+(success, disabled, failure-warns, failure-fatal) deterministically via
+injected syscall stubs, independent of the test host's actual
+capabilities — mutation-tested by reverting each of the `Max: 0` and
+`RequireSuccess` fatal-path lines in turn and confirming the corresponding
+test goes red.
+
+## Alternatives considered
+
+- **Make mlockall required (fatal by default).** Rejected: would break
+  startup on the (common) hosts that don't grant `CAP_IPC_LOCK` by default,
+  turning an availability regression into the cost of a protection most
+  operators wouldn't have configured for anyway. Matches the reasoning
+  behind Vault's own default.
+- **Gate core dump suppression behind config too, for symmetry with
+  mlockall.** Rejected: the two mechanisms don't share a failure mode.
+  mlockall has a real operator prerequisite it can legitimately lack;
+  `RLIMIT_CORE=0` does not, so there is nothing for a config switch to
+  usefully opt out of.

--- a/docs/security-review-2026-09.md
+++ b/docs/security-review-2026-09.md
@@ -222,6 +222,22 @@ that edits its own past claims without a visible trail is exactly the failure mo
   `TestBreakGlassReads_NeverPersistState` proves neither read function ever writes. Every changed behavior was
   verified by mutation (revert the fix, confirm the specific test goes red) before landing. #1653 reopened on
   GitHub with the full account, not closed with a note — its premise was falsified, not refined.
+- **Memory zeroization's durable half — swap and core dumps — closed (ADR-098).** The memory-zeroization entry
+  above deliberately scoped itself to the transient in-process exposure and left the durable exposure (plaintext
+  surviving in swap across a reboot, or in a core file after a crash) as future work, not a decision. Closed via
+  `internal/hardening.ApplyMemoryHardening`, called at server startup before any key material or decrypted secret
+  is allocated: `mlockall(MCL_CURRENT|MCL_FUTURE)` locks the process's memory against swap (opt-out via
+  `security.mlock.disabled`, default attempted; failure is a loud `WARNING` by default or fatal with
+  `security.mlock.require_success=true`, mirroring HashiCorp Vault's own mlock behavior), and `RLIMIT_CORE` is
+  unconditionally set to `{Cur:0, Max:0}`, disabling core dumps with no config gate and no operator prerequisite.
+  Verified functionally, not just by reading the config back: `mlockall` success confirmed by quoting a non-zero
+  `VmLck` from `/proc/self/status` in a real Linux container; failure confirmed to warn (not silently no-op) when
+  `CAP_IPC_LOCK`/`RLIMIT_MEMLOCK` are absent, and to be fatal when `require_success=true`; core dump suppression
+  confirmed by actually triggering a crash (`GOTRACEBACK=crash`, deliberate nil dereference) and observing no
+  core file is written even though the parent shell had `ulimit -c unlimited` — versus a 46 MB core file produced
+  by the identical crash without the hardening applied. This narrows, not closes, the zeroization gap: the
+  transient in-process exposure documented above remains, unchanged, by design — see ADR-098's "What this does
+  not protect against" section for the full boundary.
 
 ## Governing ADRs
 
@@ -229,4 +245,4 @@ ADR-084 (admin-bypass structural marker, implemented 2026-09-02), ADR-087 (Remot
 ADR-088 (system proxy layer design), ADR-091 (machine `CreatedBy` attribution classification), ADR-092 (audit
 event `UserID` for a machine principal), ADR-093 (remote `--by`-authority check), ADR-094 (time handling: UTC
 internally, wall-clock distrust), ADR-095 (database path resolution), ADR-096 (anti-enumeration, 403-for-both),
-ADR-097 (schema-epoch downgrade guard).
+ADR-097 (schema-epoch downgrade guard), ADR-098 (process memory hardening: mlock and core dump suppression).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -724,6 +724,31 @@ type SecurityConfig struct {
 	// common, supported deployment), but when off the server logs a prominent warning if
 	// it serves cleartext, so the exposure is never silent.
 	RequireTransportTLS bool `yaml:"require_transport_tls"`
+	// Mlock configures process-memory hardening applied once at startup
+	// (mlockall + core dump suppression). See ADR-098. It narrows, not
+	// closes, the memory-zeroization gap: it protects decrypted secret
+	// plaintext from surviving a reboot (swap) or a crash (core file), not
+	// from the transient in-memory exposure of a live, healthy process.
+	Mlock MlockConfig `yaml:"mlock"`
+}
+
+// MlockConfig controls whether the process locks its memory pages against
+// swap (mlockall) at startup, and how an mlockall failure is handled. Core
+// dump suppression (RLIMIT_CORE=0) is unconditional and not gated by this
+// struct — see ADR-098 for why.
+type MlockConfig struct {
+	// Disabled opts out of mlockall(MCL_CURRENT|MCL_FUTURE) at startup.
+	// mlockall is attempted by default (mirroring HashiCorp Vault's own
+	// mlock default); set this when the host/container cannot grant
+	// CAP_IPC_LOCK or a raised RLIMIT_MEMLOCK and the resulting startup
+	// warning is unwanted noise.
+	Disabled bool `yaml:"disabled"`
+	// RequireSuccess makes a failed mlockall attempt fatal at startup
+	// instead of a logged warning. Default false: mlockall failure is
+	// warned and startup continues (matching Vault's default). Set true to
+	// fail closed when swap-exposure must be guaranteed closed rather than
+	// best-effort.
+	RequireSuccess bool `yaml:"require_success"`
 }
 
 // parseDurationDefault parses a Go duration string, returning def when empty or

--- a/internal/hardening/memlock.go
+++ b/internal/hardening/memlock.go
@@ -1,0 +1,110 @@
+/*
+Keyorix Server - Enterprise Secret Management System
+Copyright (C) 2025 Keyorix Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// Package hardening applies process-level memory hardening at server
+// startup: locking pages against swap (mlockall) and disabling core dumps
+// (RLIMIT_CORE=0). See docs/adr-098-process-memory-hardening.md for the
+// design rationale and, importantly, what this does NOT protect against —
+// the transient in-process exposure of decrypted secret values documented
+// alongside #1653 remains, unchanged, by design.
+package hardening
+
+import (
+	"fmt"
+	"log"
+
+	"golang.org/x/sys/unix"
+)
+
+// mlockallFn and setrlimitFn are indirections over the real syscalls, swapped
+// out in tests so every branch below (success, failure-warns,
+// failure-is-fatal, disabled) is exercised deterministically regardless of
+// the test host's actual capabilities -- CI's CAP_IPC_LOCK/RLIMIT_MEMLOCK
+// posture is not something a unit test should depend on.
+var (
+	mlockallFn  = unix.Mlockall
+	setrlimitFn = unix.Setrlimit
+)
+
+// MemoryConfig is the subset of config.MlockConfig this package needs. It is
+// a plain struct (not config.MlockConfig itself) so this package stays
+// independently testable without importing internal/config.
+type MemoryConfig struct {
+	// Disabled opts out of the mlockall attempt. Core dump suppression is
+	// unaffected by this field — see ApplyMemoryHardening's doc comment.
+	Disabled bool
+	// RequireSuccess makes a failed mlockall attempt fatal (ApplyMemoryHardening
+	// returns a non-nil error) instead of a logged warning.
+	RequireSuccess bool
+}
+
+// ApplyMemoryHardening disables core dumps and, unless disabled, locks the
+// process's memory pages against swap. It must run once, as early as
+// possible in process startup — before any key material or decrypted
+// secret value is allocated — since mlockall(MCL_FUTURE) only covers pages
+// mapped AFTER the call, and a core dump captures whatever is resident at
+// the moment of the crash regardless of when RLIMIT_CORE was lowered.
+//
+// Core dump suppression is unconditional: lowering RLIMIT_CORE has no
+// operator prerequisite and, unlike mlockall, essentially cannot fail for a
+// process operating on its own limits, so there is no reason to gate it
+// behind config. mlockall DOES have a real operator prerequisite
+// (CAP_IPC_LOCK or a raised RLIMIT_MEMLOCK) and can fail on hosts that
+// don't grant it — many containers don't — so it is opt-out via cfg.Disabled,
+// and its failure mode (warn vs. fatal) is controlled by cfg.RequireSuccess,
+// mirroring HashiCorp Vault's own mlock behavior (warn by default, can be
+// configured to refuse to start).
+//
+// Every outcome — success, skipped-by-config, or failure — produces exactly
+// one startup log line, so the operator never has to infer whether secret
+// memory is protected: silent failure is the one unacceptable outcome here.
+func ApplyMemoryHardening(cfg MemoryConfig) error {
+	if err := disableCoreDumps(); err != nil {
+		// Lowering a limit the process already holds essentially never
+		// fails; if it does, that's a real, actionable misconfiguration
+		// (not a missing-capability case like mlockall) — fail loud rather
+		// than let the operator believe core dumps are off when they
+		// aren't.
+		return fmt.Errorf("hardening: disable core dumps: %w", err)
+	}
+	log.Printf("hardening: core dumps disabled (RLIMIT_CORE=0)")
+
+	if cfg.Disabled {
+		log.Printf("hardening: mlock disabled by config (security.mlock.disabled=true) -- " +
+			"decrypted secret memory CAN be swapped to disk")
+		return nil
+	}
+
+	if err := mlockallFn(unix.MCL_CURRENT | unix.MCL_FUTURE); err != nil {
+		msg := fmt.Sprintf("hardening: mlockall failed (%v) -- decrypted secret memory CAN be swapped "+
+			"to disk. Grant CAP_IPC_LOCK or raise RLIMIT_MEMLOCK (systemd unit: LimitMEMLOCK=infinity) "+
+			"to fix, or set security.mlock.disabled=true to silence this warning", err)
+		if cfg.RequireSuccess {
+			return fmt.Errorf("%s (refusing to start: security.mlock.require_success=true)", msg)
+		}
+		log.Printf("WARNING: %s", msg)
+		return nil
+	}
+
+	log.Printf("hardening: mlockall succeeded -- process memory locked against swap")
+	return nil
+}
+
+func disableCoreDumps() error {
+	return setrlimitFn(unix.RLIMIT_CORE, &unix.Rlimit{Cur: 0, Max: 0})
+}

--- a/internal/hardening/memlock_test.go
+++ b/internal/hardening/memlock_test.go
@@ -1,0 +1,118 @@
+/*
+Keyorix Server - Enterprise Secret Management System
+Copyright (C) 2025 Keyorix Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package hardening
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// withFakeSyscalls swaps mlockallFn/setrlimitFn for the duration of the test
+// and restores the real ones on cleanup -- these tests must never depend on
+// the CI host's actual CAP_IPC_LOCK/RLIMIT_MEMLOCK posture, which is
+// unpredictable and would make the failure-path branches flaky.
+func withFakeSyscalls(t *testing.T, mlockall func(int) error, setrlimit func(int, *unix.Rlimit) error) {
+	t.Helper()
+	origMlockall, origSetrlimit := mlockallFn, setrlimitFn
+	mlockallFn, setrlimitFn = mlockall, setrlimit
+	t.Cleanup(func() { mlockallFn, setrlimitFn = origMlockall, origSetrlimit })
+}
+
+func TestApplyMemoryHardening_CoreDumpsAlwaysDisabledRegardlessOfMlockConfig(t *testing.T) {
+	for _, cfg := range []MemoryConfig{
+		{Disabled: false, RequireSuccess: false},
+		{Disabled: true, RequireSuccess: false},
+		{Disabled: true, RequireSuccess: true},
+	} {
+		var gotResource int
+		var gotRlimit unix.Rlimit
+		withFakeSyscalls(t,
+			func(int) error { return nil },
+			func(resource int, rlim *unix.Rlimit) error {
+				gotResource, gotRlimit = resource, *rlim
+				return nil
+			},
+		)
+
+		require.NoError(t, ApplyMemoryHardening(cfg))
+		assert.Equal(t, unix.RLIMIT_CORE, gotResource, "cfg=%+v", cfg)
+		assert.Equal(t, unix.Rlimit{Cur: 0, Max: 0}, gotRlimit, "cfg=%+v -- Max must also be 0, not just Cur, or a later privileged action can raise it back", cfg)
+	}
+}
+
+func TestApplyMemoryHardening_CoreDumpDisableFailureIsAlwaysFatal(t *testing.T) {
+	withFakeSyscalls(t,
+		func(int) error {
+			t.Fatal("mlockall must not be attempted when core-dump suppression itself failed")
+			return nil
+		},
+		func(int, *unix.Rlimit) error { return errors.New("setrlimit boom") },
+	)
+
+	err := ApplyMemoryHardening(MemoryConfig{Disabled: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "setrlimit boom")
+}
+
+func TestApplyMemoryHardening_DisabledSkipsMlockallEntirely(t *testing.T) {
+	mlockallCalled := false
+	withFakeSyscalls(t,
+		func(int) error { mlockallCalled = true; return nil },
+		func(int, *unix.Rlimit) error { return nil },
+	)
+
+	require.NoError(t, ApplyMemoryHardening(MemoryConfig{Disabled: true}))
+	assert.False(t, mlockallCalled, "security.mlock.disabled=true must skip the mlockall attempt entirely, not just ignore its result")
+}
+
+func TestApplyMemoryHardening_SuccessLocksWithCurrentAndFuture(t *testing.T) {
+	var gotFlags int
+	withFakeSyscalls(t,
+		func(flags int) error { gotFlags = flags; return nil },
+		func(int, *unix.Rlimit) error { return nil },
+	)
+
+	require.NoError(t, ApplyMemoryHardening(MemoryConfig{Disabled: false}))
+	assert.Equal(t, unix.MCL_CURRENT|unix.MCL_FUTURE, gotFlags, "must lock both already-mapped pages (MCL_CURRENT) and pages mapped after this call (MCL_FUTURE) -- decrypted secret values are allocated throughout the process lifetime, not just at startup")
+}
+
+func TestApplyMemoryHardening_FailureWarnsAndContinuesByDefault(t *testing.T) {
+	withFakeSyscalls(t,
+		func(int) error { return errors.New("operation not permitted") },
+		func(int, *unix.Rlimit) error { return nil },
+	)
+
+	err := ApplyMemoryHardening(MemoryConfig{Disabled: false, RequireSuccess: false})
+	assert.NoError(t, err, "mlockall failure must not be fatal when require_success is unset -- matches Vault's default of warn, not refuse")
+}
+
+func TestApplyMemoryHardening_FailureIsFatalWhenRequireSuccessSet(t *testing.T) {
+	withFakeSyscalls(t,
+		func(int) error { return errors.New("operation not permitted") },
+		func(int, *unix.Rlimit) error { return nil },
+	)
+
+	err := ApplyMemoryHardening(MemoryConfig{Disabled: false, RequireSuccess: true})
+	require.Error(t, err, "mlockall failure must be fatal when require_success=true -- the whole point of the setting is to refuse to run with plaintext swappable")
+	assert.Contains(t, err.Error(), "operation not permitted")
+}

--- a/server/main.go
+++ b/server/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/delivery"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/evidencesink"
+	"github.com/keyorixhq/keyorix/internal/hardening"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/license"
 	"github.com/keyorixhq/keyorix/internal/notary"
@@ -88,6 +89,18 @@ func main() { // NOSONAR -- cognitive complexity 22, suppress go:S3776
 	// automatically on every boot.
 	if err := runStartupValidation(cfg); err != nil {
 		log.Fatalf("startup validation: %v", err)
+	}
+
+	// Lock process memory against swap and disable core dumps before any key material
+	// or decrypted secret value is ever allocated (ADR-098). Narrows, not closes, the
+	// memory-zeroization gap: it protects the durable paths (swap survival across a
+	// reboot, a core file surviving a crash), not the transient in-memory exposure of a
+	// live, healthy process documented alongside #1653's "three unwiped heap copies".
+	if err := hardening.ApplyMemoryHardening(hardening.MemoryConfig{
+		Disabled:       cfg.Security.Mlock.Disabled,
+		RequireSuccess: cfg.Security.Mlock.RequireSuccess,
+	}); err != nil {
+		log.Fatalf("memory hardening: %v", err)
 	}
 
 	// Initialize i18n system


### PR DESCRIPTION
## Summary
- Closes the durable half of the memory-zeroization gap the 2026-09 security review left open by design: decrypted secret plaintext could survive a reboot via swap, or a crash via a core file.
- `internal/hardening.ApplyMemoryHardening`, called once at server startup before any key material is allocated:
  - `mlockall(MCL_CURRENT|MCL_FUTURE)` locks process memory against swap. Opt-out via `security.mlock.disabled` (default: attempted). Failure warns loudly by default, or is fatal with `security.mlock.require_success=true` — mirrors HashiCorp Vault's own mlock default.
  - `RLIMIT_CORE` unconditionally set to `{Cur:0, Max:0}`, disabling core dumps with no config gate.
- Every outcome (success / skipped-by-config / warn-failure / fatal-failure) logs exactly one line — silent failure is not a code path.
- ADR-098 documents the design, operator prerequisites (`CAP_IPC_LOCK` or `LimitMEMLOCK=infinity`), and — importantly — what this does NOT protect against (the transient in-process exposure remains, by design).
- `docs/security-review-2026-09.md` updated with the closure and a pointer to ADR-098.

## Test plan
- [x] `internal/hardening/memlock_test.go`: all four branches (success, disabled, failure-warns, failure-fatal) covered via injected syscall stubs; mutation-tested (reverted `Max:0` and the `RequireSuccess` fatal branch in turn, confirmed each goes red, restored).
- [x] Functional verification in a real Linux container (`golang:1.26-bookworm`, matching this repo's pinned Go version — this dev host is macOS, which has no `mlockall`/`/proc`):
  - mlockall success: `--cap-add=IPC_LOCK` → `VmLck: 1227348 kB` (was 0 before).
  - mlockall failure (`--cap-drop=ALL --ulimit memlock=0:0`): warns, does not fail startup by default; fatal (exit 1) with `require_success=true`.
  - Core dump suppression verified by actually triggering a crash (`GOTRACEBACK=crash`, deliberate nil dereference), not by reading the rlimit back: baseline produces a 46 MB core file; the hardened process produces none, even with the parent shell's `ulimit -c unlimited`.
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `gofmt -l` clean on all touched files.
- [x] `go test ./internal/config/... ./internal/hardening/... ./server/...` — all pass.
- [x] `gosec -severity medium -exclude-generated` on touched packages — 0 issues.
- [x] `golangci-lint run` on touched packages — 1 pre-existing, unrelated staticcheck finding in `validateRemoteStorageNotServer` (untouched by this diff, confirmed via `git show origin/main` — same function, unmodified), out of scope here.