### PR TITLE
fix(storage,cli): break-glass purge race + remaining CSV formula injection sites

### DIFF
--- a/internal/cli/audit/audit.go
+++ b/internal/cli/audit/audit.go
@@ -282,7 +282,7 @@ since a point in time with --since --all.`,
 					}
 					_ = cw.Write([]string{
 						strconv.FormatUint(uint64(row.ID), 10), row.Timestamp, common.CSVSafe(row.EventType),
-						common.CSVSafe(row.Actor), row.ActorType, uintPtrStr(row.UserID), uintPtrStr(row.ProjectID),
+						common.CSVSafe(row.Actor), common.CSVSafe(row.ActorType), uintPtrStr(row.UserID), uintPtrStr(row.ProjectID),
 						uintPtrStr(row.SecretID), common.CSVSafe(row.IPAddress), strconv.FormatBool(row.Success), common.CSVSafe(row.Description),
 					})
 					continue

--- a/internal/core/csv_writer_completeness_test.go
+++ b/internal/core/csv_writer_completeness_test.go
@@ -1,0 +1,249 @@
+// csv_writer_completeness_test.go — FIX-8 (adversarial review run 2) repo-wide
+// structural guard.
+//
+// CSV formula injection (CWE-1236) was found and fixed at least 5 separate
+// times across this codebase's history (G49, #1682 web frontend,
+// secret_access_log_export.go's ActorType/IPAddress, internal/cli/audit's
+// ActorType) because each CSV-writing function carried its own local
+// encoding responsibility with nothing enforcing it repo-wide. This test
+// verifies, via go/ast across the whole repository -- not a hand-maintained
+// list of "the writers we already fixed" -- that every Go function
+// constructing an encoding/csv.Writer also calls a CSV-safety encoder
+// (csvSafe or CSVSafe) somewhere in its body, so a future CSV writer that
+// omits it is caught automatically rather than silently shipping bare.
+package core
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// csvWriterCompletenessAllowlist names CSV-writing functions deliberately
+// exempt from calling a csvSafe/CSVSafe encoder, keyed
+// "<file basename>:<function name>", with the reason as the value. Empty on
+// purpose: every real CSV writer found so far needs the fix.
+var csvWriterCompletenessAllowlist = map[string]string{}
+
+func TestCSVWriters_EncodeAgainstFormulaInjection(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed — cannot locate the repo root relative to this test file")
+	}
+	// internal/core -> repo root.
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+
+	fset := token.NewFileSet()
+	writers := discoverCSVWriterFunctions(t, fset, repoRoot)
+
+	if len(writers) == 0 {
+		t.Fatal("discovered zero CSV-writing functions across the repo — the AST walk is almost certainly broken, not that every CSV export was removed")
+	}
+	// #1682/this campaign's own audit found 12 Go CSV writers; a sharp drop
+	// below that most likely means the walk is skipping files it shouldn't,
+	// not that exports were legitimately deleted.
+	if len(writers) < 8 {
+		t.Fatalf("discovered only %d CSV-writing function(s); expected at least 8 — the AST walk may be skipping a directory it shouldn't", len(writers))
+	}
+
+	var violations []string
+	for _, w := range writers {
+		if w.CallsSafetyEncoder {
+			continue
+		}
+		key := w.key()
+		if reason, ok := csvWriterCompletenessAllowlist[key]; ok {
+			t.Logf("allowlisted CSV writer %s (does not call csvSafe/CSVSafe): %s", key, reason)
+			continue
+		}
+		violations = append(violations, w.String()+
+			": constructs an encoding/csv.Writer but never calls csvSafe/CSVSafe anywhere in its body -- any user-controlled field written to this CSV (name, description, actor, IP, etc.) is vulnerable to spreadsheet formula injection (CWE-1236) when a victim opens the export in Excel/Sheets/LibreOffice")
+	}
+	sort.Strings(violations)
+
+	if len(violations) > 0 {
+		t.Errorf("found %d CSV-writing function(s) not encoding against formula injection, and not in csvWriterCompletenessAllowlist:\n%s\n"+
+			"Fix: wrap every user-controlled string field with csvSafe(...) (server/http/handlers, internal/core) or CSVSafe(...) (internal/cli/common) before writing it, or, if every field this function writes is a controlled constant/number (never any of this), add it to csvWriterCompletenessAllowlist with a comment explaining why.",
+			len(violations), strings.Join(violations, "\n"))
+	}
+}
+
+type csvWriterFunc struct {
+	File               string // basename
+	FuncName           string // function or method name
+	CallsSafetyEncoder bool
+}
+
+func (f csvWriterFunc) key() string    { return f.File + ":" + f.FuncName }
+func (f csvWriterFunc) String() string { return f.File + ":" + f.FuncName }
+
+// csvWriterSkipDir mirrors internal/storage/store's skipDir (VCS metadata,
+// build output, the operator module's separate go.mod, and the web frontend
+// -- which has its own, separately-fixed #1682 CSV writer in TypeScript, out
+// of scope for a go/ast walk).
+func csvWriterSkipDir(name string) bool {
+	switch name {
+	case ".git", "node_modules", "dist", ".scratch", "vendor", "operator", "web":
+		return true
+	}
+	return false
+}
+
+// discoverCSVWriterFunctions walks root for every non-test .go file, parses
+// it, and finds every function/method whose body calls csv.NewWriter --
+// recording, for each, whether its body (OR a same-file helper function it
+// calls by name, one hop deep -- e.g. a writer that builds each CSV row via
+// a separate rowToCSV(r) helper rather than encoding inline) contains a call
+// to csvSafe or CSVSafe anywhere. This is a shallow syntactic check, not a
+// full call-graph analysis or per-field verification: it would not catch a
+// writer that calls csvSafe on some fields but not others, or a helper
+// defined in a DIFFERENT file/package, but every writer found to date either
+// encodes every field it writes (inline or via one same-file helper) or
+// none.
+func discoverCSVWriterFunctions(t *testing.T, fset *token.FileSet, root string) []csvWriterFunc {
+	t.Helper()
+	var out []csvWriterFunc
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if csvWriterSkipDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		file, perr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if perr != nil {
+			t.Fatalf("failed to parse %s: %v", path, perr)
+		}
+
+		funcsByName := map[string]*ast.FuncDecl{}
+		for _, decl := range file.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil {
+				funcsByName[fn.Name.Name] = fn
+			}
+		}
+
+		for _, fn := range funcsByName {
+			if !bodyCallsSelectorFunction(fn.Body, "csv", "NewWriter") {
+				continue
+			}
+			out = append(out, csvWriterFunc{
+				File:               filepath.Base(path),
+				FuncName:           fn.Name.Name,
+				CallsSafetyEncoder: bodyOrCalleesCallSafetyEncoder(fn.Body, funcsByName),
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk %s: %v", root, err)
+	}
+	return out
+}
+
+// bodyOrCalleesCallSafetyEncoder reports whether body itself calls
+// csvSafe/CSVSafe, or calls (by plain identifier, one hop) a same-file
+// helper function that does.
+func bodyOrCalleesCallSafetyEncoder(body *ast.BlockStmt, funcsByName map[string]*ast.FuncDecl) bool {
+	if bodyCallsFunctionNamed(body, "csvSafe") || bodyCallsFunctionNamed(body, "CSVSafe") {
+		return true
+	}
+	for _, callee := range calledLocalFunctions(body, funcsByName) {
+		if bodyCallsFunctionNamed(callee.Body, "csvSafe") || bodyCallsFunctionNamed(callee.Body, "CSVSafe") {
+			return true
+		}
+	}
+	return false
+}
+
+// calledLocalFunctions returns every same-file function (from funcsByName)
+// that body calls by plain identifier anywhere in its statement tree.
+func calledLocalFunctions(body *ast.BlockStmt, funcsByName map[string]*ast.FuncDecl) []*ast.FuncDecl {
+	var callees []*ast.FuncDecl
+	seen := map[string]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if fn, ok := funcsByName[ident.Name]; ok && !seen[ident.Name] {
+			seen[ident.Name] = true
+			callees = append(callees, fn)
+		}
+		return true
+	})
+	return callees
+}
+
+// bodyCallsSelectorFunction reports whether body contains a call expression
+// of the shape pkg.Fn(...) anywhere in its statement tree.
+func bodyCallsSelectorFunction(body *ast.BlockStmt, pkg, fn string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != fn {
+			return true
+		}
+		if ident, ok := sel.X.(*ast.Ident); ok && ident.Name == pkg {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// bodyCallsFunctionNamed reports whether body contains a call expression
+// whose function is exactly name -- either a bare identifier (csvSafe(...))
+// or a selector whose final name matches (common.CSVSafe(...)) -- anywhere
+// in its statement tree.
+func bodyCallsFunctionNamed(body *ast.BlockStmt, name string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			if fn.Name == name {
+				found = true
+				return false
+			}
+		case *ast.SelectorExpr:
+			if fn.Sel.Name == name {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/internal/core/secret_access_log_export.go
+++ b/internal/core/secret_access_log_export.go
@@ -96,6 +96,24 @@ func (k *KeyorixCore) ExportSecretAccessLog(ctx context.Context, actorKind strin
 	return data, "application/json; charset=utf-8", err
 }
 
+// csvSafe neutralizes spreadsheet formula injection (CWE-1236): a CSV cell
+// beginning with =, +, -, @, TAB, or CR is prefixed with a single quote so
+// Excel / LibreOffice / Sheets treat it as text rather than executing it as a
+// formula. Duplicated locally rather than shared, matching this codebase's
+// existing per-layer convention (server/http/handlers/csv_safe.go,
+// internal/cli/common/csv_safe.go each carry their own copy) -- core must not
+// import either of those packages.
+func csvSafe(s string) string {
+	if s == "" {
+		return s
+	}
+	switch s[0] {
+	case '=', '+', '-', '@', '\t', '\r':
+		return "'" + s
+	}
+	return s
+}
+
 func encodeCSV(rows []AccessLogExportRow) []byte {
 	var buf bytes.Buffer
 	w := csv.NewWriter(&buf)
@@ -110,8 +128,8 @@ func encodeCSV(rows []AccessLogExportRow) []byte {
 			fmt.Sprintf("%d", r.EventID),
 			fmt.Sprintf("%d", r.SecretID),
 			userID,
-			r.ActorType,
-			r.IPAddress,
+			csvSafe(r.ActorType),
+			csvSafe(r.IPAddress),
 			fmt.Sprintf("%t", r.Success),
 			r.EventTime.UTC().Format(time.RFC3339),
 		})

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -931,7 +931,9 @@ type Storage interface {
 	// DeleteClosedAccessReviewsBefore removes closed campaigns (closed_at < before)
 	// and their snapshot items, returning (campaigns, items) removed.
 	DeleteClosedAccessReviewsBefore(ctx context.Context, before time.Time) (campaigns int64, items int64, err error)
-	// DeleteExpiredBreakGlassBefore removes non-active activations (created_at < before).
+	// DeleteExpiredBreakGlassBefore reconciles any TTL-lapsed 'active' row to
+	// 'expired' (without deleting it in the same pass -- see local_purge.go's
+	// doc comment), then removes non-active activations (created_at < before).
 	DeleteExpiredBreakGlassBefore(ctx context.Context, before time.Time) (int64, error)
 	// DeleteResolvedAccessRequestsBefore removes terminal-state requests (resolved_at
 	// < before) and their approval records, returning (requests, approvals) removed.

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -394,21 +394,63 @@ func (ls *LocalStorage) DeleteClosedAccessReviewsBefore(ctx context.Context, bef
 }
 
 // DeleteExpiredBreakGlassBefore hard-deletes old break-glass activations before
-// the cutoff: explicitly non-active (revoked, or reconciled-expired) rows, PLUS
-// (#1653 reopened) rows still labeled 'active' whose ExpiresAt has genuinely
-// passed -- ReconcileExpiredBreakGlassActivation only ever reconciles the
-// SAME user's row at their own next activation in the SAME project, so a user
-// who activates once and never revisits that project leaves their row
-// 'active' in the DB indefinitely otherwise; this retention sweep is the
-// backstop that still reclaims it. A row genuinely still active (ExpiresAt in
-// the future, or nil) is never purged either way.
+// the cutoff: explicitly non-active (revoked, or reconciled-expired) rows.
+// Before doing so it reconciles ('active' -> 'expired') rows still labeled
+// 'active' whose ExpiresAt has genuinely passed -- ReconcileExpiredBreakGlassActivation
+// only ever reconciles the SAME user's row at their own next activation in the
+// SAME project, so a user who activates once and never revisits that project
+// leaves their row 'active' in the DB indefinitely otherwise; this retention
+// sweep is the backstop that still reclaims it. A row genuinely still active
+// (ExpiresAt in the future, or nil) is never touched either way.
+//
+// FIX-7 (adversarial review run 2): #1653 reopened's widen hard-deleted a
+// still-'active' row in the SAME statement as the reconciliation, the instant
+// its ExpiresAt passed the retention cutoff -- racing any concurrent operation
+// that expected to still find the row (in ANY state) to act on it, e.g. an
+// admin's RevokeBreakGlass, which removes the real RBAC grant
+// (c.RemoveUserRole) FIRST and only afterward conditionally updates this row
+// (RevokeBreakGlassActivation, whose WHERE already accepts BOTH 'active' and
+// 'expired' for exactly this reason). If the purge deletes the row between
+// those two steps, the already-successful revoke's own state-transition and
+// audit-event write (LogBreakGlassRevoked, only called on success) are lost --
+// the caller sees a misleading "activation is not active" error despite
+// having just genuinely revoked the grant.
+//
+// Fixed by reconciling and deleting as two separate steps: a row transitioned
+// 'active' -> 'expired' by THIS call is deliberately excluded from THIS
+// call's own delete and left for the NEXT sweep to hard-delete -- its
+// CreatedAt does not change at reconciliation, so it would otherwise ALSO
+// match the terminal-row delete criteria in this same pass (CreatedAt <=
+// ExpiresAt < before already holds); explicitly tracking and excluding the
+// IDs this call itself just reconciled is what actually defers them. On the
+// next sweep they're no longer excluded and qualify like any other
+// already-terminal row, giving one full sweep interval of grace for a
+// concurrent revoke (or any other in-flight reader) to still observe and act
+// on the row before it's purged. The original #edee956e/#1653 guarantee this
+// widen exists for is unaffected: an abandoned 'active' row is still
+// reconciled (freeing the partial-unique-index slot) on every sweep, just
+// hard-deleted one cycle later than before.
 func (ls *LocalStorage) DeleteExpiredBreakGlassBefore(ctx context.Context, before time.Time) (int64, error) {
 	// G81 (BreakGlassActivation.CreatedAt/ExpiresAt): normalize internally — see GetAuditLogs.
 	before = before.UTC()
-	result := ls.db.WithContext(ctx).
-		Where("(state <> ? AND created_at < ?) OR (state = ? AND expires_at IS NOT NULL AND expires_at < ?)",
-			breakGlassActiveState, before, breakGlassActiveState, before).
-		Delete(&models.BreakGlassActivation{})
+	var justReconciledIDs []uint
+	if err := ls.db.WithContext(ctx).Model(&models.BreakGlassActivation{}).
+		Where("state = ? AND expires_at IS NOT NULL AND expires_at < ?", breakGlassActiveState, before).
+		Pluck("id", &justReconciledIDs).Error; err != nil {
+		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	if len(justReconciledIDs) > 0 {
+		if err := ls.db.WithContext(ctx).Model(&models.BreakGlassActivation{}).
+			Where("id IN ?", justReconciledIDs).
+			Update("state", breakGlassExpiredState).Error; err != nil {
+			return 0, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+	}
+	q := ls.db.WithContext(ctx).Where("state <> ? AND created_at < ?", breakGlassActiveState, before)
+	if len(justReconciledIDs) > 0 {
+		q = q.Where("id NOT IN ?", justReconciledIDs)
+	}
+	result := q.Delete(&models.BreakGlassActivation{})
 	if result.Error != nil {
 		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), result.Error)
 	}

--- a/internal/storage/store/local_retention_test.go
+++ b/internal/storage/store/local_retention_test.go
@@ -187,12 +187,20 @@ func TestDeleteExpiredBreakGlassBefore_SkipsActive(t *testing.T) {
 // retention sweep must still reclaim it once genuinely TTL-lapsed AND past
 // the cutoff -- while a row that's merely OLD but still genuinely live
 // (ExpiresAt in the future) must never be purged, cutoff or not.
+//
+// FIX-7 (adversarial review run 2): reclaiming an unreconciled-but-expired
+// row now takes TWO sweep calls, not one -- the first reconciles it to
+// 'expired' without deleting it (closing the race a single reconcile+delete
+// statement had with any concurrent operation still expecting to find the
+// row), the second deletes it like any other already-terminal old row. See
+// DeleteExpiredBreakGlassBefore's doc comment.
 func TestDeleteExpiredBreakGlassBefore_ReclaimsUnreconciledExpired(t *testing.T) {
 	ls := newRetentionTestStore(t)
 	ctx := context.Background()
 	old := time.Now().AddDate(0, 0, -120)
 	longExpired := old.Add(time.Hour) // TTL lapsed shortly after creation, well before the cutoff below
 	stillLive := time.Now().AddDate(1, 0, 0)
+	cutoff := time.Now().AddDate(0, 0, -90)
 
 	require.NoError(t, ls.db.Create(&models.BreakGlassActivation{
 		ID: 4, State: "active", CreatedAt: old, ExpiresAt: &longExpired,
@@ -203,14 +211,62 @@ func TestDeleteExpiredBreakGlassBefore_ReclaimsUnreconciledExpired(t *testing.T)
 		ID: 5, State: "active", CreatedAt: old, ExpiresAt: &stillLive,
 	}).Error)
 
-	n, err := ls.DeleteExpiredBreakGlassBefore(ctx, time.Now().AddDate(0, 0, -90))
+	n, err := ls.DeleteExpiredBreakGlassBefore(ctx, cutoff)
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), n, "the unreconciled-but-genuinely-expired row is reclaimed")
+	assert.Zero(t, n, "first sweep only reconciles the unreconciled-but-expired row, doesn't delete it yet")
+
+	var afterFirstSweep []models.BreakGlassActivation
+	require.NoError(t, ls.db.Order("id").Find(&afterFirstSweep).Error)
+	require.Len(t, afterFirstSweep, 2, "both rows still present after the first sweep")
+	assert.Equal(t, "expired", afterFirstSweep[0].State, "row 4 reconciled to expired, not yet deleted")
+	assert.Equal(t, "active", afterFirstSweep[1].State, "the still-live row untouched")
+
+	n, err = ls.DeleteExpiredBreakGlassBefore(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "second sweep reclaims the now-reconciled row like any other old terminal row")
 
 	var remaining []models.BreakGlassActivation
 	require.NoError(t, ls.db.Find(&remaining).Error)
 	require.Len(t, remaining, 1)
 	assert.Equal(t, uint(5), remaining[0].ID, "the still-live row must survive")
+}
+
+// TestDeleteExpiredBreakGlassBefore_ReconciledRowStillRevocable is FIX-7's
+// core proving test: a row the retention sweep JUST reconciled to 'expired'
+// must still be revocable by a concurrent/subsequent RevokeBreakGlassActivation
+// call, not silently gone. Under the pre-fix behavior (reconcile-and-delete in
+// one statement), the row would already be hard-deleted by the time a
+// concurrent admin's RevokeBreakGlass reached RevokeBreakGlassActivation
+// (having already removed the real RBAC grant via RemoveUserRole first),
+// producing ErrBreakGlassNotActive despite the revoke having genuinely taken
+// effect -- losing the revoke's own audit trail (LogBreakGlassRevoked is only
+// called on success).
+func TestDeleteExpiredBreakGlassBefore_ReconciledRowStillRevocable(t *testing.T) {
+	ls := newRetentionTestStore(t)
+	ctx := context.Background()
+	old := time.Now().AddDate(0, 0, -120)
+	longExpired := old.Add(time.Hour)
+	cutoff := time.Now().AddDate(0, 0, -90)
+
+	require.NoError(t, ls.db.Create(&models.BreakGlassActivation{
+		ID: 6, State: "active", CreatedAt: old, ExpiresAt: &longExpired,
+	}).Error)
+
+	// One sweep pass: reconciles the row to 'expired' without deleting it.
+	n, err := ls.DeleteExpiredBreakGlassBefore(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Zero(t, n)
+
+	// A concurrent (or immediately-following) revoke must still find and
+	// transition the row -- RevokeBreakGlassActivation's own WHERE clause
+	// already accepts 'expired', but that only helps if the row still EXISTS.
+	revokedAt := time.Now()
+	require.NoError(t, ls.RevokeBreakGlassActivation(ctx, 6, 1, 0, revokedAt),
+		"a row the sweep just reconciled (not yet deleted) must still be revocable")
+
+	var row models.BreakGlassActivation
+	require.NoError(t, ls.db.First(&row, 6).Error)
+	assert.Equal(t, "revoked", row.State)
 }
 
 func TestDeleteResolvedAccessRequestsBefore_CascadesAndSkipsPending(t *testing.T) {


### PR DESCRIPTION
## Summary

FIX-7 and FIX-8 of the adversarial-review remediation plan (run 2), batched
per the plan's own sequencing note (both low-severity, independent, no file
overlap with each other or with FIX-1 through FIX-6).

**FIX-7 — break-glass purge can hard-delete a row mid-reconciliation.**
`DeleteExpiredBreakGlassBefore` hard-deletes old break-glass activations.
`#edee956e` widened it to also reconcile-and-delete, in one statement, a
still-'active' row whose TTL had genuinely lapsed (closing a real
"stale row blocks new activation forever" bug). That widen opened a narrow
race: a concurrent `RevokeBreakGlass` removes the real RBAC grant first
(`RemoveUserRole`), then conditionally transitions the activation row
(`RevokeBreakGlassActivation`, whose `WHERE` clause already accepts both
'active' and 'expired' for exactly this reason) — but if the purge sweep
deletes the row between those two steps, the already-successful revoke's own
audit trail (`LogBreakGlassRevoked`, only called on success) is lost, and the
caller sees a misleading "activation is not active" error despite having
genuinely revoked the grant.

