### PR TITLE
chore: dedicated CSRF-logout regression test + drop stale audit suppression

### DIFF
--- a/server/http/integration_test.go
+++ b/server/http/integration_test.go
@@ -1199,6 +1199,76 @@ func TestCSRF_RequiredForCookieAuthenticatedMutations(t *testing.T) {
 	})
 }
 
+// TestCSRF_RequiredForLogout is the dedicated regression test the security
+// review's frontend adversarial pass flagged as missing: unlike every other
+// mutating route (covered by the group-wide r.Use(RequireCSRF) at
+// router.go's /api/v1 registration, which TestCSRF_RequiredForCookieAuthenticatedMutations
+// above would catch losing), POST /auth/logout is wired individually
+// (r.With(customMiddleware.RequireCSRF).Post("/auth/logout", ...)) because it
+// lives in the pre-session route group alongside login/refresh/SSO, which are
+// correctly NOT CSRF-gated (no session cookie exists yet at that point).
+// Nothing previously asserted that lone .With(...) call is still there --
+// this closes that gap.
+func TestCSRF_RequiredForLogout(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "8080"}}}
+	testCore := newTestCore(t)
+	_ = createTestToken(t, testCore)
+
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	logoutRequest := func() *http.Request {
+		req, err := http.NewRequest(http.MethodPost, server.URL+"/auth/logout", nil)
+		require.NoError(t, err)
+		return req
+	}
+
+	t.Run("rejected with no CSRF header", func(t *testing.T) {
+		client := newCookieClient(t)
+		resp := loginViaHTTP(t, client, server.URL, "testadmin", "TestPassword123!")
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		r, err := client.Do(logoutRequest())
+		require.NoError(t, err)
+		defer func() { _ = r.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, r.StatusCode)
+	})
+
+	t.Run("rejected with a wrong CSRF header", func(t *testing.T) {
+		client := newCookieClient(t)
+		resp := loginViaHTTP(t, client, server.URL, "testadmin", "TestPassword123!")
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		req := logoutRequest()
+		req.Header.Set("X-CSRF-Token", "not-the-right-value")
+		r, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = r.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, r.StatusCode)
+	})
+
+	t.Run("accepted with the matching CSRF header", func(t *testing.T) {
+		client := newCookieClient(t)
+		resp := loginViaHTTP(t, client, server.URL, "testadmin", "TestPassword123!")
+		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		req := logoutRequest()
+		req.Header.Set("X-CSRF-Token", csrfCookieValue(t, client, server.URL))
+		r, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = r.Body.Close() }()
+		assert.Equal(t, http.StatusOK, r.StatusCode)
+	})
+}
+
 // TestImpersonationRoundTrip_CookieSwapAndRestore is the end-to-end proof for
 // the impersonation redesign: the client never sees or holds an admin token at
 // any point — starting impersonation swaps the cookie to the target's session,

--- a/web/scripts/audit-check.mjs
+++ b/web/scripts/audit-check.mjs
@@ -4,10 +4,12 @@
 //
 // Usage: pnpm audit --json --prod | node scripts/audit-check.mjs
 
-// GHSA-qwww-vcr4-c8h2: react-router RSC-mode CSRF bypass (>=7.12.0 <8.3.0).
-// Patched only in the breaking v8.x line. This app is a SPA; the RSC request
-// handler that contains the vulnerability is never loaded or executed.
-const IGNORED = new Set(['GHSA-qwww-vcr4-c8h2']);
+// No advisories are currently suppressed. If one needs to be, document the
+// GHSA id, the vulnerable range, and why it isn't reachable in this app —
+// and remove the entry once the lockfile moves past the vulnerable range
+// (a suppression for a version this app no longer has installed is dead
+// weight that silently stops meaning anything).
+const IGNORED = new Set();
 
 const chunks = [];
 for await (const chunk of process.stdin) chunks.push(chunk);


### PR DESCRIPTION
## Summary
Two small, unrelated hardening items surfaced by the frontend adversarial security review, bundled together since both are minor and low-risk.

**`server/http/integration_test.go`**: `/auth/logout` is the one route CSRF-wired individually in `router.go` (`r.With(customMiddleware.RequireCSRF).Post("/auth/logout", ...)`) rather than via the group-wide `r.Use(RequireCSRF)` on `/api/v1` — correctly, since it lives in the pre-session route group alongside login/refresh/SSO. But nothing previously asserted that one `.With(...)` call is still there; a future accidental removal wouldn't be caught the way removing the group-wide wiring would be (that's what `TestCSRF_RequiredForCookieAuthenticatedMutations` already covers, for every *other* mutating route). Added `TestCSRF_RequiredForLogout`, mirroring that test's shape for this one route.

**`web/scripts/audit-check.mjs`**: the one entry in its suppression list (`GHSA-qwww-vcr4-c8h2`, react-router RSC-mode CSRF) named a vulnerable range of `<8.3.0`; the lockfile has sat at exactly `8.3.0` (the patched floor) for a while, so `pnpm audit` no longer even reports this advisory — the suppression was dead weight silently no longer doing anything. Removed.

## Test plan
- [x] `TestCSRF_RequiredForLogout` — red-first (initially wrote it against the wrong path, `/api/v1/auth/logout`, which incidentally 403'd via the *unrelated* group-wide CSRF check for the first two subtests and only correctly failed the third — caught by running it, fixed to the real registered path `/auth/logout`).
- [x] Mutation-tested: temporarily removed the `.With(RequireCSRF)` wiring on `/auth/logout` in `router.go`, confirmed 2 of 3 subtests go red, restored.
- [x] `go build ./server/...`, `go vet ./server/...`, `gofmt -l` clean.
- [x] `go test ./server/http/...` — full package, all pass.
- [x] `pnpm audit --json --prod | node scripts/audit-check.mjs` — confirmed still exits 0 against the current (already-clean) lockfile after removing the stale suppression entry.