### PR TITLE
fix(rbac): SoD DeleteSoDPolicy authorize-before-lookup ordering + sentinel classification

### DIFF
--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -8,6 +8,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -15,6 +16,41 @@ import (
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// ErrSoDValidation, ErrSoDPermissionDenied, and ErrSoDNotFound classify
+// CreateSoDPolicy/DeleteSoDPolicy failures for server/http/handlers/sod.go to
+// match via errors.Is, rather than the substring text match it used to do
+// against these functions' i18n-prefixed messages (e.g.
+// strings.Contains(msg, "permission denied")). That match only worked because
+// every shipped locale left the underlying translation key (ErrorValidation/
+// ErrorPermissionDenied) untranslated -- the first deployment whose locale
+// translates it would silently fall through to the handler's generic 500
+// default instead of the correct 400/403.
+var (
+	ErrSoDValidation       = errors.New("sod validation")
+	ErrSoDPermissionDenied = errors.New("sod permission denied")
+	ErrSoDNotFound         = errors.New("sod policy not found")
+)
+
+// sodClassifiedError tags err as matching target for errors.Is, without
+// target's own text ever appearing in Error() -- same shape as FIX-4's
+// roleValidationError (internal/core/rbac_roles.go).
+type sodClassifiedError struct {
+	err    error
+	target error
+}
+
+func (e *sodClassifiedError) Error() string        { return e.err.Error() }
+func (e *sodClassifiedError) Unwrap() error        { return e.err }
+func (e *sodClassifiedError) Is(target error) bool { return target == e.target }
+
+func wrapSoDValidation(err error) error {
+	return &sodClassifiedError{err: err, target: ErrSoDValidation}
+}
+func wrapSoDPermissionDenied(err error) error {
+	return &sodClassifiedError{err: err, target: ErrSoDPermissionDenied}
+}
+func wrapSoDNotFound(err error) error { return &sodClassifiedError{err: err, target: ErrSoDNotFound} }
 
 // SoD audit event types. Create/Delete denial paths below reuse these SAME
 // constants (Success=false via writeAuditEventFailed distinguishes a denied
@@ -101,13 +137,13 @@ func (c *KeyorixCore) CreateSoDPolicy(ctx context.Context, actorID uint, name, d
 	permA = strings.TrimSpace(permA)
 	permB = strings.TrimSpace(permB)
 	if name == "" {
-		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a policy name is required")
+		return nil, wrapSoDValidation(fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "a policy name is required"))
 	}
 	if permA == "" || permB == "" {
-		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "two permissions are required")
+		return nil, wrapSoDValidation(fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "two permissions are required"))
 	}
 	if permA == permB {
-		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "the two permissions must be different")
+		return nil, wrapSoDValidation(fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "the two permissions must be different"))
 	}
 	// #1529 authority check runs AFTER field validation (mirrors PlaceLegalHold's
 	// own order: cheap input checks before a DB-backed authority resolution) --
