### PR TITLE
fix(server): close two /system proxy residuals on tracker-closed issues (#1551, #1572)

### DIFF
--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -565,6 +565,55 @@ const (
 // invisible until an operator goes looking for it.
 const EventUserDeactivationCleanupFailed = "user.deactivation_cleanup_failed"
 
+// RevokeUserCredentialsForDeactivation performs the SAME mandatory PAT/session
+// revocation UpdateUser's own local deactivating branch applies inline
+// against storage directly (see that branch's comment) — a MANDATORY,
+// already-decided consequence of a deactivation that has ALREADY been
+// committed by the caller, not an independent action a caller is choosing to
+// take on its own (that case is RevokeAllPersonalAccessTokensForUser/
+// DeleteSessionsForUserExcept above, which correctly gate on
+// requireUserCredentialsRevokeAuthority because there the revocation IS the
+// whole ask). #1572: the /system UpdateUserIfActiveStateMatchesProxy handler
+// used to call THOSE ceiling-gated wrappers for its own post-deactivation
+// cleanup — any caller reaching that route without users.write (the route's
+// own gate is the broader, non-project-scoped system.write every /system
+// proxy accepts, not users.write specifically) would have the deactivation
+// itself succeed while this cleanup silently failed the ceiling check and
+// was swallowed as "best-effort." Calling storage directly here, exactly as
+// UpdateUser's local branch does, removes the inappropriate re-authorization
+// instead of threading it through — the deactivation decision was already
+// authorized (or not) upstream of this call by whatever decided to persist
+// IsActive=false; revocation is not a second decision.
+//
+// Session-cache eviction is unconditional: sessionHashes is collected BEFORE
+// the revocation attempt (mirroring UpdateUser exactly) so the up-to-30s
+// warm-auth-cache window (server/middleware/auth.go's serveAuthCacheHit)
+// closes immediately regardless of whether the row deletion itself
+// succeeds — a session already blocked by IsActive=false at the DB layer
+// could otherwise still authenticate against a stale cache entry for that
+// window. PAT-hash eviction remains conditional on the revoke call
+// succeeding (it needs the returned hashes to know what to evict), matching
+// UpdateUser's identical asymmetry — a row a failed revocation leaves behind
+// is inert regardless (ValidatePATToken's live IsActive re-check blocks it),
+// only the up-to-30s cache window differs, same tradeoff UpdateUser already
+// accepts. Fire-and-forget: audits on failure, returns nothing, exactly like
+// the code path it mirrors.
+func (c *KeyorixCore) RevokeUserCredentialsForDeactivation(ctx context.Context, userID uint) {
+	sessionHashes, _ := c.storage.ListSessionTokenHashesForUser(ctx, userID)
+	patHashes, patErr := c.storage.RevokeAllPersonalAccessTokensForUser(ctx, userID)
+	sessionErr := c.storage.DeleteSessionsForUserExcept(ctx, userID, 0)
+	c.invalidateTokenCache(sessionHashes...)
+	if patErr == nil {
+		c.invalidateTokenCache(patHashes...)
+	}
+	if patErr != nil || sessionErr != nil {
+		c.writeAuditEventFailed(ctx, EventUserDeactivationCleanupFailed, nil, nil, "",
+			fmt.Sprintf("user %d deactivated, but credential cleanup was incomplete (pat_error=%v, session_error=%v) — "+
+				"the account is already login-blocked regardless, but a stale row may remain until its own expiry",
+				userID, patErr, sessionErr))
+	}
+}
+
 // DeleteUser deprovisions and soft-deletes a user by ID: blocks login
 // (AccountDeprovisioned, mirroring DeprovisionSCIMUser), terminates every session,
 // revokes every personal access token, and evicts them from the auth cache — then

--- a/server/http/handlers/handlers_s21_machine_proxy_test.go
+++ b/server/http/handlers/handlers_s21_machine_proxy_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -759,13 +760,13 @@ func TestRevokeMachineIdentityCredentialProxy_HappyPath_S21(t *testing.T) {
 	require.Equal(t, http.StatusOK, cw2.Code)
 	var credResp remoteAPIResponse
 	require.NoError(t, json.NewDecoder(cw2.Body).Decode(&credResp))
-	credID := "1"
-	_ = credResp
+	credID := strconv.FormatUint(uint64(credResp.Data.(map[string]interface{})["id"].(float64)), 10)
 
 	req := withChiParam(
 		httptest.NewRequest(http.MethodPost, "/system/machine-credentials/"+credID+"/revoke", proxyBodyS21(map[string]interface{}{"project_id": 40})),
 		"id", credID,
 	)
+	req = withOIDCAdminCtxS21(t, h, req)
 	w := httptest.NewRecorder()
 	h.RevokeMachineIdentityCredentialProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/server/http/handlers/handlers_s28_test.go
+++ b/server/http/handlers/handlers_s28_test.go
@@ -1124,7 +1124,7 @@ func TestRevokeMachineIdentityCredentialProxy_NotFound_S28(t *testing.T) {
 // credential then revokes it.
 func TestRevokeMachineIdentityCredentialProxy_HappyPath_S28(t *testing.T) {
 	t.Parallel()
-	cs := freshCoreS28(t)
+	cs, _ := freshCoreS28WithAdmin(t)
 	ctx := context.Background()
 	mi, err := cs.Storage().CreateMachineIdentity(ctx, &models.MachineIdentity{
 		Name: "s28-revoke-machine", ProjectID: 1, IdentityType: "workload", State: "active",
@@ -1138,7 +1138,7 @@ func TestRevokeMachineIdentityCredentialProxy_HappyPath_S28(t *testing.T) {
 	require.NoError(t, err)
 
 	h := NewCatalogHandler(cs)
-	req := withChiParam(httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(fmt.Sprintf(`{"project_id":%d}`, mi.ProjectID)))), "id", uintStrS28(cred.ID))
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(fmt.Sprintf(`{"project_id":%d}`, mi.ProjectID)))), "id", uintStrS28(cred.ID)))
 	w := httptest.NewRecorder()
 	h.RevokeMachineIdentityCredentialProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -95,6 +95,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
 // isAlreadyAssignedErr reports whether err is local_machine_credentials.go's
@@ -776,27 +777,34 @@ type revokeMachineIdentityCredentialProxyBody struct {
 // `id = ? AND machine_identity_id IN (project's machines)`), so a single
 // passthrough call here preserves that guarantee exactly.
 //
-// #1551: project_id is now part of the wire request (previously this route
-// took only the credential id, with no tenant check at all). The
-// legitimate spoke topology (a CLI running under storage.type: remote calls
-// core.RevokeMachineToken, which already runs core.machineInProject's
-// ownership check client-side against its own RemoteStorage-backed read
-// before ever reaching this route) never depended on this route enforcing
-// tenancy itself. A caller reaching this route directly (holding the
-// blanket system.write raw-storage capability every /system proxy in this
-// package trusts, but not going through core.RevokeMachineToken) had no
-// such check at all: any credential ID could be revoked by naming any
-// project, since neither ID was ever cross-checked against the other. The
-// fix pushes the ownership check into the storage primitive itself
-// (RevokeMachineIdentityCredential's own project_id parameter, enforced in
-// its WHERE clause) rather than adding a second, parallel authorization
-// primitive at this handler — deriving from the existing
-// core.machineInProject check's *shape*, not inventing a new one: a
-// caller-claimed tenant is now verified against the credential's real
-// owning project before the write, the same "claim vs. ground truth"
-// pattern already applied to wire-supplied actors elsewhere in this
-// package (e.g. CreateMembershipProxy's #1578 fix), just for a tenant
-// field instead of an actor field.
+// #1551, corrected 2026-09-03: the 2026-08-29 fix added project_id to the
+// wire request and enforced it in the storage WHERE clause, believing that
+// verified "a caller-claimed tenant against the credential's real owning
+// project." It does not: the WHERE clause only checks whether the credential
+// belongs to the NAMED project — a fact the attacker also knows, since it's
+// exactly the fact they're attacking with. A cross-tenant caller simply
+// supplies the credential's REAL (victim) project_id, which the WHERE
+// clause happily confirms, and the write proceeds. Nothing in that fix ever
+// asked whether the CALLER is entitled to that project — a "claim vs.
+// ground truth" check only stops a caller who gets the tenant claim WRONG,
+// not one who deliberately gets it right. Independently reproduced live
+// (HTTP 200, DB write confirmed) during the 2026-09-02 adversarial review.
+//
+// The real fix: resolve the credential's project SERVER-SIDE (never trust
+// the wire value to identify which tenant is being acted on) and require
+// the AUTHENTICATED caller to hold roles.assign at that resolved project —
+// the same permission server/http/router.go's human-facing route
+// (DELETE /projects/{id}/machine-identities/{machineId}/tokens/{tokenId})
+// requires via RequireScopedPermission(permRolesAssign, projectScope), now
+// re-derived here the way AssignMachineRoleProxy/RemoveMachineRoleProxy
+// already re-derive their own equivalents (this file's own top-of-file doc:
+// "this route group's gate also admits any caller... holding the
+// system.write PERMISSION directly, with no node credential, and THAT
+// caller is not relaying anyone's already-checked decision"). The wire
+// project_id is kept as a client-supplied assertion, still cross-checked
+// against the resolved value (a real mismatch is still a real bug worth
+// surfacing as 404, matching a genuinely unknown credential), but it is no
+// longer what authorization is computed from.
 func (h *CatalogHandler) RevokeMachineIdentityCredentialProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
@@ -812,7 +820,42 @@ func (h *CatalogHandler) RevokeMachineIdentityCredentialProxy(w http.ResponseWri
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "project_id is required")
 		return
 	}
-	if err := h.coreService.Storage().RevokeMachineIdentityCredential(r.Context(), body.ProjectID, uint(id)); err != nil {
+	cred, err := h.coreService.Storage().GetMachineIdentityCredentialByID(r.Context(), uint(id))
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errMachineCredentialNotFound)
+			return
+		}
+		log.Printf("machine-credentials proxy: revoke: resolving credential failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	machine, err := h.coreService.Storage().GetMachineIdentity(r.Context(), cred.MachineIdentityID)
+	if err != nil {
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errMachineCredentialNotFound)
+			return
+		}
+		log.Printf("machine-credentials proxy: revoke: resolving machine identity failed: %v", err)
+		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
+		return
+	}
+	if machine.ProjectID != body.ProjectID {
+		writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errMachineCredentialNotFound)
+		return
+	}
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN",
+			"revoking a machine credential requires the roles.assign permission at the credential's project")
+		return
+	}
+	if ok, aerr := h.coreService.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), "roles.assign", core.Scope{ProjectID: machine.ProjectID}); aerr != nil || !ok {
+		writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN",
+			"revoking a machine credential requires the roles.assign permission at the credential's project")
+		return
+	}
+	if err := h.coreService.Storage().RevokeMachineIdentityCredential(r.Context(), machine.ProjectID, uint(id)); err != nil {
 		if isNotFoundErr(err) {
 			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errMachineCredentialNotFound)
 			return

--- a/server/http/handlers/users_active_transition_proxy.go
+++ b/server/http/handlers/users_active_transition_proxy.go
@@ -171,36 +171,33 @@ func (h *UserHandler) UpdateUserIfActiveStateMatchesProxy(w http.ResponseWriter,
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
 	}
-	// #1572: replicate core.UpdateUser's deactivating-branch side effect --
-	// PAT/session revocation -- which a caller reaching this route directly
-	// (bypassing core.UpdateUser, e.g. holding raw system.write without going
-	// through the CLI's own core.UpdateUser call) would otherwise skip
-	// entirely, leaving the deactivated user's PATs/sessions live. The two
-	// core-level operations this calls (RevokeAllPersonalAccessTokensForUser/
-	// DeleteSessionsForUserExcept, server/http/handlers/users_credentials_proxy.go)
-	// already exist as safe, authorized, audited routes for exactly this
-	// purpose (ADR-088's own costing for #1572: "the fix is calling those same
-	// two already-safe internal/core operations directly, in sequence... no new
-	// primitive needed") -- reused here as in-process calls, not a second HTTP
-	// hop, since this handler already runs on the hub. Best-effort and
-	// non-fatal, matching core.UpdateUser's own posture toward the identical
-	// failure mode (internal/core/users.go's deactivating branch, lines
-	// ~419-463): the deactivation itself already committed via the conditional
-	// write above, and ValidateSessionToken/ValidatePATToken independently
-	// re-check the live is_active flag on every use regardless of whether
-	// revocation ran, so a failed best-effort revocation here leaves no live
-	// credential, only a stale row. Only fires when matched is true (this
-	// call's own CAS write actually won the race) and only on a real
-	// true->false transition -- calling it on every request would revoke
-	// credentials on no-op or reactivating calls too.
+	// #1572, corrected 2026-09-03: replicate core.UpdateUser's deactivating-
+	// branch side effect -- PAT/session revocation -- which a caller reaching
+	// this route directly (bypassing core.UpdateUser) would otherwise skip
+	// entirely. The original fix called core.RevokeAllPersonalAccessTokensForUser/
+	// core.DeleteSessionsForUserExcept, believing them "already-safe" reuse --
+	// but those two specifically gate on requireUserCredentialsRevokeAuthority
+	// (users.write), which is the RIGHT ceiling for a caller invoking
+	// revocation as its own standalone action, and the WRONG one here: this
+	// route's own gate is the broader, non-project-scoped system.write every
+	// /system proxy accepts, not users.write specifically, so a caller
+	// reaching this route without users.write hit that ceiling on EVERY
+	// deactivation, had the failure logged and swallowed as "best-effort,"
+	// and left the deactivated user's session warm-cache-usable for up to 30s
+	// (core.UpdateUser's own local branch evicts the session cache
+	// unconditionally, before the revocation attempt -- this proxy's use of
+	// the ceiling-gated wrappers meant that eviction never ran at all when
+	// the ceiling rejected the call, since the wrapper returns before doing
+	// anything). core.RevokeUserCredentialsForDeactivation calls storage
+	// directly instead, exactly like core.UpdateUser's own deactivating
+	// branch does -- see its doc for why no separate ceiling belongs here:
+	// revocation is a mandatory consequence of a deactivation already
+	// committed by the write above, not an independent decision. Only fires
+	// when matched is true (this call's own CAS write actually won the race)
+	// and only on a real true->false transition -- calling it on every
+	// request would revoke credentials on no-op or reactivating calls too.
 	if matched && deactivating {
-		actorType, actorID := requestActorKindAndID(r)
-		if _, err := h.coreService.RevokeAllPersonalAccessTokensForUser(r.Context(), actorType, actorID, uint(id)); err != nil {
-			log.Printf("users proxy: active-state transition: best-effort PAT revocation failed for user %d: %v", id, err)
-		}
-		if err := h.coreService.DeleteSessionsForUserExcept(r.Context(), actorType, actorID, uint(id), 0); err != nil {
-			log.Printf("users proxy: active-state transition: best-effort session revocation failed for user %d: %v", id, err)
-		}
+		h.coreService.RevokeUserCredentialsForDeactivation(r.Context(), uint(id))
 	}
 	writeRemoteAPISuccess(w, map[string]bool{"matched": matched})
 }

