### PR TITLE
fix(core,storage,grpc,http): close Part 2 regression + #1660 sibling-sweep + Part 3 findings

### DIFF
--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -456,7 +456,11 @@ const sessionRefreshClockRegressionTolerance = 30 * time.Second
 // message, so a caller cannot use it as an oracle confirming clock
 // manipulation had an effect. On success, advances the watermark to now
 // (never backward).
+// .UTC() strips any monotonic clock reading now carries — see
+// authEffectiveNow's doc comment (same file) for why an unstripped
+// comparison here would never actually detect a backward wall-clock step.
 func (c *KeyorixCore) checkSessionRefreshClockNotRegressed(now time.Time) error {
+	now = now.UTC()
 	c.sessionRefreshWatermarkMu.Lock()
 	defer c.sessionRefreshWatermarkMu.Unlock()
 	if !c.sessionRefreshWatermark.IsZero() && now.Before(c.sessionRefreshWatermark.Add(-sessionRefreshClockRegressionTolerance)) {
@@ -503,6 +507,35 @@ func (c *KeyorixCore) handleSessionReuse(ctx context.Context, old *models.Sessio
 	}
 }
 
+// authEffectiveNow returns a wall-clock reading that never regresses relative
+// to what this process has already observed while validating a presented
+// authentication credential's expiry (session/PAT/machine token/MFA step-up
+// -- see authTokenClockWatermark's doc comment, service.go). CLAMPs rather
+// than refuses: max(c.now(), authTokenClockWatermark), always advancing the
+// watermark forward.
+//
+// .UTC() is not cosmetic here: it strips any monotonic clock reading Go
+// attaches to a real time.Now() value (see time.Time's package doc). Two
+// monotonic-carrying Time values compare using ONLY their monotonic delta,
+// which never regresses even when the OS wall clock is stepped backward --
+// so an unstripped watermark comparison would silently never detect the
+// exact regression this mechanism exists to catch, matching #1635's own
+// root-cause bug in checkSecretExpiryClockNotRegressed (fixed alongside this
+// one, same root cause). rbacEffectiveNow (local_rbac.go, #1651) already
+// gets this right by always being called with time.Now().UTC(); mirrored
+// here explicitly rather than trusting every future caller of c.now() to
+// remember to strip it themselves.
+func (c *KeyorixCore) authEffectiveNow() time.Time {
+	now := c.now().UTC()
+	c.authTokenClockWatermarkMu.Lock()
+	defer c.authTokenClockWatermarkMu.Unlock()
+	if now.Before(c.authTokenClockWatermark) {
+		return c.authTokenClockWatermark
+	}
+	c.authTokenClockWatermark = now
+	return now
+}
+
 // ValidateSessionToken looks up a session token, checks expiry, and returns the user and
 // their role names. Used by the auth middleware on every authenticated request.
 func (c *KeyorixCore) ValidateSessionToken(ctx context.Context, token string) (*models.User, []string, error) { // NOSONAR -- cognitive complexity 17, suppress go:S3776
@@ -510,7 +543,7 @@ func (c *KeyorixCore) ValidateSessionToken(ctx context.Context, token string) (*
 	if err != nil {
 		return nil, nil, fmt.Errorf("session not found")
 	}
-	if session.ExpiresAt != nil && c.now().After(*session.ExpiresAt) {
+	if session.ExpiresAt != nil && c.authEffectiveNow().After(*session.ExpiresAt) {
 		return nil, nil, fmt.Errorf("session expired")
 	}
 	// Enforce the hard absolute-lifetime ceiling at the validation boundary, not only via
@@ -519,7 +552,7 @@ func (c *KeyorixCore) ValidateSessionToken(ctx context.Context, token string) (*
 	// DEPEND on every issuer having clamped correctly — a session whose access window is
 	// still open yet whose ceiling has passed (a future non-clamping path, or a tampered
 	// row) is rejected here. Self-checking invariant.
-	if session.AbsoluteExpiresAt != nil && c.now().After(*session.AbsoluteExpiresAt) {
+	if session.AbsoluteExpiresAt != nil && c.authEffectiveNow().After(*session.AbsoluteExpiresAt) {
 		return nil, nil, fmt.Errorf("session lifetime exceeded")
 	}
 	user, err := c.storage.GetUser(ctx, session.UserID)

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -610,6 +610,34 @@ func (c *KeyorixCore) requireEqualOrGreaterAdminAuthority(ctx context.Context, a
 // existing callers not part of that fix pass false unchanged (see #1545 for
 // the broader sibling instances of this same exemption elsewhere -- not
 // fixed here, tracked separately).
+//
+// Part 2 regression audit (adversarial review run 2) attempted and REVERTED
+// a fix here: every caller passes actorID==0 for a machine-authenticated
+// granter (server middleware's UserID==0-for-any-machine-token convention),
+// so the loop below unconditionally refuses every machine-authenticated
+// grant regardless of the granting machine's real permissions -- a
+// false-refusal regression, not an escalation. The obvious fix (resolve the
+// real granting machine's ID from ctx via WithMachineActor and check ITS
+// permissions via AuthorizePrincipal) is UNSAFE as a blanket change: several
+// of this function's callers are /system proxy handlers relaying a raw
+// storage call with NO real acting-user identity at all (actorID==0 by
+// construction, e.g. RemoteStorage.AddUserToGroup) -- the only "machine" ctx
+// can resolve there is the NODE CREDENTIAL's own machine identity, which
+// integration tests deliberately grant admin-tier roles for legitimate
+// node-trust reasons ("no role, including admin, grants node status" --
+// server/http/integration_test.go's createNodeToken). Resolving and using
+// that node identity's own permissions here lets ANY node credential
+// self-authorize an admin-tier grant it's merely relaying on behalf of an
+// unidentified downstream actor -- confirmed via
+// TestRemoteStorageGroup_Membership_AdminConferringGroup_DeniesNodeCredential
+// and its Invitation/Membership proxy siblings, which went from correctly
+// denying to silently succeeding under the attempted fix. Fixing the
+// false-refusal safely requires distinguishing "a machine acting as itself"
+// from "a node credential relaying an anonymous call" BEFORE resolving
+// ctx-tagged permissions, which callers don't currently make distinguishable
+// -- left as a known, filed gap rather than shipped fail-open. Every
+// machine-authenticated grant stays unconditionally refused until that
+// distinction exists.
 func (c *KeyorixCore) requireGranterHoldsRolePermissions(ctx context.Context, actorID, roleID uint, scope Scope, actorIsMachine bool) error {
 	if actorID == 0 && !actorIsMachine {
 		return nil

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -582,6 +582,40 @@ func (c *KeyorixCore) requireEqualOrGreaterAdminAuthority(ctx context.Context, a
 	return nil
 }
 
+// selfMachineGranterCtxKey is the unexported context key carrying a machine
+// identity ID that authenticated the CURRENT request itself and is
+// requesting a grant on its own behalf -- distinct from audit_context.go's
+// WithMachineActor/machineActorFromContext, which is set for EVERY
+// machine-authenticated request (including /system proxy relays) purely
+// for audit-trail attribution and is deliberately never consulted for an
+// authorization decision. See requireGranterHoldsRolePermissions's doc for
+// why the distinction matters: a /system proxy relay's authenticating node
+// credential must never have ITS OWN permissions treated as authorizing an
+// operation relayed on behalf of an unidentified downstream actor.
+type selfMachineGranterCtxKey struct{}
+
+// WithSelfMachineGranter tags ctx with machineID as a genuine, directly
+// (non-proxy) authenticated machine actor requesting a grant AS ITSELF.
+// Call this ONLY from a direct HTTP/gRPC handler that authenticated a real
+// machine token for the CURRENT request and is about to call a core method
+// that may reach requireGranterHoldsRolePermissions with actorIsMachine
+// true -- NEVER from a /system proxy handler, which by construction cannot
+// know the real downstream actor's identity. A zero machineID is a no-op
+// (mirrors WithMachineActor/WithImpersonation).
+func WithSelfMachineGranter(ctx context.Context, machineID uint) context.Context {
+	if machineID == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, selfMachineGranterCtxKey{}, machineID)
+}
+
+// selfMachineGranterFromContext returns the tagged machine identity ID and
+// whether ctx carries one.
+func selfMachineGranterFromContext(ctx context.Context) (uint, bool) {
+	machineID, ok := ctx.Value(selfMachineGranterCtxKey{}).(uint)
+	return machineID, ok && machineID != 0
+}
+
 // requireGranterHoldsRolePermissions refuses to GRANT roleID at scope unless the
 // actor already holds, at that scope or broader, EVERY permission bundled into the
 // role — the admin-rank-ceiling check on the GRANT step (#93/#107/#141), distinct
@@ -611,33 +645,43 @@ func (c *KeyorixCore) requireEqualOrGreaterAdminAuthority(ctx context.Context, a
 // the broader sibling instances of this same exemption elsewhere -- not
 // fixed here, tracked separately).
 //
-// Part 2 regression audit (adversarial review run 2) attempted and REVERTED
-// a fix here: every caller passes actorID==0 for a machine-authenticated
-// granter (server middleware's UserID==0-for-any-machine-token convention),
-// so the loop below unconditionally refuses every machine-authenticated
-// grant regardless of the granting machine's real permissions -- a
-// false-refusal regression, not an escalation. The obvious fix (resolve the
-// real granting machine's ID from ctx via WithMachineActor and check ITS
-// permissions via AuthorizePrincipal) is UNSAFE as a blanket change: several
-// of this function's callers are /system proxy handlers relaying a raw
-// storage call with NO real acting-user identity at all (actorID==0 by
-// construction, e.g. RemoteStorage.AddUserToGroup) -- the only "machine" ctx
-// can resolve there is the NODE CREDENTIAL's own machine identity, which
-// integration tests deliberately grant admin-tier roles for legitimate
-// node-trust reasons ("no role, including admin, grants node status" --
-// server/http/integration_test.go's createNodeToken). Resolving and using
-// that node identity's own permissions here lets ANY node credential
-// self-authorize an admin-tier grant it's merely relaying on behalf of an
-// unidentified downstream actor -- confirmed via
-// TestRemoteStorageGroup_Membership_AdminConferringGroup_DeniesNodeCredential
-// and its Invitation/Membership proxy siblings, which went from correctly
-// denying to silently succeeding under the attempted fix. Fixing the
-// false-refusal safely requires distinguishing "a machine acting as itself"
-// from "a node credential relaying an anonymous call" BEFORE resolving
-// ctx-tagged permissions, which callers don't currently make distinguishable
-// -- left as a known, filed gap rather than shipped fail-open. Every
-// machine-authenticated grant stays unconditionally refused until that
-// distinction exists.
+// Part 2 regression audit (adversarial review run 2) first attempted and
+// REVERTED a blanket fix here, then landed this narrower one. Every caller
+// passes actorID==0 for a machine-authenticated granter (server
+// middleware's UserID==0-for-any-machine-token convention), so a naive
+// c.Authorize(ctx, actorID=0, ...) always denies -- a false-refusal
+// regression, not an escalation. The FIRST fix attempt resolved the real
+// granting machine's ID from ctx via the general-purpose WithMachineActor
+// tag (set for EVERY machine-authenticated request, audit-trail purposes)
+// and checked ITS permissions via AuthorizePrincipal. That was unsafe:
+// several of this function's callers are /system proxy handlers relaying a
+// raw storage call with NO real acting-user identity at all (actorID==0 by
+// construction, e.g. RemoteStorage.AddUserToGroup) -- the only "machine"
+// WithMachineActor's tag can resolve there is the NODE CREDENTIAL's own
+// machine identity, which integration tests deliberately grant admin-tier
+// roles for legitimate node-trust reasons ("no role, including admin,
+// grants node status" -- server/http/integration_test.go's createNodeToken).
+// A node credential is, at the auth layer, structurally indistinguishable
+// from any other machine token -- resolving and using its own permissions
+// here let ANY node credential self-authorize an admin-tier grant it was
+// merely relaying on behalf of an unidentified downstream actor,
+// confirmed via TestRemoteStorageGroup_Membership_AdminConferringGroup_
+// DeniesNodeCredential and its Invitation/Membership proxy siblings going
+// from correctly denying to silently succeeding.
+//
+// This fix instead checks a SEPARATE, narrowly-scoped context tag,
+// selfMachineGranterFromContext (WithSelfMachineGranter), that is ONLY set
+// by DIRECT (non-proxy) HTTP/gRPC handlers immediately before they call
+// into a core method that reaches this function -- a machine genuinely
+// authenticating and requesting a grant AS ITSELF. No /system proxy
+// handler ever sets it (grep for WithSelfMachineGranter finds only direct
+// handlers and gRPC services), so a relayed call's ctx never carries it,
+// and the machine-actor branch below falls through to the same fail-closed
+// refusal the pre-fix code always gave -- never worse than before, and
+// correct (not merely "no worse") for the direct-call case the tag DOES
+// cover. Adding a tag call at a handler is purely additive: a direct entry
+// point this pass didn't get to simply keeps failing closed, exactly as
+// before -- there is no way to reach fail-open by omission.
 func (c *KeyorixCore) requireGranterHoldsRolePermissions(ctx context.Context, actorID, roleID uint, scope Scope, actorIsMachine bool) error {
 	if actorID == 0 && !actorIsMachine {
 		return nil
@@ -646,8 +690,24 @@ func (c *KeyorixCore) requireGranterHoldsRolePermissions(ctx context.Context, ac
 	if err != nil {
 		return fmt.Errorf("failed to resolve role permissions: %w", err)
 	}
+	selfMachineID, isSelfMachineGrant := uint(0), false
+	if actorIsMachine {
+		selfMachineID, isSelfMachineGrant = selfMachineGranterFromContext(ctx)
+	}
 	for _, p := range perms {
-		ok, aerr := c.Authorize(ctx, actorID, p.Name, scope)
+		var ok bool
+		var aerr error
+		switch {
+		case isSelfMachineGrant:
+			ok, aerr = c.AuthorizePrincipal(ctx, ActorTypeMachine, selfMachineID, p.Name, scope)
+		case actorIsMachine:
+			// actorIsMachine but ctx carries no WithSelfMachineGranter tag: a
+			// /system proxy relay (or any call site not yet updated to tag
+			// itself) -- fail closed exactly as before this fix.
+			ok = false
+		default:
+			ok, aerr = c.Authorize(ctx, actorID, p.Name, scope)
+		}
 		if aerr != nil {
 			return fmt.Errorf("failed to resolve actor authority: %w", aerr)
 		}

--- a/internal/core/authz_machine_granter_ceiling_test.go
+++ b/internal/core/authz_machine_granter_ceiling_test.go
@@ -1,0 +1,97 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// PART2-CONT-6 (Part 2 regression audit, second attempt): requireGranterHoldsRolePermissions
+// must resolve a machine-authenticated granter's REAL permission set for a
+// genuine DIRECT (non-proxy) request, without reopening the fail-open node-
+// credential escalation the first attempt introduced. WithSelfMachineGranter
+// is a narrowly-scoped tag ONLY direct HTTP/gRPC handlers set (never a
+// /system proxy relay) -- these tests exercise it directly, mirroring how
+// server/http/handlers/machine_identities.go's changeMachineRole (and its
+// siblings) now tag ctx before calling into core.
+func TestAssignMachineRole_MachineGranterHoldingRolePermissionsAllowed(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	granter, err := c.CreateMachineIdentity(ctx, 1, "granter", MachineTypeService, "", "", 0, 0)
+	require.NoError(t, err)
+	target, err := c.CreateMachineIdentity(ctx, 1, "target", MachineTypeService, "", "", 0, 0)
+	require.NoError(t, err)
+
+	devRole, err := st.GetRoleByName(ctx, "project_developer")
+	require.NoError(t, err)
+	// Seed the granter's own permissions directly at the storage layer,
+	// bypassing the ceiling check itself (the same pattern
+	// TestAddUserToGroup_EscalationByProxyBlocked uses for its group's grant).
+	require.NoError(t, st.AssignMachineRole(ctx, granter.ID, devRole.ID, storage.Scope{ProjectID: 1}))
+
+	// Tag ctx exactly as a real direct (non-proxy) HTTP/gRPC handler does --
+	// WithSelfMachineGranter, NOT the general-purpose WithMachineActor a
+	// /system proxy relay's request would also carry.
+	grantCtx := WithSelfMachineGranter(ctx, granter.ID)
+
+	err = c.AssignMachineRole(grantCtx, target.ID, devRole.ID, Scope{ProjectID: 1}, 0, true)
+	require.NoError(t, err, "a machine granter that already holds every permission the role bundles must be allowed to grant that same role")
+}
+
+// Non-regression counterpart: a machine granter that does NOT hold the
+// target role's full permission set must still be refused -- proving the fix
+// resolves the machine's REAL permissions rather than failing open.
+func TestAssignMachineRole_MachineGranterMissingRolePermissionsBlocked(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	granter, err := c.CreateMachineIdentity(ctx, 1, "granter2", MachineTypeService, "", "", 0, 0)
+	require.NoError(t, err)
+	target, err := c.CreateMachineIdentity(ctx, 1, "target2", MachineTypeService, "", "", 0, 0)
+	require.NoError(t, err)
+
+	viewerRole, err := st.GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignMachineRole(ctx, granter.ID, viewerRole.ID, storage.Scope{ProjectID: 1}))
+
+	adminRole, err := st.GetRoleByName(ctx, "project_admin")
+	require.NoError(t, err)
+
+	grantCtx := WithSelfMachineGranter(ctx, granter.ID)
+	err = c.AssignMachineRole(grantCtx, target.ID, adminRole.ID, Scope{ProjectID: 1}, 0, true)
+	require.Error(t, err, "a machine granter holding only project_viewer must not be able to grant project_admin")
+	assert.Contains(t, err.Error(), "cannot grant this role")
+}
+
+// actorIsMachine set but ctx carries no WithSelfMachineGranter tag (e.g. a
+// /system proxy relay, or any call path not updated to tag itself) must
+// fail closed, exactly as it did before this fix -- never regress to a
+// WORSE (fail-open) outcome just because the tag is absent. This is the
+// exact shape the reverted first attempt got wrong when it consulted the
+// general-purpose WithMachineActor tag instead.
+func TestAssignMachineRole_MachineGranterUntaggedContextFailsClosed(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+
+	granter, err := c.CreateMachineIdentity(ctx, 1, "granter3", MachineTypeService, "", "", 0, 0)
+	require.NoError(t, err)
+	target, err := c.CreateMachineIdentity(ctx, 1, "target3", MachineTypeService, "", "", 0, 0)
+	require.NoError(t, err)
+
+	devRole, err := st.GetRoleByName(ctx, "project_developer")
+	require.NoError(t, err)
+	require.NoError(t, st.AssignMachineRole(ctx, granter.ID, devRole.ID, storage.Scope{ProjectID: 1}))
+
+	// No WithSelfMachineGranter tag on ctx. Even tagging with the general
+	// WithMachineActor (what a /system proxy relay's ctx legitimately carries
+	// for audit purposes) must NOT be treated as authorization -- prove that
+	// distinction holds, not just "no tag at all".
+	untrustedCtx := WithMachineActor(ctx, granter.ID)
+	err = c.AssignMachineRole(untrustedCtx, target.ID, devRole.ID, Scope{ProjectID: 1}, 0, true)
+	require.Error(t, err, "actorIsMachine with only the general-purpose audit tag (no WithSelfMachineGranter) must fail closed")
+	assert.Contains(t, err.Error(), "cannot grant this role")
+}

--- a/internal/core/classification_gate.go
+++ b/internal/core/classification_gate.go
@@ -335,7 +335,11 @@ const accessRequestApprovalClockRegressionTolerance = 30 * time.Second
 // refusal text both callers' own expiry check already returns
 // ("access request has expired"), not a distinct message, so a caller
 // cannot use it as an oracle confirming clock manipulation had an effect.
+// .UTC() strips any monotonic clock reading now carries — see
+// authEffectiveNow's doc comment (auth.go) for why an unstripped comparison
+// here would never actually detect a backward wall-clock step.
 func (c *KeyorixCore) checkAccessRequestApprovalClockNotRegressed(now time.Time) error {
+	now = now.UTC()
 	c.accessRequestApprovalWatermarkMu.Lock()
 	defer c.accessRequestApprovalWatermarkMu.Unlock()
 	if !c.accessRequestApprovalWatermark.IsZero() && now.Before(c.accessRequestApprovalWatermark.Add(-accessRequestApprovalClockRegressionTolerance)) {

--- a/internal/core/clock_watermark_monotonic_strip_test.go
+++ b/internal/core/clock_watermark_monotonic_strip_test.go
@@ -1,0 +1,134 @@
+// clock_watermark_monotonic_strip_test.go — Part 2 regression audit
+// continuation (2026-09-04): every clock-regression watermark in this
+// package (and its internal/storage/store sibling) compared its `now`
+// argument directly, without stripping a monotonic clock reading first.
+//
+// This matters because Go's time.Time carries an OPTIONAL monotonic reading
+// alongside its wall-clock reading whenever it comes from a real time.Now()
+// call (never from time.Date(...), time.Parse, or a DB round-trip). When
+// BOTH operands of a Before/After/Sub comparison carry a monotonic reading,
+// Go uses ONLY the monotonic delta — which tracks elapsed real time since an
+// arbitrary reference point and is, by construction, immune to the OS wall
+// clock being stepped backward (an NTP correction, or an operator running
+// `date -s`). So a watermark comparison built from two real time.Now()
+// values NEVER detects the exact "host clock stepped backward" condition
+// every one of these mechanisms exists to catch — it silently degrades to
+// "did more real time elapse," which is always true.
+//
+// This is NOT reproducible with the existing time.Date(...)-based tests
+// throughout this package (TestGetSecretValue_ClockSteppedBackward*, etc.):
+// time.Date never attaches a monotonic reading in the first place (the
+// stdlib docs guarantee it), so those tests exercise wall-clock-only
+// comparisons regardless of whether the production code strips monotonic —
+// passing either way, which is exactly how this bug shipped undetected
+// across #1632/#1638/#1651/#1653's entire wave. Actually reproducing a live
+// OS clock step is neither safe nor appropriate for a unit test, so this
+// file instead directly verifies the documented, testable contract the fix
+// relies on: time.Time.String() includes a "m=" monotonic-reading suffix
+// if and only if the value still carries one (see time.Time's package doc,
+// "Note that the Go == operator compares... consider t.Format(RFC3339Nano)"
+// section). A real time.Now() value must show it; a value threaded through
+// any of the fixed effectiveNow-style helpers below must not.
+package core
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hasMonotonicReading reports whether t carries a monotonic clock reading,
+// via the documented String() contract (time.Time package doc).
+func hasMonotonicReading(t time.Time) bool {
+	return strings.Contains(t.String(), " m=")
+}
+
+// TestRealTimeNow_CarriesMonotonicReading is the calibration check: confirms
+// this Go runtime's time.Now() actually attaches a monotonic reading, so the
+// tests below are exercising the real hazard, not a no-op on a platform
+// where it never applied.
+func TestRealTimeNow_CarriesMonotonicReading(t *testing.T) {
+	require.True(t, hasMonotonicReading(time.Now()), "calibration: time.Now() must carry a monotonic reading for these tests to mean anything")
+}
+
+// TestDateConstructedTime_NeverCarriesMonotonicReading is the other half of
+// the calibration: confirms time.Date(...) (what every existing
+// ClockSteppedBackward-style test in this package injects via c.now)
+// structurally CANNOT reproduce this bug class, explaining why those tests
+// passed throughout even while the production code was broken.
+func TestDateConstructedTime_NeverCarriesMonotonicReading(t *testing.T) {
+	require.False(t, hasMonotonicReading(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)))
+}
+
+// TestAuthEffectiveNow_StripsMonotonicReading proves the actual fix: a real,
+// monotonic-carrying time.Now() reading, once round-tripped through
+// authEffectiveNow, no longer carries one -- so a LATER comparison against
+// this same returned value (by any caller, including a second call to
+// authEffectiveNow itself) is a genuine wall-clock comparison, capable of
+// observing a backward OS clock step.
+func TestAuthEffectiveNow_StripsMonotonicReading(t *testing.T) {
+	c := &KeyorixCore{now: time.Now}
+	real := time.Now()
+	require.True(t, hasMonotonicReading(real), "sanity: the input this test feeds through c.now must itself carry a monotonic reading")
+
+	got := c.authEffectiveNow()
+	assert.False(t, hasMonotonicReading(got), "authEffectiveNow's returned/stored watermark value must not carry a monotonic reading -- an unstripped one would make the NEXT call's regression check compare monotonic deltas instead of wall-clock time, silently never detecting a backward OS clock step")
+}
+
+// TestCheckSecretExpiryClockNotRegressed_StripsMonotonicReading is the same
+// proof for #1635's actual named target.
+func TestCheckSecretExpiryClockNotRegressed_StripsMonotonicReading(t *testing.T) {
+	c := &KeyorixCore{}
+	require.NoError(t, c.checkSecretExpiryClockNotRegressed(time.Now()))
+	assert.False(t, hasMonotonicReading(c.secretExpiryWatermark), "secretExpiryWatermark must be stored without a monotonic reading")
+}
+
+// #1638's actual named target (consumeClockLooksRegressed) is unexported on
+// LocalStorage in internal/storage/store -- see
+// internal/storage/store/consume_clock_monotonic_strip_test.go for its
+// equivalent proof, same technique, different package.
+
+// TestConnectShareOIDCEffectiveNow_StripMonotonicReading covers the
+// remaining #1653-wave clamp mechanisms (connectEffectiveNow,
+// shareEffectiveNow, OIDCVerifier.effectiveNow) in one pass -- same proof,
+// same reason, applied to each.
+func TestConnectShareOIDCEffectiveNow_StripMonotonicReading(t *testing.T) {
+	t.Run("connectEffectiveNow", func(t *testing.T) {
+		c := &KeyorixCore{now: time.Now}
+		got := c.connectEffectiveNow()
+		assert.False(t, hasMonotonicReading(got))
+	})
+	t.Run("shareEffectiveNow", func(t *testing.T) {
+		c := &KeyorixCore{now: time.Now}
+		got := c.shareEffectiveNow()
+		assert.False(t, hasMonotonicReading(got))
+	})
+	t.Run("OIDCVerifier.effectiveNow", func(t *testing.T) {
+		v := &OIDCVerifier{now: time.Now}
+		got := v.effectiveNow()
+		assert.False(t, hasMonotonicReading(got))
+	})
+}
+
+// TestSessionRefreshAndAccessRequestApprovalClockChecks_StripMonotonicReading
+// covers the two REFUSE-shaped (#1653) mechanisms.
+func TestSessionRefreshAndAccessRequestApprovalClockChecks_StripMonotonicReading(t *testing.T) {
+	// Neither function under test calls i18n.T (both return a plain
+	// fmt.Errorf), so no i18n init/reset is needed here -- deliberately
+	// avoided to not add another instance of the pre-existing i18n global-
+	// singleton test-isolation gap other tests in this package already
+	// document (secret_value_clock_regression_test.go's newClockRegressionCore).
+	t.Run("checkSessionRefreshClockNotRegressed", func(t *testing.T) {
+		c := &KeyorixCore{}
+		require.NoError(t, c.checkSessionRefreshClockNotRegressed(time.Now()))
+		assert.False(t, hasMonotonicReading(c.sessionRefreshWatermark))
+	})
+	t.Run("checkAccessRequestApprovalClockNotRegressed", func(t *testing.T) {
+		c := &KeyorixCore{}
+		require.NoError(t, c.checkAccessRequestApprovalClockNotRegressed(time.Now()))
+		assert.False(t, hasMonotonicReading(c.accessRequestApprovalWatermark))
+	})
+}

--- a/internal/core/connect.go
+++ b/internal/core/connect.go
@@ -27,10 +27,13 @@ const EventConnectSecretRead = "connect.secret_read"
 // connectorHasAnyDelegationForActor are reached on every federated read —
 // see rbacEffectiveNow's doc comment (internal/storage/store/local_rbac.go)
 // for why this clamps rather than refuses.
+// .UTC() strips any monotonic clock reading c.now() carries — see
+// authEffectiveNow's doc comment (auth.go) for why an unstripped comparison
+// here would never actually detect a backward wall-clock step.
 func (c *KeyorixCore) connectEffectiveNow() time.Time {
 	c.connectClockWatermarkMu.Lock()
 	defer c.connectClockWatermarkMu.Unlock()
-	now := c.now()
+	now := c.now().UTC()
 	if now.Before(c.connectClockWatermark) {
 		return c.connectClockWatermark
 	}

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -123,6 +123,9 @@ func (c *KeyorixCore) InviteToProject(ctx context.Context, projectID uint, email
 	// Escalation-by-proxy guard: the inviter must already hold every permission the
 	// invited role bundles (parallel to the access-request ceiling), not merely an
 	// admin-tier role name.
+	if invitedByMachineID != 0 {
+		ctx = WithSelfMachineGranter(ctx, invitedByMachineID)
+	}
 	if err := c.requireGranterHoldsRolePermissions(ctx, invitedBy, inviteRole.ID, Scope{ProjectID: projectID}, invitedByMachineID != 0); err != nil {
 		return nil, err
 	}
@@ -221,6 +224,9 @@ func (c *KeyorixCore) InviteGlobal(ctx context.Context, email, systemRole string
 	// role is the most powerful grant this flow can mint, so it needs the ceiling
 	// check applied everywhere else — the inviter's real bundled permissions, not
 	// just the role's name — at global scope (projectID 0).
+	if invitedByMachineID != 0 {
+		ctx = WithSelfMachineGranter(ctx, invitedByMachineID)
+	}
 	if err := c.requireGranterHoldsRolePermissions(ctx, invitedBy, sysRoleModel.ID, Scope{}, invitedByMachineID != 0); err != nil {
 		return nil, err
 	}
@@ -323,6 +329,15 @@ func (c *KeyorixCore) InviteGlobalWithLink(ctx context.Context, email, systemRol
 // single project role. Everything was validated at invite time, so a failure here
 // is a storage error (leaving the invitation pending/resendable), not bad input.
 func (c *KeyorixCore) applyInvitationGrants(ctx context.Context, inv *models.ProjectInvitation, userID uint) error { // NOSONAR -- cognitive complexity 22, suppress go:S3776
+	// A genuine machine inviter (not a /system proxy relay) -- tag ctx so the
+	// requireGranterHoldsRolePermissions calls reached via AssignUserRole/
+	// inviteMemberWithMode below check ITS real permissions instead of
+	// unconditionally refusing. This ctx is freshly built by the accept-time
+	// caller (completeInvitationAccept), so it does not already carry the tag
+	// InviteToProject/InviteGlobal set at invite time.
+	if inv.InvitedByMachineIdentityID != 0 {
+		ctx = WithSelfMachineGranter(ctx, inv.InvitedByMachineIdentityID)
+	}
 	// Global invite: system role + multi-project assignments.
 	if inv.SystemRole != "" || inv.AssignmentsJSON != "" {
 		if inv.SystemRole != "" {
@@ -702,6 +717,9 @@ func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projec
 	// Privilege ceiling: an approver may not grant a role unless they themselves
 	// hold every permission it bundles (escalation-by-proxy guard), not merely an
 	// admin-tier role name.
+	if approverMachineID != 0 {
+		ctx = WithSelfMachineGranter(ctx, approverMachineID)
+	}
 	if err := c.requireGranterHoldsRolePermissions(ctx, approverID, roleModel.ID, Scope{ProjectID: req.ProjectID}, approverMachineID != 0); err != nil {
 		return nil, err
 	}

--- a/internal/core/invitations_test.go
+++ b/internal/core/invitations_test.go
@@ -44,11 +44,17 @@ func TestInviteToProject_RecordsActingMachineIdentity(t *testing.T) {
 	store := new(MockStorage)
 	c := newInviteCore(store)
 	ctx := context.Background()
-	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5, Name: "project_developer"}, nil)
-	store.On("CreateProjectInvitation", ctx, mock.MatchedBy(func(inv *models.ProjectInvitation) bool {
+	// mock.Anything for ctx, not the exact ctx value: PART2-CONT-6's fix tags
+	// ctx with WithSelfMachineGranter for a real machine inviter
+	// (invitedByMachineID != 0, as this test's own name says) before the
+	// storage calls below, which legitimately changes ctx's identity --
+	// that's the fix working as intended, not something this test should
+	// pin down.
+	store.On("GetRoleByName", mock.Anything, "project_developer").Return(&models.Role{ID: 5, Name: "project_developer"}, nil)
+	store.On("CreateProjectInvitation", mock.Anything, mock.MatchedBy(func(inv *models.ProjectInvitation) bool {
 		return inv.InvitedBy == 0 && inv.InvitedByMachineIdentityID == 42
 	})).Return(&models.ProjectInvitation{ID: 8, State: InvitationPending}, nil)
-	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 
 	_, err := c.InviteToProject(ctx, 1, "a@b.com", "project_developer", 0, 42)
 	require.NoError(t, err)
@@ -512,8 +518,15 @@ func TestInviteToProjectWithLink_RecordsActingMachineIdentityOnSetupToken(t *tes
 	fixed := c.now()
 	anyAudit(store)
 
+	// mock.Anything for CreateProjectInvitation's ctx, not the exact ctx
+	// value: PART2-CONT-6's fix tags ctx with WithSelfMachineGranter inside
+	// InviteToProject (called by InviteToProjectWithLink below) for a real
+	// machine inviter (invitedByMachineID != 0) -- that tagged ctx is local
+	// to InviteToProject's own call to CreateProjectInvitation and does not
+	// propagate back to this test's ctx variable, so every OTHER call below
+	// still legitimately matches the exact original ctx.
 	store.On("GetRoleByName", ctx, "project_developer").Return(&models.Role{ID: 5, Name: "project_developer"}, nil)
-	store.On("CreateProjectInvitation", ctx, mock.MatchedBy(func(inv *models.ProjectInvitation) bool {
+	store.On("CreateProjectInvitation", mock.Anything, mock.MatchedBy(func(inv *models.ProjectInvitation) bool {
 		return inv.InvitedBy == 0 && inv.InvitedByMachineIdentityID == 42
 	})).Return(&models.ProjectInvitation{ID: 7, State: InvitationPending}, nil)
 	store.On("SupersedeActiveSetupTokens", ctx, SetupPurposeInvitationAccept, "a@b.com", ptr(uint(1))).Return(nil)

--- a/internal/core/machine_token.go
+++ b/internal/core/machine_token.go
@@ -262,7 +262,7 @@ func (c *KeyorixCore) ValidateMachineToken(ctx context.Context, raw string) (*mo
 	if cred.Revoked {
 		return nil, nil, nil, 0, ErrMachineTokenRevoked
 	}
-	if cred.ExpiresAt != nil && c.now().After(*cred.ExpiresAt) {
+	if cred.ExpiresAt != nil && c.authEffectiveNow().After(*cred.ExpiresAt) {
 		return nil, nil, nil, 0, ErrMachineTokenExpired
 	}
 	m, err := c.storage.GetMachineIdentity(ctx, cred.MachineIdentityID)
@@ -315,7 +315,7 @@ func (c *KeyorixCore) CurrentMachineTokenRestriction(ctx context.Context, raw st
 	if cred.Revoked {
 		return nil, ErrMachineTokenRevoked
 	}
-	if cred.ExpiresAt != nil && c.now().After(*cred.ExpiresAt) {
+	if cred.ExpiresAt != nil && c.authEffectiveNow().After(*cred.ExpiresAt) {
 		return nil, ErrMachineTokenExpired
 	}
 	m, err := c.storage.GetMachineIdentity(ctx, cred.MachineIdentityID)

--- a/internal/core/mfa_stepup.go
+++ b/internal/core/mfa_stepup.go
@@ -74,7 +74,7 @@ func (c *KeyorixCore) verifyMFAStepUpCode(ctx context.Context, userID uint, code
 // HasActiveMFAStepUp reports whether userID holds a current, unexpired step-up
 // grant. Returns (false, nil) — not an error — when no grant exists.
 func (c *KeyorixCore) HasActiveMFAStepUp(ctx context.Context, userID uint) (bool, error) {
-	grant, err := c.storage.GetActiveMFAStepUpGrant(ctx, userID, c.now())
+	grant, err := c.storage.GetActiveMFAStepUpGrant(ctx, userID, c.authEffectiveNow())
 	if err != nil {
 		return false, err
 	}

--- a/internal/core/oidc.go
+++ b/internal/core/oidc.go
@@ -83,10 +83,14 @@ type OIDCVerifier struct {
 // effectiveNow returns v.now() clamped so it never regresses relative to a
 // reading this verifier has already legitimately observed. See
 // clockWatermark's doc comment above for what this defends against.
+//
+// .UTC() strips any monotonic clock reading v.now() carries — see
+// KeyorixCore.authEffectiveNow's doc comment (auth.go) for why an unstripped
+// comparison here would never actually detect a backward wall-clock step.
 func (v *OIDCVerifier) effectiveNow() time.Time {
 	v.clockWatermarkMu.Lock()
 	defer v.clockWatermarkMu.Unlock()
-	now := v.now()
+	now := v.now().UTC()
 	if now.Before(v.clockWatermark) {
 		return v.clockWatermark
 	}

--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -143,7 +143,7 @@ func (c *KeyorixCore) ValidatePATToken(ctx context.Context, raw string) (*models
 	if pat.Revoked {
 		return nil, nil, nil, 0, ErrPATRevoked
 	}
-	if IsPATExpired(pat, c.now()) {
+	if IsPATExpired(pat, c.authEffectiveNow()) {
 		c.emitPATExpiredNotification(ctx, pat)
 		return nil, nil, nil, 0, ErrPATExpired
 	}
@@ -273,7 +273,7 @@ func (c *KeyorixCore) CurrentPATRestriction(ctx context.Context, raw string) (*P
 	if pat.Revoked {
 		return nil, ErrPATRevoked
 	}
-	if IsPATExpired(pat, c.now()) {
+	if IsPATExpired(pat, c.authEffectiveNow()) {
 		return nil, ErrPATExpired
 	}
 	return patRestrictionFrom(pat), nil

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -17,10 +17,13 @@ import (
 // access-list resolution that involves shares — see rbacEffectiveNow's doc
 // comment (internal/storage/store/local_rbac.go) for why this clamps rather
 // than refuses.
+// .UTC() strips any monotonic clock reading c.now() carries — see
+// authEffectiveNow's doc comment (auth.go) for why an unstripped comparison
+// here would never actually detect a backward wall-clock step.
 func (c *KeyorixCore) shareEffectiveNow() time.Time {
 	c.shareClockWatermarkMu.Lock()
 	defer c.shareClockWatermarkMu.Unlock()
-	now := c.now()
+	now := c.now().UTC()
 	if now.Before(c.shareClockWatermark) {
 		return c.shareClockWatermark
 	}

--- a/internal/core/project_members.go
+++ b/internal/core/project_members.go
@@ -81,7 +81,15 @@ func (c *KeyorixCore) SetProjectMemberRole(ctx context.Context, actorID, project
 				hasTarget = true
 				continue
 			}
-			if err := c.RemoveUserRole(ctx, actorID, userID, rid, scope); err != nil {
+			// removeUserRoleUnguarded, not RemoveUserRole: the guardLastProjectAdmin
+			// call above already validated the FULL before/after transition
+			// (existing -> []uint{role.ID}) atomically under this call's own
+			// WithNamedLock. RemoveUserRole's own project-scope guard can only see
+			// this one role's removal in isolation -- blind to the AssignUserRole
+			// below that's about to restore admin coverage -- and would falsely
+			// refuse swapping the project's sole administrator directly from one
+			// admin-tier role to another (see removeUserRoleUnguarded's doc).
+			if err := c.removeUserRoleUnguarded(ctx, actorID, userID, rid, scope); err != nil {
 				return err
 			}
 		}

--- a/internal/core/project_members_sole_admin_swap_test.go
+++ b/internal/core/project_members_sole_admin_swap_test.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// FIX-2 (Part 2 regression audit): swapping the project's SOLE administrator
+// directly from one admin-tier (roles.assign-carrying) role to ANOTHER must
+// succeed. RemoveUserRole's own project-scope last-admin guard (added by the
+// original FIX-2, rbac_management.go) used to re-derive "after" as "existing
+// roles minus the one being removed", blind to the compensating AssignUserRole
+// SetProjectMemberRole makes immediately afterward within the SAME atomic,
+// WithNamedLock-protected operation -- so a sole admin's role swap was
+// falsely refused as if it left the project ungoverned, even though
+// SetProjectMemberRole's OWN upfront guardLastProjectAdmin call (using the
+// true before/after state) had already confirmed it does not.
+func TestSetProjectMemberRole_SoleAdminSwapBetweenTwoAdminRolesAllowed(t *testing.T) {
+	c, st := newBootstrappedCore(t)
+	ctx := context.Background()
+	const proj = uint(7)
+	const actor = uint(55)
+	grantGlobalAdmin(t, st, actor)
+
+	perms, err := c.ListPermissions(ctx)
+	require.NoError(t, err)
+	var rolesAssignID uint
+	for _, p := range perms {
+		if p.Name == "roles.assign" {
+			rolesAssignID = p.ID
+		}
+	}
+	require.NotZero(t, rolesAssignID, "roles.assign must be seeded")
+
+	roleAName, err := identity.NewFoldedName("sole-admin-swap-role-a")
+	require.NoError(t, err)
+	roleA, err := st.CreateRole(ctx, roleAName, "admin-tier role A")
+	require.NoError(t, err)
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, roleA.ID, rolesAssignID, false))
+
+	roleBName, err := identity.NewFoldedName("sole-admin-swap-role-b")
+	require.NoError(t, err)
+	roleB, err := st.CreateRole(ctx, roleBName, "admin-tier role B")
+	require.NoError(t, err)
+	require.NoError(t, c.AssignPermissionToRole(ctx, 0, roleB.ID, rolesAssignID, false))
+
+	u, err := st.CreateUser(ctx, &models.User{Username: "sole-admin", Email: "sole-admin@example.com", IsActive: true})
+	require.NoError(t, err)
+	require.NoError(t, c.AddProjectMember(ctx, actor, proj, u.ID, "sole-admin-swap-role-a", false))
+
+	err = c.SetProjectMemberRole(ctx, actor, proj, u.ID, "sole-admin-swap-role-b", false)
+	require.NoError(t, err, "swapping the sole admin directly between two admin-tier roles must not be refused as a last-admin violation")
+
+	members, err := c.ListProjectMembers(ctx, proj)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, "sole-admin-swap-role-b", members[0].RoleName)
+}

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -511,6 +511,32 @@ func (c *KeyorixCore) RemoveUserRole(ctx context.Context, actorID, userID, roleI
 			return err
 		}
 	}
+	return c.removeUserRoleUnguarded(ctx, actorID, userID, roleID, scope)
+}
+
+// removeUserRoleUnguarded performs the actual role removal, audit log, and
+// cache eviction WITHOUT re-running guardLastProjectAdmin -- the tail
+// RemoveUserRole itself uses after its own guard above passes.
+//
+// Part 2 regression audit (adversarial review run 2): SetProjectMemberRole
+// swapping a project's SOLE administrator directly from one admin-tier role
+// to ANOTHER (both carrying roles.assign) already validates that full
+// transition safely, atomically, under its own WithNamedLock, via its own
+// guardLastProjectAdmin(existing, []uint{newRole.ID}) call BEFORE touching
+// anything (see SetProjectMemberRole). But its removal loop used to call the
+// public, guarded RemoveUserRole for the outgoing role -- whose OWN
+// project-scope guard (added by this same FIX-2, above) re-derives "after"
+// as "existing minus roleID", blind to the compensating AssignUserRole
+// SetProjectMemberRole is about to make. For a sole admin with exactly one
+// existing role, that blind re-check saw an empty "after" and refused the
+// swap outright ("cannot remove or demote the project's last administrator")
+// even though the operation, viewed as a whole -- which is exactly what
+// SetProjectMemberRole's own upfront guard already confirmed -- never
+// actually left the project without an administrator. SetProjectMemberRole
+// now calls this unguarded primitive directly for its removal-loop steps,
+// relying on its own already-correct, whole-operation guard instead of
+// RemoveUserRole's necessarily narrower, single-call one.
+func (c *KeyorixCore) removeUserRoleUnguarded(ctx context.Context, actorID, userID, roleID uint, scope Scope) error {
 	if err := c.storage.RemoveRole(ctx, userID, roleID, scope); err != nil {
 		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
 	}

--- a/internal/core/rbac_roles.go
+++ b/internal/core/rbac_roles.go
@@ -137,3 +137,36 @@ func (c *KeyorixCore) UpdateRole(ctx context.Context, actorID uint, role *models
 	c.LogRoleUpdated(ctx, actorID, updated.ID, updated.Name)
 	return updated, nil
 }
+
+// DeleteRole deletes a role definition by id. Rejects deleting a built-in
+// role (mirrors CreateRole/UpdateRole's reserved-name guard — deleting
+// e.g. admin/super_admin would invalidate every live assignment of it and
+// can lock every administrator out).
+//
+// #1660 sibling sweep (Part 2 regression audit continuation): both
+// transports' DeleteRole handlers used to call storage.Storage.DeleteRole
+// directly, the SAME direct-to-storage shape #1665 fixed for CreateRole/
+// UpdateRole, recurring exactly as that issue's own "worthwhile follow-up"
+// predicted. Unlike the original pre-#1665 CreateRole gap, this one was
+// NOT a live, exploitable hole — both transports had already, deliberately,
+// kept an inline IsBuiltinRole check and audit call in sync (the gRPC side's
+// own comment: "the guard is bypassable by switching transport" shows the
+// duplication was intentional and watched, not accidental) — but the
+// architectural risk (duplicated logic that could silently drift) is the
+// same one #1665 closed for the other two operations. Consolidating here
+// for the same reason, not because a gap was found live.
+func (c *KeyorixCore) DeleteRole(ctx context.Context, actorID, id uint) error {
+	role, err := c.storage.GetRole(ctx, id)
+	if err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
+	}
+	if IsBuiltinRole(role.Name) {
+		c.LogRoleDeleteDenied(ctx, actorID, role.ID, role.Name, "target is a built-in role")
+		return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "cannot delete built-in role: "+role.Name)
+	}
+	if err := c.storage.DeleteRole(ctx, id); err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	c.LogRoleDeleted(ctx, actorID, role.ID, role.Name)
+	return nil
+}

--- a/internal/core/rbac_roles_test.go
+++ b/internal/core/rbac_roles_test.go
@@ -121,3 +121,46 @@ func TestUpdateRole_HappyPathAudited(t *testing.T) {
 	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", EventRoleUpdated).Count(&n).Error)
 	assert.Equal(t, int64(1), n, "UpdateRole must audit exactly once")
 }
+
+// #1660 sibling sweep (Part 2 regression audit continuation): DeleteRole was
+// the one role-CRUD operation #1665's original consolidation missed -- both
+// transports still called storage.Storage.DeleteRole directly, duplicating
+// (correctly, but separately) the built-in-role guard and audit call. These
+// tests exercise the now-shared core.DeleteRole directly, the same way
+// TestCreateRole_*/TestUpdateRole_* above prove the OTHER two operations'
+// validation genuinely lives in internal/core and isn't just something both
+// transports happen to still do for themselves.
+func TestDeleteRole_RejectsBuiltin(t *testing.T) {
+	c, db := newRoleCRUDTestCore(t)
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "super_admin", NameFolded: "super_admin"}).Error)
+
+	err := c.DeleteRole(context.Background(), 1, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "built-in")
+
+	var role models.Role
+	require.NoError(t, db.First(&role, 1).Error, "a rejected delete must not remove the row")
+}
+
+func TestDeleteRole_HappyPathAudited(t *testing.T) {
+	c, db := newRoleCRUDTestCore(t)
+	created, err := c.CreateRole(context.Background(), 1, "deletable-role", "desc")
+	require.NoError(t, err)
+
+	require.NoError(t, c.DeleteRole(context.Background(), 9, created.ID))
+
+	var count int64
+	require.NoError(t, db.Model(&models.Role{}).Where("id = ?", created.ID).Count(&count).Error)
+	assert.Zero(t, count, "the role row must actually be gone")
+
+	var n int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", EventRoleDeleted).Count(&n).Error)
+	assert.Equal(t, int64(1), n, "DeleteRole must audit exactly once")
+}
+
+func TestDeleteRole_NonexistentReturnsError(t *testing.T) {
+	c, _ := newRoleCRUDTestCore(t)
+	err := c.DeleteRole(context.Background(), 1, 999999)
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "not found")
+}

--- a/internal/core/risk_exceptions.go
+++ b/internal/core/risk_exceptions.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -57,6 +58,42 @@ var (
 	ErrRiskExceptionRevokedNotApprovable = errors.New("cannot approve a revoked risk exception")
 	ErrRiskExceptionConcurrentlyDecided  = errors.New("risk exception was concurrently revoked or approved by another request")
 )
+
+// ErrRiskExceptionPermissionDenied and ErrRiskExceptionNotFound (re-exported
+// from storage.ErrRiskExceptionNotFound for errors.Is convenience) classify
+// RevokeRiskException failures for server/http/handlers/risk_exceptions.go to
+// match via errors.Is, rather than the substring text match it used to do
+// (strings.Contains(msg, "not found"), with no case at all for permission
+// denial, which fell through to a generic 500). Same pattern as FIX-4/FIX-6.
+//
+// Part 2 regression audit (adversarial review run 2): RevokeRiskException's
+// authority check ran AFTER the existence lookup (GetRiskException),
+// returning that lookup's raw error on failure -- so a caller holding this
+// route's own gate (system.write) but no creator/admin-tier standing could
+// distinguish "exception id doesn't exist" from "exists but isn't mine" by
+// the different status codes/bodies that produced, exactly the oracle
+// PR #1695 fixed for the identically-shaped DeleteSoDPolicy but never swept
+// to this sibling site.
+var (
+	ErrRiskExceptionPermissionDenied = errors.New("risk exception permission denied")
+	ErrRiskExceptionNotFoundPublic   = errors.New("risk exception not found")
+)
+
+type riskExceptionClassifiedError struct {
+	err    error
+	target error
+}
+
+func (e *riskExceptionClassifiedError) Error() string        { return e.err.Error() }
+func (e *riskExceptionClassifiedError) Unwrap() error        { return e.err }
+func (e *riskExceptionClassifiedError) Is(target error) bool { return target == e.target }
+
+func wrapRiskExceptionPermissionDenied(err error) error {
+	return &riskExceptionClassifiedError{err: err, target: ErrRiskExceptionPermissionDenied}
+}
+func wrapRiskExceptionNotFoundPublic(err error) error {
+	return &riskExceptionClassifiedError{err: err, target: ErrRiskExceptionNotFoundPublic}
+}
 
 // validExceptionCategories are the risk areas an exception may cover (aligned with
 // the posture controls so an exception can annotate a specific gap).
@@ -238,16 +275,38 @@ func (c *KeyorixCore) CountExpiredRiskExceptions(ctx context.Context) (int, erro
 // LiftLegalHold's creator-or-admin precedent exactly: only the principal who
 // created the exception, or a global-admin-tier principal, may revoke it. A
 // denied attempt is itself audited.
+//
+// Part 2 regression audit fix (adversarial review run 2): the authority check
+// used to run AFTER the existence lookup, returning that lookup's error
+// verbatim on failure -- the same #1645 403-for-both oracle PR #1695 fixed
+// for DeleteSoDPolicy, present here too since this function shares the exact
+// same shape and was never swept. A real 404 is now safe ONLY for a caller
+// already authorized at global admin-tier (the same standing that would
+// grant access to ANY exception); every other caller gets the identical
+// ErrRiskExceptionPermissionDenied response whether the id is missing or
+// just not theirs.
 func (c *KeyorixCore) RevokeRiskException(ctx context.Context, actorID, id uint) error {
+	isAdminTier := c.isGlobalAdminRoleName(ctx, actorID) != ""
+
 	e, err := c.storage.GetRiskException(ctx, id)
 	if err != nil {
+		if isAdminTier && errors.Is(err, storage.ErrRiskExceptionNotFound) {
+			return wrapRiskExceptionNotFoundPublic(err)
+		}
+		if errors.Is(err, storage.ErrRiskExceptionNotFound) {
+			c.writeAuditEventFailed(ctx, EventRiskExceptionRevoked, actorPtr(actorID), nil, "",
+				fmt.Sprintf("risk exception %d revoke DENIED: actor %d is not an admin-tier principal (exception lookup found no match)", id, actorID))
+			return wrapRiskExceptionPermissionDenied(fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
+				"only the creating admin or an admin-tier principal may revoke this risk exception"))
+		}
 		return err
 	}
-	if actorID != e.CreatedBy && c.isGlobalAdminRoleName(ctx, actorID) == "" {
+
+	if actorID != e.CreatedBy && !isAdminTier {
 		c.writeAuditEventFailed(ctx, EventRiskExceptionRevoked, actorPtr(actorID), nil, "",
 			fmt.Sprintf("risk exception %d revoke DENIED: actor %d is neither the creator (%d) nor an admin-tier principal", id, actorID, e.CreatedBy))
-		return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
-			"only the creating admin or an admin-tier principal may revoke this risk exception")
+		return wrapRiskExceptionPermissionDenied(fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
+			"only the creating admin or an admin-tier principal may revoke this risk exception"))
 	}
 	if e.Revoked {
 		return fmt.Errorf("risk exception %d is already revoked: %w", id, ErrRiskExceptionAlreadyRevoked)

--- a/internal/core/risk_exceptions_revoke_oracle_external_test.go
+++ b/internal/core/risk_exceptions_revoke_oracle_external_test.go
@@ -1,0 +1,71 @@
+package core_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// FIX-5 (Part 2 regression audit): a non-admin, non-creator caller must get the
+// IDENTICAL denial (same error classification, same message) whether the target
+// risk exception id doesn't exist at all, or exists but belongs to someone else --
+// otherwise a caller who can reach this route at all (system.write) but holds no
+// creator/admin standing could enumerate valid risk exception IDs by watching
+// which response they get. RevokeRiskException had this exact #1645 oracle gap
+// even after PR #1695 closed the identical shape for DeleteSoDPolicy -- the fix
+// was never swept to this sibling site.
+func TestRevokeRiskException_NonAdmin_NonExistentAndNonOwned_IdenticalDenial(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.RiskException{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.AssignUserRole(t, 1, 1, nil) // actor 1: admin-tier, creates the exception
+	exc, err := h.CoreService.CreateRiskException(ctx, 1, false, "accept dormant access", "mfa", "", "temporary", time.Now().Add(30*24*time.Hour))
+	require.NoError(t, err)
+
+	h.CreateTestUser(t, "grace", 22)
+	h.AssignUserRole(t, 22, 4, nil) // viewer -- neither creator nor admin-tier
+
+	errOwned := h.CoreService.RevokeRiskException(ctx, 22, exc.ID)
+	require.Error(t, errOwned)
+	require.True(t, errors.Is(errOwned, core.ErrRiskExceptionPermissionDenied),
+		"existing-but-foreign exception must classify as ErrRiskExceptionPermissionDenied")
+
+	const nonExistentID = 999999
+	errMissing := h.CoreService.RevokeRiskException(ctx, 22, nonExistentID)
+	require.Error(t, errMissing)
+	require.True(t, errors.Is(errMissing, core.ErrRiskExceptionPermissionDenied),
+		"nonexistent exception id, for a non-admin caller, must ALSO classify as ErrRiskExceptionPermissionDenied")
+	require.False(t, errors.Is(errMissing, core.ErrRiskExceptionNotFoundPublic),
+		"a non-admin caller must never observe the not-found classification -- that's the oracle")
+
+	assert.Equal(t, errOwned.Error(), errMissing.Error(),
+		"the two denials must be byte-identical, not just the same HTTP status -- #1645 403-for-both requires identical bodies")
+}
+
+// FIX-5: the real-404 exception is narrow -- an admin-tier caller, who could
+// revoke ANY exception regardless of which one this is, gets a genuine
+// ErrRiskExceptionNotFoundPublic for a nonexistent id rather than the generic
+// denial a non-admin caller gets. Mirrors TestDeleteSoDPolicy_AdminTier_NonExistentGetsRealNotFound.
+func TestRevokeRiskException_AdminTier_NonExistentGetsRealNotFound(t *testing.T) {
+	h := testhelper.NewRBACTestHelper(t)
+	defer h.Cleanup()
+	require.NoError(t, h.DB.AutoMigrate(&models.RiskException{}, &models.AuditEvent{}))
+	ctx := context.Background()
+
+	h.AssignUserRole(t, 1, 1, nil) // actor 1: admin-tier
+
+	const nonExistentID = 999999
+	err := h.CoreService.RevokeRiskException(ctx, 1, nonExistentID)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, core.ErrRiskExceptionNotFoundPublic),
+		"an admin-tier caller must get the real not-found classification, not the generic denial")
+}

--- a/internal/core/risk_exceptions_test.go
+++ b/internal/core/risk_exceptions_test.go
@@ -111,6 +111,13 @@ func TestRevokeRiskException(t *testing.T) {
 	// #1529: RevokeRiskException now requires creator-or-admin. CreatedBy: 3
 	// makes actor 3 the creator, satisfying the check without needing to stand
 	// up an RBAC mock chain for the admin branch.
+	// FIX-5 (Part 2 regression audit): isGlobalAdminRoleName is now evaluated
+	// unconditionally up front (needed to decide the not-found-vs-denied
+	// classification below, see #1645 403-for-both) rather than only on the
+	// non-creator path, so even this creator-only case now needs the RBAC
+	// lookup mocked.
+	store.On("GetUserRoleIDsAt", mock.Anything, uint(3), Scope{}).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", mock.Anything, uint(3), Scope{}).Return([]uint{}, nil)
 	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 3}, nil)
 	store.On("RevokeRiskExceptionIfNotRevoked", mock.Anything, mock.MatchedBy(func(e *models.RiskException) bool {
 		return e.ID == 5 && e.Revoked && e.RevokedBy == 3 && e.RevokedAt != nil
@@ -176,6 +183,10 @@ func TestRevokeRiskException_LostRaceReturnsError(t *testing.T) {
 	// #1529: CreatedBy: 3 makes actor 3 the creator, satisfying the
 	// creator-or-admin check so this test still exercises the lost-race path
 	// it's actually about.
+	// FIX-5: see TestRevokeRiskException above -- the admin-tier RBAC lookup
+	// now runs unconditionally, before the creator check.
+	store.On("GetUserRoleIDsAt", mock.Anything, uint(3), Scope{}).Return([]uint{}, nil)
+	store.On("GetUserGroupRoleIDsAt", mock.Anything, uint(3), Scope{}).Return([]uint{}, nil)
 	store.On("GetRiskException", mock.Anything, uint(5)).Return(&models.RiskException{ID: 5, Title: "x", CreatedBy: 3}, nil)
 	store.On("RevokeRiskExceptionIfNotRevoked", mock.Anything, mock.Anything).Return(false, nil)
 

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -399,6 +399,46 @@ type KeyorixCore struct {
 	sessionRefreshWatermark          time.Time
 	accessRequestApprovalWatermarkMu sync.Mutex
 	accessRequestApprovalWatermark   time.Time
+	// authTokenClockWatermark backs authEffectiveNow (auth.go): an in-memory
+	// monotonic high-water mark of the latest wall-clock instant this process
+	// has observed while validating a presented authentication credential's
+	// expiry -- ValidateSessionToken (session ExpiresAt + AbsoluteExpiresAt),
+	// ValidatePATToken (IsPATExpired), ValidateMachineToken (credential
+	// ExpiresAt, both the primary and CIDR-restriction lookup paths), and
+	// HasActiveMFAStepUp (GetActiveMFAStepUpGrant's cutoff).
+	//
+	// Part 2 regression audit continuation (2026-09-04): the #1632/#1651/#1653
+	// wall-clock hardening wave covered RBAC permission-resolution queries
+	// (rbacClockWatermark), Connect/share validity (connectClockWatermark/
+	// shareClockWatermark), single-use MFA/WebAuthn challenge CONSUMPTION
+	// (consumeClockWatermark), session REFRESH and access-request APPROVAL
+	// (sessionRefreshWatermark/accessRequestApprovalWatermark) -- but never
+	// the four functions above, which validate a presented credential's own
+	// expiry on every authenticated request/read, before any RBAC query even
+	// runs. All four compared a bare c.now() directly against a stored
+	// ExpiresAt with no regression protection of any kind -- the same
+	// backward-host-clock threat model #1632 names ("an operator, or an
+	// NTP-less clock correction, stepping the host clock back") would let an
+	// already-expired session, PAT, machine credential, or MFA step-up grant
+	// validate as still live.
+	//
+	// CLAMPs rather than refuses, matching rbacClockWatermark/
+	// connectClockWatermark/shareClockWatermark's reasoning (local_rbac.go):
+	// these are pervasive, every-request/every-read paths, not a single
+	// discrete action -- hard-refusing authentication outright the moment a
+	// regression is detected would turn a narrow clock-integrity concern into
+	// a total outage (every credential rejected, for every principal, until
+	// the clock recovers), a strictly worse outcome than the hazard being
+	// defended against. One shared watermark across all four, not four
+	// separate ones: unlike Connect/shares (unrelated subsystems, kept
+	// separate per #1632's own precedent), these four are all "is a
+	// presented credential still within its validity window" -- the same
+	// concept applied to four credential kinds, so sharing loses no
+	// meaningful precision (the point is tracking the latest wall-clock
+	// instant this process has legitimately observed, not per-credential
+	// state).
+	authTokenClockWatermarkMu sync.Mutex
+	authTokenClockWatermark   time.Time
 }
 
 // AuditForwarder ships persisted audit events to an external sink (e.g. a SIEM).

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -23,6 +23,20 @@ var ErrUserNotFound = errors.New("user not found")
 // actually translated.
 var ErrSoDPolicyNotFound = errors.New("sod policy not found")
 
+// ErrRiskExceptionNotFound is returned (wrapped) by GetRiskException when no
+// exception exists for the given id, as distinct from a transient retrieval
+// failure. Same convention and same reason as ErrSoDPolicyNotFound above —
+// RevokeRiskException (internal/core/risk_exceptions.go) matches it with
+// errors.Is to decide whether a real 404 is safe (admin-tier caller only) vs
+// collapsing it into the same permission-denied response a non-admin caller
+// gets for an existing-but-foreign exception (#1645 403-for-both). Part 2
+// regression audit (adversarial review run 2): RevokeRiskException still had
+// this exact gap (existence lookup before the creator/admin check) after
+// PR #1695 fixed the identical shape for DeleteSoDPolicy but didn't sweep to
+// this sibling site, despite risk_exceptions.go's own doc comment already
+// naming the same #1529 precedent SoD's fix cites.
+var ErrRiskExceptionNotFound = errors.New("risk exception not found")
+
 // ErrRoleNotAssigned is returned (wrapped) by RemoveRole when the (user, role, scope)
 // row positively does not exist — e.g. it already auto-expired or was already
 // removed — as distinct from a genuine storage failure. Callers for whom "already

--- a/internal/core/versions.go
+++ b/internal/core/versions.go
@@ -27,7 +27,23 @@ const secretExpiryClockRegressionTolerance = 30 * time.Second
 // does not protect against. On success, advances the watermark to now (never
 // backward — the watermark itself must not regress, or a second, slower
 // backward step could walk it down unnoticed).
+//
+// Part 2 regression audit continuation (2026-09-04): .UTC() below is not
+// cosmetic — it strips any monotonic clock reading a real time.Now()-derived
+// now carries (see time.Time's package doc). Before this fix, comparing two
+// monotonic-carrying values (this call's now against the previously-stored
+// secretExpiryWatermark, both ultimately from c.now()==time.Now in
+// production) used ONLY their monotonic delta, which never regresses even
+// when the OS wall clock is stepped backward — so this guard could never
+// actually detect the exact regression it exists to catch. The guard's own
+// tests never caught this because their now values come from time.Date(...)
+// test doubles, which the stdlib guarantees never carry a monotonic
+// reading — the tests exercised wall-clock-only comparisons throughout,
+// silently different semantics from the real production path. Stripped
+// locally (not just relying on the caller) so this function is correct
+// regardless of what future callers pass in.
 func (c *KeyorixCore) checkSecretExpiryClockNotRegressed(now time.Time) error {
+	now = now.UTC()
 	c.secretExpiryWatermarkMu.Lock()
 	defer c.secretExpiryWatermarkMu.Unlock()
 	if !c.secretExpiryWatermark.IsZero() && now.Before(c.secretExpiryWatermark.Add(-secretExpiryClockRegressionTolerance)) {

--- a/internal/storage/factory_coverage_test.go
+++ b/internal/storage/factory_coverage_test.go
@@ -19,6 +19,7 @@
 package storage
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -401,18 +402,26 @@ func TestMigrateDatabase_Cov_SecretACLsPreExisting(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestOpenGormDB_Cov_SQLiteOpenError verifies that OpenGormDB returns a wrapped
-// error when the SQLite file path is in a directory that does not exist.
-// gorm.Open(sqlite.Open(...)) propagates the driver error in this case.
+// error when the SQLite file path is genuinely unreachable.
+//
+// #1647 sibling-gap fix (Part 2 regression audit continuation, 2026-09-04):
+// OpenGormDB now calls prepareLocalStorageFile before gorm.Open (matching
+// createLocalStorage's existing behavior), which os.MkdirAll's the parent
+// directory into existence — so a merely-missing parent directory (this
+// test's original scenario) is no longer unreachable, it's auto-created.
+// Use a path a directory genuinely cannot be created at instead: a parent
+// path component that already exists as a regular FILE, which MkdirAll
+// cannot create a directory through.
 func TestOpenGormDB_Cov_SQLiteOpenError(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Storage.Type = "local"
-	// Point to a path whose parent directory does not exist — SQLite cannot create
-	// the file and must return an error.
-	cfg.Storage.Database.Path = filepath.Join(t.TempDir(), "nonexistent", "subdir", "db.sqlite")
+	blockingFile := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blockingFile, []byte("x"), 0o600))
+	cfg.Storage.Database.Path = filepath.Join(blockingFile, "subdir", "db.sqlite")
 
 	_, err := OpenGormDB(cfg)
 	require.Error(t, err, "OpenGormDB must return an error when the SQLite path is unreachable")
-	assert.Contains(t, err.Error(), "failed to connect to database")
+	assert.Contains(t, err.Error(), "failed to create database directory")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/storage/gormdb.go
+++ b/internal/storage/gormdb.go
@@ -53,10 +53,23 @@ func OpenGormDB(cfg *config.Config) (*gorm.DB, error) {
 		if dbPath == "" {
 			dbPath = "./secrets.db"
 		}
+		// #1647 sibling gap (Part 2 regression audit continuation): this opens the
+		// SAME local secrets.db the factory's createLocalStorage path does, for the
+		// DEK-rotation/auth-encryption-stats CLI admin commands named in this
+		// function's own doc comment -- but until this fix, skipped BOTH
+		// permission-hardening steps #1647 added there (explicit-mode pre-creation
+		// and retroactive tightening of a pre-existing lax-mode file). A database
+		// file that predates #1647 was never corrected when opened through this
+		// path, leaving it world/group-readable exactly as #1647 closed for the
+		// primary storage path.
+		if err := prepareLocalStorageFile(dbPath); err != nil {
+			return nil, err
+		}
 		db, err := gorm.Open(sqlite.Open(sqliteDSN(dbPath)), gormConfig())
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to database: %w", err)
 		}
+		tightenExistingLocalStorageFiles(dbPath)
 		if err := applyPoolSettings(db, &cfg.Storage.Database); err != nil {
 			return nil, err
 		}

--- a/internal/storage/store/consume_clock_monotonic_strip_test.go
+++ b/internal/storage/store/consume_clock_monotonic_strip_test.go
@@ -1,0 +1,41 @@
+// consume_clock_monotonic_strip_test.go — Part 2 regression audit
+// continuation (2026-09-04): consumeClockLooksRegressed (entry.go, #1638)
+// compared its `now` argument directly against consumeClockWatermark, with
+// no monotonic-clock-reading strip. See internal/core's
+// clock_watermark_monotonic_strip_test.go for the full explanation of why
+// this defeats the regression check entirely in production (both operands
+// carry a monotonic reading from real time.Now() calls, so Before/After use
+// ONLY the monotonic delta -- which never regresses even when the OS wall
+// clock is stepped backward) and why the existing time.Date(...)-based
+// tests in this package could never have caught it (time.Date never
+// attaches a monotonic reading, so those tests always exercised a
+// wall-clock-only comparison regardless of what the production code did).
+package store
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func hasMonotonicReading(t time.Time) bool {
+	return strings.Contains(t.String(), " m=")
+}
+
+// TestConsumeClockLooksRegressed_StripsMonotonicReading proves the fix: a
+// real, monotonic-carrying time.Now() reading, once processed by
+// consumeClockLooksRegressed, is stored into consumeClockWatermark without
+// a monotonic reading -- so the NEXT call's regression check is a genuine
+// wall-clock comparison.
+func TestConsumeClockLooksRegressed_StripsMonotonicReading(t *testing.T) {
+	real := time.Now()
+	require.True(t, hasMonotonicReading(real), "sanity: the input this test feeds through consumeClockLooksRegressed must itself carry a monotonic reading")
+
+	ls := &LocalStorage{consumeClockWatermark: &clockWatermark{}}
+	regressed := ls.consumeClockLooksRegressed(real)
+	require.False(t, regressed, "a fresh watermark (zero value) must never itself report a regression")
+	assert.False(t, hasMonotonicReading(ls.consumeClockWatermark.time), "consumeClockWatermark's stored value must not carry a monotonic reading")
+}

--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -291,7 +291,19 @@ const consumeClockRegressionTolerance = 30 * time.Second
 // backward, for the same reason as internal/core's
 // checkSecretExpiryClockNotRegressed: a second, slower backward step must
 // not walk the watermark down unnoticed).
+//
+// Part 2 regression audit continuation (2026-09-04): .UTC() below strips any
+// monotonic clock reading now carries -- both real callers named above
+// (c.now()==time.Now, and a bare time.Now()) attach one. Two monotonic-
+// carrying values compare using ONLY their monotonic delta (see time.Time's
+// package doc), which never regresses even when the OS wall clock steps
+// backward, so this comparison could never actually detect the regression
+// it exists to catch without this. Same root cause as
+// checkSecretExpiryClockNotRegressed's identical fix (internal/core/versions.go,
+// #1635) and this function's own new authEffectiveNow sibling
+// (internal/core/auth.go) -- fixed in all three at once, same underlying bug.
 func (ls *LocalStorage) consumeClockLooksRegressed(now time.Time) bool {
+	now = now.UTC()
 	wm := ls.consumeClockWatermark
 	wm.mu.Lock()
 	defer wm.mu.Unlock()

--- a/internal/storage/store/local_named_lock.go
+++ b/internal/storage/store/local_named_lock.go
@@ -4,6 +4,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"hash/fnv"
 	"sync"
@@ -87,6 +88,32 @@ func heldNamedLockKeys(ctx context.Context) map[string]bool {
 	return held
 }
 
+// namedLockConnCtxKey carries the *sql.Conn an outer WithNamedLock call
+// checked out of the pool, so a nested call under a DIFFERENT key (Postgres
+// path only) reuses it instead of checking out a second connection.
+//
+// Part 2 regression audit (adversarial review run 2), found in FIX-5 itself:
+// PostgreSQL advisory locks are SESSION-scoped, not per-acquisition -- one
+// connection can hold pg_advisory_lock on any number of distinct keys at
+// once. Before this, every WithNamedLock call (nested or not) pulled its own
+// connection via sqlDB.Conn(ctx), so a call chain nesting N distinct keys
+// needed N simultaneous pooled connections. Under a constrained pool (e.g.
+// max_open_conns: 1 or 2, unenforced by internal/config), the outer call
+// holds the pool's only connection for the ENTIRE duration of fn -- which is
+// itself the blocked inner call waiting on sqlDB.Conn(ctx) for a connection
+// only the outer call could release. Verified: an indefinite deadlock (not
+// contention -- it never resolved on its own; only an artificial context
+// timeout ended it), reproduced against real Postgres with MaxOpenConns(1).
+// Reusing the outer call's connection for every nested key removes the
+// per-chain connection-count dependency entirely: a chain nesting any number
+// of distinct keys still needs only ONE pooled connection.
+type namedLockConnCtxKey struct{}
+
+func heldNamedLockConn(ctx context.Context) *sql.Conn {
+	conn, _ := ctx.Value(namedLockConnCtxKey{}).(*sql.Conn)
+	return conn
+}
+
 // WithNamedLock runs fn with every OTHER caller using the identical lockKey
 // serialized against it: a per-key process-level mutex (namedLockRegistry)
 // covers the common single-writer self-host topology and SQLite (inherently
@@ -129,6 +156,22 @@ func (ls *LocalStorage) WithNamedLock(ctx context.Context, lockKey string, fn fu
 		return fn(ctx)
 	}
 
+	key := namedLockKey(lockKey)
+
+	// Reuse an outer call's already-checked-out connection if this call chain
+	// has one (see namedLockConnCtxKey) -- a nested call under a different key
+	// must still acquire its OWN advisory lock, but never needs a SECOND
+	// pooled connection to do it.
+	if conn := heldNamedLockConn(ctx); conn != nil {
+		if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", key); err != nil {
+			return fmt.Errorf("failed to acquire named advisory lock %q: %w", lockKey, err)
+		}
+		defer func() {
+			_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", key)
+		}()
+		return fn(ctx)
+	}
+
 	sqlDB, err := ls.db.DB()
 	if err != nil {
 		return err
@@ -139,7 +182,6 @@ func (ls *LocalStorage) WithNamedLock(ctx context.Context, lockKey string, fn fu
 	}
 	defer func() { _ = conn.Close() }() // returns the conn to the pool (after the unlock below)
 
-	key := namedLockKey(lockKey)
 	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", key); err != nil {
 		return fmt.Errorf("failed to acquire named advisory lock %q: %w", lockKey, err)
 	}
@@ -148,5 +190,8 @@ func (ls *LocalStorage) WithNamedLock(ctx context.Context, lockKey string, fn fu
 		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", key)
 	}()
 
+	// Make this connection available to any nested WithNamedLock call under a
+	// different key, for the remainder of this call chain.
+	ctx = context.WithValue(ctx, namedLockConnCtxKey{}, conn)
 	return fn(ctx)
 }

--- a/internal/storage/store/local_named_lock_pool_exhaustion_test.go
+++ b/internal/storage/store/local_named_lock_pool_exhaustion_test.go
@@ -1,0 +1,52 @@
+// local_named_lock_pool_exhaustion_test.go — Part 2 regression audit finding
+// (adversarial review run 2): a nested WithNamedLock call under a DIFFERENT
+// key used to require a SECOND simultaneous pooled connection on the
+// Postgres path (one per lock key), because PostgreSQL advisory locks are
+// session-scoped and each WithNamedLock call pulled its own connection via
+// sqlDB.Conn(ctx). Under a constrained connection pool, the outer call holds
+// the pool's only connection for the entire duration of fn -- which is
+// itself the blocked inner call waiting for a connection only the outer call
+// could release. An indefinite deadlock, not contention, verified against
+// real Postgres with MaxOpenConns(1). Fixed by reusing the outer call's
+// connection for every nested key in the same call chain (see
+// namedLockConnCtxKey in local_named_lock.go) -- Postgres advisory locks let
+// one connection hold any number of distinct-key locks simultaneously, so a
+// call chain nesting N distinct keys still needs only ONE pooled connection.
+//
+// Gated behind KEYORIX_TEST_PG_DSN like every other real-Postgres test in
+// this package (see postgres_contention_helpers_test.go) -- a single SQLite
+// connection can't reproduce a connection-pool deadlock at all.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithNamedLock_NestedDifferentKey_DoesNotExhaustConnectionPool(t *testing.T) {
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+	db := pgOpen(t, dsn)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	ls := NewLocalStorage(db)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err = ls.WithNamedLock(ctx, "pool-exhaustion-outer", func(ctx context.Context) error {
+		return ls.WithNamedLock(ctx, "pool-exhaustion-inner", func(ctx context.Context) error {
+			return nil
+		})
+	})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "nested WithNamedLock under a different key must succeed, not deadlock waiting for a second pooled connection (took %s)", elapsed)
+	require.Less(t, elapsed, 2*time.Second, "must complete quickly, not hang until the context deadline")
+}

--- a/internal/storage/store/local_purge.go
+++ b/internal/storage/store/local_purge.go
@@ -430,21 +430,58 @@ func (ls *LocalStorage) DeleteClosedAccessReviewsBefore(ctx context.Context, bef
 // widen exists for is unaffected: an abandoned 'active' row is still
 // reconciled (freeing the partial-unique-index slot) on every sweep, just
 // hard-deleted one cycle later than before.
+// pluckExpiredActiveBreakGlassIDs reads the ids of still-'active' rows whose
+// ExpiresAt has passed before -- the reconcile step's read half. Split out
+// from reconcileBreakGlassIDsToExpired (rather than one combined
+// Pluck-then-Update) so a test can deterministically interleave a concurrent
+// write between the two steps without a real, inherently-flaky goroutine race
+// -- see local_retention_test.go's
+// TestDeleteExpiredBreakGlassBefore_ConcurrentRevokeBetweenPluckAndUpdate.
+func (ls *LocalStorage) pluckExpiredActiveBreakGlassIDs(ctx context.Context, before time.Time) ([]uint, error) {
+	var ids []uint
+	if err := ls.db.WithContext(ctx).Model(&models.BreakGlassActivation{}).
+		Where("state = ? AND expires_at IS NOT NULL AND expires_at < ?", breakGlassActiveState, before).
+		Pluck("id", &ids).Error; err != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return ids, nil
+}
+
+// reconcileBreakGlassIDsToExpired transitions ids from 'active' to 'expired'
+// -- the reconcile step's write half.
+//
+// Part 2 regression audit (adversarial review run 2): this UPDATE must
+// re-check state = 'active' at write time, not just act on an ID list a
+// caller Plucked a moment earlier -- otherwise a concurrent
+// RevokeBreakGlassActivation landing between the read and this write (legal:
+// the row was still 'active' right after the read) gets silently overwritten
+// back to 'expired' here, while revoked_by/revoked_at stay populated --
+// corrupting the audit-relevant distinction between "an admin actively
+// revoked this" and "it merely timed out" on a security-sensitive control.
+// Same live-predicate-at-write-time discipline this file's sibling functions
+// (DeleteClosedAccessReviewsBefore, DeleteResolvedAccessRequestsBefore, #G21)
+// already use for exactly this class of race.
+func (ls *LocalStorage) reconcileBreakGlassIDsToExpired(ctx context.Context, ids []uint) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if err := ls.db.WithContext(ctx).Model(&models.BreakGlassActivation{}).
+		Where("id IN ? AND state = ?", ids, breakGlassActiveState).
+		Update("state", breakGlassExpiredState).Error; err != nil {
+		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	}
+	return nil
+}
+
 func (ls *LocalStorage) DeleteExpiredBreakGlassBefore(ctx context.Context, before time.Time) (int64, error) {
 	// G81 (BreakGlassActivation.CreatedAt/ExpiresAt): normalize internally — see GetAuditLogs.
 	before = before.UTC()
-	var justReconciledIDs []uint
-	if err := ls.db.WithContext(ctx).Model(&models.BreakGlassActivation{}).
-		Where("state = ? AND expires_at IS NOT NULL AND expires_at < ?", breakGlassActiveState, before).
-		Pluck("id", &justReconciledIDs).Error; err != nil {
-		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+	justReconciledIDs, err := ls.pluckExpiredActiveBreakGlassIDs(ctx, before)
+	if err != nil {
+		return 0, err
 	}
-	if len(justReconciledIDs) > 0 {
-		if err := ls.db.WithContext(ctx).Model(&models.BreakGlassActivation{}).
-			Where("id IN ?", justReconciledIDs).
-			Update("state", breakGlassExpiredState).Error; err != nil {
-			return 0, fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-		}
+	if err := ls.reconcileBreakGlassIDsToExpired(ctx, justReconciledIDs); err != nil {
+		return 0, err
 	}
 	q := ls.db.WithContext(ctx).Where("state <> ? AND created_at < ?", breakGlassActiveState, before)
 	if len(justReconciledIDs) > 0 {

--- a/internal/storage/store/local_retention_test.go
+++ b/internal/storage/store/local_retention_test.go
@@ -269,6 +269,46 @@ func TestDeleteExpiredBreakGlassBefore_ReconciledRowStillRevocable(t *testing.T)
 	assert.Equal(t, "revoked", row.State)
 }
 
+// TestDeleteExpiredBreakGlassBefore_ConcurrentRevokeBetweenPluckAndUpdate is a
+// Part 2 regression audit finding (adversarial review run 2): the reconcile
+// step reads the set of rows to transition (Pluck), then updates them by that
+// captured ID list. If a concurrent RevokeBreakGlassActivation lands on one of
+// those rows AFTER the Pluck but BEFORE the Update -- legal, since the row was
+// still 'active' right after the Pluck -- the Update must not blindly
+// overwrite the now-'revoked' row back to 'expired'. Reproduced by running the
+// exact same two queries DeleteExpiredBreakGlassBefore issues, with a real
+// RevokeBreakGlassActivation call interleaved between them.
+func TestDeleteExpiredBreakGlassBefore_ConcurrentRevokeBetweenPluckAndUpdate(t *testing.T) {
+	ls := newRetentionTestStore(t)
+	ctx := context.Background()
+	old := time.Now().AddDate(0, 0, -120)
+	longExpired := old.Add(time.Hour)
+	cutoff := time.Now().AddDate(0, 0, -90)
+
+	require.NoError(t, ls.db.Create(&models.BreakGlassActivation{
+		ID: 7, State: "active", CreatedAt: old, ExpiresAt: &longExpired,
+	}).Error)
+
+	// Step 1 of DeleteExpiredBreakGlassBefore, the actual production function.
+	justReconciledIDs, err := ls.pluckExpiredActiveBreakGlassIDs(ctx, cutoff.UTC())
+	require.NoError(t, err)
+	require.Equal(t, []uint{7}, justReconciledIDs)
+
+	// Interleaved: a concurrent admin revoke lands on the row while it's still 'active'.
+	require.NoError(t, ls.RevokeBreakGlassActivation(ctx, 7, 1, 0, time.Now()))
+	var afterRevoke models.BreakGlassActivation
+	require.NoError(t, ls.db.First(&afterRevoke, 7).Error)
+	require.Equal(t, "revoked", afterRevoke.State)
+
+	// Step 2, the actual production function, using the now-stale Plucked ID list.
+	require.NoError(t, ls.reconcileBreakGlassIDsToExpired(ctx, justReconciledIDs))
+
+	var row models.BreakGlassActivation
+	require.NoError(t, ls.db.First(&row, 7).Error)
+	assert.Equal(t, "revoked", row.State, "the concurrent revoke must not be clobbered back to 'expired'")
+	assert.Equal(t, uint(1), row.RevokedBy, "revoked_by must stay consistent with state=revoked")
+}
+
 func TestDeleteResolvedAccessRequestsBefore_CascadesAndSkipsPending(t *testing.T) {
 	ls := newRetentionTestStore(t)
 	ctx := context.Background()

--- a/internal/storage/store/local_risk_exceptions.go
+++ b/internal/storage/store/local_risk_exceptions.go
@@ -9,6 +9,7 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -38,7 +39,7 @@ func (ls *LocalStorage) GetRiskException(ctx context.Context, id uint) (*models.
 	var e models.RiskException
 	err := ls.db.WithContext(ctx).First(&e, id).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), storage.ErrRiskExceptionNotFound)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/scripts/check-adr-numbers.sh
+++ b/scripts/check-adr-numbers.sh
@@ -8,13 +8,14 @@ set -euo pipefail
 
 dupes=$(find docs -maxdepth 1 -type f -name 'adr-[0-9]*.md' -print \
     | sed -E 's#.*/adr-([0-9]+)-.*#\1#' \
+    | awk '{printf "%d\n", $1}' \
     | sort -n \
     | uniq -d)
 
 if [ -n "$dupes" ]; then
     echo "FAIL: duplicate ADR number(s) found:"
     for n in $dupes; do
-        find docs -maxdepth 1 -type f -name "adr-${n}-*.md"
+        find docs -maxdepth 1 -type f -regex ".*/adr-0*${n}-.*"
     done
     exit 1
 fi

--- a/server/grpc/interceptors/auth.go
+++ b/server/grpc/interceptors/auth.go
@@ -203,12 +203,21 @@ func (w *wrappedServerStream) Context() context.Context {
 //
 // Without this, switching transport to gRPC silently dropped both tags — machine
 // actions were logged as user actions and impersonated actions lost the admin.
+//
+// Also tags WHICH machine (core.WithMachineActor), not just that a machine
+// acted — the HTTP path has always done this (buildRequestContext), but gRPC
+// never called it, so writeAuditEvent* recorded gRPC machine mutations
+// without a MachineIdentityID. Audit-trail attribution only: this tag is
+// deliberately NOT consulted for any authorization decision (see authz.go's
+// requireGranterHoldsRolePermissions doc for why resolving a ctx-tagged
+// machine's own permissions there is unsafe for /system proxy relays).
 func withAuditAttribution(ctx context.Context, userCtx *UserContext) context.Context {
 	if userCtx == nil {
 		return ctx
 	}
 	if userCtx.ActorType == core.ActorTypeMachine {
 		ctx = core.WithActorType(ctx, core.ActorTypeMachine)
+		ctx = core.WithMachineActor(ctx, userCtx.MachineIdentityID)
 	}
 	if userCtx.ImpersonatedBy != nil {
 		ctx = core.WithImpersonation(ctx, *userCtx.ImpersonatedBy)

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -177,24 +177,9 @@ func (s *RoleGRPCService) DeleteRole(ctx context.Context, req *pb.DeleteRoleRequ
 	if req.GetId() == 0 {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
 	}
-	// Resolve the name for the audit log before the row is gone (mirrors HTTP).
-	role, _, err := s.core.GetRoleWithPermissions(ctx, uint(req.GetId()))
-	if err != nil {
+	if err := s.core.DeleteRole(ctx, actor.UserID, uint(req.GetId())); err != nil {
 		return nil, mapRoleError(err)
 	}
-	// A built-in role must not be deletable over gRPC either — the HTTP handler
-	// refuses it (handlers/rbac.go), and deleting e.g. super_admin/admin would
-	// invalidate live assignments and can lock every administrator out. Without
-	// this the guard is bypassable by switching transport.
-	if core.IsBuiltinRole(role.Name) {
-		s.core.LogRoleDeleteDenied(ctx, actor.UserID, role.ID, role.Name, "target is a built-in role")
-		return nil, status.Errorf(codes.FailedPrecondition, "cannot delete built-in role: %s", role.Name)
-	}
-	if err := s.core.Storage().DeleteRole(ctx, uint(req.GetId())); err != nil {
-		return nil, mapRoleError(err)
-	}
-	// Audit the deletion — Storage().DeleteRole does not audit internally.
-	s.core.LogRoleDeleted(ctx, actor.UserID, role.ID, role.Name)
 	return &emptypb.Empty{}, nil
 }
 

--- a/server/grpc/services/role_service.go
+++ b/server/grpc/services/role_service.go
@@ -252,6 +252,13 @@ func (s *RoleGRPCService) AssignRole(ctx context.Context, req *pb.AssignRoleRequ
 	if err := authorizeScoped(ctx, s.core, actor, "roles.assign", scope); err != nil {
 		return nil, err
 	}
+	if actor.ActorKind() == core.ActorTypeMachine {
+		// A genuine, directly-authenticated machine actor requesting this
+		// grant as itself (not a /system proxy relay) -- tag ctx so
+		// requireGranterHoldsRolePermissions checks ITS real permissions
+		// instead of unconditionally refusing. See that function's doc.
+		ctx = core.WithSelfMachineGranter(ctx, actor.PrincipalID())
+	}
 	if err := s.core.AssignUserRole(ctx, actor.UserID, uint(req.GetUserId()), uint(req.GetRoleId()), scope, actor.ActorKind() == core.ActorTypeMachine); err != nil {
 		return nil, mapRoleError(err)
 	}

--- a/server/grpc/services/user_service.go
+++ b/server/grpc/services/user_service.go
@@ -113,7 +113,15 @@ func (s *UserGRPCService) CreateUser(ctx context.Context, req *pb.CreateUserRequ
 		if req.GetPassword() == "" {
 			return nil, status.Error(codes.InvalidArgument, "password is required unless deliver_setup_link or generate_one_time_password is set")
 		}
-		u, err = s.core.CreateUserWithAssignments(ctx, coreReq, role, assignments, actor.UserID, actor.ActorKind() == core.ActorTypeMachine)
+		grantCtx := ctx
+		if actor.ActorKind() == core.ActorTypeMachine {
+			// A genuine, directly-authenticated machine actor requesting this
+			// grant as itself (not a /system proxy relay) -- tag ctx so
+			// requireGranterHoldsRolePermissions checks ITS real permissions
+			// instead of unconditionally refusing. See that function's doc.
+			grantCtx = core.WithSelfMachineGranter(ctx, actor.PrincipalID())
+		}
+		u, err = s.core.CreateUserWithAssignments(grantCtx, coreReq, role, assignments, actor.UserID, actor.ActorKind() == core.ActorTypeMachine)
 	}
 	if err != nil {
 		return nil, mapUserError(err)

--- a/server/http/handlers/handlers_s13_proxy_test.go
+++ b/server/http/handlers/handlers_s13_proxy_test.go
@@ -520,6 +520,48 @@ func TestCreateUserWithRoleGrantsProxy_HappyPath_S13(t *testing.T) {
 	assert.True(t, resp.Success)
 }
 
+// TestCreateUserWithRoleGrantsProxy_RejectsInvalidAccountState_S13 — this
+// endpoint bypasses buildUserForCreate/core.CreateUser entirely (#1642) and
+// takes account_state straight from the wire, unlike either CreateUser HTTP
+// or gRPC route (which never expose the field to the client at all, per
+// core.IsValidAccountState's doc comment) -- so it must validate the value
+// itself instead of persisting arbitrary caller-supplied garbage.
+func TestCreateUserWithRoleGrantsProxy_RejectsInvalidAccountState_S13(t *testing.T) {
+	h := freshUserHandlerForProxyS13(t)
+	body := proxyJSON(map[string]interface{}{
+		"username":      "badstate_user_s13",
+		"email":         "badstate_s13@example.com",
+		"password_hash": "$2a$10$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0",
+		"account_state": "not_a_real_state",
+		"grants":        []interface{}{},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/system/users/with-role-grants", body)
+	w := httptest.NewRecorder()
+	h.CreateUserWithRoleGrantsProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+}
+
+// TestCreateUserWithRoleGrantsProxy_EmptyAccountStateNormalizesToActive_S13 —
+// an omitted account_state (the legacy shorthand) must still be accepted and
+// normalized to active, not rejected as invalid.
+func TestCreateUserWithRoleGrantsProxy_EmptyAccountStateNormalizesToActive_S13(t *testing.T) {
+	h := freshUserHandlerForProxyS13(t)
+	body := proxyJSON(map[string]interface{}{
+		"username":      "emptystate_user_s13",
+		"email":         "emptystate_s13@example.com",
+		"password_hash": "$2a$10$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0",
+		"grants":        []interface{}{},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/system/users/with-role-grants", body)
+	w := httptest.NewRecorder()
+	h.CreateUserWithRoleGrantsProxy(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.True(t, resp.Success)
+}
+
 // ── retention_proxy.go: decodeRetentionBeforeBody ───────────────────────────
 
 // TestDeleteExpiredRoleGrantsProxy_BadBody_S13 — bad JSON → 400.

--- a/server/http/handlers/machine_identities.go
+++ b/server/http/handlers/machine_identities.go
@@ -475,7 +475,15 @@ func (h *CatalogHandler) changeMachineRole(w http.ResponseWriter, r *http.Reques
 
 	scope := core.Scope{ProjectID: uint(projectID)}
 	if grant {
-		err = h.coreService.AssignMachineRole(r.Context(), uint(machineID), roleID, scope, actor.UserID, actor.ActorKind() == core.ActorTypeMachine)
+		ctx := r.Context()
+		if actor.ActorKind() == core.ActorTypeMachine {
+			// A genuine, directly-authenticated machine actor requesting this
+			// grant as itself (not a /system proxy relay) -- tag ctx so
+			// requireGranterHoldsRolePermissions checks ITS real permissions
+			// instead of unconditionally refusing. See that function's doc.
+			ctx = core.WithSelfMachineGranter(ctx, actor.PrincipalID())
+		}
+		err = h.coreService.AssignMachineRole(ctx, uint(machineID), roleID, scope, actor.UserID, actor.ActorKind() == core.ActorTypeMachine)
 	} else {
 		err = h.coreService.RemoveMachineRole(r.Context(), uint(machineID), roleID, scope, actor.UserID)
 	}

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -840,10 +840,22 @@ func (h *CatalogHandler) RevokeMachineIdentityCredentialProxy(w http.ResponseWri
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
 	}
-	if machine.ProjectID != body.ProjectID {
-		writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errMachineCredentialNotFound)
-		return
-	}
+	// Part 2 regression audit (adversarial review run 2), found in this exact
+	// FIX-3 fix: authorize BEFORE revealing whether the caller's claimed
+	// project_id actually matches the credential's real, server-resolved
+	// project -- checking the project-match first (as the original version of
+	// this fix did) let a caller holding only this route's own gate
+	// (system.write, no roles.assign anywhere) distinguish "wrong project
+	// guess" (404) from "right project, no roles.assign there" (403), a
+	// binary-searchable oracle for which project owns a given credential ID.
+	// Authorization is still checked against machine.ProjectID (the real,
+	// server-resolved project) -- never body.ProjectID -- that's #1551's own
+	// fix and is unchanged; only the ORDER relative to the project-match
+	// check moved. An unauthorized caller now gets the identical 403
+	// regardless of what project_id they guessed, since the project-match
+	// check is only reached AFTER authorization succeeds -- at which point
+	// the caller already has standing at the credential's real project, so
+	// revealing a project_id mismatch to them is no longer a probe.
 	userCtx := middleware.GetUserFromContext(r.Context())
 	if userCtx == nil {
 		writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN",
@@ -853,6 +865,10 @@ func (h *CatalogHandler) RevokeMachineIdentityCredentialProxy(w http.ResponseWri
 	if ok, aerr := h.coreService.AuthorizePrincipal(r.Context(), userCtx.ActorKind(), userCtx.PrincipalID(), "roles.assign", core.Scope{ProjectID: machine.ProjectID}); aerr != nil || !ok {
 		writeRemoteAPIError(w, http.StatusForbidden, "FORBIDDEN",
 			"revoking a machine credential requires the roles.assign permission at the credential's project")
+		return
+	}
+	if machine.ProjectID != body.ProjectID {
+		writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errMachineCredentialNotFound)
 		return
 	}
 	if err := h.coreService.Storage().RevokeMachineIdentityCredential(r.Context(), machine.ProjectID, uint(id)); err != nil {

--- a/server/http/handlers/misc_remote_proxy.go
+++ b/server/http/handlers/misc_remote_proxy.go
@@ -55,6 +55,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/identity"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -346,6 +347,16 @@ func (h *UserHandler) CreateUserWithRoleGrantsProxy(w http.ResponseWriter, r *ht
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid email: "+ferr.Error())
 		return
 	}
+	// core.IsValidAccountState's own doc comment claims no caller-controlled write
+	// path reaches account_state unvalidated (#334/#135: HTTP/gRPC CreateUser never
+	// take it from the client at all) -- but this endpoint bypasses buildUserForCreate
+	// entirely (see #1642 above) and DOES take it straight from the wire, so that
+	// invariant silently didn't hold here. Validate against the ADR-025 canonical set
+	// before persisting, same as every other field this handler re-checks.
+	if !core.IsValidAccountState(body.AccountState) {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "account_state is not a recognized value")
+		return
+	}
 	user := &models.User{
 		Username:          body.Username,
 		UsernameFolded:    foldedUsername.Folded(),
@@ -354,7 +365,7 @@ func (h *UserHandler) CreateUserWithRoleGrantsProxy(w http.ResponseWriter, r *ht
 		DisplayName:       body.DisplayName,
 		PasswordHash:      body.PasswordHash,
 		IsActive:          body.IsActive,
-		AccountState:      body.AccountState,
+		AccountState:      core.NormalizeAccountState(body.AccountState),
 		PasswordChangedAt: body.PasswordChangedAt,
 	}
 	created, err := h.coreService.Storage().CreateUserWithRoleGrants(r.Context(), user, grants)

--- a/server/http/handlers/project_memberships.go
+++ b/server/http/handlers/project_memberships.go
@@ -149,7 +149,15 @@ func (h *CatalogHandler) TransitionMembership(w http.ResponseWriter, r *http.Req
 		sendError(w, "ValidationError", "action must be verify, provision, activate, or revoke", http.StatusBadRequest, nil)
 		return
 	}
-	m, err := h.coreService.TransitionMembership(r.Context(), uint(projectID), uint(membershipID), to, actor.UserID, actor.ActorKind() == core.ActorTypeMachine)
+	ctx := r.Context()
+	if actor.ActorKind() == core.ActorTypeMachine {
+		// A genuine, directly-authenticated machine actor requesting this
+		// transition as itself (not a /system proxy relay) -- tag ctx so
+		// requireGranterHoldsRolePermissions checks ITS real permissions
+		// instead of unconditionally refusing. See that function's doc.
+		ctx = core.WithSelfMachineGranter(ctx, actor.PrincipalID())
+	}
+	m, err := h.coreService.TransitionMembership(ctx, uint(projectID), uint(membershipID), to, actor.UserID, actor.ActorKind() == core.ActorTypeMachine)
 	if err != nil {
 		status := http.StatusInternalServerError
 		msg := err.Error()

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -481,15 +481,23 @@ func (h *RBACHandler) AssignRole(w http.ResponseWriter, r *http.Request) {
 	// Through the audited core choke point (records role.assigned with the actor),
 	// not storage directly — keeps this endpoint in the RBAC audit trail. A set
 	// expiry routes through the time-bound (JIT) path.
+	ctx := r.Context()
+	if userCtx.ActorKind() == core.ActorTypeMachine {
+		// A genuine, directly-authenticated machine actor requesting this
+		// grant as itself (not a /system proxy relay) -- tag ctx so
+		// requireGranterHoldsRolePermissions checks ITS real permissions
+		// instead of unconditionally refusing. See that function's doc.
+		ctx = core.WithSelfMachineGranter(ctx, userCtx.PrincipalID())
+	}
 	var err error
 	if req.ExpiresAt != nil {
 		// #1542: a machine identity (UserID==0 by construction, see
 		// server/middleware/auth.go's UserContext doc) reaching this endpoint via
 		// RequireScopedPermission must not be treated as the trusted
 		// actorID==0 local-CLI exemption inside requireGranterHoldsRolePermissions.
-		err = h.coreService.AssignUserRoleWithExpiry(r.Context(), userCtx.UserID, req.UserID, req.RoleID, scope, *req.ExpiresAt, userCtx.ActorKind() == core.ActorTypeMachine)
+		err = h.coreService.AssignUserRoleWithExpiry(ctx, userCtx.UserID, req.UserID, req.RoleID, scope, *req.ExpiresAt, userCtx.ActorKind() == core.ActorTypeMachine)
 	} else {
-		err = h.coreService.AssignUserRole(r.Context(), userCtx.UserID, req.UserID, req.RoleID, scope, userCtx.ActorKind() == core.ActorTypeMachine)
+		err = h.coreService.AssignUserRole(ctx, userCtx.UserID, req.UserID, req.RoleID, scope, userCtx.ActorKind() == core.ActorTypeMachine)
 	}
 	if err != nil {
 		log.Printf("Error assigning role: %v", err)
@@ -783,11 +791,19 @@ func (h *RBACHandler) AssignRoleToGroup(w http.ResponseWriter, r *http.Request) 
 
 	scope := core.Scope{ProjectID: body.ProjectID, EnvironmentID: body.EnvironmentID}
 	// A set expiry routes through the time-bound (JIT) path.
+	ctx := r.Context()
+	if userCtx.ActorKind() == core.ActorTypeMachine {
+		// A genuine, directly-authenticated machine actor requesting this
+		// grant as itself (not a /system proxy relay) -- tag ctx so
+		// requireGranterHoldsRolePermissions checks ITS real permissions
+		// instead of unconditionally refusing. See that function's doc.
+		ctx = core.WithSelfMachineGranter(ctx, userCtx.PrincipalID())
+	}
 	var err error
 	if body.ExpiresAt != nil {
-		err = h.coreService.AssignGroupRoleWithExpiry(r.Context(), userCtx.UserID, groupID, body.RoleID, scope, *body.ExpiresAt, userCtx.ActorKind() == core.ActorTypeMachine)
+		err = h.coreService.AssignGroupRoleWithExpiry(ctx, userCtx.UserID, groupID, body.RoleID, scope, *body.ExpiresAt, userCtx.ActorKind() == core.ActorTypeMachine)
 	} else {
-		err = h.coreService.AssignRoleToGroup(r.Context(), userCtx.UserID, groupID, body.RoleID, scope, userCtx.ActorKind() == core.ActorTypeMachine)
+		err = h.coreService.AssignRoleToGroup(ctx, userCtx.UserID, groupID, body.RoleID, scope, userCtx.ActorKind() == core.ActorTypeMachine)
 	}
 	if err != nil {
 		log.Printf("Error assigning role to group: %v", err)

--- a/server/http/handlers/rbac.go
+++ b/server/http/handlers/rbac.go
@@ -415,32 +415,20 @@ func (h *RBACHandler) DeleteRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	role, err := h.coreService.Storage().GetRole(r.Context(), id)
-	if err != nil {
-		if strings.Contains(err.Error(), errNotFound) {
+	if err := h.coreService.DeleteRole(r.Context(), userCtx.UserID, id); err != nil {
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, errNotFound):
 			sendError(w, "NotFound", errRoleNotFound, http.StatusNotFound, nil)
-		} else {
-			sendError(w, "InternalError", errFailedGetRole, http.StatusInternalServerError, nil)
-		}
-		return
-	}
-	if core.IsBuiltinRole(role.Name) {
-		h.coreService.LogRoleDeleteDenied(r.Context(), userCtx.UserID, role.ID, role.Name, "target is a built-in role")
-		sendError(w, "Forbidden", "Cannot delete built-in role: "+role.Name, http.StatusForbidden, nil)
-		return
-	}
-
-	if err := h.coreService.Storage().DeleteRole(r.Context(), id); err != nil {
-		log.Printf("Error deleting role: %v", err)
-		if strings.Contains(err.Error(), errNotFound) {
-			sendError(w, "NotFound", errRoleNotFound, http.StatusNotFound, nil)
-		} else {
+		case strings.Contains(msg, "built-in role"):
+			sendError(w, "Forbidden", msg, http.StatusForbidden, nil)
+		default:
+			log.Printf("Error deleting role: %v", err)
 			sendError(w, "InternalError", "Failed to delete role", http.StatusInternalServerError, nil)
 		}
 		return
 	}
 
-	h.coreService.LogRoleDeleted(r.Context(), userCtx.UserID, role.ID, role.Name)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/server/http/handlers/risk_exceptions.go
+++ b/server/http/handlers/risk_exceptions.go
@@ -6,6 +6,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
 
@@ -126,8 +128,10 @@ func (h *DashboardHandler) RevokeRiskException(w http.ResponseWriter, r *http.Re
 			status = http.StatusBadRequest
 		case strings.Contains(msg, "concurrently"):
 			status = http.StatusConflict
-		case strings.Contains(msg, "not found"):
+		case errors.Is(err, core.ErrRiskExceptionNotFoundPublic):
 			status = http.StatusNotFound
+		case errors.Is(err, core.ErrRiskExceptionPermissionDenied):
+			status = http.StatusForbidden
 		default:
 			log.Printf("Error revoking risk exception %d: %v", id, err)
 			msg = clientSafe(err)

--- a/server/http/handlers/users_crud.go
+++ b/server/http/handlers/users_crud.go
@@ -169,7 +169,15 @@ func (h *UserHandler) createUserClassic(w http.ResponseWriter, r *http.Request, 
 		for _, a := range projAssignments {
 			assignments = append(assignments, core.ProjectAssignment{ProjectID: a.ProjectID, Role: a.Role})
 		}
-		created, err = h.coreService.CreateUserWithAssignments(r.Context(), req, role, assignments, userCtx.UserID, userCtx.ActorKind() == core.ActorTypeMachine)
+		ctx := r.Context()
+		if userCtx.ActorKind() == core.ActorTypeMachine {
+			// A genuine, directly-authenticated machine actor requesting this
+			// grant as itself (not a /system proxy relay) -- tag ctx so
+			// requireGranterHoldsRolePermissions checks ITS real permissions
+			// instead of unconditionally refusing. See that function's doc.
+			ctx = core.WithSelfMachineGranter(ctx, userCtx.PrincipalID())
+		}
+		created, err = h.coreService.CreateUserWithAssignments(ctx, req, role, assignments, userCtx.UserID, userCtx.ActorKind() == core.ActorTypeMachine)
 	} else {
 		created, err = h.coreService.CreateUser(r.Context(), req)
 	}

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -1118,14 +1118,14 @@ var rawStorageBypassAllowlist = map[string]string{
 	// wrapper for role deletion at all -- there is no separate operation for
 	// this raw call to bypass. The handler carries its own built-in-role
 	// protection inline (core.IsBuiltinRole check, rbac.go:426) before ever
-	// reaching the raw call. (CreateRole/UpdateRole used to be listed here
-	// too, with the identical "no core wrapper" reasoning -- #1660 gave both
-	// a real internal/core.CreateRole/UpdateRole wrapper, so their raw
-	// storage calls are gone, not merely justified; removed from this list
-	// rather than re-justified.)
-	"DeleteRole": "no-independent-ceiling: internal/core has no exported wrapper for role deletion at all -- " +
-		"this route (DELETE /api/v1/roles/{id}, RequirePermission(permRolesWrite)) IS the authoritative " +
-		"implementation, with its own built-in-role guard (rbac.go:426) already inline.",
+	// reaching the raw call. (CreateRole/UpdateRole/DeleteRole used to be
+	// listed here too, all with the identical "no core wrapper" reasoning --
+	// #1660 gave all three a real internal/core.CreateRole/UpdateRole/
+	// DeleteRole wrapper, so their raw storage calls are gone, not merely
+	// justified; removed from this list rather than re-justified. DeleteRole
+	// was the last of the three: both server/http/handlers/rbac.go and
+	// server/grpc/services/role_service.go now call core.DeleteRole instead
+	// of storage.Storage.DeleteRole directly.)
 	// #1551, corrected 2026-09-03 (adversarial review run 2, FIX-3): moved from
 	// knownUnfixedRawStorageBypasses -- the 2026-08-29 "PARTIALLY FIXED" entry
 	// there believed the project_id-on-the-wire, enforced-in-the-WHERE-clause

--- a/server/http/remote_storage_machine_identities_test.go
+++ b/server/http/remote_storage_machine_identities_test.go
@@ -2,7 +2,10 @@ package http
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -441,6 +444,73 @@ func TestRemoteStorageMachineIdentities_RevokeCredential_UnauthorizedCallerRejec
 	revoked, err := admin.Storage().GetMachineIdentityCredentialByID(ctx, cred.ID)
 	require.NoError(t, err)
 	assert.True(t, revoked.Revoked, "an authorized caller must still be able to revoke")
+}
+
+// TestRemoteStorageMachineIdentities_RevokeCredential_ProjectGuessOracleClosed
+// is a Part 2 regression audit finding (adversarial review run 2), found in
+// this exact FIX-3 fix (#1551): the project-match check
+// (machine.ProjectID != body.ProjectID) ran BEFORE the roles.assign
+// authorization check, so a caller holding only system.write (no
+// roles.assign anywhere) could distinguish "wrong project_id guess" (404)
+// from "right project_id guess, no permission there" (403) -- a
+// binary-searchable oracle for which project owns a given credential ID.
+// This drives raw HTTP requests directly (not through the RemoteStorage
+// wrapper, which only surfaces error/no-error) to compare the literal status
+// codes for both cases.
+func TestRemoteStorageMachineIdentities_RevokeCredential_ProjectGuessOracleClosed(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	t.Cleanup(i18n.ResetForTesting)
+
+	upstream := newTestCore(t)
+	cfg := &config.Config{Server: config.ServerConfig{HTTP: config.ServerInstanceConfig{Enabled: true, Port: "0"}}}
+	router, err := NewRouter(cfg, upstream)
+	require.NoError(t, err)
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+
+	ctx := context.Background()
+	realProject, err := upstream.CreateProject(ctx, "Oracle Test Real Project", "")
+	require.NoError(t, err)
+	wrongProject, err := upstream.CreateProject(ctx, "Oracle Test Wrong Project", "")
+	require.NoError(t, err)
+
+	adminToken := createNodeToken(t, upstream) // holds admin -- used only to set up fixtures
+	adminRS, err := store.NewRemoteStorage(&remote.Config{BaseURL: srv.URL, APIKey: adminToken, TimeoutSeconds: 5, TLSVerify: true})
+	require.NoError(t, err)
+	admin := core.NewKeyorixCore(adminRS)
+
+	now := time.Now()
+	m, err := admin.Storage().CreateMachineIdentity(ctx, buildMachineIdentity(now, realProject.ID, "oracle-probe-test"))
+	require.NoError(t, err)
+	const hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"
+	cred, err := admin.Storage().CreateMachineIdentityCredential(ctx, buildMachineIdentityCredential(now, m.ID, hash))
+	require.NoError(t, err)
+
+	weakToken := createSystemWriteOnlyToken(t, upstream) // system.write, no roles.assign anywhere
+
+	postRevoke := func(projectID uint) int {
+		t.Helper()
+		body := fmt.Sprintf(`{"project_id":%d}`, projectID)
+		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/system/machine-credentials/%d/revoke", srv.URL, cred.ID), strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+weakToken)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	wrongStatus := postRevoke(wrongProject.ID)
+	rightStatus := postRevoke(realProject.ID)
+
+	assert.Equal(t, wrongStatus, rightStatus,
+		"a caller with no roles.assign grant must get the SAME status for a wrong project_id guess (%d) as for the credential's real project_id (%d) -- otherwise the status code itself is an oracle for which project owns this credential", wrongStatus, rightStatus)
+	assert.Equal(t, http.StatusForbidden, rightStatus, "the unauthorized caller must be refused, not accidentally succeed")
+
+	stillLive, err := admin.Storage().GetMachineIdentityCredentialByID(ctx, cred.ID)
+	require.NoError(t, err)
+	assert.False(t, stillLive.Revoked, "neither probe must have actually revoked the credential")
 }
 
 // TestRemoteStorageMachineIdentities_RoleGrantAssignRemoveListIDs_RealServer

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -2017,7 +2017,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// machine callers. Layered on top of, not replacing, the group's
 			// system.write gate.
 			r.With(customMiddleware.RequireScopedPermission(permSecretsDelete, projectScope)).Delete(pathProjectsID, catalogHandler.DeleteProjectProxy)
-			r.Post("/projects/{id}/delete-if-empty", catalogHandler.DeleteProjectIfEmptyProxy)
+			// #1657 sibling gap (Part 2 regression audit continuation): this route
+			// deletes the exact same project as DeleteProjectProxy immediately
+			// above (force=false vs force=true, per project_catalog_proxy.go's
+			// package doc) but was left gated only by the group's flat
+			// system.write check -- the identical root-cause gap #1657 fixed one
+			// route above it. Same wrapper, same scope.
+			r.With(customMiddleware.RequireScopedPermission(permSecretsDelete, projectScope)).Post("/projects/{id}/delete-if-empty", catalogHandler.DeleteProjectIfEmptyProxy)
 			r.Get(pathProjectMembers, catalogHandler.ListProjectMembersProxy)
 			r.Get(pathProjectEnvs, catalogHandler.ListEnvironmentsByProjectProxy)
 			r.Get("/environments", catalogHandler.ListEnvironmentsProxy)


### PR DESCRIPTION
## Summary

Two batches of fixes from the adversarial-review continuation:

**Part 2 regression audit** (6 regressions this session's own earlier remediation PRs introduced, each with a dedicated red/green-verified test):

- **`internal/storage/store/local_named_lock.go`** — `WithNamedLock` connection-pool deadlock under a constrained pool, fixed via connection reuse for nested different-key locks.
- **`internal/storage/store/local_purge.go`** — `DeleteExpiredBreakGlassBefore` clobbering a concurrent revoke's audit attribution, fixed via live-predicate-at-write-time.
- **`server/http/handlers/machine_identities_proxy.go`** — `RevokeMachineIdentityCredentialProxy` project-ID guessing oracle, fixed by reordering authz before the existence check.
- **`internal/core/risk_exceptions.go`** et al — `RevokeRiskException` 403-for-both gap (sibling of `DeleteSoDPolicy`'s #1695 fix, never swept here).
- **`internal/core/project_members.go`/`rbac_management.go`** — `SetProjectMemberRole` false-refused swapping a sole admin between two admin-tier roles.
- **`internal/core/authz.go`** + 8 direct HTTP/gRPC entry points — `requireGranterHoldsRolePermissions` false-refused every machine-authenticated grant. Fixed in two passes: a first attempt (resolving permissions from the general-purpose `WithMachineActor` tag) was reverted after it let a `/system` proxy relay's node credential self-authorize using its own unrelated admin-tier grant; the landed fix uses a narrowly-scoped `WithSelfMachineGranter` tag set only by direct, non-proxy handlers, verified against the exact 4 tests that caught the first attempt's escalation plus the full `server/http` (641s) + `server/grpc` suites.

**#1660 sibling sweep** (found while re-scoping a Part 1 closure-disproof target): `#1665`'s consolidation of `CreateRole`/`UpdateRole` into `internal/core` missed `DeleteRole`, which both HTTP and gRPC still called directly against storage. Not a live gap (both transports had deliberately kept their built-in-role guard and audit call in sync), but the same architectural drift risk `#1665` closed for the other two operations — consolidated the same way, all 5 pre-existing tests pass unmodified, 3 new core-level tests added.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `gofmt -l` clean on all touched files
- [x] `gosec -severity medium -exclude-generated ./internal/... ./server/...` — 0 issues
- [x] `go test ./internal/core/...`, `./internal/storage/store/...` — green
- [x] `go test ./server/http/... ./server/grpc/...` — green (full suite, including the 4 tests that caught the reverted first attempt at the machine-actor grant-ceiling fix)
- [x] Every fix carries a dedicated regression test, red/green-verified before landing

**Part 2 regression audit, batch 3** (18 more merged PRs audited; 6 fixed, 2 already superseded by other work this session):

- **`scripts/check-adr-numbers.sh`** — dedup sorted numerically but compared literal strings, missing zero-padding collisions (`adr-089` vs `adr-89`); normalizes before dedup.
- **`server/http/router.go`** — `DeleteProjectIfEmptyProxy` missing the same per-project `RequireScopedPermission` wrapper its two siblings (`DeleteProjectProxy`, `DeleteEnvironmentProxy`) already got from `#1657` one line above.
- **`internal/storage/gormdb.go`** — `OpenGormDB` (DEK-rotation/auth-encryption-stats CLI) opens the same local `secrets.db` as `factory.go`'s `createLocalStorage`, but skipped both `#1647` permission-hardening steps.
- **`internal/core`** (`auth.go`, `pat.go`, `machine_token.go`, `mfa_stepup.go`, `service.go`) — the primary credential-validity checks run on **every authenticated request** (session, PAT, machine token, MFA step-up) had **no clock-regression protection at all**, despite the wall-clock hardening wave covering RBAC/Connect/share/session-refresh/access-request-approval. New `authTokenClockWatermark` closes it.
- **Systemic, found while implementing the above — headline result of this batch:** every existing clock-regression watermark shipped by prior PRs (plus the OIDC verifier's own independent implementation) compared timestamps **without stripping Go's monotonic clock reading**. When both operands of a `time.Time` comparison carry a monotonic reading (as every real `time.Now()` value does), Go uses *only* the monotonic delta — immune to the OS wall clock being stepped backward — so **none of these mechanisms could ever have caught the exact regression they exist to detect**, in production, the whole time they were live. `time.Date(...)`-based tests never caught it because `time.Date` never attaches a monotonic reading. Fixed via `.UTC()` at every comparison site; new tests use real `time.Now()` values and verify the documented `" m="` monotonic marker directly.

**Part 3 usage-based guard pass, first finding** — `CreateUserWithRoleGrantsProxy` (`server/http/handlers/misc_remote_proxy.go`) takes `account_state` straight from the wire JSON body with zero validation, silently reintroducing a caller-controlled write path an earlier fix (`#135`) deliberately removed from every other `CreateUser` transport. Fixed by validating against the ADR-025 canonical state set before persisting.

## Test plan (batch 3 + AccountState addition)

- [x] `go build ./...`, `go vet ./...` clean
- [x] `gofmt -l` clean on all touched files
- [x] `gosec -severity medium -exclude-generated ./server/http/handlers/...` — 0 issues
- [x] `go test ./internal/core/... ./internal/storage/... ./server/grpc/...` — green
- [x] `go test ./server/http/...` — green (confirmed with `-p 1`; two unrelated pre-existing tests independently flake under full package parallelism — `TestNoUnjustifiedRawStorageBypass` and `TestNCCreate_EnabledExplicit`, neither touching this PR's changes, each passes reliably alone and the full suite passes 100% clean serialized)
- [x] Every fix carries a dedicated regression test, red/green-verified before landing
