### PR TITLE
fix(core): move last-project-admin protection to the shared primitives

### DIFF
--- a/internal/core/break_glass_revoke_test.go
+++ b/internal/core/break_glass_revoke_test.go
@@ -42,6 +42,14 @@ func TestRevokeBreakGlass_GenuineRoleRemovalFailureAbortsRevoke(t *testing.T) {
 	activation := newTestActivation()
 	mockStorage.On("GetBreakGlassActivation", mock.Anything, uint(7)).Return(activation, nil)
 
+	// FIX-2: RemoveUserRole now guards project-scope removals too
+	// (guardLastProjectAdmin) — "editor" (role 3) doesn't carry roles.assign, so
+	// the guard's own permission check short-circuits before it needs to resolve
+	// any project administrators, but the mock still needs these two calls
+	// stubbed to reach that short-circuit.
+	mockStorage.On("GetUserRoleIDsExact", mock.Anything, uint(10), storage.Scope{ProjectID: 2}).Return([]uint{3}, nil)
+	mockStorage.On("RoleSetHasPermission", mock.Anything, []uint{3}, permRolesAssign).Return(false, nil)
+
 	dbErr := errors.New("connection reset by peer")
 	mockStorage.On("RemoveRole", mock.Anything, uint(10), uint(3), storage.Scope{ProjectID: 2}).Return(dbErr)
 
@@ -68,6 +76,10 @@ func TestRevokeBreakGlass_AlreadyGoneRoleRemovalIsNotAFailure(t *testing.T) {
 
 	activation := newTestActivation()
 	mockStorage.On("GetBreakGlassActivation", mock.Anything, uint(7)).Return(activation, nil)
+	// FIX-2: see the identical stubs' comment in
+	// TestRevokeBreakGlass_GenuineRoleRemovalFailureAbortsRevoke above.
+	mockStorage.On("GetUserRoleIDsExact", mock.Anything, uint(10), storage.Scope{ProjectID: 2}).Return([]uint{3}, nil)
+	mockStorage.On("RoleSetHasPermission", mock.Anything, []uint{3}, permRolesAssign).Return(false, nil)
 	mockStorage.On("RemoveRole", mock.Anything, uint(10), uint(3), storage.Scope{ProjectID: 2}).
 		Return(storage.ErrRoleNotAssigned)
 	mockStorage.On("RevokeBreakGlassActivation", mock.Anything, uint(7), uint(1), uint(0), now).Return(nil)

--- a/internal/core/concurrency_g04_threshold_race_test.go
+++ b/internal/core/concurrency_g04_threshold_race_test.go
@@ -108,7 +108,7 @@ func TestConcurrency_DecideAccessReviewItem_AttestRevokeRace(t *testing.T) {
 	const trials = 30
 	for trial := 0; trial < trials; trial++ {
 		db := openRaceDB(t, fmt.Sprintf("arc_mixed_%d", trial))
-		require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}, &models.UserRole{}, &models.GroupRole{}, &models.Group{}))
+		require.NoError(t, db.AutoMigrate(&models.AccessReviewCampaign{}, &models.AccessReviewItem{}, &models.AuditEvent{}, &models.UserRole{}, &models.GroupRole{}, &models.Group{}, &models.Permission{}, &models.RolePermission{}))
 
 		const proj = uint(2)
 		campaign := &models.AccessReviewCampaign{ProjectID: proj, Name: "race", State: core.CampaignStateOpen}

--- a/internal/core/last_admin_guard_external_test.go
+++ b/internal/core/last_admin_guard_external_test.go
@@ -20,6 +20,7 @@ func TestRemoveUserRole_RefusesLastGlobalAdmin(t *testing.T) {
 
 	const superAdminRoleID = uint(1) // seeded by the helper
 	h.CreateTestUser(t, "root", 100)
+	h.CreateTestUser(t, "root2", 101)
 	h.AssignUserRole(t, 100, superAdminRoleID, nil) // global super_admin
 
 	// User 100 is the only global admin → removal refused.
@@ -27,13 +28,22 @@ func TestRemoveUserRole_RefusesLastGlobalAdmin(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "last install administrator")
 
-	// A project-scoped admin removal is NOT guarded (recoverable by a global admin).
+	// FIX-2: a project-scoped admin removal is now guarded too (previously it
+	// fell straight through to storage.RemoveRole with no last-admin check at
+	// all — recoverable by a global admin, but still an availability risk this
+	// fix now refuses outright, mirroring SetProjectMemberRole/
+	// RemoveProjectMember's identical stance for direct grants).
 	h.AssignUserRole(t, 100, superAdminRoleID, ptrUint(2))
+	err = h.CoreService.RemoveUserRole(ctx, 0, 100, superAdminRoleID, core.Scope{ProjectID: 2})
+	require.Error(t, err, "user 100 is project 2's only roles.assign holder")
+	assert.Contains(t, err.Error(), "last administrator")
+
+	// Once a second project admin exists, the first can be removed.
+	h.AssignUserRole(t, 101, superAdminRoleID, ptrUint(2))
 	require.NoError(t, h.CoreService.RemoveUserRole(ctx, 0, 100, superAdminRoleID, core.Scope{ProjectID: 2}),
-		"a project-scoped admin role can be removed")
+		"a project-scoped admin role can be removed once another project admin survives")
 
 	// Add a SECOND global admin; now the first can be removed.
-	h.CreateTestUser(t, "root2", 101)
 	h.AssignUserRole(t, 101, superAdminRoleID, nil)
 	require.NoError(t, h.CoreService.RemoveUserRole(ctx, 0, 100, superAdminRoleID, core.Scope{}),
 		"removing one global admin is fine while another remains")

--- a/internal/core/last_admin_primitive_test.go
+++ b/internal/core/last_admin_primitive_test.go
@@ -1,0 +1,218 @@
+// last_admin_primitive_test.go — regression coverage for FIX-2 (adversarial
+// review run 2): the last-project-admin guard sat on entry points
+// (SetProjectMemberRole, RemoveProjectMember), not on the shared primitives
+// (RemoveUserRole, RemoveRoleFromGroup) those entry points funnel through.
+// Any OTHER caller reaching a primitive directly — the plain /user-roles HTTP
+// route, the gRPC RemoveRole RPC, the /system RemoveRoleGrantProxy, or
+// RemoveRoleFromGroup's own callers — bypassed project-admin protection
+// entirely. These tests exercise the primitives DIRECTLY, the same way those
+// bypassing entry points do, proving the guard now holds regardless of which
+// caller reaches it.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoveUserRole_RefusesLastProjectAdminAtThePrimitive proves the fix's
+// core claim: calling RemoveUserRole DIRECTLY at project scope (as the plain
+// /user-roles HTTP route, the gRPC RemoveRole RPC, and the /system
+// RemoveRoleGrantProxy all do — none of them route through
+// SetProjectMemberRole/RemoveProjectMember) refuses to strip a project of its
+// last roles.assign holder, even though NEITHER of those entry-point guards
+// is anywhere in this call path.
+func TestRemoveUserRole_RefusesLastProjectAdminAtThePrimitive(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin", false))
+
+	// Bypass SetProjectMemberRole/RemoveProjectMember entirely — call the
+	// shared primitive the way an entry point with no guard of its own would.
+	err = c.RemoveUserRole(ctx, actor, u.ID, adminRole.ID, Scope{ProjectID: proj})
+	require.Error(t, err, "must refuse to strip project 7's last roles.assign holder")
+	assert.Contains(t, err.Error(), "last administrator")
+
+	ids, err := st.GetUserRoleIDsExact(ctx, u.ID, storage.Scope{ProjectID: proj})
+	require.NoError(t, err)
+	assert.Contains(t, ids, adminRole.ID, "the grant must survive when the guard refuses")
+}
+
+// TestRemoveUserRole_AllowsProjectAdminRemovalWhenAnotherSurvives is the
+// positive control: the guard only bites on the LAST holder, not every
+// project-admin removal.
+func TestRemoveUserRole_AllowsProjectAdminRemovalWhenAnotherSurvives(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+	other, err := st.CreateUser(ctx, &models.User{Username: "raj", Email: "raj@example.com", IsActive: true})
+	require.NoError(t, err)
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "project_admin", false))
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, other.ID, "project_admin", false))
+
+	err = c.RemoveUserRole(ctx, actor, u.ID, adminRole.ID, Scope{ProjectID: proj})
+	require.NoError(t, err, "removal is fine while another project admin survives")
+}
+
+// TestRemoveUserRole_EnvironmentScopeUnaffected confirms the new guard is
+// scoped to project-level grants only (environment_id = 0), matching
+// guardLastProjectAdmin/resolveProjectAdminHolders' existing convention that
+// an environment-scoped role never independently confers project-admin
+// authority (RemoveProjectMember's own doc comment: it removes environment-
+// scoped grants too, without additional guarding). An environment-scoped
+// removal must proceed even when it's the user's only grant.
+func TestRemoveUserRole_EnvironmentScopeUnaffected(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj, env = uint(7), uint(3)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	require.NoError(t, c.AssignUserRole(ctx, actor, u.ID, adminRole.ID, Scope{ProjectID: proj, EnvironmentID: env}, false))
+
+	err = c.RemoveUserRole(ctx, actor, u.ID, adminRole.ID, Scope{ProjectID: proj, EnvironmentID: env})
+	require.NoError(t, err, "an environment-scoped grant never independently conferred project-admin authority")
+}
+
+// TestRemoveRoleFromGroup_RefusesLastProjectAdmin proves the third of the
+// three sibling gaps: a group's project-admin-conferring role grant is the
+// third way (alongside group deletion and membership removal, both already
+// guarded — TestDeleteGroup_RefusesLastProjectAdmin /
+// TestRemoveUserFromGroup_RefusesLastProjectAdminMember in
+// project_scoped_group_admin_guard_test.go) a group can stop conferring
+// project-admin authority, and had no guard at all.
+func TestRemoveRoleFromGroup_RefusesLastProjectAdmin(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+
+	err = c.RemoveRoleFromGroup(ctx, actor, group.ID, adminRole.ID, Scope{ProjectID: proj})
+	require.Error(t, err, "must refuse to remove project 7's last roles.assign grant from the group holding it")
+	assert.Contains(t, err.Error(), "last administrative role grant")
+
+	roles, err := st.GetGroupRoles(ctx, group.ID)
+	require.NoError(t, err)
+	found := false
+	for _, r := range roles {
+		if r.ID == adminRole.ID {
+			found = true
+		}
+	}
+	assert.True(t, found, "the grant must survive when the guard refuses")
+}
+
+// TestRemoveRoleFromGroup_AllowsWhenAnotherProjectAdminExists is the positive
+// control.
+func TestRemoveRoleFromGroup_AllowsWhenAnotherProjectAdminExists(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	other, err := st.CreateUser(ctx, &models.User{Username: "raj", Email: "raj@example.com", IsActive: true})
+	require.NoError(t, err)
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	// An independent, direct project_admin grant at the same project survives
+	// the group's role removal.
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, other.ID, "project_admin", false))
+
+	err = c.RemoveRoleFromGroup(ctx, actor, group.ID, adminRole.ID, Scope{ProjectID: proj})
+	require.NoError(t, err, "removal is fine while another project admin survives")
+}
+
+// TestRemoveRoleFromGroup_AllowsNonAdminRole confirms the new guard only
+// bites on a roles.assign-bearing role — removing an ordinary role from a
+// group must never be blocked, regardless of the project's admin count.
+func TestRemoveRoleFromGroup_AllowsNonAdminRole(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	viewerRole, err := st.GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-viewers"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, viewerRole.ID, storage.Scope{ProjectID: proj}))
+
+	err = c.RemoveRoleFromGroup(ctx, actor, group.ID, viewerRole.ID, Scope{ProjectID: proj})
+	require.NoError(t, err, "a non-admin role grant must never be blocked by the last-admin guard")
+}
+
+// TestReconcileSSOGroups_RefusesStrandingLastProjectAdmin proves the third
+// FIX-2 gap: SSO group-membership de-provisioning (an IdP that stops
+// asserting a user's admin-conferring group) previously called
+// storage.RemoveUserFromGroup directly, bypassing every core-layer guard.
+// This drives the same reconciliation path used on every SSO login and
+// confirms the user's membership in a group holding a project's last
+// roles.assign grant survives when the IdP stops asserting it.
+func TestReconcileSSOGroups_RefusesStrandingLastProjectAdmin(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "priya", Email: "priya@example.com", IsActive: true})
+	require.NoError(t, err)
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+	group, err := st.CreateGroup(ctx, &models.Group{Name: "proj7-admins"})
+	require.NoError(t, err)
+	require.NoError(t, st.AssignRoleToGroup(ctx, group.ID, adminRole.ID, storage.Scope{ProjectID: proj}))
+	require.NoError(t, c.AddUserToGroup(ctx, actor, false, u.ID, group.ID, 0))
+
+	// The IdP no longer asserts "proj7-admins" for this user (desired is
+	// empty) — reconcileSSOGroupRemovals must refuse the removal rather than
+	// silently stranding project 7.
+	removed := c.reconcileSSOGroupRemovals(ctx, u.ID, map[uint]bool{}, map[uint]bool{group.ID: true})
+	assert.Equal(t, 0, removed, "the last-admin-conferring group membership must not have been removed")
+
+	groups, err := st.GetUserGroups(ctx, u.ID)
+	require.NoError(t, err)
+	found := false
+	for _, g := range groups {
+		if g.ID == group.ID {
+			found = true
+		}
+	}
+	assert.True(t, found, "the group membership must survive when the guard refuses")
+}

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -304,6 +304,35 @@ func (c *KeyorixCore) guardLastProjectAdminGroupMembership(ctx context.Context, 
 	return nil
 }
 
