### PR TITLE
fix(storage): key WithNamedLock's reentrancy guard on lockKey, not "any lock held"

### DIFF
--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -197,14 +197,13 @@ type LocalStorage struct {
 	// LocalStorage must share its parent's mutex.
 	bootstrapMu *sync.Mutex
 	// namedLockMu is the in-process fallback for WithNamedLock (#1646) on a
-	// non-Postgres backend (SQLite, single-process by construction): a single
-	// shared mutex, not sharded per lock key, mirroring auditCheckpointMu/
-	// bootstrapMu's own single-mutex shape. On PostgreSQL, WithNamedLock instead
-	// takes a session advisory lock keyed by lockKey's hash, extending the
-	// serialization across replicas (ADR-039 HA) -- this mutex is skipped
-	// entirely on that path. A pointer for the same sharing reason as every
+	// non-Postgres backend (SQLite, single-process by construction): a registry
+	// handing out one *sync.Mutex per lock key, mirroring PostgreSQL's
+	// per-key pg_advisory_lock semantics exactly (see WithNamedLock's own doc
+	// comment, FIX-5) rather than one shared mutex serializing every unrelated
+	// key against every other. A pointer for the same sharing reason as every
 	// other mutex on this struct.
-	namedLockMu *sync.Mutex
+	namedLockMu *namedLockRegistry
 	// consumeClockWatermark backs consumeClockLooksRegressed (#1632): an
 	// in-memory monotonic high-water mark of the latest wall-clock instant a
 	// single-use-token consumption (ConsumeMFAChallenge, ConsumeWebAuthnSession)
@@ -243,7 +242,7 @@ func NewLocalStorage(db *gorm.DB) *LocalStorage {
 		auditChainMu:          &sync.Mutex{},
 		auditCheckpointMu:     &sync.Mutex{},
 		bootstrapMu:           &sync.Mutex{},
-		namedLockMu:           &sync.Mutex{},
+		namedLockMu:           newNamedLockRegistry(),
 		consumeClockWatermark: &clockWatermark{},
 		rbacClockWatermark:    &clockWatermark{},
 	}

--- a/internal/storage/store/local_named_lock.go
+++ b/internal/storage/store/local_named_lock.go
@@ -6,7 +6,45 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"sync"
 )
+
+// namedLockRegistry hands out one *sync.Mutex per lock key, creating it on
+// first use, so the non-Postgres WithNamedLock fallback (SQLite,
+// single-process by construction) serializes callers per-key exactly like
+// PostgreSQL's pg_advisory_lock does -- not one shared mutex serializing every
+// unrelated key against every other. FIX-5 (adversarial review run 2): this
+// replaces a single process-wide *sync.Mutex that WAS shared across every
+// lock key -- with the reentrancy guard now keyed on lockKey (see
+// namedLockHeldCtxKey), a nested WithNamedLock call under a DIFFERENT key
+// must actually be able to acquire its OWN lock rather than either
+// (old, wrong) silently skipping it, or (a naive per-key reentrancy fix atop
+// the OLD single shared mutex) self-deadlocking by re-locking the same mutex
+// the outer call already holds.
+type namedLockRegistry struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newNamedLockRegistry() *namedLockRegistry {
+	return &namedLockRegistry{locks: make(map[string]*sync.Mutex)}
+}
+
+// forKey returns the mutex for lockKey, creating it if this is the first
+// caller to ever name it. The registry's own mu only guards the map lookup
+// itself, not the returned mutex's Lock/Unlock -- callers hold the returned
+// mutex for the duration of their critical section, same as before this type
+// existed.
+func (r *namedLockRegistry) forKey(lockKey string) *sync.Mutex {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	m, ok := r.locks[lockKey]
+	if !ok {
+		m = &sync.Mutex{}
+		r.locks[lockKey] = m
+	}
+	return m
+}
 
 // namedLockKey derives a stable int64 advisory-lock key from an arbitrary lockKey
 // string via FNV-1a (Go-side, not a Postgres SQL function, so the same key always
@@ -18,22 +56,45 @@ func namedLockKey(lockKey string) int64 {
 }
 
 // namedLockHeldCtxKey marks a context as already running inside a WithNamedLock