--- a/server/http/handlers/users_active_transition_proxy_credential_revoke_test.go
+++ b/server/http/handlers/users_active_transition_proxy_credential_revoke_test.go
@@ -97,6 +97,83 @@ func TestUpdateUserIfActiveStateMatchesProxy_DeactivationRevokesCredentials_Real
 	_ = session
 }
 
+// TestUpdateUserIfActiveStateMatchesProxy_DeactivationRevokesCredentialsEvenWithoutUsersWrite_RealServer
+// is #1572 corrected 2026-09-03: the original fix called
+// core.RevokeAllPersonalAccessTokensForUser/core.DeleteSessionsForUserExcept,
+// which gate on requireUserCredentialsRevokeAuthority (users.write) — the
+// RIGHT ceiling for a caller invoking revocation as its OWN standalone
+// action, but the WRONG one here, since this /system route's own gate is the
+// broader system.write every /system proxy accepts, not users.write
+// specifically. A caller reaching this route holding system.write but NOT
+// users.write hit that ceiling on every deactivation, had the revocation
+// failure logged and swallowed as "best-effort," and left the deactivated
+// user's PAT/session live and warm-cache-usable. This drives the exact
+// scenario with a caller who does not hold users.write and confirms both
+// credentials come back revoked anyway — proving core.RevokeUserCredentialsForDeactivation
+// no longer re-authorizes the caller for what is a mandatory consequence of
+// an already-committed deactivation, not an independent decision.
+func TestUpdateUserIfActiveStateMatchesProxy_DeactivationRevokesCredentialsEvenWithoutUsersWrite_RealServer(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// A caller with system.write but explicitly NO users.write anywhere —
+	// requireUserCredentialsRevokeAuthority would refuse this actor outright.
+	caller, err := cs.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "g80-1572-caller", Email: "g80-1572-caller@example.com",
+		DisplayName: "G80 1572 Caller", Password: "NotArealpassword123!",
+	})
+	require.NoError(t, err)
+
+	target, err := cs.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "g80-1572-target2", Email: "g80-1572-target2@example.com",
+		DisplayName: "G80 1572 Target 2", Password: "NotArealpassword123!",
+	})
+	require.NoError(t, err)
+
+	pat, err := cs.Storage().CreatePersonalAccessToken(ctx, &models.PersonalAccessToken{
+		UserID: target.ID, Name: "ci", TokenHash: "hash-1572b-pat", TokenPrefix: "kx_pat_1572b",
+	})
+	require.NoError(t, err)
+	_, err = cs.Storage().CreateSession(ctx, &models.Session{
+		UserID: target.ID, SessionToken: "hash-1572b-session", CreatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	hashes, err := cs.Storage().ListSessionTokenHashesForUser(ctx, target.ID)
+	require.NoError(t, err)
+	require.Len(t, hashes, 1, "target must have exactly one live session before deactivation")
+
+	body, err := json.Marshal(map[string]interface{}{
+		"username": target.Username, "email": target.Email,
+		"active": false, "updated_at": time.Now(), "from_active": true,
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest("PUT", "/", bytes.NewReader(body))
+	// caller holds no roles at all -- not even users.write, let alone
+	// roles.assign -- deliberately, to prove revocation no longer depends on
+	// the caller's own permission set.
+	uc := &middleware.UserContext{UserID: caller.ID, Username: caller.Username, Email: caller.Email}
+	req = req.WithContext(context.WithValue(req.Context(), middleware.GetUserContextKey(), uc))
+	req = withChiParams(req, map[string]string{"id": machineUintToStr(target.ID)})
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	require.Equal(t, 200, w.Code, "deactivation itself must still succeed: %s", w.Body.String())
+
+	reloaded, err := cs.Storage().GetUser(ctx, target.ID)
+	require.NoError(t, err)
+	assert.False(t, reloaded.IsActive)
+
+	patAfter, err := cs.Storage().GetPersonalAccessTokenByHash(ctx, "hash-1572b-pat")
+	require.NoError(t, err)
+	assert.True(t, patAfter.Revoked, "the target's PAT must be revoked even though the caller holds no users.write grant")
+	assert.Equal(t, pat.ID, patAfter.ID)
+
+	hashesAfter, err := cs.Storage().ListSessionTokenHashesForUser(ctx, target.ID)
+	require.NoError(t, err)
+	assert.Empty(t, hashesAfter, "the target's session must be deleted even though the caller holds no users.write grant")
+}
+
 // TestUpdateUserIfActiveStateMatchesProxy_ReactivationDoesNotRevoke_RealServer
 // is the control: flipping IsActive from false->true (or any non-deactivating
 // call) must never trigger a revocation attempt -- only a real true->false

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -1126,6 +1126,35 @@ var rawStorageBypassAllowlist = map[string]string{
 	"DeleteRole": "no-independent-ceiling: internal/core has no exported wrapper for role deletion at all -- " +
 		"this route (DELETE /api/v1/roles/{id}, RequirePermission(permRolesWrite)) IS the authoritative " +
 		"implementation, with its own built-in-role guard (rbac.go:426) already inline.",
+	// #1551, corrected 2026-09-03 (adversarial review run 2, FIX-3): moved from
+	// knownUnfixedRawStorageBypasses -- the 2026-08-29 "PARTIALLY FIXED" entry
+	// there believed the project_id-on-the-wire, enforced-in-the-WHERE-clause
+	// check closed the cross-tenant gap. It did not: that check only verifies
+	// the NAMED project actually owns the credential, a fact an attacker also
+	// knows (it's exactly the fact they're attacking with) -- it never asked
+	// whether the CALLER is entitled to that project. A cross-tenant caller
+	// simply supplied the credential's real (victim) project_id and the
+	// "verification" happily confirmed it. Independently reproduced live
+	// (HTTP 200, DB write confirmed) during the 2026-09-02 adversarial
+	// review. Real fix: the handler now resolves the credential's project
+	// SERVER-SIDE (GetMachineIdentityCredentialByID -> GetMachineIdentity,
+	// never trusting the wire value to identify the tenant) and calls
+	// AuthorizePrincipal(actor, "roles.assign", Scope{ProjectID: resolved})
+	// inline before the raw storage call -- the same permission the
+	// human-facing route (DELETE /projects/{id}/machine-identities/{machineId}/tokens/{tokenId})
+	// requires via RequireScopedPermission, now re-derived here the way
+	// AssignMachineRoleProxy/RemoveMachineRoleProxy already re-derive their
+	// own equivalents. The wire project_id is kept as a client assertion,
+	// still cross-checked against the resolved value (a mismatch is a 404,
+	// matching an unknown credential), but authorization no longer comes
+	// from it. Audit + cache-eviction hand-off remain a SEPARATE, still-open,
+	// narrower residual (unchanged by this fix, not silently dropped) --
+	// this raw call still doesn't log an audit event or evict the auth-token
+	// cache the way core.RevokeMachineToken's caller-side eviction contract
+	// expects; out of this fix's scope (not an escalation).
+	"RevokeMachineIdentityCredentialProxy": "FIXED: AuthorizePrincipal(actor, \"roles.assign\", " +
+		"Scope{ProjectID: <server-resolved from the credential>}) now runs inline before the raw storage call -- " +
+		"see the FIXED comment immediately above this entry for the full reasoning.",
 }
 
 // knownUnfixedRawStorageBypasses is the set of /system handlers confirmed, by
@@ -1256,36 +1285,14 @@ var knownUnfixedRawStorageBypasses = map[string]string{
 	// CreateMachineIdentityProxy is FIXED (moved to rawStorageBypassAllowlist);
 	// CreateMachineIdentityCredentialProxy is HALF-FIXED (see its entry below) --
 	// neither belongs here with its original pre-fix text.
-	// #1551 cross-tenant half FIXED 2026-08-29 (Wave 2, ADR-088):
-	// storage.Storage.RevokeMachineIdentityCredential now takes a projectID
-	// parameter, enforced in the WHERE clause (LocalStorage) and carried on
-	// the wire (RemoteStorage/RevokeMachineIdentityCredentialProxy) --
-	// deriving the existing core.machineInProject ownership-check *shape*
-	// rather than inventing a new authorization primitive: a caller-claimed
-	// project_id is now verified against the credential's real owning
-	// project before the write, the same claim-vs-ground-truth pattern
-	// already used for wire-supplied actors elsewhere in this package.
-	// Verified red/green via a real upstream/downstream integration test
-	// (server/http/remote_storage_machine_identities_test.go,
-	// TestRemoteStorageMachineIdentities_RevokeCredential_CrossTenantRejected_RealServer).
-	// Audit + cache-eviction hand-off remain a SEPARATE, still-open residual
-	// (unchanged by this fix, not silently dropped): this raw call still
-	// doesn't log an audit event or return the token hash for auth-cache
-	// eviction the way core.RevokeMachineToken's caller-side eviction
-	// contract expects -- and unlike the tenant check, that gap isn't closed
-	// by a wire parameter alone (it needs either an audit call here or a
-	// wire-carried hash in the response), so still belongs in this list under
-	// its own remaining half.
-	"RevokeMachineIdentityCredentialProxy": "PARTIALLY FIXED 2026-08-29 (#1551, Wave 2): cross-tenant revoke is " +
-		"now rejected (project_id required on the wire, enforced in the storage layer's WHERE clause). Still " +
-		"open: no audit event, no token-hash returned for auth-cache eviction (core.RevokeMachineToken's own " +
-		"caller-side eviction contract is unmet by this raw passthrough) -- narrower residual, not an " +
-		"escalation, not part of #1551's stated cross-tenant scope. " +
-		"ADR-085 (Accepted, 2026-08-25) closed the node-credential axis specifically: the /system group's own " +
-		"gate now requires system.write for every caller (see " +
-		"TestSystemWriteCeiling_RevokeMachineIdentityCredentialProxy_NodeCredential_DeniedAtGate, " +
-		"system_write_ceiling_table_test.go) -- irrelevant to the tenant check either way, since that check now " +
-		"runs for every caller regardless of credential class.",
+	// #1551: RevokeMachineIdentityCredentialProxy moved to
+	// rawStorageBypassAllowlist 2026-09-03 -- the 2026-08-29 "PARTIALLY
+	// FIXED" claim here was itself wrong (the WHERE-clause check it relied on
+	// verifies the named project owns the credential, not that the CALLER is
+	// entitled to that project -- an attacker who supplies the credential's
+	// real project_id sails through). See that entry for the real fix
+	// (AuthorizePrincipal, server-resolved project, inline before the raw
+	// call) and what narrower residual (audit + cache-eviction) remains.
 	// UpsertMFASecretProxy, CreateMFAStepUpGrantProxy, UpdateProjectProxy,
 	// RestoreProjectProxy, DeleteAnomalyAlertsBeforeProxy,
 	// DeleteClosedAccessReviewsBeforeProxy, DeleteExpiredBreakGlassBeforeProxy,

--- a/server/http/remote_storage_machine_identities_test.go
+++ b/server/http/remote_storage_machine_identities_test.go
@@ -382,6 +382,67 @@ func TestRemoteStorageMachineIdentities_RevokeCredential_CrossTenantRejected_Rea
 	assert.True(t, revoked.Revoked, "revoking with the credential's real project_id must still succeed")
 }
 
+// TestRemoteStorageMachineIdentities_RevokeCredential_UnauthorizedCallerRejected_RealServer
+// is #1551's REAL exploit shape, corrected 2026-09-03: the CrossTenantRejected
+// test above only proves the wire-supplied project_id is checked against the
+// credential's real owner — it does not prove the CALLER is entitled to that
+// project. A caller supplying the credential's actual (correct) project_id
+// was never rejected by that check at all, since the WHERE clause happily
+// confirms a true fact. This drives exactly that: a caller holding
+// system.write (passes the /system group's own gate) but NO roles.assign
+// grant anywhere revokes a credential by naming its real, correct project —
+// before the 2026-09-03 fix this succeeded outright (independently
+// reproduced live: HTTP 200, DB write confirmed); now it must be refused.
+func TestRemoteStorageMachineIdentities_RevokeCredential_UnauthorizedCallerRejected_RealServer(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream := newTestCore(t)
+	cfg := &config.Config{Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"}}}
+	router, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+
+	ctx := context.Background()
+	project, err := upstream.CreateProject(ctx, "Unauthorized Revoke Test Project", "")
+	require.NoError(t, err)
+
+	adminToken := createNodeToken(t, upstream) // holds admin -- used only to set up fixtures
+	adminRS, err := store.NewRemoteStorage(&remote.Config{BaseURL: srv.URL, APIKey: adminToken, TimeoutSeconds: 5, TLSVerify: true})
+	require.NoError(t, err)
+	admin := core.NewKeyorixCore(adminRS)
+
+	now := time.Now()
+	m, err := admin.Storage().CreateMachineIdentity(ctx, buildMachineIdentity(now, project.ID, "unauth-revoke-test"))
+	require.NoError(t, err)
+	const hash = "deadbeef00112233445566778899aabbccddeeff0011223344556677889900"
+	cred, err := admin.Storage().CreateMachineIdentityCredential(ctx, buildMachineIdentityCredential(now, m.ID, hash))
+	require.NoError(t, err)
+
+	// A caller with system.write and nothing else — no roles.assign anywhere.
+	weakToken := createSystemWriteOnlyToken(t, upstream)
+	weakRS, err := store.NewRemoteStorage(&remote.Config{BaseURL: srv.URL, APIKey: weakToken, TimeoutSeconds: 5, TLSVerify: true})
+	require.NoError(t, err)
+	weak := core.NewKeyorixCore(weakRS)
+
+	// The CORRECT project_id — this is the point: the old fix's check would
+	// have PASSED here, because the claim is true. Only the caller's own
+	// authority is what should be able to refuse this.
+	err = weak.Storage().RevokeMachineIdentityCredential(ctx, project.ID, cred.ID)
+	require.Error(t, err, "a caller with no roles.assign grant must not be able to revoke a credential, even by naming its real project")
+
+	stillLive, err := admin.Storage().GetMachineIdentityCredentialByID(ctx, cred.ID)
+	require.NoError(t, err)
+	assert.False(t, stillLive.Revoked, "an unauthorized revoke attempt must not revoke the credential")
+
+	// Positive control: the SAME credential is still revocable by the admin caller.
+	require.NoError(t, admin.Storage().RevokeMachineIdentityCredential(ctx, project.ID, cred.ID))
+	revoked, err := admin.Storage().GetMachineIdentityCredentialByID(ctx, cred.ID)
+	require.NoError(t, err)
+	assert.True(t, revoked.Revoked, "an authorized caller must still be able to revoke")
+}
+
 // TestRemoteStorageMachineIdentities_RoleGrantAssignRemoveListIDs_RealServer
 // proves the fix for AssignMachineRole/RemoveMachineRole/GetMachineRoleIDsAt/
 // GetMachineRoles.

--- a/server/http/system_write_ceiling_table_test.go
+++ b/server/http/system_write_ceiling_table_test.go
@@ -27,13 +27,15 @@
 // -- no live caller). Its
 // RevokeMachineIdentityCredentialProxy coverage
 // (RevokeMachineIdentityCredentialProxy_NodeCredential_DeniedAtGate below) was
-// originally gate-level only, since the wire contract (POST-by-bare-
-// credential-ID, no project/scope parameter at all) couldn't express a
-// per-grant scope check without a RemoteStorage client-side change first —
-// filed as #1551. That wire change landed (Wave 2, 2026-08-29): the route now
-// requires project_id and rejects a cross-tenant claim in the storage layer's
-// own WHERE clause (see raw_storage_bypass_guard_test.go's entry for this
-// handler for the still-open residual, audit + cache-eviction hand-off).
+// gate-level (a bare node credential is refused before the request body is
+// ever read). The deeper #1551 cross-tenant gap -- any system.write holder
+// could revoke any credential by naming any project -- is fixed separately
+// (2026-09-03): the handler resolves the credential's real project
+// server-side and requires the caller hold roles.assign there via
+// AuthorizePrincipal, inline before the raw storage call (see
+// raw_storage_bypass_guard_test.go's rawStorageBypassAllowlist entry for
+// this handler for the full reasoning and the still-open, narrower audit +
+// cache-eviction residual).
 //
 // A second dimension: "Node-credential-path rows" below exercise the
 // human-caller rows' SAME write routes again, but with a bare node-type
@@ -758,11 +760,12 @@ func TestSystemWriteCeiling_AssignRoleWithExpiryProxy_NodeCredential_DeniedAtGat
 // group's own system.write gate (ADR-085) — before the request body is ever
 // read, so this holds regardless of the handler's own body shape. #1551's
 // deeper cross-tenant gap (any system.write holder could revoke any
-// credential by naming any project) is now FIXED separately (Wave 2,
-// 2026-08-29): RevokeMachineIdentityCredentialProxy requires project_id on
-// the wire and storage.Storage.RevokeMachineIdentityCredential enforces it in
-// its WHERE clause. Audit + cache-eviction hand-off remain a separate, still-
-// open residual (raw_storage_bypass_guard_test.go's own entry for this
+// credential by naming any project) is now FIXED separately (2026-09-03):
+// the handler resolves the credential's real project server-side and
+// requires the caller hold roles.assign there via AuthorizePrincipal,
+// inline before the raw storage call. Audit + cache-eviction hand-off
+// remain a separate, still-open residual (raw_storage_bypass_guard_test.go's
+// own entry for this
 // handler).
 func TestSystemWriteCeiling_RevokeMachineIdentityCredentialProxy_NodeCredential_DeniedAtGate(t *testing.T) {
 	f := setupCeilingTableFixtures(t)


### PR DESCRIPTION
## Summary

FIX-3 of the adversarial-review remediation plan (run 2). Two independent
`/system` proxy residuals whose landed fix was partial, both on
tracker-closed issues.

**#1551 — `RevokeMachineIdentityCredentialProxy`**
(`machine_identities_proxy.go`). The 2026-08-29 fix added a `project_id` wire
field and enforced it in the storage `WHERE` clause — but that only verifies
the *named* project actually owns the credential, a fact the attacker also
knows since it's exactly what they're attacking with. It never checked
whether the *caller* is entitled to that project. Cross-tenant revoke still
reproduced (HTTP 200, DB write confirmed). Fixed by re-deriving the caller's
real authorization server-side via `AuthorizePrincipal` against
`roles.assign` at the credential's actual owning project scope — matching
the human-facing counterpart's real authorization in `router.go` — never
trusting the wire-supplied `project_id` for identity.

**#1572 — `UpdateUserIfActiveStateMatchesProxy`**
(`users_active_transition_proxy.go`). Deactivation succeeded, but the
PAT/session revocation meant to accompany it was a best-effort side effect
routed through core functions that enforce their own independent
`users.write` authorization — for a caller without that permission,
revocation silently failed, leaving the deactivated user's credentials live
and usable. Revocation of a caller's own already-authorized deactivation
decision isn't a new, independently-authorized action; it's a mandatory
consequence of one already taken. Added
`core.RevokeUserCredentialsForDeactivation`, which revokes unconditionally as
part of the deactivation itself (storage layer directly, no re-authorization
gate), and routed the proxy through it.

Also fixed the machine-identity lookup error mapping to distinguish genuine
storage failures from not-found (`isNotFoundErr`) instead of collapsing both
to 404.

Stacked on `fix-1-grant-ceiling` (PR #1685, unmerged) since both touch
machine-identity/RBAC territory in `internal/core`.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `internal/core` suite green (67.8s)
- [x] `server/http/handlers` suite green (32.5s, includes contracttest)
- [x] `server/http` suite green (672.3s standalone; the whole-repo run's
      earlier apparent FAIL at 604.7s was the default 10-min per-package
      timeout under contention, not a real failure — reproduced clean twice
      in isolation)
- [x] New regression tests: real-server cross-tenant-caller-rejected test for
      #1551, real-server deactivation-revokes-without-`users.write` test for
      #1572
- [x] Fixed 3 pre-existing tests whose fixtures had gaps the old,
      ceiling-free code paths never exposed
- [x] `gofmt -l` clean on touched files
- [x] `gosec -severity medium -exclude-generated` clean on touched packages