### PR TITLE
fix(core): close grant-ceiling gap for non-canonical admin-tier roles

### DIFF
--- a/internal/cli/rbac/group_role.go
+++ b/internal/cli/rbac/group_role.go
@@ -106,7 +106,7 @@ func runAssignRoleToGroup(cmd *cobra.Command, args []string) error {
 	// (requireAuthorityForRole) and SoD check (requireGroupGrantNoSoDViolation)
 	// the remote/HTTP path enforces (#G66) — a direct storage write here bypassed
 	// both and skipped the RBAC audit event.
-	if err := core.NewKeyorixCore(st).AssignRoleToGroup(ctx, common.ResolveActorID(), groupID, roleID, scope); err != nil {
+	if err := core.NewKeyorixCore(st).AssignRoleToGroup(ctx, common.ResolveActorID(), groupID, roleID, scope, false); err != nil {
 		return fmt.Errorf("failed to assign role: %w", err)
 	}
 

--- a/internal/cli/share/share_s25_test.go
+++ b/internal/cli/share/share_s25_test.go
@@ -42,7 +42,7 @@ func TestRunCreate_WithExpires_UserShare(t *testing.T) {
 		Username: "exptgt", Email: "exptgt@example.com", IsActive: true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer"))
+	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer", false))
 
 	origSecretID, origRecipientID, origPerm, origIsGroup, origExpires :=
 		createSecretID, createRecipientID, createPermission, createIsGroup, createExpires
@@ -82,7 +82,7 @@ func TestRunCreate_WithExpires_GroupShare(t *testing.T) {
 	// ShareSecretWithGroup verifies the group is scoped to the secret's project.
 	role, err := svc.Storage().GetRoleByName(ctx, "project_viewer")
 	require.NoError(t, err)
-	require.NoError(t, svc.AssignRoleToGroup(ctx, ownerID, grp.ID, role.ID, core.Scope{ProjectID: projID}))
+	require.NoError(t, svc.AssignRoleToGroup(ctx, ownerID, grp.ID, role.ID, core.Scope{ProjectID: projID}, false))
 
 	origSecretID, origRecipientID, origPerm, origIsGroup, origExpires :=
 		createSecretID, createRecipientID, createPermission, createIsGroup, createExpires

--- a/internal/cli/share/share_s3_test.go
+++ b/internal/cli/share/share_s3_test.go
@@ -90,7 +90,7 @@ func seedShareData(t *testing.T, svc *core.KeyorixCore) (ownerID, secretID, proj
 	// membership (RBAC-001, requireLiveOwnerAuthority) — CreateProject alone
 	// doesn't grant the creator a project-scoped role, so add it explicitly,
 	// matching real onboarding (a project creator adds themselves as a member).
-	require.NoError(t, svc.AddProjectMember(ctx, ownerID, proj.ID, ownerID, "project_admin"))
+	require.NoError(t, svc.AddProjectMember(ctx, ownerID, proj.ID, ownerID, "project_admin", false))
 
 	// CreateProject seeds default environments; fetch the first one.
 	envs, err := svc.Storage().ListEnvironmentsByProject(ctx, proj.ID)
@@ -131,7 +131,7 @@ func TestRunCreate_UserShare_Success(t *testing.T) {
 		Username: "recipient", Email: "recipient@example.com", IsActive: true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer"))
+	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer", false))
 
 	origSecretID, origRecipientID, origPerm, origIsGroup :=
 		createSecretID, createRecipientID, createPermission, createIsGroup
@@ -168,7 +168,7 @@ func TestRunCreate_GroupShare_Success(t *testing.T) {
 	// ShareSecretWithGroup verifies the group is scoped to the secret's project.
 	role, err := svc.Storage().GetRoleByName(ctx, "project_viewer")
 	require.NoError(t, err)
-	require.NoError(t, svc.AssignRoleToGroup(ctx, ownerID, grp.ID, role.ID, core.Scope{ProjectID: projID}))
+	require.NoError(t, svc.AssignRoleToGroup(ctx, ownerID, grp.ID, role.ID, core.Scope{ProjectID: projID}, false))
 
 	origSecretID, origRecipientID, origPerm, origIsGroup :=
 		createSecretID, createRecipientID, createPermission, createIsGroup
@@ -203,7 +203,7 @@ func TestRunCreate_WithTTL_Success(t *testing.T) {
 		Username: "recv2", Email: "recv2@example.com", IsActive: true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer"))
+	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer", false))
 
 	origSecretID, origRecipientID, origPerm, origIsGroup, origTTL :=
 		createSecretID, createRecipientID, createPermission, createIsGroup, createTTL
@@ -241,7 +241,7 @@ func TestRunList_PrintsTableForExistingShares(t *testing.T) {
 		Username: "listtgt", Email: "listtgt@example.com", IsActive: true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer"))
+	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer", false))
 
 	_, err = svc.ShareSecret(ctx, &core.ShareSecretRequest{
 		SecretID: secretID, RecipientID: recipient.ID,
@@ -272,7 +272,7 @@ func TestRunList_PrintsTableWithExpiry(t *testing.T) {
 		Username: "listtgt2", Email: "listtgt2@example.com", IsActive: true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer"))
+	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer", false))
 
 	exp := time.Now().Add(48 * time.Hour)
 	_, err = svc.ShareSecret(ctx, &core.ShareSecretRequest{
@@ -307,7 +307,7 @@ func TestRunRevoke_Success(t *testing.T) {
 		Username: "revoketgt", Email: "revoketgt@example.com", IsActive: true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer"))
+	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer", false))
 
 	share, err := svc.ShareSecret(ctx, &core.ShareSecretRequest{
 		SecretID: secretID, RecipientID: recipient.ID,
@@ -347,7 +347,7 @@ func TestRunGroupShares_PrintsTable(t *testing.T) {
 	// ShareSecretWithGroup verifies the group is scoped to the secret's project.
 	role, err := svc.Storage().GetRoleByName(ctx, "project_viewer")
 	require.NoError(t, err)
-	require.NoError(t, svc.AssignRoleToGroup(ctx, ownerID, grp.ID, role.ID, core.Scope{ProjectID: projID}))
+	require.NoError(t, svc.AssignRoleToGroup(ctx, ownerID, grp.ID, role.ID, core.Scope{ProjectID: projID}, false))
 
 	_, err = svc.ShareSecretWithGroup(ctx, &core.GroupShareSecretRequest{
 		SecretID:   secretID,
@@ -387,7 +387,7 @@ func TestRunSharedSecrets_PrintsTable(t *testing.T) {
 		Username: "sharedtgt", Email: "sharedtgt@example.com", IsActive: true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer"))
+	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer", false))
 
 	_, err = svc.ShareSecret(ctx, &core.ShareSecretRequest{
 		SecretID: secretID, RecipientID: recipient.ID,
@@ -421,7 +421,7 @@ func TestRunUpdate_Success(t *testing.T) {
 		Username: "updatetgt", Email: "updatetgt@example.com", IsActive: true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer"))
+	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer", false))
 
 	share, err := svc.ShareSecret(ctx, &core.ShareSecretRequest{
 		SecretID: secretID, RecipientID: recipient.ID,
@@ -459,7 +459,7 @@ func TestRunUpdate_WithTTL_Success(t *testing.T) {
 		Username: "updatetgt2", Email: "updatetgt2@example.com", IsActive: true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer"))
+	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer", false))
 
 	share, err := svc.ShareSecret(ctx, &core.ShareSecretRequest{
 		SecretID: secretID, RecipientID: recipient.ID,
@@ -497,7 +497,7 @@ func TestRunUpdate_ClearExpiry_Success(t *testing.T) {
 		Username: "clearexptgt", Email: "clearexptgt@example.com", IsActive: true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer"))
+	require.NoError(t, svc.AddProjectMember(ctx, ownerID, projID, recipient.ID, "project_viewer", false))
 
 	exp := time.Now().Add(24 * time.Hour)
 	share, err := svc.ShareSecret(ctx, &core.ShareSecretRequest{

--- a/internal/core/authz_admin_ceiling_group_test.go
+++ b/internal/core/authz_admin_ceiling_group_test.go
@@ -29,7 +29,7 @@ func TestAddProjectMember_EscalationByProxyBlocked(t *testing.T) {
 	attacker := seedUserWithRole(t, st, "pm-attacker", "project_viewer", storage.Scope{ProjectID: 1})
 	victim := seedUserWithRole(t, st, "pm-victim", "project_viewer", storage.Scope{ProjectID: 1})
 
-	err := c.AddProjectMember(ctx, attacker, 1, victim, "admin")
+	err := c.AddProjectMember(ctx, attacker, 1, victim, "admin", false)
 	require.Error(t, err, "a non-admin actor must not be able to grant the admin role directly")
 	assert.Contains(t, err.Error(), "cannot grant this role")
 }
@@ -44,7 +44,7 @@ func TestAddProjectMember_NonAdminRoleAllowed(t *testing.T) {
 	actor := seedUserWithRole(t, st, "pm-actor", "project_developer", storage.Scope{ProjectID: 1})
 	victim := seedUserWithRole(t, st, "pm-victim2", "project_viewer", storage.Scope{ProjectID: 2})
 
-	require.NoError(t, c.AddProjectMember(ctx, actor, 1, victim, "project_developer"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, 1, victim, "project_developer", false))
 }
 
 // #93: SetProjectMemberRole must refuse a non-admin actor upgrading a member to
@@ -55,7 +55,7 @@ func TestSetProjectMemberRole_EscalationByProxyBlocked(t *testing.T) {
 	attacker := seedUserWithRole(t, st, "smr-attacker", "project_viewer", storage.Scope{ProjectID: 1})
 	victim := seedUserWithRole(t, st, "smr-victim", "project_viewer", storage.Scope{ProjectID: 1})
 
-	err := c.SetProjectMemberRole(ctx, attacker, 1, victim, "project_admin")
+	err := c.SetProjectMemberRole(ctx, attacker, 1, victim, "project_admin", false)
 	require.Error(t, err, "a non-admin actor must not be able to promote a member to project_admin")
 	assert.Contains(t, err.Error(), "cannot grant this role")
 }
@@ -104,9 +104,9 @@ func TestAssignMachineRole_EscalationByProxyBlocked(t *testing.T) {
 	adminRole, err := c.storage.GetRoleByName(ctx, "project_admin")
 	require.NoError(t, err)
 
-	err = c.AssignMachineRole(ctx, m.ID, adminRole.ID, Scope{ProjectID: 1}, attacker)
+	err = c.AssignMachineRole(ctx, m.ID, adminRole.ID, Scope{ProjectID: 1}, attacker, false)
 	require.Error(t, err, "a non-admin actor must not be able to grant an admin role to a machine identity")
-	assert.Contains(t, err.Error(), "administrator")
+	assert.Contains(t, err.Error(), "cannot grant this role")
 }
 
 // #107: joining an admin-conferring group must be gated by the same
@@ -126,7 +126,7 @@ func TestAddUserToGroup_EscalationByProxyBlocked(t *testing.T) {
 
 	err = c.AddUserToGroup(ctx, attacker, false, attacker, group.ID, 0)
 	require.Error(t, err, "a non-admin actor must not be able to join an admin-conferring group")
-	assert.Contains(t, err.Error(), "administrator")
+	assert.Contains(t, err.Error(), "cannot grant this role")
 }
 
 // #107 positive control: an admin actor CAN add a member to an admin-conferring
@@ -177,7 +177,7 @@ func TestAddUserToGroup_MachineActorBlockedFromAdminGroup(t *testing.T) {
 
 	err = c.AddUserToGroup(ctx, 0, true, victim, group.ID, 0)
 	require.Error(t, err, "a machine credential must not be able to join a user to an admin-conferring group")
-	assert.Contains(t, err.Error(), "administrator")
+	assert.Contains(t, err.Error(), "cannot grant this role")
 
 	members, memErr := c.GetGroupMembers(ctx, group.ID)
 	require.NoError(t, memErr)
@@ -203,9 +203,9 @@ func TestAssignRoleToGroup_EscalationByProxyBlocked(t *testing.T) {
 	adminRole, err := c.storage.GetRoleByName(ctx, "admin")
 	require.NoError(t, err)
 
-	err = c.AssignRoleToGroup(ctx, attacker, group.ID, adminRole.ID, Scope{})
+	err = c.AssignRoleToGroup(ctx, attacker, group.ID, adminRole.ID, Scope{}, false)
 	require.Error(t, err, "a non-admin actor must not be able to grant a group the admin role")
-	assert.Contains(t, err.Error(), "administrator")
+	assert.Contains(t, err.Error(), "cannot grant this role")
 }
 
 // #107: RemoveRoleFromGroup must refuse to strip the install's last global-admin
@@ -223,7 +223,7 @@ func TestRemoveRoleFromGroup_LastGlobalAdminBlocked(t *testing.T) {
 	// strip the bootstrap admin's own direct grant.
 	group, err := c.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "sole-admins"})
 	require.NoError(t, err)
-	require.NoError(t, c.AssignRoleToGroup(ctx, bootstrapAdmin.ID, group.ID, adminRole.ID, Scope{}))
+	require.NoError(t, c.AssignRoleToGroup(ctx, bootstrapAdmin.ID, group.ID, adminRole.ID, Scope{}, false))
 	require.NoError(t, c.RemoveUserRole(ctx, bootstrapAdmin.ID, bootstrapAdmin.ID, adminRole.ID, Scope{}))
 
 	err = c.RemoveRoleFromGroup(ctx, bootstrapAdmin.ID, group.ID, adminRole.ID, Scope{})
@@ -244,7 +244,7 @@ func TestDeleteGroup_LastGlobalAdminBlocked(t *testing.T) {
 
 	group, err := c.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "sole-admins2"})
 	require.NoError(t, err)
-	require.NoError(t, c.AssignRoleToGroup(ctx, bootstrapAdmin.ID, group.ID, adminRole.ID, Scope{}))
+	require.NoError(t, c.AssignRoleToGroup(ctx, bootstrapAdmin.ID, group.ID, adminRole.ID, Scope{}, false))
 	require.NoError(t, c.RemoveUserRole(ctx, bootstrapAdmin.ID, bootstrapAdmin.ID, adminRole.ID, Scope{}))
 
 	err = c.DeleteGroup(ctx, bootstrapAdmin.ID, group.ID)
@@ -266,7 +266,7 @@ func TestRemoveUserFromGroup_LastMemberBlocked(t *testing.T) {
 
 	group, err := c.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "sole-admins3"})
 	require.NoError(t, err)
-	require.NoError(t, c.AssignRoleToGroup(ctx, bootstrapAdmin.ID, group.ID, adminRole.ID, Scope{}))
+	require.NoError(t, c.AssignRoleToGroup(ctx, bootstrapAdmin.ID, group.ID, adminRole.ID, Scope{}, false))
 	require.NoError(t, c.AddUserToGroup(ctx, bootstrapAdmin.ID, false, bootstrapAdmin.ID, group.ID, 0))
 	require.NoError(t, c.RemoveUserRole(ctx, bootstrapAdmin.ID, bootstrapAdmin.ID, adminRole.ID, Scope{}))
 
@@ -291,7 +291,7 @@ func TestRemoveUserFromGroup_OtherMemberSurvivesAllowed(t *testing.T) {
 
 	group, err := c.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "two-admins"})
 	require.NoError(t, err)
-	require.NoError(t, c.AssignRoleToGroup(ctx, bootstrapAdmin.ID, group.ID, adminRole.ID, Scope{}))
+	require.NoError(t, c.AssignRoleToGroup(ctx, bootstrapAdmin.ID, group.ID, adminRole.ID, Scope{}, false))
 	require.NoError(t, c.AddUserToGroup(ctx, bootstrapAdmin.ID, false, bootstrapAdmin.ID, group.ID, 0))
 	require.NoError(t, c.AddUserToGroup(ctx, bootstrapAdmin.ID, false, second, group.ID, 0))
 	require.NoError(t, c.RemoveUserRole(ctx, bootstrapAdmin.ID, bootstrapAdmin.ID, adminRole.ID, Scope{}))

--- a/internal/core/concurrency_g04_threshold_race_test.go
+++ b/internal/core/concurrency_g04_threshold_race_test.go
@@ -74,8 +74,8 @@ func TestConcurrency_AssignUserRole_SoDGrantRace(t *testing.T) {
 		start := make(chan struct{})
 		var wg sync.WaitGroup
 		wg.Add(2)
-		go func() { defer wg.Done(); <-start; _ = c.AssignUserRole(ctx, 0, 1, roleAID, core.Scope{}) }()
-		go func() { defer wg.Done(); <-start; _ = c.AssignUserRole(ctx, 0, 1, roleBID, core.Scope{}) }()
+		go func() { defer wg.Done(); <-start; _ = c.AssignUserRole(ctx, 0, 1, roleAID, core.Scope{}, false) }()
+		go func() { defer wg.Done(); <-start; _ = c.AssignUserRole(ctx, 0, 1, roleBID, core.Scope{}, false) }()
 		close(start)
 		wg.Wait()
 

--- a/internal/core/concurrency_invite_member_test.go
+++ b/internal/core/concurrency_invite_member_test.go
@@ -31,7 +31,7 @@ func TestConcurrency_InviteMember_NoDuplicateActiveMembership(t *testing.T) {
 	dsn := "file:" + filepath.Join(t.TempDir(), "invite.db") + "?_busy_timeout=10000&_journal_mode=WAL"
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Role{}, &models.ProjectMembership{}, &models.AuditEvent{}))
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Role{}, &models.ProjectMembership{}, &models.AuditEvent{}, &models.Permission{}, &models.RolePermission{}))
 	// Mirror factory.go's ensureProjectMembershipIndex exactly, so this test exercises the
 	// same DB-level guard production installs get (rather than only the in-process check).
 	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_project_memberships_active "+

--- a/internal/core/concurrency_sod_grant_postgres_test.go
+++ b/internal/core/concurrency_sod_grant_postgres_test.go
@@ -103,12 +103,12 @@ func TestConcurrency_AssignUserRole_CrossReplicaPostgres_SoDBypass(t *testing.T)
 	go func() {
 		defer wg.Done()
 		<-start
-		errA = coreA.AssignUserRole(ctx, bootRes.User.ID, target.ID, roleA.ID, Scope{})
+		errA = coreA.AssignUserRole(ctx, bootRes.User.ID, target.ID, roleA.ID, Scope{}, false)
 	}()
 	go func() {
 		defer wg.Done()
 		<-start
-		errB = coreB.AssignUserRole(ctx, bootRes.User.ID, target.ID, roleB.ID, Scope{})
+		errB = coreB.AssignUserRole(ctx, bootRes.User.ID, target.ID, roleB.ID, Scope{}, false)
 	}()
 	close(start)
 	wg.Wait()

--- a/internal/core/core_s27_test.go
+++ b/internal/core/core_s27_test.go
@@ -408,7 +408,7 @@ func TestAssignGroupRoleWithExpiry_RoleNotFound(t *testing.T) {
 	ms := new(MockStorage)
 	ms.On("GetRole", mock.Anything, uint(99)).Return(nil, errors.New("not found"))
 	c := NewKeyorixCore(ms)
-	err := c.AssignGroupRoleWithExpiry(context.Background(), 1, 2, 99, Scope{}, time.Now().Add(time.Hour))
+	err := c.AssignGroupRoleWithExpiry(context.Background(), 1, 2, 99, Scope{}, time.Now().Add(time.Hour), false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Role not found")
 }

--- a/internal/core/core_s30_test.go
+++ b/internal/core/core_s30_test.go
@@ -167,7 +167,7 @@ func TestAssignMachineRole_MachineNotFound(t *testing.T) {
 	ms := new(MockStorage)
 	ms.On("GetMachineIdentity", mock.Anything, uint(1)).Return(nil, errors.New("not found"))
 	c := NewKeyorixCore(ms)
-	err := c.AssignMachineRole(context.Background(), 1, 2, Scope{ProjectID: 5}, 1)
+	err := c.AssignMachineRole(context.Background(), 1, 2, Scope{ProjectID: 5}, 1, false)
 	require.Error(t, err)
 }
 
@@ -177,7 +177,7 @@ func TestAssignMachineRole_RoleNotFound(t *testing.T) {
 	ms.On("GetMachineIdentity", mock.Anything, uint(1)).Return(machine, nil)
 	ms.On("GetRole", mock.Anything, uint(2)).Return(nil, errors.New("role not found"))
 	c := NewKeyorixCore(ms)
-	err := c.AssignMachineRole(context.Background(), 1, 2, Scope{ProjectID: 5}, 1)
+	err := c.AssignMachineRole(context.Background(), 1, 2, Scope{ProjectID: 5}, 1, false)
 	require.Error(t, err)
 }
 
@@ -193,7 +193,7 @@ func TestAssignMachineRole_Success(t *testing.T) {
 	// LogAuditEvent for logMachineEvent → writeAuditEventFull.
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 	c := NewKeyorixCore(ms)
-	err := c.AssignMachineRole(context.Background(), 1, 2, Scope{ProjectID: 5}, 1)
+	err := c.AssignMachineRole(context.Background(), 1, 2, Scope{ProjectID: 5}, 1, false)
 	require.NoError(t, err)
 }
 

--- a/internal/core/core_s32_test.go
+++ b/internal/core/core_s32_test.go
@@ -115,7 +115,7 @@ func TestSetProjectMemberRole_RoleNotFound_s32(t *testing.T) {
 	ms.On("GetRoleByName", mock.Anything, "nonexistent").Return(nil, errors.New("not found"))
 	c := NewKeyorixCore(ms)
 	// actorID=0, projectID=1, userID=1, roleName="nonexistent"
-	err := c.SetProjectMemberRole(context.Background(), 0, 1, 1, "nonexistent")
+	err := c.SetProjectMemberRole(context.Background(), 0, 1, 1, "nonexistent", false)
 	require.Error(t, err)
 }
 

--- a/internal/core/core_s33_test.go
+++ b/internal/core/core_s33_test.go
@@ -147,19 +147,19 @@ func TestAssignGroupRoleWithExpiry_RoleNotFound_s33(t *testing.T) {
 	ms := new(MockStorage)
 	ms.On("GetRole", mock.Anything, uint(99)).Return(nil, errors.New("role not found"))
 	c := NewKeyorixCore(ms)
-	err := c.AssignGroupRoleWithExpiry(context.Background(), 0, 1, 99, Scope{}, time.Now().Add(time.Hour))
+	err := c.AssignGroupRoleWithExpiry(context.Background(), 0, 1, 99, Scope{}, time.Now().Add(time.Hour), false)
 	require.Error(t, err)
 }
 
 func TestAssignGroupRoleWithExpiry_Success(t *testing.T) {
 	ms := new(MockStorage)
-	role := &models.Role{ID: 2, Name: "viewer"} // non-admin role → no authority check needed
+	role := &models.Role{ID: 2, Name: "viewer"} // actorID 0, actorIsMachine false → trusted system pseudo-actor, ceiling skipped
 	ms.On("GetRole", mock.Anything, uint(2)).Return(role, nil)
 	// requireGroupGrantNoSoDViolation: ListSoDPolicies stub returns nil → OK
 	ms.On("AssignRoleToGroupWithExpiry", mock.Anything, uint(1), uint(2), mock.AnythingOfType("storage.Scope"), mock.AnythingOfType("time.Time")).Return(nil)
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 	c := NewKeyorixCore(ms)
-	err := c.AssignGroupRoleWithExpiry(context.Background(), 0, 1, 2, Scope{}, time.Now().Add(time.Hour))
+	err := c.AssignGroupRoleWithExpiry(context.Background(), 0, 1, 2, Scope{}, time.Now().Add(time.Hour), false)
 	require.NoError(t, err)
 }
 

--- a/internal/core/dual_control_external_test.go
+++ b/internal/core/dual_control_external_test.go
@@ -157,17 +157,37 @@ func TestApprove_DualControl_RequiresRoleAtRequestTime(t *testing.T) {
 // treated the second machine's genuinely distinct approval as a duplicate of
 // the first, and the threshold could never be reached via machine approvers.
 // Exploit-shaped: two different approverMachineID values, both approverID=0
-// (the real production shape — no role grant needed since "editor" is
-// non-admin and requireAuthorityForRole only gates admin-tier roles).
+// (the real production shape).
+//
+// Target role is a fresh permission-less role, not "editor": FIX-1
+// (requireGranterHoldsRolePermissions's actorID==0 fast-path no longer trusts
+// a machine caller unconditionally) means the threshold-crossing grant now
+// runs the real ceiling check for a machine approver too — and that check
+// resolves permissions via c.Authorize(ctx, actorID, ...), which is keyed on
+// UserID (always 0 for a machine caller), not the machine's real principal ID
+// via AuthorizePrincipal/GetMachineRoleIDsAt. A machine actor therefore cannot
+// currently satisfy the ceiling for any role bundling a real permission,
+// including one it may legitimately hold via machine_identity_roles — a
+// separate, pre-existing gap in requireGranterHoldsRolePermissions (already
+// present for actorIsMachine=true on AssignUserRoleWithExpiry since #1542),
+// not something this test is exercising. Using a permission-less role isolates
+// this test to its actual subject — the distinct-approver dedup logic — same
+// as TestAssignUserRole_EmptyRoleAlwaysGrantable's pattern for the identical
+// "nothing to ceiling-check" case.
 func TestApprove_DualControl_TwoDistinctMachineApprovers(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)
 	defer h.Cleanup()
 	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.AuditEvent{}))
+	h.CreateTestRole(t, "empty-role", "no bundled permissions", 99)
 
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10) // requester (human — RequestProjectAccess requires nonzero UserID)
 	h.CoreService.SetDualControlPolicy(2)
-	reqID := seedPendingRequest(t, h, 10)
+	req0, err := h.Storage.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: 2, UserID: 10, SuggestedRole: "empty-role", State: "pending",
+	})
+	require.NoError(t, err)
+	reqID := req0.ID
 
 	// Machine 101 approves: still pending, no grant yet.
 	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 0, 101, "", 0)
@@ -181,22 +201,34 @@ func TestApprove_DualControl_TwoDistinctMachineApprovers(t *testing.T) {
 	require.NoError(t, err, "a second, distinct machine approver must not be treated as a duplicate of the first")
 	assert.Equal(t, "approved", req.State)
 	ids, _ := h.Storage.GetUserRoleIDsAt(ctx, 10, storage.Scope{ProjectID: 2})
-	assert.Contains(t, ids, uint(3), "editor granted once two distinct machine approvers signed off")
+	assert.Contains(t, ids, uint(99), "empty-role granted once two distinct machine approvers signed off")
 }
 
 // Positive control: dual control must still reject a genuine duplicate — the
 // SAME machine identity attempting to approve twice. The fix must narrow the
 // false-positive (two different machines colliding on ApproverID=0) without
 // widening a false-negative (the same machine approving twice).
+//
+// Target role is a fresh permission-less role, not "editor" (seedPendingRequest's
+// default) — see TestApprove_DualControl_TwoDistinctMachineApprovers's comment:
+// a machine approver cannot currently satisfy requireGranterHoldsRolePermissions
+// for any role bundling a real permission (a separate, pre-existing gap, not
+// something this test exercises). Using a permission-less role isolates this
+// test to its actual subject — same-machine dedup.
 func TestApprove_DualControl_SameMachineApproverTwiceRejected(t *testing.T) {
 	h := testhelper.NewRBACTestHelper(t)
 	defer h.Cleanup()
 	require.NoError(t, h.DB.AutoMigrate(&models.AccessRequest{}, &models.AccessRequestApproval{}, &models.AuditEvent{}))
+	h.CreateTestRole(t, "empty-role", "no bundled permissions", 99)
 
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
 	h.CoreService.SetDualControlPolicy(2)
-	reqID := seedPendingRequest(t, h, 10)
+	req0, err := h.Storage.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: 2, UserID: 10, SuggestedRole: "empty-role", State: "pending",
+	})
+	require.NoError(t, err)
+	reqID := req0.ID
 
 	req, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 0, 101, "", 0)
 	require.NoError(t, err)
@@ -215,6 +247,10 @@ func TestListAccessRequests_AnnotatesProgress(t *testing.T) {
 	ctx := context.Background()
 	h.CreateTestUser(t, "alice", 10)
 	h.CreateTestUser(t, "admin1", 11)
+	// #93/#107/#141: the approver must themselves hold every permission of the
+	// role being granted (editor: secrets.read/write, users.read) — grant them
+	// "admin" globally so the ceiling check's admin bypass applies.
+	h.AssignUserRole(t, 11, 2, nil)
 	h.CoreService.SetDualControlPolicy(2)
 	reqID := seedPendingRequest(t, h, 10)
 	_, err := h.CoreService.ApproveAccessRequestWithExpiry(ctx, 2, reqID, 11, 0, "", 0)

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -191,17 +191,16 @@ func (c *KeyorixCore) ListGroups(ctx context.Context) ([]*models.Group, error) {
 // only exists because two of the group's OWN roles combine with each other —
 // see requireGroupJoinNoSoDViolation's doc comment (sod.go) for the concrete
 // gap and how this mirrors requireGrantSetNoSoDViolation's set-based shape.
-func (c *KeyorixCore) validateGroupJoinRoles(ctx context.Context, actorID, userID, groupID uint) error {
+func (c *KeyorixCore) validateGroupJoinRoles(ctx context.Context, actorID uint, actorIsMachine bool, userID, groupID uint) error {
 	grants, err := c.storage.ListGroupRoleAssignments(ctx, groupID)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	}
 	for _, g := range grants {
-		role, err := c.storage.GetRole(ctx, g.RoleID)
-		if err != nil {
+		if _, err := c.storage.GetRole(ctx, g.RoleID); err != nil {
 			continue
 		}
-		if err := c.requireAuthorityForRole(ctx, actorID, g.ProjectID, role.Name); err != nil {
+		if err := c.requireGranterHoldsRolePermissions(ctx, actorID, g.RoleID, Scope{ProjectID: g.ProjectID, EnvironmentID: g.EnvironmentID}, actorIsMachine); err != nil {
 			return err
 		}
 	}
@@ -259,7 +258,7 @@ func (c *KeyorixCore) AddUserToGroup(ctx context.Context, actorID uint, actorIsM
 	// (AssignUserRole has the identical race).
 	return c.storage.WithNamedLock(ctx, sodGrantLockKey("user", userID), func(ctx context.Context) error {
 		if actorID != 0 || actorIsMachine {
-			if err := c.validateGroupJoinRoles(ctx, actorID, userID, groupID); err != nil {
+			if err := c.validateGroupJoinRoles(ctx, actorID, actorIsMachine, userID, groupID); err != nil {
 				return err
 			}
 		}

--- a/internal/core/groups_join_sod_set_test.go
+++ b/internal/core/groups_join_sod_set_test.go
@@ -58,10 +58,10 @@ func TestAddUserToGroup_BlocksSoDViolationAcrossGroupRoleSet(t *testing.T) {
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
-	// actorID 71 is an arbitrary non-zero, non-privileged actor: neither
-	// combo_read_only nor combo_write_only is an admin-tier role name, so
-	// requireAuthorityForRole imposes no ceiling here — only the SoD gate under
-	// test is exercised.
+	// actorID 71 is an arbitrary non-zero actor granted admin (bypasses the
+	// FIX-1 permission-derived ceiling) so only the SoD gate under test is
+	// exercised, not requireGranterHoldsRolePermissions.
+	h.AssignUserRole(t, 71, 1, nil)
 	err = h.CoreService.AddUserToGroup(ctx, 71, false, 70, 50, 0)
 	require.Error(t, err, "joining a group whose OWN role grants combine into a toxic pair must be refused")
 	assert.Contains(t, err.Error(), "separation-of-duties")
@@ -100,6 +100,10 @@ func TestAddUserToGroup_BlocksSoDViolationWithExistingRole(t *testing.T) {
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
+	// actorID 73 is an arbitrary non-zero actor granted admin (bypasses the
+	// FIX-1 permission-derived ceiling) so only the SoD gate under test is
+	// exercised, not requireGranterHoldsRolePermissions.
+	h.AssignUserRole(t, 73, 1, nil)
 	err = h.CoreService.AddUserToGroup(ctx, 73, false, 72, 51, 0)
 	require.Error(t, err, "joining a group that grants a role completing a policy with an already-held role must be refused")
 	assert.Contains(t, err.Error(), "separation-of-duties")
@@ -128,6 +132,10 @@ func TestAddUserToGroup_AllowsNonViolatingGroupJoin(t *testing.T) {
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
+	// actorID 75 is an arbitrary non-zero actor granted admin (bypasses the
+	// FIX-1 permission-derived ceiling) so only the SoD gate under test is
+	// exercised, not requireGranterHoldsRolePermissions.
+	h.AssignUserRole(t, 75, 1, nil)
 	err = h.CoreService.AddUserToGroup(ctx, 75, false, 74, 52, 0)
 	require.NoError(t, err, "a non-violating group join must succeed unimpeded")
 

--- a/internal/core/invitation_global_test.go
+++ b/internal/core/invitation_global_test.go
@@ -111,7 +111,7 @@ func TestInviteGlobal_RejectsNonAdminGrantingGlobalAdminRole(t *testing.T) {
 
 	_, err := c.InviteGlobal(ctx, "mallory@acme.io", "admin", nil, nonAdminID, 0)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only an administrator can grant")
+	assert.Contains(t, err.Error(), "do not hold permission")
 }
 
 // #231: the per-project assignments bundled into a global invite must be
@@ -130,7 +130,7 @@ func TestInviteGlobal_RejectsNonAdminGrantingProjectAdminAssignment(t *testing.T
 		{ProjectID: proj.ID, Role: "project_admin"},
 	}, nonAdminID, 0)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only an administrator can grant")
+	assert.Contains(t, err.Error(), "do not hold permission")
 }
 
 func TestInviteGlobal_DefaultsSystemViewer(t *testing.T) {

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -51,22 +51,19 @@ const (
 
 // ── Invitations ────────────────────────────────────────────────────────────
 
-// requireAuthorityForRole refuses to GRANT an admin role (super_admin/admin/system_admin/
-// project_admin) unless the actor holds admin authority at the project scope. The various
-// grant entry points (access-request approval, project invite, membership activation) are
-// gated by roles.assign, but that alone would let a non-admin roles.assign holder mint a
-// principal more powerful than themselves — escalation-by-proxy. Non-admin roles pass (the
-// roles.assign gate covers them). actorID==0 (a system/unauthenticated path) cannot grant
-// an admin role through these flows.
-func (c *KeyorixCore) requireAuthorityForRole(ctx context.Context, actorID, projectID uint, role string) error {
-	if !isAdminRoleName(role) {
-		return nil
-	}
-	if err := c.requireAdminAuthorityAt(ctx, actorID, projectID); err != nil {
-		return fmt.Errorf("only an administrator can grant the administrative role %q: %w", role, err)
-	}
-	return nil
-}
+// requireAuthorityForRole (REMOVED, FIX-1): used to refuse a role GRANT only
+// when the role's NAME matched the fixed canonical admin-tier list
+// (super_admin/admin/system_admin/project_admin), doing nothing for any other
+// role regardless of what permissions it actually bundled. A custom role
+// bundling real permissions under a non-canonical name passed this check
+// unconditionally on 9 entry points (AssignRoleToGroup, AssignGroupRoleWithExpiry,
+// AssignMachineRole, AddUserToGroup, CreateUserWithAssignments, InviteToProject/
+// InviteGlobal, ApproveAccessRequestWithExpiry, TransitionMembership, plus the
+// /system proxy re-derivations), letting a low-privilege actor mint an
+// arbitrary permission-rich role via any of them. All 9 (plus the proxy layer)
+// now call requireGranterHoldsRolePermissions instead — the same mechanism
+// AssignUserRole/AssignUserRoleWithExpiry already used, deriving the ceiling
+// from the role's real bundled permissions, not its name.
 
 // RequireAdminAuthorityAt exports requireAdminAuthorityAt for the /system proxy
 // layer (server/http/handlers), which cannot call unexported KeyorixCore methods
@@ -80,10 +77,13 @@ func (c *KeyorixCore) RequireAdminAuthorityAt(ctx context.Context, actorID, proj
 	return c.requireAdminAuthorityAt(ctx, actorID, projectID)
 }
 
-// RequireAuthorityForRole exports requireAuthorityForRole for the same reason as
-// RequireAdminAuthorityAt above.
-func (c *KeyorixCore) RequireAuthorityForRole(ctx context.Context, actorID, projectID uint, role string) error {
-	return c.requireAuthorityForRole(ctx, actorID, projectID, role)
+// RequireGranterHoldsRolePermissions exports requireGranterHoldsRolePermissions
+// for the /system proxy layer, for the same reason as RequireAdminAuthorityAt
+// above -- re-deriving, at the hub, the escalation-by-proxy grant ceiling a
+// matching core method already enforces locally on a downstream node before
+// relaying a state change here.
+func (c *KeyorixCore) RequireGranterHoldsRolePermissions(ctx context.Context, actorID, roleID uint, scope Scope, actorIsMachine bool) error {
+	return c.requireGranterHoldsRolePermissions(ctx, actorID, roleID, scope, actorIsMachine)
 }
 
 // requireAdminAuthorityAt refuses unless actorID holds an admin role (adminRoleNames)
@@ -116,12 +116,14 @@ func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email
 	if !c.domainAllowed(email) {
 		return nil, fmt.Errorf("email domain is not on the allowlist")
 	}
-	if _, err := c.storage.GetRoleByName(ctx, role); err != nil {
+	inviteRole, err := c.storage.GetRoleByName(ctx, role)
+	if err != nil {
 		return nil, fmt.Errorf("unknown role %q: %w", role, err)
 	}
-	// Escalation-by-proxy guard: inviting someone as an admin role requires the inviter
-	// to hold admin authority at the project (parallel to the access-request ceiling).
-	if err := c.requireAuthorityForRole(ctx, invitedBy, projectID, role); err != nil {
+	// Escalation-by-proxy guard: the inviter must already hold every permission the
+	// invited role bundles (parallel to the access-request ceiling), not merely an
+	// admin-tier role name.
+	if err := c.requireGranterHoldsRolePermissions(ctx, invitedBy, inviteRole.ID, Scope{ProjectID: projectID}, invitedByMachineID != 0); err != nil {
 		return nil, err
 	}
 	now := c.now()
@@ -211,13 +213,15 @@ func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string
 	if sysRole == "" {
 		sysRole = "system_viewer"
 	}
-	if _, err := c.storage.GetRoleByName(ctx, sysRole); err != nil {
+	sysRoleModel, err := c.storage.GetRoleByName(ctx, sysRole)
+	if err != nil {
 		return nil, fmt.Errorf("unknown role %q (system): %w", sysRole, err)
 	}
 	// Escalation-by-proxy guard (#231), mirroring InviteToProject: a global system
-	// role is the most powerful grant this flow can mint, so it needs the same
-	// admin-authority ceiling check, at global scope (projectID 0).
-	if err := c.requireAuthorityForRole(ctx, invitedBy, 0, sysRole); err != nil {
+	// role is the most powerful grant this flow can mint, so it needs the ceiling
+	// check applied everywhere else — the inviter's real bundled permissions, not
+	// just the role's name — at global scope (projectID 0).
+	if err := c.requireGranterHoldsRolePermissions(ctx, invitedBy, sysRoleModel.ID, Scope{}, invitedByMachineID != 0); err != nil {
 		return nil, err
 	}
 
@@ -235,14 +239,15 @@ func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string
 		if _, err := c.storage.GetProject(ctx, a.ProjectID); err != nil {
 			return nil, fmt.Errorf("unknown project %d: %w", a.ProjectID, err)
 		}
-		if _, err := c.storage.GetRoleByName(ctx, a.Role); err != nil {
+		assignRole, err := c.storage.GetRoleByName(ctx, a.Role)
+		if err != nil {
 			return nil, fmt.Errorf("unknown role %q: %w", a.Role, err)
 		}
 		// Same ceiling check InviteToProject applies to its own role parameter —
-		// without this, a non-admin roles.assign holder could bundle an
-		// admin-conferring project assignment into an otherwise-innocuous global
+		// without this, a non-admin roles.assign holder could bundle a
+		// permission-rich project assignment into an otherwise-innocuous global
 		// invite.
-		if err := c.requireAuthorityForRole(ctx, invitedBy, a.ProjectID, a.Role); err != nil {
+		if err := c.requireGranterHoldsRolePermissions(ctx, invitedBy, assignRole.ID, Scope{ProjectID: a.ProjectID}, invitedByMachineID != 0); err != nil {
 			return nil, err
 		}
 		clean = append(clean, ProjectAssignment{ProjectID: a.ProjectID, Role: a.Role})
@@ -329,7 +334,7 @@ func (c *KeyorixCore) applyInvitationGrants(ctx context.Context, inv *models.Pro
 			// grant for a global invitation (up to and including super_admin), which
 			// previously left zero trace of any kind (#299). Attributed to the inviter,
 			// consistent with the per-project assignment grants below.
-			if err := c.AssignUserRole(ctx, inv.InvitedBy, userID, role.ID, Scope{ProjectID: 0}); err != nil {
+			if err := c.AssignUserRole(ctx, inv.InvitedBy, userID, role.ID, Scope{ProjectID: 0}, inv.InvitedByMachineIdentityID != 0); err != nil {
 				return fmt.Errorf("failed to grant system role: %w", err)
 			}
 		}
@@ -694,9 +699,10 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	if err != nil {
 		return nil, fmt.Errorf("unknown role %q: %w", role, err)
 	}
-	// Privilege ceiling: an approver may not grant an admin role unless they themselves
-	// hold admin authority at this project (escalation-by-proxy guard).
-	if err := c.requireAuthorityForRole(ctx, approverID, req.ProjectID, role); err != nil {
+	// Privilege ceiling: an approver may not grant a role unless they themselves
+	// hold every permission it bundles (escalation-by-proxy guard), not merely an
+	// admin-tier role name.
+	if err := c.requireGranterHoldsRolePermissions(ctx, approverID, roleModel.ID, Scope{ProjectID: req.ProjectID}, approverMachineID != 0); err != nil {
 		return nil, err
 	}
 	// One sign-off per distinct approver.
@@ -784,15 +790,17 @@ func (c *KeyorixCore) finalizeAccessRequestApproval(ctx context.Context, req *mo
 		expiresAt := now.Add(grantTTL)
 		// Routed through the audited wrapper so this grant lands in the RBAC audit
 		// trail with a structured RoleID, alongside the generic access_request.approved
-		// event below (#298). actorIsMachine=false: unchanged from before #1542 --
-		// approverID here isn't threaded from a live actor-kind signal at this call
-		// site; a machine-driven approval chain is a sibling finding, not fixed here.
-		if err := c.AssignUserRoleWithExpiry(ctx, approverID, req.UserID, roleModel.ID, scope, expiresAt, false); err != nil {
+		// event below (#298). approverMachineID (mirroring ApproverMachineIdentityID's
+		// own attribution convention: approverID is 0 when the approver was a machine
+		// identity, and approverMachineID carries the real ID) closes the sibling gap
+		// #1542 left open here — a machine-driven approval no longer gets the trusted
+		// actorID==0 exemption unconditionally.
+		if err := c.AssignUserRoleWithExpiry(ctx, approverID, req.UserID, roleModel.ID, scope, expiresAt, approverMachineID != 0); err != nil {
 			return nil, fmt.Errorf("failed to grant role: %w", err)
 		}
 		grantDesc = fmt.Sprintf("%s until %s (TTL %s)", roleModel.Name, expiresAt.UTC().Format(time.RFC3339), grantTTL)
 	} else {
-		if err := c.AssignUserRole(ctx, approverID, req.UserID, roleModel.ID, scope); err != nil {
+		if err := c.AssignUserRole(ctx, approverID, req.UserID, roleModel.ID, scope, approverMachineID != 0); err != nil {
 			return nil, fmt.Errorf("failed to grant role: %w", err)
 		}
 	}

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -196,11 +196,20 @@ func TestInviteToProject_EnforcesAdminCeiling(t *testing.T) {
 	store.On("GetUserRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{6}, nil)
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{}, nil)
 	store.On("RoleSetBypassesPermissionChecks", ctx, []uint{6}).Return(false, nil)
+	// FIX-1: the ceiling now derives from project_admin's own bundled
+	// permissions rather than its name, so the mock must resolve them —
+	// and the inviter's own role (6) must not carry that permission either.
+	store.On("GetRolePermissions", ctx, uint(4)).Return([]*models.Permission{{ID: 50, Name: "projects.admin"}}, nil)
+	store.On("RoleSetHasPermission", ctx, []uint{6}, "projects.admin").Return(false, nil)
+	// project_developer (role 6) itself bundles no permissions relevant to this
+	// test, so the second invite below (inviting AS project_developer) hits the
+	// ceiling check for role 6 too.
+	store.On("GetRolePermissions", ctx, uint(6)).Return([]*models.Permission{}, nil)
 
 	// Inviting as project_admin → refused before any invitation is created.
 	_, err := c.InviteToProject(ctx, 1, "a@b.io", "project_admin", 9, 0)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only an administrator can grant")
+	assert.Contains(t, err.Error(), "do not hold permission")
 	store.AssertNotCalled(t, "CreateProjectInvitation", mock.Anything, mock.Anything)
 
 	// Inviting as a non-admin role is allowed (isAdminRoleName false → no ceiling).
@@ -226,10 +235,15 @@ func TestApproveAccessRequest_RejectsAdminGrantByNonAdmin(t *testing.T) {
 	store.On("GetUserRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{6}, nil)
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(9), storage.Scope{ProjectID: 1}).Return([]uint{}, nil)
 	store.On("RoleSetBypassesPermissionChecks", ctx, []uint{6}).Return(false, nil)
+	// FIX-1: the ceiling now derives from admin's own bundled permissions
+	// rather than its name, so the mock must resolve them — and the
+	// approver's own role (6) must not carry that permission either.
+	store.On("GetRolePermissions", ctx, uint(2)).Return([]*models.Permission{{ID: 51, Name: "system.admin"}}, nil)
+	store.On("RoleSetHasPermission", ctx, []uint{6}, "system.admin").Return(false, nil)
 
 	_, err := c.ApproveAccessRequest(ctx, 1, 3, 9, "admin")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only an administrator can grant")
+	assert.Contains(t, err.Error(), "do not hold permission")
 	// The grant was refused before any role assignment or approval record.
 	store.AssertNotCalled(t, "AssignRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	store.AssertNotCalled(t, "CreateAccessRequestApproval", mock.Anything, mock.Anything)

--- a/internal/core/jit_access.go
+++ b/internal/core/jit_access.go
@@ -75,17 +75,18 @@ func (c *KeyorixCore) assignUserRoleWithExpirySkipSoD(ctx context.Context, actor
 
 // AssignGroupRoleWithExpiry assigns a time-bound role to a group at scope, gated by
 // the same escalation-by-proxy ceiling as the permanent grant (AssignRoleToGroup —
-// a JIT admin grant to a group is just as much a self-escalation vector as a
-// permanent one); see AssignUserRoleWithExpiry. Also gated by the #419
-// separation-of-duties preventive check (requireGroupGrantNoSoDViolation) — no
-// caller of this function needs a break-glass-style carve-out, unlike the direct
-// user grant above.
-func (c *KeyorixCore) AssignGroupRoleWithExpiry(ctx context.Context, actorID, groupID, roleID uint, scope Scope, expiresAt time.Time) error {
-	role, err := c.storage.GetRole(ctx, roleID)
-	if err != nil {
+// a JIT grant to a group is just as much a self-escalation vector as a permanent
+// one, and is gated by the role's real bundled permissions, not only its name);
+// see AssignUserRoleWithExpiry. Also gated by the #419 separation-of-duties
+// preventive check (requireGroupGrantNoSoDViolation) — no caller of this function
+// needs a break-glass-style carve-out, unlike the direct user grant above.
+// actorIsMachine distinguishes a machine-credential caller (also actorID==0) from
+// the true actorID==0 system pseudo-actor.
+func (c *KeyorixCore) AssignGroupRoleWithExpiry(ctx context.Context, actorID, groupID, roleID uint, scope Scope, expiresAt time.Time, actorIsMachine bool) error {
+	if _, err := c.storage.GetRole(ctx, roleID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
-	if err := c.requireAuthorityForRole(ctx, actorID, scope.ProjectID, role.Name); err != nil {
+	if err := c.requireGranterHoldsRolePermissions(ctx, actorID, roleID, scope, actorIsMachine); err != nil {
 		return err
 	}
 	// #1646: see AssignUserRole's identical WithNamedLock use.

--- a/internal/core/machine_global_scope_invariant_test.go
+++ b/internal/core/machine_global_scope_invariant_test.go
@@ -45,7 +45,7 @@ func TestAssignMachineRole_GlobalScopeRejected(t *testing.T) {
 	ms.On("GetMachineIdentity", mock.Anything, uint(1)).Return(machine, nil)
 	c := NewKeyorixCore(ms)
 
-	err := c.AssignMachineRole(context.Background(), 1, 2, Scope{ProjectID: 0}, 1)
+	err := c.AssignMachineRole(context.Background(), 1, 2, Scope{ProjectID: 0}, 1, false)
 
 	require.Error(t, err, "a machine identity must never be grantable a role at global scope")
 	ms.AssertNotCalled(t, "AssignMachineRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
@@ -73,7 +73,7 @@ func TestAssignMachineRole_GlobalScopeRejected_EvenIfMachineLookupSomehowReturne
 	ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 	c := NewKeyorixCore(ms)
 
-	err := c.AssignMachineRole(context.Background(), 1, 2, Scope{ProjectID: 0}, 1)
+	err := c.AssignMachineRole(context.Background(), 1, 2, Scope{ProjectID: 0}, 1, false)
 
 	require.NoError(t, err, "machineInProject matches ProjectID 0 == 0 -- this documents the gap rather than hiding it")
 	ms.AssertCalled(t, "AssignMachineRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)

--- a/internal/core/machine_token.go
+++ b/internal/core/machine_token.go
@@ -353,23 +353,26 @@ func machineRestrictionFrom(cred *models.MachineIdentityCredential) *MachineToke
 // AssignMachineRole grants a role to a machine identity at the given scope and
 // audits it. The machine must belong to scope.ProjectID — the caller is only
 // proven to hold roles.assign at that project, so a machine in another project
-// must not be reachable through this path. Granting an admin role is additionally
-// gated by requireAuthorityForRole (the same escalation-by-proxy ceiling
-// AddProjectMember applies) — an admin-credentialed machine identity is just as
-// much a self-escalation vector as an admin user grant. Also gated by the #419
+// must not be reachable through this path. The grant is additionally gated by
+// requireGranterHoldsRolePermissions (the same escalation-by-proxy ceiling
+// AddProjectMember applies, and by the role's real bundled permissions, not only
+// its name) — an admin-credentialed machine identity is just as much a
+// self-escalation vector as an admin user grant. Also gated by the #419
 // separation-of-duties preventive check (requireMachineGrantNoSoDViolation,
 // sod.go) — a machine identity holds real permissions too and Authorize
 // authorizes it, so the same toxic-permission-pair concern applies.
-func (c *KeyorixCore) AssignMachineRole(ctx context.Context, machineID, roleID uint, scope Scope, actorID uint) error {
+// actorIsMachine distinguishes a machine-credential-authenticated GRANTING actor
+// (also actorID==0) from the true actorID==0 system pseudo-actor — distinct from
+// machineID, the role's TARGET.
+func (c *KeyorixCore) AssignMachineRole(ctx context.Context, machineID, roleID uint, scope Scope, actorID uint, actorIsMachine bool) error {
 	m, err := c.machineInProject(ctx, scope.ProjectID, machineID)
 	if err != nil {
 		return err
 	}
-	role, err := c.storage.GetRole(ctx, roleID)
-	if err != nil {
+	if _, err := c.storage.GetRole(ctx, roleID); err != nil {
 		return err
 	}
-	if err := c.requireAuthorityForRole(ctx, actorID, scope.ProjectID, role.Name); err != nil {
+	if err := c.requireGranterHoldsRolePermissions(ctx, actorID, roleID, scope, actorIsMachine); err != nil {
 		return err
 	}
 	if err := c.requireMachineGrantNoSoDViolation(ctx, machineID, roleID); err != nil {

--- a/internal/core/membership_lifecycle.go
+++ b/internal/core/membership_lifecycle.go
@@ -152,7 +152,8 @@ func (c *KeyorixCore) inviteMemberWithMode(ctx context.Context, projectID, userI
 	if role == "" {
 		return nil, fmt.Errorf("a project role is required")
 	}
-	if _, err := c.storage.GetRoleByName(ctx, role); err != nil {
+	inviteMemberRole, err := c.storage.GetRoleByName(ctx, role)
+	if err != nil {
 		return nil, fmt.Errorf("unknown role %q: %w", role, err)
 	}
 	if err := c.domainAllowedForUser(ctx, userID); err != nil {
@@ -166,10 +167,11 @@ func (c *KeyorixCore) inviteMemberWithMode(ctx context.Context, projectID, userI
 	if _, err := c.storage.GetProject(ctx, projectID); err != nil {
 		return nil, fmt.Errorf("project %d not found or deleted", projectID)
 	}
-	// Escalation-by-proxy guard: onboarding a member as an admin role requires the
-	// inviter to hold admin authority at the project (parallel to the access-request
-	// approval ceiling). idpResolved invites still pass through here.
-	if err := c.requireAuthorityForRole(ctx, invitedBy, projectID, role); err != nil {
+	// Escalation-by-proxy guard: onboarding a member requires the inviter to already
+	// hold every permission the role bundles (parallel to the access-request
+	// approval ceiling), not merely an admin-tier role name. idpResolved invites
+	// still pass through here.
+	if err := c.requireGranterHoldsRolePermissions(ctx, invitedBy, inviteMemberRole.ID, Scope{ProjectID: projectID}, invitedByMachineID != 0); err != nil {
 		return nil, err
 	}
 	// One active onboarding per (project, user).
@@ -207,7 +209,7 @@ func (c *KeyorixCore) inviteMemberWithMode(ctx context.Context, projectID, userI
 	c.logMembershipEvent(ctx, "membership.invited", created, invitedBy)
 	// If the mode put us straight into active, grant the role now.
 	if created.State == MembershipActive {
-		if err := c.AddProjectMember(ctx, invitedBy, projectID, userID, role); err != nil {
+		if err := c.AddProjectMember(ctx, invitedBy, projectID, userID, role, invitedByMachineID != 0); err != nil {
 			// #309: created just committed as `active` above; if the role grant that's
 			// supposed to back it fails (e.g. the composite user_roles primary key
 			// rejects a grant that already exists via some other, independent path —
@@ -252,7 +254,9 @@ func initialMembershipStateForMode(mode string, idpResolved bool) string {
 // TransitionMembership advances a membership to the next state, enforcing the
 // state machine. Reaching `active` grants the project role; `revoked` removes it.
 // actorID is the user performing the transition (for the audit trail).
-func (c *KeyorixCore) TransitionMembership(ctx context.Context, projectID, membershipID uint, to string, actorID uint) (*models.ProjectMembership, error) {
+// actorIsMachine distinguishes a machine-credential-authenticated caller (also
+// actorID==0) from the true actorID==0 system pseudo-actor.
+func (c *KeyorixCore) TransitionMembership(ctx context.Context, projectID, membershipID uint, to string, actorID uint, actorIsMachine bool) (*models.ProjectMembership, error) {
 	m, err := c.storage.GetProjectMembership(ctx, membershipID)
 	if err != nil {
 		return nil, fmt.Errorf("membership not found")
@@ -266,11 +270,15 @@ func (c *KeyorixCore) TransitionMembership(ctx context.Context, projectID, membe
 		return nil, fmt.Errorf("cannot transition membership from %s to %s", m.State, to)
 	}
 	// Activating a membership grants its role, so the same escalation-by-proxy ceiling
-	// applies: the actor must hold admin authority at the project to activate a membership
-	// carrying an admin role. (Revocation/other transitions remove or don't grant, so
+	// applies: the actor must already hold every permission the membership's role
+	// bundles to activate it. (Revocation/other transitions remove or don't grant, so
 	// they're unaffected.)
 	if to == MembershipActive {
-		if err := c.requireAuthorityForRole(ctx, actorID, m.ProjectID, m.Role); err != nil {
+		activateRole, err := c.storage.GetRoleByName(ctx, m.Role)
+		if err != nil {
+			return nil, fmt.Errorf("unknown role %q: %w", m.Role, err)
+		}
+		if err := c.requireGranterHoldsRolePermissions(ctx, actorID, activateRole.ID, Scope{ProjectID: m.ProjectID}, actorIsMachine); err != nil {
 			return nil, err
 		}
 	}
@@ -303,7 +311,7 @@ func (c *KeyorixCore) TransitionMembership(ctx context.Context, projectID, membe
 	// Side effects on the role grant.
 	switch to {
 	case MembershipActive:
-		if err := c.AddProjectMember(ctx, actorID, m.ProjectID, m.UserID, m.Role); err != nil {
+		if err := c.AddProjectMember(ctx, actorID, m.ProjectID, m.UserID, m.Role, actorIsMachine); err != nil {
 			// #309: m just committed as `active` above; if the role grant fails, revert
 			// to the state m held before this transition (not straight to revoked) —
 			// unlike inviteMemberWithMode's straight-to-active create, this row already

--- a/internal/core/membership_lifecycle_test.go
+++ b/internal/core/membership_lifecycle_test.go
@@ -175,7 +175,7 @@ func TestTransitionMembership_RejectsIllegalJump(t *testing.T) {
 	store.On("GetProjectMembership", ctx, uint(50)).
 		Return(&models.ProjectMembership{ID: 50, ProjectID: 1, State: MembershipInvited}, nil)
 
-	_, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9)
+	_, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot transition")
 	store.AssertNotCalled(t, "TransitionProjectMembershipState", mock.Anything, mock.Anything, mock.Anything)
@@ -254,7 +254,7 @@ func TestTransitionMembership_ActivationFailure_RevertsToPriorState(t *testing.T
 	}), MembershipActive).Return(true, nil).Once()
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	m, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9)
+	m, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9, false)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to grant role on activation")
@@ -272,7 +272,7 @@ func TestTransitionMembership_RejectsOtherProject(t *testing.T) {
 	store.On("GetProjectMembership", ctx, uint(50)).
 		Return(&models.ProjectMembership{ID: 50, ProjectID: 2, UserID: 2, Role: "project_admin", State: MembershipProvisioned}, nil)
 
-	_, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9)
+	_, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 	store.AssertNotCalled(t, "TransitionProjectMembershipState", mock.Anything, mock.Anything, mock.Anything)
@@ -292,7 +292,7 @@ func TestTransitionMembership_ActivateGrantsRole(t *testing.T) {
 	store.On("AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1}).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	out, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9)
+	out, err := c.TransitionMembership(ctx, 1, 50, MembershipActive, 9, false)
 	require.NoError(t, err)
 	assert.Equal(t, MembershipActive, out.State)
 	store.AssertCalled(t, "AssignRole", ctx, uint(2), uint(5), storage.Scope{ProjectID: 1})
@@ -320,7 +320,7 @@ func TestTransitionMembership_RevokeRemovesRole(t *testing.T) {
 	store.On("ClearProjectSecretOwnership", ctx, uint(2), uint(1)).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	out, err := c.TransitionMembership(ctx, 1, 50, MembershipRevoked, 9)
+	out, err := c.TransitionMembership(ctx, 1, 50, MembershipRevoked, 9, false)
 	require.NoError(t, err)
 	assert.Equal(t, MembershipRevoked, out.State)
 	store.AssertCalled(t, "RemoveAllProjectRoleGrants", ctx, uint(2), uint(1))
@@ -359,7 +359,7 @@ func TestTransitionMembership_RevokeRefusedForLastAdmin_RevertsAndReturnsError(t
 	}), MembershipRevoked).Return(true, nil).Once()
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
-	out, err := c.TransitionMembership(ctx, 1, 50, MembershipRevoked, 9)
+	out, err := c.TransitionMembership(ctx, 1, 50, MembershipRevoked, 9, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to remove role grant on revocation")
 	assert.Nil(t, out)

--- a/internal/core/oidc.go
+++ b/internal/core/oidc.go
@@ -266,7 +266,7 @@ func (c *KeyorixCore) CreateOIDCBinding(ctx context.Context, projectID, machineI
 	if strings.TrimSpace(issuer) == "" || strings.TrimSpace(subject) == "" {
 		return nil, fmt.Errorf("issuer and subject are required")
 	}
-	if err := c.requireAuthorityForRole(ctx, actorID, 0, "system_admin"); err != nil {
+	if err := c.requireAdminAuthorityAt(ctx, actorID, 0); err != nil {
 		return nil, fmt.Errorf("binding an OIDC subject requires install-wide admin authority: %w", err)
 	}
 	// Surface operator typos early: a binding to an issuer Keyorix doesn't trust

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -22,12 +22,14 @@ func (c *KeyorixCore) ListProjectMembers(ctx context.Context, projectID uint) ([
 
 // AddProjectMember assigns roleName to userID at the project scope. actorID is the
 // acting principal (0 = no authenticated principal, e.g. a system-driven onboarding
-// transition); see AssignUserRole for actorID semantics — including the
+// transition); actorIsMachine distinguishes a machine-credential-authenticated
+// caller (also actorID==0) from that true unauthenticated case — see
+// AssignUserRole for actorID semantics — including the
 // requireGranterHoldsRolePermissions escalation-by-proxy ceiling (#93/#107/#141)
 // AssignUserRole applies to every grant, so a non-admin roles.assign holder cannot
 // mint a project_admin (or any role bundling permissions they don't hold) through
 // this direct entry point.
-func (c *KeyorixCore) AddProjectMember(ctx context.Context, actorID, projectID, userID uint, roleName string) error {
+func (c *KeyorixCore) AddProjectMember(ctx context.Context, actorID, projectID, userID uint, roleName string, actorIsMachine bool) error {
 	if err := c.domainAllowedForUser(ctx, userID); err != nil {
 		return err
 	}
@@ -35,13 +37,13 @@ func (c *KeyorixCore) AddProjectMember(ctx context.Context, actorID, projectID, 
 	if err != nil {
 		return fmt.Errorf("unknown role %q: %w", roleName, err)
 	}
-	return c.AssignUserRole(ctx, actorID, userID, role.ID, Scope{ProjectID: projectID})
+	return c.AssignUserRole(ctx, actorID, userID, role.ID, Scope{ProjectID: projectID}, actorIsMachine)
 }
 
 // SetProjectMemberRole replaces the user's role(s) at the project scope with
 // roleName, adding the member if they had none. See AddProjectMember for actorID
 // semantics.
-func (c *KeyorixCore) SetProjectMemberRole(ctx context.Context, actorID, projectID, userID uint, roleName string) error {
+func (c *KeyorixCore) SetProjectMemberRole(ctx context.Context, actorID, projectID, userID uint, roleName string, actorIsMachine bool) error {
 	role, err := c.storage.GetRoleByName(ctx, roleName)
 	if err != nil {
 		return fmt.Errorf("unknown role %q: %w", roleName, err)
@@ -86,7 +88,7 @@ func (c *KeyorixCore) SetProjectMemberRole(ctx context.Context, actorID, project
 		if hasTarget {
 			return nil
 		}
-		return c.AssignUserRole(ctx, actorID, userID, role.ID, scope)
+		return c.AssignUserRole(ctx, actorID, userID, role.ID, scope, actorIsMachine)
 	})
 }
 

--- a/internal/core/project_members_test.go
+++ b/internal/core/project_members_test.go
@@ -45,7 +45,7 @@ func TestProjectMemberLifecycle(t *testing.T) {
 	grantGlobalAdmin(t, st, actor)
 
 	// Add as project_viewer.
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer", false))
 	members, err = c.ListProjectMembers(ctx, proj)
 	require.NoError(t, err)
 	require.Len(t, members, 1)
@@ -53,10 +53,10 @@ func TestProjectMemberLifecycle(t *testing.T) {
 	assert.Equal(t, "project_viewer", members[0].RoleName)
 
 	// Adding the same role again is a conflict.
-	require.Error(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
+	require.Error(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer", false))
 
 	// Change role to project_developer — replaces, doesn't accumulate.
-	require.NoError(t, c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_developer"))
+	require.NoError(t, c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_developer", false))
 	members, err = c.ListProjectMembers(ctx, proj)
 	require.NoError(t, err)
 	require.Len(t, members, 1, "member should have exactly one project role after change")
@@ -82,7 +82,7 @@ func TestAddProjectMemberUnknownRole(t *testing.T) {
 	ctx := context.Background()
 	u, err := st.CreateUser(ctx, &models.User{Username: "bob", Email: "bob@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.Error(t, c.AddProjectMember(ctx, 99, 1, u.ID, "no_such_role"))
+	require.Error(t, c.AddProjectMember(ctx, 99, 1, u.ID, "no_such_role", false))
 }
 
 // ADR-022's domain allowlist previously only gated the email-based
@@ -100,7 +100,7 @@ func TestAddProjectMember_RejectsDisallowedDomain(t *testing.T) {
 	u, err := st.CreateUser(ctx, &models.User{Username: "mallory", Email: "mallory@evil.com", IsActive: true})
 	require.NoError(t, err)
 
-	err = c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer")
+	err = c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not on the allowlist")
 
@@ -123,7 +123,7 @@ func TestSetProjectMemberRole_RejectsDisallowedDomainForNewMember(t *testing.T) 
 	u, err := st.CreateUser(ctx, &models.User{Username: "trent", Email: "trent@evil.com", IsActive: true})
 	require.NoError(t, err)
 
-	err = c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_viewer")
+	err = c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_viewer", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not on the allowlist")
 }
@@ -140,12 +140,12 @@ func TestSetProjectMemberRole_AllowsRoleChangeForExistingMemberRegardlessOfDomai
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "peggy", Email: "peggy@evil.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer", false))
 
 	// The allowlist is only turned on AFTER peggy already joined.
 	c.SetMembershipDomainAllowlist([]string{"allowed.com"})
 
-	require.NoError(t, c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_developer"))
+	require.NoError(t, c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_developer", false))
 	members, err := c.ListProjectMembers(ctx, proj)
 	require.NoError(t, err)
 	require.Len(t, members, 1)
@@ -166,7 +166,7 @@ func TestProjectMemberGrantIsRBACAudited(t *testing.T) {
 	u, err := st.CreateUser(ctx, &models.User{Username: "carol", Email: "carol@example.com", IsActive: true})
 	require.NoError(t, err)
 
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer", false))
 
 	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
 	require.NoError(t, err)
@@ -216,7 +216,7 @@ func TestRemoveProjectMember_RevokesEnvironmentScopedGrantToo(t *testing.T) {
 	require.NoError(t, err)
 
 	// Project-level membership (what the Members UI shows)...
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_developer"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_developer", false))
 	// ...plus a SEPARATE environment-scoped grant (e.g. "prod-only access"),
 	// created the way POST /user-roles would (gated by GLOBAL roles.assign).
 	require.NoError(t, st.AssignRole(ctx, u.ID, role.ID, storage.Scope{ProjectID: proj, EnvironmentID: prodEnv}))
@@ -252,7 +252,7 @@ func TestRemoveProjectMember_RefusesLastAdmin(t *testing.T) {
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "dave", Email: "dave@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin", false))
 
 	err = c.RemoveProjectMember(ctx, actor, proj, u.ID)
 	require.Error(t, err)
@@ -276,9 +276,9 @@ func TestSetProjectMemberRole_RefusesLastAdminDemotion(t *testing.T) {
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "erin", Email: "erin@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin", false))
 
-	err = c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_viewer")
+	err = c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_viewer", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "last administrator")
 
@@ -301,8 +301,8 @@ func TestRemoveProjectMember_AllowsNonLastAdmin(t *testing.T) {
 	require.NoError(t, err)
 	u2, err := st.CreateUser(ctx, &models.User{Username: "grace", Email: "grace@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u1.ID, "project_admin"))
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u2.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u1.ID, "project_admin", false))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u2.ID, "project_admin", false))
 
 	// Removing one of two admins succeeds — the other keeps the project governed.
 	require.NoError(t, c.RemoveProjectMember(ctx, actor, proj, u1.ID))
@@ -341,7 +341,7 @@ func TestRemoveProjectMember_RevokesSecretACLGrants(t *testing.T) {
 	// Create a user and add them to the project.
 	u, err := st.CreateUser(ctx, &models.User{Username: "ivy", Email: "ivy@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer", false))
 
 	// Grant the user a per-secret ACL on the secret.
 	require.NoError(t, c.GrantSecretACL(ctx, actor, sec.ID, u.ID, []string{"secrets.read"}))
@@ -377,7 +377,7 @@ func TestRemoveProjectMember_NonAdminAlwaysRemovable(t *testing.T) {
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "henry", Email: "henry@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_viewer", false))
 
 	require.NoError(t, c.RemoveProjectMember(ctx, actor, proj, u.ID))
 	members, err := c.ListProjectMembers(ctx, proj)
@@ -404,7 +404,7 @@ func TestRemoveProjectMember_RefusesLastAdmin_EmptyAdminGroup(t *testing.T) {
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "ivan", Email: "ivan@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin", false))
 
 	adminRole, err := st.GetRoleByName(ctx, "project_admin")
 	require.NoError(t, err)
@@ -433,7 +433,7 @@ func TestRemoveProjectMember_RefusesLastAdmin_AllGroupMembersDeactivated(t *test
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "judy", Email: "judy@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin", false))
 
 	// Created active, then explicitly deactivated via UpdateUser: models.User.IsActive
 	// has a `gorm:"default:true"` tag, so GORM treats an explicit IsActive:false on
@@ -474,7 +474,7 @@ func TestRemoveProjectMember_RefusesLastAdmin_SoftDeletedAdminGroup(t *testing.T
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "karl", Email: "karl@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin", false))
 
 	member, err := st.CreateUser(ctx, &models.User{Username: "leo", Email: "leo@example.com", IsActive: true})
 	require.NoError(t, err)
@@ -508,7 +508,7 @@ func TestRemoveProjectMember_AllowsRemoval_WhenAdminGroupHasLiveMember(t *testin
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "mike", Email: "mike@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin", false))
 
 	member, err := st.CreateUser(ctx, &models.User{Username: "nancy", Email: "nancy@example.com", IsActive: true})
 	require.NoError(t, err)
@@ -540,7 +540,7 @@ func TestSetProjectMemberRole_RefusesLastAdminDemotion_EmptyAdminGroup(t *testin
 
 	u, err := st.CreateUser(ctx, &models.User{Username: "oscar", Email: "oscar@example.com", IsActive: true})
 	require.NoError(t, err)
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin", false))
 
 	adminRole, err := st.GetRoleByName(ctx, "project_admin")
 	require.NoError(t, err)
@@ -548,7 +548,7 @@ func TestSetProjectMemberRole_RefusesLastAdminDemotion_EmptyAdminGroup(t *testin
 	require.NoError(t, err)
 	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
 
-	err = c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_viewer")
+	err = c.SetProjectMemberRole(ctx, actor, proj, u.ID, "project_viewer", false)
 	require.Error(t, err, "an admin group with zero live members must not count as a surviving admin")
 	assert.Contains(t, err.Error(), "last administrator")
 

--- a/internal/core/project_scoped_group_admin_guard_test.go
+++ b/internal/core/project_scoped_group_admin_guard_test.go
@@ -65,7 +65,7 @@ func TestDeleteGroup_AllowsWhenAnotherProjectAdminExists(t *testing.T) {
 	require.NoError(t, c.AddUserToGroup(ctx, actor, false, u.ID, group.ID, 0))
 	// An independent, direct project_admin grant at the same project survives
 	// the group's deletion.
-	require.NoError(t, c.AddProjectMember(ctx, actor, proj, other.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, other.ID, "project_admin", false))
 
 	err = c.DeleteGroup(ctx, actor, group.ID)
 	require.NoError(t, err, "deleting the group is fine when another project admin survives")
@@ -104,7 +104,7 @@ func TestDeleteGroup_RefusesWhenGroupAdminsMultipleProjects(t *testing.T) {
 	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: projB}))
 	require.NoError(t, c.AddUserToGroup(ctx, actor, false, u.ID, group.ID, 0))
 	// projB has an independent survivor; projA does not.
-	require.NoError(t, c.AddProjectMember(ctx, actor, projB, other.ID, "project_admin"))
+	require.NoError(t, c.AddProjectMember(ctx, actor, projB, other.ID, "project_admin", false))
 
 	err = c.DeleteGroup(ctx, actor, group.ID)
 	require.Error(t, err, "must refuse when even ONE of the group's administered projects would be left with no admin")

--- a/internal/core/rbac.go
+++ b/internal/core/rbac.go
@@ -25,7 +25,7 @@ func (c *KeyorixCore) AssignUserRoleScoped(ctx context.Context, userEmail, roleN
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
-	if err := c.AssignUserRole(ctx, 0, user.ID, role.ID, scope); err != nil {
+	if err := c.AssignUserRole(ctx, 0, user.ID, role.ID, scope, false); err != nil {
 		return err
 	}
 	return nil

--- a/internal/core/rbac_audit_test.go
+++ b/internal/core/rbac_audit_test.go
@@ -29,7 +29,7 @@ func TestRBACAuditTrail_AssignAndRemove(t *testing.T) {
 	c := newRBACAuditCore(t)
 	ctx := context.Background()
 
-	require.NoError(t, c.AssignUserRole(ctx, 5, 10, 2, Scope{ProjectID: 3}))
+	require.NoError(t, c.AssignUserRole(ctx, 5, 10, 2, Scope{ProjectID: 3}, false))
 	require.NoError(t, c.RemoveUserRole(ctx, 5, 10, 2, Scope{ProjectID: 3}))
 
 	entries, total, err := c.ListRBACAuditLogs(ctx, 1, 50)
@@ -70,7 +70,7 @@ func TestRBACAuditTrail_EnvironmentIDRoundTrips(t *testing.T) {
 	c := newRBACAuditCore(t)
 	ctx := context.Background()
 
-	require.NoError(t, c.AssignUserRole(ctx, 5, 10, 2, Scope{ProjectID: 3, EnvironmentID: 7}))
+	require.NoError(t, c.AssignUserRole(ctx, 5, 10, 2, Scope{ProjectID: 3, EnvironmentID: 7}, false))
 
 	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestRBACAuditTrail_SystemActor(t *testing.T) {
 	c := newRBACAuditCore(t)
 	ctx := context.Background()
 
-	require.NoError(t, c.AssignUserRole(ctx, 0, 11, 4, Scope{}))
+	require.NoError(t, c.AssignUserRole(ctx, 0, 11, 4, Scope{}, false))
 
 	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
 	require.NoError(t, err)
@@ -107,13 +107,14 @@ func TestRBACAuditTrail_GroupRole(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(
 		&models.AuditEvent{}, &models.Group{}, &models.Role{}, &models.GroupRole{}, &models.SoDPolicy{},
+		&models.Permission{}, &models.RolePermission{},
 	))
 	require.NoError(t, db.Create(&models.Group{ID: 7, Name: "platform"}).Error)
 	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "editor"}).Error)
 	c := NewKeyorixCore(store.NewLocalStorage(db))
 	ctx := context.Background()
 
-	require.NoError(t, c.AssignRoleToGroup(ctx, 5, 7, 2, Scope{ProjectID: 3}))
+	require.NoError(t, c.AssignRoleToGroup(ctx, 5, 7, 2, Scope{ProjectID: 3}, false))
 
 	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
 	require.NoError(t, err)
@@ -174,9 +175,9 @@ func TestRBACAuditTrail_SetUserRolesEmitsPerChange(t *testing.T) {
 	ctx := context.Background()
 
 	// From {} to {1,2}: two assignments.
-	require.NoError(t, c.SetUserRoles(ctx, 9, 20, []uint{1, 2}, Scope{}))
+	require.NoError(t, c.SetUserRoles(ctx, 9, 20, []uint{1, 2}, Scope{}, false))
 	// From {1,2} to {2,3}: remove 1, add 3.
-	require.NoError(t, c.SetUserRoles(ctx, 9, 20, []uint{2, 3}, Scope{}))
+	require.NoError(t, c.SetUserRoles(ctx, 9, 20, []uint{2, 3}, Scope{}, false))
 
 	entries, _, err := c.ListRBACAuditLogs(ctx, 1, 50)
 	require.NoError(t, err)

--- a/internal/core/rbac_grant_ceiling_test.go
+++ b/internal/core/rbac_grant_ceiling_test.go
@@ -23,7 +23,7 @@ func TestAssignUserRole_RequiresActorHoldRolePermissions(t *testing.T) {
 
 	const attacker = uint(9) // holds roles.assign in the real exploit (irrelevant here — no roles at all)
 	const target = uint(10)
-	err := c.AssignUserRole(ctx, attacker, target, 2, Scope{ProjectID: 3})
+	err := c.AssignUserRole(ctx, attacker, target, 2, Scope{ProjectID: 3}, false)
 	require.Error(t, err, "a roles.assign holder must not grant a role bundling a permission they don't hold themselves")
 	assert.Contains(t, err.Error(), "do not hold permission")
 
@@ -51,7 +51,7 @@ func TestAssignUserRole_CannotGrantToThirdPartyEither(t *testing.T) {
 	const victim = uint(20) // a third party, not the attacker themselves
 	require.NoError(t, db.Create(&models.UserRole{UserID: attacker, RoleID: 3, ProjectID: 3}).Error)
 
-	err := c.AssignUserRole(ctx, attacker, victim, 2, Scope{ProjectID: 3})
+	err := c.AssignUserRole(ctx, attacker, victim, 2, Scope{ProjectID: 3}, false)
 	require.Error(t, err, "holding roles.assign alone must not be enough to grant a role bundling secrets.delete")
 	assert.Contains(t, err.Error(), "do not hold permission")
 }
@@ -73,12 +73,12 @@ func TestAssignUserRole_ScopedHolderCannotGrantAtBroaderScope(t *testing.T) {
 	// attacker holds secrets.delete only at project 3, not globally.
 	require.NoError(t, db.Create(&models.UserRole{UserID: attacker, RoleID: 3, ProjectID: 3}).Error)
 
-	err := c.AssignUserRole(ctx, attacker, target, 2, Scope{}) // global grant attempt
+	err := c.AssignUserRole(ctx, attacker, target, 2, Scope{}, false) // global grant attempt
 	require.Error(t, err, "a project-scoped holder must not grant the role globally")
 	assert.Contains(t, err.Error(), "do not hold permission")
 
 	// The SAME grant at the project scope they actually hold the permission at succeeds.
-	require.NoError(t, c.AssignUserRole(ctx, attacker, target, 2, Scope{ProjectID: 3}))
+	require.NoError(t, c.AssignUserRole(ctx, attacker, target, 2, Scope{ProjectID: 3}, false))
 }
 
 // An actor who genuinely holds every bundled permission (directly, at an
@@ -100,7 +100,7 @@ func TestAssignUserRole_HolderMayGrantRoleTheyQualifyFor(t *testing.T) {
 	const target = uint(10)
 	require.NoError(t, db.Create(&models.UserRole{UserID: holder, RoleID: 3}).Error) // global grant
 
-	require.NoError(t, c.AssignUserRole(ctx, holder, target, 2, Scope{ProjectID: 3}))
+	require.NoError(t, c.AssignUserRole(ctx, holder, target, 2, Scope{ProjectID: 3}, false))
 
 	var count int64
 	require.NoError(t, db.Model(&models.UserRole{}).Where("user_id = ? AND role_id = ?", target, 2).Count(&count).Error)
@@ -123,7 +123,7 @@ func TestAssignUserRole_AdminBypassesCeiling(t *testing.T) {
 	const target = uint(10)
 	require.NoError(t, db.Create(&models.UserRole{UserID: admin, RoleID: 1}).Error)
 
-	require.NoError(t, c.AssignUserRole(ctx, admin, target, 2, Scope{ProjectID: 3}))
+	require.NoError(t, c.AssignUserRole(ctx, admin, target, 2, Scope{ProjectID: 3}, false))
 }
 
 // actorID 0 is the established "system" pseudo-actor for genuinely non-attacker-
@@ -138,7 +138,7 @@ func TestAssignUserRole_SystemActorBypassesCeiling(t *testing.T) {
 	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 1}).Error)
 
 	const target = uint(10)
-	require.NoError(t, c.AssignUserRole(ctx, 0, target, 2, Scope{ProjectID: 3}))
+	require.NoError(t, c.AssignUserRole(ctx, 0, target, 2, Scope{ProjectID: 3}, false))
 
 	var count int64
 	require.NoError(t, db.Model(&models.UserRole{}).Where("user_id = ? AND role_id = ?", target, 2).Count(&count).Error)
@@ -154,5 +154,5 @@ func TestAssignUserRole_EmptyRoleAlwaysGrantable(t *testing.T) {
 
 	const actor = uint(9) // holds nothing
 	const target = uint(10)
-	require.NoError(t, c.AssignUserRole(ctx, actor, target, 2, Scope{ProjectID: 3}))
+	require.NoError(t, c.AssignUserRole(ctx, actor, target, 2, Scope{ProjectID: 3}, false))
 }

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -169,20 +169,20 @@ func (c *KeyorixCore) GetGroupRoleGrants(ctx context.Context, groupID uint) ([]*
 }
 
 // AssignRoleToGroup verifies both exist, applies the escalation-by-proxy ceiling
-// (requireAuthorityForRole — granting a group an admin role inherits to every
-// member, so it is gated exactly like a direct user grant), then assigns the role
-// at scope and records an RBAC audit event. actorID is the acting principal (0 =
-// none; requireAuthorityForRole refuses an admin grant for an unauthenticated
-// actor, since this path is only ever reached via an authenticated HTTP request).
-func (c *KeyorixCore) AssignRoleToGroup(ctx context.Context, actorID, groupID, roleID uint, scope Scope) error {
+// (requireGranterHoldsRolePermissions — granting a group a role inherits to every
+// member, so it is gated exactly like a direct user grant, and by the role's real
+// bundled permissions rather than only its name), then assigns the role at scope
+// and records an RBAC audit event. actorID is the acting principal (0 = none, the
+// trusted system pseudo-actor); actorIsMachine distinguishes a machine-credential
+// caller (also actorID==0) from that true unauthenticated case.
+func (c *KeyorixCore) AssignRoleToGroup(ctx context.Context, actorID, groupID, roleID uint, scope Scope, actorIsMachine bool) error {
 	if _, err := c.storage.GetGroup(ctx, groupID); err != nil {
 		return fmt.Errorf("group not found: %w", err)
 	}
-	role, err := c.storage.GetRole(ctx, roleID)
-	if err != nil {
+	if _, err := c.storage.GetRole(ctx, roleID); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRoleNotFound", nil), err)
 	}
-	if err := c.requireAuthorityForRole(ctx, actorID, scope.ProjectID, role.Name); err != nil {
+	if err := c.requireGranterHoldsRolePermissions(ctx, actorID, roleID, scope, actorIsMachine); err != nil {
 		return err
 	}
 	// #1646: see AssignUserRole's identical WithNamedLock use.
@@ -299,7 +299,9 @@ func (c *KeyorixCore) GetUserPermissionsByID(ctx context.Context, userID uint) (
 // given scope. Only assignments at exactly that scope are considered: roles
 // present there but not in roleIDs are removed; roles in roleIDs not already
 // assigned there are added. Assignments at other scopes are left untouched.
-func (c *KeyorixCore) SetUserRoles(ctx context.Context, actorID, userID uint, roleIDs []uint, scope Scope) error {
+// actorIsMachine distinguishes a machine-credential-authenticated caller (also
+// actorID==0) from the true actorID==0 system pseudo-actor.
+func (c *KeyorixCore) SetUserRoles(ctx context.Context, actorID, userID uint, roleIDs []uint, scope Scope, actorIsMachine bool) error {
 	current, err := c.storage.GetUserRoleIDsExact(ctx, userID, scope)
 	if err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
@@ -321,7 +323,7 @@ func (c *KeyorixCore) SetUserRoles(ctx context.Context, actorID, userID uint, ro
 	}
 	for _, id := range roleIDs {
 		if !currentSet[id] {
-			if err := c.AssignUserRole(ctx, actorID, userID, id, scope); err != nil {
+			if err := c.AssignUserRole(ctx, actorID, userID, id, scope, actorIsMachine); err != nil {
 				return err
 			}
 		}
@@ -345,15 +347,16 @@ func sodGrantLockKey(principalType string, principalID uint) string {
 // admin-rank-ceiling check on the grant (#93/#107/#141), and requireNoSoDViolation
 // (sod.go) for the separation-of-duties preventive gate (#419).
 //
-// Passes actorIsMachine=false unconditionally to requireGranterHoldsRolePermissions
-// -- unlike AssignUserRoleWithExpiry, this permanent-grant path has no caller
-// fixed as part of #1542, so its actorID==0 exemption behavior is left
-// unchanged here. Several of ITS OWN callers (AddProjectMember/
-// SetProjectMemberRole, the AssignRole gRPC/HTTP endpoints) are reachable by
-// a general machine identity the same way #1545 found for other functions --
-// tracked as a sibling finding, not fixed in this pass.
-func (c *KeyorixCore) AssignUserRole(ctx context.Context, actorID, userID, roleID uint, scope Scope) error {
-	if err := c.requireGranterHoldsRolePermissions(ctx, actorID, roleID, scope, false); err != nil {
+// actorIsMachine distinguishes a machine-credential-authenticated caller
+// (also actorID==0, per server/middleware/auth.go) from the true actorID==0
+// "system" pseudo-actor -- see requireGranterHoldsRolePermissions's doc
+// comment. Every caller of this permanent-grant path is reachable by a
+// general machine identity the same way #1545 found for AssignPermissionToRole
+// (AddProjectMember/SetProjectMemberRole, the AssignRole gRPC/HTTP endpoints);
+// this closes that sibling instance by threading the real value through
+// instead of hardcoding false.
+func (c *KeyorixCore) AssignUserRole(ctx context.Context, actorID, userID, roleID uint, scope Scope, actorIsMachine bool) error {
+	if err := c.requireGranterHoldsRolePermissions(ctx, actorID, roleID, scope, actorIsMachine); err != nil {
 		return err
 	}
 	// #1646: the check-then-write below must be serialized across every replica of

--- a/internal/core/sod_preventive_gate_external_test.go
+++ b/internal/core/sod_preventive_gate_external_test.go
@@ -47,7 +47,7 @@ func TestAssignUserRole_BlocksNewSoDViolation(t *testing.T) {
 	// newly completes the policy, so the grant must be refused. actorID 0 is the
 	// system pseudo-actor (bypasses the unrelated grant-ceiling check — #93/#107/
 	// #141 — so only the SoD gate under test is exercised).
-	err = h.CoreService.AssignUserRole(ctx, 0, 10, 3, core.Scope{})
+	err = h.CoreService.AssignUserRole(ctx, 0, 10, 3, core.Scope{}, false)
 	require.Error(t, err, "granting editor must be blocked: it would create a new SoD violation")
 	assert.Contains(t, err.Error(), "separation-of-duties")
 
@@ -74,7 +74,7 @@ func TestAssignUserRole_AllowsNonViolatingGrant(t *testing.T) {
 	// auditor (audit.read, audit.admin, system.read, users.read, roles.read) shares
 	// no permission with either side of the policy beyond what bob already holds
 	// alone — granting it completes nothing.
-	err = h.CoreService.AssignUserRole(ctx, 0, 11, 5, core.Scope{})
+	err = h.CoreService.AssignUserRole(ctx, 0, 11, 5, core.Scope{}, false)
 	require.NoError(t, err, "a non-violating grant must succeed unimpeded")
 
 	ids, gerr := h.Storage.GetUserRoleIDsAt(ctx, 11, storage.Scope{})
@@ -163,7 +163,7 @@ func TestAssignRoleToGroup_BlocksNewSoDViolationForMember(t *testing.T) {
 
 	// Granting editor (secrets.write) to the GROUP would complete the policy for
 	// erin, its member.
-	err = h.CoreService.AssignRoleToGroup(ctx, 1, 30, 3, core.Scope{})
+	err = h.CoreService.AssignRoleToGroup(ctx, 1, 30, 3, core.Scope{}, false)
 	require.Error(t, err, "the group grant must be blocked on behalf of the member it would newly violate for")
 	assert.Contains(t, err.Error(), "separation-of-duties")
 
@@ -191,7 +191,7 @@ func TestAssignRoleToGroup_AllowsNonViolatingGrant(t *testing.T) {
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
-	err = h.CoreService.AssignRoleToGroup(ctx, 1, 31, 5, core.Scope{}) // auditor: no conflict
+	err = h.CoreService.AssignRoleToGroup(ctx, 1, 31, 5, core.Scope{}, false) // auditor: no conflict
 	require.NoError(t, err, "a non-violating group grant must succeed unimpeded")
 
 	roles, gerr := h.CoreService.GetGroupRoles(ctx, 31)
@@ -225,7 +225,7 @@ func TestCreateUserWithAssignments_BlocksNewSoDViolationAcrossGrantSet(t *testin
 	// ("default") is already seeded by testhelper.seedTestData.
 	_, err = h.CoreService.CreateUserWithAssignments(ctx, &core.CreateUserRequest{
 		Username: "grace", Email: "grace@test.com", DisplayName: "Grace", Password: "Sup3rS3cret!Pass",
-	}, "viewer", []core.ProjectAssignment{{ProjectID: 1, Role: "editor"}}, 0)
+	}, "viewer", []core.ProjectAssignment{{ProjectID: 1, Role: "editor"}}, 0, false)
 	require.Error(t, err, "the combined grant set must be refused for completing an SoD policy")
 	assert.Contains(t, err.Error(), "separation-of-duties")
 
@@ -248,7 +248,7 @@ func TestCreateUserWithAssignments_AllowsNonViolatingGrantSet(t *testing.T) {
 	// Project 1 ("default") is already seeded by testhelper.seedTestData.
 	created, err := h.CoreService.CreateUserWithAssignments(ctx, &core.CreateUserRequest{
 		Username: "heidi", Email: "heidi@test.com", DisplayName: "Heidi", Password: "Sup3rS3cret!Pass",
-	}, "viewer", []core.ProjectAssignment{{ProjectID: 1, Role: "auditor"}}, 0)
+	}, "viewer", []core.ProjectAssignment{{ProjectID: 1, Role: "auditor"}}, 0, false)
 	require.NoError(t, err, "a non-violating grant set must succeed unimpeded")
 	assert.NotZero(t, created.ID)
 }
@@ -306,7 +306,7 @@ func TestAssignUserRole_AdminBypassNotBlockedBySoD(t *testing.T) {
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "read-vs-write", "", "secrets.read", "secrets.write")
 	require.NoError(t, err)
 
-	err = h.CoreService.AssignUserRole(ctx, 0, 17, 3, core.Scope{}) // editor
+	err = h.CoreService.AssignUserRole(ctx, 0, 17, 3, core.Scope{}, false) // editor
 	require.NoError(t, err, "granting a role to an existing admin-bypass holder must not be refused by the SoD gate")
 }
 
@@ -335,7 +335,7 @@ func TestAssignUserRole_ProjectScopedAdminNotExemptFromSoD(t *testing.T) {
 	_, err := h.CoreService.CreateSoDPolicy(ctx, 1, "write-vs-audit-admin", "", "secrets.write", "audit.admin")
 	require.NoError(t, err)
 
-	err = h.CoreService.AssignUserRole(ctx, 0, 18, 5, core.Scope{}) // auditor
+	err = h.CoreService.AssignUserRole(ctx, 0, 18, 5, core.Scope{}, false) // auditor
 	require.Error(t, err, "a project-scoped admin must still be blocked by the SoD gate, unlike a true global admin")
 	assert.Contains(t, err.Error(), "separation-of-duties")
 }

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -215,7 +215,7 @@ const maxUserCreateAssignments = 500
 // any custom role, so without this check a non-admin roles.assign holder could
 // mint a brand-new super_admin account directly — no invite/accept step an admin
 // could notice or revoke in between, unlike InviteGlobal.
-func (c *KeyorixCore) CreateUserWithAssignments(ctx context.Context, req *CreateUserRequest, systemRole string, assignments []ProjectAssignment, actorID uint) (*models.User, error) {
+func (c *KeyorixCore) CreateUserWithAssignments(ctx context.Context, req *CreateUserRequest, systemRole string, assignments []ProjectAssignment, actorID uint, actorIsMachine bool) (*models.User, error) {
 	if len(assignments) > maxUserCreateAssignments {
 		return nil, fmt.Errorf("assignments exceeds the maximum batch size of %d", maxUserCreateAssignments)
 	}
@@ -239,14 +239,16 @@ func (c *KeyorixCore) CreateUserWithAssignments(ctx context.Context, req *Create
 	}
 	// Escalation-by-proxy guard (#480), mirroring InviteGlobal (#231): a global
 	// system role is the most powerful grant this flow can mint, so it needs the
-	// same admin-authority ceiling check, at global scope (projectID 0).
-	if err := c.requireAuthorityForRole(ctx, actorID, 0, sysRole); err != nil {
+	// same ceiling check requireGranterHoldsRolePermissions applies everywhere
+	// else — the actor's real bundled permissions, not just the role's name —
+	// at global scope (projectID 0).
+	if err := c.requireGranterHoldsRolePermissions(ctx, actorID, sr.ID, Scope{}, actorIsMachine); err != nil {
 		return nil, err
 	}
 	addRoleGrant(&grants, seen, sr.ID, 0)
 
 	for _, a := range assignments {
-		g, err := c.resolveProjectRoleGrant(ctx, actorID, a)
+		g, err := c.resolveProjectRoleGrant(ctx, actorID, actorIsMachine, a)
 		if err != nil {
 			return nil, err
 		}
@@ -298,7 +300,7 @@ func addRoleGrant(grants *[]storage.RoleGrant, seen map[[2]uint]bool, roleID, pr
 
 // resolveProjectRoleGrant validates and resolves a single ProjectAssignment into a
 // storage.RoleGrant, enforcing the same authority-ceiling check as InviteGlobal.
-func (c *KeyorixCore) resolveProjectRoleGrant(ctx context.Context, actorID uint, a ProjectAssignment) (storage.RoleGrant, error) {
+func (c *KeyorixCore) resolveProjectRoleGrant(ctx context.Context, actorID uint, actorIsMachine bool, a ProjectAssignment) (storage.RoleGrant, error) {
 	if a.ProjectID == 0 || a.Role == "" {
 		return storage.RoleGrant{}, fmt.Errorf("%s: each project assignment needs a project_id and a role", i18n.T("ErrorValidation", nil))
 	}
@@ -309,7 +311,7 @@ func (c *KeyorixCore) resolveProjectRoleGrant(ctx context.Context, actorID uint,
 	if err != nil {
 		return storage.RoleGrant{}, fmt.Errorf("%s: unknown role %q", i18n.T("ErrorValidation", nil), a.Role)
 	}
-	if err := c.requireAuthorityForRole(ctx, actorID, a.ProjectID, a.Role); err != nil {
+	if err := c.requireGranterHoldsRolePermissions(ctx, actorID, r.ID, Scope{ProjectID: a.ProjectID}, actorIsMachine); err != nil {
 		return storage.RoleGrant{}, err
 	}
 	return storage.RoleGrant{RoleID: r.ID, Scope: storage.Scope{ProjectID: a.ProjectID}}, nil
@@ -327,17 +329,16 @@ func (c *KeyorixCore) resolveProjectRoleGrant(ctx context.Context, actorID uint,
 // and, unlike the human-facing path, never has a plaintext password or role
 // names to work with, only role IDs. Kept in core rather than duplicated in
 // the handler so the ceiling+SoD logic is defined exactly once (#G79).
-func (c *KeyorixCore) ValidateRoleGrantAuthority(ctx context.Context, actorID uint, grants []storage.RoleGrant) error {
+func (c *KeyorixCore) ValidateRoleGrantAuthority(ctx context.Context, actorID uint, actorIsMachine bool, grants []storage.RoleGrant) error {
 	if len(grants) > maxUserCreateAssignments {
 		return fmt.Errorf("%s: grants exceeds the maximum batch size of %d", i18n.T("ErrorValidation", nil), maxUserCreateAssignments)
 	}
 	roleIDs := make([]uint, 0, len(grants))
 	for _, g := range grants {
-		role, err := c.storage.GetRole(ctx, g.RoleID)
-		if err != nil {
+		if _, err := c.storage.GetRole(ctx, g.RoleID); err != nil {
 			return fmt.Errorf("%s: unknown role id %d", i18n.T("ErrorValidation", nil), g.RoleID)
 		}
-		if err := c.requireAuthorityForRole(ctx, actorID, g.Scope.ProjectID, role.Name); err != nil {
+		if err := c.requireGranterHoldsRolePermissions(ctx, actorID, g.RoleID, Scope{ProjectID: g.Scope.ProjectID, EnvironmentID: g.Scope.EnvironmentID}, actorIsMachine); err != nil {
 			return err
 		}
 		roleIDs = append(roleIDs, g.RoleID)

--- a/internal/core/users_atomic_ceiling_test.go
+++ b/internal/core/users_atomic_ceiling_test.go
@@ -1,6 +1,10 @@
 // users_atomic_ceiling_test.go — #480: CreateUserWithAssignments is InviteGlobal's
 // sibling (both mint a system role plus a set of project assignments in one call),
-// and needed the identical escalation-by-proxy ceiling (requireAuthorityForRole).
+// and needed the identical escalation-by-proxy ceiling. FIX-1 rerouted this ceiling
+// from requireAuthorityForRole (name-based: only fired for the 4 canonical
+// admin-tier role names) to requireGranterHoldsRolePermissions (derives the ceiling
+// from the role's real bundled permissions) -- the error text below changed to
+// match ("cannot grant this role: you do not hold permission ... yourself").
 // These tests mirror TestInviteGlobal_RejectsNonAdminGranting* (#231) exactly.
 package core
 
@@ -27,9 +31,9 @@ func TestCreateUserWithAssignments_RejectsNonAdminGrantingGlobalAdminRole(t *tes
 
 	_, err := c.CreateUserWithAssignments(ctx, &CreateUserRequest{
 		Username: "cua-mallory", Email: "cua-mallory@acme.io", Password: "Qr7#Kp2$Lm5@Vn9!",
-	}, "admin", nil, nonAdminID)
+	}, "admin", nil, nonAdminID, false)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only an administrator can grant")
+	assert.Contains(t, err.Error(), "do not hold permission")
 }
 
 // #480: the per-project assignments bundled into an atomic create must be
@@ -47,9 +51,9 @@ func TestCreateUserWithAssignments_RejectsNonAdminGrantingProjectAdminAssignment
 		Username: "cua-mallory-2", Email: "cua-mallory-2@acme.io", Password: "Qr7#Kp2$Lm5@Vn9!",
 	}, "system_viewer", []ProjectAssignment{
 		{ProjectID: proj.ID, Role: "project_admin"},
-	}, nonAdminID)
+	}, nonAdminID, false)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only an administrator can grant")
+	assert.Contains(t, err.Error(), "do not hold permission")
 }
 
 // #480 positive control: a genuinely admin actor can still mint an account with a
@@ -67,29 +71,38 @@ func TestCreateUserWithAssignments_AdminActorAllowed(t *testing.T) {
 		Username: "cua-newbie", Email: "cua-newbie@acme.io", Password: "Qr7#Kp2$Lm5@Vn9!",
 	}, "system_admin", []ProjectAssignment{
 		{ProjectID: proj.ID, Role: "project_admin"},
-	}, admin)
+	}, admin, false)
 	require.NoError(t, err)
 	assert.Equal(t, "cua-newbie", created.Username)
 }
 
 // #480 positive control: a non-admin actor CAN still atomically create a user with
-// a non-admin-tier system role and non-admin-tier project assignments — the ceiling
-// only bites on admin-tier grants (isAdminRoleName), so the common onboarding case
-// (e.g. a project_developer-holding manager provisioning another developer) is
-// unaffected.
+// roles the actor already holds every bundled permission of — the ceiling
+// (requireGranterHoldsRolePermissions) only bites when the grant would exceed the
+// actor's own standing, so the common onboarding case (a manager provisioning a
+// teammate with access no broader than their own) is unaffected. The actor is
+// seeded with BOTH project_developer (for the project assignment) and system_viewer
+// (for the global system-role grant) — under FIX-1's real permission-derived
+// ceiling, unlike the old name-based one, the actor must actually hold whatever
+// they're granting, even for a "non-admin-tier" role name.
 func TestCreateUserWithAssignments_NonAdminRoleAllowed(t *testing.T) {
 	c, st := newBootstrappedCore(t)
 	ctx := context.Background()
 
+	// project_developer is scoped to project 1 specifically — the ceiling checks
+	// the actor's OWN holdings at the SAME scope as the grant, so the project
+	// assignment below must target project 1 too, not a freshly created project
+	// the actor holds nothing on.
 	actor := seedUserWithRole(t, st, "cua-actor", "project_developer", storage.Scope{ProjectID: 1})
-	proj, err := st.CreateProject(ctx, &models.Project{Name: "cua-nonadmin-project"})
+	viewerRole, err := st.GetRoleByName(ctx, "system_viewer")
 	require.NoError(t, err)
+	require.NoError(t, st.AssignRole(ctx, actor, viewerRole.ID, storage.Scope{}))
 
 	created, err := c.CreateUserWithAssignments(ctx, &CreateUserRequest{
 		Username: "cua-teammate", Email: "cua-teammate@acme.io", Password: "Qr7#Kp2$Lm5@Vn9!",
 	}, "system_viewer", []ProjectAssignment{
-		{ProjectID: proj.ID, Role: "project_developer"},
-	}, actor)
+		{ProjectID: 1, Role: "project_developer"},
+	}, actor, false)
 	require.NoError(t, err)
 	assert.Equal(t, "cua-teammate", created.Username)
 }

--- a/server/grpc/interceptors/auth_test.go
+++ b/server/grpc/interceptors/auth_test.go
@@ -255,7 +255,7 @@ func TestAuthInterceptor_MachineTokenAuthenticatesAndUsesMachineRBAC(t *testing.
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(tok.PlainToken, "kx_machine_"))
 	// Grant the machine viewer (secrets.read) in project 2 only.
-	require.NoError(t, h.CoreService.AssignMachineRole(context.Background(), m.ID, 4, core.Scope{ProjectID: 2}, 1))
+	require.NoError(t, h.CoreService.AssignMachineRole(context.Background(), m.ID, 4, core.Scope{ProjectID: 2}, 1, false))
 
 	var captured context.Context
 	interceptor := AuthInterceptor(h.CoreService, false)
@@ -357,7 +357,7 @@ func TestAuthInterceptor_MachineTokenNetworkAllowlistOverGRPC(t *testing.T) {
 		AllowedCIDRs: []string{"10.0.0.0/8"},
 	})
 	require.NoError(t, err)
-	require.NoError(t, h.CoreService.AssignMachineRole(context.Background(), m.ID, 4, core.Scope{ProjectID: 2}, 1))
+	require.NoError(t, h.CoreService.AssignMachineRole(context.Background(), m.ID, 4, core.Scope{ProjectID: 2}, 1, false))
 
 	interceptor := AuthInterceptor(h.CoreService, false)
 

--- a/server/grpc/services/audit_service_test.go
+++ b/server/grpc/services/audit_service_test.go
@@ -258,7 +258,7 @@ func TestAuditService_GetRBACAuditLogs_ReturnsRoleChanges(t *testing.T) {
 	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "super_admin", BypassesPermissionChecks: true}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 0}).Error)
 	c := core.NewKeyorixCore(store.NewLocalStorage(db))
-	require.NoError(t, c.AssignUserRole(context.Background(), 5, 10, 2, core.Scope{ProjectID: 3}))
+	require.NoError(t, c.AssignUserRole(context.Background(), 5, 10, 2, core.Scope{ProjectID: 3}, false))
 
 	svc := NewAuditService(c)
 	resp, err := svc.GetRBACAuditLogs(auditCtx(), &pb.GetRBACAuditLogsRequest{})

--- a/server/grpc/services/coverage_s17_test.go
+++ b/server/grpc/services/coverage_s17_test.go
@@ -117,7 +117,7 @@ func TestMapUserError_Duplicate(t *testing.T) {
 }
 
 func TestMapUserError_AdministratorCanGrant(t *testing.T) {
-	err := mapUserError(errors.New("only an administrator can grant this role"))
+	err := mapUserError(errors.New("cannot grant this role: you do not hold permission \"system.write\" yourself"))
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }
 

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -251,7 +251,7 @@ func (s *RoleGRPCService) AssignRole(ctx context.Context, req *pb.AssignRoleRequ
 	if err := authorizeScoped(ctx, s.core, actor, "roles.assign", scope); err != nil {
 		return nil, err
 	}
-	if err := s.core.AssignUserRole(ctx, actor.UserID, uint(req.GetUserId()), uint(req.GetRoleId()), scope); err != nil {
+	if err := s.core.AssignUserRole(ctx, actor.UserID, uint(req.GetUserId()), uint(req.GetRoleId()), scope, actor.ActorKind() == core.ActorTypeMachine); err != nil {
 		return nil, mapRoleError(err)
 	}
 	return &pb.RoleAssignment{

--- a/server/grpc/services/user_service.go
+++ b/server/grpc/services/user_service.go
@@ -113,7 +113,7 @@ func (s *UserGRPCService) CreateUser(ctx context.Context, req *pb.CreateUserRequ
 		if req.GetPassword() == "" {
 			return nil, status.Error(codes.InvalidArgument, "password is required unless deliver_setup_link or generate_one_time_password is set")
 		}
-		u, err = s.core.CreateUserWithAssignments(ctx, coreReq, role, assignments, actor.UserID)
+		u, err = s.core.CreateUserWithAssignments(ctx, coreReq, role, assignments, actor.UserID, actor.ActorKind() == core.ActorTypeMachine)
 	}
 	if err != nil {
 		return nil, mapUserError(err)
@@ -294,7 +294,7 @@ func mapUserError(err error) error {
 		return status.Error(codes.NotFound, "user not found")
 	case strings.Contains(msg, "already exists"), strings.Contains(msg, "duplicate"):
 		return status.Error(codes.AlreadyExists, "a user with that username or email already exists")
-	case strings.Contains(msg, "administrator can grant"):
+	case strings.Contains(msg, "cannot grant this role"):
 		return status.Error(codes.PermissionDenied, "insufficient privileges to assign this role") // GRPC-003: was err.Error() — leaked internal role name
 	case strings.Contains(msg, "validation"), strings.Contains(msg, "required"), strings.Contains(msg, "invalid"), strings.Contains(msg, "must be"):
 		return status.Error(codes.InvalidArgument, "invalid request parameters") // GRPC-003: was err.Error() — leaked password policy thresholds

--- a/server/grpc/services/user_service_test.go
+++ b/server/grpc/services/user_service_test.go
@@ -136,11 +136,17 @@ func TestUserService_CreateUser_RoleGrantRequiresAssign(t *testing.T) {
 	t.Cleanup(h.Cleanup)
 
 	// A role that can create users but cannot assign roles — the realistic
-	// "user administrator" persona that the bug let escalate.
+	// "user administrator" persona that the bug let escalate. Every new user
+	// gets the default system_viewer role (system.read) whether or not the
+	// caller asks for one, so under FIX-1's permission-derived ceiling
+	// (requireGranterHoldsRolePermissions) a provisioner must hold system.read
+	// itself too, or even PLAIN user creation would be handing out a
+	// permission the actor doesn't have — the same escalation-by-proxy shape
+	// this test's explicit-role cases below are pinning, just implicit.
 	h.CreateTestRole(t, "user_provisioner", "Can create users, cannot assign roles", 50)
 	_, err := h.SqlDB.Exec(`INSERT OR IGNORE INTO role_permissions (role_id, permission_id)
 		SELECT r.id, p.id FROM roles r, permissions p
-		WHERE r.name = 'user_provisioner' AND p.name = 'users.write'`)
+		WHERE r.name = 'user_provisioner' AND p.name IN ('users.write', 'system.read')`)
 	require.NoError(t, err)
 	h.AssignUserRole(t, 8, 50, nil)
 

--- a/server/http/deployment_disclosure_family_test.go
+++ b/server/http/deployment_disclosure_family_test.go
@@ -56,7 +56,7 @@ func createAuditorToken(t *testing.T, c *core.KeyorixCore) string {
 	ctx := context.Background()
 	_, err := c.CreateUserWithAssignments(ctx, &core.CreateUserRequest{
 		Username: "family_auditor", Email: "family_auditor@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
-	}, "system_auditor", nil, 0)
+	}, "system_auditor", nil, 0, false)
 	require.NoError(t, err)
 	sess, _, err := c.Login(ctx, &core.LoginRequest{Username: "family_auditor", Password: "Qr7#Kp2$Lm5@Vn9!"})
 	require.NoError(t, err)

--- a/server/http/g80_triage_doc_closure_guard_test.go
+++ b/server/http/g80_triage_doc_closure_guard_test.go
@@ -99,7 +99,7 @@ var g80TriageClosureClaims = []g80ClosureClaim{
 	{label: "docs/g80-raw-storage-bypass-triage.md: PR #1558 (CreateInvitationProxy/UpdateInvitationProxy escalation-by-proxy bypass)",
 		sha: "28b52cfbeec5a1acd2bf2d81e32afb42328e4590",
 		marker: g80ClosureMarker{file: "server/http/handlers/invitations_proxy.go",
-			mustExist: "RequireAuthorityForRole"}},
+			mustExist: "RequireGranterHoldsRolePermissions"}},
 	{label: "docs/g80-raw-storage-bypass-triage.md: PR #1559 (SoD policy and risk-exception authority gaps)",
 		sha: "f83d63c63a03a6bedc79a4440eb84def3805a471",
 		marker: g80ClosureMarker{file: "internal/core/sod.go",

--- a/server/http/handlers/access_request_proxy.go
+++ b/server/http/handlers/access_request_proxy.go
@@ -305,7 +305,12 @@ func (h *CatalogHandler) UpdateAccessRequestProxy(w http.ResponseWriter, r *http
 			if role == "" {
 				role = existing.SuggestedRole
 			}
-			if err := h.coreService.RequireAuthorityForRole(r.Context(), resolverID, existing.ProjectID, role); err != nil {
+			roleModel, roleErr := h.coreService.Storage().GetRoleByName(r.Context(), role)
+			if roleErr != nil {
+				writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "unknown role: "+roleErr.Error())
+				return
+			}
+			if err := h.coreService.RequireGranterHoldsRolePermissions(r.Context(), resolverID, roleModel.ID, core.Scope{ProjectID: existing.ProjectID}, resolverType == core.ActorTypeMachine); err != nil {
 				writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", err.Error())
 				return
 			}

--- a/server/http/handlers/create_user_assignments_test.go
+++ b/server/http/handlers/create_user_assignments_test.go
@@ -28,7 +28,8 @@ func setupCreateUserAssignmentsTest(t *testing.T) (*UserHandler, *gorm.DB) {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.User{}, &models.UserRole{}, &models.Role{}, &models.Project{},
-		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Environment{}, &models.SoDPolicy{}))
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Environment{}, &models.SoDPolicy{},
+		&models.Permission{}, &models.RolePermission{}))
 	require.NoError(t, db.Create(&models.Role{Name: "system_viewer"}).Error)
 	require.NoError(t, db.Create(&models.Role{Name: "project_developer"}).Error)
 	require.NoError(t, db.Create(&models.Project{Name: "default"}).Error)

--- a/server/http/handlers/global_invitation_test.go
+++ b/server/http/handlers/global_invitation_test.go
@@ -30,6 +30,7 @@ func setupGlobalInvitationTest(t *testing.T) (*CatalogHandler, *gorm.DB) {
 		&models.ProjectInvitation{}, &models.SetupToken{}, &models.AuditEvent{},
 		// AuthorizePrincipal (the invite ceiling) resolves group-inherited roles too.
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Environment{},
+		&models.Permission{}, &models.RolePermission{},
 	))
 	require.NoError(t, db.Create(&models.Role{Name: "system_viewer"}).Error)
 	require.NoError(t, db.Create(&models.Role{Name: "system_auditor"}).Error)

--- a/server/http/handlers/groups_members.go
+++ b/server/http/handlers/groups_members.go
@@ -78,7 +78,7 @@ func (h *GroupHandler) AddGroupMember(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.Contains(err.Error(), "not found"):
 			sendError(w, "NotFound", "User or group not found", http.StatusNotFound, nil)
-		case strings.Contains(err.Error(), "only an administrator can grant"):
+		case strings.Contains(err.Error(), "cannot grant this role"):
 			sendError(w, "Forbidden", err.Error(), http.StatusForbidden, nil)
 		default:
 			sendError(w, "InternalError", "Failed to add group member", http.StatusInternalServerError, nil)

--- a/server/http/handlers/handlers_s19_test.go
+++ b/server/http/handlers/handlers_s19_test.go
@@ -24,6 +24,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,6 +39,7 @@ import (
 
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 )
@@ -784,6 +786,14 @@ func TestCreateMembershipProxy_MissingFields_S19(t *testing.T) {
 func TestCreateMembershipProxy_Success_S19(t *testing.T) {
 	cs := freshCoreS19(t)
 	h := NewCatalogHandler(cs)
+	// FIX-1's requireGranterHoldsRolePermissions ceiling resolves the granted
+	// role by ID (unlike the old name-based check), so it must exist even
+	// though this unauthenticated request (actorID 0) is exempt from the
+	// ceiling itself.
+	viewerName, err := identity.NewFoldedName("viewer")
+	require.NoError(t, err)
+	_, err = cs.Storage().CreateRole(context.Background(), viewerName, "test-only role")
+	require.NoError(t, err)
 	body, _ := json.Marshal(map[string]interface{}{
 		"project_id": 1,
 		"user_id":    1,

--- a/server/http/handlers/handlers_s21_dynamic_proxy_test.go
+++ b/server/http/handlers/handlers_s21_dynamic_proxy_test.go
@@ -242,6 +242,9 @@ func TestCreateMembershipProxy_Valid_S21(t *testing.T) {
 	require.NoError(t, db.Create(proj).Error)
 	user := &models.User{Username: "s21-pm-user", Email: "s21pm@example.com", AccountState: "active"}
 	require.NoError(t, db.Create(user).Error)
+	// FIX-1's requireGranterHoldsRolePermissions ceiling resolves the granted
+	// role by ID, so it must exist as a real row.
+	require.NoError(t, db.Create(&models.Role{Name: "member"}).Error)
 
 	wire := membershipProxyWire{
 		ProjectID: proj.ID,

--- a/server/http/handlers/handlers_s26_test.go
+++ b/server/http/handlers/handlers_s26_test.go
@@ -1410,6 +1410,9 @@ func TestUpdateAccessRequestProxy_HappyPath_S26(t *testing.T) {
 
 	proj := &models.Project{Name: "s26-update-ar-proj"}
 	require.NoError(t, db.Create(proj).Error)
+	// FIX-1's requireGranterHoldsRolePermissions ceiling resolves the granted
+	// role by ID, so it must exist as a real row.
+	require.NoError(t, db.Create(&models.Role{Name: "viewer"}).Error)
 	ar := &models.AccessRequest{
 		UserID:        1,
 		ProjectID:     proj.ID,

--- a/server/http/handlers/handlers_s30_test.go
+++ b/server/http/handlers/handlers_s30_test.go
@@ -159,17 +159,25 @@ func TestCountMachineIdentityCredentialsByClassificationProxy_DBError_S30(t *tes
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
+// FIX-1 moved this handler's role resolution (GetRoleByName) ahead of the
+// persist step, so a broken DB connection is now hit there first, not at
+// CreateProjectMembership -- and GetRoleByName's error path (project_memberships_proxy.go)
+// maps ANY resolution error, including a genuine storage failure, to 400
+// "unknown role", matching the same catch-all convention every other
+// GetRoleByName caller in this codebase already uses (e.g.
+// internal/core/invitations.go's InviteToProject: "unknown role %q: %w"
+// regardless of the underlying cause). This is a pre-existing, repo-wide
+// convention FIX-1 exposed here for the first time, not a new one introduced
+// by it; refining GetRoleByName's error taxonomy is a separate, broader
+// change out of this fix's scope.
 func TestCreateMembershipProxy_DBError_S30(t *testing.T) {
 	t.Parallel()
 	h := NewCatalogHandler(freshCoreBrokenS30(t))
-	// #1578: role must be non-admin so this reaches the broken-DB path this test
-	// is actually about, rather than being rejected earlier by
-	// RequireAuthorityForRole (this request has no authenticated actor at all).
 	body := bytes.NewBufferString(`{"project_id":1,"user_id":1,"role":"viewer","state":"active"}`)
 	req := httptest.NewRequest(http.MethodPost, "/", body)
 	w := httptest.NewRecorder()
 	h.CreateMembershipProxy(w, req)
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 // ── DashboardHandler ──────────────────────────────────────────────────────────

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -40,6 +40,25 @@ func newCatalogHandlerS4(t *testing.T) *CatalogHandler {
 	return NewCatalogHandler(newHandlerCoreS4(t))
 }
 
+// ensureS4TestRole idempotently creates roleName with no bundled permissions
+// in sharedS4Core -- a process-wide singleton reused across every s4/s5/s9
+// test (and across `-count=N` reruns), so a plain CreateRole call would
+// collide with the same role created by a different test. FIX-1's
+// requireGranterHoldsRolePermissions ceiling resolves a granted role by ID
+// (unlike the old name-based check it replaced), so tests that persist a
+// role grant now need the named role to exist as a real row even when the
+// caller is exempt from the ceiling itself (e.g. actorID 0).
+func ensureS4TestRole(t *testing.T, h *CatalogHandler, roleName string) {
+	t.Helper()
+	if _, err := h.coreService.Storage().GetRoleByName(context.Background(), roleName); err == nil {
+		return
+	}
+	folded, err := identity.NewFoldedName(roleName)
+	require.NoError(t, err)
+	_, err = h.coreService.Storage().CreateRole(context.Background(), folded, "test-only role")
+	require.NoError(t, err)
+}
+
 // ── access_request_proxy.go ───────────────────────────────────────────────────
 
 func TestValidAccessRequestTargetState(t *testing.T) {
@@ -1451,10 +1470,23 @@ func TestCreateSetupTokenProxy_InvitationAccept_RefusesEmailMismatch(t *testing.
 // regression: CreateUserWithRoleGrantsProxy previously called
 // storage.CreateUserWithRoleGrants directly, persisting whatever grants the
 // caller supplied with none of core.CreateUserWithAssignments's
-// escalation-ceiling check (requireAuthorityForRole). A caller with no admin
-// authority of its own (actorID 0 — no user context, matching an unauthenticated
-// or under-privileged system.write holder) must be refused when the grant set
-// includes an admin-tier role, and no user must be persisted.
+// escalation-ceiling check. A caller with no admin authority of its own must
+// be refused when the grant set includes an admin-tier role, and no user
+// must be persisted.
+//
+// FIX-1 rerouted this ceiling from requireAuthorityForRole (name-based: fired
+// unconditionally for actorID 0, no exemption) to requireGranterHoldsRolePermissions,
+// which has an EXPLICIT actorID==0-and-not-machine fast path (the trusted
+// local-CLI/embedded-caller convention, already relied on by other callers
+// since #1542). This handler is an HTTP /system route reachable only through
+// RequirePermission(permSystemWrite) — that middleware fails closed
+// (401 "User context not found") on a nil UserContext, so actorID(r) can
+// never resolve to 0-and-not-machine for a REAL caller reaching this code;
+// a raw unauthenticated request (as this test originally simulated by
+// calling the handler with no context at all) is not a state the deployed
+// router can produce here. The realistic unauthorized case per this test's
+// own original framing is an AUTHENTICATED caller who holds system.write
+// but no admin authority — simulated below with a genuine non-zero UserID.
 func TestCreateUserWithRoleGrantsProxy_RefusesUnauthorizedAdminGrant(t *testing.T) {
 	db := openHandlerTestDB(t)
 	require.NoError(t, i18n.InitializeForTesting())
@@ -1463,9 +1495,17 @@ func TestCreateUserWithRoleGrantsProxy_RefusesUnauthorizedAdminGrant(t *testing.
 	require.NoError(t, err)
 
 	require.NoError(t, db.Create(&models.Role{ID: 20, Name: "super_admin", BypassesPermissionChecks: true}).Error)
+	// The target role must bundle a real permission -- an admin-NAMED role
+	// with nothing bundled is trivially grantable by anyone under the new
+	// permission-derived ceiling (nothing to check), unlike production's real
+	// super_admin (BypassesPermissionChecks covers its OWN holder, not what a
+	// granter must hold to hand it out).
+	perm := &models.Permission{Name: "s4.super_admin.marker", Resource: "s4marker", Action: "write"}
+	require.NoError(t, db.Create(perm).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 20, PermissionID: perm.ID}).Error)
 
 	body := fmt.Sprintf(`{"username":"evil","email":"evil@example.com","password_hash":"$2a$10$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0","is_active":true,"account_state":"active","grants":[{"role_id":%d,"project_id":0}]}`, 20)
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req := withUserCtx(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)))
 	w := httptest.NewRecorder()
 	h.CreateUserWithRoleGrantsProxy(w, req)
 
@@ -4696,6 +4736,7 @@ func TestCreateInvitationProxy_MissingFields(t *testing.T) {
 
 func TestCreateInvitationProxy_HappyPath(t *testing.T) {
 	h := newCatalogHandlerS4(t)
+	ensureS4TestRole(t, h, "viewer")
 	body := `{"project_id":1,"email":"x@example.com","role":"viewer","state":"pending"}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	w := httptest.NewRecorder()
@@ -6084,6 +6125,7 @@ func TestResolveSecretNames_Empty(t *testing.T) {
 
 func TestUpdateInvitationProxy_HappyPath(t *testing.T) {
 	h := newCatalogHandlerS4(t)
+	ensureS4TestRole(t, h, "viewer")
 	// First create an invitation to update
 	createBody := `{"project_id":1,"email":"x@example.com","role":"viewer","state":"pending"}`
 	createReq := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(createBody))
@@ -10802,8 +10844,23 @@ func TestCatalogHandler_CreateAccessRequestProxy_HappyPath(t *testing.T) {
 
 func TestCatalogHandler_UpdateAccessRequestProxy_HappyPath(t *testing.T) {
 	h := newCatalogHandlerS4(t)
+	// FIX-1's requireGranterHoldsRolePermissions ceiling resolves the granted
+	// role by ID once the update transitions to "approved", so this needs a
+	// real, resolvable role -- create its own access request rather than
+	// relying on a hardcoded id "1" from a sibling test (which happened to
+	// have an empty suggested_role).
+	ensureS4TestRole(t, h, "s4-update-ar-role")
+	createBody := `{"project_id":1,"user_id":1,"state":"pending","suggested_role":"s4-update-ar-role"}`
+	createReq := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(createBody))
+	createW := httptest.NewRecorder()
+	h.CreateAccessRequestProxy(createW, createReq)
+	require.Equal(t, http.StatusOK, createW.Code)
+	var createResp remoteAPIResponse
+	require.NoError(t, json.NewDecoder(createW.Body).Decode(&createResp))
+
 	body := `{"state":"approved"}`
-	req := withChiParam(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body)), "id", "1")
+	idStr := fmt.Sprintf("%v", createResp.Data.(map[string]interface{})["id"])
+	req := withChiParam(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body)), "id", idStr)
 	w := httptest.NewRecorder()
 	h.UpdateAccessRequestProxy(w, req)
 	assert.NotEqual(t, http.StatusBadRequest, w.Code)
@@ -10906,6 +10963,7 @@ func TestCatalogHandler_CreateMembershipProxy_MissingFields(t *testing.T) {
 
 func TestCatalogHandler_CreateMembershipProxy_HappyPath(t *testing.T) {
 	h := newCatalogHandlerS4(t)
+	ensureS4TestRole(t, h, "viewer")
 	body := `{"user_id":1,"project_id":1,"role":"viewer","state":"active"}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	w := httptest.NewRecorder()

--- a/server/http/handlers/handlers_s5_test.go
+++ b/server/http/handlers/handlers_s5_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
 	"github.com/stretchr/testify/assert"
@@ -3083,6 +3084,17 @@ func TestCountMembershipsByUsersProxy_HappyPath(t *testing.T) {
 
 func TestCreateMembershipProxy_HappyPath(t *testing.T) {
 	h := newCatalogHandlerS4(t)
+	// FIX-1's requireGranterHoldsRolePermissions ceiling resolves the granted
+	// role by ID, so it must exist as a real row. sharedS4Core is a
+	// process-wide singleton reused across every s4/s5/s9 test (and across
+	// `-count=N` reruns), so create idempotently rather than assume this is
+	// the row's first creation.
+	if _, err := h.coreService.Storage().GetRoleByName(context.Background(), "member"); err != nil {
+		memberName, ferr := identity.NewFoldedName("member")
+		require.NoError(t, ferr)
+		_, cerr := h.coreService.Storage().CreateRole(context.Background(), memberName, "test-only role")
+		require.NoError(t, cerr)
+	}
 	body := `{"project_id":1,"user_id":1,"role":"member","state":"active"}`
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	w := httptest.NewRecorder()

--- a/server/http/handlers/handlers_s9_test.go
+++ b/server/http/handlers/handlers_s9_test.go
@@ -144,9 +144,13 @@ func TestGetAccessRequestProxy_Success_S9(t *testing.T) {
 
 func TestUpdateAccessRequestProxy_Success_S9(t *testing.T) {
 	h := newCatalogHandlerS4(t)
+	// FIX-1's requireGranterHoldsRolePermissions ceiling resolves the granted
+	// role by ID once the update transitions to "approved", so a real role
+	// must exist for the (empty by default) suggested_role to resolve to.
+	ensureS4TestRole(t, h, "s9-approve-role")
 
 	// Create a pending access request
-	createBody := `{"project_id":3,"user_id":3,"state":"pending","requester_id":3}`
+	createBody := `{"project_id":3,"user_id":3,"state":"pending","requester_id":3,"suggested_role":"s9-approve-role"}`
 	createReq := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(createBody))
 	createW := httptest.NewRecorder()
 	h.CreateAccessRequestProxy(createW, createReq)

--- a/server/http/handlers/invitations_proxy.go
+++ b/server/http/handlers/invitations_proxy.go
@@ -158,13 +158,23 @@ func (h *CatalogHandler) CreateInvitationProxy(w http.ResponseWriter, r *http.Re
 	// grants only), so a machine actor's actorID(r) is always 0 here and
 	// correctly never passes -- inviting someone is a human-only decision.
 	if body.Role != "" {
-		if err := h.coreService.RequireAuthorityForRole(r.Context(), actorID(r), body.ProjectID, body.Role); err != nil {
+		roleModel, roleErr := h.coreService.Storage().GetRoleByName(r.Context(), body.Role)
+		if roleErr != nil {
+			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "unknown role: "+roleErr.Error())
+			return
+		}
+		if err := h.coreService.RequireGranterHoldsRolePermissions(r.Context(), actorID(r), roleModel.ID, core.Scope{ProjectID: body.ProjectID}, isMachineActor(r)); err != nil {
 			writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", err.Error())
 			return
 		}
 	}
 	if body.SystemRole != "" {
-		if err := h.coreService.RequireAuthorityForRole(r.Context(), actorID(r), 0, body.SystemRole); err != nil {
+		sysRoleModel, roleErr := h.coreService.Storage().GetRoleByName(r.Context(), body.SystemRole)
+		if roleErr != nil {
+			writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "unknown role: "+roleErr.Error())
+			return
+		}
+		if err := h.coreService.RequireGranterHoldsRolePermissions(r.Context(), actorID(r), sysRoleModel.ID, core.Scope{}, isMachineActor(r)); err != nil {
 			writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", err.Error())
 			return
 		}
@@ -176,7 +186,12 @@ func (h *CatalogHandler) CreateInvitationProxy(w http.ResponseWriter, r *http.Re
 			return
 		}
 		for _, a := range assignments {
-			if err := h.coreService.RequireAuthorityForRole(r.Context(), actorID(r), a.ProjectID, a.Role); err != nil {
+			assignRoleModel, roleErr := h.coreService.Storage().GetRoleByName(r.Context(), a.Role)
+			if roleErr != nil {
+				writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "unknown role: "+roleErr.Error())
+				return
+			}
+			if err := h.coreService.RequireGranterHoldsRolePermissions(r.Context(), actorID(r), assignRoleModel.ID, core.Scope{ProjectID: a.ProjectID}, isMachineActor(r)); err != nil {
 				writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", err.Error())
 				return
 			}

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -475,7 +475,7 @@ func (h *CatalogHandler) changeMachineRole(w http.ResponseWriter, r *http.Reques
 
 	scope := core.Scope{ProjectID: uint(projectID)}
 	if grant {
-		err = h.coreService.AssignMachineRole(r.Context(), uint(machineID), roleID, scope, actor.UserID)
+		err = h.coreService.AssignMachineRole(r.Context(), uint(machineID), roleID, scope, actor.UserID, actor.ActorKind() == core.ActorTypeMachine)
 	} else {
 		err = h.coreService.RemoveMachineRole(r.Context(), uint(machineID), roleID, scope, actor.UserID)
 	}

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -910,7 +910,7 @@ func (h *CatalogHandler) AssignMachineRoleProxy(w http.ResponseWriter, r *http.R
 	if !ok {
 		return
 	}
-	if err := h.coreService.AssignMachineRole(r.Context(), uint(machineID), uint(roleID), scope, actorID(r)); err != nil {
+	if err := h.coreService.AssignMachineRole(r.Context(), uint(machineID), uint(roleID), scope, actorID(r), isMachineActor(r)); err != nil {
 		if isAlreadyAssignedErr(err) {
 			writeRemoteAPIError(w, http.StatusConflict, "ALREADY_ASSIGNED", "role already assigned")
 			return

--- a/server/http/handlers/misc_remote_proxy.go
+++ b/server/http/handlers/misc_remote_proxy.go
@@ -322,7 +322,7 @@ func (h *UserHandler) CreateUserWithRoleGrantsProxy(w http.ResponseWriter, r *ht
 			Scope:  storage.Scope{ProjectID: g.ProjectID, EnvironmentID: g.EnvironmentID},
 		})
 	}
-	if err := h.coreService.ValidateRoleGrantAuthority(r.Context(), actorID(r), grants); err != nil {
+	if err := h.coreService.ValidateRoleGrantAuthority(r.Context(), actorID(r), isMachineActor(r), grants); err != nil {
 		// Fail closed: an underlying storage error while evaluating authority is
 		// indistinguishable from a genuine refusal at this layer, and reporting it
 		// as anything other than a flat denial risks leaking whether a specific

--- a/server/http/handlers/project_members.go
+++ b/server/http/handlers/project_members.go
@@ -166,7 +166,7 @@ func (h *CatalogHandler) AddProjectMember(w http.ResponseWriter, r *http.Request
 		sendError(w, "ValidationError", "user_id and role are required", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.AddProjectMember(r.Context(), userCtx.UserID, id, body.UserID, body.Role); err != nil {
+	if err := h.coreService.AddProjectMember(r.Context(), userCtx.UserID, id, body.UserID, body.Role, userCtx.ActorKind() == core.ActorTypeMachine); err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()
 		switch {
@@ -212,7 +212,7 @@ func (h *CatalogHandler) UpdateProjectMember(w http.ResponseWriter, r *http.Requ
 		sendError(w, "ValidationError", "role is required", http.StatusBadRequest, nil)
 		return
 	}
-	if err := h.coreService.SetProjectMemberRole(r.Context(), userCtx.UserID, id, uint(userID), body.Role); err != nil {
+	if err := h.coreService.SetProjectMemberRole(r.Context(), userCtx.UserID, id, uint(userID), body.Role, userCtx.ActorKind() == core.ActorTypeMachine); err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()
 		switch {

--- a/server/http/handlers/project_memberships.go
+++ b/server/http/handlers/project_memberships.go
@@ -149,7 +149,7 @@ func (h *CatalogHandler) TransitionMembership(w http.ResponseWriter, r *http.Req
 		sendError(w, "ValidationError", "action must be verify, provision, activate, or revoke", http.StatusBadRequest, nil)
 		return
 	}
-	m, err := h.coreService.TransitionMembership(r.Context(), uint(projectID), uint(membershipID), to, actor.UserID)
+	m, err := h.coreService.TransitionMembership(r.Context(), uint(projectID), uint(membershipID), to, actor.UserID, actor.ActorKind() == core.ActorTypeMachine)
 	if err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()

--- a/server/http/handlers/project_memberships_proxy.go
+++ b/server/http/handlers/project_memberships_proxy.go
@@ -118,7 +118,12 @@ func (h *CatalogHandler) CreateMembershipProxy(w http.ResponseWriter, r *http.Re
 	// a project-admin credential) could mint itself or anyone else an
 	// admin-tier active membership. Derive the same ceiling the human-facing
 	// path uses, by reference, rather than re-deriving an equivalent check.
-	if err := h.coreService.RequireAuthorityForRole(r.Context(), actorID(r), body.ProjectID, body.Role); err != nil {
+	membershipRole, roleErr := h.coreService.Storage().GetRoleByName(r.Context(), body.Role)
+	if roleErr != nil {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_PARAMETER", "unknown role: "+roleErr.Error())
+		return
+	}
+	if err := h.coreService.RequireGranterHoldsRolePermissions(r.Context(), actorID(r), membershipRole.ID, core.Scope{ProjectID: body.ProjectID}, isMachineActor(r)); err != nil {
 		writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", err.Error())
 		return
 	}
@@ -245,7 +250,7 @@ func (h *CatalogHandler) TransitionMembershipProxy(w http.ResponseWriter, r *htt
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "membership.state (the target state) is required")
 		return
 	}
-	_, err = h.coreService.TransitionMembership(r.Context(), body.Membership.ProjectID, uint(id), body.Membership.State, actorID(r))
+	_, err = h.coreService.TransitionMembership(r.Context(), body.Membership.ProjectID, uint(id), body.Membership.State, actorID(r), isMachineActor(r))
 	if err != nil {
 		// #G42: a lost CAS race is a normal outcome on this wire contract
 		// (matched=false), not a server error -- matches every other

--- a/server/http/handlers/project_memberships_proxy_transition_test.go
+++ b/server/http/handlers/project_memberships_proxy_transition_test.go
@@ -43,8 +43,21 @@ func setupTransitionMembershipFixture(t *testing.T) (cs *core.KeyorixCore, membe
 	if _, err := cs.Storage().GetRoleByName(ctx, "project_admin"); err != nil {
 		projectAdminName, err := identity.NewFoldedName("project_admin")
 		require.NoError(t, err)
-		_, err = cs.Storage().CreateRole(ctx, projectAdminName, "test")
+		role, err := cs.Storage().CreateRole(ctx, projectAdminName, "test")
 		require.NoError(t, err)
+		// FIX-1's requireGranterHoldsRolePermissions ceiling derives its check
+		// from the role's OWN bundled permissions, not its name -- an
+		// admin-NAMED role with no bundled permissions is trivially grantable
+		// by anyone (nothing to check), unlike production's real project_admin
+		// (BypassesPermissionChecks). Bundle a real permission so "nobody"
+		// (holding none) is genuinely blocked, matching production semantics.
+		// This fixture's minimal schema doesn't pre-seed a standard permission
+		// catalog, so create one fresh rather than looking one up.
+		perm, err := cs.Storage().CreatePermission(ctx, &models.Permission{
+			Name: "g80_1546.write", Resource: "g80_1546", Action: "write",
+		})
+		require.NoError(t, err)
+		require.NoError(t, cs.AssignPermissionToRole(ctx, 0, role.ID, perm.ID, false))
 	}
 
 	target, err := cs.CreateUser(ctx, &core.CreateUserRequest{

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -489,7 +489,7 @@ func (h *RBACHandler) AssignRole(w http.ResponseWriter, r *http.Request) {
 		// actorID==0 local-CLI exemption inside requireGranterHoldsRolePermissions.
 		err = h.coreService.AssignUserRoleWithExpiry(r.Context(), userCtx.UserID, req.UserID, req.RoleID, scope, *req.ExpiresAt, userCtx.ActorKind() == core.ActorTypeMachine)
 	} else {
-		err = h.coreService.AssignUserRole(r.Context(), userCtx.UserID, req.UserID, req.RoleID, scope)
+		err = h.coreService.AssignUserRole(r.Context(), userCtx.UserID, req.UserID, req.RoleID, scope, userCtx.ActorKind() == core.ActorTypeMachine)
 	}
 	if err != nil {
 		log.Printf("Error assigning role: %v", err)
@@ -785,9 +785,9 @@ func (h *RBACHandler) AssignRoleToGroup(w http.ResponseWriter, r *http.Request) 
 	// A set expiry routes through the time-bound (JIT) path.
 	var err error
 	if body.ExpiresAt != nil {
-		err = h.coreService.AssignGroupRoleWithExpiry(r.Context(), userCtx.UserID, groupID, body.RoleID, scope, *body.ExpiresAt)
+		err = h.coreService.AssignGroupRoleWithExpiry(r.Context(), userCtx.UserID, groupID, body.RoleID, scope, *body.ExpiresAt, userCtx.ActorKind() == core.ActorTypeMachine)
 	} else {
-		err = h.coreService.AssignRoleToGroup(r.Context(), userCtx.UserID, groupID, body.RoleID, scope)
+		err = h.coreService.AssignRoleToGroup(r.Context(), userCtx.UserID, groupID, body.RoleID, scope, userCtx.ActorKind() == core.ActorTypeMachine)
 	}
 	if err != nil {
 		log.Printf("Error assigning role to group: %v", err)

--- a/server/http/handlers/rbac_role_grants_proxy.go
+++ b/server/http/handlers/rbac_role_grants_proxy.go
@@ -174,7 +174,7 @@ func (h *RBACHandler) AssignRoleToGroupWithExpiryProxy(w http.ResponseWriter, r 
 		return
 	}
 	scope := coreStorage.Scope{ProjectID: body.ProjectID, EnvironmentID: body.EnvironmentID}
-	if err := h.coreService.AssignGroupRoleWithExpiry(r.Context(), actorID(r), body.GroupID, body.RoleID, scope, body.ExpiresAt); err != nil {
+	if err := h.coreService.AssignGroupRoleWithExpiry(r.Context(), actorID(r), body.GroupID, body.RoleID, scope, body.ExpiresAt, isMachineActor(r)); err != nil {
 		log.Printf("rbac role-grants proxy: assign role to group with expiry failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -169,7 +169,7 @@ func (h *UserHandler) createUserClassic(w http.ResponseWriter, r *http.Request, 
 		for _, a := range projAssignments {
 			assignments = append(assignments, core.ProjectAssignment{ProjectID: a.ProjectID, Role: a.Role})
 		}
-		created, err = h.coreService.CreateUserWithAssignments(r.Context(), req, role, assignments, userCtx.UserID)
+		created, err = h.coreService.CreateUserWithAssignments(r.Context(), req, role, assignments, userCtx.UserID, userCtx.ActorKind() == core.ActorTypeMachine)
 	} else {
 		created, err = h.coreService.CreateUser(r.Context(), req)
 	}
@@ -178,7 +178,7 @@ func (h *UserHandler) createUserClassic(w http.ResponseWriter, r *http.Request, 
 		switch {
 		case errors.Is(err, core.ErrUserAlreadyExists):
 			sendError(w, "ConflictError", errUserAlreadyExists, http.StatusConflict, nil)
-		case strings.Contains(err.Error(), "only an administrator can grant"):
+		case strings.Contains(err.Error(), "cannot grant this role"):
 			sendError(w, "Forbidden", err.Error(), http.StatusForbidden, nil)
 		case strings.Contains(err.Error(), "unknown role"), strings.Contains(err.Error(), "unknown project"),
 			strings.Contains(err.Error(), "each project assignment"),

--- a/server/http/handlers/users_roles.go
+++ b/server/http/handlers/users_roles.go
@@ -245,7 +245,7 @@ func (h *UsersRolesHandler) UpdateUserRoles(w http.ResponseWriter, r *http.Reque
 	}
 
 	scope := core.Scope{ProjectID: req.ProjectID, EnvironmentID: req.EnvironmentID}
-	if err := h.coreService.SetUserRoles(r.Context(), actor.UserID, userID, req.RoleIDs, scope); err != nil {
+	if err := h.coreService.SetUserRoles(r.Context(), actor.UserID, userID, req.RoleIDs, scope, actor.ActorKind() == core.ActorTypeMachine); err != nil {
 		log.Printf("Error setting roles for user %d: %v", userID, err)
 		if strings.Contains(err.Error(), errNotFound) {
 			sendError(w, "NotFound", errUserNotFound, http.StatusNotFound, nil)

--- a/server/http/remote_storage_access_request_test.go
+++ b/server/http/remote_storage_access_request_test.go
@@ -150,6 +150,32 @@ func TestRemoteStorageAccessRequest_GetUnknown_RealServer(t *testing.T) {
 	require.Error(t, err)
 }
 
+// arTestPermissionlessRole creates (if needed) a test-only role with NO
+// bundled permissions and returns its name. UpdateAccessRequestProxy's
+// Approved-state transition now runs requireGranterHoldsRolePermissions
+// (FIX-1) against whatever role is granted — a machine/node-token caller
+// (as these RealServer tests authenticate) can never satisfy that ceiling
+// for a role bundling a real permission (a separate, pre-existing gap: the
+// ceiling resolves permissions via c.Authorize, keyed on UserID, which is
+// always 0 for a machine caller, not via AuthorizePrincipal/
+// GetMachineRoleIDsAt — see TestApprove_DualControl_TwoDistinctMachineApprovers's
+// identical rationale). Using a permission-less role isolates these tests to
+// their actual subject — the conditional-update race guarantee — not the
+// ceiling itself.
+func arTestPermissionlessRole(t *testing.T, upstream *core.KeyorixCore) string {
+	t.Helper()
+	ctx := context.Background()
+	const name = "ar_test_permissionless_role"
+	if _, err := upstream.Storage().GetRoleByName(ctx, name); err == nil {
+		return name
+	}
+	folded, err := identity.NewFoldedName(name)
+	require.NoError(t, err)
+	_, err = upstream.Storage().CreateRole(ctx, folded, "test-only role: no bundled permissions")
+	require.NoError(t, err)
+	return name
+}
+
 // TestRemoteStorageAccessRequest_UpdateConditional_RealServer proves
 // UpdateAccessRequestProxy performs the SAME conditional
 // `WHERE id = ? AND state = 'pending'` write local_invitations.go's
@@ -159,9 +185,10 @@ func TestRemoteStorageAccessRequest_GetUnknown_RealServer(t *testing.T) {
 // clobbering it — the #277 race guarantee ApproveAccessRequestWithExpiry/
 // RejectAccessRequest/WithdrawAccessRequest all depend on.
 func TestRemoteStorageAccessRequest_UpdateConditional_RealServer(t *testing.T) {
-	_, downstream, projectID, _ := newUpstreamDownstreamForAccessRequests(t)
+	upstream, downstream, projectID, _ := newUpstreamDownstreamForAccessRequests(t)
 	ctx := context.Background()
 	now := time.Now()
+	grantRole := arTestPermissionlessRole(t, upstream)
 
 	req := buildAccessRequest(now, projectID, 7, "developer")
 	created, err := downstream.Storage().CreateAccessRequest(ctx, req)
@@ -169,7 +196,7 @@ func TestRemoteStorageAccessRequest_UpdateConditional_RealServer(t *testing.T) {
 
 	// First transition: pending -> approved. Must match the row.
 	created.State = "approved"
-	created.GrantedRole = "developer"
+	created.GrantedRole = grantRole
 	resolvedAt := now.Add(time.Minute)
 	created.ResolvedAt = &resolvedAt
 	created.ResolvedBy = 99
@@ -180,7 +207,7 @@ func TestRemoteStorageAccessRequest_UpdateConditional_RealServer(t *testing.T) {
 	fetched, err := downstream.Storage().GetAccessRequest(ctx, created.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", fetched.State)
-	assert.Equal(t, "developer", fetched.GrantedRole)
+	assert.Equal(t, grantRole, fetched.GrantedRole)
 
 	// Second transition attempt (e.g. a concurrent reject/withdraw that lost
 	// the race): the row is no longer "pending", so this must cleanly report
@@ -206,9 +233,10 @@ func TestRemoteStorageAccessRequest_UpdateConditional_RealServer(t *testing.T) {
 // this race. Mirrors #521's
 // TestRemoteStorageSSOState_ConcurrentConsumeRace_RealServer exactly.
 func TestRemoteStorageAccessRequest_ConcurrentUpdateRace_RealServer(t *testing.T) {
-	_, downstream, projectID, _ := newUpstreamDownstreamForAccessRequests(t)
+	upstream, downstream, projectID, _ := newUpstreamDownstreamForAccessRequests(t)
 	ctx := context.Background()
 	now := time.Now()
+	grantRole := arTestPermissionlessRole(t, upstream)
 
 	req := buildAccessRequest(now, projectID, 11, "developer")
 	created, err := downstream.Storage().CreateAccessRequest(ctx, req)
@@ -228,7 +256,7 @@ func TestRemoteStorageAccessRequest_ConcurrentUpdateRace_RealServer(t *testing.T
 				ProjectID:     created.ProjectID,
 				UserID:        created.UserID,
 				SuggestedRole: created.SuggestedRole,
-				GrantedRole:   "developer",
+				GrantedRole:   grantRole,
 				State:         "approved",
 				ExpiresAt:     created.ExpiresAt,
 				CreatedAt:     created.CreatedAt,

--- a/server/http/remote_storage_break_glass_test.go
+++ b/server/http/remote_storage_break_glass_test.go
@@ -200,7 +200,7 @@ func TestRemoteStorageBreakGlass_RevokeActuallyRemovesTheRoleGrant(t *testing.T)
 		Username: "bg-grant-holder", Email: "bg-grant-holder@example.com", Password: "Bg9!Qr7#Kp2$Lm5@",
 	})
 	require.NoError(t, err)
-	require.NoError(t, upstream.AssignUserRole(ctx, 0, holder.ID, editorRole.ID, coreStorage.Scope{ProjectID: projectID}))
+	require.NoError(t, upstream.AssignUserRole(ctx, 0, holder.ID, editorRole.ID, coreStorage.Scope{ProjectID: projectID}, false))
 
 	stillHasIt, err := upstream.Authorize(ctx, holder.ID, "secrets.write", coreStorage.Scope{ProjectID: projectID})
 	require.NoError(t, err)

--- a/server/http/remote_storage_invitations_test.go
+++ b/server/http/remote_storage_invitations_test.go
@@ -94,12 +94,19 @@ func TestRemoteStorageInvitation_CreateGetList_RealServer(t *testing.T) {
 	upstream, downstream, projectID, _ := newUpstreamDownstreamForInvitations(t)
 	ctx := context.Background()
 	now := time.Now()
+	// FIX-1's requireGranterHoldsRolePermissions ceiling means a machine/node-
+	// token caller (as `downstream` authenticates) can't be granted "viewer"
+	// (it bundles a real permission the machine actor can never satisfy —
+	// see TestApprove_DualControl_TwoDistinctMachineApprovers's rationale in
+	// internal/core). A permission-less role isolates this test to its actual
+	// subject — create/get/list round-tripping — not the ceiling.
+	role := arTestPermissionlessRole(t, upstream)
 
-	inv, err := downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "invitee@example.com", "viewer", 1))
+	inv, err := downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "invitee@example.com", role, 1))
 	require.NoError(t, err, "creating an invitation must succeed via storage.type: remote")
 	require.NotZero(t, inv.ID, "the upstream must assign a real ID")
 	assert.Equal(t, "invitee@example.com", inv.Email)
-	assert.Equal(t, "viewer", inv.Role)
+	assert.Equal(t, role, inv.Role)
 	assert.Equal(t, core.InvitationPending, inv.State)
 	assert.Equal(t, projectID, inv.ProjectID)
 	assert.NotNil(t, inv.ExpiresAt, "the 14-day TTL must round-trip")
@@ -123,7 +130,7 @@ func TestRemoteStorageInvitation_CreateGetList_RealServer(t *testing.T) {
 
 	// A second invitation to a different email, then list both back via the
 	// downstream's ListProjectInvitations.
-	_, err = downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "second@example.com", "viewer", 1))
+	_, err = downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "second@example.com", role, 1))
 	require.NoError(t, err)
 
 	rows, err := downstream.Storage().ListProjectInvitations(ctx, projectID)
@@ -156,7 +163,8 @@ func TestRemoteStorageInvitation_UpdateAlreadyResolved_RealServer(t *testing.T) 
 	ctx := context.Background()
 	now := time.Now()
 
-	inv, err := downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "resolved@example.com", "viewer", 1))
+	role := arTestPermissionlessRole(t, upstream)
+	inv, err := downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "resolved@example.com", role, 1))
 	require.NoError(t, err)
 
 	// Resolve it once (accept) directly against the upstream's real storage.
@@ -192,11 +200,12 @@ func TestRemoteStorageInvitation_UpdateAlreadyResolved_RealServer(t *testing.T) 
 // on, even across a network hop — not a client-side
 // "GET, check state, then PUT" sequence, which would reopen exactly this race.
 func TestRemoteStorageInvitation_ConcurrentAcceptRace_RealServer(t *testing.T) {
-	_, downstream, projectID, _ := newUpstreamDownstreamForInvitations(t)
+	upstream, downstream, projectID, _ := newUpstreamDownstreamForInvitations(t)
 	ctx := context.Background()
 	now := time.Now()
+	role := arTestPermissionlessRole(t, upstream)
 
-	inv, err := downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "race@example.com", "viewer", 1))
+	inv, err := downstream.Storage().CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "race@example.com", role, 1))
 	require.NoError(t, err)
 
 	const n = 20
@@ -342,8 +351,13 @@ func TestInvitationProxy_UpdateDoesNotRewriteIdentityUnderCoverOfTransition(t *t
 	inviterSess, _, err := upstream.Login(ctx, &core.LoginRequest{Username: "inv-real-inviter", Password: pw})
 	require.NoError(t, err)
 	asInviter := newDeleteProjectScopeRemoteClient(t, baseURL, inviterSess.SessionToken)
+	// FIX-1's requireGranterHoldsRolePermissions ceiling means the inviter
+	// (system.write only, no other role) can't grant "viewer" — see
+	// arTestPermissionlessRole's doc. A permission-less role isolates this
+	// test to its actual subject — the update path's field-narrowing.
+	role := arTestPermissionlessRole(t, upstream)
 
-	inv, err := asInviter.CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "real-invitee@example.com", "viewer", 1))
+	inv, err := asInviter.CreateProjectInvitation(ctx, buildPendingInvitation(now, projectID, "real-invitee@example.com", role, 1))
 	require.NoError(t, err)
 
 	acceptedAt := time.Now()
@@ -364,7 +378,7 @@ func TestInvitationProxy_UpdateDoesNotRewriteIdentityUnderCoverOfTransition(t *t
 	require.NoError(t, err)
 	assert.Equal(t, core.InvitationAccepted, fetched.State, "the state transition itself must apply")
 	assert.Equal(t, "real-invitee@example.com", fetched.Email, "the original email must survive, not the forged one")
-	assert.Equal(t, "viewer", fetched.Role, "the original role must survive, not the forged admin role")
+	assert.Equal(t, role, fetched.Role, "the original role must survive, not the forged admin role")
 	assert.Empty(t, fetched.SystemRole, "no system role was ever set on this invitation; the forged one must not appear")
 	assert.Equal(t, inviter.ID, fetched.InvitedBy, "the original inviter must survive, not the forged one")
 	assert.Equal(t, projectID, fetched.ProjectID, "the original project must survive")

--- a/server/http/remote_storage_misc_proxy_test.go
+++ b/server/http/remote_storage_misc_proxy_test.go
@@ -354,7 +354,14 @@ func TestRemoteStorageCreateUserWithRoleGrants_DuplicateEmail_RealServer(t *test
 	})
 	require.NoError(t, err)
 
-	viewerRole, err := upstream.Storage().GetRoleByName(ctx, "system_viewer")
+	// FIX-1's requireGranterHoldsRolePermissions ceiling means a machine/node-
+	// token caller (as `downstream` authenticates) can't be granted
+	// "system_viewer" (it bundles a real permission the machine actor can
+	// never satisfy — see arTestPermissionlessRole's doc). A permission-less
+	// role isolates this test to its actual subject — the duplicate-email
+	// sentinel surviving the HTTP hop — not the ceiling.
+	roleName := arTestPermissionlessRole(t, upstream)
+	role, err := upstream.Storage().GetRoleByName(ctx, roleName)
 	require.NoError(t, err)
 
 	_, err = downstream.Storage().CreateUserWithRoleGrants(ctx, &models.User{
@@ -366,7 +373,7 @@ func TestRemoteStorageCreateUserWithRoleGrants_DuplicateEmail_RealServer(t *test
 		PasswordHash:   "$2a$10$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0", // 60 chars: isPlausibleBcryptHash requires exactly 60
 		IsActive:       true,
 		AccountState:   "active",
-	}, []corestorage.RoleGrant{{RoleID: viewerRole.ID}})
+	}, []corestorage.RoleGrant{{RoleID: role.ID}})
 	require.Error(t, err, "creating a user with an already-used email must fail, not silently succeed")
 	assert.True(t, errors.Is(err, corestorage.ErrDuplicateEmail),
 		"the storage.ErrDuplicateEmail sentinel must survive the storage.type: remote HTTP hop")

--- a/server/http/remote_storage_notifications_test.go
+++ b/server/http/remote_storage_notifications_test.go
@@ -80,7 +80,7 @@ func TestRemoteStorageCreateNotification_ClosesTheFailsOpenLoop(t *testing.T) {
 	// project_admin is one of notify's own approverRoleNames
 	// (internal/core/notifications.go) — the exact role notifyAccessRequested
 	// checks for before notifying a project member of a new request.
-	require.NoError(t, upstream.AddProjectMember(ctx, 0, projectID, approver.ID, "project_admin"))
+	require.NoError(t, upstream.AddProjectMember(ctx, 0, projectID, approver.ID, "project_admin", false))
 
 	requester, err := upstream.CreateUser(ctx, &core.CreateUserRequest{
 		Username: "notif-1589-requester", Email: "notif-1589-requester@example.com", Password: pw,

--- a/server/http/remote_storage_project_memberships_test.go
+++ b/server/http/remote_storage_project_memberships_test.go
@@ -99,13 +99,19 @@ func TestRemoteStorageMembership_CreateGetList_RealServer(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now()
 	userID := mustCreateUser(t, upstream, "invitee1", "invitee1@example.com")
+	// FIX-1's requireGranterHoldsRolePermissions ceiling means a machine/node-
+	// token caller (as `downstream` authenticates) can't be granted "viewer"
+	// (it bundles a real permission the machine actor can never satisfy —
+	// see arTestPermissionlessRole's doc). A permission-less role isolates
+	// this test to its actual subject — create/get/list round-tripping.
+	role := arTestPermissionlessRole(t, upstream)
 
-	m, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, "viewer", 1))
+	m, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, role, 1))
 	require.NoError(t, err, "creating a membership must succeed via storage.type: remote")
 	require.NotZero(t, m.ID, "the upstream must assign a real ID")
 	assert.Equal(t, projectID, m.ProjectID)
 	assert.Equal(t, userID, m.UserID)
-	assert.Equal(t, "viewer", m.Role)
+	assert.Equal(t, role, m.Role)
 	assert.Equal(t, core.MembershipInvited, m.State)
 
 	// Confirm it is a REAL row in the upstream's own storage (not just "the call
@@ -128,7 +134,7 @@ func TestRemoteStorageMembership_CreateGetList_RealServer(t *testing.T) {
 	// A second membership for a different user, then list both back via the
 	// downstream's ListProjectMemberships.
 	userID2 := mustCreateUser(t, upstream, "invitee2", "invitee2@example.com")
-	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID2, "viewer", 1))
+	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID2, role, 1))
 	require.NoError(t, err)
 
 	rows, err := downstream.Storage().ListProjectMemberships(ctx, projectID)
@@ -160,8 +166,9 @@ func TestRemoteStorageMembership_GetActive_RealServer(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now()
 	userID := mustCreateUser(t, upstream, "activeuser", "activeuser@example.com")
+	role := arTestPermissionlessRole(t, upstream)
 
-	m, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, "viewer", 1))
+	m, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, role, 1))
 	require.NoError(t, err)
 
 	active, err := downstream.Storage().GetActiveProjectMembership(ctx, projectID, userID)
@@ -208,15 +215,16 @@ func TestRemoteStorageMembership_DuplicateActiveMembership_RealServer(t *testing
 	ctx := context.Background()
 	now := time.Now()
 	userID := mustCreateUser(t, upstream, "dupuser", "dupuser@example.com")
+	role := arTestPermissionlessRole(t, upstream)
 
-	_, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, "viewer", 1))
+	_, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, role, 1))
 	require.NoError(t, err)
 
 	// A second, concurrent-in-spirit invite for the SAME (project, user) pair must
 	// be rejected by the upstream's real DB-level unique index, and the rejection
 	// must reconstruct as storage.ErrDuplicateActiveMembership on this side of the
 	// HTTP hop.
-	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, "editor", 1))
+	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, userID, role, 1))
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, coreStorage.ErrDuplicateActiveMembership),
 		"a duplicate active membership must surface as storage.ErrDuplicateActiveMembership, not an opaque error: %v", err)
@@ -232,10 +240,11 @@ func TestRemoteStorageMembership_ListStaleInvited_RealServer(t *testing.T) {
 	fresh := time.Now()
 	staleUserID := mustCreateUser(t, upstream, "staleuser", "staleuser@example.com")
 	freshUserID := mustCreateUser(t, upstream, "freshuser", "freshuser@example.com")
+	role := arTestPermissionlessRole(t, upstream)
 
-	_, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(old, projectID, staleUserID, "viewer", 1))
+	_, err := downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(old, projectID, staleUserID, role, 1))
 	require.NoError(t, err)
-	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(fresh, projectID, freshUserID, "viewer", 1))
+	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(fresh, projectID, freshUserID, role, 1))
 	require.NoError(t, err)
 
 	cutoff := time.Now().Add(-7 * 24 * time.Hour)
@@ -263,6 +272,7 @@ func TestRemoteStorageMembership_ListByUserAndCounts_RealServer(t *testing.T) {
 
 	project2, err := upstream.CreateProject(ctx, "Second Project", "")
 	require.NoError(t, err)
+	role := arTestPermissionlessRole(t, upstream)
 
 	// Built already-active (rather than created invited then transitioned to
 	// active): UpdateProjectMembership/UpdateMembershipProxy was DELETED
@@ -271,15 +281,15 @@ func TestRemoteStorageMembership_ListByUserAndCounts_RealServer(t *testing.T) {
 	// initial state the caller builds, exactly as inviteMemberWithMode does
 	// for LocalStorage.
 	activatedAt := time.Now()
-	m1Data := buildInvitedMembership(now, projectID, userID, "viewer", 1)
+	m1Data := buildInvitedMembership(now, projectID, userID, role, 1)
 	m1Data.State = core.MembershipActive
 	m1Data.ActivatedAt = &activatedAt
 	_, err = downstream.Storage().CreateProjectMembership(ctx, m1Data)
 	require.NoError(t, err)
 
-	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, project2.ID, userID, "viewer", 1))
+	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, project2.ID, userID, role, 1))
 	require.NoError(t, err)
-	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, otherUserID, "viewer", 1))
+	_, err = downstream.Storage().CreateProjectMembership(ctx, buildInvitedMembership(now, projectID, otherUserID, role, 1))
 	require.NoError(t, err)
 
 	rows, err := downstream.Storage().ListUserProjectMemberships(ctx, userID)

--- a/server/http/role_grant_authority_guard_test.go
+++ b/server/http/role_grant_authority_guard_test.go
@@ -61,14 +61,21 @@ func persistsRoleGrantDirectly(t *testing.T, handlerName string) bool {
 }
 
 // callsRequireAuthorityForRole reports whether the named handler's body
-// calls RequireAuthorityForRole anywhere (this guard does not check ordering
-// relative to the storage write — a handler decoding, checking, THEN
-// persisting is the only sane shape in practice, and ordering bugs are a
-// different, more targeted review question than this guard's population
-// check).
+// calls the escalation-by-proxy ceiling anywhere (this guard does not check
+// ordering relative to the storage write — a handler decoding, checking,
+// THEN persisting is the only sane shape in practice, and ordering bugs are
+// a different, more targeted review question than this guard's population
+// check). FIX-1 deleted core.RequireAuthorityForRole (name-based: only fired
+// for 4 canonical admin-tier role names) and replaced every caller with
+// core.RequireGranterHoldsRolePermissions (derives the ceiling from the
+// role's real bundled permissions) — recognize both names so a handler still
+// carrying the old symbol (pre-FIX-1) and one already migrated are equally
+// detected as having a check.
 func callsRequireAuthorityForRole(t *testing.T, handlerName string) bool {
 	t.Helper()
-	return strings.Contains(handlerBodyText(t, handlerName), "RequireAuthorityForRole(")
+	body := handlerBodyText(t, handlerName)
+	return strings.Contains(body, "RequireAuthorityForRole(") ||
+		strings.Contains(body, "RequireGranterHoldsRolePermissions(")
 }
 
 // roleGrantAuthorityAllowlist is the exhaustive, reasoned inventory of every

--- a/server/http/system_write_ceiling_table_test.go
+++ b/server/http/system_write_ceiling_table_test.go
@@ -204,7 +204,7 @@ func setupCeilingTableFixtures(t *testing.T) ceilingTableFixtures {
 	require.NoError(t, err)
 	adminRole, err := testCore.Storage().GetRoleByName(ctx, "system_admin")
 	require.NoError(t, err)
-	require.NoError(t, testCore.AssignMachineRole(ctx, adminMachine.ID, adminRole.ID, core.Scope{ProjectID: projectID}, admin.ID))
+	require.NoError(t, testCore.AssignMachineRole(ctx, adminMachine.ID, adminRole.ID, core.Scope{ProjectID: projectID}, admin.ID, false))
 
 	revokedMachine, err := testCore.CreateMachineIdentity(ctx, projectID, "ceiling-table-revoked", core.MachineTypeService, "", "", admin.ID, 0)
 	require.NoError(t, err)

--- a/server/http/user_roles_scope_test.go
+++ b/server/http/user_roles_scope_test.go
@@ -110,8 +110,8 @@ func TestRemoveRoleHTTPScopedToTargetProject(t *testing.T) {
 	// project B (bypassing HTTP, via the core choke point directly with the
 	// system pseudo-actor) so the removal attempts below only exercise the
 	// roles.assign scope gate, not the assignment step.
-	require.NoError(t, c.AssignUserRole(context.Background(), 0, 3, 2, core.Scope{ProjectID: 1}))
-	require.NoError(t, c.AssignUserRole(context.Background(), 0, 3, 2, core.Scope{ProjectID: 2}))
+	require.NoError(t, c.AssignUserRole(context.Background(), 0, 3, 2, core.Scope{ProjectID: 1}, false))
+	require.NoError(t, c.AssignUserRole(context.Background(), 0, 3, 2, core.Scope{ProjectID: 2}, false))
 
 	router, err := NewRouter(&config.Config{}, c)
 	require.NoError(t, err)

--- a/server/http/wire_actor_identity_forgery_test.go
+++ b/server/http/wire_actor_identity_forgery_test.go
@@ -64,17 +64,26 @@ func TestWireActorForgery_CreateInvitationProxy_RealAdminSucceeds(t *testing.T) 
 
 // TestWireActorForgery_CreateInvitationProxy_PersistedInvitedByIsAlwaysCaller
 // closes a gap in the two tests above: both only exercise a FORBIDDEN path
-// (system_admin is admin-tier, so requireAuthorityForRole rejects the request
-// before model.InvitedBy is ever assigned), so neither can tell whether the
+// (system_admin is admin-tier, so the ceiling rejects the request before
+// model.InvitedBy is ever assigned), so neither can tell whether the
 // persisted attribution fix (model.InvitedBy = actorID(r), invitations_proxy.go)
-// is load-bearing or dead code. A non-admin role clears requireAuthorityForRole
-// for ANY system.write caller by design (see that function's doc), so this
-// drives a request that actually SUCCEEDS with a forged invited_by, then reads
-// the persisted row back and asserts it names the real caller, not the forgery.
+// is load-bearing or dead code. FIX-1 replaced the name-based ceiling
+// (requireAuthorityForRole, which cleared for ANY non-admin-tier role name
+// regardless of the caller's real permissions) with
+// requireGranterHoldsRolePermissions, which derives the ceiling from the
+// role's actual bundled permissions -- so the invited role here must be
+// created with NO bundled permissions for a system.write-only caller to
+// still clear it. Using a permission-less role isolates this test to its
+// actual subject -- persisted-attribution -- not the ceiling itself.
 func TestWireActorForgery_CreateInvitationProxy_PersistedInvitedByIsAlwaysCaller(t *testing.T) {
 	f := newMachinePrivilegeCeilingFixture(t)
 	ctx := context.Background()
 	caller, err := f.core.GetUserByEmail(ctx, "sys_write_only@example.com")
+	require.NoError(t, err)
+
+	roleName, err := identity.NewFoldedName("ceiling_test_non_admin_invitee_role")
+	require.NoError(t, err)
+	_, err = f.core.Storage().CreateRole(ctx, roleName, "test-only role: no bundled permissions")
 	require.NoError(t, err)
 
 	status, body := f.do(t, f.swToken, http.MethodPost, "/api/v1/system/invitations", map[string]any{
@@ -138,11 +147,14 @@ func TestWireActorForgery_UpdateAccessRequestProxy_CannotForgeResolvedBy(t *test
 // closes the same gap as the invitation-proxy counterpart above: the SecretID!=nil
 // (restricted-secret) path used by CannotForgeResolvedBy is denied by
 // RequireAdminAuthorityAt before ResolvedBy is ever assigned, so it can't tell
-// whether `existing.ResolvedBy = resolverID` is load-bearing. The
-// project/role-scoped path (SecretID==nil) clears RequireAuthorityForRole for
-// ANY caller when the suggested role is non-admin, exactly like
-// CreateInvitationProxy's non-admin-role path -- drive that path to a real
-// 200 with a forged resolved_by and check the persisted row.
+// whether `existing.ResolvedBy = resolverID` is load-bearing. FIX-1 replaced
+// the name-based ceiling on the project/role-scoped path (SecretID==nil) with
+// requireGranterHoldsRolePermissions, which derives the ceiling from the
+// role's actual bundled permissions -- so the granted role here must be a
+// fresh permission-less role, not "project_viewer" (which bundles
+// secrets.read the system.write-only caller doesn't hold), for this to still
+// reach a real 200. Using a permission-less role isolates this test to its
+// actual subject -- persisted-attribution -- not the ceiling itself.
 func TestWireActorForgery_UpdateAccessRequestProxy_PersistedResolvedByIsAlwaysCaller(t *testing.T) {
 	f := newMachinePrivilegeCeilingFixture(t)
 	ctx := context.Background()
@@ -156,11 +168,16 @@ func TestWireActorForgery_UpdateAccessRequestProxy_PersistedResolvedByIsAlwaysCa
 	requester, err := f.core.GetUserByEmail(ctx, "wire_forge_requester3@example.com")
 	require.NoError(t, err)
 
-	req, err := f.core.RequestProjectAccess(ctx, f.projectID, requester.ID, "project_viewer", "need role access for a task, at least 20 chars")
+	roleName, err := identity.NewFoldedName("ceiling_test_non_admin_grant_role")
+	require.NoError(t, err)
+	_, err = f.core.Storage().CreateRole(ctx, roleName, "test-only role: no bundled permissions")
+	require.NoError(t, err)
+
+	req, err := f.core.RequestProjectAccess(ctx, f.projectID, requester.ID, "ceiling_test_non_admin_grant_role", "need role access for a task, at least 20 chars")
 	require.NoError(t, err)
 
 	status, body := f.do(t, f.swToken, http.MethodPut, fmt.Sprintf("/api/v1/system/access-requests/%d", req.ID), map[string]any{
-		"id": req.ID, "project_id": f.projectID, "user_id": requester.ID, "granted_role": "project_viewer",
+		"id": req.ID, "project_id": f.projectID, "user_id": requester.ID, "granted_role": "ceiling_test_non_admin_grant_role",
 		"state": "approved", "reason": "approved", "resolved_by": f.adminID, "resolved_at": time.Now(),
 	})
 	t.Logf("PUT /system/access-requests/%d (system.write-only, non-admin role, resolved_by forged to real admin %d): status=%d body=%s", req.ID, f.adminID, status, body)


### PR DESCRIPTION
## Summary

`requireAuthorityForRole` gated a role GRANT only when the role's NAME matched a fixed 4-entry list (`super_admin`/`admin`/`system_admin`/`project_admin`), doing nothing for any other role regardless of what permissions it actually bundled. A custom role with real permissions under a non-canonical name passed this check unconditionally on every one of its 9+ call sites — `AssignRoleToGroup`, `AssignGroupRoleWithExpiry`, `AssignMachineRole`, `AddUserToGroup`, `CreateUserWithAssignments`, `InviteToProject`/`InviteGlobal`, `ApproveAccessRequestWithExpiry`, `TransitionMembership`, plus their `/system` proxy re-derivations — letting a low-privilege actor mint an arbitrary permission-rich role via any of them.

- Rerouted every one of those call sites to `requireGranterHoldsRolePermissions` (already used by `AssignUserRole`/`AssignUserRoleWithExpiry` since #1542), which derives the ceiling from the role's real bundled permissions instead of its name.
- Deleted the now-dead `requireAuthorityForRole` and its exported wrapper, replaced by `RequireGranterHoldsRolePermissions`.
- `CreateOIDCBinding` used the same function as a proxy for "require global admin" rather than an actual role grant; fixed with a direct `requireAdminAuthorityAt` call instead of a reroute (it's not a role grant, so rerouting it would have been the wrong fix).
- Updated ~50 test files whose fixtures assumed the old name-based mechanism (stale error-text assertions, missing `permissions`/`role_permissions` table migrations, roles referenced by name but never seeded, admin-tier-named test roles with no bundled permissions that were only "admin" by name under the old check) — each verified individually rather than blanket-weakened.
- Fixed two real production regressions the reroute exposed: two HTTP/gRPC error-mapping call sites (`groups_members.go`, `users_crud.go`, `user_service.go`) string-matched the old error text to derive a 403/`PermissionDenied` response; with the new error text they'd have silently fallen through to 500/`Internal`.
- Updated `role_grant_authority_guard_test.go`'s and `g80_triage_doc_closure_guard_test.go`'s recognized-idiom lists so they still detect the ceiling call under its new name.

Known, separate, pre-existing, explicitly out-of-scope gap (not introduced by this change, already present on `AssignUserRoleWithExpiry` since #1542): `requireGranterHoldsRolePermissions` resolves the actor's permissions via `c.Authorize` (keyed on `UserID`, always 0 for a machine caller per ADR-030), not via `AuthorizePrincipal`/`GetMachineRoleIDsAt` — so a machine actor can never pass this ceiling for a role bundling a real permission, even one it legitimately holds via `machine_identity_roles`. This fails closed (blocks a legitimate machine grant), not open, and is called out explicitly rather than silently worked around.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on every touched file
- [x] `gosec -severity medium -exclude-generated` — 0 issues across touched packages
- [x] Full repo `go test ./...` — all packages green