-// closure. WithNamedLock is meant to guard against concurrent OTHER callers
-// racing the same check-then-act sequence; it is not meant to serialize a single
-// call chain against itself. Without this guard, one guarded core method calling
-// another (e.g. SetProjectMemberRole → AssignUserRole, both #1646 call sites)
+// closure for one or more SPECIFIC lock keys (see heldNamedLockKeys). WithNamedLock
+// is meant to guard against concurrent OTHER callers racing the same check-then-act
+// sequence for a given lockKey; it is not meant to serialize a single call chain
+// against itself reacquiring that SAME key. Without this guard, one guarded core
+// method calling another under the identical key (e.g. SetProjectMemberRole →
+// guardLastProjectAdmin's own re-entry, both keyed on projectAdminGuardLockKey)
 // self-deadlocks: the SQLite/single-process path re-locks ls.namedLockMu (not
 // reentrant), and the Postgres path pulls a SECOND connection from the pool and
 // blocks it on pg_advisory_lock behind the first connection's own held lock —
 // which, under a small pool, also starves connectionOpener into a permanent
 // select (reproduced: internal/core's suite hung 600s on exactly this shape).
+//
+// FIX-5 (adversarial review run 2): the marker used to be a single untyped
+// boolean, so ANY already-held lock -- regardless of key -- caused a nested
+// WithNamedLock call under a DIFFERENT key to skip acquiring it entirely. That is
+// the wrong invariant: WithNamedLock's whole point is per-key cross-replica
+// serialization, and a nested call under a different key still needs its own
+// lock actually taken (e.g. SetProjectMemberRole holds projectAdminGuardLockKey
+// and calls AssignUserRole, which must still acquire its own
+// sodGrantLockKey("user", userID) -- a different resource, not covered by the
+// outer lock at all). The marker is now the SET of keys currently held by this
+// call chain, so only a re-entrant acquisition of the SAME key is skipped.
 type namedLockHeldCtxKey struct{}
 
+// heldNamedLockKeys reads the set of lock keys already held by this call chain,
+// or nil if none.
+func heldNamedLockKeys(ctx context.Context) map[string]bool {
+	held, _ := ctx.Value(namedLockHeldCtxKey{}).(map[string]bool)
+	return held
+}
+
 // WithNamedLock runs fn with every OTHER caller using the identical lockKey
-// serialized against it: a process-level mutex covers the common single-writer
-// self-host topology and SQLite (inherently single-instance — there is no DB-level
-// advisory lock to take); a PostgreSQL session-scoped advisory lock (pg_advisory_lock),
-// keyed by lockKey's FNV-1a hash, extends that across processes/replicas (ADR-039 HA).
+// serialized against it: a per-key process-level mutex (namedLockRegistry)
+// covers the common single-writer self-host topology and SQLite (inherently
+// single-instance — there is no DB-level advisory lock to take); a PostgreSQL
+// session-scoped advisory lock (pg_advisory_lock), keyed by lockKey's FNV-1a
+// hash, extends that across processes/replicas (ADR-039 HA). Both paths give
+// two DIFFERENT lock keys independent locks — only callers sharing the same
+// key ever serialize against each other.
 //
 // Like WithBootstrapLock/WithAuditCheckpointLock, this BLOCKS until the lock is
 // acquired rather than skipping on contention — a caller that loses the race must
@@ -41,21 +102,30 @@ type namedLockHeldCtxKey struct{}
 // state, not silently no-op.
 //
 // fn receives the (possibly lock-marked) context so that a nested WithNamedLock