+// guardLastProjectAdminGroupRole is guardLastGlobalAdminGroupRole's project-scope
+// counterpart (FIX-2): refuses to remove a group's roles.assign-conferring role
+// grant at a project's scope when doing so would leave that project with no
+// surviving roles.assign holder (direct or group-derived). A group losing its
+// project-admin-conferring role grant is the third way a group can stop
+// conferring project-admin authority — group deletion and membership removal
+// were already guarded (guardLastProjectAdminGroupDelete/
+// guardLastProjectAdminGroupMembership); this one, exercised through
+// RemoveRoleFromGroup, was not. Mirrors SetProjectMemberRole/
+// RemoveProjectMember's "not a permanent lockout (a global admin can always
+// re-add one), but still an availability risk worth refusing outright" stance
+// for direct grants, rather than guardLastGlobalAdminGroupRole's narrower
+// "project admins are recoverable, so don't bother" one.
+func (c *KeyorixCore) guardLastProjectAdminGroupRole(ctx context.Context, groupID, roleID, projectID uint) error {
+	hasAssign, err := c.storage.RoleSetHasPermission(ctx, []uint{roleID}, permRolesAssign)
+	if err != nil {
+		return err
+	}
+	if !hasAssign {
+		return nil // not removing a roles.assign-bearing role
+	}
+	if err := c.guardProjectAdminSurvivesGroupChange(ctx, projectID, func(a storage.RoleAssignment) bool {
+		return a.PrincipalType == "group" && a.PrincipalID == groupID && a.RoleID == roleID
+	}, nil); err != nil {
+		return fmt.Errorf("refusing to remove role %d from group %d: %w", roleID, groupID, err)
+	}
+	return nil
+}
+
 // projectAdminScopesHeldByGroup returns the project IDs at which groupID
 // holds a project-level (environment_id = 0) role granting roles.assign —
 // every project whose governance depends, at least in part, on this group.

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -201,13 +201,29 @@ func (c *KeyorixCore) AssignRoleToGroup(ctx context.Context, actorID, groupID, r
 // RemoveRoleFromGroup verifies the group exists then removes the role at scope
 // and records an RBAC audit event. actorID is the acting principal (0 = none). It
 // refuses to remove the install's last global-admin-conferring group grant (#107;
-// see guardLastGlobalAdminGroupRole).
+// see guardLastGlobalAdminGroupRole), OR a project's last roles.assign-conferring
+// group grant (FIX-2; see guardLastProjectAdminGroupRole) — a group losing its
+// project-admin-conferring role is the third way (alongside group deletion and
+// membership removal, both already guarded — guardLastProjectAdminGroupDelete/
+// guardLastProjectAdminGroupMembership) a group can stop conferring project-admin
+// authority, and had no guard at all.
 func (c *KeyorixCore) RemoveRoleFromGroup(ctx context.Context, actorID, groupID, roleID uint, scope Scope) error {
 	if _, err := c.storage.GetGroup(ctx, groupID); err != nil {
 		return fmt.Errorf("group not found: %w", err)
 	}
 	if err := c.guardLastGlobalAdminGroupRole(ctx, groupID, roleID, scope); err != nil {
 		return err
+	}
+	if scope.ProjectID != 0 && scope.EnvironmentID == 0 {
+		// #1646: serialize the guard's read against every HA replica via the same
+		// per-project named lock SetProjectMemberRole/RemoveProjectMember/
+		// RemoveUserRole use, so a concurrent removal racing this one can't each
+		// observe "another admin survives" before either write commits.
+		if err := c.storage.WithNamedLock(ctx, projectAdminGuardLockKey(scope.ProjectID), func(ctx context.Context) error {
+			return c.guardLastProjectAdminGroupRole(ctx, groupID, roleID, scope.ProjectID)
+		}); err != nil {
+			return err
+		}
 	}
 	if err := c.storage.RemoveRoleFromGroup(ctx, groupID, roleID, scope); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
@@ -440,20 +456,28 @@ func (c *KeyorixCore) assignUserRoleSystemGrant(ctx context.Context, actorID, us
 // kept as a cheap same-process fast-path serializer (mirroring
 // login_lockout.go's recordFailedLogin two-layer pattern), not as the sole
 // correctness mechanism.
+//
+// FIX-2: RemoveUserRole was scope-blind past the global check — a project-scoped
+// removal (scope.ProjectID != 0) fell straight through to storage.RemoveRole with
+// no last-admin protection at all, even though this is THE shared primitive
+// SetProjectMemberRole/RemoveProjectMember funnel through for their OWN
+// project-scope guard (guardLastProjectAdmin, itself WithNamedLock-wrapped by
+// those two callers per #1646). Any OTHER caller reaching this primitive
+// directly at project scope — and there are several: the plain /user-roles HTTP
+// route (RemoveRole, server/http/handlers/rbac.go), the gRPC RemoveRole RPC, and
+// the /system RemoveRoleGrantProxy — bypassed project-admin protection entirely,
+// letting a project's last roles.assign holder remove their own (or anyone's)
+// project-admin grant with no refusal. Guard the primitive itself, scope-aware,
+// so no entry point can bypass it going forward — the same "move the check to
+// where it cannot be skipped" fix SetProjectMemberRole/RemoveProjectMember
+// already apply one layer up, generalized to the actual choke point.
 func (c *KeyorixCore) RemoveUserRole(ctx context.Context, actorID, userID, roleID uint, scope Scope) error {
-	c.globalAdminGuardMu.Lock()
-	defer c.globalAdminGuardMu.Unlock()
-
 	if scope.ProjectID == 0 && scope.EnvironmentID == 0 {
-		adminIDs := c.installAdminRoleIDSet(ctx)
-		if adminIDs[roleID] {
-			ids := make([]uint, 0, len(adminIDs))
-			for id := range adminIDs {
-				ids = append(ids, id)
-			}
-			if err := c.storage.RemoveGlobalAdminRoleGuarded(ctx, userID, roleID, ids); err != nil {
-				return err
-			}
+		handled, err := c.removeGlobalAdminRoleIfApplicable(ctx, userID, roleID)
+		if err != nil {
+			return err
+		}
+		if handled {
 			c.LogRoleRemoved(ctx, actorID, userID, roleID, scope)
 			// Evict the auth cache so a just-revoked role stops authorizing on the
 			// very next request instead of the up-to-30s positive-cache window every
@@ -464,12 +488,65 @@ func (c *KeyorixCore) RemoveUserRole(ctx context.Context, actorID, userID, roleI
 			return nil
 		}
 	}
+	if scope.ProjectID != 0 && scope.EnvironmentID == 0 {
+		// #1646: the guard's read (existing roles) and the removal below must be
+		// serialized across every replica of an HA deployment, matching
+		// SetProjectMemberRole/RemoveProjectMember's identical use of the same
+		// per-project named lock — two concurrent removals of two different
+		// project admins' grants could otherwise each observe "another admin
+		// survives" before either write commits.
+		if err := c.storage.WithNamedLock(ctx, projectAdminGuardLockKey(scope.ProjectID), func(ctx context.Context) error {
+			existing, err := c.storage.GetUserRoleIDsExact(ctx, userID, scope)
+			if err != nil {
+				return err
+			}
+			after := make([]uint, 0, len(existing))
+			for _, id := range existing {
+				if id != roleID {
+					after = append(after, id)
+				}
+			}
+			return c.guardLastProjectAdmin(ctx, scope.ProjectID, userID, existing, after)
+		}); err != nil {
+			return err
+		}
+	}
 	if err := c.storage.RemoveRole(ctx, userID, roleID, scope); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}
 	c.LogRoleRemoved(ctx, actorID, userID, roleID, scope)
 	c.evictUserSessionCache(ctx, userID)
 	return nil
+}
+
+// removeGlobalAdminRoleIfApplicable performs RemoveUserRole's global-scope
+// admin-conferring-role removal (the #340/#525 atomic path) when roleID is one
+// of installAdminRoleNames, returning handled=true (removal performed or
+// refused) in that case. handled=false means roleID is not a global-admin role
+// and the caller should fall through to the ordinary removal path. Split out of
+// RemoveUserRole so globalAdminGuardMu's critical section stays scoped to
+// exactly this branch — it must never be held while the function's OTHER branch
+// (the project-scope guard below) acquires storage.WithNamedLock, or a
+// project-scope RemoveUserRole call racing a SetProjectMemberRole/
+// RemoveProjectMember call (which acquires WithNamedLock BEFORE calling back
+// into RemoveUserRole, per #1646) would lock-order-invert: the former acquires
+// globalAdminGuardMu then waits on WithNamedLock, the latter holds WithNamedLock
+// and waits on globalAdminGuardMu.
+func (c *KeyorixCore) removeGlobalAdminRoleIfApplicable(ctx context.Context, userID, roleID uint) (handled bool, err error) {
+	c.globalAdminGuardMu.Lock()
+	defer c.globalAdminGuardMu.Unlock()
+	adminIDs := c.installAdminRoleIDSet(ctx)
+	if !adminIDs[roleID] {
+		return false, nil
+	}
+	ids := make([]uint, 0, len(adminIDs))
+	for id := range adminIDs {
+		ids = append(ids, id)
+	}
+	if err := c.storage.RemoveGlobalAdminRoleGuarded(ctx, userID, roleID, ids); err != nil {
+		return true, err
+	}
+	return true, nil
 }
 
 // installAdminRoleNames are the roles that confer install-wide administration when

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -657,11 +657,25 @@ func (c *KeyorixCore) reconcileSSOGroupAdditions(ctx context.Context, userID uin
 	return added, blocked
 }
 
+// FIX-2: this used to call c.storage.RemoveUserFromGroup directly, bypassing
+// the core-layer RemoveUserFromGroup's last-admin guards entirely
+// (guardLastGlobalAdminMembership, guardLastProjectAdminGroupMembership) — an
+// IdP that stopped asserting a user's admin-conferring group membership (a
+// misconfigured claim, a stale IdP-side group, or a malicious IdP) could
+// silently strand the install or a project with no admin on the user's very
+// next login, with no refusal and no error surfaced anywhere. Routed through
+// RemoveUserFromGroupGlobal — the guarded wrapper this file's own doc comment
+// already names as the one JIT/SSO de-provisioning callers should use — so
+// this is exactly as safe as any other de-provisioning path.
 func (c *KeyorixCore) reconcileSSOGroupRemovals(ctx context.Context, userID uint, desired, currentSet map[uint]bool) (removed int) {
-	// De-escalating removals are unconditional (dropping a group only reduces privilege).
+	// De-escalating removals are unconditional (dropping a group only reduces
+	// privilege) EXCEPT when doing so would strand the install or a project
+	// with no remaining admin — RemoveUserFromGroupGlobal refuses those. The
+	// acting principal is the logging-in user themself, matching this file's
+	// audit-logging convention (actorPtr(userID), reconcileSSOGroups above).
 	for id := range currentSet {
 		if !desired[id] {
-			if err := c.storage.RemoveUserFromGroup(ctx, userID, id, 0); err == nil {
+			if err := c.RemoveUserFromGroupGlobal(ctx, userID, userID, id); err == nil {
 				removed++
 			}
 		}

--- a/internal/core/sso_test.go
+++ b/internal/core/sso_test.go
@@ -466,6 +466,15 @@ func TestSyncSSOGroups(t *testing.T) {
 		store.On("AddUserToGroup", mock.Anything, uint(7), uint(1), uint(0)).Return(nil)      // admins: asserted, not current → add (global)
 		store.On("RemoveUserFromGroup", mock.Anything, uint(7), uint(3), uint(0)).Return(nil) // ops: current, not asserted → remove (global)
 		store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+		// FIX-2: removals now route through the guarded RemoveUserFromGroupGlobal
+		// (guardLastGlobalAdminMembership, guardLastProjectAdminGroupMembership)
+		// instead of calling storage.RemoveUserFromGroup directly — both guards
+		// short-circuit cleanly (no admin-tier role anywhere in this fixture), but
+		// still need these lookups stubbed.
+		store.On("GetRoleByName", mock.Anything, "super_admin").Return(nil, assert.AnError)
+		store.On("GetRoleByName", mock.Anything, "admin").Return(nil, assert.AnError)
+		store.On("GetRoleByName", mock.Anything, "system_admin").Return(nil, assert.AnError)
+		store.On("ListGroupRoleAssignments", mock.Anything, uint(3)).Return(nil, nil)
 
 		c.syncSSOGroups(context.Background(), p, 7, raw)
 


### PR DESCRIPTION
## Summary

Stacked on #1685 (FIX-1) — this branch is based on `fix-1-grant-ceiling`, not `main`, because FIX-2 also touches `rbac_management.go` (the file the remediation plan explicitly warned not to batch with FIX-1's own change). Labeled `stacked-pr` per this repo's `base-branch-check` CI gate. Should be retargeted to `main` once #1685 merges.

The last-project-admin guard sat on entry points (`SetProjectMemberRole`, `RemoveProjectMember`), not on the primitives (`RemoveUserRole`, `RemoveRoleFromGroup`) those entry points funnel through. Any OTHER caller reaching a primitive directly bypassed protection entirely:

- `RemoveUserRole`'s last-admin check was scope-gated to global only (project 0, environment 0); a project-scoped removal fell straight through to `storage.RemoveRole` with no guard at all. Live bypasses: the plain `/user-roles` HTTP route, the gRPC `RemoveRole` RPC, and the `/system` `RemoveRoleGrantProxy`.
- `RemoveRoleFromGroup` only checked the install's last global-admin grant; a group losing its project-admin-conferring role grant (the third way, alongside group deletion and membership removal, a group can stop conferring project-admin authority) had no guard.
- `reconcileSSOGroupRemovals` called `storage.RemoveUserFromGroup` directly, bypassing the core-layer guards entirely — an IdP that stopped asserting a user's admin-conferring group membership could silently strand a project (or the install) with no admin on the user's next login.

Moved the check down to the primitives, scope-aware, mirroring `SetProjectMemberRole`/`RemoveProjectMember`'s existing stance. Routed `reconcileSSOGroupRemovals` through the already-guarded `RemoveUserFromGroupGlobal` instead of the raw storage call.

`globalAdminGuardMu`'s critical section is narrowed to exactly the global-scope branch it was written for, so it can never nest with the new project-scope branch's `storage.WithNamedLock` — a project-scoped `RemoveUserRole` call racing a `SetProjectMemberRole`/`RemoveProjectMember` call (which acquires `WithNamedLock` before calling back into `RemoveUserRole`) would otherwise lock-order-invert.

Each of the three fixes is independently verified red-then-green (temporarily reverted, confirmed the new regression test fails, restored).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on every touched file
- [x] `gosec -severity medium -exclude-generated` — 0 issues
- [x] Full repo `go test ./...` — all packages green
- [x] Each of the 3 closed gaps has a dedicated regression test, independently verified red without the fix