Fixed by splitting reconcile and delete into two passes: a row this call
itself reconciles is excluded from this same call's delete and left for the
next sweep, giving one full sweep interval of grace for a concurrent
operation to still find and act on it. The original `#edee956e` guarantee is
unaffected.

**FIX-8 — CSV formula injection, remaining sites.** Two remaining sites
(`internal/core/secret_access_log_export.go`'s `ActorType`/`IPAddress`,
`internal/cli/audit/audit.go`'s `ActorType`), plus a new repo-wide invariant
test (`TestCSVWriters_EncodeAgainstFormulaInjection`) that walks every Go
function constructing an `encoding/csv.Writer` via `go/ast` and fails if it
never calls `csvSafe`/`CSVSafe` anywhere in its body (one hop into a
same-file helper also counts) — this is what actually closes the class
(5th recurrence of this exact finding shape), not just today's two sites.

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] FIX-7: new regression test proving the actual guarantee — a row the
      sweep just reconciled is still revocable by a subsequent/concurrent
      `RevokeBreakGlassActivation` call. Red/green verified against the old
      single-statement reconcile+delete.
- [x] FIX-7: fixed the existing `TestDeleteExpiredBreakGlassBefore_ReclaimsUnreconciledExpired`
      to reflect the two-pass design (reclaim now takes two sweep calls, not
      one)
- [x] FIX-8: new invariant test — verified green on the known-good case and
      red against a temporarily-stripped encoder; also caught and fixed a
      false positive during development (`export_matrix.go`'s
      `writeMatrixRemote` delegates to a helper that already encodes every
      field — the one-hop-helper resolution exists because of this)
- [x] `internal/core`, `internal/storage/store`, `internal/cli/audit` suites
      all green
- [x] `gofmt -l` clean on touched files
- [x] `gosec -severity medium -exclude-generated` clean on touched packages
- [ ] Full-repo `go test ./...` (running in background)