### PR TITLE
fix(rbac): restore ErrRoleValidation precision without reintroducing raw-error echo

### DIFF
--- a/internal/core/rbac_roles.go
+++ b/internal/core/rbac_roles.go
@@ -17,12 +17,48 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// ErrRoleValidation marks a CreateRole failure as an application-generated
+// validation error (name length, folded-name charset/bidi rejection) rather
+// than a storage/driver failure, so a caller like mapRoleError
+// (server/grpc/services/role_service.go) can confirm via errors.Is that the
+// failure is safe to classify as InvalidArgument instead of guessing from
+// its text.
+//
+// FIX-4 (adversarial review run 2), restored 2026-09-03: this sentinel was
+// introduced by #1668 (e78bab59) and reverted 22 hours later by #1669, as a
+// side effect of resolving a merge conflict while ALSO fixing a genuinely
+// real, separate problem (see mapRoleError's comment) — #1669's commit
+// message says so explicitly: "the sentinel machinery was removed... this
+// fixed-message approach is simpler." That conflation is exactly the gap:
+// #1669's message-safety fix (never pass err.Error() to status.Error,
+// required by the keyorix-raw-error-to-client Semgrep gate) is correct and
+// stays; #1669's classification regression (back to strings.Contains(msg,
+// "validation"), the imprecise substring match #1668 existed specifically
+// to close) does not need to accompany it — the two are independent, and
+// restoring the sentinel here does not require echoing its content anywhere.
+var ErrRoleValidation = errors.New("role validation")
+
+// roleValidationError tags err as matching ErrRoleValidation for errors.Is,
+// without ErrRoleValidation's own text ever appearing in Error() -- the
+// displayed message stays exactly err's, unchanged from before this marker
+// existed.
+type roleValidationError struct{ err error }
+
+func (e *roleValidationError) Error() string        { return e.err.Error() }
+func (e *roleValidationError) Unwrap() error        { return e.err }
+func (e *roleValidationError) Is(target error) bool { return target == ErrRoleValidation }
+
+// WrapRoleValidation marks err as an ErrRoleValidation match for errors.Is,
+// without altering its Error() text.
+func WrapRoleValidation(err error) error { return &roleValidationError{err: err} }
 
 // Role Name/Description length bounds — the single source of truth both
 // transports' own early-reject validation (server/http/handlers/rbac.go's
@@ -60,11 +96,11 @@ func validateRoleNameLength(name string) error {
 // authenticated principal).
 func (c *KeyorixCore) CreateRole(ctx context.Context, actorID uint, name, description string) (*models.Role, error) {
 	if err := validateRoleNameLength(name); err != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+		return nil, WrapRoleValidation(fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err))
 	}
 	foldedName, ferr := identity.NewFoldedName(name)
 	if ferr != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr)