-// call made from within fn — even under a different lockKey — sees the marker
-// via namedLockHeldCtxKey and runs directly instead of re-acquiring: the outer
-// lock already gives this call chain exclusivity over every other goroutine/replica.
-// Callers that thread ctx through to further WithNamedLock calls MUST use the
-// ctx passed to fn, not whatever ctx they closed over — otherwise the marker
-// never propagates and the nested call self-deadlocks (see namedLockHeldCtxKey).
+// call made from within fn, under the SAME lockKey, sees the marker via
+// namedLockHeldCtxKey and runs directly instead of re-acquiring: the outer lock
+// already gives this call chain exclusivity over every other goroutine/replica
+// for that key. A nested call under a DIFFERENT lockKey is not covered by the
+// outer lock at all and still acquires its own. Callers that thread ctx through
+// to further WithNamedLock calls MUST use the ctx passed to fn, not whatever ctx
+// they closed over — otherwise the marker never propagates and a same-key nested
+// call self-deadlocks (see namedLockHeldCtxKey).
 func (ls *LocalStorage) WithNamedLock(ctx context.Context, lockKey string, fn func(ctx context.Context) error) error {
-	if ctx.Value(namedLockHeldCtxKey{}) != nil {
+	held := heldNamedLockKeys(ctx)
+	if held[lockKey] {
 		return fn(ctx)
 	}
-	ctx = context.WithValue(ctx, namedLockHeldCtxKey{}, true)
+	next := make(map[string]bool, len(held)+1)
+	for k := range held {
+		next[k] = true
+	}
+	next[lockKey] = true
+	ctx = context.WithValue(ctx, namedLockHeldCtxKey{}, next)
 
 	if ls.db.Dialector.Name() != "postgres" {
-		ls.namedLockMu.Lock()
-		defer ls.namedLockMu.Unlock()
+		mu := ls.namedLockMu.forKey(lockKey)
+		mu.Lock()
+		defer mu.Unlock()
 		return fn(ctx)
 	}
 

--- a/internal/storage/store/local_named_lock_test.go
+++ b/internal/storage/store/local_named_lock_test.go
@@ -1,0 +1,125 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func newNamedLockTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	return NewLocalStorage(db)
+}
+
+// A same-key nested WithNamedLock call must be skipped (not re-acquired) --
+// this is the original #1646 self-deadlock guard, and must still hold after
+// FIX-5 keys the guard on lockKey.
+func TestWithNamedLock_ReentrantSameKey_DoesNotDeadlock(t *testing.T) {
+	ls := newNamedLockTestStore(t)
+	ctx := context.Background()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ls.WithNamedLock(ctx, "same-key", func(ctx context.Context) error {
+			return ls.WithNamedLock(ctx, "same-key", func(ctx context.Context) error {
+				return nil
+			})
+		})
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("same-key reentrant WithNamedLock call deadlocked")
+	}
+}
+
+// FIX-5 (adversarial review run 2): a nested WithNamedLock call under a
+// DIFFERENT key from the one already held must actually acquire its own
+// lock, not silently skip acquisition because SOME lock (a different one) is
+// already held by this call chain. Before this fix, the reentrancy guard was
+// a single untyped boolean keyed on "is any lock held at all" -- so
+// SetProjectMemberRole holding projectAdminGuardLockKey(projectID) and then
+// calling AssignUserRole, which needs its own sodGrantLockKey("user", userID),
+// never actually took the second lock, losing AssignUserRole's cross-replica
+// SoD check-then-act serialization entirely whenever reached through that
+// call chain.
+//
+// Proven here by holding "key-B" open in one goroutine and confirming a
+// nested WithNamedLock(ctx, "key-B", ...) call -- issued from inside an outer
+// WithNamedLock(ctx, "key-A", ...) closure on a SEPARATE call chain -- blocks
+// until the first goroutine releases it. Under the old bug, the nested call
+// would return immediately (wrongly treating key-B as already covered by
+// key-A's own lock), which this test's ordering assertion would catch.
+func TestWithNamedLock_NestedDifferentKey_StillSerializesAgainstOtherHolder(t *testing.T) {
+	ls := newNamedLockTestStore(t)
+	ctx := context.Background()
+
+	const holdKey = "key-B"
+	holderEntered := make(chan struct{})
+	releaseHolder := make(chan struct{})
+	holderDone := make(chan error, 1)
+
+	go func() {
+		holderDone <- ls.WithNamedLock(context.Background(), holdKey, func(ctx context.Context) error {
+			close(holderEntered)
+			<-releaseHolder
+			return nil
+		})
+	}()
+
+	select {
+	case <-holderEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("holder goroutine never entered its critical section")
+	}
+
+	var releasedBeforeNestedAcquired bool
+	nestedDone := make(chan error, 1)
+	go func() {
+		nestedDone <- ls.WithNamedLock(ctx, "key-A", func(ctx context.Context) error {
+			// A DIFFERENT call chain (this goroutine) than the holder above is
+			// currently blocking on holdKey. This nested call, under a
+			// different key than "key-A", must still contend for holdKey's
+			// own lock rather than skipping acquisition.
+			return ls.WithNamedLock(ctx, holdKey, func(ctx context.Context) error {
+				releasedBeforeNestedAcquired = true
+				return nil
+			})
+		})
+	}()
+
+	// Give the nested call every opportunity to (wrongly) complete early if
+	// the reentrancy guard were still skipping on "any lock held" rather than
+	// "this exact key held" -- it must NOT have finished yet.
+	select {
+	case <-nestedDone:
+		t.Fatal("nested WithNamedLock(key-B) returned before the other holder released it -- " +
+			"the different-key lock was skipped instead of actually acquired")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(releaseHolder)
+
+	select {
+	case err := <-holderDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("holder goroutine never completed")
+	}
+
+	select {
+	case err := <-nestedDone:
+		require.NoError(t, err)
+		require.True(t, releasedBeforeNestedAcquired)
+	case <-time.After(5 * time.Second):
+		t.Fatal("nested WithNamedLock(key-B) never completed after the holder released")
+	}
+}


### PR DESCRIPTION
## Summary

FIX-5 of the adversarial-review remediation plan (run 2).

The `#1646` reentrancy guard existed to stop one guarded core method calling
another under the SAME lock key from self-deadlocking (`SetProjectMemberRole`'s
closure re-entering `guardLastProjectAdmin`'s own lock). It was implemented as
a single untyped context marker meaning "some `WithNamedLock` call is already
in progress on this call chain" — so a nested call under a DIFFERENT key
skipped acquiring its own lock entirely, not just the one already held.

This is live, not theoretical: `SetProjectMemberRole` holds
`projectAdminGuardLockKey(projectID)` and, inside that closure, calls
`AssignUserRole`, which needs its own `sodGrantLockKey("user", userID)` to
serialize `requireNoSoDViolation`'s check-then-act sequence across replicas.
Reached through that call chain, `AssignUserRole`'s SoD lock was never
actually taken — silently losing the cross-replica serialization `#1646`
added it for, on exactly the nested path the guard's own doc comment names as
the motivating case.

## Fix

- Keyed the reentrancy guard on the specific `lockKey` (a set of held keys
  threaded through context, not a boolean) — only a re-entrant acquisition of
  the SAME key is skipped now.
- That alone isn't sufficient on the non-Postgres fallback path (SQLite,
  single-process): it used ONE shared `*sync.Mutex` for every lock key, so a
  per-key reentrancy check atop it would make a nested DIFFERENT-key call
  re-lock the same mutex the outer call already holds — a new deadlock on
  every non-Postgres deployment, worse than the bug being fixed. Replaced the
  single shared mutex with `namedLockRegistry`, handing out one `*sync.Mutex`
  per key on first use, mirroring PostgreSQL's per-key `pg_advisory_lock`
  semantics exactly on both backends.

Stacked on `fix-2-last-admin-primitive` (PR #1686, unmerged) since both touch
`internal/storage/store` project-admin-guard territory.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] New tests: same-key reentrant call still completes without deadlocking
      (the original guarantee); a nested call under a different key genuinely
      blocks against a concurrent holder of that key until released (the
      actual FIX-5 guarantee) — proven by ordering assertions against a
      goroutine holding the second key open, not just absence-of-panic
- [x] Red/green verified: reverting the per-key check to the old "any lock
      held" condition makes the new serialization test fail
- [x] `-race` clean on the new tests
- [x] `internal/storage/store` suite green (82.2s)
- [x] `internal/core` suite green (69.4s)
- [x] `gofmt -l` clean on touched files
- [x] `gosec -severity medium -exclude-generated` clean on touched package
- [ ] Full-repo `go test ./...` (running in background)