@@ -115,8 +151,8 @@ func (c *KeyorixCore) CreateSoDPolicy(ctx context.Context, actorID uint, name, d
 	if c.isGlobalAdminRoleName(ctx, actorID) == "" {
 		c.writeAuditEventFailed(ctx, EventSoDPolicyCreated, actorPtr(actorID), nil, "",
 			fmt.Sprintf("SoD policy create DENIED: actor %d is not an admin-tier principal", actorID))
-		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
-			"only an admin-tier principal may define a SoD policy")
+		return nil, wrapSoDPermissionDenied(fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
+			"only an admin-tier principal may define a SoD policy"))
 	}
 	policy, err := c.storage.CreateSoDPolicy(ctx, &models.SoDPolicy{
 		Name: name, Description: description, PermissionA: permA, PermissionB: permB,
@@ -155,16 +191,49 @@ func (c *KeyorixCore) ListSoDPolicies(ctx context.Context) ([]*models.SoDPolicy,
 // mirrors LiftLegalHold's creator-or-admin precedent exactly: only the
 // principal who originally created the policy, or a global-admin-tier
 // principal, may delete it. A denied attempt is itself audited.
+//
+// FIX-6 (adversarial review run 2): the authority check used to run AFTER the
+// existence lookup, and returned that lookup's error verbatim on failure --
+// so a caller holding the deliberately-broad system.write (this route's own
+// gate; see this file's own doc comment) but no creator/admin-tier standing
+// could tell "policy id doesn't exist" (404, from GetSoDPolicy's own error)
+// apart from "policy id exists but isn't mine" (403, from the check below): a
+// reliable ID-enumeration oracle. Fixed per ADR-096's 403-for-both
+// convention, already the house standard for exactly this shape
+// (server/middleware/auth.go's handleScopeResolutionError): a real 404 is
+// safe ONLY for a caller already authorized at global admin-tier -- the SAME
+// standing that would grant access to this resource had it existed, mirroring
+// handleScopeResolutionError's own "authorized at global scope" condition --
+// since an admin-tier caller can already see/delete every policy regardless
+// of which id this is. Every other caller gets the IDENTICAL
+// ErrSoDPermissionDenied response whether the id is missing or just not
+// theirs -- same status, same message, same error classification -- closing
+// the oracle rather than merely renaming it.
 func (c *KeyorixCore) DeleteSoDPolicy(ctx context.Context, actorID, id uint) error {
+	isAdminTier := c.isGlobalAdminRoleName(ctx, actorID) != ""
+
 	policy, err := c.storage.GetSoDPolicy(ctx, id)
 	if err != nil {
+		if isAdminTier && errors.Is(err, storage.ErrSoDPolicyNotFound) {
+			return wrapSoDNotFound(err)
+		}
+		if errors.Is(err, storage.ErrSoDPolicyNotFound) {
+			// Non-admin caller: collapse "doesn't exist" into the identical
+			// denial a non-owning caller gets for an EXISTING policy below --
+			// see this function's doc comment.
+			c.writeAuditEventFailed(ctx, EventSoDPolicyDeleted, actorPtr(actorID), nil, "",
+				fmt.Sprintf("SoD policy %d delete DENIED: actor %d is not an admin-tier principal (policy lookup found no match)", id, actorID))
+			return wrapSoDPermissionDenied(fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
+				"only the creating admin or an admin-tier principal may delete this SoD policy"))
+		}
 		return err
 	}
-	if actorID != policy.CreatedBy && c.isGlobalAdminRoleName(ctx, actorID) == "" {
+
+	if actorID != policy.CreatedBy && !isAdminTier {
 		c.writeAuditEventFailed(ctx, EventSoDPolicyDeleted, actorPtr(actorID), nil, "",
 			fmt.Sprintf("SoD policy %d delete DENIED: actor %d is neither the creator (%d) nor an admin-tier principal", id, actorID, policy.CreatedBy))
-		return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
-			"only the creating admin or an admin-tier principal may delete this SoD policy")
+		return wrapSoDPermissionDenied(fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
+			"only the creating admin or an admin-tier principal may delete this SoD policy"))
 	}
 	if err := c.storage.DeleteSoDPolicy(ctx, id); err != nil {
 		return err

--- a/internal/core/sod_external_test.go
+++ b/internal/core/sod_external_test.go
@@ -2,8 +2,10 @@ package core_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/testhelper"
 	"github.com/stretchr/testify/assert"
@@ -270,4 +272,63 @@ func TestDeleteSoDPolicy_CreatorSucceedsEvenIfNoLongerAdmin(t *testing.T) {
 	h.ExecuteRawSQL(t, "DELETE FROM user_roles WHERE user_id = ? AND role_id = ?", 1, 1)
 
 	require.NoError(t, h.CoreService.DeleteSoDPolicy(ctx, 1, p.ID), "the creator must still be able to delete their own policy without admin-tier status")
+}
+
+// FIX-6 (adversarial review run 2): a non-admin, non-creator caller must get
+// the IDENTICAL denial (same error classification, same message) whether the
+// target policy id doesn't exist at all, or exists but belongs to someone
+// else -- otherwise a caller holding this route's own gate (system.write) but
+// no creator/admin standing can enumerate valid SoD policy IDs by watching
+// which response they get. Before this fix, a nonexistent id surfaced
+// GetSoDPolicy's raw "not found" error (404) while an existing-but-foreign id
+// surfaced a distinct "permission denied" error (403) -- a reliable oracle.
+func TestDeleteSoDPolicy_NonAdmin_NonExistentAndNonOwned_IdenticalDenial(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.AssignUserRole(t, 1, 1, nil) // actor 1: admin-tier, creates the policy
+	p, err := h.CoreService.CreateSoDPolicy(ctx, 1, "no-write-and-audit", "", "secrets.write", "audit.read")
+	require.NoError(t, err)
+
+	h.CreateTestUser(t, "grace", 22)
+	h.AssignUserRole(t, 22, 4, nil) // viewer -- neither creator nor admin-tier
+
+	errOwned := h.CoreService.DeleteSoDPolicy(ctx, 22, p.ID)
+	require.Error(t, errOwned)
+	require.True(t, errors.Is(errOwned, core.ErrSoDPermissionDenied),
+		"existing-but-foreign policy must classify as ErrSoDPermissionDenied")
+
+	const nonExistentID = 999999
+	errMissing := h.CoreService.DeleteSoDPolicy(ctx, 22, nonExistentID)
+	require.Error(t, errMissing)
+	require.True(t, errors.Is(errMissing, core.ErrSoDPermissionDenied),
+		"nonexistent policy id, for a non-admin caller, must ALSO classify as ErrSoDPermissionDenied -- not ErrSoDNotFound")
+	require.False(t, errors.Is(errMissing, core.ErrSoDNotFound),
+		"a non-admin caller must never observe the not-found classification -- that's the oracle")
+
+	assert.Equal(t, errOwned.Error(), errMissing.Error(),
+		"the two denials must be byte-identical, not just the same HTTP status -- #1645 403-for-both requires identical bodies")
+}
+
+// FIX-6: the real-404 exception is narrow -- an admin-tier caller, who could
+// delete ANY policy regardless of which one this is, gets a genuine
+// ErrSoDNotFound for a nonexistent id rather than the generic denial a
+// non-admin caller gets. This is the "same standing that would have granted
+// access had it existed" condition ADR-096/#1645 requires for the exception
+// to apply.
+func TestDeleteSoDPolicy_AdminTier_NonExistentGetsRealNotFound(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.SoDPolicy{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.AssignUserRole(t, 1, 1, nil) // actor 1: admin-tier
+
+	const nonExistentID = 999999
+	err := h.CoreService.DeleteSoDPolicy(ctx, 1, nonExistentID)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, core.ErrSoDNotFound),
+		"an admin-tier caller must get the real not-found classification, not the generic denial")
 }

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -12,6 +12,17 @@ import (
 // gone?" — should match it with errors.Is rather than treating any error as absence.
 var ErrUserNotFound = errors.New("user not found")
 
+// ErrSoDPolicyNotFound is returned (wrapped) by GetSoDPolicy when no policy exists
+// for the given id, as distinct from a transient retrieval failure. DeleteSoDPolicy
+// (internal/core/sod.go) matches it with errors.Is to decide whether a real 404 is
+// safe to return (only when the caller is authorized at global admin-tier
+// regardless of which policy this is) versus collapsing it into the same
+// permission-denied response a non-admin caller gets for an existing policy they
+// don't own (#1645 403-for-both) — a string match against a translatable "not
+// found" message would silently stop working the moment that translation key is
+// actually translated.
+var ErrSoDPolicyNotFound = errors.New("sod policy not found")
+
 // ErrRoleNotAssigned is returned (wrapped) by RemoveRole when the (user, role, scope)
 // row positively does not exist — e.g. it already auto-expired or was already
 // removed — as distinct from a genuine storage failure. Callers for whom "already

--- a/internal/storage/store/local_sod.go
+++ b/internal/storage/store/local_sod.go
@@ -9,6 +9,7 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -33,7 +34,7 @@ func (ls *LocalStorage) GetSoDPolicy(ctx context.Context, id uint) (*models.SoDP
 	var p models.SoDPolicy
 	err := ls.db.WithContext(ctx).First(&p, id).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), storage.ErrSoDPolicyNotFound)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/server/http/handlers/handlers_s11_test.go
+++ b/server/http/handlers/handlers_s11_test.go
@@ -1578,6 +1578,9 @@ func TestListSoDPoliciesProxy_HappyPath_S11(t *testing.T) {
 }
 
 // TestDeleteSoDPolicyProxy_NotFound_S11 — nonexistent policy → 404.
+// FIX-6 (#1645 403-for-both): no user context resolves actorID(r) to 0, not
+// admin-tier, so a nonexistent policy id gets the same denial as an
+// existing-but-foreign one, not a distinguishing 404.
 func TestDeleteSoDPolicyProxy_NotFound_S11(t *testing.T) {
 	t.Parallel()
 	h := NewCatalogHandler(freshCoreS11(t))
@@ -1585,8 +1588,7 @@ func TestDeleteSoDPolicyProxy_NotFound_S11(t *testing.T) {
 	r = withChiParamS8(r, "id", "99999")
 	w := httptest.NewRecorder()
 	h.DeleteSoDPolicyProxy(w, r)
-	// SQLite returns not-found for a DELETE on a missing row.
-	assert.True(t, w.Code == http.StatusNotFound || w.Code == http.StatusOK, "unexpected: %d", w.Code)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 // TestDeleteSoDPolicyProxy_BadID_S11 — non-numeric id → 400.

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -2047,12 +2047,15 @@ func TestDeleteSoDPolicyProxy_BadID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// FIX-6 (#1645 403-for-both): no user context resolves actorID(r) to 0, not
+// admin-tier, so a nonexistent policy id gets the same denial as an
+// existing-but-foreign one.
 func TestDeleteSoDPolicyProxy_NotFound(t *testing.T) {
 	h := newCatalogHandlerS4(t)
 	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "9999")
 	w := httptest.NewRecorder()
 	h.DeleteSoDPolicyProxy(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 // ── deployment_hygiene.go ─────────────────────────────────────────────────────
@@ -8498,12 +8501,15 @@ func TestSoDPolicy_Create_MissingFields(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// FIX-6 (#1645 403-for-both): withUserCtx's actor has no admin-tier role, so
+// a nonexistent policy id gets the same 403 denial as an existing-but-foreign
+// one, not a distinguishing 404.
 func TestSoDPolicy_Delete_NotFound(t *testing.T) {
 	h := newCatalogHandlerS4(t)
 	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "9999"))
 	w := httptest.NewRecorder()
 	h.DeleteSoDPolicy(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 // ── secrets_reassign_owner.go: ReassignOwner ─────────────────────────────────

--- a/server/http/handlers/handlers_s5_test.go
+++ b/server/http/handlers/handlers_s5_test.go
@@ -1555,12 +1555,15 @@ func TestSoDProxy_DeleteSoDPolicyProxy_BadID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// FIX-6 (#1645 403-for-both): no user context resolves actorID(r) to 0, which
+// is not admin-tier, so a nonexistent policy id gets the same denial as an
+// existing-but-foreign one -- see DeleteSoDPolicyProxy's doc comment.
 func TestSoDProxy_DeleteSoDPolicyProxy_NotFound(t *testing.T) {
 	h := newCatalogHandlerS4(t)
 	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "9999")
 	w := httptest.NewRecorder()
 	h.DeleteSoDPolicyProxy(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 // ── webauthn_proxy.go ──────────────────────────────────────────────────────────
@@ -3694,8 +3697,9 @@ func TestDeleteSoDPolicyProxy_NotFoundS5(t *testing.T) {
 	req := withChiParam(httptest.NewRequest("DELETE", "/", nil), "id", "99999")
 	w := httptest.NewRecorder()
 	h.DeleteSoDPolicyProxy(w, req)
-	// No such policy → 404, not bad-request.
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	// No such policy, and no user context (actorID 0, not admin-tier) → 403
+	// (FIX-6, #1645 403-for-both), not the 404 that would leak existence.
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 // ── setup_tokens_proxy.go — missing happy paths ───────────────────────────────

--- a/server/http/handlers/handlers_s7_test.go
+++ b/server/http/handlers/handlers_s7_test.go
@@ -398,12 +398,15 @@ func TestCatalogHandler_DeleteSoDPolicy_BadID_S7(t *testing.T) {
 }
 
 // TestCatalogHandler_DeleteSoDPolicy_NotFound_S7 tests deleting non-existent policy.
+// FIX-6 (#1645 403-for-both): withUserCtxS7's actor has no admin-tier role,
+// so a nonexistent policy id gets the same 403 denial as an
+// existing-but-foreign one, not a distinguishing 404.
 func TestCatalogHandler_DeleteSoDPolicy_NotFound_S7(t *testing.T) {
 	h := newCatalogHandlerS7(t)
 	req := withUserCtxS7(withChiParamS7(httptest.NewRequest(http.MethodDelete, "/sod/policies/9999", nil), "id", "9999"))
 	w := httptest.NewRecorder()
 	h.DeleteSoDPolicy(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 // ── machine_token_hygiene.go: MachineTokenHygiene ──────────────────────────

--- a/server/http/handlers/sod.go
+++ b/server/http/handlers/sod.go
@@ -7,13 +7,14 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
@@ -50,9 +51,9 @@ func (h *CatalogHandler) CreateSoDPolicy(w http.ResponseWriter, r *http.Request)
 		status := http.StatusInternalServerError
 		msg := err.Error()
 		switch {
-		case strings.Contains(msg, "required") || strings.Contains(msg, "must be different"):
+		case errors.Is(err, core.ErrSoDValidation):
 			status = http.StatusBadRequest
-		case strings.Contains(msg, "permission denied"):
+		case errors.Is(err, core.ErrSoDPermissionDenied):
 			status = http.StatusForbidden
 		default:
 			log.Printf("Error creating SoD policy: %v", err)
@@ -81,9 +82,9 @@ func (h *CatalogHandler) DeleteSoDPolicy(w http.ResponseWriter, r *http.Request)
 		status := http.StatusInternalServerError
 		msg := err.Error()
 		switch {
-		case strings.Contains(msg, "not found"):
+		case errors.Is(err, core.ErrSoDNotFound):
 			status = http.StatusNotFound
-		case strings.Contains(msg, "permission denied"):
+		case errors.Is(err, core.ErrSoDPermissionDenied):
 			status = http.StatusForbidden
 		default:
 			log.Printf("Error deleting SoD policy %d: %v", id, err)

--- a/server/http/handlers/sod_proxy.go
+++ b/server/http/handlers/sod_proxy.go
@@ -42,11 +42,13 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -109,7 +111,18 @@ func (h *CatalogHandler) ListSoDPoliciesProxy(w http.ResponseWriter, r *http.Req
 
 // DeleteSoDPolicyProxy handles DELETE /api/v1/system/sod-policies/{id}. Routes
 // through core.KeyorixCore.DeleteSoDPolicy (not a bare storage.DeleteSoDPolicy)
-// so the audit-event write also covers a deletion via node-sync (#G79).
+// so the audit-event write also covers a deletion via node-sync (#G79) --
+// which also means it's subject to DeleteSoDPolicy's own creator-or-admin-tier
+// authority check (#1529: an uncredentialed proxy caller, actorID==0, is
+// exactly the case that check exists to deny).
+//
+// FIX-6 (adversarial review run 2): classifies core.ErrSoDPermissionDenied as
+// 403, not just core.ErrSoDNotFound as 404 -- previously ANY error besides a
+// bare not-found (including a real permission-denied from the authority
+// check above) fell through to a generic 500, and errors.Is against the
+// core-layer sentinels (rather than isNotFoundErr's substring match) is what
+// makes DeleteSoDPolicy's own 403-for-both fix (see its doc comment) actually
+// observable as 403 here instead of masquerading as 500.
 func (h *CatalogHandler) DeleteSoDPolicyProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
@@ -117,12 +130,15 @@ func (h *CatalogHandler) DeleteSoDPolicyProxy(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if err := h.coreService.DeleteSoDPolicy(r.Context(), actorID(r), uint(id)); err != nil {
-		if isNotFoundErr(err) {
+		switch {
+		case errors.Is(err, core.ErrSoDNotFound):
 			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "SoD policy not found")
-			return
+		case errors.Is(err, core.ErrSoDPermissionDenied):
+			writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN", "only the creating admin or an admin-tier principal may delete this SoD policy")
+		default:
+			log.Printf("sod-policies proxy: delete failed: %v", err)
+			writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		}
-		log.Printf("sod-policies proxy: delete failed: %v", err)
-		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
 	}
 	writeRemoteAPISuccess(w, map[string]bool{"deleted": true})

--- a/server/http/handlers/sod_s13_test.go
+++ b/server/http/handlers/sod_s13_test.go
@@ -116,8 +116,34 @@ func TestDeleteSoDPolicy_BadID_S13(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// FIX-6 (adversarial review run 2, #1645 403-for-both): withUserCtx's
+// hardcoded UserID=1 has no role assigned, so it is not admin-tier -- a
+// nonexistent policy id now surfaces the SAME 403 a non-admin caller gets for
+// an existing-but-foreign policy (TestDeleteSoDPolicy_PermissionDenied_S13
+// below), not a distinguishing 404. Real 404 is reserved for an admin-tier
+// caller; see TestDeleteSoDPolicy_AdminTier_NotFound_S13.
 func TestDeleteSoDPolicy_NotFound_S13(t *testing.T) {
 	h := newCatalogHandlerSoDSodS13(t)
+	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "999999"))
+	w := httptest.NewRecorder()
+	h.DeleteSoDPolicy(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// The real-404 exception: an admin-tier caller gets a genuine not-found for a
+// nonexistent policy id, since they could delete any policy regardless of
+// which one this is -- the same standing #1645/ADR-096 requires for the
+// real-404 exception to apply.
+func TestDeleteSoDPolicy_AdminTier_NotFound_S13(t *testing.T) {
+	h := newCatalogHandlerSoDSodS13(t)
+	ctx := context.Background()
+	systemAdminName, err := identity.NewFoldedName("system_admin")
+	require.NoError(t, err)
+	adminRole, err := h.coreService.Storage().CreateRole(ctx, systemAdminName, "Administrator")
+	require.NoError(t, err)
+	require.NoError(t, h.coreService.Storage().SetRoleBypassesPermissionChecks(ctx, adminRole.ID, true))
+	require.NoError(t, h.coreService.Storage().AssignRole(ctx, 1, adminRole.ID, storage.Scope{}))
+
 	req := withUserCtx(withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "999999"))
 	w := httptest.NewRecorder()
 	h.DeleteSoDPolicy(w, req)
@@ -235,10 +261,15 @@ func TestDeleteSoDPolicyProxy_BadID_S13(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// FIX-6: a request with no user context resolves actorID(r) to 0 (an
+// uncredentialed/system pseudo-actor), which DeleteSoDPolicy's #1529
+// authority check has never treated as admin-tier -- so a nonexistent policy
+// id surfaces the same 403 denial as an existing-but-foreign one, not a
+// distinguishing 404 (see DeleteSoDPolicyProxy's doc comment).
 func TestDeleteSoDPolicyProxy_NotFound_S13(t *testing.T) {
 	h := newCatalogHandlerSoDSodS13(t)
 	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/", nil), "id", "999999")
 	w := httptest.NewRecorder()
 	h.DeleteSoDPolicyProxy(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }


### PR DESCRIPTION
## Summary

FIX-6 of the adversarial-review remediation plan (run 2).

`DeleteSoDPolicy`'s authority check (creator OR global-admin-tier) ran AFTER
the existence lookup, returning that lookup's error verbatim on failure. A
caller holding this route's own gate (`system.write`, deliberately broad) but
no creator/admin-tier standing could distinguish "policy id doesn't exist"
(404) from "policy id exists but isn't mine" (403) — a reliable
ID-enumeration oracle for SoD policy IDs.

## Fix

Applied ADR-096's already-established 403-for-both convention
(`server/middleware/auth.go`'s `handleScopeResolutionError`): a real 404 is
safe only for a caller already authorized at global admin-tier — the same
standing that would grant access to any policy had it existed. Every other
caller now gets the byte-identical `ErrSoDPermissionDenied` response whether
the id is missing or just not theirs.

Also replaced substring text matching (`strings.Contains(msg, "permission
denied")` etc.) with `errors.Is` against new core-layer sentinels
(`ErrSoDValidation`/`ErrSoDPermissionDenied`/`ErrSoDNotFound`), matching
FIX-4's established pattern — the substring match only worked because every
shipped locale left the underlying i18n translation keys untranslated; the
first deployment to translate them would have silently reverted to 500.

**Found and fixed beyond the plan's literal scope**: `DeleteSoDPolicyProxy`
(the `/system` proxy) routes through the same `DeleteSoDPolicy` and had the
identical gap one layer up — its own classification only recognized
"not found," so a permission-denied error fell through to a generic 500
instead of 403. Fixed alongside since it shares the exact root cause and is
reached by the exact same call chain.

Stacked on `fix-1-grant-ceiling` (PR #1685, unmerged) since both touch
`server/http/handlers/sod.go`.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] New tests prove the actual guarantee: a non-admin caller gets
      byte-identical denials for a nonexistent vs. an existing-but-foreign
      policy id; an admin-tier caller still gets a real not-found
- [x] Red/green verified: reverting the fix makes the identical-denial test
      fail
- [x] Fixed 8 existing tests across 5 files that asserted the old,
      oracle-producing 404-for-nonexistent behavior for non-admin/
      uncredentialed callers on both the human-facing and `/system` proxy
      routes
- [x] `internal/core` suite green (87.1s)
- [x] `internal/storage/store` suite green (84.6s)
- [x] `server/http/handlers` suite green (32.2s, includes contracttest)
- [x] `server/http` SoD-related tests green
- [x] `gofmt -l` clean on touched files
- [x] `gosec -severity medium -exclude-generated` clean on touched packages
- [ ] Full-repo `go test ./...` (running in background)