+		return nil, WrapRoleValidation(fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), ferr))
 	}
 	if IsBuiltinRole(foldedName.Folded()) {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this role name is reserved and cannot be created")

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/core"
@@ -414,22 +415,24 @@ func mapRoleError(err error) error {
 		return status.Error(codes.AlreadyExists, "this role name is reserved and cannot be created")
 	case strings.Contains(msg, "already exists"), strings.Contains(msg, "duplicate"), strings.Contains(msg, "unique"):
 		return status.Error(codes.AlreadyExists, "a role with that name already exists")
-	// #1660: core.CreateRole/UpdateRole's own validation (name fold rejects
-	// control/bidi characters, length bounds) surfaces here now that both
-	// RPCs route through them instead of storage directly. A fixed message,
-	// not err.Error(), per this file's gRPC convention (semgrep
-	// keyorix-raw-error-to-client): core's validation error wraps
-	// identity.NewFoldedName's raw-input echo (%q of the caller's own
-	// string), which is safe content but not a "known safe sentinel with a
-	// fixed string" the rule's nosemgrep exception covers, so it goes
-	// through mapRoleError like every other case instead of being
-	// special-cased. (An earlier fix on main took the sentinel route --
-	// wrapping CreateRole's validation errors in a core.ErrRoleValidation
-	// marker checked via errors.Is -- but this fixed-message approach is
-	// simpler, matches every other case in this switch, and needs no
-	// wrapper type; the sentinel machinery was removed from
-	// internal/core/rbac_roles.go when resolving this conflict.)
-	case strings.Contains(msg, "validation"):
+	// #1660/FIX-4 (restored 2026-09-03): core.CreateRole's own validation
+	// (name fold rejects control/bidi characters, length bounds) surfaces
+	// here now that the RPC routes through it instead of storage directly.
+	// errors.Is against core.ErrRoleValidation confirms the failure is
+	// application-generated (never a storage/driver error that merely
+	// happens to mention the word "validation", e.g. a constraint named
+	// *_validation_*) — restoring #1668's actual precision guarantee, lost
+	// 22 hours later when #1669 reverted the classification back to the
+	// bare substring match as a side effect of ALSO (correctly) fixing a
+	// different problem: err.Error() here wraps identity.NewFoldedName's
+	// raw-input echo (%q of the caller's own string) — safe content, but
+	// not a "known safe sentinel with an already-fixed string" the
+	// keyorix-raw-error-to-client Semgrep gate's nosemgrep exception
+	// requires, so it is NOT echoed to the client; the fixed message #1669
+	// introduced is kept. The two fixes are independent: restoring
+	// PRECISION here does not require reintroducing the CI-blocking MESSAGE
+	// #1669 was correct to remove.
+	case errors.Is(err, core.ErrRoleValidation):
 		return status.Error(codes.InvalidArgument, "invalid role name or description")
 	case strings.Contains(msg, "built-in"):
 		return status.Error(codes.FailedPrecondition, "cannot modify a built-in role")

--- a/server/grpc/services/services_s2_test.go
+++ b/server/grpc/services/services_s2_test.go
@@ -196,15 +196,37 @@ func TestMapRoleError_Default(t *testing.T) {
 // InvalidArgument with a fixed message -- never err.Error() verbatim, since
 // identity.NewFoldedName's error text echoes the caller's raw input (%q) and
 // isn't the "known safe sentinel with a fixed string" this file's
-// keyorix-raw-error-to-client convention requires for echoing.
+// keyorix-raw-error-to-client convention requires for echoing. Classification
+// goes through core.WrapRoleValidation/errors.Is (restored by FIX-4), not a
+// substring match on the word "validation" -- see
+// TestMapRoleError_ValidationTextWithoutSentinel_NotEchoed for why that
+// distinction matters.
 func TestMapRoleError_Validation(t *testing.T) {
-	err := mapRoleError(fmt.Errorf("validation error: invalid name %q: control characters not allowed", "role\x00name"))
+	err := mapRoleError(core.WrapRoleValidation(fmt.Errorf("validation error: invalid name %q: control characters not allowed", "role\x00name")))
 	st, _ := status.FromError(err)
 	if st.Code() != codes.InvalidArgument {
 		t.Errorf("expected InvalidArgument, got %v", st.Code())
 	}
 	if st.Message() != "invalid role name or description" {
 		t.Errorf("expected the fixed safe message, got %q (raw error text -- including caller input -- must not leak)", st.Message())
+	}
+}
+
+// A storage/driver error that merely happens to mention the word
+// "validation" (e.g. a constraint or column named *_validation_*) must NOT
+// be classified as InvalidArgument just because its text contains that
+// substring -- only an error the application itself marked with
+// core.WrapRoleValidation (via errors.Is) is a real validation failure. This
+// is the precision gap #1668 introduced core.ErrRoleValidation to close and
+// #1669 regressed 22 hours later (reverting mapRoleError's classification to
+// strings.Contains(msg, "validation") as a side effect of a different,
+// legitimate fix); FIX-4 restores the errors.Is check without reintroducing
+// #1669's real problem (see TestMapRoleError_Validation's fixed message).
+func TestMapRoleError_ValidationTextWithoutSentinel_NotEchoed(t *testing.T) {
+	err := mapRoleError(errors.New("pq: insert failed: check constraint \"role_name_validation_chk\" violated"))
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Internal {
+		t.Errorf("expected Internal (not InvalidArgument) for an unmarked error that merely mentions \"validation\", got %v", st.Code())
 	}
 }
 


### PR DESCRIPTION
## Summary

FIX-4 of the adversarial-review remediation plan (run 2).

`mapRoleError` (server/grpc/services/role_service.go) classified role-validation
failures via a bare `strings.Contains(msg, "validation")` substring match,
misclassifying any storage/driver error that merely happens to mention the word
"validation" (e.g. a constraint literally named `*_validation_*`) as a
client-facing `InvalidArgument`.

`#1668` fixed this with a `core.ErrRoleValidation` sentinel checked via
`errors.Is`, but `#1669` reverted that sentinel machinery 22 hours later as an
incidental side effect of a genuinely separate, correct fix: the
`keyorix-raw-error-to-client` Semgrep gate rightly blocked echoing `err.Error()`
(which wraps `identity.NewFoldedName`'s raw `%q`-quoted caller input) to the
client. `#1669`'s own commit message confirms the sentinel removal was
incidental, not deliberate.

The two fixes are independent. This restores the sentinel and `errors.Is`
classification for precision, while keeping `#1669`'s fixed, non-interpolated
client message — this does not reintroduce the CI-blocking issue `#1669` fixed.

## Changes

- `internal/core/rbac_roles.go`: restore `ErrRoleValidation`/`WrapRoleValidation`,
  wrap both of `CreateRole`'s validation-error returns.
- `server/grpc/services/role_service.go`: restore `errors.Is(err,
  core.ErrRoleValidation)` classification in `mapRoleError`, keeping the fixed
  safe message.
- `server/grpc/services/services_s2_test.go`: fix `TestMapRoleError_Validation`
  to construct its input the way `core.CreateRole` actually produces it now
  (via `WrapRoleValidation`); add
  `TestMapRoleError_ValidationTextWithoutSentinel_NotEchoed`, which verifies an
  unmarked error merely containing the word "validation" is no longer
  misclassified as `InvalidArgument`.

Stacked on `fix-1-grant-ceiling` (PR #1685, unmerged) since both touch RBAC
role-service files.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./server/grpc/services/...` green
- [x] `go test ./internal/core/...` green
- [x] Red/green verified: reverting the `errors.Is` classification makes
      `TestMapRoleError_ValidationTextWithoutSentinel_NotEchoed` fail, restoring
      it passes
- [x] `gofmt -l` clean on touched files
- [x] `gosec -severity medium -exclude-generated` clean on touched packages
- [ ] Full-repo `go test ./...` (running in background)