### PR TITLE
test: raise coverage across 8 low/zero-coverage packages

### DIFF
--- a/cmd/keyorix-k8s-sync/main.go
+++ b/cmd/keyorix-k8s-sync/main.go
@@ -48,22 +48,34 @@ func main() {
 	if err != nil {
 		log.Fatalf("k8s-sync: kubernetes: %v", err)
 	}
+	fetcher := k8ssync.NewKeyorixFetcher(cfg.KeyorixURL, token, cfg.ProjectID)
+	os.Exit(runAgent(cfg, fetcher, sink, *once, *dryRun, *cleanup))
+}
 
+// runAgent holds everything that happens once a Fetcher and Sink exist: engine
+// wiring, the one-shot/loop split, and (loop mode only) the health server. Split out
+// from main so tests can drive it with a fake Fetcher/Sink instead of the real
+// in-cluster ones (which need a live Kubernetes API and mounted service-account
+// files main() can't fake). Returns the process exit code instead of calling
+// os.Exit directly, so deferred cleanup (context cancel, signal.Stop, health server
+// shutdown) always runs.
+func runAgent(cfg *k8ssync.Config, fetcher k8ssync.Fetcher, sink k8ssync.Sink, once, dryRun, cleanup bool) int {
 	var engineOpts []k8ssync.Option
-	if *dryRun {
+	if dryRun {
 		engineOpts = append(engineOpts, k8ssync.WithDryRun())
 	}
 	// Cleanup is enabled by either the config file or the -cleanup flag; the flag lets a
 	// one-shot run preview/perform a reap without editing the mounted config.
-	if cfg.Cleanup || *cleanup {
+	if cfg.Cleanup || cleanup {
 		engineOpts = append(engineOpts, k8ssync.WithCleanup())
 	}
-	engine := k8ssync.NewEngine(k8ssync.NewKeyorixFetcher(cfg.KeyorixURL, token, cfg.ProjectID), sink, engineOpts...)
+	engine := k8ssync.NewEngine(fetcher, sink, engineOpts...)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sig)
 	go func() {
 		<-sig
 		log.Println("k8s-sync: shutdown signal received")
@@ -72,18 +84,18 @@ func main() {
 
 	// One-shot mode: a single reconcile, then exit non-zero if anything failed (handy
 	// as a CI gate or a Kubernetes Job). No health server / loop.
-	if *once {
+	if once {
 		mode := ""
-		if *dryRun {
+		if dryRun {
 			mode = " (dry-run)"
 		}
 		log.Printf("k8s-sync: one-shot reconcile of %d mapping(s) from %s%s",
 			len(cfg.Mappings), cfg.KeyorixURL, mode)
 		res := k8ssync.Sync(ctx, engine, cfg.Mappings, log.Printf)
 		if res.Failed > 0 {
-			os.Exit(1)
+			return 1
 		}
-		return
+		return 0
 	}
 
 	// Health/readiness server for Kubernetes probes (/healthz, /readyz, /status).
@@ -105,13 +117,14 @@ func main() {
 	}()
 
 	loopMode := ""
-	if *dryRun {
+	if dryRun {
 		loopMode = " (dry-run)"
 	}
 	log.Printf("k8s-sync: syncing %d mapping(s) from %s every %s (health :%d)%s",
 		len(cfg.Mappings), cfg.KeyorixURL, cfg.GetInterval(), cfg.GetHealthPort(), loopMode)
 	k8ssync.Run(ctx, engine, cfg.Mappings, cfg.GetInterval(), log.Printf, status)
 	log.Println("k8s-sync: stopped")
+	return 0
 }
 
 func envOr(key, def string) string {

--- a/cmd/keyorix-k8s-sync/main_test.go
+++ b/cmd/keyorix-k8s-sync/main_test.go
@@ -1,0 +1,402 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/k8ssync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- envOr ----
+
+func TestEnvOr_ReturnsEnvValueWhenSet(t *testing.T) {
+	t.Setenv("KEYORIX_K8S_SYNC_CONFIG_TEST", "/custom/path.yaml")
+	assert.Equal(t, "/custom/path.yaml", envOr("KEYORIX_K8S_SYNC_CONFIG_TEST", "/etc/keyorix/k8s-sync.yaml"))
+}
+
+func TestEnvOr_ReturnsDefaultWhenUnset(t *testing.T) {
+	assert.Equal(t, "/etc/keyorix/k8s-sync.yaml", envOr("KEYORIX_K8S_SYNC_CONFIG_TEST_UNSET", "/etc/keyorix/k8s-sync.yaml"))
+}
+
+// ---- fakes for runAgent ----
+
+// fakeFetcher serves values from a map; a ref absent from the map returns err (or a
+// generic not-found error when err is nil).
+type fakeFetcher struct {
+	values map[string][]byte
+	err    error
+}
+
+func (f *fakeFetcher) Fetch(_ context.Context, ref string) ([]byte, error) {
+	if v, ok := f.values[ref]; ok {
+		return v, nil
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return nil, fmt.Errorf("fakeFetcher: no value for ref %q", ref)
+}
+
+// fakeSink is a minimal in-memory k8ssync.Sink: Get always reports "not found" (nil,
+// nil) so every apply is a Create, and List/Delete are recorded so cleanup wiring can
+// be asserted without needing a real orphan to reap.
+type fakeSink struct {
+	mu        sync.Mutex
+	applied   map[string]map[string][]byte
+	listCalls int
+	deleted   []string
+}
+
+func newFakeSink() *fakeSink {
+	return &fakeSink{applied: map[string]map[string][]byte{}}
+}
+
+func (s *fakeSink) Get(_ context.Context, _, _ string) (map[string][]byte, error) {
+	return nil, nil
+}
+
+func (s *fakeSink) Apply(_ context.Context, ns, name string, data map[string][]byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.applied[ns+"/"+name] = data
+	return nil
+}
+
+func (s *fakeSink) List(_ context.Context, _ string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listCalls++
+	return nil, nil
+}
+
+func (s *fakeSink) Delete(_ context.Context, ns, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deleted = append(s.deleted, ns+"/"+name)
+	return nil
+}
+
+func (s *fakeSink) applyCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.applied)
+}
+
+func (s *fakeSink) listCallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.listCalls
+}
+
+func testConfig(healthPort int) *k8ssync.Config {
+	return &k8ssync.Config{
+		KeyorixURL: "https://keyorix.example.com",
+		ProjectID:  1,
+		HealthPort: healthPort,
+		Mappings: []k8ssync.SecretMapping{
+			{Ref: "production/db-password", Namespace: "default", Name: "db-secret", Key: "password"},
+		},
+	}
+}
+
+// captureLog redirects the standard logger to a buffer for the duration of fn and
+// restores it afterward. runAgent and main() both log via the standard "log" package.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+	fn()
+	return buf.String()
+}
+
+// ---- runAgent: once mode ----
+
+func TestRunAgent_OnceMode_AllSucceed_ReturnsZero(t *testing.T) {
+	cfg := testConfig(0)
+	fetcher := &fakeFetcher{values: map[string][]byte{"production/db-password": []byte("s3cr3t")}}
+	sink := newFakeSink()
+
+	var code int
+	out := captureLog(t, func() {
+		code = runAgent(cfg, fetcher, sink, true, false, false)
+	})
+
+	assert.Equal(t, 0, code)
+	assert.Equal(t, 1, sink.applyCount(), "the single mapping must have been applied")
+	assert.Equal(t, 0, sink.listCallCount(), "cleanup disabled: List must never be called")
+	assert.Contains(t, out, "one-shot reconcile of 1 mapping(s)")
+	assert.NotContains(t, out, "(dry-run)")
+}
+
+func TestRunAgent_OnceMode_FetchFailure_ReturnsOne(t *testing.T) {
+	cfg := testConfig(0)
+	fetcher := &fakeFetcher{err: errors.New("upstream unreachable")}
+	sink := newFakeSink()
+
+	var code int
+	out := captureLog(t, func() {
+		code = runAgent(cfg, fetcher, sink, true, false, false)
+	})
+
+	assert.Equal(t, 1, code, "a failed mapping must produce a non-zero exit code")
+	assert.Equal(t, 0, sink.applyCount())
+	assert.Contains(t, out, "one-shot reconcile of 1 mapping(s)")
+}
+
+// ---- runAgent: dry-run wiring ----
+
+func TestRunAgent_DryRun_DoesNotApply(t *testing.T) {
+	cfg := testConfig(0)
+	fetcher := &fakeFetcher{values: map[string][]byte{"production/db-password": []byte("s3cr3t")}}
+	sink := newFakeSink()
+
+	var code int
+	out := captureLog(t, func() {
+		code = runAgent(cfg, fetcher, sink, true, true, false)
+	})
+
+	assert.Equal(t, 0, code)
+	assert.Equal(t, 0, sink.applyCount(), "dry-run must never write a Secret")
+	assert.Contains(t, out, "one-shot reconcile of 1 mapping(s) from https://keyorix.example.com (dry-run)")
+}
+
+// ---- runAgent: cleanup wiring (config vs flag) ----
+
+func TestRunAgent_CleanupViaConfig_ListsOwnedSecrets(t *testing.T) {
+	cfg := testConfig(0)
+	cfg.Cleanup = true
+	fetcher := &fakeFetcher{values: map[string][]byte{"production/db-password": []byte("s3cr3t")}}
+	sink := newFakeSink()
+
+	code := runAgent(cfg, fetcher, sink, true, false, false)
+
+	assert.Equal(t, 0, code)
+	assert.Equal(t, 1, sink.listCallCount(), "cfg.Cleanup=true must enable orphan reaping")
+}
+
+func TestRunAgent_CleanupViaFlag_ListsOwnedSecrets(t *testing.T) {
+	cfg := testConfig(0)
+	fetcher := &fakeFetcher{values: map[string][]byte{"production/db-password": []byte("s3cr3t")}}
+	sink := newFakeSink()
+
+	code := runAgent(cfg, fetcher, sink, true, false, true)
+
+	assert.Equal(t, 0, code)
+	assert.Equal(t, 1, sink.listCallCount(), "-cleanup must enable orphan reaping even when the config doesn't")
+}
+
+// ---- runAgent: loop mode + health server + signal shutdown ----
+
+// TestRunAgent_LoopMode_ShutdownOnSignal drives the non-once branch: it starts the
+// health server and the reconcile loop, sends this process a SIGTERM shortly after
+// (mirroring how Kubernetes stops a Pod), and asserts runAgent returns cleanly rather
+// than hanging. This is the only way to exercise the loop/health-server branch without
+// a real Kubernetes cluster to run forever against.
+func TestRunAgent_LoopMode_ShutdownOnSignal(t *testing.T) {
+	cfg := testConfig(18765)
+	fetcher := &fakeFetcher{values: map[string][]byte{"production/db-password": []byte("s3cr3t")}}
+	sink := newFakeSink()
+
+	done := make(chan int, 1)
+	var out string
+	completed := make(chan struct{})
+	go func() {
+		out = captureLog(t, func() {
+			done <- runAgent(cfg, fetcher, sink, false, false, false)
+		})
+		close(completed)
+	}()
+
+	// Give the loop time to run its first sync pass and start the health server.
+	time.Sleep(150 * time.Millisecond)
+	self, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, self.Signal(syscall.SIGTERM))
+
+	select {
+	case code := <-done:
+		<-completed
+		assert.Equal(t, 0, code)
+	case <-time.After(10 * time.Second):
+		t.Fatal("runAgent did not return within 10s of SIGTERM")
+	}
+
+	assert.Equal(t, 1, sink.applyCount(), "the first immediate sync pass must have run")
+	assert.Contains(t, out, "k8s-sync: syncing 1 mapping(s)")
+	assert.Contains(t, out, "k8s-sync: shutdown signal received")
+	assert.Contains(t, out, "k8s-sync: stopped")
+}
+
+// TestRunAgent_LoopMode_HealthServerBindError_LogsButContinues occupies the health
+// port before starting runAgent so ListenAndServe fails immediately, covering the
+// "health server error" log branch (the loop itself must still run and shut down
+// cleanly on signal, same as when the port is free). It also runs with dryRun=true
+// in loop mode, covering the "(dry-run)" loop-log branch that the plain loop-mode
+// test above (dryRun=false) doesn't exercise.
+func TestRunAgent_LoopMode_HealthServerBindError_LogsButContinues(t *testing.T) {
+	const port = 18766
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	require.NoError(t, err)
+	defer l.Close() //nolint:errcheck
+
+	cfg := testConfig(port)
+	fetcher := &fakeFetcher{values: map[string][]byte{"production/db-password": []byte("s3cr3t")}}
+	sink := newFakeSink()
+
+	done := make(chan int, 1)
+	completed := make(chan struct{})
+	var out string
+	go func() {
+		out = captureLog(t, func() {
+			done <- runAgent(cfg, fetcher, sink, false, true, false)
+		})
+		close(completed)
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	self, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, self.Signal(syscall.SIGTERM))
+
+	select {
+	case code := <-done:
+		<-completed
+		assert.Equal(t, 0, code)
+	case <-time.After(10 * time.Second):
+		t.Fatal("runAgent did not return within 10s of SIGTERM")
+	}
+
+	assert.Contains(t, out, "k8s-sync: health server error")
+	assert.Contains(t, out, "k8s-sync: syncing 1 mapping(s) from https://keyorix.example.com every")
+	assert.Contains(t, out, "(dry-run)")
+}
+
+// ---- main(): subprocess re-exec, mirrors cmd/keyorix-mcp/main_test.go's pattern ----
+//
+// main() itself only ever reaches the log.Fatalf branches in this environment: past
+// KEYORIX_TOKEN validation it calls k8ssync.NewInClusterSink(), which requires a real
+// in-cluster Kubernetes API and mounted service-account files
+// (/var/run/secrets/kubernetes.io/serviceaccount/{token,ca.crt}, hardcoded constants
+// in internal/k8ssync/rest_sink.go) that cannot be faked from a test process. The same
+// function is only 41.2% covered by internal/k8ssync's own test suite for the same
+// reason (verified via go tool cover -func) -- this is a pre-existing, documented wall
+// in this codebase, not something new to this package. The interesting logic that used
+// to live after that call was extracted into runAgent (tested directly, above) so it
+// doesn't sit behind the same wall.
+
+// runMainSubprocess re-execs this test binary scoped to a single test via
+// -test.run. It deliberately never passes any of main()'s own flags (-config,
+// -once, -dry-run, -cleanup) as extra argv: main() calls flag.Parse() a second
+// time inside the subprocess against the SAME os.Args the testing package already
+// parsed once (to consume -test.run) using flag.CommandLine, so any extra argv this
+// process doesn't already recognize -- including main()'s own flags, since they
+// aren't registered until main() runs, after testing's own parse -- would make
+// THAT first parse fail with "flag provided but not defined" before main() ever
+// gets to run. The config path is instead driven via KEYORIX_K8S_SYNC_CONFIG (the
+// flag's own documented env-var fallback, see envOr), which sidesteps argv
+// entirely.
+func runMainSubprocess(t *testing.T, testName string, extraEnv []string) (stderr string, exitCode int, runErr error) {
+	t.Helper()
+
+	var env []string
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "KEYORIX_") || strings.HasPrefix(kv, "KUBERNETES_") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env, extraEnv...)
+	env = append(env, "KEYORIX_K8S_SYNC_MAIN_SUBPROCESS=1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^"+testName+"$")
+	cmd.Env = env
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	runErr = cmd.Run()
+	exitCode = 0
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		exitCode = exitErr.ExitCode()
+	}
+	return stderrBuf.String(), exitCode, runErr
+}
+
+// A config file that fails to parse/validate must abort startup via log.Fatalf.
+func TestMainSubprocess_ConfigLoadError(t *testing.T) {
+	if os.Getenv("KEYORIX_K8S_SYNC_MAIN_SUBPROCESS") == "1" {
+		main()
+		return
+	}
+	stderr, exitCode, runErr := runMainSubprocess(t, "TestMainSubprocess_ConfigLoadError",
+		[]string{"KEYORIX_K8S_SYNC_CONFIG=/does/not/exist.yaml"})
+	require.Error(t, runErr, "main() must exit non-zero when the config file can't be loaded")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "k8s-sync: config:")
+}
+
+// A missing KEYORIX_TOKEN must be a fatal, immediate startup error (checked after the
+// config loads successfully).
+func TestMainSubprocess_MissingToken(t *testing.T) {
+	if os.Getenv("KEYORIX_K8S_SYNC_MAIN_SUBPROCESS") == "1" {
+		main()
+		return
+	}
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "k8s-sync.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(validConfigYAML), 0600))
+
+	stderr, exitCode, runErr := runMainSubprocess(t, "TestMainSubprocess_MissingToken",
+		[]string{"KEYORIX_K8S_SYNC_CONFIG=" + cfgPath})
+	require.Error(t, runErr, "main() must exit non-zero when KEYORIX_TOKEN is unset")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "KEYORIX_TOKEN is required")
+}
+
+// With a valid config and a token, main() reaches k8ssync.NewInClusterSink(), which
+// fails outside a real cluster (no KUBERNETES_SERVICE_HOST/PORT, no mounted
+// service-account files) -- see the block comment above.
+func TestMainSubprocess_KubernetesSinkError(t *testing.T) {
+	if os.Getenv("KEYORIX_K8S_SYNC_MAIN_SUBPROCESS") == "1" {
+		main()
+		return
+	}
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "k8s-sync.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(validConfigYAML), 0600))
+
+	stderr, exitCode, runErr := runMainSubprocess(t, "TestMainSubprocess_KubernetesSinkError",
+		[]string{"KEYORIX_K8S_SYNC_CONFIG=" + cfgPath, "KEYORIX_TOKEN=t"})
+	require.Error(t, runErr, "main() must exit non-zero when not running in-cluster")
+	assert.Equal(t, 1, exitCode)
+	assert.Contains(t, stderr, "k8s-sync: kubernetes:")
+}
+
+const validConfigYAML = `
+keyorix_url: "https://keyorix.example.com"
+project_id: 1
+mappings:
+  - ref: "production/db-password"
+    namespace: "default"
+    name: "db-secret"
+    key: "password"
+`

--- a/internal/cli/secret/access_rune_test.go
+++ b/internal/cli/secret/access_rune_test.go
@@ -1,0 +1,151 @@
+// access_rune_test.go — exercises accessCmd.RunE and accessLogCmd.RunE directly
+// (access_remote_test.go only tests fetchAccessors/fetchAccessLog).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func accessRuneStub(t *testing.T, path, body string) func() {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == path {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	return srv.Close
+}
+
+func resetAccessFlags(t *testing.T) {
+	t.Helper()
+	orig := accessID
+	t.Cleanup(func() { accessID = orig })
+}
+
+func resetAccessLogFlags(t *testing.T) {
+	t.Helper()
+	origID, origDays := accessLogID, accessLogDays
+	t.Cleanup(func() { accessLogID = origID; accessLogDays = origDays })
+}
+
+func TestAccessCmd_MissingID(t *testing.T) {
+	resetAccessFlags(t)
+	accessID = 0
+	err := accessCmd.RunE(accessCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id")
+}
+
+func TestAccessCmd_NoServer(t *testing.T) {
+	resetAccessFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	accessID = 7
+	err := accessCmd.RunE(accessCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestAccessCmd_Success_Empty(t *testing.T) {
+	resetAccessFlags(t)
+	done := accessRuneStub(t, "/api/v1/secrets/7/access", `{"data":{"accessors":[]}}`)
+	defer done()
+	accessID = 7
+
+	out := captureStdoutForFolder(t, func() {
+		err := accessCmd.RunE(accessCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "No accessors")
+}
+
+func TestAccessCmd_Success_WithRows(t *testing.T) {
+	resetAccessFlags(t)
+	done := accessRuneStub(t, "/api/v1/secrets/7/access", `{"data":{"accessors":[{"username":"alice","permission":"read","source":"direct"}]}}`)
+	defer done()
+	accessID = 7
+
+	out := captureStdoutForFolder(t, func() {
+		err := accessCmd.RunE(accessCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "alice")
+	assert.Contains(t, out, "direct")
+}
+
+func TestAccessCmd_FetchError(t *testing.T) {
+	resetAccessFlags(t)
+	done := accessRuneStub(t, "/nonexistent", `{}`)
+	defer done()
+	accessID = 7
+
+	err := accessCmd.RunE(accessCmd, nil)
+	require.Error(t, err)
+}
+
+func TestAccessLogCmd_MissingID(t *testing.T) {
+	resetAccessLogFlags(t)
+	accessLogID = 0
+	err := accessLogCmd.RunE(accessLogCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id")
+}
+
+func TestAccessLogCmd_NoServer(t *testing.T) {
+	resetAccessLogFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	accessLogID = 7
+	err := accessLogCmd.RunE(accessLogCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestAccessLogCmd_Success_Empty(t *testing.T) {
+	resetAccessLogFlags(t)
+	done := accessRuneStub(t, "/api/v1/secrets/7/access-log", `{"data":{"access_log":[]}}`)
+	defer done()
+	accessLogID = 7
+	accessLogDays = 0
+
+	out := captureStdoutForFolder(t, func() {
+		err := accessLogCmd.RunE(accessLogCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "No reads")
+}
+
+func TestAccessLogCmd_Success_WithDaysAndRows(t *testing.T) {
+	resetAccessLogFlags(t)
+	done := accessRuneStub(t, "/api/v1/secrets/7/access-log", `{"data":{"access_log":[{"AccessedBy":"bob","Action":"read","IPAddress":"1.2.3.4","AccessTime":"2026-01-01T00:00:00Z"}]}}`)
+	defer done()
+	accessLogID = 7
+	accessLogDays = 7
+
+	out := captureStdoutForFolder(t, func() {
+		err := accessLogCmd.RunE(accessLogCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "bob")
+	assert.Contains(t, out, "1.2.3.4")
+}
+
+func TestAccessLogCmd_FetchError(t *testing.T) {
+	resetAccessLogFlags(t)
+	done := accessRuneStub(t, "/nonexistent", `{}`)
+	defer done()
+	accessLogID = 7
+
+	err := accessLogCmd.RunE(accessLogCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/acl_test.go
+++ b/internal/cli/secret/acl_test.go
@@ -1,0 +1,249 @@
+// acl_test.go — CLI tests for `keyorix secret acl list/grant/revoke` (RBAC Phase 3).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func aclRemoteStub(t *testing.T, handler http.HandlerFunc) func() {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	return srv.Close
+}
+
+func TestAclClient_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	_, err := aclClient()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestAclClient_WithServer(t *testing.T) {
+	done := aclRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {})
+	defer done()
+	c, err := aclClient()
+	require.NoError(t, err)
+	require.NotNil(t, c)
+}
+
+// ── acl list ──────────────────────────────────────────────────────────────────
+
+func TestAclListCmd_Success_Empty(t *testing.T) {
+	done := aclRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/secrets/7/acl", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := aclListCmd.RunE(aclListCmd, []string{"7"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "No ACL grants")
+}
+
+func TestAclListCmd_Success_WithEntries(t *testing.T) {
+	done := aclRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1,"secret_id":7,"user_id":3,"permissions":["secrets.read","secrets.write"],"granted_by":1}]}`))
+	})
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := aclListCmd.RunE(aclListCmd, []string{"7"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "secrets.read,secrets.write")
+}
+
+func TestAclListCmd_InvalidSecretArg(t *testing.T) {
+	err := aclListCmd.RunE(aclListCmd, []string{"abc"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid secret id")
+}
+
+func TestAclListCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := aclListCmd.RunE(aclListCmd, []string{"7"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestAclListCmd_APIError(t *testing.T) {
+	done := aclRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer done()
+	err := aclListCmd.RunE(aclListCmd, []string{"7"})
+	require.Error(t, err)
+}
+
+// ── acl grant ─────────────────────────────────────────────────────────────────
+
+func resetAclGrantFlags(t *testing.T) {
+	t.Helper()
+	origUser, origPerms := aclGrantUser, aclGrantPerms
+	t.Cleanup(func() { aclGrantUser = origUser; aclGrantPerms = origPerms })
+}
+
+func TestAclGrantCmd_MissingSecret(t *testing.T) {
+	require.NoError(t, aclGrantCmd.Flags().Set("secret", "0"))
+	err := aclGrantCmd.RunE(aclGrantCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--secret")
+}
+
+func TestAclGrantCmd_MissingUser(t *testing.T) {
+	resetAclGrantFlags(t)
+	require.NoError(t, aclGrantCmd.Flags().Set("secret", "7"))
+	t.Cleanup(func() { _ = aclGrantCmd.Flags().Set("secret", "0") })
+	aclGrantUser = 0
+	err := aclGrantCmd.RunE(aclGrantCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--user")
+}
+
+func TestAclGrantCmd_MissingPerm(t *testing.T) {
+	resetAclGrantFlags(t)
+	require.NoError(t, aclGrantCmd.Flags().Set("secret", "7"))
+	t.Cleanup(func() { _ = aclGrantCmd.Flags().Set("secret", "0") })
+	aclGrantUser = 3
+	aclGrantPerms = nil
+	err := aclGrantCmd.RunE(aclGrantCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--perm")
+}
+
+func TestAclGrantCmd_NoServer(t *testing.T) {
+	resetAclGrantFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, aclGrantCmd.Flags().Set("secret", "7"))
+	t.Cleanup(func() { _ = aclGrantCmd.Flags().Set("secret", "0") })
+	aclGrantUser = 3
+	aclGrantPerms = []string{"secrets.read"}
+	err := aclGrantCmd.RunE(aclGrantCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestAclGrantCmd_Success(t *testing.T) {
+	resetAclGrantFlags(t)
+	var capturedBody map[string]interface{}
+	done := aclRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/v1/secrets/7/acl", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"created":true}}`))
+		_ = capturedBody
+	})
+	defer done()
+
+	require.NoError(t, aclGrantCmd.Flags().Set("secret", "7"))
+	t.Cleanup(func() { _ = aclGrantCmd.Flags().Set("secret", "0") })
+	aclGrantUser = 3
+	aclGrantPerms = []string{"secrets.read"}
+
+	out := captureStdoutForFolder(t, func() {
+		err := aclGrantCmd.RunE(aclGrantCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "ACL granted")
+}
+
+func TestAclGrantCmd_APIError(t *testing.T) {
+	resetAclGrantFlags(t)
+	done := aclRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer done()
+
+	require.NoError(t, aclGrantCmd.Flags().Set("secret", "7"))
+	t.Cleanup(func() { _ = aclGrantCmd.Flags().Set("secret", "0") })
+	aclGrantUser = 3
+	aclGrantPerms = []string{"secrets.read"}
+
+	err := aclGrantCmd.RunE(aclGrantCmd, nil)
+	require.Error(t, err)
+}
+
+// ── acl revoke ────────────────────────────────────────────────────────────────
+
+func TestAclRevokeCmd_MissingSecret(t *testing.T) {
+	require.NoError(t, aclRevokeCmd.Flags().Set("secret", "0"))
+	err := aclRevokeCmd.RunE(aclRevokeCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--secret")
+}
+
+func TestAclRevokeCmd_MissingAcl(t *testing.T) {
+	require.NoError(t, aclRevokeCmd.Flags().Set("secret", "7"))
+	require.NoError(t, aclRevokeCmd.Flags().Set("acl", "0"))
+	t.Cleanup(func() { _ = aclRevokeCmd.Flags().Set("secret", "0") })
+	err := aclRevokeCmd.RunE(aclRevokeCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--acl")
+}
+
+func TestAclRevokeCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	require.NoError(t, aclRevokeCmd.Flags().Set("secret", "7"))
+	require.NoError(t, aclRevokeCmd.Flags().Set("acl", "5"))
+	t.Cleanup(func() {
+		_ = aclRevokeCmd.Flags().Set("secret", "0")
+		_ = aclRevokeCmd.Flags().Set("acl", "0")
+	})
+	err := aclRevokeCmd.RunE(aclRevokeCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestAclRevokeCmd_Success(t *testing.T) {
+	done := aclRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		require.Equal(t, "/api/v1/secrets/7/acl/5", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer done()
+
+	require.NoError(t, aclRevokeCmd.Flags().Set("secret", "7"))
+	require.NoError(t, aclRevokeCmd.Flags().Set("acl", "5"))
+	t.Cleanup(func() {
+		_ = aclRevokeCmd.Flags().Set("secret", "0")
+		_ = aclRevokeCmd.Flags().Set("acl", "0")
+	})
+
+	out := captureStdoutForFolder(t, func() {
+		err := aclRevokeCmd.RunE(aclRevokeCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "ACL 5 revoked")
+}
+
+func TestAclRevokeCmd_APIError(t *testing.T) {
+	done := aclRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer done()
+
+	require.NoError(t, aclRevokeCmd.Flags().Set("secret", "7"))
+	require.NoError(t, aclRevokeCmd.Flags().Set("acl", "5"))
+	t.Cleanup(func() {
+		_ = aclRevokeCmd.Flags().Set("secret", "0")
+		_ = aclRevokeCmd.Flags().Set("acl", "0")
+	})
+
+	err := aclRevokeCmd.RunE(aclRevokeCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/audit_rune_test.go
+++ b/internal/cli/secret/audit_rune_test.go
@@ -1,0 +1,90 @@
+// audit_rune_test.go — exercises auditCmd.RunE directly
+// (audit_remote_test.go only tests fetchAuditTrail).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetAuditFlags(t *testing.T) {
+	t.Helper()
+	origID, origLimit := auditID, auditLimit
+	t.Cleanup(func() { auditID = origID; auditLimit = origLimit })
+}
+
+func TestAuditCmd_MissingID(t *testing.T) {
+	resetAuditFlags(t)
+	auditID = 0
+	err := auditCmd.RunE(auditCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id")
+}
+
+func TestAuditCmd_NoServer(t *testing.T) {
+	resetAuditFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	auditID = 7
+	err := auditCmd.RunE(auditCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestAuditCmd_Success_Empty(t *testing.T) {
+	resetAuditFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"audit":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	auditID = 7
+
+	out := captureStdoutForFolder(t, func() {
+		err := auditCmd.RunE(auditCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "No audit events")
+}
+
+func TestAuditCmd_Success_WithLimitAndRows(t *testing.T) {
+	resetAuditFlags(t)
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"audit":[{"event_type":"rotated","timestamp":"2026-01-01T00:00:00Z","actor_type":"human","description":"rotated by alice"}]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	auditID = 7
+	auditLimit = 5
+
+	out := captureStdoutForFolder(t, func() {
+		err := auditCmd.RunE(auditCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, gotQuery, "limit=5")
+	assert.Contains(t, out, "rotated by alice")
+}
+
+func TestAuditCmd_FetchError(t *testing.T) {
+	resetAuditFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	auditID = 7
+
+	err := auditCmd.RunE(auditCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/autorotate_rune_test.go
+++ b/internal/cli/secret/autorotate_rune_test.go
@@ -1,0 +1,107 @@
+// autorotate_rune_test.go — exercises autoRotateCmd.RunE (entirely untested
+// before this file: no other test in the package references autoRotateCmd).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetAutoRotateFlags(t *testing.T) {
+	t.Helper()
+	origID, origOff, origLen, origCharset, origBackend, origRef :=
+		autoRotateID, autoRotateOff, autoRotateLength, autoRotateCharset, autoRotateBackend, autoRotateRef
+	t.Cleanup(func() {
+		autoRotateID = origID
+		autoRotateOff = origOff
+		autoRotateLength = origLen
+		autoRotateCharset = origCharset
+		autoRotateBackend = origBackend
+		autoRotateRef = origRef
+	})
+}
+
+func TestAutoRotateCmd_NoServer(t *testing.T) {
+	resetAutoRotateFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	autoRotateID = 7
+	err := autoRotateCmd.RunE(autoRotateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func autoRotateStub(t *testing.T, path string) func() {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == path {
+			require.Equal(t, http.MethodPatch, r.Method)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	return srv.Close
+}
+
+func TestAutoRotateCmd_Success_Enable(t *testing.T) {
+	resetAutoRotateFlags(t)
+	done := autoRotateStub(t, "/api/v1/secrets/7/auto-rotate")
+	defer done()
+	autoRotateID = 7
+	autoRotateOff = false
+
+	out := captureStdoutForFolder(t, func() {
+		err := autoRotateCmd.RunE(autoRotateCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "enabled")
+}
+
+func TestAutoRotateCmd_Success_Disable(t *testing.T) {
+	resetAutoRotateFlags(t)
+	done := autoRotateStub(t, "/api/v1/secrets/7/auto-rotate")
+	defer done()
+	autoRotateID = 7
+	autoRotateOff = true
+
+	out := captureStdoutForFolder(t, func() {
+		err := autoRotateCmd.RunE(autoRotateCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "disabled")
+}
+
+func TestAutoRotateCmd_Success_WithBackendAndRef(t *testing.T) {
+	resetAutoRotateFlags(t)
+	done := autoRotateStub(t, "/api/v1/secrets/7/auto-rotate")
+	defer done()
+	autoRotateID = 7
+	autoRotateBackend = "vault"
+	autoRotateRef = "secret/foo"
+	autoRotateCharset = "hex"
+
+	err := autoRotateCmd.RunE(autoRotateCmd, nil)
+	require.NoError(t, err)
+}
+
+func TestAutoRotateCmd_APIError(t *testing.T) {
+	resetAutoRotateFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	autoRotateID = 7
+
+	err := autoRotateCmd.RunE(autoRotateCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/blast_radius_rune_test.go
+++ b/internal/cli/secret/blast_radius_rune_test.go
@@ -1,0 +1,54 @@
+// blast_radius_rune_test.go — exercises blastRadiusCmd.RunE directly
+// (blast_radius_test.go tests fetchBlastRadius/printBlastRadius/blastRadiusClient
+// individually, never the command closure that wires them together).
+package secret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlastRadiusCmd_Success(t *testing.T) {
+	_, done := blastRadiusStub(t)
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := blastRadiusCmd.RunE(blastRadiusCmd, []string{"7"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "db-password")
+	assert.Contains(t, out, "app-token")
+}
+
+func TestBlastRadiusCmd_NoDependents(t *testing.T) {
+	_, done := blastRadiusStub(t)
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := blastRadiusCmd.RunE(blastRadiusCmd, []string{"8"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "No dependents")
+}
+
+func TestBlastRadiusCmd_InvalidArg(t *testing.T) {
+	err := blastRadiusCmd.RunE(blastRadiusCmd, []string{"0"})
+	require.Error(t, err)
+}
+
+func TestBlastRadiusCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := blastRadiusCmd.RunE(blastRadiusCmd, []string{"7"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestBlastRadiusCmd_FetchError(t *testing.T) {
+	_, done := blastRadiusStub(t)
+	defer done()
+	err := blastRadiusCmd.RunE(blastRadiusCmd, []string{"9999"})
+	require.Error(t, err)
+}

--- a/internal/cli/secret/bulk_rename_rune_test.go
+++ b/internal/cli/secret/bulk_rename_rune_test.go
@@ -1,0 +1,107 @@
+// bulk_rename_rune_test.go — exercises bulkRenameCmd.RunE directly
+// (bulk_rename_remote_test.go only tests postBulkRename/parseRenamePairs).
+package secret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetBulkRenameFlags(t *testing.T) {
+	t.Helper()
+	origProject, origApply, origPairs := bulkRenameProject, bulkRenameApply, bulkRenamePairs
+	t.Cleanup(func() {
+		bulkRenameProject = origProject
+		bulkRenameApply = origApply
+		bulkRenamePairs = origPairs
+	})
+}
+
+func TestBulkRenameCmd_MissingProject(t *testing.T) {
+	resetBulkRenameFlags(t)
+	bulkRenameProject = 0
+	err := bulkRenameCmd.RunE(bulkRenameCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project")
+}
+
+func TestBulkRenameCmd_MissingRenames(t *testing.T) {
+	resetBulkRenameFlags(t)
+	bulkRenameProject = 5
+	bulkRenamePairs = nil
+	err := bulkRenameCmd.RunE(bulkRenameCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--rename")
+}
+
+func TestBulkRenameCmd_InvalidPair(t *testing.T) {
+	resetBulkRenameFlags(t)
+	bulkRenameProject = 5
+	bulkRenamePairs = []string{"noequals"}
+	err := bulkRenameCmd.RunE(bulkRenameCmd, nil)
+	require.Error(t, err)
+}
+
+func TestBulkRenameCmd_NoServer(t *testing.T) {
+	resetBulkRenameFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	bulkRenameProject = 5
+	bulkRenamePairs = []string{"12=NEW_NAME"}
+	err := bulkRenameCmd.RunE(bulkRenameCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestBulkRenameCmd_Success_DryRun(t *testing.T) {
+	resetBulkRenameFlags(t)
+	rc, done := bulkRenameStub(t, nil)
+	defer done()
+	_ = rc
+
+	bulkRenameProject = 5
+	bulkRenamePairs = []string{"12=DB_PW"}
+	bulkRenameApply = false
+
+	out := captureStdoutForFolder(t, func() {
+		err := bulkRenameCmd.RunE(bulkRenameCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "Dry run")
+	assert.Contains(t, out, "would be renamed")
+}
+
+func TestBulkRenameCmd_Success_Apply(t *testing.T) {
+	resetBulkRenameFlags(t)
+	var captured map[string]interface{}
+	rc, done := bulkRenameStub(t, &captured)
+	defer done()
+	_ = rc
+
+	bulkRenameProject = 5
+	bulkRenamePairs = []string{"12=DB_PW"}
+	bulkRenameApply = true
+
+	captureStdoutForFolder(t, func() {
+		err := bulkRenameCmd.RunE(bulkRenameCmd, nil)
+		require.NoError(t, err)
+	})
+	// bulkRenameStub's fixture always reports dry_run:true regardless of what was
+	// sent; what matters here is that --apply sent dry_run:false in the request.
+	assert.Equal(t, false, captured["dry_run"])
+}
+
+func TestBulkRenameCmd_PostError(t *testing.T) {
+	resetBulkRenameFlags(t)
+	rc, done := bulkRenameStub(t, nil)
+	defer done()
+	_ = rc
+
+	bulkRenameProject = 999
+	bulkRenamePairs = []string{"12=DB_PW"}
+
+	err := bulkRenameCmd.RunE(bulkRenameCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/bulk_rotate_rune_test.go
+++ b/internal/cli/secret/bulk_rotate_rune_test.go
@@ -1,0 +1,214 @@
+// bulk_rotate_rune_test.go — covers splitNames, resolveSecretNamesToIDs, and the
+// bulkRotateCmd.RunE closure itself (bulk_rotate_test.go only exercises
+// postBulkRotate and the early --confirm guard).
+package secret
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitNames(t *testing.T) {
+	assert.Equal(t, []string{"a", "b", "c"}, splitNames("a,b,c"))
+	assert.Equal(t, []string{"a", "b"}, splitNames(" a , b "))
+	assert.Equal(t, []string{"solo"}, splitNames("solo"))
+	assert.Empty(t, splitNames(""))
+	assert.Equal(t, []string{"a", "b"}, splitNames("a,,b"))
+}
+
+func bulkRotateNamesStub(t *testing.T) (*common.RemoteClient, func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/secrets":
+			_, _ = w.Write([]byte(`{"data":{"secrets":[{"ID":10,"Name":"alpha"},{"ID":11,"Name":"beta"}]}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/projects/7/secrets/bulk-rotate":
+			_, _ = w.Write([]byte(`{"data":{"triggered":[10,11],"total":2}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	return rc, srv.Close
+}
+
+func TestResolveSecretNamesToIDs_Found(t *testing.T) {
+	rc, done := bulkRotateNamesStub(t)
+	defer done()
+
+	ids, err := resolveSecretNamesToIDs(context.Background(), rc, 7, 0, []string{"alpha", "beta"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{10, 11}, ids)
+}
+
+func TestResolveSecretNamesToIDs_NotFound_Skipped(t *testing.T) {
+	rc, done := bulkRotateNamesStub(t)
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		ids, err := resolveSecretNamesToIDs(context.Background(), rc, 7, 0, []string{"alpha", "ghost"})
+		require.NoError(t, err)
+		assert.Equal(t, []uint{10}, ids)
+	})
+	assert.Contains(t, out, "ghost")
+	assert.Contains(t, out, "not found")
+}
+
+func TestResolveSecretNamesToIDs_WithEnvFilter(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"secrets":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	_, err := resolveSecretNamesToIDs(context.Background(), rc, 7, 3, []string{"x"})
+	require.NoError(t, err)
+	assert.Contains(t, gotQuery, "environment_id=3")
+}
+
+func TestResolveSecretNamesToIDs_GetError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	_, err := resolveSecretNamesToIDs(context.Background(), rc, 7, 0, []string{"x"})
+	require.Error(t, err)
+}
+
+// ── bulkRotateCmd.RunE ────────────────────────────────────────────────────────
+
+func resetBulkRotateFlags(t *testing.T) {
+	t.Helper()
+	origProject, origEnv, origClass, origNames, origConfirm :=
+		bulkRotateProject, bulkRotateEnv, bulkRotateClassification, bulkRotateNames, bulkRotateConfirm
+	t.Cleanup(func() {
+		bulkRotateProject = origProject
+		bulkRotateEnv = origEnv
+		bulkRotateClassification = origClass
+		bulkRotateNames = origNames
+		bulkRotateConfirm = origConfirm
+	})
+}
+
+func TestBulkRotateCmd_MissingProject(t *testing.T) {
+	resetBulkRotateFlags(t)
+	bulkRotateProject = 0
+	bulkRotateConfirm = true
+	err := bulkRotateCmd.RunE(bulkRotateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project")
+}
+
+func TestBulkRotateCmd_NoServer(t *testing.T) {
+	resetBulkRotateFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	bulkRotateProject = 7
+	bulkRotateConfirm = true
+	err := bulkRotateCmd.RunE(bulkRotateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestBulkRotateCmd_Success_NoNames(t *testing.T) {
+	resetBulkRotateFlags(t)
+	_, done := bulkRotateStub(t, http.StatusOK, `{"data":{"triggered":[1,2],"total":2}}`, nil)
+	defer done()
+
+	bulkRotateProject = 7
+	bulkRotateConfirm = true
+	bulkRotateNames = ""
+
+	out := captureStdoutForFolder(t, func() {
+		err := bulkRotateCmd.RunE(bulkRotateCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "2 scheduled")
+}
+
+func TestBulkRotateCmd_Success_WithNames(t *testing.T) {
+	resetBulkRotateFlags(t)
+	_, done := bulkRotateNamesStub(t)
+	defer done()
+
+	bulkRotateProject = 7
+	bulkRotateConfirm = true
+	bulkRotateNames = "alpha,beta"
+
+	out := captureStdoutForFolder(t, func() {
+		err := bulkRotateCmd.RunE(bulkRotateCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "2 scheduled")
+}
+
+func TestBulkRotateCmd_ResolveNamesError(t *testing.T) {
+	resetBulkRotateFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	bulkRotateProject = 7
+	bulkRotateConfirm = true
+	bulkRotateNames = "alpha"
+
+	err := bulkRotateCmd.RunE(bulkRotateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolve secret names")
+}
+
+func TestBulkRotateCmd_PartialFailure_PrintsFailed(t *testing.T) {
+	resetBulkRotateFlags(t)
+	_, done := bulkRotateStub(t, http.StatusOK, `{"data":{"triggered":[1],"failed":[{"secret_id":2,"name":"broken","error":"no rotation config"},{"secret_id":3,"error":"denied"}],"total":3}}`, nil)
+	defer done()
+
+	bulkRotateProject = 7
+	bulkRotateConfirm = true
+	bulkRotateNames = ""
+
+	out := captureStdoutForFolder(t, func() {
+		err := bulkRotateCmd.RunE(bulkRotateCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "broken")
+	assert.Contains(t, out, "no rotation config")
+	assert.Contains(t, out, "id:3")
+	assert.Contains(t, out, "denied")
+}
+
+func TestBulkRotateCmd_PostError(t *testing.T) {
+	resetBulkRotateFlags(t)
+	_, done := bulkRotateStub(t, http.StatusInternalServerError, `boom`, nil)
+	defer done()
+
+	bulkRotateProject = 7
+	bulkRotateConfirm = true
+	bulkRotateNames = ""
+
+	err := bulkRotateCmd.RunE(bulkRotateCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/certificate_rune_test.go
+++ b/internal/cli/secret/certificate_rune_test.go
@@ -1,0 +1,77 @@
+// certificate_rune_test.go — exercises certCmd.RunE directly (the only existing
+// test, TestFetchCertificate, calls rc.Get on the fixture but never invokes the
+// command closure that formats and prints it).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func certStub(t *testing.T, path, body string) func() {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == path {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	return srv.Close
+}
+
+func TestCertCmd_Success_NotExpired_SelfSigned_WithSANs(t *testing.T) {
+	done := certStub(t, "/api/v1/secrets/7/certificate", `{"data":{"secret_id":7,"secret_name":"tls-cert","subject":"CN=example.com","issuer":"CN=example.com","serial_number":"4242","not_before":"2025-06-23T00:00:00Z","not_after":"2026-09-21T00:00:00Z","days_until_expiry":90,"is_expired":false,"is_ca":false,"self_signed":true,"dns_names":["example.com","www.example.com"],"signature_algorithm":"ECDSA-SHA256","public_key_algorithm":"ECDSA"}}`)
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := certCmd.RunE(certCmd, []string{"7"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "90 days left")
+	assert.Contains(t, out, "self-signed")
+	assert.Contains(t, out, "example.com")
+	assert.Contains(t, out, "SANs:")
+}
+
+func TestCertCmd_Success_Expired_NotSelfSigned_NoSANs(t *testing.T) {
+	done := certStub(t, "/api/v1/secrets/8/certificate", `{"data":{"secret_id":8,"secret_name":"old-cert","subject":"CN=old.example.com","issuer":"CN=CA","serial_number":"1","not_before":"2020-01-01T00:00:00Z","not_after":"2021-01-01T00:00:00Z","days_until_expiry":0,"is_expired":true,"is_ca":true,"self_signed":false,"dns_names":[],"signature_algorithm":"SHA256-RSA","public_key_algorithm":"RSA"}}`)
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := certCmd.RunE(certCmd, []string{"8"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "EXPIRED")
+	assert.NotContains(t, out, "self-signed")
+	assert.NotContains(t, out, "SANs:")
+	assert.Contains(t, out, "CA:         true")
+}
+
+func TestCertCmd_InvalidSecretArg(t *testing.T) {
+	err := certCmd.RunE(certCmd, []string{"abc"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid secret id")
+}
+
+func TestCertCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := certCmd.RunE(certCmd, []string{"7"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestCertCmd_APIError(t *testing.T) {
+	done := certStub(t, "/api/v1/secrets/7/certificate", `{}`)
+	defer done()
+	err := certCmd.RunE(certCmd, []string{"999"})
+	require.Error(t, err)
+}

--- a/internal/cli/secret/classify_rune_test.go
+++ b/internal/cli/secret/classify_rune_test.go
@@ -1,0 +1,99 @@
+// classify_rune_test.go — exercises classifyCmd.RunE (entirely untested before
+// this file: no other test in the package references classifyCmd).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetClassifyFlags(t *testing.T) {
+	t.Helper()
+	origID, origLevel := classifyID, classifyLevel
+	t.Cleanup(func() { classifyID = origID; classifyLevel = origLevel })
+}
+
+func TestClassifyCmd_MissingID(t *testing.T) {
+	resetClassifyFlags(t)
+	classifyID = 0
+	err := classifyCmd.RunE(classifyCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id")
+}
+
+func TestClassifyCmd_InvalidLevel(t *testing.T) {
+	resetClassifyFlags(t)
+	classifyID = 7
+	classifyLevel = "bogus"
+	err := classifyCmd.RunE(classifyCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--level")
+}
+
+func TestClassifyCmd_NoServer(t *testing.T) {
+	resetClassifyFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	classifyID = 7
+	classifyLevel = "confidential"
+	err := classifyCmd.RunE(classifyCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestClassifyCmd_Success_WithLevel(t *testing.T) {
+	resetClassifyFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	classifyID = 7
+	classifyLevel = "confidential"
+
+	out := captureStdoutForFolder(t, func() {
+		err := classifyCmd.RunE(classifyCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "confidential")
+}
+
+func TestClassifyCmd_Success_ClearsToUnclassified(t *testing.T) {
+	resetClassifyFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	classifyID = 7
+	classifyLevel = ""
+
+	out := captureStdoutForFolder(t, func() {
+		err := classifyCmd.RunE(classifyCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "unclassified")
+}
+
+func TestClassifyCmd_APIError(t *testing.T) {
+	resetClassifyFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	classifyID = 7
+
+	err := classifyCmd.RunE(classifyCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/copy_environment_rune_test.go
+++ b/internal/cli/secret/copy_environment_rune_test.go
@@ -1,0 +1,82 @@
+// copy_environment_rune_test.go — exercises copyEnvironmentCmd.RunE directly
+// (copy_environment_remote_test.go only tests copyEnvironmentSecrets).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetCopyEnvFlags(t *testing.T) {
+	t.Helper()
+	origProject, origFrom, origTo := copyEnvProject, copyEnvFrom, copyEnvTo
+	t.Cleanup(func() {
+		copyEnvProject = origProject
+		copyEnvFrom = origFrom
+		copyEnvTo = origTo
+	})
+}
+
+func TestCopyEnvironmentCmd_MissingFlags(t *testing.T) {
+	resetCopyEnvFlags(t)
+	copyEnvProject, copyEnvFrom, copyEnvTo = 0, 0, 0
+	err := copyEnvironmentCmd.RunE(copyEnvironmentCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project")
+}
+
+func TestCopyEnvironmentCmd_SameFromTo(t *testing.T) {
+	resetCopyEnvFlags(t)
+	copyEnvProject, copyEnvFrom, copyEnvTo = 1, 2, 2
+	err := copyEnvironmentCmd.RunE(copyEnvironmentCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must differ")
+}
+
+func TestCopyEnvironmentCmd_NoServer(t *testing.T) {
+	resetCopyEnvFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	copyEnvProject, copyEnvFrom, copyEnvTo = 1, 2, 3
+	err := copyEnvironmentCmd.RunE(copyEnvironmentCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestCopyEnvironmentCmd_Success(t *testing.T) {
+	resetCopyEnvFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/projects/1/environments/2/copy-secrets", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"copied":3,"skipped":1}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	copyEnvProject, copyEnvFrom, copyEnvTo = 1, 2, 3
+
+	out := captureStdoutForFolder(t, func() {
+		err := copyEnvironmentCmd.RunE(copyEnvironmentCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "3 copied")
+	assert.Contains(t, out, "1 skipped")
+}
+
+func TestCopyEnvironmentCmd_APIError(t *testing.T) {
+	resetCopyEnvFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	copyEnvProject, copyEnvFrom, copyEnvTo = 1, 2, 3
+
+	err := copyEnvironmentCmd.RunE(copyEnvironmentCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/copy_rune_test.go
+++ b/internal/cli/secret/copy_rune_test.go
@@ -1,0 +1,92 @@
+// copy_rune_test.go — exercises copyCmd.RunE directly (copy_remote_test.go only
+// tests copySecret).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetCopyFlags(t *testing.T) {
+	t.Helper()
+	origID, origToEnv, origName := copyID, copyToEnv, copyNewName
+	t.Cleanup(func() {
+		copyID = origID
+		copyToEnv = origToEnv
+		copyNewName = origName
+	})
+}
+
+func TestCopyCmd_MissingFlags(t *testing.T) {
+	resetCopyFlags(t)
+	copyID, copyToEnv = 0, 0
+	err := copyCmd.RunE(copyCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id")
+}
+
+func TestCopyCmd_NoServer(t *testing.T) {
+	resetCopyFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	copyID, copyToEnv = 5, 3
+	err := copyCmd.RunE(copyCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestCopyCmd_Success_DefaultName(t *testing.T) {
+	resetCopyFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/secrets/5/copy", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"ID":99}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	copyID, copyToEnv = 5, 3
+	copyNewName = ""
+
+	out := captureStdoutForFolder(t, func() {
+		err := copyCmd.RunE(copyCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "new secret 99")
+}
+
+func TestCopyCmd_Success_WithName(t *testing.T) {
+	resetCopyFlags(t)
+	var capturedBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"ID":100}}`))
+		_ = capturedBody
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	copyID, copyToEnv = 5, 3
+	copyNewName = "renamed-copy"
+
+	err := copyCmd.RunE(copyCmd, nil)
+	require.NoError(t, err)
+}
+
+func TestCopyCmd_APIError(t *testing.T) {
+	resetCopyFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	copyID, copyToEnv = 5, 3
+
+	err := copyCmd.RunE(copyCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/dependencies_rune_test.go
+++ b/internal/cli/secret/dependencies_rune_test.go
@@ -1,0 +1,176 @@
+// dependencies_rune_test.go — exercises the depsList/depsAdd/depsRemove/depsImpact
+// RunE closures directly (dependencies_remote_test.go only tests the extracted
+// fetch/print helpers, never the command wiring).
+package secret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDepsListCmd_Success(t *testing.T) {
+	_, done := depsStub(t)
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := depsListCmd.RunE(depsListCmd, []string{"7"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "db-password")
+	assert.Contains(t, out, "edge-cert")
+}
+
+func TestDepsListCmd_InvalidArg(t *testing.T) {
+	err := depsListCmd.RunE(depsListCmd, []string{"0"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid secret id")
+}
+
+func TestDepsListCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := depsListCmd.RunE(depsListCmd, []string{"7"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestDepsListCmd_FetchError(t *testing.T) {
+	_, done := depsStub(t)
+	defer done()
+	err := depsListCmd.RunE(depsListCmd, []string{"9999"})
+	require.Error(t, err)
+}
+
+func TestDepsAddCmd_Success(t *testing.T) {
+	_, done := depsStub(t)
+	defer done()
+
+	origNote := depNote
+	t.Cleanup(func() { depNote = origNote })
+	depNote = "derives from"
+
+	out := captureStdoutForFolder(t, func() {
+		err := depsAddCmd.RunE(depsAddCmd, []string{"7", "2"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "Added")
+}
+
+func TestDepsAddCmd_InvalidFirstArg(t *testing.T) {
+	err := depsAddCmd.RunE(depsAddCmd, []string{"0", "2"})
+	require.Error(t, err)
+}
+
+func TestDepsAddCmd_InvalidSecondArg(t *testing.T) {
+	err := depsAddCmd.RunE(depsAddCmd, []string{"7", "0"})
+	require.Error(t, err)
+}
+
+func TestDepsAddCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := depsAddCmd.RunE(depsAddCmd, []string{"7", "2"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestDepsAddCmd_APIError(t *testing.T) {
+	_, done := depsStub(t)
+	defer done()
+	err := depsAddCmd.RunE(depsAddCmd, []string{"999", "2"})
+	require.Error(t, err)
+}
+
+func TestDepsRemoveCmd_Success(t *testing.T) {
+	_, done := depsStub(t)
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := depsRemoveCmd.RunE(depsRemoveCmd, []string{"7", "12"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "Removed dependency edge 12")
+}
+
+func TestDepsRemoveCmd_InvalidFirstArg(t *testing.T) {
+	err := depsRemoveCmd.RunE(depsRemoveCmd, []string{"0", "12"})
+	require.Error(t, err)
+}
+
+func TestDepsRemoveCmd_InvalidSecondArg(t *testing.T) {
+	err := depsRemoveCmd.RunE(depsRemoveCmd, []string{"7", "0"})
+	require.Error(t, err)
+}
+
+func TestDepsRemoveCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := depsRemoveCmd.RunE(depsRemoveCmd, []string{"7", "12"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestDepsRemoveCmd_APIError(t *testing.T) {
+	_, done := depsStub(t)
+	defer done()
+	err := depsRemoveCmd.RunE(depsRemoveCmd, []string{"999", "12"})
+	require.Error(t, err)
+}
+
+func TestDepsImpactCmd_Success(t *testing.T) {
+	_, done := depsStub(t)
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := depsImpactCmd.RunE(depsImpactCmd, []string{"7"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "app-token")
+	assert.Contains(t, out, "edge-cert")
+}
+
+func TestDepsImpactCmd_InvalidArg(t *testing.T) {
+	err := depsImpactCmd.RunE(depsImpactCmd, []string{"0"})
+	require.Error(t, err)
+}
+
+func TestDepsImpactCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := depsImpactCmd.RunE(depsImpactCmd, []string{"7"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestDepsImpactCmd_FetchError(t *testing.T) {
+	_, done := depsStub(t)
+	defer done()
+	err := depsImpactCmd.RunE(depsImpactCmd, []string{"9999"})
+	require.Error(t, err)
+}
+
+// TestPrintImpact_NoAffected covers the zero-affected branch of printImpact,
+// which the stub's fixture data never reaches (it always has 2 affected secrets).
+func TestPrintImpact_NoAffected(t *testing.T) {
+	v := &impactView{SecretID: 3, SecretName: "standalone", Affected: nil}
+	out := captureStdoutForFolder(t, func() { printImpact(v) })
+	assert.Contains(t, out, "affects no other secrets")
+}
+
+// TestPrintDependencies_WithNotes covers the noteSuffix branch when a note is
+// present (the "  — <note>" suffix on each edge line).
+func TestPrintDependencies_WithNotes(t *testing.T) {
+	v := &depsView{
+		SecretID: 7,
+		DependsOn: []depEdgeView{
+			{ID: 1, SecretID: 2, SecretName: "db", Note: "derives from"},
+		},
+		Dependents: []depEdgeView{
+			{ID: 2, SecretID: 3, SecretName: "cert"},
+		},
+	}
+	out := captureStdoutForFolder(t, func() { printDependencies(v) })
+	assert.Contains(t, out, "— derives from")
+}

--- a/internal/cli/secret/description_rune_test.go
+++ b/internal/cli/secret/description_rune_test.go
@@ -1,0 +1,130 @@
+// description_rune_test.go — exercises descriptionCmd.RunE directly
+// (description_remote_test.go only tests getSecretDescription/setSecretDescription).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func descriptionRuneStub(t *testing.T, handler http.HandlerFunc) func() {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	return srv.Close
+}
+
+func resetDescriptionFlags(t *testing.T) {
+	t.Helper()
+	origID, origSet := descID, descSet
+	t.Cleanup(func() {
+		descID = origID
+		descSet = origSet
+		descriptionCmd.Flags().Lookup("set").Changed = false
+	})
+}
+
+func TestDescriptionCmd_MissingID(t *testing.T) {
+	resetDescriptionFlags(t)
+	descID = 0
+	err := descriptionCmd.RunE(descriptionCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id")
+}
+
+func TestDescriptionCmd_NoServer(t *testing.T) {
+	resetDescriptionFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	descID = 7
+	err := descriptionCmd.RunE(descriptionCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestDescriptionCmd_Show_Empty(t *testing.T) {
+	resetDescriptionFlags(t)
+	done := descriptionRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"Description":""}}`))
+	})
+	defer done()
+	descID = 7
+
+	out := captureStdoutForFolder(t, func() {
+		err := descriptionCmd.RunE(descriptionCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "(no description)")
+}
+
+func TestDescriptionCmd_Show_WithValue(t *testing.T) {
+	resetDescriptionFlags(t)
+	done := descriptionRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"Description":"prod DB"}}`))
+	})
+	defer done()
+	descID = 7
+
+	out := captureStdoutForFolder(t, func() {
+		err := descriptionCmd.RunE(descriptionCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "prod DB")
+}
+
+func TestDescriptionCmd_Show_FetchError(t *testing.T) {
+	resetDescriptionFlags(t)
+	done := descriptionRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer done()
+	descID = 7
+
+	err := descriptionCmd.RunE(descriptionCmd, nil)
+	require.Error(t, err)
+}
+
+func TestDescriptionCmd_Set_Success(t *testing.T) {
+	resetDescriptionFlags(t)
+	patched := false
+	done := descriptionRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPatch {
+			patched = true
+			_, _ = w.Write([]byte(`{"data":{}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"Description":"new note"}}`))
+	})
+	defer done()
+	descID = 7
+	require.NoError(t, descriptionCmd.Flags().Set("set", "new note"))
+
+	out := captureStdoutForFolder(t, func() {
+		err := descriptionCmd.RunE(descriptionCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.True(t, patched)
+	assert.Contains(t, out, "new note")
+}
+
+func TestDescriptionCmd_Set_PatchError(t *testing.T) {
+	resetDescriptionFlags(t)
+	done := descriptionRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer done()
+	descID = 7
+	require.NoError(t, descriptionCmd.Flags().Set("set", "new note"))
+
+	err := descriptionCmd.RunE(descriptionCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/expiring_rune_test.go
+++ b/internal/cli/secret/expiring_rune_test.go
@@ -1,0 +1,90 @@
+// expiring_rune_test.go — exercises expiringCmd.RunE directly
+// (expiring_remote_test.go only tests fetchExpiring).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func expiringRuneStub(t *testing.T, path, body string) func() {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == path {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	return srv.Close
+}
+
+func resetExpiringFlags(t *testing.T) {
+	t.Helper()
+	origProject, origDays := expiringProject, expiringDays
+	t.Cleanup(func() { expiringProject = origProject; expiringDays = origDays })
+}
+
+func TestExpiringCmd_MissingProject(t *testing.T) {
+	resetExpiringFlags(t)
+	expiringProject = 0
+	err := expiringCmd.RunE(expiringCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project")
+}
+
+func TestExpiringCmd_NoServer(t *testing.T) {
+	resetExpiringFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	expiringProject = 4
+	err := expiringCmd.RunE(expiringCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestExpiringCmd_Success_Empty(t *testing.T) {
+	resetExpiringFlags(t)
+	done := expiringRuneStub(t, "/api/v1/projects/4/secrets/expiring", `{"data":{"expiring":[]}}`)
+	defer done()
+	expiringProject = 4
+
+	out := captureStdoutForFolder(t, func() {
+		err := expiringCmd.RunE(expiringCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "No expiring secrets")
+}
+
+func TestExpiringCmd_Success_ExpiredAndExpiring(t *testing.T) {
+	resetExpiringFlags(t)
+	done := expiringRuneStub(t, "/api/v1/projects/4/secrets/expiring",
+		`{"data":{"expiring":[{"id":1,"name":"a","type":"generic","environment_id":1,"expiration":"2020-01-01","expired":true},{"id":2,"name":"b","type":"generic","environment_id":1,"expiration":"2030-01-01","expired":false}]}}`)
+	defer done()
+	expiringProject = 4
+	expiringDays = 30
+
+	out := captureStdoutForFolder(t, func() {
+		err := expiringCmd.RunE(expiringCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "EXPIRED")
+	assert.Contains(t, out, "expiring")
+}
+
+func TestExpiringCmd_FetchError(t *testing.T) {
+	resetExpiringFlags(t)
+	done := expiringRuneStub(t, "/nonexistent", `{}`)
+	defer done()
+	expiringProject = 4
+
+	err := expiringCmd.RunE(expiringCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/folder_test.go
+++ b/internal/cli/secret/folder_test.go
@@ -1,0 +1,543 @@
+// folder_test.go — CLI tests for `keyorix secret folder create` / `folder list`
+// (runFolderCreate, printFolder, runFolderList, printFolderList): remote mode via
+// httptest, embedded mode via a real InitializeCoreService-backed SQLite DB.
+package secret
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureStdoutForFolder redirects os.Stdout to a pipe for the duration of fn and
+// returns everything written to it.
+func captureStdoutForFolder(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	fn()
+
+	require.NoError(t, w.Close())
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	os.Stdout = orig
+	return buf.String()
+}
+
+func resetFolderCreateFlags(t *testing.T) {
+	t.Helper()
+	origName, origProject, origEnv, origParent := folderCreateName, folderCreateProject, folderCreateEnvID, folderCreateParent
+	t.Cleanup(func() {
+		folderCreateName = origName
+		folderCreateProject = origProject
+		folderCreateEnvID = origEnv
+		folderCreateParent = origParent
+	})
+}
+
+func resetFolderListFlags(t *testing.T) {
+	t.Helper()
+	origProject, origParent := folderListProject, folderListParent
+	t.Cleanup(func() {
+		folderListProject = origProject
+		folderListParent = origParent
+	})
+}
+
+// ── printFolder / printFolderList (direct) ──────────────────────────────────
+
+func TestPrintFolder_NoParent(t *testing.T) {
+	f := &models.SecretNode{ID: 5, Name: "configs", ProjectID: 1, EnvironmentID: 2}
+	out := captureStdoutForFolder(t, func() { printFolder(f) })
+	assert.Contains(t, out, "Folder created successfully!")
+	assert.Contains(t, out, "configs")
+	assert.NotContains(t, out, "Parent ID:")
+}
+
+func TestPrintFolder_WithParent(t *testing.T) {
+	parent := uint(9)
+	f := &models.SecretNode{ID: 6, Name: "nested/special chars äöü", ProjectID: 1, EnvironmentID: 2, ParentID: &parent}
+	out := captureStdoutForFolder(t, func() { printFolder(f) })
+	assert.Contains(t, out, "Parent ID:   9")
+	assert.Contains(t, out, "nested/special chars äöü")
+}
+
+func TestPrintFolderList_Empty(t *testing.T) {
+	out := captureStdoutForFolder(t, func() { printFolderList(nil) })
+	assert.Contains(t, out, "No folders found.")
+}
+
+func TestPrintFolderList_Many(t *testing.T) {
+	parent := uint(1)
+	folders := []*models.SecretNode{
+		{ID: 1, Name: "root-folder", ProjectID: 1, EnvironmentID: 1},
+		{ID: 2, Name: "nested", ProjectID: 1, EnvironmentID: 1, ParentID: &parent},
+	}
+	out := captureStdoutForFolder(t, func() { printFolderList(folders) })
+	assert.Contains(t, out, "root-folder")
+	assert.Contains(t, out, "nested")
+	assert.Contains(t, out, "-")
+}
+
+// ── runFolderCreate: validation ──────────────────────────────────────────────
+
+func TestRunFolderCreate_MissingName(t *testing.T) {
+	resetFolderCreateFlags(t)
+	folderCreateName = ""
+	err := runFolderCreate(folderCreateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--name")
+}
+
+// ── runFolderCreate: remote mode ─────────────────────────────────────────────
+
+func folderRemoteStub(t *testing.T, handler http.HandlerFunc) func() {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	return srv.Close
+}
+
+func TestRunFolderCreate_Remote_Success(t *testing.T) {
+	resetFolderCreateFlags(t)
+	done := folderRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/v1/folders", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":10,"name":"configs","project_id":1,"environment_id":1}}`))
+	})
+	defer done()
+
+	folderCreateName = "configs"
+	folderCreateProject = 1
+	folderCreateEnvID = 1
+	folderCreateParent = 0
+
+	out := captureStdoutForFolder(t, func() {
+		err := runFolderCreate(folderCreateCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "configs")
+}
+
+func TestRunFolderCreate_Remote_WithParent_SendsParentID(t *testing.T) {
+	resetFolderCreateFlags(t)
+	var capturedBody map[string]interface{}
+	done := folderRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &capturedBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":11,"name":"nested","project_id":1,"environment_id":1,"parent_id":9}}`))
+	})
+	defer done()
+
+	folderCreateName = "nested"
+	folderCreateProject = 1
+	folderCreateEnvID = 1
+	folderCreateParent = 9
+
+	err := runFolderCreate(folderCreateCmd, nil)
+	require.NoError(t, err)
+	assert.Equal(t, float64(9), capturedBody["parent_id"])
+}
+
+func TestRunFolderCreate_Remote_APIError(t *testing.T) {
+	resetFolderCreateFlags(t)
+	done := folderRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer done()
+
+	folderCreateName = "configs"
+	folderCreateProject = 1
+	folderCreateEnvID = 1
+
+	err := runFolderCreate(folderCreateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create folder")
+}
+
+// ── runFolderList: remote mode ───────────────────────────────────────────────
+
+func TestRunFolderList_Remote_Empty(t *testing.T) {
+	resetFolderListFlags(t)
+	done := folderRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	defer done()
+
+	folderListProject = 0
+	folderListParent = 0
+
+	out := captureStdoutForFolder(t, func() {
+		err := runFolderList(folderListCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "No folders found.")
+}
+
+func TestRunFolderList_Remote_WithFilters(t *testing.T) {
+	resetFolderListFlags(t)
+	var gotQuery string
+	done := folderRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1,"name":"a","project_id":3,"environment_id":1},{"id":2,"name":"b","project_id":3,"environment_id":1}]}`))
+	})
+	defer done()
+
+	folderListProject = 3
+	folderListParent = 5
+
+	out := captureStdoutForFolder(t, func() {
+		err := runFolderList(folderListCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, gotQuery, "project_id=3")
+	assert.Contains(t, gotQuery, "parent_id=5")
+	assert.Contains(t, out, "a")
+	assert.Contains(t, out, "b")
+}
+
+func TestRunFolderList_Remote_APIError(t *testing.T) {
+	resetFolderListFlags(t)
+	done := folderRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer done()
+
+	err := runFolderList(folderListCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list folders")
+}
+
+// ── embedded mode ─────────────────────────────────────────────────────────────
+
+// folderEmbeddedEnv points InitializeCoreService at a fresh temp SQLite DB and
+// clears any remote-mode env vars so common.NewRemoteClient() returns !ok.
+func folderEmbeddedEnv(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	dbPath := filepath.Join(dir, "folder_embedded.db")
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`storage:
+  type: local
+  database:
+    path: "`+dbPath+`"
+locale:
+  language: "en"
+  fallback_language: "en"
+`), 0600))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Chdir(dir)
+}
+
+func TestRunFolderCreate_Embedded_Success(t *testing.T) {
+	folderEmbeddedEnv(t)
+	resetFolderCreateFlags(t)
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	proj, err := svc.CreateProject(context.Background(), "embed-proj", "")
+	require.NoError(t, err)
+	env, err := svc.CreateEnvironment(context.Background(), proj.ID, "prod")
+	require.NoError(t, err)
+
+	folderCreateName = "embedded-folder"
+	folderCreateProject = proj.ID
+	folderCreateEnvID = env.ID
+	folderCreateParent = 0
+
+	out := captureStdoutForFolder(t, func() {
+		err := runFolderCreate(folderCreateCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "embedded-folder")
+}
+
+func TestRunFolderCreate_Embedded_WithParent(t *testing.T) {
+	folderEmbeddedEnv(t)
+	resetFolderCreateFlags(t)
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	proj, err := svc.CreateProject(context.Background(), "embed-proj2", "")
+	require.NoError(t, err)
+	env, err := svc.CreateEnvironment(context.Background(), proj.ID, "prod")
+	require.NoError(t, err)
+	parent, err := svc.CreateFolder(context.Background(), 0, "parent-folder", proj.ID, env.ID, nil)
+	require.NoError(t, err)
+
+	folderCreateName = "child-folder"
+	folderCreateProject = proj.ID
+	folderCreateEnvID = env.ID
+	folderCreateParent = parent.ID
+
+	out := captureStdoutForFolder(t, func() {
+		err := runFolderCreate(folderCreateCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "child-folder")
+	assert.Contains(t, out, "Parent ID:")
+}
+
+// TestRunFolderCreate_Embedded_DuplicateName exercises the CreateFolder conflict
+// path: folders share secret_nodes' (project, environment, name) unique index, so
+// creating the same name twice in the same project/environment must fail on the
+// second attempt rather than silently succeeding.
+func TestRunFolderCreate_Embedded_DuplicateName(t *testing.T) {
+	folderEmbeddedEnv(t)
+	resetFolderCreateFlags(t)
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	proj, err := svc.CreateProject(context.Background(), "embed-proj3", "")
+	require.NoError(t, err)
+	env, err := svc.CreateEnvironment(context.Background(), proj.ID, "prod")
+	require.NoError(t, err)
+
+	folderCreateName = "dup-folder"
+	folderCreateProject = proj.ID
+	folderCreateEnvID = env.ID
+
+	err = runFolderCreate(folderCreateCmd, nil)
+	require.NoError(t, err, "first create should succeed")
+
+	err = runFolderCreate(folderCreateCmd, nil)
+	require.Error(t, err, "creating a folder with an already-existing name in the same project/environment must fail")
+}
+
+func TestRunFolderCreate_Embedded_InitError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "")
+	resetFolderCreateFlags(t)
+
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`storage:
+  type: local
+  database:
+    path: "`+dir+`/folder_init_err.db"
+  encryption:
+    enabled: true
+    dek_path: "dek.json"
+    salt_path: "salt.bin"
+locale:
+  language: "en"
+  fallback_language: "en"
+`), 0600))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Chdir(dir)
+
+	folderCreateName = "whatever"
+	folderCreateProject = 1
+	folderCreateEnvID = 1
+
+	err := runFolderCreate(folderCreateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunFolderList_Embedded_EmptyAndPopulated(t *testing.T) {
+	folderEmbeddedEnv(t)
+	resetFolderListFlags(t)
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	proj, err := svc.CreateProject(context.Background(), "embed-list-proj", "")
+	require.NoError(t, err)
+	env, err := svc.CreateEnvironment(context.Background(), proj.ID, "prod")
+	require.NoError(t, err)
+
+	folderListProject = proj.ID
+	folderListParent = 0
+
+	out := captureStdoutForFolder(t, func() {
+		err := runFolderList(folderListCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "No folders found.")
+
+	_, err = svc.CreateFolder(context.Background(), 0, "embed-listed-folder", proj.ID, env.ID, nil)
+	require.NoError(t, err)
+
+	out = captureStdoutForFolder(t, func() {
+		err := runFolderList(folderListCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "embed-listed-folder")
+}
+
+func TestRunFolderList_Embedded_InitError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "")
+	resetFolderListFlags(t)
+
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`storage:
+  type: local
+  database:
+    path: "`+dir+`/folder_list_init_err.db"
+  encryption:
+    enabled: true
+    dek_path: "dek.json"
+    salt_path: "salt.bin"
+locale:
+  language: "en"
+  fallback_language: "en"
+`), 0600))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Chdir(dir)
+
+	err := runFolderList(folderListCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+// ── runFolderDelete: embedded mode ───────────────────────────────────────────
+
+func TestRunFolderDelete_Embedded_Force(t *testing.T) {
+	folderEmbeddedEnv(t)
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	proj, err := svc.CreateProject(context.Background(), "embed-del-proj", "")
+	require.NoError(t, err)
+	env, err := svc.CreateEnvironment(context.Background(), proj.ID, "prod")
+	require.NoError(t, err)
+	folder, err := svc.CreateFolder(context.Background(), 0, "to-delete", proj.ID, env.ID, nil)
+	require.NoError(t, err)
+
+	origID, origForce := folderDeleteID, folderDeleteForce
+	t.Cleanup(func() { folderDeleteID = origID; folderDeleteForce = origForce })
+	folderDeleteID = folder.ID
+	folderDeleteForce = true
+
+	out := captureStdoutForFolder(t, func() {
+		err := runFolderDelete(folderDeleteCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "deleted")
+}
+
+func TestRunFolderDelete_MissingID(t *testing.T) {
+	origID := folderDeleteID
+	t.Cleanup(func() { folderDeleteID = origID })
+	folderDeleteID = 0
+
+	err := runFolderDelete(folderDeleteCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id")
+}
+
+func TestRunFolderDelete_Remote_APIError(t *testing.T) {
+	done := folderRemoteStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer done()
+
+	origID, origForce := folderDeleteID, folderDeleteForce
+	t.Cleanup(func() { folderDeleteID = origID; folderDeleteForce = origForce })
+	folderDeleteID = 123
+	folderDeleteForce = true
+
+	err := runFolderDelete(folderDeleteCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete folder")
+}
+
+func TestRunFolderDelete_Embedded_InitError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	t.Setenv("KEYORIX_MASTER_PASSWORD", "")
+
+	cfgPath := filepath.Join(dir, "keyorix.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`storage:
+  type: local
+  database:
+    path: "`+dir+`/folder_delete_init_err.db"
+  encryption:
+    enabled: true
+    dek_path: "dek.json"
+    salt_path: "salt.bin"
+locale:
+  language: "en"
+  fallback_language: "en"
+`), 0600))
+	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
+	t.Chdir(dir)
+
+	origID, origForce := folderDeleteID, folderDeleteForce
+	t.Cleanup(func() { folderDeleteID = origID; folderDeleteForce = origForce })
+	folderDeleteID = 1
+	folderDeleteForce = true
+
+	err := runFolderDelete(folderDeleteCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to initialize service")
+}
+
+func TestRunFolderList_Embedded_WithParentFilter(t *testing.T) {
+	folderEmbeddedEnv(t)
+	resetFolderListFlags(t)
+
+	svc, err := common.InitializeCoreService()
+	require.NoError(t, err)
+	proj, err := svc.CreateProject(context.Background(), "embed-parent-filter-proj", "")
+	require.NoError(t, err)
+	env, err := svc.CreateEnvironment(context.Background(), proj.ID, "prod")
+	require.NoError(t, err)
+	parent, err := svc.CreateFolder(context.Background(), 0, "parent", proj.ID, env.ID, nil)
+	require.NoError(t, err)
+	_, err = svc.CreateFolder(context.Background(), 0, "child", proj.ID, env.ID, &parent.ID)
+	require.NoError(t, err)
+
+	folderListProject = proj.ID
+	folderListParent = parent.ID
+
+	out := captureStdoutForFolder(t, func() {
+		err := runFolderList(folderListCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "child")
+}
+
+func TestRunFolderDelete_Embedded_NotFound(t *testing.T) {
+	folderEmbeddedEnv(t)
+
+	_, err := common.InitializeCoreService()
+	require.NoError(t, err)
+
+	origID, origForce := folderDeleteID, folderDeleteForce
+	t.Cleanup(func() { folderDeleteID = origID; folderDeleteForce = origForce })
+	folderDeleteID = 999999
+	folderDeleteForce = true
+
+	err = runFolderDelete(folderDeleteCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete folder")
+}

--- a/internal/cli/secret/info_rune_test.go
+++ b/internal/cli/secret/info_rune_test.go
@@ -1,0 +1,94 @@
+// info_rune_test.go — exercises infoCmd.RunE directly (info_remote_test.go only
+// tests fetchInfo and the orDefault/boolWord helpers).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetInfoFlags(t *testing.T) {
+	t.Helper()
+	orig := infoID
+	t.Cleanup(func() { infoID = orig })
+}
+
+func TestInfoCmd_MissingID(t *testing.T) {
+	resetInfoFlags(t)
+	infoID = 0
+	err := infoCmd.RunE(infoCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id")
+}
+
+func TestInfoCmd_NoServer(t *testing.T) {
+	resetInfoFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	infoID = 7
+	err := infoCmd.RunE(infoCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestInfoCmd_Success_FullFields(t *testing.T) {
+	resetInfoFlags(t)
+	_, done := infoStub(t)
+	defer done()
+	infoID = 7
+
+	out := captureStdoutForFolder(t, func() {
+		err := infoCmd.RunE(infoCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "Secret 7: db")
+	assert.Contains(t, out, "confidential")
+	assert.Contains(t, out, "user #3")
+	assert.Contains(t, out, "yes")
+	assert.Contains(t, out, "alice")
+	assert.Contains(t, out, "prod, tier1")
+	assert.Contains(t, out, "prod DB")
+}
+
+func TestInfoCmd_Success_TagsFetchFails_BestEffort(t *testing.T) {
+	resetInfoFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/secrets/7" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"ID":7,"Name":"db","Type":"password"}}`))
+			return
+		}
+		// /api/v1/secrets/7/tags errors — must not fail the whole summary.
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+	_ = rc
+	infoID = 7
+
+	out := captureStdoutForFolder(t, func() {
+		err := infoCmd.RunE(infoCmd, nil)
+		require.NoError(t, err, "a failed best-effort tags fetch must not fail the summary")
+	})
+	assert.Contains(t, out, "Secret 7: db")
+	assert.Contains(t, out, "unclassified")
+	assert.Contains(t, out, "—")
+}
+
+func TestInfoCmd_FetchInfoError(t *testing.T) {
+	resetInfoFlags(t)
+	_, done := infoStub(t)
+	defer done()
+	infoID = 999
+
+	err := infoCmd.RunE(infoCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/name_conformance_rune_test.go
+++ b/internal/cli/secret/name_conformance_rune_test.go
@@ -1,0 +1,110 @@
+// name_conformance_rune_test.go — exercises nameConformanceCmd.RunE directly
+// (name_conformance_remote_test.go only tests the fetch helpers).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func nameConformanceRuneStub(t *testing.T, path, body string) func() {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == path {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	return srv.Close
+}
+
+func resetNameConformanceFlags(t *testing.T) {
+	t.Helper()
+	orig := nameConformanceProject
+	t.Cleanup(func() { nameConformanceProject = orig })
+}
+
+func TestNameConformanceCmd_NoServer(t *testing.T) {
+	resetNameConformanceFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := nameConformanceCmd.RunE(nameConformanceCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestNameConformanceCmd_ProjectScoped_PolicyDisabled(t *testing.T) {
+	resetNameConformanceFlags(t)
+	done := nameConformanceRuneStub(t, "/api/v1/projects/4/secrets/name-conformance", `{"data":{"policy_enabled":false}}`)
+	defer done()
+	nameConformanceProject = 4
+
+	out := captureStdoutForFolder(t, func() {
+		err := nameConformanceCmd.RunE(nameConformanceCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "No secret naming policy")
+}
+
+func TestNameConformanceCmd_ProjectScoped_NoViolations(t *testing.T) {
+	resetNameConformanceFlags(t)
+	done := nameConformanceRuneStub(t, "/api/v1/projects/4/secrets/name-conformance", `{"data":{"policy_enabled":true,"total_secrets":5,"violations":[]}}`)
+	defer done()
+	nameConformanceProject = 4
+
+	out := captureStdoutForFolder(t, func() {
+		err := nameConformanceCmd.RunE(nameConformanceCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "All 5 secret(s) conform")
+}
+
+func TestNameConformanceCmd_ProjectScoped_WithViolations(t *testing.T) {
+	resetNameConformanceFlags(t)
+	done := nameConformanceRuneStub(t, "/api/v1/projects/4/secrets/name-conformance",
+		`{"data":{"policy_enabled":true,"total_secrets":3,"violations":[{"id":8,"name":"db-pass","type":"password","environment_id":2,"reason":"bad pattern"}]}}`)
+	defer done()
+	nameConformanceProject = 4
+
+	out := captureStdoutForFolder(t, func() {
+		err := nameConformanceCmd.RunE(nameConformanceCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "1 of 3 secret(s) violate")
+	assert.Contains(t, out, "db-pass")
+	assert.NotContains(t, out, "PROJECT")
+}
+
+func TestNameConformanceCmd_OrgWide_WithViolations(t *testing.T) {
+	resetNameConformanceFlags(t)
+	done := nameConformanceRuneStub(t, "/api/v1/secrets/name-conformance",
+		`{"data":{"policy_enabled":true,"total_secrets":10,"violations":[{"id":8,"name":"db-pass","type":"password","environment_id":2,"reason":"bad pattern","project_name":"alpha"}]}}`)
+	defer done()
+	nameConformanceProject = 0
+
+	out := captureStdoutForFolder(t, func() {
+		err := nameConformanceCmd.RunE(nameConformanceCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "PROJECT")
+	assert.Contains(t, out, "alpha")
+	assert.Contains(t, out, "db-pass")
+}
+
+func TestNameConformanceCmd_FetchError(t *testing.T) {
+	resetNameConformanceFlags(t)
+	done := nameConformanceRuneStub(t, "/nonexistent", `{}`)
+	defer done()
+	nameConformanceProject = 4
+
+	err := nameConformanceCmd.RunE(nameConformanceCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/orphaned_rune_test.go
+++ b/internal/cli/secret/orphaned_rune_test.go
@@ -1,0 +1,86 @@
+// orphaned_rune_test.go — exercises orphanedCmd.RunE directly
+// (orphaned_remote_test.go only tests fetchOrphaned).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetOrphanedFlags(t *testing.T) {
+	t.Helper()
+	orig := orphanedProject
+	t.Cleanup(func() { orphanedProject = orig })
+}
+
+func TestOrphanedCmd_MissingProject(t *testing.T) {
+	resetOrphanedFlags(t)
+	orphanedProject = 0
+	err := orphanedCmd.RunE(orphanedCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project")
+}
+
+func TestOrphanedCmd_NoServer(t *testing.T) {
+	resetOrphanedFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	orphanedProject = 4
+	err := orphanedCmd.RunE(orphanedCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestOrphanedCmd_Success_Empty(t *testing.T) {
+	resetOrphanedFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"orphaned":[]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	orphanedProject = 4
+
+	out := captureStdoutForFolder(t, func() {
+		err := orphanedCmd.RunE(orphanedCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "No orphaned secrets")
+}
+
+func TestOrphanedCmd_Success_WithRows(t *testing.T) {
+	resetOrphanedFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"orphaned":[{"id":1,"name":"stray","type":"generic","classification":"internal","owner_id":99}]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	orphanedProject = 4
+
+	out := captureStdoutForFolder(t, func() {
+		err := orphanedCmd.RunE(orphanedCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "stray")
+}
+
+func TestOrphanedCmd_FetchError(t *testing.T) {
+	resetOrphanedFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	orphanedProject = 4
+
+	err := orphanedCmd.RunE(orphanedCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/quota_rune_test.go
+++ b/internal/cli/secret/quota_rune_test.go
@@ -1,0 +1,69 @@
+// quota_rune_test.go — exercises quotaReportCmd.RunE directly.
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func quotaRuneStub(t *testing.T, body string) func() {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/secrets/quota-report" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	return srv.Close
+}
+
+func TestQuotaReportCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := quotaReportCmd.RunE(quotaReportCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestQuotaReportCmd_Success_Empty(t *testing.T) {
+	done := quotaRuneStub(t, `{"data":{"secrets":[]}}`)
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := quotaReportCmd.RunE(quotaReportCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "No secrets with a read quota")
+}
+
+func TestQuotaReportCmd_Success_WithRows(t *testing.T) {
+	done := quotaRuneStub(t, `{"data":{"secrets":[{"secret_id":1,"secret_name":"db-pw","read_count":90,"max_reads":100,"usage_pct":90,"status":"warning"}]}}`)
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := quotaReportCmd.RunE(quotaReportCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "db-pw")
+	assert.Contains(t, out, "warning")
+}
+
+func TestQuotaReportCmd_FetchError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	err := quotaReportCmd.RunE(quotaReportCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/reassign_owner_rune_test.go
+++ b/internal/cli/secret/reassign_owner_rune_test.go
@@ -1,0 +1,73 @@
+// reassign_owner_rune_test.go — exercises reassignOwnerCmd.RunE directly
+// (reassign_owner_remote_test.go only tests reassignOwner).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetReassignOwnerFlags(t *testing.T) {
+	t.Helper()
+	origProject, origFrom, origTo := reassignProject, reassignFrom, reassignTo
+	t.Cleanup(func() {
+		reassignProject = origProject
+		reassignFrom = origFrom
+		reassignTo = origTo
+	})
+}
+
+func TestReassignOwnerCmd_MissingFlags(t *testing.T) {
+	resetReassignOwnerFlags(t)
+	reassignProject, reassignFrom, reassignTo = 0, 0, 0
+	err := reassignOwnerCmd.RunE(reassignOwnerCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project")
+}
+
+func TestReassignOwnerCmd_NoServer(t *testing.T) {
+	resetReassignOwnerFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	reassignProject, reassignFrom, reassignTo = 1, 2, 3
+	err := reassignOwnerCmd.RunE(reassignOwnerCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestReassignOwnerCmd_Success(t *testing.T) {
+	resetReassignOwnerFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/projects/1/secrets/reassign-owner", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"reassigned":4}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	reassignProject, reassignFrom, reassignTo = 1, 2, 3
+
+	out := captureStdoutForFolder(t, func() {
+		err := reassignOwnerCmd.RunE(reassignOwnerCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "Reassigned 4 secret(s)")
+}
+
+func TestReassignOwnerCmd_APIError(t *testing.T) {
+	resetReassignOwnerFlags(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	reassignProject, reassignFrom, reassignTo = 1, 2, 3
+
+	err := reassignOwnerCmd.RunE(reassignOwnerCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/recycle_rune_test.go
+++ b/internal/cli/secret/recycle_rune_test.go
@@ -1,0 +1,145 @@
+// recycle_rune_test.go — exercises trashCmd.RunE and restoreCmd.RunE directly
+// (recycle_remote_test.go only tests fetchTrash/restoreSecret).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func recycleRuneStub(t *testing.T, handler http.HandlerFunc) func() {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	return srv.Close
+}
+
+func resetTrashFlags(t *testing.T) {
+	t.Helper()
+	origProject, origLimit := trashProject, trashLimit
+	t.Cleanup(func() { trashProject = origProject; trashLimit = origLimit })
+}
+
+func resetRestoreFlags(t *testing.T) {
+	t.Helper()
+	orig := restoreID
+	t.Cleanup(func() { restoreID = orig })
+}
+
+func TestTrashCmd_MissingProject(t *testing.T) {
+	resetTrashFlags(t)
+	trashProject = 0
+	err := trashCmd.RunE(trashCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--project")
+}
+
+func TestTrashCmd_NoServer(t *testing.T) {
+	resetTrashFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	trashProject = 4
+	err := trashCmd.RunE(trashCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestTrashCmd_Success_Empty(t *testing.T) {
+	resetTrashFlags(t)
+	done := recycleRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"deleted":[]}}`))
+	})
+	defer done()
+	trashProject = 4
+
+	out := captureStdoutForFolder(t, func() {
+		err := trashCmd.RunE(trashCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "Recycle bin is empty")
+}
+
+func TestTrashCmd_Success_WithLimitAndRows(t *testing.T) {
+	resetTrashFlags(t)
+	var gotQuery string
+	done := recycleRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"deleted":[{"id":1,"name":"gone","type":"generic","classification":"internal","deleted_at":"2026-01-01"}]}}`))
+	})
+	defer done()
+	trashProject = 4
+	trashLimit = 10
+
+	out := captureStdoutForFolder(t, func() {
+		err := trashCmd.RunE(trashCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, gotQuery, "limit=10")
+	assert.Contains(t, out, "gone")
+}
+
+func TestTrashCmd_FetchError(t *testing.T) {
+	resetTrashFlags(t)
+	done := recycleRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer done()
+	trashProject = 4
+
+	err := trashCmd.RunE(trashCmd, nil)
+	require.Error(t, err)
+}
+
+func TestRestoreCmd_MissingID(t *testing.T) {
+	resetRestoreFlags(t)
+	restoreID = 0
+	err := restoreCmd.RunE(restoreCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id")
+}
+
+func TestRestoreCmd_NoServer(t *testing.T) {
+	resetRestoreFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	restoreID = 5
+	err := restoreCmd.RunE(restoreCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestRestoreCmd_Success(t *testing.T) {
+	resetRestoreFlags(t)
+	done := recycleRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/secrets/5/restore", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":5,"restored":true}}`))
+	})
+	defer done()
+	restoreID = 5
+
+	out := captureStdoutForFolder(t, func() {
+		err := restoreCmd.RunE(restoreCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "restored")
+}
+
+func TestRestoreCmd_APIError(t *testing.T) {
+	resetRestoreFlags(t)
+	done := recycleRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer done()
+	restoreID = 5
+
+	err := restoreCmd.RunE(restoreCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/rotate_success_test.go
+++ b/internal/cli/secret/rotate_success_test.go
@@ -36,8 +36,8 @@ func TestRunRotate_RotateRequestError(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.Method == http.MethodGet:
+		switch r.Method {
+		case http.MethodGet:
 			_, _ = w.Write([]byte(`{"data":{"secrets":[{"ID":9,"Name":"db-password"}]}}`))
 		default:
 			http.Error(w, "boom", http.StatusInternalServerError)

--- a/internal/cli/secret/rotate_success_test.go
+++ b/internal/cli/secret/rotate_success_test.go
@@ -1,0 +1,53 @@
+// rotate_success_test.go — exercises runRotate's full remote success path and
+// the "secret not found" branch; rotate_test.go only covers the value-flag
+// warning, the no-terminal prompt failure, and the hung-server timeout.
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunRotate_ListSecretsError(t *testing.T) {
+	isolateCLIConfig(t)
+	resetRotateFlags(t)
+	require.NoError(t, rotateCmd.Flags().Set("value", "new-value"))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	err := runRotate(rotateCmd, []string{"db-password"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list secrets")
+}
+
+func TestRunRotate_RotateRequestError(t *testing.T) {
+	isolateCLIConfig(t)
+	resetRotateFlags(t)
+	require.NoError(t, rotateCmd.Flags().Set("value", "new-value"))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"data":{"secrets":[{"ID":9,"Name":"db-password"}]}}`))
+		default:
+			http.Error(w, "boom", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	err := runRotate(rotateCmd, []string{"db-password"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rotate request failed")
+}

--- a/internal/cli/secret/schedule_success_test.go
+++ b/internal/cli/secret/schedule_success_test.go
@@ -1,0 +1,102 @@
+// schedule_success_test.go — exercises the setScheduleCmd/getScheduleCmd/
+// clearScheduleCmd RunE closures on the success path (schedule_rune_test.go only
+// covers early error returns before any network call).
+package secret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetScheduleCmd_Success(t *testing.T) {
+	_, done := scheduleStub(t)
+	defer done()
+
+	schedDays = "mon,fri"
+	schedStartHour = 9
+	schedEndHour = 17
+	schedTimezone = ""
+
+	out := captureStdoutForFolder(t, func() {
+		err := setScheduleCmd.RunE(setScheduleCmd, []string{"42"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "Schedule set")
+}
+
+func TestSetScheduleCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	schedDays = "mon,fri"
+	schedStartHour = 9
+	schedEndHour = 17
+	err := setScheduleCmd.RunE(setScheduleCmd, []string{"42"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestSetScheduleCmd_APIError(t *testing.T) {
+	_, done := scheduleStub(t)
+	defer done()
+
+	schedDays = "mon,fri"
+	schedStartHour = 9
+	schedEndHour = 17
+	err := setScheduleCmd.RunE(setScheduleCmd, []string{"999"})
+	require.Error(t, err)
+}
+
+func TestGetScheduleCmd_Success(t *testing.T) {
+	_, done := scheduleStub(t)
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := getScheduleCmd.RunE(getScheduleCmd, []string{"42"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "schedule:")
+	assert.Contains(t, out, "UTC")
+}
+
+func TestGetScheduleCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := getScheduleCmd.RunE(getScheduleCmd, []string{"42"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestGetScheduleCmd_APIError(t *testing.T) {
+	_, done := scheduleStub(t)
+	defer done()
+	err := getScheduleCmd.RunE(getScheduleCmd, []string{"999"})
+	require.Error(t, err)
+}
+
+func TestClearScheduleCmd_Success(t *testing.T) {
+	_, done := scheduleStub(t)
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := clearScheduleCmd.RunE(clearScheduleCmd, []string{"42"})
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "Schedule cleared")
+}
+
+func TestClearScheduleCmd_NoServer(t *testing.T) {
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	err := clearScheduleCmd.RunE(clearScheduleCmd, []string{"42"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestClearScheduleCmd_APIError(t *testing.T) {
+	_, done := scheduleStub(t)
+	defer done()
+	err := clearScheduleCmd.RunE(clearScheduleCmd, []string{"999"})
+	require.Error(t, err)
+}

--- a/internal/cli/secret/suspend_rune_test.go
+++ b/internal/cli/secret/suspend_rune_test.go
@@ -1,0 +1,90 @@
+// suspend_rune_test.go — exercises suspendCmd.RunE and resumeCmd.RunE directly
+// (suspend_remote_test.go only calls runSuspendRemote/runResumeRemote directly).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSuspendCmd_MissingID(t *testing.T) {
+	origID := suspendID
+	t.Cleanup(func() { suspendID = origID })
+	suspendID = 0
+	err := suspendCmd.RunE(suspendCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id")
+}
+
+func TestSuspendCmd_NoServer(t *testing.T) {
+	origID := suspendID
+	t.Cleanup(func() { suspendID = origID })
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	suspendID = 42
+	err := suspendCmd.RunE(suspendCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestSuspendCmd_Success(t *testing.T) {
+	origID := suspendID
+	t.Cleanup(func() { suspendID = origID })
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	suspendID = 42
+
+	out := captureStdoutForFolder(t, func() {
+		err := suspendCmd.RunE(suspendCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "suspended")
+}
+
+func TestResumeCmd_MissingID(t *testing.T) {
+	origID := resumeID
+	t.Cleanup(func() { resumeID = origID })
+	resumeID = 0
+	err := resumeCmd.RunE(resumeCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id")
+}
+
+func TestResumeCmd_NoServer(t *testing.T) {
+	origID := resumeID
+	t.Cleanup(func() { resumeID = origID })
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	resumeID = 42
+	err := resumeCmd.RunE(resumeCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestResumeCmd_Success(t *testing.T) {
+	origID := resumeID
+	t.Cleanup(func() { resumeID = origID })
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	resumeID = 42
+
+	out := captureStdoutForFolder(t, func() {
+		err := resumeCmd.RunE(resumeCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "resumed")
+}

--- a/internal/cli/secret/tags_rune_test.go
+++ b/internal/cli/secret/tags_rune_test.go
@@ -1,0 +1,125 @@
+// tags_rune_test.go — exercises tagsCmd.RunE directly
+// (tags_remote_test.go only tests getSecretTags/setSecretTags/splitTags).
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func tagsRuneStub(t *testing.T, handler http.HandlerFunc) func() {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	return srv.Close
+}
+
+func resetTagsFlags(t *testing.T) {
+	t.Helper()
+	origID, origSet := tagsID, tagsSet
+	t.Cleanup(func() {
+		tagsID = origID
+		tagsSet = origSet
+		tagsCmd.Flags().Lookup("set").Changed = false
+	})
+}
+
+func TestTagsCmd_MissingID(t *testing.T) {
+	resetTagsFlags(t)
+	tagsID = 0
+	err := tagsCmd.RunE(tagsCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--id")
+}
+
+func TestTagsCmd_NoServer(t *testing.T) {
+	resetTagsFlags(t)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	tagsID = 7
+	err := tagsCmd.RunE(tagsCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+func TestTagsCmd_List_Empty(t *testing.T) {
+	resetTagsFlags(t)
+	done := tagsRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"tags":[]}}`))
+	})
+	defer done()
+	tagsID = 7
+
+	out := captureStdoutForFolder(t, func() {
+		err := tagsCmd.RunE(tagsCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "(no tags)")
+}
+
+func TestTagsCmd_List_WithTags(t *testing.T) {
+	resetTagsFlags(t)
+	done := tagsRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"tags":["prod","tier1"]}}`))
+	})
+	defer done()
+	tagsID = 7
+
+	out := captureStdoutForFolder(t, func() {
+		err := tagsCmd.RunE(tagsCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "prod, tier1")
+}
+
+func TestTagsCmd_List_FetchError(t *testing.T) {
+	resetTagsFlags(t)
+	done := tagsRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer done()
+	tagsID = 7
+
+	err := tagsCmd.RunE(tagsCmd, nil)
+	require.Error(t, err)
+}
+
+func TestTagsCmd_Set_Success(t *testing.T) {
+	resetTagsFlags(t)
+	done := tagsRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"tags":["new"]}}`))
+	})
+	defer done()
+	tagsID = 7
+	tagsSet = "new"
+	require.NoError(t, tagsCmd.Flags().Set("set", "new"))
+
+	out := captureStdoutForFolder(t, func() {
+		err := tagsCmd.RunE(tagsCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "new")
+}
+
+func TestTagsCmd_Set_Error(t *testing.T) {
+	resetTagsFlags(t)
+	done := tagsRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	defer done()
+	tagsID = 7
+	require.NoError(t, tagsCmd.Flags().Set("set", "new"))
+
+	err := tagsCmd.RunE(tagsCmd, nil)
+	require.Error(t, err)
+}

--- a/internal/cli/secret/templates_rune_test.go
+++ b/internal/cli/secret/templates_rune_test.go
@@ -1,0 +1,78 @@
+// templates_rune_test.go — covers the connected success-path line in each
+// template RunE closure (the `return runTemplateXxx(...)` call itself), which
+// templates_test.go never reaches: it tests runTemplateList/Get/Create/Delete
+// directly and only drives the RunE closures down the NoServer/validation
+// error branches, never through to a live stub server.
+package secret
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func templatesRuneStub(t *testing.T, handler http.HandlerFunc) func() {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+	return srv.Close
+}
+
+func TestTemplateListCmd_Success(t *testing.T) {
+	done := templatesRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"templates":[]}}`))
+	})
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := templateListCmd.RunE(templateListCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "No templates found")
+}
+
+func TestTemplateGetCmd_Success(t *testing.T) {
+	done := templatesRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"templates":[]}}`))
+	})
+	defer done()
+
+	err := templateGetCmd.RunE(templateGetCmd, []string{"missing"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestTemplateCreateCmd_Success(t *testing.T) {
+	origName := tmplName
+	t.Cleanup(func() { tmplName = origName })
+	tmplName = "my-template"
+	done := templatesRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":1,"name":"my-template"}}`))
+	})
+	defer done()
+
+	out := captureStdoutForFolder(t, func() {
+		err := templateCreateCmd.RunE(templateCreateCmd, nil)
+		require.NoError(t, err)
+	})
+	assert.Contains(t, out, "my-template")
+}
+
+func TestTemplateDeleteCmd_Success(t *testing.T) {
+	done := templatesRuneStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"templates":[]}}`))
+	})
+	defer done()
+
+	err := templateDeleteCmd.RunE(templateDeleteCmd, []string{"missing"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/cli/share/share_remote_test.go
+++ b/internal/cli/share/share_remote_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/stretchr/testify/assert"
@@ -185,4 +186,134 @@ func TestRunUpdate_ClearExpiryWithTTL(t *testing.T) {
 	err := runUpdate(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--clear-expiry cannot be combined")
+}
+
+func TestRunRevokeRemote_Success(t *testing.T) {
+	var gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runRevokeRemote(rc, 42))
+	assert.Equal(t, "/api/v1/shares/42", gotPath)
+	assert.Equal(t, "DELETE", gotMethod)
+}
+
+func TestRunRevokeRemote_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	err := runRevokeRemote(rc, 42)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to revoke share")
+}
+
+func TestRunUpdateRemote_Success(t *testing.T) {
+	var gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_, _ = w.Write([]byte(`{"data":{
+			"ID":42,"SecretID":7,"OwnerID":1,"RecipientID":5,"IsGroup":false,"Permission":"write",
+			"CreatedAt":"2026-06-08T10:00:00Z","ExpiresAt":"2027-06-08T10:00:00Z"
+		}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	expires := time.Date(2027, 6, 8, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, runUpdateRemote(rc, 42, "write", &expires, false))
+	assert.Equal(t, "/api/v1/shares/42", gotPath)
+	assert.Equal(t, "PUT", gotMethod)
+}
+
+func TestRunUpdateRemote_ClearExpiry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{
+			"ID":42,"SecretID":7,"OwnerID":1,"RecipientID":5,"IsGroup":false,"Permission":"read",
+			"CreatedAt":"2026-06-08T10:00:00Z"
+		}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	require.NoError(t, runUpdateRemote(rc, 42, "read", nil, true))
+}
+
+func TestRunUpdateRemote_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	err := runUpdateRemote(rc, 42, "write", nil, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update share permission")
+}
+
+// TestRunRevoke_Remote_RoutesThroughRemoteClient and
+// TestRunUpdate_Remote_RoutesThroughRemoteClient confirm the cobra-level
+// runRevoke/runUpdate dispatch to the remote client when connected, matching
+// the sibling *_Remote_RoutesThroughRemoteClient tests for list/group-shares.
+func TestRunRevoke_Remote_RoutesThroughRemoteClient(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origID := revokeShareID
+	defer func() { revokeShareID = origID }()
+	revokeShareID = 13
+
+	require.NoError(t, runRevoke(nil, nil))
+	assert.Equal(t, "/api/v1/shares/13", gotPath)
+}
+
+func TestRunUpdate_Remote_RoutesThroughRemoteClient(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{
+			"ID":13,"SecretID":7,"OwnerID":1,"RecipientID":5,"IsGroup":false,"Permission":"read",
+			"CreatedAt":"2026-06-08T10:00:00Z"
+		}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "test-token")
+
+	origPerm, origID := updatePermission, updateShareID
+	defer func() { updatePermission = origPerm; updateShareID = origID }()
+	updatePermission = "read"
+	updateShareID = 13
+
+	require.NoError(t, runUpdate(nil, nil))
+	assert.Equal(t, "/api/v1/shares/13", gotPath)
 }

--- a/internal/cli/usage/usage_test.go
+++ b/internal/cli/usage/usage_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 // resetFlags restores the package-level flag vars to their zero/default
@@ -170,6 +172,120 @@ func TestRunShow_LocalModeStorageInitFailure(t *testing.T) {
 	err := runShow(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load config")
+}
+
+// setupEmbeddedUsageMode points config.Load("") at a temp-dir keyorix.yaml
+// (local/embedded SQLite storage) and clears remote-mode signals, mirroring
+// internal/cli/rbac's setupEmbeddedMode helper. HOME is also redirected so
+// common.NewRemoteClient() can't pick up a real ~/.keyorix/cli.yaml on the
+// machine running the test (see TestRunShow_LocalModeStorageInitFailure's
+// comment for the same pitfall).
+func setupEmbeddedUsageMode(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	yaml := "storage:\n  type: local\n  database:\n    path: " + dir + "/secrets.db\n"
+	require.NoError(t, os.WriteFile(dir+"/keyorix.yaml", []byte(yaml), 0600))
+}
+
+// TestRunShow_LocalModeSuccess_NoProjectFilter drives runShow's embedded-mode
+// success path (InitializeStorage -> core.NewKeyorixCore -> GetUsageReport ->
+// printReport) with flagProjectID left at zero, covering the "all projects"
+// branch (the projectID pointer stays nil) plus the final printReport call.
+func TestRunShow_LocalModeSuccess_NoProjectFilter(t *testing.T) {
+	resetFlags(t)
+	setupEmbeddedUsageMode(t)
+
+	flagDays = 30
+	flagProjectID = 0
+	flagFormat = "table"
+
+	out, err := captureStdout(t, func() error { return runShow(nil, nil) })
+	require.NoError(t, err)
+	assert.Contains(t, out, "last 30 days")
+	assert.Contains(t, out, "(no data)")
+}
+
+// TestRunShow_LocalModeSuccess_WithProjectFilter covers the flagProjectID != 0
+// branch inside runShow (the `id := flagProjectID; projectID = &id` block),
+// which TestRunShow_LocalModeSuccess_NoProjectFilter's zero-value flag can't
+// reach. The filtered project need not exist in storage — GetProjectUsageStats
+// simply returns no matching rows, which is enough to exercise the branch.
+func TestRunShow_LocalModeSuccess_WithProjectFilter(t *testing.T) {
+	resetFlags(t)
+	setupEmbeddedUsageMode(t)
+
+	flagDays = 7
+	flagProjectID = 99
+	flagFormat = "json"
+
+	out, err := captureStdout(t, func() error { return runShow(nil, nil) })
+	require.NoError(t, err)
+
+	var decoded storage.UsageReport
+	require.NoError(t, json.Unmarshal([]byte(out), &decoded))
+	assert.Equal(t, 7, decoded.WindowDays)
+}
+
+// TestRunShow_LocalModeGetUsageReportError covers runShow's
+// "failed to generate usage report" wrap -- the one embedded-mode branch not
+// reachable via a plain InitializeStorage success/failure. GetUsageReport's
+// only error source is the underlying GetProjectUsageStats query
+// (internal/storage/store/local_usage.go), which is a raw GORM Scan into a
+// `ProjectID uint` field. audit_events.project_id has no NOT NULL/CHECK
+// constraint at the schema level (see models.AuditEvent), so a row inserted
+// via a raw connection with project_id = -1 passes SQLite's dynamic typing
+// on INSERT but fails database/sql's uint conversion on Scan
+// ("converting driver.Value type int64 (\"-1\") to a uint: invalid syntax"),
+// producing a genuine backend error without any storage/interface changes.
+func TestRunShow_LocalModeGetUsageReportError(t *testing.T) {
+	resetFlags(t)
+	setupEmbeddedUsageMode(t)
+
+	_, err := common.InitializeStorage()
+	require.NoError(t, err)
+
+	rawDB, err := gorm.Open(sqlite.Open("secrets.db"))
+	require.NoError(t, err)
+	res := rawDB.Exec("INSERT INTO audit_events (event_type, project_id, event_time, success) VALUES (?, ?, ?, ?)",
+		"secret.read", -1, time.Now().UTC(), true)
+	require.NoError(t, res.Error)
+
+	flagDays = 30
+	flagProjectID = 0
+	flagFormat = "table"
+
+	err = runShow(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to generate usage report")
+}
+
+// TestPrintReport_NoDataWriteError forces the "(no data)" Fprintln call to
+// fail by closing os.Stdout before printReport runs. This is the one
+// tabwriter-buffered write error branch that's actually reachable: per
+// text/tabwriter's Write implementation, a line with no tab characters (a
+// single cell) triggers an immediate internal flush to the underlying
+// writer, unlike the header/row lines below which contain tabs and stay
+// buffered until an explicit Flush() (see the header/row write-error
+// branches' doc comment on why those can't be covered the same way).
+func TestPrintReport_NoDataWriteError(t *testing.T) {
+	resetFlags(t)
+	flagFormat = "table"
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	require.NoError(t, w.Close())
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	report := &storage.UsageReport{WindowDays: 30, GeneratedAt: time.Now()}
+	err = printReport(report)
+	require.Error(t, err)
 }
 
 func TestPrintReport_JSONFormat(t *testing.T) {

--- a/internal/core/authz_guard_functions_test.go
+++ b/internal/core/authz_guard_functions_test.go
@@ -1,0 +1,518 @@
+// authz_guard_functions_test.go — coverage for a cluster of authorization/
+// session-liveness guard functions that sat at 0% (or near it): the
+// escalation-by-proxy ceilings (RequireMachinePrivilegeCeiling,
+// RequireAdminAuthorityAt, ValidateRoleGrantAuthority,
+// requireUserCredentialsRevokeAuthority), the machine-lifecycle legality
+// check (IsValidMachineTransition), the session/account liveness re-checks
+// #G18 added for the long-lived-stream cache-hit path (SessionStillLive,
+// AccountStillUsable), the last-admin lockout guard (GuardLastAdminDeactivation),
+// and the two /system proxy entry points built on the revoke ceiling
+// (RevokeAllPersonalAccessTokensForUser, DeleteSessionsForUserExcept). These
+// are exactly the security-boundary functions where an untested allow/deny
+// edge is a privilege-escalation risk, so each gets its allow case, its deny
+// case, and the boundary the function's own name implies.
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ── RequireMachinePrivilegeCeiling (MACH-001) ───────────────────────────────
+
+func TestRequireMachinePrivilegeCeiling_AdminTargetActorGlobalAdmin_Allowed(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetMachineRoles", mock.Anything, uint(7)).Return([]*models.Role{{ID: 50, Name: "admin"}}, nil)
+	ms.On("RoleSetBypassesPermissionChecks", mock.Anything, []uint{50}).Return(true, nil)
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(3), Scope{}).Return([]uint{99}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(3), Scope{}).Return([]uint{}, nil)
+	ms.On("RoleSetBypassesPermissionChecks", mock.Anything, []uint{99}).Return(true, nil)
+
+	c := NewKeyorixCore(ms)
+	err := c.RequireMachinePrivilegeCeiling(context.Background(), ActorTypeUser, 3, 2, 7)
+	require.NoError(t, err, "a global admin may mint a credential for an admin-tier machine identity")
+}
+
+func TestRequireMachinePrivilegeCeiling_AdminTargetActorNotGlobalAdmin_Denied(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetMachineRoles", mock.Anything, uint(7)).Return([]*models.Role{{ID: 50, Name: "admin"}}, nil)
+	ms.On("RoleSetBypassesPermissionChecks", mock.Anything, []uint{50}).Return(true, nil)
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(3), Scope{}).Return([]uint{11}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(3), Scope{}).Return([]uint{}, nil)
+	ms.On("RoleSetBypassesPermissionChecks", mock.Anything, []uint{11}).Return(false, nil)
+
+	c := NewKeyorixCore(ms)
+	err := c.RequireMachinePrivilegeCeiling(context.Background(), ActorTypeUser, 3, 2, 7)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMachinePrivilegeCeilingDenied)
+}
+
+// ADR-030: a machine is never a global admin, so a machine actor can never
+// clear the admin-tier-target branch regardless of what permissions it
+// bundles -- IsGlobalAdmin must not even be consulted for a machine actor.
+func TestRequireMachinePrivilegeCeiling_AdminTarget_MachineActorAlwaysDenied(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetMachineRoles", mock.Anything, uint(7)).Return([]*models.Role{{ID: 50, Name: "admin"}}, nil)
+	ms.On("RoleSetBypassesPermissionChecks", mock.Anything, []uint{50}).Return(true, nil)
+
+	c := NewKeyorixCore(ms)
+	err := c.RequireMachinePrivilegeCeiling(context.Background(), ActorTypeMachine, 3, 2, 7)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMachinePrivilegeCeilingDenied)
+}
+
+// machineID==0: the identity doesn't exist yet (creation-time check), so the
+// ceiling falls to the actor's own roles.assign authority at the target
+// project scope -- the SAME authority the human-facing creation route
+// requires.
+func TestRequireMachinePrivilegeCeiling_NewIdentity_ActorHasRolesAssign_Allowed(t *testing.T) {
+	ms := new(MockStorage)
+	stubAuthorizedPrincipal(ms, 3, Scope{ProjectID: 2}, permRolesAssign)
+
+	c := NewKeyorixCore(ms)
+	err := c.RequireMachinePrivilegeCeiling(context.Background(), ActorTypeUser, 3, 2, 0)
+	require.NoError(t, err)
+}
+
+func TestRequireMachinePrivilegeCeiling_NewIdentity_ActorLacksRolesAssign_Denied(t *testing.T) {
+	ms := new(MockStorage)
+	stubUnauthorizedPrincipal(ms, 3, Scope{ProjectID: 2})
+
+	c := NewKeyorixCore(ms)
+	err := c.RequireMachinePrivilegeCeiling(context.Background(), ActorTypeUser, 3, 2, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMachinePrivilegeCeilingDenied)
+}
+
+// A machine identity that exists but doesn't (yet) hold an admin-tier role
+// falls through to the SAME roles.assign check as machineID==0 -- an actor
+// without it must still be refused, even though the target itself isn't
+// admin-tier.
+func TestRequireMachinePrivilegeCeiling_NonAdminTarget_ActorLacksRolesAssign_Denied(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetMachineRoles", mock.Anything, uint(7)).Return([]*models.Role{{ID: 12, Name: "project_viewer"}}, nil)
+	ms.On("RoleSetBypassesPermissionChecks", mock.Anything, []uint{12}).Return(false, nil)
+	stubUnauthorizedPrincipal(ms, 3, Scope{ProjectID: 2})
+
+	c := NewKeyorixCore(ms)
+	err := c.RequireMachinePrivilegeCeiling(context.Background(), ActorTypeUser, 3, 2, 7)
+	require.Error(t, err)
+}
+
+// ── RequireAdminAuthorityAt ──────────────────────────────────────────────
+
+func TestRequireAdminAuthorityAt_Allowed(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(3), Scope{ProjectID: 2}).Return([]uint{50}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(3), Scope{ProjectID: 2}).Return([]uint{}, nil)
+	ms.On("RoleSetBypassesPermissionChecks", mock.Anything, []uint{50}).Return(true, nil)
+
+	c := NewKeyorixCore(ms)
+	err := c.RequireAdminAuthorityAt(context.Background(), 3, 2)
+	require.NoError(t, err)
+}
+
+func TestRequireAdminAuthorityAt_Denied(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(3), Scope{ProjectID: 2}).Return([]uint{11}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(3), Scope{ProjectID: 2}).Return([]uint{}, nil)
+	ms.On("RoleSetBypassesPermissionChecks", mock.Anything, []uint{11}).Return(false, nil)
+
+	c := NewKeyorixCore(ms)
+	err := c.RequireAdminAuthorityAt(context.Background(), 3, 2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "admin authority is required")
+}
+
+// projectID 0 means global scope -- a distinct Scope{} lookup, not just
+// Scope{ProjectID: 0} coincidentally matching.
+func TestRequireAdminAuthorityAt_GlobalScopeAllowed(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(3), Scope{}).Return([]uint{50}, nil)
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(3), Scope{}).Return([]uint{}, nil)
+	ms.On("RoleSetBypassesPermissionChecks", mock.Anything, []uint{50}).Return(true, nil)
+
+	c := NewKeyorixCore(ms)
+	err := c.RequireAdminAuthorityAt(context.Background(), 3, 0)
+	require.NoError(t, err)
+}
+
+// ── ValidateRoleGrantAuthority ───────────────────────────────────────────
+
+func TestValidateRoleGrantAuthority_Allowed(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetRole", mock.Anything, uint(5)).Return(&models.Role{ID: 5, Name: "custom"}, nil)
+	ms.On("GetRolePermissions", mock.Anything, uint(5)).Return([]*models.Permission{{Name: "secrets.read"}}, nil)
+	stubAuthorizedPrincipal(ms, 1, Scope{ProjectID: 2}, "secrets.read")
+
+	c := NewKeyorixCore(ms)
+	grants := []storage.RoleGrant{{RoleID: 5, Scope: storage.Scope{ProjectID: 2}}}
+	err := c.ValidateRoleGrantAuthority(context.Background(), 1, false, grants)
+	require.NoError(t, err)
+}
+
+func TestValidateRoleGrantAuthority_DeniedWhenActorLacksBundledPermission(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetRole", mock.Anything, uint(5)).Return(&models.Role{ID: 5, Name: "custom"}, nil)
+	ms.On("GetRolePermissions", mock.Anything, uint(5)).Return([]*models.Permission{{Name: "secrets.read"}}, nil)
+	stubUnauthorizedPrincipal(ms, 1, Scope{ProjectID: 2})
+
+	c := NewKeyorixCore(ms)
+	grants := []storage.RoleGrant{{RoleID: 5, Scope: storage.Scope{ProjectID: 2}}}
+	err := c.ValidateRoleGrantAuthority(context.Background(), 1, false, grants)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "you do not hold permission")
+}
+
+func TestValidateRoleGrantAuthority_RejectsOversizedBatch(t *testing.T) {
+	c := NewKeyorixCore(new(MockStorage))
+	grants := make([]storage.RoleGrant, maxUserCreateAssignments+1)
+	err := c.ValidateRoleGrantAuthority(context.Background(), 1, false, grants)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds the maximum batch size")
+}
+
+func TestValidateRoleGrantAuthority_UnknownRoleID(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetRole", mock.Anything, uint(999)).Return(nil, errors.New("record not found"))
+
+	c := NewKeyorixCore(ms)
+	grants := []storage.RoleGrant{{RoleID: 999, Scope: storage.Scope{ProjectID: 2}}}
+	err := c.ValidateRoleGrantAuthority(context.Background(), 1, false, grants)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown role id")
+}
+
+// ── IsValidMachineTransition ─────────────────────────────────────────────
+
+func TestIsValidMachineTransition(t *testing.T) {
+	cases := []struct {
+		name      string
+		from, to  string
+		wantLegal bool
+	}{
+		{"pending to active", MachinePending, MachineActive, true},
+		{"pending to revoked", MachinePending, MachineRevoked, true},
+		{"pending to suspended is illegal", MachinePending, MachineSuspended, false},
+		{"active to suspended", MachineActive, MachineSuspended, true},
+		{"active to revoked", MachineActive, MachineRevoked, true},
+		{"active back to pending is illegal", MachineActive, MachinePending, false},
+		{"suspended to active", MachineSuspended, MachineActive, true},
+		{"suspended to revoked", MachineSuspended, MachineRevoked, true},
+		{"revoked is terminal: to active illegal", MachineRevoked, MachineActive, false},
+		{"revoked is terminal: to pending illegal", MachineRevoked, MachinePending, false},
+		{"revoked is terminal: to suspended illegal", MachineRevoked, MachineSuspended, false},
+		{"self-transition is illegal", MachineActive, MachineActive, false},
+		{"unknown state is illegal", "bogus", MachineActive, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantLegal, IsValidMachineTransition(tc.from, tc.to))
+		})
+	}
+}
+
+// ── SessionStillLive (#G18) ──────────────────────────────────────────────
+
+func TestSessionStillLive(t *testing.T) {
+	fixed := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	newCore := func(sess *models.Session, err error) *KeyorixCore {
+		ms := new(MockStorage)
+		ms.On("GetSessionByID", mock.Anything, uint(1)).Return(sess, err)
+		c := NewKeyorixCore(ms)
+		c.now = func() time.Time { return fixed }
+		return c
+	}
+
+	t.Run("live session", func(t *testing.T) {
+		exp := fixed.Add(time.Hour)
+		abs := fixed.Add(24 * time.Hour)
+		c := newCore(&models.Session{ID: 1, ExpiresAt: &exp, AbsoluteExpiresAt: &abs}, nil)
+		live, err := c.SessionStillLive(context.Background(), 1)
+		require.NoError(t, err)
+		assert.True(t, live)
+	})
+
+	t.Run("rotated away is not live", func(t *testing.T) {
+		rotated := fixed.Add(-time.Minute)
+		c := newCore(&models.Session{ID: 1, RotatedAt: &rotated}, nil)
+		live, err := c.SessionStillLive(context.Background(), 1)
+		require.NoError(t, err)
+		assert.False(t, live, "a rotated session must never be reported live regardless of its expiry fields")
+	})
+
+	t.Run("access window expired", func(t *testing.T) {
+		exp := fixed.Add(-time.Minute)
+		c := newCore(&models.Session{ID: 1, ExpiresAt: &exp}, nil)
+		live, err := c.SessionStillLive(context.Background(), 1)
+		require.NoError(t, err)
+		assert.False(t, live)
+	})
+
+	t.Run("absolute lifetime ceiling expired even within the access window", func(t *testing.T) {
+		exp := fixed.Add(time.Hour)
+		abs := fixed.Add(-time.Minute)
+		c := newCore(&models.Session{ID: 1, ExpiresAt: &exp, AbsoluteExpiresAt: &abs}, nil)
+		live, err := c.SessionStillLive(context.Background(), 1)
+		require.NoError(t, err)
+		assert.False(t, live)
+	})
+
+	t.Run("no expiry fields set at all is live", func(t *testing.T) {
+		c := newCore(&models.Session{ID: 1}, nil)
+		live, err := c.SessionStillLive(context.Background(), 1)
+		require.NoError(t, err)
+		assert.True(t, live)
+	})
+
+	t.Run("storage error fails closed", func(t *testing.T) {
+		c := newCore(nil, errors.New("connection reset"))
+		live, err := c.SessionStillLive(context.Background(), 1)
+		require.Error(t, err)
+		assert.False(t, live)
+	})
+}
+
+// ── AccountStillUsable (#G18) ─────────────────────────────────────────────
+
+func TestAccountStillUsable(t *testing.T) {
+	newCore := func(user *models.User, err error) *KeyorixCore {
+		ms := new(MockStorage)
+		ms.On("GetUser", mock.Anything, uint(1)).Return(user, err)
+		return NewKeyorixCore(ms)
+	}
+
+	t.Run("active account is usable", func(t *testing.T) {
+		c := newCore(&models.User{ID: 1, IsActive: true, AccountState: AccountActive}, nil)
+		ok, err := c.AccountStillUsable(context.Background(), 1)
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("deactivated (is_active=false) account is not usable even with AccountState active", func(t *testing.T) {
+		c := newCore(&models.User{ID: 1, IsActive: false, AccountState: AccountActive}, nil)
+		ok, err := c.AccountStillUsable(context.Background(), 1)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("suspended account is not usable even with IsActive true", func(t *testing.T) {
+		c := newCore(&models.User{ID: 1, IsActive: true, AccountState: AccountSuspended}, nil)
+		ok, err := c.AccountStillUsable(context.Background(), 1)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("storage error fails closed", func(t *testing.T) {
+		c := newCore(nil, errors.New("connection reset"))
+		ok, err := c.AccountStillUsable(context.Background(), 1)
+		require.Error(t, err)
+		assert.False(t, ok)
+	})
+}
+
+// ── GuardLastAdminDeactivation ────────────────────────────────────────────
+// Reuses newSCIMGuardCore (scim_guards_test.go), a real-SQLite fixture, since
+// this guard's own resolution (resolveGlobalAdminHolders, group-aware) is
+// awkward to hand-mock faithfully and the fixture already exists for exactly
+// this purpose.
+
+func TestGuardLastAdminDeactivation_RefusesLastAdmin(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin", BypassesPermissionChecks: true}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 10}).Error)
+
+	err := c.GuardLastAdminDeactivation(ctx, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "last install administrator")
+}
+
+func TestGuardLastAdminDeactivation_AllowsWhenAnotherAdminRemains(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "root", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 2, Username: "second", IsActive: true, AccountState: AccountActive}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 10, Name: "admin", BypassesPermissionChecks: true}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 10}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 10}).Error)
+
+	err := c.GuardLastAdminDeactivation(ctx, 1)
+	require.NoError(t, err, "a second admin survives, so deactivating the first must be allowed")
+}
+
+func TestGuardLastAdminDeactivation_AllowsNonAdminTarget(t *testing.T) {
+	c, db := newSCIMGuardCore(t)
+	ctx := context.Background()
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "viewer", IsActive: true, AccountState: AccountActive}).Error)
+
+	err := c.GuardLastAdminDeactivation(ctx, 1)
+	require.NoError(t, err, "a non-admin target is never the last-admin case")
+}
+
+// ── requireUserCredentialsRevokeAuthority / RevokeAllPersonalAccessTokensForUser / DeleteSessionsForUserExcept ──
+
+func TestRevokeAllPersonalAccessTokensForUser(t *testing.T) {
+	t.Run("authorized actor revokes and audits", func(t *testing.T) {
+		ms := new(MockStorage)
+		stubAuthorizedPrincipal(ms, 9, Scope{}, permUsersWrite)
+		ms.On("RevokeAllPersonalAccessTokensForUser", mock.Anything, uint(5)).Return([]string{"hash-1"}, nil)
+		ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+		c := NewKeyorixCore(ms)
+		hashes, err := c.RevokeAllPersonalAccessTokensForUser(context.Background(), ActorTypeUser, 9, 5)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"hash-1"}, hashes)
+	})
+
+	t.Run("actor without users.write is refused before any revocation", func(t *testing.T) {
+		ms := new(MockStorage)
+		stubUnauthorizedPrincipal(ms, 9, Scope{})
+
+		c := NewKeyorixCore(ms)
+		_, err := c.RevokeAllPersonalAccessTokensForUser(context.Background(), ActorTypeUser, 9, 5)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "users.write authority")
+		// No RevokeAllPersonalAccessTokensForUser/LogAuditEvent stub was set up above:
+		// if the ceiling check didn't short-circuit, the unmet mock expectation
+		// below would fail the test on AssertExpectations.
+		ms.AssertNotCalled(t, "RevokeAllPersonalAccessTokensForUser", mock.Anything, mock.Anything)
+	})
+
+	t.Run("machine actor without users.write is refused", func(t *testing.T) {
+		ms := new(MockStorage)
+		ms.On("GetMachineRoleIDsAt", mock.Anything, uint(9), Scope{}).Return([]uint{}, nil)
+
+		c := NewKeyorixCore(ms)
+		_, err := c.RevokeAllPersonalAccessTokensForUser(context.Background(), ActorTypeMachine, 9, 5)
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteSessionsForUserExcept(t *testing.T) {
+	t.Run("authorized actor deletes and audits", func(t *testing.T) {
+		ms := new(MockStorage)
+		stubAuthorizedPrincipal(ms, 9, Scope{}, permUsersWrite)
+		ms.On("ListSessionTokenHashesForUser", mock.Anything, uint(5)).Return([]string{"hash-1"}, nil)
+		ms.On("DeleteSessionsForUserExcept", mock.Anything, uint(5), uint(3)).Return(nil)
+		ms.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+		c := NewKeyorixCore(ms)
+		err := c.DeleteSessionsForUserExcept(context.Background(), ActorTypeUser, 9, 5, 3)
+		require.NoError(t, err)
+	})
+
+	t.Run("actor without users.write is refused before any deletion", func(t *testing.T) {
+		ms := new(MockStorage)
+		stubUnauthorizedPrincipal(ms, 9, Scope{})
+
+		c := NewKeyorixCore(ms)
+		err := c.DeleteSessionsForUserExcept(context.Background(), ActorTypeUser, 9, 5, 3)
+		require.Error(t, err)
+		ms.AssertNotCalled(t, "DeleteSessionsForUserExcept", mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+// ── RequireGranterHoldsRolePermissions ────────────────────────────────────
+// This is the escalation-by-proxy ceiling every role-GRANT choke point uses
+// (InviteToProject, CreateUserWithAssignments, ValidateRoleGrantAuthority
+// above, ...): the granter must already hold, themselves, every permission
+// the role being granted bundles -- the modern, permission-derived successor
+// to the old fixed-name requireAuthorityForRole (see invitations.go's REMOVED
+// doc comment). RequireGranterHoldsRolePermissions is its /system-proxy-layer
+// export, for a caller outside internal/core (server/http/handlers) that
+// needs to re-derive the SAME ceiling a matching core method already enforced
+// locally before relaying a state change.
+
+func TestRequireGranterHoldsRolePermissions_Allowed(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetRolePermissions", mock.Anything, uint(5)).Return([]*models.Permission{{Name: "secrets.read"}, {Name: "secrets.write"}}, nil)
+	stubAuthorizedPrincipal(ms, 1, Scope{ProjectID: 2}, "secrets.read")
+	stubAuthorizedPrincipal(ms, 1, Scope{ProjectID: 2}, "secrets.write")
+
+	c := NewKeyorixCore(ms)
+	err := c.RequireGranterHoldsRolePermissions(context.Background(), 1, 5, Scope{ProjectID: 2}, false)
+	require.NoError(t, err)
+}
+
+func TestRequireGranterHoldsRolePermissions_DeniedWhenMissingOneBundledPermission(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetRolePermissions", mock.Anything, uint(5)).Return([]*models.Permission{{Name: "secrets.read"}, {Name: "secrets.write"}}, nil)
+	// The actor holds secrets.read but not secrets.write -- the role grant must
+	// still be refused, since it would hand them the write permission by proxy.
+	const roleID = uint(10)
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(1), Scope{ProjectID: 2}).Return([]uint{roleID}, nil).Maybe()
+	ms.On("GetUserGroupRoleIDsAt", mock.Anything, uint(1), Scope{ProjectID: 2}).Return([]uint{}, nil).Maybe()
+	ms.On("RoleSetBypassesPermissionChecks", mock.Anything, mock.Anything).Return(false, nil).Maybe()
+	ms.On("RoleSetHasPermission", mock.Anything, []uint{roleID}, "secrets.read").Return(true, nil).Maybe()
+	ms.On("RoleSetHasPermission", mock.Anything, []uint{roleID}, "secrets.write").Return(false, nil).Maybe()
+
+	c := NewKeyorixCore(ms)
+	err := c.RequireGranterHoldsRolePermissions(context.Background(), 1, 5, Scope{ProjectID: 2}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "you do not hold permission")
+}
+
+// actorID==0 with actorIsMachine==false is the bootstrap/system-initiated
+// grant case (no human/machine actor to check authority against) -- the
+// ceiling is a deliberate no-op here, not an oversight, so GetRolePermissions
+// must never even be consulted.
+func TestRequireGranterHoldsRolePermissions_BootstrapActorBypasses(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	err := c.RequireGranterHoldsRolePermissions(context.Background(), 0, 5, Scope{ProjectID: 2}, false)
+	require.NoError(t, err)
+	ms.AssertNotCalled(t, "GetRolePermissions", mock.Anything, mock.Anything)
+}
+
+func TestRequireGranterHoldsRolePermissions_RoleLookupErrorFailsClosed(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetRolePermissions", mock.Anything, uint(5)).Return(nil, errors.New("connection reset"))
+	c := NewKeyorixCore(ms)
+	err := c.RequireGranterHoldsRolePermissions(context.Background(), 1, 5, Scope{ProjectID: 2}, false)
+	require.Error(t, err)
+}
+
+// ── remaining branches: requireUserCredentialsRevokeAuthority's own
+// AuthorizePrincipal-error path, and the underlying storage-error paths in
+// RevokeAllPersonalAccessTokensForUser/DeleteSessionsForUserExcept ─────────
+
+func TestRequireUserCredentialsRevokeAuthority_StorageErrorFailsClosed(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetUserRoleIDsAt", mock.Anything, uint(9), Scope{}).Return(nil, errors.New("connection reset"))
+	c := NewKeyorixCore(ms)
+	_, err := c.RevokeAllPersonalAccessTokensForUser(context.Background(), ActorTypeUser, 9, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve actor authority")
+}
+
+func TestRevokeAllPersonalAccessTokensForUser_StorageErrorPropagates(t *testing.T) {
+	ms := new(MockStorage)
+	stubAuthorizedPrincipal(ms, 9, Scope{}, permUsersWrite)
+	ms.On("RevokeAllPersonalAccessTokensForUser", mock.Anything, uint(5)).Return(nil, errors.New("db down"))
+
+	c := NewKeyorixCore(ms)
+	_, err := c.RevokeAllPersonalAccessTokensForUser(context.Background(), ActorTypeUser, 9, 5)
+	require.Error(t, err)
+}
+
+func TestDeleteSessionsForUserExcept_StorageErrorPropagates(t *testing.T) {
+	ms := new(MockStorage)
+	stubAuthorizedPrincipal(ms, 9, Scope{}, permUsersWrite)
+	ms.On("ListSessionTokenHashesForUser", mock.Anything, uint(5)).Return([]string{}, nil)
+	ms.On("DeleteSessionsForUserExcept", mock.Anything, uint(5), uint(3)).Return(errors.New("db down"))
+
+	c := NewKeyorixCore(ms)
+	err := c.DeleteSessionsForUserExcept(context.Background(), ActorTypeUser, 9, 5, 3)
+	require.Error(t, err)
+}

--- a/internal/core/webauthn_spec_vectors_test.go
+++ b/internal/core/webauthn_spec_vectors_test.go
@@ -1,0 +1,531 @@
+// webauthn_spec_vectors_test.go — exercises the go-webauthn library's REAL
+// cryptographic verification path (ValidateLogin/ValidatePasskeyLogin/
+// CreateCredential) using the W3C spec test vectors
+// (https://www.w3.org/TR/webauthn-3/#sctn-test-vectors-none-es256), the same
+// fixed, known-good assertion/attestation bytes go-webauthn's own test suite
+// uses (webauthn/login_test.go's testLoginSpecVectorNoneES256,
+// webauthn/registration_test.go's testRegistrationSpecVectorNoneES256).
+//
+// webauthn_test.go's existing coverage stops short of the actual
+// library-verification calls (CreateCredential/ValidateLogin/
+// ValidatePasskeyLogin) because those need a real, internally-consistent
+// signature over a real challenge+clientData+authenticatorData — not
+// something a hand-rolled fixture can fake. The spec vectors are real
+// recorded ceremony data (RPID "example.org", origin "https://example.org"),
+// so pointing a WebAuthn RP configured for that RPID/origin at them exercises
+// FinishWebAuthnRegistration/FinishWebAuthnLogin/FinishWebAuthnPasswordlessLogin's
+// success paths (session minting, audit, clone-detection no-op) for real,
+// plus the failure paths that only manifest post-verification (a corrupted
+// signature, a credential-ID mismatch).
+package core
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/protocol/webauthncose"
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// Spec test vector constants (NoneES256), reproduced verbatim from
+// go-webauthn's own test suite so the assertion/attestation are internally
+// consistent (real ECDSA signature over the real challenge/clientData/
+// authenticatorData for RPID "example.org").
+const (
+	specLoginAuthenticatorDataHex = "bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b51900000000"
+	specLoginClientDataJSONHex    = "7b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a224f63446e55685158756c5455506f334a5558543049393770767a7a59425039745a63685879617630314167222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a66616c73657d"
+	specLoginSignatureHex         = "3046022100f50a4e2e4409249c4a853ba361282f09841df4dd4547a13a87780218deffcd380221008480ac0f0b93538174f575bf11a1dd5d78c6e486013f937295ea13653e331e87"
+	specCredentialIDHex           = "f91f391db4c9b2fde0ea70189cba3fb63f579ba6122b33ad94ff3ec330084be4" //nolint:gosec
+	specLoginChallengeHex         = "39c0e7521417ba54d43e8dc95174f423dee9bf3cd804ff6d65c857c9abf4d408"
+	specCredentialPubKeyHex       = "a5010203262001215820afefa16f97ca9b2d23eb86ccb64098d20db90856062eb249c33a9b672f26df61225820930a56b87a2fca66334b03458abf879717c12cc68ed73290af2e2664796b9220"
+
+	specRegAttestationObjectHex = "a363666d74646e6f6e656761747453746d74a068617574684461746158a4bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b559000000008446ccb9ab1db374750b2367ff6f3a1f0020f91f391db4c9b2fde0ea70189cba3fb63f579ba6122b33ad94ff3ec330084be4a5010203262001215820afefa16f97ca9b2d23eb86ccb64098d20db90856062eb249c33a9b672f26df61225820930a56b87a2fca66334b03458abf879717c12cc68ed73290af2e2664796b9220"
+	specRegClientDataJSONHex    = "7b2274797065223a22776562617574686e2e637265617465222c226368616c6c656e6765223a22414d4d507434557878475453746e63647134313759447742466938767049612d7077386f4f755657345441222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a66616c73652c22657874726144617461223a22636c69656e74446174614a534f4e206d617920626520657874656e6465642077697468206164646974696f6e616c206669656c647320696e20746865206675747572652c207375636820617320746869733a20426b5165446a646354427258426941774a544c453551227d"
+	specRegChallengeHex         = "00c30fb78531c464d2b6771dab8d7b603c01162f2fa486bea70f283ae556e130"
+)
+
+func specHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return b
+}
+
+// specLoginAssertion parses the NoneES256 login spec vector into a
+// ParsedCredentialAssertionData plus the base64url challenge it was signed
+// against.
+func specLoginAssertion(t *testing.T) (*protocol.ParsedCredentialAssertionData, string) {
+	t.Helper()
+	id := base64.RawURLEncoding.EncodeToString(specHex(t, specCredentialIDHex))
+	body := map[string]any{
+		"id": id, "rawId": id, "type": "public-key",
+		"response": map[string]any{
+			"authenticatorData": base64.RawURLEncoding.EncodeToString(specHex(t, specLoginAuthenticatorDataHex)),
+			"clientDataJSON":    base64.RawURLEncoding.EncodeToString(specHex(t, specLoginClientDataJSONHex)),
+			"signature":         base64.RawURLEncoding.EncodeToString(specHex(t, specLoginSignatureHex)),
+		},
+	}
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+	parsed, err := protocol.ParseCredentialRequestResponseBytes(data)
+	require.NoError(t, err)
+	challenge := base64.RawURLEncoding.EncodeToString(specHex(t, specLoginChallengeHex))
+	return parsed, challenge
+}
+
+// specRegistrationAttestation parses the NoneES256 registration spec vector
+// into a ParsedCredentialCreationData plus the base64url challenge it was
+// signed against.
+func specRegistrationAttestation(t *testing.T) (*protocol.ParsedCredentialCreationData, string) {
+	t.Helper()
+	id := base64.RawURLEncoding.EncodeToString(specHex(t, specCredentialIDHex))
+	body := map[string]any{
+		"id": id, "rawId": id, "type": "public-key",
+		"response": map[string]any{
+			"attestationObject": base64.RawURLEncoding.EncodeToString(specHex(t, specRegAttestationObjectHex)),
+			"clientDataJSON":    base64.RawURLEncoding.EncodeToString(specHex(t, specRegClientDataJSONHex)),
+		},
+	}
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+	parsed, err := protocol.ParseCredentialCreationResponseBytes(data)
+	require.NoError(t, err)
+	challenge := base64.RawURLEncoding.EncodeToString(specHex(t, specRegChallengeHex))
+	return parsed, challenge
+}
+
+// specWebAuthnID mirrors webauthnUser.WebAuthnID()'s 8-byte big-endian
+// encoding, needed to hand-build a SessionData/UserHandle that the library
+// will accept as belonging to userID.
+func specWebAuthnID(userID uint) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(userID))
+	return b
+}
+
+// newWebAuthnSpecTestCore builds a core over real SQLite with a WebAuthn
+// relying party configured for the spec vectors' own RPID/origin
+// ("example.org" / "https://example.org") -- deliberately NOT "localhost"
+// like newWebAuthnTestCore, since the vectors' authenticatorData RPIDHash and
+// clientDataJSON origin are baked in and must match exactly for verification
+// to succeed. Seeds user id 1 = "alice", active, with a real bcrypt password.
+func newWebAuthnSpecTestCore(t *testing.T) (*KeyorixCore, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Session{}, &models.AuditEvent{},
+		&models.MFAChallenge{}, &models.WebAuthnCredential{}, &models.WebAuthnSession{}, &models.Notification{},
+		&models.MFAStepupToken{}, &models.MFAStepUpGrant{}))
+	hash, err := bcrypt.GenerateFromPassword([]byte(webauthnTestPassword), bcrypt.DefaultCost)
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.User{ID: 1, Username: "alice", UsernameFolded: "alice", Email: "a@b.com", EmailFolded: "a@b.com",
+		PasswordHash: string(hash), IsActive: true, AccountState: "active"}).Error)
+
+	fixed := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: func() time.Time { return fixed }, passwordPolicy: DefaultPasswordPolicy()}
+	rp, err := webauthn.New(&webauthn.Config{
+		RPID: "example.org", RPDisplayName: "Keyorix", RPOrigins: []string{"https://example.org"},
+	})
+	require.NoError(t, err)
+	c.SetWebAuthn(rp)
+	return c, db
+}
+
+// seedSpecCredential stores the spec vector's credential (ID + public key)
+// as userID's registered passkey, matching the Flags (UserPresent,
+// BackupEligible) the vector's authenticatorData actually asserts -- a
+// mismatch there is its own rejection (login.go's "Backup Eligible flag
+// inconsistency" check), so the seeded record must agree with the vector,
+// not with arbitrary defaults.
+func seedSpecCredential(t *testing.T, c *KeyorixCore, db *gorm.DB, userID uint) []byte {
+	t.Helper()
+	credID := specHex(t, specCredentialIDHex)
+	pubKey := specHex(t, specCredentialPubKeyHex)
+	blob, err := json.Marshal(webauthn.Credential{
+		ID:        credID,
+		PublicKey: pubKey,
+		Flags:     webauthn.CredentialFlags{UserPresent: true, BackupEligible: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.WebAuthnCredential{
+		UserID: userID, CredentialID: credID, Name: "yubikey", CredentialBlob: blob,
+	}).Error)
+	require.NoError(t, c.storage.SetUserWebAuthnEnabled(context.Background(), userID, true))
+	return credID
+}
+
+// TestFinishWebAuthnRegistration_SucceedsWithRealAttestation drives
+// CreateCredential's actual attestation-verification success path (not
+// reachable with a hand-rolled fixture, see the file doc comment), confirming
+// the credential row is stored, WebAuthn is enabled for the account, and the
+// registration is audited.
+func TestFinishWebAuthnRegistration_SucceedsWithRealAttestation(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	ctx := context.Background()
+
+	parsed, challenge := specRegistrationAttestation(t)
+	sd := &webauthn.SessionData{
+		Challenge:  challenge,
+		UserID:     specWebAuthnID(1),
+		CredParams: []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
+	}
+	token, err := c.storeWebAuthnSession(ctx, 1, "register", sd)
+	require.NoError(t, err)
+
+	cred, err := c.FinishWebAuthnRegistration(ctx, 1, token, "yubikey", webauthnTestPassword, parsed)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	assert.Equal(t, specHex(t, specCredentialIDHex), cred.CredentialID)
+
+	var user models.User
+	require.NoError(t, db.First(&user, 1).Error)
+	assert.True(t, user.WebAuthnEnabled, "the first successful registration must enable WebAuthn")
+
+	var events int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "webauthn.registered").Count(&events).Error)
+	assert.Equal(t, int64(1), events)
+}
+
+// TestFinishWebAuthnRegistration_RejectsUserIDMismatch confirms the
+// session/user binding check (CreateCredential's "ID mismatch for User and
+// Session") is reachable: a session minted for a DIFFERENT user's
+// WebAuthnID must not let userID 1 complete it, even with an otherwise
+// perfectly valid attestation.
+func TestFinishWebAuthnRegistration_RejectsUserIDMismatch(t *testing.T) {
+	c, _ := newWebAuthnSpecTestCore(t)
+	ctx := context.Background()
+
+	parsed, challenge := specRegistrationAttestation(t)
+	sd := &webauthn.SessionData{
+		Challenge:  challenge,
+		UserID:     specWebAuthnID(999), // wrong user
+		CredParams: []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
+	}
+	token, err := c.storeWebAuthnSession(ctx, 1, "register", sd)
+	require.NoError(t, err)
+
+	_, err = c.FinishWebAuthnRegistration(ctx, 1, token, "yubikey", webauthnTestPassword, parsed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to verify attestation")
+}
+
+// TestFinishWebAuthnLogin_SucceedsWithRealAssertion drives ValidateLogin's
+// actual cryptographic success path, confirming a session is minted, the
+// account owner is returned, the credential's signature counter is
+// persisted, a genuine MFAStepUpGrant is minted, and the login is audited.
+func TestFinishWebAuthnLogin_SucceedsWithRealAssertion(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	ctx := context.Background()
+	seedSpecCredential(t, c, db, 1)
+
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	parsed, challenge := specLoginAssertion(t)
+	token, err := c.storeWebAuthnSession(ctx, 1, "login", &webauthn.SessionData{Challenge: challenge, UserID: specWebAuthnID(1)})
+	require.NoError(t, err)
+
+	session, user, err := c.FinishWebAuthnLogin(ctx, ch, token, "test-agent", "203.0.113.5", parsed)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.NotNil(t, user)
+	assert.Equal(t, uint(1), user.ID)
+	assert.NotEmpty(t, session.SessionToken)
+
+	var events int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "webauthn.login_verified").Count(&events).Error)
+	assert.Equal(t, int64(1), events)
+
+	var credRow models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ?", 1).First(&credRow).Error)
+	assert.False(t, credRow.Disabled, "a normal, un-flagged assertion must not trip clone detection")
+	require.NotNil(t, credRow.LastUsedAt, "a successful login must persist the credential's LastUsedAt")
+
+	var grants int64
+	require.NoError(t, db.Model(&models.MFAStepUpGrant{}).Where("user_id = ?", 1).Count(&grants).Error)
+	assert.Equal(t, int64(1), grants, "a WebAuthn login must mint a step-up grant for later requireReauth calls")
+
+	// Replay: both the MFA challenge and the webauthn ceremony session are
+	// single-use -- reusing either after a completed login must fail, not
+	// silently mint a second session.
+	_, _, err = c.FinishWebAuthnLogin(ctx, ch, token, "test-agent", "203.0.113.5", parsed)
+	require.Error(t, err, "a consumed challenge/session pair must not be replayable")
+}
+
+// TestFinishWebAuthnLogin_RejectsCredentialMismatch presents a real,
+// validly-signed assertion whose credential ID does not match ANY of the
+// account's stored passkeys (a different/unregistered credential) --
+// go-webauthn's own "unable to find the credential" rejection, reachable only
+// once verification gets far enough to look the credential up.
+func TestFinishWebAuthnLogin_RejectsCredentialMismatch(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	c.loginLockout = LoginLockoutPolicy{Enabled: true, MaxAttempts: 3, Window: time.Hour, BaseCooldown: 15 * time.Minute, MaxCooldown: time.Hour}
+	ctx := context.Background()
+	seedSpecCredential(t, c, db, 1)
+
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	parsed, challenge := specLoginAssertion(t)
+	parsed.RawID = []byte("some-other-credential-id-entirely")
+	token, err := c.storeWebAuthnSession(ctx, 1, "login", &webauthn.SessionData{Challenge: challenge, UserID: specWebAuthnID(1)})
+	require.NoError(t, err)
+
+	_, _, err = c.FinishWebAuthnLogin(ctx, ch, token, "test-agent", "203.0.113.5", parsed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assertion verification failed")
+
+	var user models.User
+	require.NoError(t, db.First(&user, 1).Error)
+	assert.Equal(t, 1, user.FailedLoginAttempts, "a failed second-factor assertion must count toward the lockout")
+}
+
+// TestFinishWebAuthnLogin_RejectsCorruptedSignature presents a real
+// assertion whose signature has been tampered with -- go-webauthn's
+// cryptographic verification itself must reject it (not merely a shape/
+// lookup failure), and the failure must be audited + counted toward the
+// account's lockout, mirroring a bad-password attempt.
+func TestFinishWebAuthnLogin_RejectsCorruptedSignature(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	ctx := context.Background()
+	seedSpecCredential(t, c, db, 1)
+
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	parsed, challenge := specLoginAssertion(t)
+	corrupted := append([]byte(nil), parsed.Response.Signature...)
+	corrupted[0] ^= 0xFF
+	parsed.Response.Signature = corrupted
+	token, err := c.storeWebAuthnSession(ctx, 1, "login", &webauthn.SessionData{Challenge: challenge, UserID: specWebAuthnID(1)})
+	require.NoError(t, err)
+
+	_, _, err = c.FinishWebAuthnLogin(ctx, ch, token, "test-agent", "203.0.113.5", parsed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assertion verification failed")
+
+	var failedEvents int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "webauthn.failed").Count(&failedEvents).Error)
+	assert.Equal(t, int64(1), failedEvents)
+}
+
+// TestFinishWebAuthnPasswordlessLogin_SucceedsWithRealAssertion drives
+// ValidatePasskeyLogin's actual success path: the discoverable handler
+// resolves the user from the assertion's user handle (our WebAuthnID
+// encoding), the credential verifies, and a full passwordless login
+// completes (session minted, step-up grant minted, audited).
+func TestFinishWebAuthnPasswordlessLogin_SucceedsWithRealAssertion(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	ctx := context.Background()
+	seedSpecCredential(t, c, db, 1)
+
+	parsed, challenge := specLoginAssertion(t)
+	parsed.Response.UserHandle = specWebAuthnID(1)
+	token, err := c.storeWebAuthnSession(ctx, 0, "passwordless", &webauthn.SessionData{Challenge: challenge})
+	require.NoError(t, err)
+
+	session, user, err := c.FinishWebAuthnPasswordlessLogin(ctx, token, "test-agent", "203.0.113.5", parsed)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.NotNil(t, user)
+	assert.Equal(t, uint(1), user.ID)
+
+	var events int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "webauthn.passwordless_login").Count(&events).Error)
+	assert.Equal(t, int64(1), events)
+
+	var grants int64
+	require.NoError(t, db.Model(&models.MFAStepUpGrant{}).Where("user_id = ?", 1).Count(&grants).Error)
+	assert.Equal(t, int64(1), grants)
+}
+
+// TestFinishWebAuthnPasswordlessLogin_RejectsUnknownUserHandle presents a
+// validly-signed assertion whose user handle does not resolve to any
+// account -- the discoverable handler's loadWebAuthnUser lookup fails, and
+// that failure must refuse the login (not panic or silently proceed
+// unauthenticated).
+func TestFinishWebAuthnPasswordlessLogin_RejectsUnknownUserHandle(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	ctx := context.Background()
+	seedSpecCredential(t, c, db, 1)
+
+	parsed, challenge := specLoginAssertion(t)
+	parsed.Response.UserHandle = specWebAuthnID(999) // no such user
+	token, err := c.storeWebAuthnSession(ctx, 0, "passwordless", &webauthn.SessionData{Challenge: challenge})
+	require.NoError(t, err)
+
+	_, _, err = c.FinishWebAuthnPasswordlessLogin(ctx, token, "test-agent", "203.0.113.5", parsed)
+	require.Error(t, err)
+
+	var failedEvents int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", "webauthn.failed").Count(&failedEvents).Error)
+	assert.Equal(t, int64(1), failedEvents)
+}
+
+// TestFinishWebAuthnPasswordlessLogin_RejectsCredentialMismatch mirrors
+// TestFinishWebAuthnLogin_RejectsCredentialMismatch for the passwordless
+// path: the user handle resolves correctly, but the asserted credential ID
+// does not match any of that user's stored passkeys.
+func TestFinishWebAuthnPasswordlessLogin_RejectsCredentialMismatch(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	ctx := context.Background()
+	seedSpecCredential(t, c, db, 1)
+
+	parsed, challenge := specLoginAssertion(t)
+	parsed.Response.UserHandle = specWebAuthnID(1)
+	parsed.RawID = []byte("some-other-credential-id-entirely")
+	token, err := c.storeWebAuthnSession(ctx, 0, "passwordless", &webauthn.SessionData{Challenge: challenge})
+	require.NoError(t, err)
+
+	_, _, err = c.FinishWebAuthnPasswordlessLogin(ctx, token, "test-agent", "203.0.113.5", parsed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assertion verification failed")
+}
+
+// TestFinishWebAuthnPasswordlessLogin_RejectsReplayedSession confirms the
+// webauthn ceremony session (the only single-use gate a discoverable/
+// passwordless login has, since there is no separate MFA challenge) cannot
+// be replayed after a completed login.
+func TestFinishWebAuthnPasswordlessLogin_RejectsReplayedSession(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	ctx := context.Background()
+	seedSpecCredential(t, c, db, 1)
+
+	parsed, challenge := specLoginAssertion(t)
+	parsed.Response.UserHandle = specWebAuthnID(1)
+	token, err := c.storeWebAuthnSession(ctx, 0, "passwordless", &webauthn.SessionData{Challenge: challenge})
+	require.NoError(t, err)
+
+	_, _, err = c.FinishWebAuthnPasswordlessLogin(ctx, token, "test-agent", "203.0.113.5", parsed)
+	require.NoError(t, err)
+
+	_, _, err = c.FinishWebAuthnPasswordlessLogin(ctx, token, "test-agent", "203.0.113.5", parsed)
+	require.Error(t, err, "a consumed passwordless ceremony session must not be replayable")
+}
+
+// TestFinishWebAuthnLogin_ClonedCredentialRejectsAndDisablesEndToEnd drives
+// clone detection (#212) through the REAL FinishWebAuthnLogin path (not
+// rejectIfCloned called directly, as TestWebAuthn_RejectIfCloned_* do): a
+// stored credential whose SignCount is ahead of the asserted counter (5 -> 0)
+// is go-webauthn's own signature-counter-regression signal
+// (Authenticator.UpdateCounter), so a cryptographically valid assertion must
+// still be refused, the credential disabled, and the clone audited -- all
+// from inside FinishWebAuthnLogin's own call sequence.
+func TestFinishWebAuthnLogin_ClonedCredentialRejectsAndDisablesEndToEnd(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	ctx := context.Background()
+	credID := specHex(t, specCredentialIDHex)
+	blob, err := json.Marshal(webauthn.Credential{
+		ID:            credID,
+		PublicKey:     specHex(t, specCredentialPubKeyHex),
+		Flags:         webauthn.CredentialFlags{UserPresent: true, BackupEligible: true},
+		Authenticator: webauthn.Authenticator{SignCount: 5},
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.WebAuthnCredential{UserID: 1, CredentialID: credID, Name: "yubikey", CredentialBlob: blob}).Error)
+	require.NoError(t, c.storage.SetUserWebAuthnEnabled(ctx, 1, true))
+
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	parsed, challenge := specLoginAssertion(t)
+	token, err := c.storeWebAuthnSession(ctx, 1, "login", &webauthn.SessionData{Challenge: challenge, UserID: specWebAuthnID(1)})
+	require.NoError(t, err)
+
+	_, _, err = c.FinishWebAuthnLogin(ctx, ch, token, "test-agent", "203.0.113.5", parsed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cloned authenticator")
+
+	var row models.WebAuthnCredential
+	require.NoError(t, db.Where("credential_id = ?", credID).First(&row).Error)
+	assert.True(t, row.Disabled, "a clone-signaled credential must be disabled from inside FinishWebAuthnLogin")
+
+	var events int64
+	require.NoError(t, db.Model(&models.AuditEvent{}).Where("event_type = ?", EventWebAuthnCloneDetected).Count(&events).Error)
+	assert.Equal(t, int64(1), events)
+}
+
+// TestFinishWebAuthnRegistration_SecondPasskeyDoesNotRepurgeSessions covers
+// the firstEnrol==false branch: registering a SECOND passkey (WebAuthn
+// already enabled from a first one) must still succeed but must not re-run
+// the pre-enrolment session purge -- that only fires once, on the passkey
+// that first turns WebAuthn on.
+func TestFinishWebAuthnRegistration_SecondPasskeyDoesNotRepurgeSessions(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	ctx := context.Background()
+	seedCredential(t, c, db, 1, "already-registered-cred")
+	seedStepUpGrant(t, db, 1, c.now()) // WebAuthn already enrolled: password alone no longer satisfies reauth.
+
+	parsed, challenge := specRegistrationAttestation(t)
+	sd := &webauthn.SessionData{
+		Challenge:  challenge,
+		UserID:     specWebAuthnID(1),
+		CredParams: []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
+	}
+	token, err := c.storeWebAuthnSession(ctx, 1, "register", sd)
+	require.NoError(t, err)
+
+	cred, err := c.FinishWebAuthnRegistration(ctx, 1, token, "second key", webauthnTestPassword, parsed)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+
+	var count int64
+	require.NoError(t, db.Model(&models.WebAuthnCredential{}).Where("user_id = ?", 1).Count(&count).Error)
+	assert.Equal(t, int64(2), count, "the user now has two registered passkeys")
+}
+
+// TestFinishWebAuthnPasswordlessLogin_RejectsSuspendedAccount mirrors
+// TestWebAuthn_FinishLoginRejectsSuspendedAccount for the passwordless path:
+// an account suspended after the ceremony began must still be refused, even
+// with an otherwise cryptographically valid assertion.
+func TestFinishWebAuthnPasswordlessLogin_RejectsSuspendedAccount(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	ctx := context.Background()
+	seedSpecCredential(t, c, db, 1)
+	require.NoError(t, db.Model(&models.User{}).Where("id = ?", 1).Update("account_state", AccountSuspended).Error)
+
+	parsed, challenge := specLoginAssertion(t)
+	parsed.Response.UserHandle = specWebAuthnID(1)
+	token, err := c.storeWebAuthnSession(ctx, 0, "passwordless", &webauthn.SessionData{Challenge: challenge})
+	require.NoError(t, err)
+
+	_, _, err = c.FinishWebAuthnPasswordlessLogin(ctx, token, "test-agent", "203.0.113.5", parsed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not active")
+}
+
+// TestFinishWebAuthnLogin_RecordsMFAStepupTokenWhenClassificationRequires
+// covers the classificationRestrictedRequiresMFAStepUp branch in both
+// FinishWebAuthnLogin and FinishWebAuthnPasswordlessLogin: when the
+// classification gate is configured to require a step-up window, a
+// successful WebAuthn login must also upsert an MFAStepupToken (in addition
+// to the unconditional MFAStepUpGrant both paths always mint).
+func TestFinishWebAuthnLogin_RecordsMFAStepupTokenWhenClassificationRequires(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	c.classificationRestrictedRequiresMFAStepUp = true
+	ctx := context.Background()
+	seedSpecCredential(t, c, db, 1)
+
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	parsed, challenge := specLoginAssertion(t)
+	token, err := c.storeWebAuthnSession(ctx, 1, "login", &webauthn.SessionData{Challenge: challenge, UserID: specWebAuthnID(1)})
+	require.NoError(t, err)
+
+	_, _, err = c.FinishWebAuthnLogin(ctx, ch, token, "test-agent", "203.0.113.5", parsed)
+	require.NoError(t, err)
+
+	var count int64
+	require.NoError(t, db.Model(&models.MFAStepupToken{}).Where("user_id = ?", 1).Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}

--- a/internal/core/webauthn_storage_error_test.go
+++ b/internal/core/webauthn_storage_error_test.go
@@ -1,0 +1,319 @@
+// webauthn_storage_error_test.go — closes the storage-failure branches
+// webauthn.go's Begin/Finish functions each guard but MockStorage cannot
+// exercise: several WebAuthn storage.Storage methods (CreateWebAuthnSession,
+// ConsumeWebAuthnSession, ListWebAuthnCredentials, CreateWebAuthnCredential,
+// DeleteWebAuthnCredential, CountWebAuthnCredentials, SetUserWebAuthnEnabled)
+// are FIXED no-op stubs on MockStorage (mock_storage_test.go), not real
+// mock.Called() expectations — they cannot be made to return an error via
+// ms.On(...). webauthnStorageErrStub instead wraps a real LocalStorage
+// (over SQLite) and overrides exactly one method at a time to inject a
+// targeted failure, mirroring the userRoleScopesStub pattern already used in
+// authz_readable_scopes_test.go for the same reason.
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/protocol/webauthncose"
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// webauthnStorageErrStub wraps a real storage.Storage and overrides
+// individual WebAuthn-related methods to return a fixed error, leaving
+// everything else (including the OTHER WebAuthn methods) to the real
+// implementation.
+type webauthnStorageErrStub struct {
+	corestorage.Storage
+	createSessionErr error
+	listCredsErr     error
+	createCredErr    error
+	deleteCredErr    error
+	countCredsErr    error
+	setEnabledErr    error
+}
+
+func (s *webauthnStorageErrStub) CreateWebAuthnSession(ctx context.Context, sess *models.WebAuthnSession) error {
+	if s.createSessionErr != nil {
+		return s.createSessionErr
+	}
+	return s.Storage.CreateWebAuthnSession(ctx, sess)
+}
+
+func (s *webauthnStorageErrStub) ListWebAuthnCredentials(ctx context.Context, userID uint) ([]*models.WebAuthnCredential, error) {
+	if s.listCredsErr != nil {
+		return nil, s.listCredsErr
+	}
+	return s.Storage.ListWebAuthnCredentials(ctx, userID)
+}
+
+func (s *webauthnStorageErrStub) CreateWebAuthnCredential(ctx context.Context, cred *models.WebAuthnCredential) error {
+	if s.createCredErr != nil {
+		return s.createCredErr
+	}
+	return s.Storage.CreateWebAuthnCredential(ctx, cred)
+}
+
+func (s *webauthnStorageErrStub) DeleteWebAuthnCredential(ctx context.Context, userID, id uint) error {
+	if s.deleteCredErr != nil {
+		return s.deleteCredErr
+	}
+	return s.Storage.DeleteWebAuthnCredential(ctx, userID, id)
+}
+
+func (s *webauthnStorageErrStub) CountWebAuthnCredentials(ctx context.Context, userID uint) (int64, error) {
+	if s.countCredsErr != nil {
+		return 0, s.countCredsErr
+	}
+	return s.Storage.CountWebAuthnCredentials(ctx, userID)
+}
+
+func (s *webauthnStorageErrStub) SetUserWebAuthnEnabled(ctx context.Context, userID uint, enabled bool) error {
+	if s.setEnabledErr != nil {
+		return s.setEnabledErr
+	}
+	return s.Storage.SetUserWebAuthnEnabled(ctx, userID, enabled)
+}
+
+// ── storeWebAuthnSession ──────────────────────────────────────────────────
+
+func TestStoreWebAuthnSession_StorageErrorPropagates(t *testing.T) {
+	c, _ := newWebAuthnTestCore(t, true)
+	wantErr := errors.New("db down")
+	c.storage = &webauthnStorageErrStub{Storage: c.storage, createSessionErr: wantErr}
+
+	_, err := c.storeWebAuthnSession(context.Background(), 1, "login", &webauthn.SessionData{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// ── BeginWebAuthnRegistration ────────────────────────────────────────────
+
+func TestBeginWebAuthnRegistration_StoreSessionFails(t *testing.T) {
+	c, _ := newWebAuthnTestCore(t, true)
+	wantErr := errors.New("db down")
+	c.storage = &webauthnStorageErrStub{Storage: c.storage, createSessionErr: wantErr}
+
+	_, _, err := c.BeginWebAuthnRegistration(context.Background(), 1)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// ── BeginWebAuthnLogin ────────────────────────────────────────────────────
+
+func TestBeginWebAuthnLogin_DisabledServerRejects(t *testing.T) {
+	c, _ := newWebAuthnTestCore(t, false)
+	_, _, err := c.BeginWebAuthnLogin(context.Background(), "irrelevant")
+	require.ErrorIs(t, err, ErrWebAuthnDisabled)
+}
+
+func TestBeginWebAuthnLogin_LoadUserFails(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	seedCredential(t, c, db, 1, "cred-1")
+	ch, err := c.CreateMFAChallenge(context.Background(), 1)
+	require.NoError(t, err)
+
+	wantErr := errors.New("db down")
+	c.storage = &webauthnStorageErrStub{Storage: c.storage, listCredsErr: wantErr}
+
+	_, _, err = c.BeginWebAuthnLogin(context.Background(), ch)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestBeginWebAuthnLogin_StoreSessionFails(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	seedCredential(t, c, db, 1, "cred-1")
+	ch, err := c.CreateMFAChallenge(context.Background(), 1)
+	require.NoError(t, err)
+
+	wantErr := errors.New("db down")
+	c.storage = &webauthnStorageErrStub{Storage: c.storage, createSessionErr: wantErr}
+
+	_, _, err = c.BeginWebAuthnLogin(context.Background(), ch)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// ── BeginWebAuthnPasswordlessLogin ───────────────────────────────────────
+
+func TestBeginWebAuthnPasswordlessLogin_StoreSessionFails(t *testing.T) {
+	c, _ := newWebAuthnTestCore(t, true)
+	wantErr := errors.New("db down")
+	c.storage = &webauthnStorageErrStub{Storage: c.storage, createSessionErr: wantErr}
+
+	_, _, err := c.BeginWebAuthnPasswordlessLogin(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// ── FinishWebAuthnRegistration ───────────────────────────────────────────
+
+func TestFinishWebAuthnRegistration_SessionPurposeMismatch(t *testing.T) {
+	c, _ := newWebAuthnTestCore(t, true)
+	ctx := context.Background()
+	// A session minted for the LOGIN flow must not complete a registration.
+	tok, err := c.storeWebAuthnSession(ctx, 1, "login", &webauthn.SessionData{Challenge: "x"})
+	require.NoError(t, err)
+	_, err = c.FinishWebAuthnRegistration(ctx, 1, tok, "laptop", webauthnTestPassword, &protocol.ParsedCredentialCreationData{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "registration session mismatch")
+}
+
+func TestFinishWebAuthnRegistration_InvalidSessionToken(t *testing.T) {
+	c, _ := newWebAuthnTestCore(t, true)
+	ctx := context.Background()
+	_, err := c.FinishWebAuthnRegistration(ctx, 1, "not-a-real-token", "laptop", webauthnTestPassword, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid or expired registration session")
+}
+
+func TestFinishWebAuthnRegistration_CreateCredentialStorageFails(t *testing.T) {
+	c, db := newWebAuthnSpecTestCore(t)
+	ctx := context.Background()
+
+	parsed, challenge := specRegistrationAttestation(t)
+	sd := &webauthn.SessionData{
+		Challenge:  challenge,
+		UserID:     specWebAuthnID(1),
+		CredParams: []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
+	}
+	token, err := c.storeWebAuthnSession(ctx, 1, "register", sd)
+	require.NoError(t, err)
+
+	wantErr := errors.New("db down")
+	c.storage = &webauthnStorageErrStub{Storage: c.storage, createCredErr: wantErr}
+
+	_, err = c.FinishWebAuthnRegistration(ctx, 1, token, "yubikey", webauthnTestPassword, parsed)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to store credential")
+
+	var count int64
+	require.NoError(t, db.Model(&models.WebAuthnCredential{}).Count(&count).Error)
+	assert.Zero(t, count, "a failed store must not leave a partial credential row")
+}
+
+// ── DeleteWebAuthnCredential ─────────────────────────────────────────────
+
+func TestDeleteWebAuthnCredential_GetUserFails(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	seedCredential(t, c, db, 1, "cred-1")
+	var cred models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ?", 1).First(&cred).Error)
+
+	err := c.DeleteWebAuthnCredential(context.Background(), 999, cred.ID, webauthnTestPassword)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user not found")
+}
+
+// Deleting one of TWO passkeys must succeed and leave WebAuthn enabled,
+// unlike deleting the LAST one (already covered by
+// TestWebAuthn_DeleteClearsFlagOnLastAndIsUserScoped) -- the n>0 branch.
+func TestDeleteWebAuthnCredential_NotLastPasskeyStaysEnabled(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	seedCredential(t, c, db, 1, "cred-1")
+	seedCredential(t, c, db, 1, "cred-2")
+	seedStepUpGrant(t, db, 1, c.now())
+
+	var first models.WebAuthnCredential
+	require.NoError(t, db.Where("credential_id = ?", []byte("cred-1")).First(&first).Error)
+
+	require.NoError(t, c.DeleteWebAuthnCredential(context.Background(), 1, first.ID, webauthnTestPassword))
+
+	var user models.User
+	require.NoError(t, db.First(&user, 1).Error)
+	assert.True(t, user.WebAuthnEnabled, "one passkey remains, so WebAuthn must stay enabled")
+
+	var remaining int64
+	require.NoError(t, db.Model(&models.WebAuthnCredential{}).Where("user_id = ?", 1).Count(&remaining).Error)
+	assert.Equal(t, int64(1), remaining)
+}
+
+func TestDeleteWebAuthnCredential_StorageDeleteFails(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	seedCredential(t, c, db, 1, "cred-1")
+	seedStepUpGrant(t, db, 1, c.now())
+	var cred models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ?", 1).First(&cred).Error)
+
+	wantErr := errors.New("db down")
+	c.storage = &webauthnStorageErrStub{Storage: c.storage, deleteCredErr: wantErr}
+
+	err := c.DeleteWebAuthnCredential(context.Background(), 1, cred.ID, webauthnTestPassword)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestDeleteWebAuthnCredential_CountFails(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	seedCredential(t, c, db, 1, "cred-1")
+	seedStepUpGrant(t, db, 1, c.now())
+	var cred models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ?", 1).First(&cred).Error)
+
+	wantErr := errors.New("db down")
+	c.storage = &webauthnStorageErrStub{Storage: c.storage, countCredsErr: wantErr}
+
+	err := c.DeleteWebAuthnCredential(context.Background(), 1, cred.ID, webauthnTestPassword)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestDeleteWebAuthnCredential_SetEnabledFalseFails(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	seedCredential(t, c, db, 1, "cred-1")
+	seedStepUpGrant(t, db, 1, c.now())
+	var cred models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ?", 1).First(&cred).Error)
+
+	wantErr := errors.New("db down")
+	c.storage = &webauthnStorageErrStub{Storage: c.storage, setEnabledErr: wantErr}
+
+	err := c.DeleteWebAuthnCredential(context.Background(), 1, cred.ID, webauthnTestPassword)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// ── loadWebAuthnUser ──────────────────────────────────────────────────────
+
+// An unreadable stored credential blob (corrupted JSON) must be skipped, not
+// fail the whole ceremony -- one bad row shouldn't lock the user out of every
+// OTHER passkey they hold.
+func TestLoadWebAuthnUser_SkipsUnreadableCredentialBlob(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	seedCredential(t, c, db, 1, "cred-good")
+	require.NoError(t, db.Create(&models.WebAuthnCredential{
+		UserID: 1, CredentialID: []byte("cred-bad"), Name: "corrupt", CredentialBlob: []byte("{not json"),
+	}).Error)
+
+	wu, err := c.loadWebAuthnUser(context.Background(), 1)
+	require.NoError(t, err)
+	require.Len(t, wu.creds, 1, "only the readable credential should load")
+	assert.Equal(t, []byte("cred-good"), wu.creds[0].ID)
+}
+
+// A credential flagged Disabled (#212 clone detection) must never be offered
+// to a NEW ceremony, whether login candidate set or registration exclusion
+// list.
+func TestLoadWebAuthnUser_SkipsDisabledCredential(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	seedCredential(t, c, db, 1, "cred-active")
+	blob, err := json.Marshal(webauthn.Credential{ID: []byte("cred-disabled")})
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&models.WebAuthnCredential{
+		UserID: 1, CredentialID: []byte("cred-disabled"), Name: "disabled", CredentialBlob: blob, Disabled: true,
+	}).Error)
+
+	wu, err := c.loadWebAuthnUser(context.Background(), 1)
+	require.NoError(t, err)
+	require.Len(t, wu.creds, 1)
+	assert.Equal(t, []byte("cred-active"), wu.creds[0].ID)
+}

--- a/internal/core/webauthn_test.go
+++ b/internal/core/webauthn_test.go
@@ -84,6 +84,33 @@ func TestWebAuthn_DisabledServerRejects(t *testing.T) {
 	require.ErrorIs(t, err, ErrWebAuthnDisabled)
 }
 
+// FinishWebAuthnRegistration and FinishWebAuthnLogin must refuse just as
+// early as their Begin counterparts when no relying party is configured --
+// neither should reach the requireReauth/challenge-consumption steps below.
+func TestWebAuthn_FinishDisabledServerRejects(t *testing.T) {
+	c, _ := newWebAuthnTestCore(t, false)
+	ctx := context.Background()
+	_, err := c.FinishWebAuthnRegistration(ctx, 1, "tok", "laptop", webauthnTestPassword, nil)
+	require.ErrorIs(t, err, ErrWebAuthnDisabled)
+	_, _, err = c.FinishWebAuthnLogin(ctx, "ch", "tok", "ua", "1.2.3.4", nil)
+	require.ErrorIs(t, err, ErrWebAuthnDisabled)
+}
+
+// A malformed/unknown webauthn ceremony session token must be rejected before
+// any assertion is parsed -- distinct from TestWebAuthn_FinishLoginRejectsMismatchedSession,
+// which covers a session that consumes fine but belongs to the wrong purpose/user.
+func TestWebAuthn_FinishLoginRejectsInvalidSessionToken(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	ctx := context.Background()
+	seedCredential(t, c, db, 1, "cred-1")
+
+	ch, err := c.CreateMFAChallenge(ctx, 1)
+	require.NoError(t, err)
+	_, _, err = c.FinishWebAuthnLogin(ctx, ch, "not-a-real-session-token", "ua", "1.2.3.4", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "webauthn session")
+}
+
 func TestWebAuthn_RegistrationBeginIssuesSingleUseSession(t *testing.T) {
 	c, _ := newWebAuthnTestCore(t, true)
 	ctx := context.Background()

--- a/internal/storage/factory_postgres_bootstrap_test.go
+++ b/internal/storage/factory_postgres_bootstrap_test.go
@@ -1,0 +1,116 @@
+// factory_postgres_bootstrap_test.go — the real-Postgres counterpart to
+// TestCreateStorage_Postgres_FailsFast/TestOpenGormDB_Postgres_ConnectFailure
+// (storage_s2_test.go). Those only ever drive the connection-refused branch
+// of createPostgresStorage/OpenGormDB: gorm.Open never succeeds, so neither
+// function ever reaches applyPoolSettings, withMigrationLock, or the final
+// success return -- leaving createPostgresStorage at 45.5% coverage (per this
+// campaign's survey) despite the function being almost entirely the success
+// path plus one error-propagation branch. Uses the same isolated-database
+// helpers (pgTestDSN/pgIsolatedDatabaseDSN/pgRawOpen) as
+// postgres_pk_rebuild_helpers_test.go, gated on KEYORIX_TEST_PG_DSN so
+// go test ./... still passes cleanly with no Postgres available.
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// TestCreateStorage_Postgres_Success drives createPostgresStorage's entire
+// success path against a real, fresh Postgres database: DSN resolves
+// non-empty, gorm.Open connects, applyPoolSettings applies pool limits,
+// withMigrationLock acquires the advisory lock and runs migrateDatabase, and
+// the factory returns a usable store.LocalStorage. This is the first test in
+// the repo to reach createPostgresStorage's final `return
+// store.NewLocalStorage(db), nil` and withMigrationLock's isPostgres success
+// branch (both previously 0%-covered: every other Postgres test either fails
+// fast on connect or drives migrateDatabase directly, bypassing the factory
+// entirely).
+func TestCreateStorage_Postgres_Success(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	base := pgTestDSN(t)
+	dsn := pgIsolatedDatabaseDSN(t, base)
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "postgres"
+	cfg.Storage.Database.DSN = dsn
+	cfg.Storage.Database.MaxOpenConns = 5
+	cfg.Storage.Database.MaxIdleConns = 2
+	cfg.Storage.Database.ConnMaxLifetimeMinutes = 10
+
+	st, err := NewStorageFactory().CreateStorage(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+
+	// A real migration ran: verify via a table only AutoMigrate/migrateDatabase
+	// would have created, and that the schema epoch was recorded (ADR-097).
+	db := pgRawOpen(t, dsn)
+	assert.True(t, tableExists(db, "users"), "migrateDatabase must have created the users table")
+	var m models.SystemMetadata
+	require.NoError(t, db.Where("key = ?", schemaEpochMetadataKey).Take(&m).Error)
+	assert.Equal(t, "1", m.Value)
+}
+
+// TestCreateStorage_Postgres_MigrationFailure_Propagates seeds a
+// system_metadata row with a corrupt (unparseable) schema_epoch BEFORE
+// calling CreateStorage -- checkSchemaEpoch fails closed (ADR-097), so
+// migrateDatabase returns an error, which createPostgresStorage must wrap and
+// propagate rather than returning a live (but never-migrated) storage
+// instance. This exercises createPostgresStorage's own
+// `withMigrationLock(...); err != nil` branch (previously 0%-covered), not
+// just checkSchemaEpoch's parse-error branch (already covered against
+// SQLite).
+func TestCreateStorage_Postgres_MigrationFailure_Propagates(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	base := pgTestDSN(t)
+	dsn := pgIsolatedDatabaseDSN(t, base)
+
+	seed := pgRawOpen(t, dsn)
+	require.NoError(t, seed.AutoMigrate(&models.SystemMetadata{}))
+	require.NoError(t, seed.Create(&models.SystemMetadata{
+		Key: schemaEpochMetadataKey, Value: "not-a-number",
+	}).Error)
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "postgres"
+	cfg.Storage.Database.DSN = dsn
+
+	st, err := NewStorageFactory().CreateStorage(cfg)
+	require.Error(t, err)
+	assert.Nil(t, st)
+	assert.Contains(t, err.Error(), "failed to migrate database")
+	assert.Contains(t, err.Error(), "not a valid integer")
+}
+
+// TestOpenGormDB_Postgres_Success drives OpenGormDB's postgres branch to its
+// success return (previously 0%-covered for the same reason as
+// createPostgresStorage above: TestOpenGormDB_Postgres_ConnectFailure only
+// ever exercises the connection-refused branch). Unlike CreateStorage,
+// OpenGormDB deliberately does not migrate -- confirm no tables get created.
+func TestOpenGormDB_Postgres_Success(t *testing.T) {
+	base := pgTestDSN(t)
+	dsn := pgIsolatedDatabaseDSN(t, base)
+
+	cfg := &config.Config{}
+	cfg.Storage.Type = "postgres"
+	cfg.Storage.Database.DSN = dsn
+
+	db, err := OpenGormDB(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Ping())
+	assert.False(t, tableExists(db, "users"), "OpenGormDB must not migrate -- it exists for raw admin access to an already-initialized database")
+}

--- a/internal/storage/factory_schema_epoch_test.go
+++ b/internal/storage/factory_schema_epoch_test.go
@@ -132,6 +132,43 @@ func TestSchemaEpoch_CorruptRecordedEpoch_FailsClosed(t *testing.T) {
 	assert.Contains(t, err.Error(), "not a valid integer")
 }
 
+// TestCheckSchemaEpoch_ReadQueryError_FailsClosed exercises checkSchemaEpoch's
+// third error branch: system_metadata exists (tableExists is true) but the
+// query against it fails for a reason OTHER than "no row" -- here, the table
+// is missing the very "key" column the WHERE clause references, so the read
+// itself errors instead of returning gorm.ErrRecordNotFound. This is
+// deliberately NOT the same branch as
+// TestSchemaEpoch_CorruptRecordedEpoch_FailsClosed (a value that reads fine
+// but fails to parse) -- that test never reaches this one, since a
+// successful read short-circuits past it.
+func TestCheckSchemaEpoch_ReadQueryError_FailsClosed(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "epoch-read-error.db"))
+	require.NoError(t, err)
+	// system_metadata exists (so tableExists is true) but has no "key" column.
+	require.NoError(t, db.Exec(`CREATE TABLE system_metadata (id INTEGER PRIMARY KEY, value TEXT)`).Error)
+
+	err = checkSchemaEpoch(db)
+	require.Error(t, err, "a genuine query error reading schema_epoch must fail closed, not be treated as absent")
+	assert.Contains(t, err.Error(), "failed to read schema epoch")
+}
+
+// TestRecordSchemaEpoch_MissingTable_ReturnsError exercises recordSchemaEpoch
+// directly (rather than through migrateDatabase, which always AutoMigrates
+// system_metadata first and so never reaches this branch): the upsert Create
+// call against a database where system_metadata was never created must
+// return a wrapped error, not panic or silently no-op.
+func TestRecordSchemaEpoch_MissingTable_ReturnsError(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "epoch-record-missing-table.db"))
+	require.NoError(t, err)
+
+	err = recordSchemaEpoch(db)
+	require.Error(t, err, "recordSchemaEpoch against a database with no system_metadata table must return an error")
+	assert.Contains(t, err.Error(), "failed to record schema epoch")
+}
+
 // TestSchemaEpoch_FailedMigration_DoesNotAdvanceEpoch: if a later migration
 // step fails, the epoch must NOT be recorded -- recordSchemaEpoch only runs
 // after every other step succeeds, so a crash mid-migration can't advance

--- a/internal/storage/normalize_backfill_test.go
+++ b/internal/storage/normalize_backfill_test.go
@@ -78,6 +78,40 @@ func TestBackfillFoldedColumn_HappyPathBackfillsDistinctRows(t *testing.T) {
 	assert.Equal(t, "manually-set", afterRerun, "a non-empty folded column must not be recomputed")
 }
 
+// TestBackfillFoldedColumn_FoldFunctionError exercises the branch where fold
+// (foldIdentity, wrapping identity.NewFoldedName) rejects a stored raw value
+// outright -- a control character embedded in a name, the same PRECIS
+// rejection identity's own tests pin. This is distinct from the collision
+// branch above: here there is only one row, and it fails to normalize at all
+// rather than colliding with another row.
+func TestBackfillFoldedColumn_FoldFunctionError(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "backfill-fold-error.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, username_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, ?, '', NULL)`, "bad\nname").Error)
+
+	err = backfillFoldedColumn(db, "users", "id", "username", "username_folded", "", foldIdentity)
+	require.Error(t, err, "a raw value the fold function rejects must fail the backfill, not panic or skip silently")
+	assert.Contains(t, err.Error(), "failed to normalize users.username")
+}
+
+// TestBackfillFoldedColumn_UpdateError exercises the write-back error branch:
+// the read (Scan) and the fold both succeed, but the subsequent Update fails.
+// A BEFORE UPDATE trigger that always aborts reproduces a write failure
+// (e.g. a constraint or permission error in production) without needing to
+// break the connection between the read and the write.
+func TestBackfillFoldedColumn_UpdateError(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "backfill-update-error.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, username_folded TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'Alice', '', NULL)`).Error)
+	require.NoError(t, db.Exec(`CREATE TRIGGER block_users_update BEFORE UPDATE ON users BEGIN SELECT RAISE(ABORT, 'blocked for test'); END`).Error)
+
+	err = backfillFoldedColumn(db, "users", "id", "username", "username_folded", "", foldIdentity)
+	require.Error(t, err, "a write failure during backfill must be surfaced, not swallowed")
+	assert.Contains(t, err.Error(), "failed to backfill users.username_folded")
+}
+
 // TestNormalizeColumnInPlace_RefusesOnCollision mirrors the FoldedColumn
 // collision-refusal test above, for the in-place NFC-only normalizer used by
 // secret_nodes.name (no separate folded column -- see normalize_backfill.go).
@@ -101,4 +135,48 @@ func TestNormalizeColumnInPlace_RefusesOnCollision(t *testing.T) {
 	require.NoError(t, db2.Exec(`INSERT INTO secret_nodes VALUES (2, 'prod_key', NULL)`).Error)
 	require.NoError(t, normalizeColumnInPlace(db2, "secret_nodes", "id", "name", "", normalizeAddress),
 		"case-distinct secret names must not be treated as colliding")
+}
+
+// TestNormalizeColumnInPlace_ReadQueryError exercises the Scan error branch:
+// an invalid whereClause (referencing a column that doesn't exist) makes the
+// initial read itself fail, before any row is ever normalized.
+func TestNormalizeColumnInPlace_ReadQueryError(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "normalize-read-error.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE secret_nodes (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO secret_nodes VALUES (1, 'prod_key', NULL)`).Error)
+
+	err = normalizeColumnInPlace(db, "secret_nodes", "id", "name", "no_such_column = 1", normalizeAddress)
+	require.Error(t, err, "a query error reading rows to normalize must be surfaced, not panic or skip silently")
+	assert.Contains(t, err.Error(), "failed to read secret_nodes for name normalization")
+}
+
+// TestNormalizeColumnInPlace_NormalizeFunctionError mirrors
+// TestBackfillFoldedColumn_FoldFunctionError for the in-place normalizer: a
+// stored secret name containing a control character is rejected by
+// normalizeAddress (identity.NewAddressName) outright.
+func TestNormalizeColumnInPlace_NormalizeFunctionError(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "normalize-fn-error.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE secret_nodes (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO secret_nodes VALUES (1, ?, NULL)`, "bad\nname").Error)
+
+	err = normalizeColumnInPlace(db, "secret_nodes", "id", "name", "", normalizeAddress)
+	require.Error(t, err, "a raw value the normalize function rejects must fail the pass, not panic or skip silently")
+	assert.Contains(t, err.Error(), "failed to normalize secret_nodes.name")
+}
+
+// TestNormalizeColumnInPlace_UpdateError mirrors
+// TestBackfillFoldedColumn_UpdateError: the read and normalize both succeed,
+// but the write-back fails.
+func TestNormalizeColumnInPlace_UpdateError(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "normalize-update-error.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE secret_nodes (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO secret_nodes VALUES (1, ?, NULL)`, nfdCafe).Error)
+	require.NoError(t, db.Exec(`CREATE TRIGGER block_secret_nodes_update BEFORE UPDATE ON secret_nodes BEGIN SELECT RAISE(ABORT, 'blocked for test'); END`).Error)
+
+	err = normalizeColumnInPlace(db, "secret_nodes", "id", "name", "", normalizeAddress)
+	require.Error(t, err, "a write failure during normalization must be surfaced, not swallowed")
+	assert.Contains(t, err.Error(), "failed to normalize secret_nodes.name for id=1")
 }

--- a/internal/storage/store/concurrency_bootstrap_lock_postgres_test.go
+++ b/internal/storage/store/concurrency_bootstrap_lock_postgres_test.go
@@ -1,0 +1,111 @@
+package store
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrency_WithBootstrapLock_MultiInstancePostgres_ExactlyOneRunsAtOnce
+// exercises local_bootstrap_lock.go's pg_advisory_lock across genuinely
+// independent connections, the same way
+// TestConcurrency_WithAuditCheckpointLock_MultiInstancePostgres_ExactlyOneRunsAtOnce
+// exercises its sibling lock: many independent LocalStorage instances (own
+// *gorm.DB, own Postgres backend connection) racing BootstrapSystem's
+// check-then-create sequence. A single-connection test (see
+// TestWithBootstrapLock_SerializesConcurrentCallers in local_bootstrap_lock_test.go)
+// only proves the process-local ls.bootstrapMu works — it can't say anything
+// about the pg_advisory_lock branch, which is the ONLY thing serializing two
+// different replica PROCESSES (two independent *gorm.DB connections) racing
+// POST /system/init against the same shared database (#core-auth-03). Like
+// WithAuditCheckpointLock (and unlike WithSchedulerLock), WithBootstrapLock
+// BLOCKS until it acquires the lock rather than skipping on contention, so
+// every racer here is expected to eventually run fn — the assertion is that
+// none of them ever run it concurrently with another.
+func TestConcurrency_WithBootstrapLock_MultiInstancePostgres_ExactlyOneRunsAtOnce(t *testing.T) {
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	const instances = 8
+
+	stores := make([]*LocalStorage, instances)
+	for i := 0; i < instances; i++ {
+		stores[i] = NewLocalStorage(pgOpen(t, dsn))
+	}
+
+	var running int32
+	var maxConcurrent int32
+	var completed int32
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < instances; i++ {
+		wg.Add(1)
+		go func(ls *LocalStorage) {
+			defer wg.Done()
+			<-start
+			err := ls.WithBootstrapLock(context.Background(), func() error {
+				n := atomic.AddInt32(&running, 1)
+				for {
+					m := atomic.LoadInt32(&maxConcurrent)
+					if n <= m || atomic.CompareAndSwapInt32(&maxConcurrent, m, n) {
+						break
+					}
+				}
+				time.Sleep(75 * time.Millisecond) // hold the lock long enough for every racer to attempt while it's held
+				atomic.AddInt32(&running, -1)
+				return nil
+			})
+			require.NoError(t, err)
+			atomic.AddInt32(&completed, 1)
+		}(stores[i])
+	}
+	close(start) // release every instance's attempt at once
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&maxConcurrent),
+		"at most one replica's bootstrap check-then-create critical section may run at a time")
+	assert.Equal(t, int32(instances), atomic.LoadInt32(&completed),
+		"WithBootstrapLock blocks rather than skips, so every racer must eventually run fn")
+}
+
+// TestConcurrency_WithBootstrapLock_MultiInstancePostgres_ErrorStillReleases
+// confirms a losing racer isn't permanently blocked behind a winner whose fn
+// returned an error: the advisory lock (and the pooled connection carrying
+// it) must still be released via the deferred pg_advisory_unlock/Close even
+// on the error path, or every subsequent replica attempting to bootstrap
+// would hang forever after the first bootstrap attempt fails.
+func TestConcurrency_WithBootstrapLock_MultiInstancePostgres_ErrorStillReleases(t *testing.T) {
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	first := NewLocalStorage(pgOpen(t, dsn))
+	sentinel := assert.AnError
+	err := first.WithBootstrapLock(context.Background(), func() error {
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+
+	second := NewLocalStorage(pgOpen(t, dsn))
+	ran := false
+	done := make(chan error, 1)
+	go func() {
+		done <- second.WithBootstrapLock(context.Background(), func() error {
+			ran = true
+			return nil
+		})
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("second replica's WithBootstrapLock never returned — the first racer's error left the advisory lock held")
+	}
+	assert.True(t, ran, "the second replica must be able to acquire and run after the first racer's fn errored")
+}

--- a/internal/storage/store/concurrency_named_lock_postgres_test.go
+++ b/internal/storage/store/concurrency_named_lock_postgres_test.go
@@ -1,0 +1,124 @@
+package store
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrency_WithNamedLock_MultiInstancePostgres_SameKeySerializes
+// exercises local_named_lock.go's pg_advisory_lock branch across genuinely
+// independent connections, the same shape as the sibling
+// WithBootstrapLock/WithAuditCheckpointLock Postgres tests: many independent
+// LocalStorage instances (own *gorm.DB, own Postgres backend connection)
+// racing WithNamedLock under the SAME lockKey. Only the Postgres branch can
+// say anything about cross-PROCESS exclusion — the SQLite/process-mutex path
+// (local_named_lock_test.go) only proves one process's own namedLockRegistry
+// works, which says nothing about the pg_advisory_lock(namedLockKey(...))
+// call this test is the only coverage for.
+func TestConcurrency_WithNamedLock_MultiInstancePostgres_SameKeySerializes(t *testing.T) {
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	const instances = 8
+	const lockKey = "concurrency-named-lock-postgres-test"
+
+	stores := make([]*LocalStorage, instances)
+	for i := 0; i < instances; i++ {
+		stores[i] = NewLocalStorage(pgOpen(t, dsn))
+	}
+
+	var running int32
+	var maxConcurrent int32
+	var completed int32
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < instances; i++ {
+		wg.Add(1)
+		go func(ls *LocalStorage) {
+			defer wg.Done()
+			<-start
+			err := ls.WithNamedLock(context.Background(), lockKey, func(_ context.Context) error {
+				n := atomic.AddInt32(&running, 1)
+				for {
+					m := atomic.LoadInt32(&maxConcurrent)
+					if n <= m || atomic.CompareAndSwapInt32(&maxConcurrent, m, n) {
+						break
+					}
+				}
+				time.Sleep(75 * time.Millisecond)
+				atomic.AddInt32(&running, -1)
+				return nil
+			})
+			require.NoError(t, err)
+			atomic.AddInt32(&completed, 1)
+		}(stores[i])
+	}
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&maxConcurrent),
+		"at most one holder of a given lockKey may run fn at a time, across independent connections")
+	assert.Equal(t, int32(instances), atomic.LoadInt32(&completed),
+		"WithNamedLock blocks rather than skips, so every racer must eventually run fn")
+}
+
+// TestConcurrency_WithNamedLock_MultiInstancePostgres_DifferentKeysDontContend
+// is the mirror check: two DIFFERENT lockKeys must NOT serialize against each
+// other across independent connections either — namedLockKey hashes each
+// string to its own advisory-lock key, so a holder of key "A" must never
+// block a concurrent holder of key "B".
+func TestConcurrency_WithNamedLock_MultiInstancePostgres_DifferentKeysDontContend(t *testing.T) {
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	holderA := NewLocalStorage(pgOpen(t, dsn))
+	holderB := NewLocalStorage(pgOpen(t, dsn))
+
+	release := make(chan struct{})
+	aRunning := make(chan struct{})
+	aDone := make(chan error, 1)
+	go func() {
+		aDone <- holderA.WithNamedLock(context.Background(), "distinct-key-A", func(_ context.Context) error {
+			close(aRunning)
+			<-release
+			return nil
+		})
+	}()
+
+	select {
+	case <-aRunning:
+	case <-time.After(5 * time.Second):
+		t.Fatal("holder A never entered its critical section")
+	}
+
+	// While A holds "distinct-key-A", B must be able to acquire "distinct-key-B"
+	// immediately — no shared serialization between unrelated keys.
+	bDone := make(chan error, 1)
+	go func() {
+		bDone <- holderB.WithNamedLock(context.Background(), "distinct-key-B", func(_ context.Context) error {
+			return nil
+		})
+	}()
+
+	select {
+	case err := <-bDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("holder B blocked on a DIFFERENT lockKey while holder A held its own -- the two keys wrongly contended")
+	}
+
+	close(release)
+	select {
+	case err := <-aDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("holder A never completed")
+	}
+}

--- a/internal/storage/store/local_audit_cascade_sweep_test.go
+++ b/internal/storage/store/local_audit_cascade_sweep_test.go
@@ -1,0 +1,84 @@
+// local_audit_cascade_sweep_test.go — partial-coverage sweep for
+// local_audit.go: GetAuditLogs' two Find-error branches, GetSecretReadCounts'
+// Scan error, and DeleteAuditLogsBefore's head-lookup error / genuine
+// re-anchor branches. NOTE: line 114 (PrincipalSecretFirstSeen's `if
+// r.FirstSeen.t == nil { continue }`) is intentionally NOT covered here --
+// investigation found it very likely unreachable: the query's own WHERE
+// clause ("access_time >= ?") excludes NULL access_time rows before they can
+// ever reach GROUP BY/MIN(), so a matched group's MIN(access_time) can never
+// itself be SQL NULL. Same defensive-dead-code shape as
+// local_purge.go:PurgeDeletedSecretsBefore's analogous `continue` (see
+// local_purge_cascade_sweep_test.go's package doc).
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAuditLogs_AscendingFindFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.AuditEvent{})
+	dropTableAfterQueries(t, ls.db, 1, "audit_events")
+
+	_, _, err := ls.GetAuditLogs(context.Background(), &storage.AuditFilter{Ascending: true, PageSize: 10})
+	require.Error(t, err)
+}
+
+func TestGetAuditLogs_FindFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.AuditEvent{})
+	dropTableAfterQueries(t, ls.db, 1, "audit_events")
+
+	_, _, err := ls.GetAuditLogs(context.Background(), &storage.AuditFilter{PageSize: 10})
+	require.Error(t, err)
+}
+
+func TestGetSecretReadCounts_ScanFails(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetSecretReadCounts(context.Background(), 1, time.Now().Add(-time.Hour), time.Now(), 10)
+	require.Error(t, err)
+}
+
+func TestDeleteAuditLogsBefore_HeadLookupFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.AuditEvent{})
+	ctx := context.Background()
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, ls.db.Create(&models.AuditEvent{EventType: "secret.read", EventTime: old}).Error)
+
+	// The Delete (RowsAffected > 0) is a different callback family and runs
+	// fine; drop the table before the very first Row-family (Scan) call, the
+	// head lookup right after.
+	dropTableAfterRows(t, ls.db, 0, "audit_events")
+
+	_, _, err := ls.DeleteAuditLogsBefore(ctx, time.Now())
+	require.Error(t, err)
+}
+
+func TestDeleteAuditLogsBefore_ReanchorsSurvivingChainedRow(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.AuditEvent{})
+	ctx := context.Background()
+	old := time.Now().Add(-48 * time.Hour)
+	surviving := time.Now().Add(-time.Hour)
+	require.NoError(t, ls.db.Create(&models.AuditEvent{EventType: "secret.read", EventTime: old}).Error)
+	require.NoError(t, ls.db.Create(&models.AuditEvent{
+		EventType: "secret.read", EventTime: surviving,
+		PrevHash: "mid-chain-prev-hash", EntryHash: "mid-chain-entry-hash",
+	}).Error)
+
+	cutoff := time.Now().Add(-24 * time.Hour)
+	deleted, anchor, err := ls.DeleteAuditLogsBefore(ctx, cutoff)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), deleted)
+	require.NotNil(t, anchor)
+	require.Equal(t, "mid-chain-prev-hash", anchor.PrevHash)
+	require.Equal(t, "mid-chain-entry-hash", anchor.EntryHash)
+}

--- a/internal/storage/store/local_audit_chain_cascade_sweep_test.go
+++ b/internal/storage/store/local_audit_chain_cascade_sweep_test.go
@@ -1,0 +1,61 @@
+// local_audit_chain_cascade_sweep_test.go — partial-coverage sweep for
+// local_audit_chain.go: VerifyAuditChain/MigrateAuditChainEncoding DB-error
+// and anchor-mismatch branches. NOTE: LogAuditEvent's and
+// MigrateAuditChainEncoding's `tx.Dialector.Name() == "postgres"` advisory-
+// lock branches (lines 174-175, 279-281) are genuinely unreachable via
+// SQLite and are intentionally NOT covered here -- out of scope per this
+// sweep's instructions (reserved for the dedicated lock-function tests).
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyAuditChain_FindFails(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.VerifyAuditChain(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestVerifyAuditChain_AnchorMismatch(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.AuditEvent{})
+	require.NoError(t, ls.db.Create(&models.AuditEvent{
+		EventType: "secret.read", EntryHash: "abc123", PrevHash: "not-genesis-and-not-anchor",
+	}).Error)
+
+	result, err := ls.VerifyAuditChain(context.Background(), &storage.AuditChainAnchor{
+		RowID: 999, PrevHash: "some-other-prev", EntryHash: "some-other-entry",
+	})
+	require.NoError(t, err)
+	require.False(t, result.Valid)
+	require.NotNil(t, result.FirstBrokenID)
+}
+
+func TestMigrateAuditChainEncoding_FindFails(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.MigrateAuditChainEncoding(context.Background(), false, nil)
+	require.Error(t, err)
+}
+
+func TestMigrateAuditChainEncoding_UpdatesFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.AuditEvent{})
+	// A chained row (non-empty EntryHash) whose stored hash/prev_hash won't
+	// match the freshly recomputed value, forcing the corrective Updates call.
+	require.NoError(t, ls.db.Create(&models.AuditEvent{
+		EventType: "secret.read", EntryHash: "stale-hash", PrevHash: "stale-prev",
+	}).Error)
+
+	dropTableAfterQueries(t, ls.db, 1, "audit_events")
+
+	_, err := ls.MigrateAuditChainEncoding(context.Background(), false, nil)
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_audit_checkpoint_cascade_sweep_test.go
+++ b/internal/storage/store/local_audit_checkpoint_cascade_sweep_test.go
@@ -1,0 +1,27 @@
+// local_audit_checkpoint_cascade_sweep_test.go — partial-coverage sweep for
+// local_audit_checkpoint.go's AuditEntryHashByID: the second (existence
+// Count) query's own DB-error branch, isolated from the first (Scan) query
+// which store_coverage_gaps_test.go's TestAuditEntryHashByID_BrokenDB already
+// covers via a fully-broken DB.
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestAuditEntryHashByID_CountFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.AuditEvent{})
+
+	require.NoError(t, ls.db.Callback().Query().Before("gorm:query").Register("drop-audit_events-before-count", func(tx *gorm.DB) {
+		tx.Exec("DROP TABLE IF EXISTS audit_events")
+	}))
+
+	_, _, err := ls.AuditEntryHashByID(context.Background(), 1)
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_auth_cascade_sweep_test.go
+++ b/internal/storage/store/local_auth_cascade_sweep_test.go
@@ -1,0 +1,50 @@
+// local_auth_cascade_sweep_test.go — partial-coverage sweep for
+// local_auth.go: RotateSession's post-CAS-win Create failure,
+// EnforceSessionLimit's Delete failure, and
+// RevokeAllPersonalAccessTokensForUser's Update failure.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRotateSession_CreateFailsAfterWinningCAS(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Session{})
+	old := &models.Session{UserID: 1, SessionToken: "old-hash"}
+	require.NoError(t, ls.db.Create(old).Error)
+
+	dropTableAfterUpdates(t, ls.db, 1, "sessions")
+
+	_, _, err := ls.RotateSession(context.Background(), old.ID, &models.Session{UserID: 1, SessionToken: "new-plaintext"}, time.Now())
+	require.Error(t, err)
+}
+
+func TestEnforceSessionLimit_DeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Session{})
+	require.NoError(t, ls.db.Create(&models.Session{UserID: 1, SessionToken: "s1"}).Error)
+
+	dropTableAfterQueries(t, ls.db, 1, "sessions")
+
+	err := ls.EnforceSessionLimit(context.Background(), 1, 1)
+	require.Error(t, err)
+}
+
+func TestRevokeAllPersonalAccessTokensForUser_UpdateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.PersonalAccessToken{})
+	require.NoError(t, ls.db.Create(&models.PersonalAccessToken{
+		UserID: 1, Name: "tok", TokenHash: "hash1",
+	}).Error)
+
+	dropTableAfterQueries(t, ls.db, 1, "personal_access_tokens")
+
+	_, err := ls.RevokeAllPersonalAccessTokensForUser(context.Background(), 1)
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_billing.go
+++ b/internal/storage/store/local_billing.go
@@ -198,9 +198,13 @@ func (ls *LocalStorage) billingCountsByProject(ctx context.Context, from, to tim
 	if err != nil {
 		return nil, err
 	}
+	// "machine_identity" (models.AuditEvent.ActorType / core.ActorTypeMachine), not
+	// "machine" — this previously used the wrong literal, so MachineReads always
+	// reported 0 regardless of real machine-identity read activity; caught by
+	// GetBillingReport's first real (non-zero-coverage) test.
 	machineReads, err := ls.countByProject(ctx, "audit_events",
 		"project_id IN ? AND event_type = ? AND actor_type = ? AND event_time >= ? AND event_time < ?",
-		projectIDs, "secret.read", "machine", from, to)
+		projectIDs, "secret.read", "machine_identity", from, to)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/store/local_billing_cascade_sweep_test.go
+++ b/internal/storage/store/local_billing_cascade_sweep_test.go
@@ -1,0 +1,77 @@
+// local_billing_cascade_sweep_test.go — partial-coverage sweep for
+// local_billing.go's GetBillingReport pipeline: each sequential aggregation
+// step's own DB-error branch AND the caller-level error-wrap branch it
+// triggers, reached via newBrokenDB, partial migration, or
+// dropTableAfterRows (shared helper, local_secrets_cascade_sweep_test.go) --
+// billing.go uses .Table(...).Scan(...) throughout, which routes through
+// GORM's "gorm:row" callback family, not "gorm:query".
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBillingReport_AllProjectIDsFails(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetBillingReport(context.Background(), time.Now().Add(-time.Hour), time.Now(), nil)
+	require.Error(t, err)
+}
+
+func TestGetBillingReport_ProjectNamesFails(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetBillingReport(context.Background(), time.Now().Add(-time.Hour), time.Now(), []uint{1})
+	require.Error(t, err)
+}
+
+func TestGetBillingReport_SecretCountsFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{})
+	_, err := ls.GetBillingReport(context.Background(), time.Now().Add(-time.Hour), time.Now(), []uint{1})
+	require.Error(t, err)
+}
+
+func TestGetBillingReport_ReadsFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.SecretNode{})
+	_, err := ls.GetBillingReport(context.Background(), time.Now().Add(-time.Hour), time.Now(), []uint{1})
+	require.Error(t, err)
+}
+
+func TestGetBillingReport_WritesFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.SecretNode{}, &models.AuditEvent{})
+	dropTableAfterRows(t, ls.db, 2, "audit_events")
+	_, err := ls.GetBillingReport(context.Background(), time.Now().Add(-time.Hour), time.Now(), []uint{1})
+	require.Error(t, err)
+}
+
+func TestGetBillingReport_RotationsFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.SecretNode{}, &models.AuditEvent{})
+	dropTableAfterRows(t, ls.db, 3, "audit_events")
+	_, err := ls.GetBillingReport(context.Background(), time.Now().Add(-time.Hour), time.Now(), []uint{1})
+	require.Error(t, err)
+}
+
+func TestGetBillingReport_DistinctUsersFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.SecretNode{}, &models.AuditEvent{})
+	dropTableAfterRows(t, ls.db, 4, "audit_events")
+	_, err := ls.GetBillingReport(context.Background(), time.Now().Add(-time.Hour), time.Now(), []uint{1})
+	require.Error(t, err)
+}
+
+func TestGetBillingReport_MachineReadsFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.SecretNode{}, &models.AuditEvent{})
+	dropTableAfterRows(t, ls.db, 5, "audit_events")
+	_, err := ls.GetBillingReport(context.Background(), time.Now().Add(-time.Hour), time.Now(), []uint{1})
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_billing_test.go
+++ b/internal/storage/store/local_billing_test.go
@@ -1,0 +1,177 @@
+// local_billing_test.go — coverage for GetBillingReport (local_billing.go),
+// previously entirely untested (0%).
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func newBillingTestStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.SecretNode{}, &models.AuditEvent{}))
+	return NewLocalStorage(db)
+}
+
+// TestGetBillingReport_AggregatesPerProjectAndOmitsInactive is the main
+// end-to-end pass: two projects with distinct activity, a third project with
+// neither secrets nor activity (must be omitted), and a soft-deleted secret
+// that must not count. Also pins the machine-identity-read fix directly:
+// audit_events rows must be tagged actor_type="machine_identity" (the real
+// value models.AuditEvent.ActorType / core.ActorTypeMachine uses), not
+// "machine", to be counted as MachineReads.
+func TestGetBillingReport_AggregatesPerProjectAndOmitsInactive(t *testing.T) {
+	ls := newBillingTestStore(t)
+	ctx := context.Background()
+	db := ls.DB()
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "alpha"}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 2, Name: "beta"}).Error)
+	require.NoError(t, db.Create(&models.Project{ID: 3, Name: "empty"}).Error) // no secrets, no activity
+
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, ProjectID: 1, EnvironmentID: 1, Name: "s1", IsSecret: true, Status: "active"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 2, ProjectID: 1, EnvironmentID: 1, Name: "s2", IsSecret: true, Status: "active"}).Error)
+	// Soft-deleted secret in project 1 must not count toward SecretCount.
+	deletedAt := time.Now()
+	require.NoError(t, db.Create(&models.SecretNode{ID: 3, ProjectID: 1, EnvironmentID: 1, Name: "s3-deleted", IsSecret: true, Status: "active", DeletedAt: gorm.DeletedAt{Time: deletedAt, Valid: true}}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 4, ProjectID: 2, EnvironmentID: 1, Name: "s4", IsSecret: true, Status: "active"}).Error)
+
+	from := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	inWindow := from.Add(24 * time.Hour)
+	outOfWindow := from.Add(-24 * time.Hour)
+
+	projID1, projID2 := uint(1), uint(2)
+	userA, userB := uint(10), uint(11)
+
+	mkEvent := func(projectID uint, eventType string, userID *uint, actorType string, at time.Time) {
+		require.NoError(t, db.Create(&models.AuditEvent{
+			ProjectID: &projectID, EventType: eventType, UserID: userID, ActorType: actorType,
+			Success: boolPtr(true), EventTime: at,
+		}).Error)
+	}
+
+	// Project 1: 2 reads (1 human, 1 machine), 1 write, 1 rotate (also a write),
+	// 2 distinct human users, 1 event outside the window (must not count).
+	mkEvent(projID1, "secret.read", &userA, "user", inWindow)
+	mkEvent(projID1, "secret.read", nil, "machine_identity", inWindow)
+	mkEvent(projID1, "secret.create", &userA, "user", inWindow)
+	mkEvent(projID1, "secret.rotate", &userB, "user", inWindow)
+	mkEvent(projID1, "secret.read", &userA, "user", outOfWindow)
+
+	// Project 2: 1 read only.
+	mkEvent(projID2, "secret.read", &userB, "user", inWindow)
+
+	report, err := ls.GetBillingReport(ctx, from, to, nil)
+	require.NoError(t, err)
+	assert.True(t, from.Equal(report.From))
+	assert.True(t, to.Equal(report.To))
+	assert.False(t, report.GeneratedAt.IsZero())
+
+	// Project 3 (no secrets, no activity) must be omitted; only 1 and 2 remain.
+	require.Len(t, report.Projects, 2)
+	seenProjects := map[uint]bool{}
+	for _, p := range report.Projects {
+		seenProjects[p.ProjectID] = true
+	}
+	assert.True(t, seenProjects[1])
+	assert.True(t, seenProjects[2])
+	assert.False(t, seenProjects[3], "a project with no secrets and no activity must be omitted")
+}
+
+// TestGetBillingReport_ProjectStatFields asserts every field of a single
+// project's BillingProjectStat (and the report-level Totals), the real
+// per-metric coverage this file's first test only checks membership for.
+func TestGetBillingReport_ProjectStatFields(t *testing.T) {
+	ls := newBillingTestStore(t)
+	ctx := context.Background()
+	db := ls.DB()
+
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "alpha"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, ProjectID: 1, EnvironmentID: 1, Name: "s1", IsSecret: true, Status: "active"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 2, ProjectID: 1, EnvironmentID: 1, Name: "s2", IsSecret: true, Status: "active"}).Error)
+
+	from := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	inWindow := from.Add(24 * time.Hour)
+
+	projID := uint(1)
+	userA, userB := uint(10), uint(11)
+	mkEvent := func(eventType string, userID *uint, actorType string) {
+		require.NoError(t, db.Create(&models.AuditEvent{
+			ProjectID: &projID, EventType: eventType, UserID: userID, ActorType: actorType,
+			Success: boolPtr(true), EventTime: inWindow,
+		}).Error)
+	}
+	mkEvent("secret.read", &userA, "user")
+	mkEvent("secret.read", nil, "machine_identity")
+	mkEvent("secret.read", nil, "machine_identity")
+	mkEvent("secret.create", &userA, "user")
+	mkEvent("secret.update", &userB, "user")
+	mkEvent("secret.rotate", &userA, "user")
+
+	report, err := ls.GetBillingReport(ctx, from, to, []uint{1})
+	require.NoError(t, err)
+	require.Len(t, report.Projects, 1)
+	stat := report.Projects[0]
+
+	assert.Equal(t, projID, stat.ProjectID)
+	assert.Equal(t, "alpha", stat.ProjectName)
+	assert.Equal(t, int64(2), stat.SecretCount)
+	assert.Equal(t, int64(3), stat.SecretReads, "SecretReads counts every secret.read event, human and machine alike")
+	assert.Equal(t, int64(2), stat.MachineReads, "MachineReads is the machine_identity SUBSET of SecretReads, not exclusive of it")
+	assert.Equal(t, int64(3), stat.SecretWrites, "create + update + rotate")
+	assert.Equal(t, int64(1), stat.SecretRotations)
+	assert.Equal(t, 2, stat.UniqueUsers, "userA and userB")
+
+	assert.Equal(t, 1, report.Totals.Projects)
+	assert.Equal(t, int64(2), report.Totals.SecretCount)
+	assert.Equal(t, int64(3), report.Totals.SecretReads)
+	assert.Equal(t, int64(2), report.Totals.MachineReads)
+}
+
+// A project_id filter over the cap is rejected outright rather than silently
+// truncated.
+func TestGetBillingReport_TooManyProjectIDs(t *testing.T) {
+	ls := newBillingTestStore(t)
+	ids := make([]uint, maxBillingReportProjectIDs+1)
+	for i := range ids {
+		ids[i] = uint(i + 1)
+	}
+	report, err := ls.GetBillingReport(context.Background(), time.Now(), time.Now(), ids)
+	require.Error(t, err)
+	assert.Nil(t, report)
+}
+
+// No projects at all (fresh install) returns an empty, non-nil report rather
+// than erroring.
+func TestGetBillingReport_NoProjects(t *testing.T) {
+	ls := newBillingTestStore(t)
+	report, err := ls.GetBillingReport(context.Background(), time.Now(), time.Now(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	assert.Empty(t, report.Projects)
+	assert.Equal(t, 0, report.Totals.Projects)
+}
+
+// An explicit projectIDs filter that names a project with no secrets/activity
+// is still omitted from the report, same as the nil-filter "all projects" case.
+func TestGetBillingReport_ExplicitFilterStillOmitsInactiveProject(t *testing.T) {
+	ls := newBillingTestStore(t)
+	db := ls.DB()
+	require.NoError(t, db.Create(&models.Project{ID: 5, Name: "quiet"}).Error)
+
+	report, err := ls.GetBillingReport(context.Background(), time.Now().Add(-time.Hour), time.Now().Add(time.Hour), []uint{5})
+	require.NoError(t, err)
+	assert.Empty(t, report.Projects)
+}

--- a/internal/storage/store/local_break_glass_test.go
+++ b/internal/storage/store/local_break_glass_test.go
@@ -182,3 +182,86 @@ func TestBreakGlassReads_NeverPersistState(t *testing.T) {
 	assert.Equal(t, "active", stored.State,
 		"neither read above may have persisted the projection -- the row's real, stored state must be unchanged")
 }
+
+// TestReconcileExpiredBreakGlassActivation_TransitionsOnlyTheMatchingRow is
+// the ONE place a TTL-lapse transition is actually persisted (see
+// ActivateBreakGlass, its sole caller) -- it must flip exactly the row named
+// by (projectID, userID) that is still 'active' and past its expiry, and
+// leave every other row (different project/user, already revoked, not yet
+// expired, permanent/no-expiry) untouched.
+func TestReconcileExpiredBreakGlassActivation_TransitionsOnlyTheMatchingRow(t *testing.T) {
+	ls := newBreakGlassStore(t)
+	ctx := context.Background()
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+
+	target, err := ls.CreateBreakGlassActivation(ctx, &models.BreakGlassActivation{
+		ProjectID: 1, UserID: 10, RoleID: 3, RoleName: "editor", State: "active", ExpiresAt: &past,
+	})
+	require.NoError(t, err)
+
+	// Different user, same project, also expired -- must stay untouched.
+	otherUser, err := ls.CreateBreakGlassActivation(ctx, &models.BreakGlassActivation{
+		ProjectID: 1, UserID: 11, RoleID: 3, RoleName: "editor", State: "active", ExpiresAt: &past,
+	})
+	require.NoError(t, err)
+
+	// Same (project, user) but not yet expired -- must stay 'active'.
+	notExpired, err := ls.CreateBreakGlassActivation(ctx, &models.BreakGlassActivation{
+		ProjectID: 2, UserID: 10, RoleID: 3, RoleName: "editor", State: "active", ExpiresAt: &future,
+	})
+	require.NoError(t, err)
+
+	// Permanent grant (no expiry) for the same (project, user) -- must never
+	// be reconciled regardless of how much time has passed.
+	permanent, err := ls.CreateBreakGlassActivation(ctx, &models.BreakGlassActivation{
+		ProjectID: 3, UserID: 10, RoleID: 3, RoleName: "editor", State: "active",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, ls.ReconcileExpiredBreakGlassActivation(ctx, 1, 10))
+
+	var got1 models.BreakGlassActivation
+	require.NoError(t, ls.db.First(&got1, target.ID).Error)
+	assert.Equal(t, "expired", got1.State, "the matching, expired, still-active row must transition")
+
+	var got2 models.BreakGlassActivation
+	require.NoError(t, ls.db.First(&got2, otherUser.ID).Error)
+	assert.Equal(t, "active", got2.State, "a different user's expired row must not be touched")
+
+	var got3 models.BreakGlassActivation
+	require.NoError(t, ls.db.First(&got3, notExpired.ID).Error)
+	assert.Equal(t, "active", got3.State, "a not-yet-expired row for the same user must stay active")
+
+	var got4 models.BreakGlassActivation
+	require.NoError(t, ls.db.First(&got4, permanent.ID).Error)
+	assert.Equal(t, "active", got4.State, "a permanent (no ExpiresAt) grant must never be reconciled to expired")
+}
+
+// A row already revoked must not be reverted to 'expired' by a later
+// reconcile -- Reconcile only ever transitions FROM active, never from
+// revoked (#1653's "revoked always wins" invariant).
+func TestReconcileExpiredBreakGlassActivation_LeavesRevokedRowAlone(t *testing.T) {
+	ls := newBreakGlassStore(t)
+	ctx := context.Background()
+	past := time.Now().Add(-time.Hour)
+
+	activation, err := ls.CreateBreakGlassActivation(ctx, &models.BreakGlassActivation{
+		ProjectID: 1, UserID: 10, RoleID: 3, RoleName: "editor", State: "active", ExpiresAt: &past,
+	})
+	require.NoError(t, err)
+	require.NoError(t, ls.db.Model(&models.BreakGlassActivation{}).Where("id = ?", activation.ID).
+		Update("state", "revoked").Error)
+
+	require.NoError(t, ls.ReconcileExpiredBreakGlassActivation(ctx, 1, 10))
+
+	var got models.BreakGlassActivation
+	require.NoError(t, ls.db.First(&got, activation.ID).Error)
+	assert.Equal(t, "revoked", got.State, "a revoked row must never be reverted to expired by a later reconcile")
+}
+
+// No matching row at all is a harmless no-op, not an error.
+func TestReconcileExpiredBreakGlassActivation_NoMatchIsNoop(t *testing.T) {
+	ls := newBreakGlassStore(t)
+	require.NoError(t, ls.ReconcileExpiredBreakGlassActivation(context.Background(), 404, 404))
+}

--- a/internal/storage/store/local_connector_project_bindings_test.go
+++ b/internal/storage/store/local_connector_project_bindings_test.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func newConnectorProjectBindingStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.ConnectorProjectBinding{}))
+	return NewLocalStorage(db)
+}
+
+func TestConnectorProjectBinding_CreateGetList(t *testing.T) {
+	ls := newConnectorProjectBindingStore(t)
+	ctx := context.Background()
+
+	created, err := ls.CreateConnectorProjectBinding(ctx, &models.ConnectorProjectBinding{
+		Connector: "k8s-prod", ProjectID: 5, ProjectName: "prod",
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, created.ID)
+
+	got, err := ls.GetConnectorProjectBinding(ctx, "k8s-prod")
+	require.NoError(t, err)
+	assert.Equal(t, uint(5), got.ProjectID)
+	assert.Equal(t, "prod", got.ProjectName)
+
+	_, err = ls.CreateConnectorProjectBinding(ctx, &models.ConnectorProjectBinding{
+		Connector: "k8s-staging", ProjectID: 6, ProjectName: "staging",
+	})
+	require.NoError(t, err)
+
+	all, err := ls.ListConnectorProjectBindings(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+}
+
+func TestConnectorProjectBinding_GetNotFound(t *testing.T) {
+	ls := newConnectorProjectBindingStore(t)
+	binding, err := ls.GetConnectorProjectBinding(context.Background(), "does-not-exist")
+	require.Error(t, err)
+	assert.Nil(t, binding)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// Connector has a unique index — a second binding for an already-bound
+// connector must conflict, matching CreateConnectorProjectBinding's own doc
+// comment ("callers must check GetConnectorProjectBinding first").
+func TestConnectorProjectBinding_DuplicateConnectorConflicts(t *testing.T) {
+	ls := newConnectorProjectBindingStore(t)
+	ctx := context.Background()
+
+	_, err := ls.CreateConnectorProjectBinding(ctx, &models.ConnectorProjectBinding{
+		Connector: "k8s-prod", ProjectID: 5, ProjectName: "prod",
+	})
+	require.NoError(t, err)
+
+	_, err = ls.CreateConnectorProjectBinding(ctx, &models.ConnectorProjectBinding{
+		Connector: "k8s-prod", ProjectID: 9, ProjectName: "other",
+	})
+	require.Error(t, err)
+}
+
+func TestConnectorProjectBinding_ListEmpty(t *testing.T) {
+	ls := newConnectorProjectBindingStore(t)
+	all, err := ls.ListConnectorProjectBindings(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, all)
+}

--- a/internal/storage/store/local_machine_credentials_test.go
+++ b/internal/storage/store/local_machine_credentials_test.go
@@ -200,3 +200,35 @@ func TestGetMachineRoleIDsAt_DeletedEnvironmentStopsAuthorizing(t *testing.T) {
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []uint{30}, ids, "restored environment: the grant authorizes again")
 }
+
+// GetMachineRoleScopes returns the distinct (project, environment) pairs a
+// machine identity holds ANY role grant at -- used to enumerate a machine's
+// reachable scopes without needing to know which role IDs to ask about.
+func TestGetMachineRoleScopes(t *testing.T) {
+	ls := newMachineCredTestStore(t)
+	ctx := context.Background()
+	const machineID = uint(1)
+
+	require.NoError(t, ls.AssignMachineRole(ctx, machineID, 100, storage.Scope{})) // global: (0, 0)
+	require.NoError(t, ls.AssignMachineRole(ctx, machineID, 200, storage.Scope{ProjectID: 2}))
+	require.NoError(t, ls.AssignMachineRole(ctx, machineID, 300, storage.Scope{ProjectID: 2, EnvironmentID: 5}))
+	// A second role at the SAME scope as an existing grant must not duplicate the scope.
+	require.NoError(t, ls.AssignMachineRole(ctx, machineID, 400, storage.Scope{ProjectID: 2}))
+	// A different machine's grant must not leak into machineID's scopes.
+	require.NoError(t, ls.AssignMachineRole(ctx, 2, 500, storage.Scope{ProjectID: 9}))
+
+	scopes, err := ls.GetMachineRoleScopes(ctx, machineID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []storage.Scope{
+		{ProjectID: 0, EnvironmentID: 0},
+		{ProjectID: 2, EnvironmentID: 0},
+		{ProjectID: 2, EnvironmentID: 5},
+	}, scopes)
+}
+
+func TestGetMachineRoleScopes_NoGrantsReturnsEmpty(t *testing.T) {
+	ls := newMachineCredTestStore(t)
+	scopes, err := ls.GetMachineRoleScopes(context.Background(), 404)
+	require.NoError(t, err)
+	assert.Empty(t, scopes)
+}

--- a/internal/storage/store/local_mfa_stepup_grant.go
+++ b/internal/storage/store/local_mfa_stepup_grant.go
@@ -43,7 +43,14 @@ func (ls *LocalStorage) DeleteMFAStepUpGrantsFor(ctx context.Context, userID uin
 // PruneMFAStepUpGrants deletes grants whose ExpiresAt predates `before` and
 // returns how many were removed (store-mfa-002 maintenance sweep — see
 // internal/core.KeyorixCore.PruneMFAStepUpGrants, the sole intended caller).
+//
+// G81 (ExpiresAt, this file's third recurrence): normalize `before` internally
+// rather than trusting the caller — see GetAuditLogs. core.KeyorixCore's cutoff
+// is derived from time.Now() (server-local, not guaranteed UTC), while
+// MFAStepUpGrant.BeforeSave always normalizes ExpiresAt to UTC before writing;
+// on SQLite (plain string comparison) a non-UTC `before` silently drifts from
+// what's actually stored whenever the server process isn't pinned to TZ=UTC.
 func (ls *LocalStorage) PruneMFAStepUpGrants(ctx context.Context, before time.Time) (int64, error) {
-	res := ls.db.WithContext(ctx).Where("expires_at < ?", before).Delete(&models.MFAStepUpGrant{})
+	res := ls.db.WithContext(ctx).Where("expires_at < ?", before.UTC()).Delete(&models.MFAStepUpGrant{})
 	return res.RowsAffected, res.Error
 }

--- a/internal/storage/store/local_mfa_stepup_grant_test.go
+++ b/internal/storage/store/local_mfa_stepup_grant_test.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func newMFAStepUpGrantStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.MFAStepUpGrant{}))
+	return NewLocalStorage(db)
+}
+
+func TestMFAStepUpGrant_CreateAndDeleteFor(t *testing.T) {
+	ls := newMFAStepUpGrantStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
+		UserID: 1, ExpiresAt: time.Now().Add(10 * time.Minute),
+	}))
+	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
+		UserID: 1, ExpiresAt: time.Now().Add(20 * time.Minute),
+	}))
+	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
+		UserID: 2, ExpiresAt: time.Now().Add(10 * time.Minute),
+	}))
+
+	g, err := ls.GetActiveMFAStepUpGrant(ctx, 1, time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, g)
+	assert.Equal(t, uint(1), g.UserID)
+
+	require.NoError(t, ls.DeleteMFAStepUpGrantsFor(ctx, 1))
+
+	g, err = ls.GetActiveMFAStepUpGrant(ctx, 1, time.Now())
+	require.NoError(t, err)
+	assert.Nil(t, g, "all of user 1's grants were deleted")
+
+	// User 2's grant must be untouched.
+	g2, err := ls.GetActiveMFAStepUpGrant(ctx, 2, time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, g2)
+}
+
+func TestMFAStepUpGrant_PruneRemovesOnlyExpired(t *testing.T) {
+	ls := newMFAStepUpGrantStore(t)
+	ctx := context.Background()
+
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+
+	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: 1, ExpiresAt: past}))
+	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: 2, ExpiresAt: past}))
+	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: 3, ExpiresAt: future}))
+
+	deleted, err := ls.PruneMFAStepUpGrants(ctx, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), deleted)
+
+	g3, err := ls.GetActiveMFAStepUpGrant(ctx, 3, time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, g3, "the not-yet-expired grant must survive the prune")
+}
+
+func TestMFAStepUpGrant_GetActiveNoneReturnsNilNil(t *testing.T) {
+	ls := newMFAStepUpGrantStore(t)
+	g, err := ls.GetActiveMFAStepUpGrant(context.Background(), 99, time.Now())
+	require.NoError(t, err)
+	assert.Nil(t, g)
+}
+
+func TestMFAStepUpGrant_DeleteForNoneIsNoop(t *testing.T) {
+	ls := newMFAStepUpGrantStore(t)
+	require.NoError(t, ls.DeleteMFAStepUpGrantsFor(context.Background(), 404))
+}

--- a/internal/storage/store/local_misc2_error_sweep_test.go
+++ b/internal/storage/store/local_misc2_error_sweep_test.go
@@ -1,0 +1,112 @@
+// local_misc2_error_sweep_test.go — DB-error and small-logic-branch sweep for
+// local_alert_escalation.go, local_access_activity.go, local_webauthn.go, and
+// local_version_comments.go.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAlertEscalationPolicy_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetAlertEscalationPolicy(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestListAlertEscalationPolicies_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.ListAlertEscalationPolicies(context.Background())
+	require.Error(t, err)
+}
+
+func TestUpdateAlertEscalationPolicy_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	err := ls.UpdateAlertEscalationPolicy(context.Background(), &models.AlertEscalationPolicy{ID: 1})
+	require.Error(t, err)
+}
+
+func TestDeleteAlertEscalationPolicy_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	err := ls.DeleteAlertEscalationPolicy(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestListUnacknowledgedAnomalyAlertsBefore_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.ListUnacknowledgedAnomalyAlertsBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestLastUserSecretActivity_SkipsRealZeroUserID(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.AuditEvent{})
+	ctx := context.Background()
+	pid := uint(7)
+	uid := uint(3)
+	require.NoError(t, ls.db.Create(&models.AuditEvent{
+		EventType: "secret.read", ProjectID: &pid, UserID: &uid, EventTime: time.Now(),
+	}).Error)
+	// A REAL stored user_id=0 (not NULL) still passes "user_id IS NOT NULL",
+	// unlike a nil *uint field (which never reaches the query result at all).
+	require.NoError(t, ls.db.Exec("UPDATE audit_events SET user_id = 0 WHERE user_id = ?", uid).Error)
+
+	m, err := ls.LastUserSecretActivity(ctx, pid)
+	require.NoError(t, err)
+	assert.NotContains(t, m, uint(0))
+	assert.Empty(t, m)
+}
+
+func TestAdvanceWebAuthnCredentialCounter_UnmarshalFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.WebAuthnCredential{})
+	require.NoError(t, ls.db.Create(&models.WebAuthnCredential{
+		UserID: 1, CredentialID: []byte("cred-1"), CredentialBlob: []byte("not-json"),
+	}).Error)
+
+	_, err := ls.AdvanceWebAuthnCredentialCounter(context.Background(), []byte("cred-1"), 1, []byte(`{"authenticator":{"signCount":5}}`), 5, time.Now())
+	require.Error(t, err)
+}
+
+func TestAdvanceWebAuthnCredentialCounter_UpdateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.WebAuthnCredential{})
+	require.NoError(t, ls.db.Create(&models.WebAuthnCredential{
+		UserID: 1, CredentialID: []byte("cred-2"), CredentialBlob: []byte(`{"authenticator":{"signCount":1}}`),
+	}).Error)
+
+	dropTableAfterQueries(t, ls.db, 1, "web_authn_credentials")
+
+	_, err := ls.AdvanceWebAuthnCredentialCounter(context.Background(), []byte("cred-2"), 1, []byte(`{"authenticator":{"signCount":5}}`), 5, time.Now())
+	require.Error(t, err)
+}
+
+func TestConsumeWebAuthnSession_LoadFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.WebAuthnSession{})
+	require.NoError(t, ls.db.Create(&models.WebAuthnSession{
+		UserID: 1, TokenHash: "sess-tok", ExpiresAt: time.Now().Add(time.Hour),
+	}).Error)
+
+	dropTableAfterUpdates(t, ls.db, 1, "web_authn_sessions")
+
+	_, err := ls.ConsumeWebAuthnSession(context.Background(), "sess-tok", time.Now())
+	require.Error(t, err)
+}
+
+func TestDeleteSecretVersionComment_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	err := ls.DeleteSecretVersionComment(context.Background(), 1, 2, 3)
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_misc3_error_sweep_test.go
+++ b/internal/storage/store/local_misc3_error_sweep_test.go
@@ -1,0 +1,138 @@
+// local_misc3_error_sweep_test.go — DB-error and small-logic-branch sweep for
+// local_system_metadata.go, local_stats.go, local_sso.go, local_sod.go,
+// local_secret_acl.go, and local_secret_schedule.go.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestGetSystemMetadata_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, _, err := ls.GetSystemMetadata(context.Background(), "some-key")
+	require.Error(t, err)
+}
+
+func TestGetStats_UsersCountFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{})
+	_, err := ls.GetStats(context.Background())
+	require.Error(t, err)
+}
+
+func TestGetStats_RolesCountFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{}, &models.User{})
+	_, err := ls.GetStats(context.Background())
+	require.Error(t, err)
+}
+
+func TestGetStats_SessionsCountFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{}, &models.User{}, &models.Role{})
+	_, err := ls.GetStats(context.Background())
+	require.Error(t, err)
+}
+
+func TestGetPreviousDeploymentStatsSnapshot_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetPreviousDeploymentStatsSnapshot(context.Background())
+	require.Error(t, err)
+}
+
+func TestConsumeSSOLoginState_DeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SSOLoginState{})
+	require.NoError(t, ls.db.Create(&models.SSOLoginState{
+		State: "state-1", Nonce: "nonce-1", Provider: "oidc", ExpiresAt: time.Now().Add(time.Hour),
+	}).Error)
+
+	dropTableAfterQueries(t, ls.db, 1, "sso_login_states")
+
+	_, err := ls.ConsumeSSOLoginState(context.Background(), "state-1")
+	require.Error(t, err)
+}
+
+func TestConsumeSSOLoginState_LostRace(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SSOLoginState{})
+	require.NoError(t, ls.db.Create(&models.SSOLoginState{
+		State: "state-2", Nonce: "nonce-2", Provider: "oidc", ExpiresAt: time.Now().Add(time.Hour),
+	}).Error)
+
+	// Simulate a concurrent consumer winning the DELETE race between this
+	// call's own First() and its own Delete().
+	require.NoError(t, ls.db.Callback().Query().After("gorm:query").Register("sso-race-delete", func(_ *gorm.DB) {
+		ls.db.Exec("DELETE FROM sso_login_states WHERE state = ?", "state-2")
+	}))
+
+	_, err := ls.ConsumeSSOLoginState(context.Background(), "state-2")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestGetSoDPolicy_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetSoDPolicy(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestCreateOrUpdateSecretACL_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	err := ls.CreateOrUpdateSecretACL(context.Background(), &models.SecretACL{SecretID: 1, UserID: 2})
+	require.Error(t, err)
+}
+
+func TestListSecretACLs_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.ListSecretACLs(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestListSecretACLsByUser_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.ListSecretACLsByUser(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestDeleteSecretACL_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	err := ls.DeleteSecretACL(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestDeleteSecretACLsByUserAndProject_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	err := ls.DeleteSecretACLsByUserAndProject(context.Background(), 1, 2)
+	require.Error(t, err)
+}
+
+func TestSetSecretAccessSchedule_UpdateExistingSaveFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretAccessSchedule{})
+	require.NoError(t, ls.db.Create(&models.SecretAccessSchedule{
+		SecretNodeID: 1, AllowedDays: "1,2,3", StartHour: 9, EndHour: 17, Timezone: "UTC",
+	}).Error)
+
+	dropTableAfterQueries(t, ls.db, 1, "secret_access_schedules")
+
+	err := ls.SetSecretAccessSchedule(context.Background(), &models.SecretAccessSchedule{
+		SecretNodeID: 1, AllowedDays: "1,2,3,4,5", StartHour: 8, EndHour: 18, Timezone: "UTC",
+	})
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_misc_error_sweep_test.go
+++ b/internal/storage/store/local_misc_error_sweep_test.go
@@ -1,0 +1,108 @@
+// local_misc_error_sweep_test.go — DB-error branch sweep, following the
+// newBrokenDB pattern (store_s35_test.go), for several small single-function
+// files: local_memberships.go, local_machine_identities.go,
+// local_machine_credentials.go, local_mfa.go, local_mfa_stepup_grant.go.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransitionProjectMembershipState_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.TransitionProjectMembershipState(context.Background(), &models.ProjectMembership{ID: 1}, "active")
+	require.Error(t, err)
+}
+
+func TestGetMachineIdentity_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetMachineIdentity(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestGetMachineIdentityCredentialByID_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetMachineIdentityCredentialByID(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestAssignMachineRole_CreateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.MachineIdentityRole{})
+	dropTableAfterQueries(t, ls.db, 1, "machine_identity_roles")
+
+	err := ls.AssignMachineRole(context.Background(), 1, 2, storage.Scope{})
+	require.Error(t, err)
+}
+
+func TestGetMachineRoleScopes_ScanFails(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetMachineRoleScopes(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestGetOIDCBindingByID_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetOIDCBindingByID(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestConsumeMFAChallenge_LoadFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.MFAChallenge{})
+	ctx := context.Background()
+	require.NoError(t, ls.db.Create(&models.MFAChallenge{
+		TokenHash: "tok-abc", ExpiresAt: time.Now().Add(time.Hour),
+	}).Error)
+
+	dropTableAfterUpdates(t, ls.db, 1, "mfa_challenges")
+
+	_, err := ls.ConsumeMFAChallenge(ctx, "tok-abc", time.Now())
+	require.Error(t, err)
+}
+
+func TestGetActiveMFAStepUpGrant_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetActiveMFAStepUpGrant(context.Background(), 1, time.Now())
+	require.Error(t, err)
+}
+
+func TestGetConnectorProjectBinding_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetConnectorProjectBinding(context.Background(), "connector-1")
+	require.Error(t, err)
+}
+
+func TestListConnectorProjectBindings_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.ListConnectorProjectBindings(context.Background())
+	require.Error(t, err)
+}
+
+func TestGetBreakGlassActivation_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetBreakGlassActivation(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestReconcileExpiredBreakGlassActivation_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	err := ls.ReconcileExpiredBreakGlassActivation(context.Background(), 1, 2)
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_named_lock_test.go
+++ b/internal/storage/store/local_named_lock_test.go
@@ -123,3 +123,17 @@ func TestWithNamedLock_NestedDifferentKey_StillSerializesAgainstOtherHolder(t *t
 		t.Fatal("nested WithNamedLock(key-B) never completed after the holder released")
 	}
 }
+
+// namedLockKey must be a pure, stable function of its input: the Postgres
+// path (local_named_lock.go's WithNamedLock) relies on the same lockKey
+// string always hashing to the same advisory-lock key, on every connection,
+// every process, every run -- otherwise two replicas naming the "same" lock
+// key would take out advisory locks on two DIFFERENT Postgres keys and never
+// actually serialize against each other.
+func TestNamedLockKey_StableAndKeyDependent(t *testing.T) {
+	require.Equal(t, namedLockKey("project-admin-guard"), namedLockKey("project-admin-guard"),
+		"the same lockKey string must always hash to the same advisory-lock key")
+	require.NotEqual(t, namedLockKey("key-A"), namedLockKey("key-B"),
+		"different lockKey strings should (in practice) hash to different keys")
+	require.NotEqual(t, int64(0), namedLockKey(""), "even an empty lockKey must produce a deterministic, usable key")
+}

--- a/internal/storage/store/local_purge_cascade_sweep_test.go
+++ b/internal/storage/store/local_purge_cascade_sweep_test.go
@@ -1,0 +1,216 @@
+// local_purge_cascade_sweep_test.go — partial-coverage sweep for
+// local_purge.go: each retention-purge transaction's individual per-table
+// delete-error branches, reached via partial migration (earlier steps'
+// tables present, target step's table absent) or dropTableAfterDeletes /
+// dropTableAfterQueries (shared helpers, local_secrets_cascade_sweep_test.go).
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func newPurgeUsersFixture(t *testing.T, extraModels ...any) *LocalStorage {
+	t.Helper()
+	ls := newPartialSecretsDB(t, append([]any{&models.User{}}, extraModels...)...)
+	u := &models.User{Username: "purge-me", UsernameFolded: "purge-me", EmailFolded: "purge-me@example.com"}
+	require.NoError(t, ls.db.Create(u).Error)
+	require.NoError(t, ls.db.Exec("UPDATE users SET deleted_at = ? WHERE id = ?", time.Now().Add(-48*time.Hour), u.ID).Error)
+	return ls
+}
+
+func TestPurgeDeletedUsersBefore_UserRoleDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeUsersFixture(t)
+	_, err := ls.PurgeDeletedUsersBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestPurgeDeletedUsersBefore_UserGroupDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeUsersFixture(t, &models.UserRole{})
+	_, err := ls.PurgeDeletedUsersBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestPurgeDeletedUsersBefore_ShareRecordDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeUsersFixture(t, &models.UserRole{}, &models.UserGroup{})
+	_, err := ls.PurgeDeletedUsersBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestPurgeDeletedUsersBefore_PersonalAccessTokenDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeUsersFixture(t, &models.UserRole{}, &models.UserGroup{}, &models.ShareRecord{})
+	_, err := ls.PurgeDeletedUsersBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestPurgeDeletedUsersBefore_SecretACLDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeUsersFixture(t, &models.UserRole{}, &models.UserGroup{}, &models.ShareRecord{}, &models.PersonalAccessToken{})
+	_, err := ls.PurgeDeletedUsersBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestPurgeDeletedUsersBefore_SessionDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeUsersFixture(t, &models.UserRole{}, &models.UserGroup{}, &models.ShareRecord{}, &models.PersonalAccessToken{}, &models.SecretACL{})
+	_, err := ls.PurgeDeletedUsersBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestPurgeDeletedUsersBefore_FinalUserDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeUsersFixture(t, &models.UserRole{}, &models.UserGroup{}, &models.ShareRecord{},
+		&models.PersonalAccessToken{}, &models.SecretACL{}, &models.Session{})
+
+	// 6 delete-family statements precede the final User delete: UserRole,
+	// UserGroup, ShareRecord, PersonalAccessToken, SecretACL, Session.
+	dropTableAfterDeletes(t, ls.db, 6, "users")
+
+	_, err := ls.PurgeDeletedUsersBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func newPurgeProjectsFixture(t *testing.T, extraModels ...any) *LocalStorage {
+	t.Helper()
+	ls := newPartialSecretsDB(t, append([]any{&models.Project{}}, extraModels...)...)
+	p := &models.Project{Name: "purge-me"}
+	require.NoError(t, ls.db.Create(p).Error)
+	require.NoError(t, ls.db.Exec("UPDATE projects SET deleted_at = ? WHERE id = ?", time.Now().Add(-48*time.Hour), p.ID).Error)
+	return ls
+}
+
+func TestPurgeDeletedProjectsBefore_UserRoleDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeProjectsFixture(t)
+	_, err := ls.PurgeDeletedProjectsBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestPurgeDeletedProjectsBefore_GroupRoleDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeProjectsFixture(t, &models.UserRole{})
+	_, err := ls.PurgeDeletedProjectsBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestPurgeDeletedProjectsBefore_FinalProjectDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeProjectsFixture(t, &models.UserRole{}, &models.GroupRole{})
+
+	// 2 delete-family statements precede the final Project delete.
+	dropTableAfterDeletes(t, ls.db, 2, "projects")
+
+	_, err := ls.PurgeDeletedProjectsBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func newPurgeSecretsFixture(t *testing.T, extraModels ...any) *LocalStorage {
+	t.Helper()
+	ls := newPartialSecretsDB(t, append([]any{&models.SecretNode{}}, extraModels...)...)
+	s := &models.SecretNode{ProjectID: 1, EnvironmentID: 1, Name: "purge-me", IsSecret: true}
+	require.NoError(t, ls.db.Create(s).Error)
+	require.NoError(t, ls.db.Exec("UPDATE secret_nodes SET deleted_at = ? WHERE id = ?", time.Now().Add(-48*time.Hour), s.ID).Error)
+	return ls
+}
+
+func TestPurgeDeletedSecretsBefore_SecretVersionDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeSecretsFixture(t)
+	_, err := ls.PurgeDeletedSecretsBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestPurgeDeletedSecretsBefore_SecretDependencyDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeSecretsFixture(t, &models.SecretVersion{})
+	_, err := ls.PurgeDeletedSecretsBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestPurgeDeletedSecretsBefore_SecretACLDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeSecretsFixture(t, &models.SecretVersion{}, &models.SecretDependency{})
+	_, err := ls.PurgeDeletedSecretsBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestPurgeDeletedSecretsBefore_FinalSecretNodeDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPurgeSecretsFixture(t, &models.SecretVersion{}, &models.SecretDependency{}, &models.SecretACL{})
+
+	// 3 delete-family statements precede the final SecretNode delete.
+	dropTableAfterDeletes(t, ls.db, 3, "secret_nodes")
+
+	_, err := ls.PurgeDeletedSecretsBefore(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestDeleteClosedAccessReviewsBefore_CampaignDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.AccessReviewCampaign{}, &models.AccessReviewItem{})
+	ctx := context.Background()
+	closedAt := time.Now().Add(-48 * time.Hour)
+	c := &models.AccessReviewCampaign{ProjectID: 1, Name: "campaign", State: "closed", ClosedAt: &closedAt}
+	require.NoError(t, ls.db.Create(c).Error)
+
+	// 1 delete-family statement (the item delete, 0 rows) precedes the
+	// campaign delete.
+	dropTableAfterDeletes(t, ls.db, 1, "access_review_campaigns")
+
+	_, _, err := ls.DeleteClosedAccessReviewsBefore(ctx, time.Now())
+	require.Error(t, err)
+}
+
+func TestDeleteResolvedAccessRequestsBefore_RequestDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.AccessRequest{}, &models.AccessRequestApproval{})
+	ctx := context.Background()
+	resolvedAt := time.Now().Add(-48 * time.Hour)
+	r := &models.AccessRequest{ProjectID: 1, UserID: 1, State: "approved", ResolvedAt: &resolvedAt}
+	require.NoError(t, ls.db.Create(r).Error)
+
+	// 1 delete-family statement (the approval delete, 0 rows) precedes the
+	// request delete.
+	dropTableAfterDeletes(t, ls.db, 1, "access_requests")
+
+	_, _, err := ls.DeleteResolvedAccessRequestsBefore(ctx, time.Now())
+	require.Error(t, err)
+}
+
+func TestDeleteExpiredBreakGlassBefore_ReconcileUpdateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.BreakGlassActivation{})
+	ctx := context.Background()
+	pastExpiry := time.Now().Add(-time.Hour)
+	bg := &models.BreakGlassActivation{ProjectID: 1, UserID: 1, State: "active", ExpiresAt: &pastExpiry, CreatedAt: time.Now().Add(-48 * time.Hour)}
+	require.NoError(t, ls.db.Create(bg).Error)
+
+	// The Pluck (1 query-family call) finds this row (justReconciledIDs
+	// non-empty); drop the table right after so the reconcile Update fails.
+	dropTableAfterQueries(t, ls.db, 1, "break_glass_activations")
+
+	_, err := ls.DeleteExpiredBreakGlassBefore(ctx, time.Now())
+	require.Error(t, err)
+}
+
+func TestDeleteExpiredBreakGlassBefore_FinalDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.BreakGlassActivation{})
+	ctx := context.Background()
+
+	// No rows to reconcile (Pluck returns empty), so the Update step is
+	// skipped entirely; drop the table right after the Pluck so the final
+	// Delete fails instead.
+	dropTableAfterQueries(t, ls.db, 1, "break_glass_activations")
+
+	_, err := ls.DeleteExpiredBreakGlassBefore(ctx, time.Now())
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_rbac_cascade_sweep_test.go
+++ b/internal/storage/store/local_rbac_cascade_sweep_test.go
@@ -1,0 +1,169 @@
+// local_rbac_cascade_sweep_test.go — partial-coverage sweep for
+// local_rbac.go: DB-error paths in the multi-step RBAC read/assign/expiry
+// functions, reached via newBrokenDB, partial migration, or
+// dropTableAfterQueries/dropTableAfterDeletes (shared helpers,
+// local_secrets_cascade_sweep_test.go).
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestSetRoleBypassesPermissionChecks_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	err := ls.SetRoleBypassesPermissionChecks(context.Background(), 1, true)
+	require.Error(t, err)
+}
+
+func TestAssignUserRole_StaleRowDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.UserRole{})
+	ctx := context.Background()
+	expired := time.Now().Add(-time.Hour)
+	require.NoError(t, ls.db.Create(&models.UserRole{UserID: 1, RoleID: 2, ExpiresAt: &expired}).Error)
+
+	dropTableAfterQueries(t, ls.db, 1, "user_roles")
+
+	err := ls.AssignRole(ctx, 1, 2, storage.Scope{})
+	require.Error(t, err)
+}
+
+func TestAssignUserRole_CreateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.UserRole{})
+	ctx := context.Background()
+
+	// dropTableAfterQueries' After-Query hook doesn't reliably take effect
+	// here: it fires on the SAME tx reference as the not-found First() that
+	// just ran, whose stale statement state silently no-ops a later Exec on
+	// it, and a separate outer-db connection can't see this transaction's
+	// uncommitted state either. A Before-Create hook gets a FRESH tx for the
+	// new statement, which reliably drops the table right before Create runs.
+	require.NoError(t, ls.db.Callback().Create().Before("gorm:create").Register("drop-user_roles-before-create", func(tx *gorm.DB) {
+		tx.Exec("DROP TABLE IF EXISTS user_roles")
+	}))
+
+	err := ls.AssignRole(ctx, 1, 2, storage.Scope{})
+	require.Error(t, err)
+}
+
+func TestGetUserRoleScopes_ViaGroupsScanFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.UserRole{})
+	_, err := ls.GetUserRoleScopes(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestListProjectRoleAssignments_GroupRowsFindFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.UserRole{})
+	_, err := ls.ListProjectRoleAssignments(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestListGlobalAdminAssignmentsForUpdate_GroupRowsFindFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.UserRole{})
+	_, err := ls.ListGlobalAdminAssignmentsForUpdate(context.Background(), []uint{1, 2})
+	require.Error(t, err)
+}
+
+func TestRemoveGlobalAdminRoleGuarded_ListError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	err := ls.RemoveGlobalAdminRoleGuarded(context.Background(), 1, 2, []uint{3})
+	require.Error(t, err)
+}
+
+func TestIsProjectMember_ViaGroupCountFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.UserRole{})
+	_, err := ls.IsProjectMember(context.Background(), 1, 5)
+	require.Error(t, err)
+}
+
+func TestIsGroupProjectScoped_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.IsGroupProjectScoped(context.Background(), 1, 5)
+	require.Error(t, err)
+}
+
+func TestRoleSetBypassesPermissionChecks_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.RoleSetBypassesPermissionChecks(context.Background(), []uint{1})
+	require.Error(t, err)
+}
+
+func TestAssignGroupRole_StaleRowDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.GroupRole{})
+	ctx := context.Background()
+	expired := time.Now().Add(-time.Hour)
+	require.NoError(t, ls.db.Create(&models.GroupRole{GroupID: 1, RoleID: 2, ExpiresAt: &expired}).Error)
+
+	dropTableAfterQueries(t, ls.db, 1, "group_roles")
+
+	err := ls.AssignRoleToGroup(ctx, 1, 2, storage.Scope{})
+	require.Error(t, err)
+}
+
+func TestAssignGroupRole_CreateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.GroupRole{})
+	ctx := context.Background()
+
+	// See TestAssignUserRole_CreateFails for why a Before-Create hook is used
+	// instead of dropTableAfterQueries here.
+	require.NoError(t, ls.db.Callback().Create().Before("gorm:create").Register("drop-group_roles-before-create", func(tx *gorm.DB) {
+		tx.Exec("DROP TABLE IF EXISTS group_roles")
+	}))
+
+	err := ls.AssignRoleToGroup(ctx, 1, 2, storage.Scope{})
+	require.Error(t, err)
+}
+
+func TestDeleteExpiredRoleGrants_GroupRowsFindFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.UserRole{})
+	_, err := ls.DeleteExpiredRoleGrants(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestDeleteExpiredRoleGrants_UserRoleDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.UserRole{}, &models.GroupRole{})
+	ctx := context.Background()
+	expired := time.Now().Add(-time.Hour)
+	require.NoError(t, ls.db.Create(&models.UserRole{UserID: 1, RoleID: 2, ExpiresAt: &expired}).Error)
+
+	// Both Finds (userRows non-empty, groupRows empty) succeed first.
+	dropTableAfterQueries(t, ls.db, 2, "user_roles")
+
+	_, err := ls.DeleteExpiredRoleGrants(ctx, time.Now())
+	require.Error(t, err)
+}
+
+func TestDeleteExpiredRoleGrants_GroupRoleDeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.UserRole{}, &models.GroupRole{})
+	ctx := context.Background()
+	expired := time.Now().Add(-time.Hour)
+	require.NoError(t, ls.db.Create(&models.GroupRole{GroupID: 1, RoleID: 2, ExpiresAt: &expired}).Error)
+
+	// Both Finds (userRows empty, groupRows non-empty) succeed first, so the
+	// skipped-when-empty UserRole delete never runs; only GroupRole delete does.
+	dropTableAfterQueries(t, ls.db, 2, "group_roles")
+
+	_, err := ls.DeleteExpiredRoleGrants(ctx, time.Now())
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_rbac_zero_coverage_test.go
+++ b/internal/storage/store/local_rbac_zero_coverage_test.go
@@ -1,0 +1,166 @@
+// local_rbac_zero_coverage_test.go covers local_rbac.go functions that were
+// still at 0%: SetRoleBypassesPermissionChecks, RoleSetBypassesPermissionChecks,
+// IsGroupProjectScoped, ListAllGroupRoleGrants, ListAllUserRoleGrants.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetRoleBypassesPermissionChecks(t *testing.T) {
+	ls := newRBACStore(t)
+	ctx := context.Background()
+	name, err := identity.NewFoldedName("bypasser")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, name, "bypasses checks")
+	require.NoError(t, err)
+	assert.False(t, role.BypassesPermissionChecks)
+
+	require.NoError(t, ls.SetRoleBypassesPermissionChecks(ctx, role.ID, true))
+	got, err := ls.GetRole(ctx, role.ID)
+	require.NoError(t, err)
+	assert.True(t, got.BypassesPermissionChecks)
+
+	require.NoError(t, ls.SetRoleBypassesPermissionChecks(ctx, role.ID, false))
+	got, err = ls.GetRole(ctx, role.ID)
+	require.NoError(t, err)
+	assert.False(t, got.BypassesPermissionChecks)
+}
+
+func TestRoleSetBypassesPermissionChecks(t *testing.T) {
+	ls := newRBACStore(t)
+	ctx := context.Background()
+
+	nameA, err := identity.NewFoldedName("role-a")
+	require.NoError(t, err)
+	roleA, err := ls.CreateRole(ctx, nameA, "a")
+	require.NoError(t, err)
+
+	nameB, err := identity.NewFoldedName("role-b")
+	require.NoError(t, err)
+	roleB, err := ls.CreateRole(ctx, nameB, "b")
+	require.NoError(t, err)
+
+	bypasses, err := ls.RoleSetBypassesPermissionChecks(ctx, []uint{roleA.ID, roleB.ID})
+	require.NoError(t, err)
+	assert.False(t, bypasses, "neither role bypasses yet")
+
+	require.NoError(t, ls.SetRoleBypassesPermissionChecks(ctx, roleB.ID, true))
+	bypasses, err = ls.RoleSetBypassesPermissionChecks(ctx, []uint{roleA.ID, roleB.ID})
+	require.NoError(t, err)
+	assert.True(t, bypasses, "at least one role in the set bypasses")
+
+	bypasses, err = ls.RoleSetBypassesPermissionChecks(ctx, nil)
+	require.NoError(t, err)
+	assert.False(t, bypasses, "an empty role set never bypasses")
+}
+
+func TestIsGroupProjectScoped(t *testing.T) {
+	ls := newRBACStore(t)
+	ctx := context.Background()
+
+	name, err := identity.NewFoldedName("scoped-role")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, name, "scoped")
+	require.NoError(t, err)
+
+	group, err := ls.CreateGroup(ctx, &models.Group{Name: "scoped-group", NameFolded: "scoped-group"})
+	require.NoError(t, err)
+
+	// projectID == 0 short-circuits to false without querying.
+	scoped, err := ls.IsGroupProjectScoped(ctx, group.ID, 0)
+	require.NoError(t, err)
+	assert.False(t, scoped)
+
+	// No grant yet at project 7.
+	scoped, err = ls.IsGroupProjectScoped(ctx, group.ID, 7)
+	require.NoError(t, err)
+	assert.False(t, scoped)
+
+	require.NoError(t, ls.AssignRoleToGroup(ctx, group.ID, role.ID, storage.Scope{ProjectID: 7}))
+
+	scoped, err = ls.IsGroupProjectScoped(ctx, group.ID, 7)
+	require.NoError(t, err)
+	assert.True(t, scoped)
+
+	// A different project must not be considered scoped.
+	scoped, err = ls.IsGroupProjectScoped(ctx, group.ID, 8)
+	require.NoError(t, err)
+	assert.False(t, scoped)
+}
+
+// An expired group-role grant must not count as project-scoping.
+func TestIsGroupProjectScoped_ExpiredGrantExcluded(t *testing.T) {
+	ls := newRBACStore(t)
+	ctx := context.Background()
+
+	name, err := identity.NewFoldedName("scoped-role-2")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, name, "scoped")
+	require.NoError(t, err)
+	group, err := ls.CreateGroup(ctx, &models.Group{Name: "scoped-group-2", NameFolded: "scoped-group-2"})
+	require.NoError(t, err)
+
+	require.NoError(t, ls.AssignRoleToGroupWithExpiry(ctx, group.ID, role.ID, storage.Scope{ProjectID: 9}, time.Now().Add(-time.Hour)))
+
+	scoped, err := ls.IsGroupProjectScoped(ctx, group.ID, 9)
+	require.NoError(t, err)
+	assert.False(t, scoped, "an expired grant must not count as project scoping")
+}
+
+func TestListAllGroupRoleGrants(t *testing.T) {
+	ls := newRBACStore(t)
+	ctx := context.Background()
+
+	grants, err := ls.ListAllGroupRoleGrants(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, grants)
+
+	name, err := identity.NewFoldedName("gr-role")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, name, "x")
+	require.NoError(t, err)
+	group, err := ls.CreateGroup(ctx, &models.Group{Name: "gr-group", NameFolded: "gr-group"})
+	require.NoError(t, err)
+	require.NoError(t, ls.AssignRoleToGroup(ctx, group.ID, role.ID, storage.Scope{ProjectID: 1}))
+
+	grants, err = ls.ListAllGroupRoleGrants(ctx)
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	assert.Equal(t, group.ID, grants[0].GroupID)
+	assert.Equal(t, role.ID, grants[0].RoleID)
+}
+
+func TestListAllUserRoleGrants(t *testing.T) {
+	ls := newRBACStore(t)
+	ctx := context.Background()
+
+	grants, err := ls.ListAllUserRoleGrants(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, grants)
+
+	name, err := identity.NewFoldedName("ur-role")
+	require.NoError(t, err)
+	role, err := ls.CreateRole(ctx, name, "x")
+	require.NoError(t, err)
+	user, err := ls.CreateUser(ctx, &models.User{
+		Username: "ur-user", UsernameFolded: "ur-user", Email: "ur-user@example.com", EmailFolded: "ur-user@example.com",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, ls.AssignRole(ctx, user.ID, role.ID, storage.Scope{ProjectID: 1}))
+
+	grants, err = ls.ListAllUserRoleGrants(ctx)
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	assert.Equal(t, user.ID, grants[0].UserID)
+	assert.Equal(t, role.ID, grants[0].RoleID)
+}

--- a/internal/storage/store/local_risk_exceptions_error_test.go
+++ b/internal/storage/store/local_risk_exceptions_error_test.go
@@ -1,0 +1,35 @@
+// local_risk_exceptions_error_test.go — DB-error branch sweep for
+// local_risk_exceptions.go, following the newBrokenDB pattern established in
+// store_s35_test.go.
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRiskException_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetRiskException(context.Background(), 1)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "ErrorNotFound")
+}
+
+func TestRevokeRiskExceptionIfNotRevoked_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.RevokeRiskExceptionIfNotRevoked(context.Background(), &models.RiskException{ID: 1})
+	require.Error(t, err)
+}
+
+func TestApproveRiskExceptionIfPending_DBError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.ApproveRiskExceptionIfPending(context.Background(), &models.RiskException{ID: 1})
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_role_expiry_test.go
+++ b/internal/storage/store/local_role_expiry_test.go
@@ -1,0 +1,55 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func newRoleExpiryStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.UserRole{}))
+	return NewLocalStorage(db)
+}
+
+func TestListExpiringUserRoles(t *testing.T) {
+	ls := newRoleExpiryStore(t)
+	db := ls.DB()
+
+	cutoff := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	past := cutoff.Add(-48 * time.Hour) // already expired -- must still be included
+	soon := cutoff.Add(-time.Hour)      // expiring before cutoff -- included
+	later := cutoff.Add(time.Hour)      // expires after cutoff -- excluded
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ExpiresAt: &past}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ExpiresAt: &soon}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 1, ExpiresAt: &later}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 4, RoleID: 1}).Error) // permanent, ExpiresAt nil -- excluded
+
+	grants, err := ls.ListExpiringUserRoles(context.Background(), cutoff)
+	require.NoError(t, err)
+	require.Len(t, grants, 2)
+	gotUsers := map[uint]bool{}
+	for _, g := range grants {
+		gotUsers[g.UserID] = true
+	}
+	assert.True(t, gotUsers[1], "already-expired grants must be included")
+	assert.True(t, gotUsers[2])
+	assert.False(t, gotUsers[3], "a grant expiring after the cutoff must be excluded")
+	assert.False(t, gotUsers[4], "a permanent grant (no ExpiresAt) must be excluded")
+}
+
+func TestListExpiringUserRoles_NoneMatch(t *testing.T) {
+	ls := newRoleExpiryStore(t)
+	grants, err := ls.ListExpiringUserRoles(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	assert.Empty(t, grants)
+}

--- a/internal/storage/store/local_scheduler_lock_lease_cascade_sweep_test.go
+++ b/internal/storage/store/local_scheduler_lock_lease_cascade_sweep_test.go
@@ -1,0 +1,57 @@
+// local_scheduler_lock_lease_cascade_sweep_test.go — partial-coverage sweep
+// for local_scheduler_lock_lease.go's TryAcquireSchedulerLock: the three
+// SQLite-reachable DB-error branches (the ON CONFLICT Create itself, the
+// existing-row Take, and the renew Updates). The `tx.Dialector.Name() ==
+// "postgres"` FOR UPDATE clause (line 85-87) is out of scope (Postgres-only).
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestTryAcquireSchedulerLock_CreateFails(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.TryAcquireSchedulerLock(context.Background(), 1, "holder-a", time.Minute)
+	require.Error(t, err)
+}
+
+func TestTryAcquireSchedulerLock_TakeFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SchedulerLockLease{})
+	require.NoError(t, ls.db.Create(&models.SchedulerLockLease{
+		Key: 1, Holder: "holder-a", ExpiresAt: time.Now().Add(time.Hour),
+	}).Error)
+
+	// The ON CONFLICT Create hits the existing row (RowsAffected 0) and falls
+	// through to Take; drop the table right before that Take runs.
+	require.NoError(t, ls.db.Callback().Query().Before("gorm:query").Register("drop-lease-before-take", func(tx *gorm.DB) {
+		tx.Exec("DROP TABLE IF EXISTS scheduler_lock_leases")
+	}))
+
+	_, err := ls.TryAcquireSchedulerLock(context.Background(), 1, "holder-b", time.Minute)
+	require.Error(t, err)
+}
+
+func TestTryAcquireSchedulerLock_RenewUpdatesFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SchedulerLockLease{})
+	require.NoError(t, ls.db.Create(&models.SchedulerLockLease{
+		Key: 1, Holder: "holder-a", ExpiresAt: time.Now().Add(time.Hour),
+	}).Error)
+
+	// Same holder renewing its own still-live lease: Take succeeds, falls
+	// through to the renew Updates; drop the table right before that Updates.
+	require.NoError(t, ls.db.Callback().Update().Before("gorm:update").Register("drop-lease-before-update", func(tx *gorm.DB) {
+		tx.Exec("DROP TABLE IF EXISTS scheduler_lock_leases")
+	}))
+
+	_, err := ls.TryAcquireSchedulerLock(context.Background(), 1, "holder-a", time.Minute)
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_secret_acl_test.go
+++ b/internal/storage/store/local_secret_acl_test.go
@@ -192,3 +192,68 @@ func TestLocalACL_DeleteMissing(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
+
+// ── ListSecretACLsByUser ────────────────────────────────────────────────────────
+
+// TestLocalACL_ListByUser verifies ListSecretACLsByUser returns every ACL row
+// for a user across secrets, and none for a different user.
+func TestLocalACL_ListByUser(t *testing.T) {
+	ls, secretID := newACLStore(t)
+	ctx := context.Background()
+
+	second := &models.SecretNode{ProjectID: 1, EnvironmentID: 1, Name: "acl-store-secret-2", IsSecret: true, Status: "active"}
+	require.NoError(t, ls.db.Create(second).Error)
+
+	require.NoError(t, ls.CreateOrUpdateSecretACL(ctx, &models.SecretACL{
+		SecretID: secretID, UserID: 70, Permissions: `["secrets.read"]`, GrantedBy: 1,
+	}))
+	require.NoError(t, ls.CreateOrUpdateSecretACL(ctx, &models.SecretACL{
+		SecretID: second.ID, UserID: 70, Permissions: `["secrets.write"]`, GrantedBy: 1,
+	}))
+	require.NoError(t, ls.CreateOrUpdateSecretACL(ctx, &models.SecretACL{
+		SecretID: secretID, UserID: 71, Permissions: `["secrets.read"]`, GrantedBy: 1,
+	}))
+
+	rows, err := ls.ListSecretACLsByUser(ctx, 70)
+	require.NoError(t, err)
+	assert.Len(t, rows, 2, "both grants for user 70, across secrets, must be returned")
+
+	rows, err = ls.ListSecretACLsByUser(ctx, 999)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+// ── DeleteSecretACLsByUserAndProject ────────────────────────────────────────────
+
+// TestLocalACL_DeleteByUserAndProject verifies that only ACL grants for the
+// given user on secrets belonging to the given project are removed — a grant
+// for the same user on a DIFFERENT project's secret must survive (#G53:
+// offboarding a user from one project must not touch their access elsewhere).
+func TestLocalACL_DeleteByUserAndProject(t *testing.T) {
+	ls, secretID := newACLStore(t) // secretID belongs to project 1
+	ctx := context.Background()
+
+	otherProjectSecret := &models.SecretNode{ProjectID: 2, EnvironmentID: 1, Name: "other-project-secret", IsSecret: true, Status: "active"}
+	require.NoError(t, ls.db.Create(otherProjectSecret).Error)
+
+	require.NoError(t, ls.CreateOrUpdateSecretACL(ctx, &models.SecretACL{
+		SecretID: secretID, UserID: 80, Permissions: `["secrets.read"]`, GrantedBy: 1,
+	}))
+	require.NoError(t, ls.CreateOrUpdateSecretACL(ctx, &models.SecretACL{
+		SecretID: otherProjectSecret.ID, UserID: 80, Permissions: `["secrets.read"]`, GrantedBy: 1,
+	}))
+
+	require.NoError(t, ls.DeleteSecretACLsByUserAndProject(ctx, 80, 1))
+
+	_, err := ls.GetSecretACL(ctx, secretID, 80)
+	require.Error(t, err, "the project-1 grant must be gone")
+
+	got, err := ls.GetSecretACL(ctx, otherProjectSecret.ID, 80)
+	require.NoError(t, err, "the project-2 grant for the same user must survive")
+	assert.Equal(t, uint(80), got.UserID)
+}
+
+func TestLocalACL_DeleteByUserAndProject_NoMatchIsNoop(t *testing.T) {
+	ls, _ := newACLStore(t)
+	require.NoError(t, ls.DeleteSecretACLsByUserAndProject(context.Background(), 404, 404))
+}

--- a/internal/storage/store/local_secret_dependencies_cascade_sweep_test.go
+++ b/internal/storage/store/local_secret_dependencies_cascade_sweep_test.go
@@ -1,0 +1,60 @@
+// local_secret_dependencies_cascade_sweep_test.go — partial-coverage sweep
+// for local_secret_dependencies.go: GetSecretDependency's error path and
+// CreateSecretDependencyExclusive's Create-failure branches (generic error
+// and the genuine concurrent-insert race, #260's belt-and-suspenders catch).
+// NOTE: the two `tx.Dialector.Name() == "postgres"` row-lock branches
+// (ListSecretDependenciesForProjectForUpdate line 50,
+// CreateSecretDependencyExclusive line 83) are intentionally NOT covered --
+// genuinely unreachable via SQLite, out of scope per this sweep's
+// instructions.
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestGetSecretDependency_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetSecretDependency(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestCreateSecretDependencyExclusive_CreateFailsGenericError(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretDependency{})
+	dropTableAfterQueries(t, ls.db, 1, "secret_dependencies")
+
+	_, err := ls.CreateSecretDependencyExclusive(context.Background(), &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 10, DependsOnSecretID: 20,
+	})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, storage.ErrDuplicateSecretDependency)
+}
+
+func TestCreateSecretDependencyExclusive_ConcurrentInsertRaceCaught(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretDependency{})
+	ctx := context.Background()
+
+	// Fire right before the function's own real INSERT, using a raw SQL Exec
+	// (not a nested GORM Create) via the callback's own tx handle -- a
+	// concurrent winner inserting the exact same edge between this
+	// transaction's own read and its write.
+	require.NoError(t, ls.db.Callback().Create().Before("gorm:create").Register("dep-race-insert", func(tx *gorm.DB) {
+		tx.Exec("INSERT INTO secret_dependencies (project_id, dependent_secret_id, depends_on_secret_id, created_at) VALUES (1, 10, 20, datetime('now'))")
+	}))
+
+	_, err := ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 10, DependsOnSecretID: 20,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrDuplicateSecretDependency)
+}

--- a/internal/storage/store/local_secrets_cascade_sweep_test.go
+++ b/internal/storage/store/local_secrets_cascade_sweep_test.go
@@ -1,0 +1,534 @@
+// local_secrets_error_sweep_test.go — partial-coverage sweep for local_secrets.go:
+// DB-error branches deep inside deleteProjectCascade/RestoreProject/RestoreSecret/
+// ListSecrets/SetSecretTags that a fully-broken DB (newBrokenDB) can't reach on its
+// own, because an earlier statement in the same function/transaction would fail
+// first. Two techniques are used beyond newBrokenDB:
+//
+//  1. Partial migration: migrate only the tables an earlier step needs, leaving a
+//     later step's table absent so IT fails instead.
+//  2. dropTableAfterQueries / dropTableAfterUpdates: register a one-shot GORM
+//     callback that drops a table after the Nth query/update statement succeeds,
+//     so the (N+1)th statement against that same table fails — used when two
+//     steps hit the SAME table (so partial migration can't separate them) or a
+//     later step in the same transaction must fail only after earlier steps in
+//     that same transaction already committed their effect.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// dropTableBothHandles drops tableName via BOTH the callback's own tx handle
+// and the outer db handle. Which one actually shares the live connection that
+// matters depends on context in ways that aren't safe to assume either way:
+//   - Inside an active ls.db.Transaction(...), the transaction holds the
+//     pool's only real connection to this :memory: DB, so db.Exec from
+//     outside would silently operate on a different (separate, empty)
+//     connection — only tx.Exec reaches the real table.
+//   - Immediately after a not-found First() on the SAME session chain,
+//     re-using that tx handle for a later Exec can inherit/reuse the prior
+//     statement's state and silently no-op — only db.Exec reaches the real
+//     table there.
+//
+// IF EXISTS makes firing both unconditionally safe: whichever handle doesn't
+// share the live connection just no-ops on an empty/already-gone table.
+func dropTableBothHandles(tx, db *gorm.DB, tableName string) {
+	tx.Exec("DROP TABLE IF EXISTS " + tableName)
+	db.Exec("DROP TABLE IF EXISTS " + tableName)
+}
+
+// dropTableAfterQueries registers a one-shot callback on db that drops
+// tableName immediately after the Nth statement passing through GORM's
+// "gorm:query" callback family (First/Find/Count) completes, causing the
+// (N+1)th such statement to fail with "no such table". NOTE: a `.Table(...).
+// Scan(...)`-style raw query (used throughout local_billing.go and similar
+// aggregation helpers) does NOT go through this family — it calls Rows()
+// internally, which runs the separate "gorm:row" family; use
+// dropTableAfterRows for those.
+func dropTableAfterQueries(t *testing.T, db *gorm.DB, n int, tableName string) {
+	t.Helper()
+	calls := 0
+	err := db.Callback().Query().After("gorm:query").Register("drop-"+tableName+"-after-query", func(tx *gorm.DB) {
+		calls++
+		if calls == n {
+			dropTableBothHandles(tx, db, tableName)
+		}
+	})
+	require.NoError(t, err)
+}
+
+// dropTableAfterUpdates is dropTableAfterQueries' twin for GORM's "gorm:update"
+// callback family (Update/Updates/UpdateColumn), used to fail a later UPDATE in
+// the same transaction after N earlier UPDATEs already succeeded.
+func dropTableAfterUpdates(t *testing.T, db *gorm.DB, n int, tableName string) {
+	t.Helper()
+	calls := 0
+	err := db.Callback().Update().After("gorm:update").Register("drop-"+tableName+"-after-update", func(tx *gorm.DB) {
+		calls++
+		if calls == n {
+			dropTableBothHandles(tx, db, tableName)
+		}
+	})
+	require.NoError(t, err)
+}
+
+// dropTableAfterDeletes is dropTableAfterQueries' twin for GORM's "gorm:delete"
+// callback family, used to fail a later DELETE in the same transaction after N
+// earlier DELETEs already succeeded.
+func dropTableAfterDeletes(t *testing.T, db *gorm.DB, n int, tableName string) {
+	t.Helper()
+	calls := 0
+	err := db.Callback().Delete().After("gorm:delete").Register("drop-"+tableName+"-after-delete", func(tx *gorm.DB) {
+		calls++
+		if calls == n {
+			dropTableBothHandles(tx, db, tableName)
+		}
+	})
+	require.NoError(t, err)
+}
+
+// dropTableAfterRows is dropTableAfterQueries' twin for GORM's "gorm:row"
+// callback family (Rows/Scan on a raw .Table(...)-based builder — see
+// dropTableAfterQueries' note).
+// dropTableAfterRows uses a Before-hook (unlike its Query/Update/Delete
+// siblings, which use After): a Row-family call (Rows/Scan) leaves its
+// *sql.Rows cursor open across the After hook, holding the pool's real
+// connection hostage, so a drop issued there silently lands on a different,
+// separate :memory: connection instead. By the time the (n+1)th call's
+// Before-hook fires, the Nth call's cursor has already been closed and the
+// real connection is free again.
+func dropTableAfterRows(t *testing.T, db *gorm.DB, n int, tableName string) {
+	t.Helper()
+	calls := 0
+	err := db.Callback().Row().Before("gorm:row").Register("drop-"+tableName+"-before-row", func(tx *gorm.DB) {
+		calls++
+		if calls == n+1 {
+			dropTableBothHandles(tx, db, tableName)
+		}
+	})
+	require.NoError(t, err)
+}
+
+// newPartialSecretsDB returns a LocalStorage with only the given models
+// migrated onto a fresh in-memory SQLite DB, for tests that need a specific
+// subset of tables present/absent to isolate one step of a multi-step
+// operation.
+func newPartialSecretsDB(t *testing.T, models ...any) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	if len(models) > 0 {
+		require.NoError(t, db.AutoMigrate(models...))
+	}
+	return NewLocalStorage(db)
+}
+
+// ---------------------------------------------------------------------------
+// ListProjectsWithCounts / GetProjectByName — DB error paths
+// ---------------------------------------------------------------------------
+
+func TestListProjectsWithCounts_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.ListProjectsWithCounts(context.Background(), false)
+	require.Error(t, err)
+}
+
+func TestGetProjectByName_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetProjectByName(context.Background(), "anything")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "project not found")
+}
+
+// ---------------------------------------------------------------------------
+// deleteProjectCascade (via DeleteProject) — mid-cascade DB error paths
+// ---------------------------------------------------------------------------
+
+func TestDeleteProjectCascade_EnvironmentUpdateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.SecretNode{}, &models.ShareRecord{})
+	ctx := context.Background()
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "casc-env"})
+	require.NoError(t, err)
+
+	err = ls.DeleteProject(ctx, p.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "soft-delete project environments")
+}
+
+func TestDeleteProjectCascade_DynamicConfigUpdateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.SecretNode{}, &models.ShareRecord{}, &models.Environment{})
+	ctx := context.Background()
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "casc-dyn"})
+	require.NoError(t, err)
+
+	err = ls.DeleteProject(ctx, p.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disable project dynamic-secret configs")
+}
+
+func TestDeleteProjectCascade_ProjectUpdateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.SecretNode{}, &models.ShareRecord{},
+		&models.Environment{}, &models.DynamicSecretConfig{})
+	ctx := context.Background()
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "casc-proj"})
+	require.NoError(t, err)
+
+	// Cascade update order inside a single transaction: SecretNode(1),
+	// Environment(2), DynamicSecretConfig(3), Project(4). Drop `projects`
+	// right after the 3rd update so the 4th (the project's own row) fails.
+	dropTableAfterUpdates(t, ls.db, 3, "projects")
+
+	err = ls.DeleteProject(ctx, p.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete project")
+}
+
+// ---------------------------------------------------------------------------
+// DeleteProjectIfEmpty — DB error + outer propagation
+// ---------------------------------------------------------------------------
+
+func TestDeleteProjectIfEmpty_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.DeleteProjectIfEmpty(context.Background(), 1)
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// RestoreProject — mid-transaction DB error paths
+// ---------------------------------------------------------------------------
+
+func newSoftDeletedProject(t *testing.T, ls *LocalStorage, name string) uint {
+	t.Helper()
+	p := &models.Project{Name: name}
+	require.NoError(t, ls.db.Create(p).Error)
+	require.NoError(t, ls.db.Exec("UPDATE projects SET deleted_at = ? WHERE id = ?", time.Now().Add(-time.Hour), p.ID).Error)
+	return p.ID
+}
+
+func TestRestoreProject_EnvironmentUpdateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{})
+	id := newSoftDeletedProject(t, ls, "restore-env-fail")
+
+	_, _, err := ls.RestoreProject(context.Background(), id)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restore project environments")
+}
+
+func TestRestoreProject_SecretUpdateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.Environment{})
+	id := newSoftDeletedProject(t, ls, "restore-sec-fail")
+
+	_, _, err := ls.RestoreProject(context.Background(), id)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restore project secrets")
+}
+
+func TestRestoreProject_FinalProjectUpdateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.Environment{}, &models.SecretNode{})
+	id := newSoftDeletedProject(t, ls, "restore-proj-fail")
+
+	// envResult(1), secResult(2) succeed; drop `projects` before the final update(3).
+	dropTableAfterUpdates(t, ls.db, 2, "projects")
+
+	_, _, err := ls.RestoreProject(context.Background(), id)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to restore project:")
+}
+
+// ---------------------------------------------------------------------------
+// GetEnvironment / DeleteEnvironment / RestoreEnvironment — DB error paths
+// ---------------------------------------------------------------------------
+
+func TestGetEnvironment_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetEnvironment(context.Background(), 1)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "environment not found")
+}
+
+func TestDeleteEnvironment_DeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{})
+	err := ls.DeleteEnvironment(context.Background(), 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete environment")
+}
+
+func TestRestoreEnvironment_UpdateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{})
+	ctx := context.Background()
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "env-restore-fail"})
+	require.NoError(t, err)
+
+	err = ls.RestoreEnvironment(ctx, p.ID, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to restore environment")
+}
+
+// ---------------------------------------------------------------------------
+// GetSecretByName — invalid-name early return (real logic, no DB access)
+// ---------------------------------------------------------------------------
+
+func TestGetSecretByName_InvalidNameRejectedBeforeQuery(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetSecretByName(context.Background(), "bad\x00name", 1, 1)
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// DeleteSecret — SecretACL revoke error path
+// ---------------------------------------------------------------------------
+
+func TestDeleteSecret_ACLRevokeFails(t *testing.T) {
+	t.Parallel()
+	// newSecretsFullStore (store_s3_local3_test.go) migrates SecretNode/
+	// ShareRecord but not SecretACL, so the cascade's ACL-revoke step fails.
+	ls := newSecretsFullStore(t)
+	ctx := context.Background()
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "acl-revoke-fail"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{ProjectID: p.ID, Name: "prod"})
+	require.NoError(t, err)
+	secret, err := ls.CreateSecret(ctx, &models.SecretNode{
+		ProjectID: p.ID, EnvironmentID: env.ID, Name: "acl-secret", IsSecret: true,
+	})
+	require.NoError(t, err)
+
+	err = ls.DeleteSecret(ctx, secret.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "revoke secret ACLs")
+}
+
+// ---------------------------------------------------------------------------
+// RestoreSecret — every DB error / not-found branch
+// ---------------------------------------------------------------------------
+
+func TestRestoreSecret_NotActuallyDeleted(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.Environment{}, &models.SecretNode{})
+	ctx := context.Background()
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "restore-secret-live"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{ProjectID: p.ID, Name: "prod"})
+	require.NoError(t, err)
+	secret, err := ls.CreateSecret(ctx, &models.SecretNode{
+		ProjectID: p.ID, EnvironmentID: env.ID, Name: "live-secret", IsSecret: true,
+	})
+	require.NoError(t, err)
+
+	err = ls.RestoreSecret(ctx, secret.ID)
+	require.Error(t, err)
+}
+
+func TestRestoreSecret_RequireLiveProjectFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{})
+	ctx := context.Background()
+	secret := &models.SecretNode{ProjectID: 1, EnvironmentID: 0, Name: "orphan-secret", IsSecret: true}
+	require.NoError(t, ls.db.Create(secret).Error)
+
+	err := ls.RestoreSecret(ctx, secret.ID)
+	require.Error(t, err)
+}
+
+func TestRestoreSecret_RequireLiveEnvironmentFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.SecretNode{})
+	ctx := context.Background()
+	p, err := ls.CreateProject(context.Background(), &models.Project{Name: "restore-env-check"})
+	require.NoError(t, err)
+	secret := &models.SecretNode{ProjectID: p.ID, EnvironmentID: 7, Name: "env-check-secret", IsSecret: true}
+	require.NoError(t, ls.db.Create(secret).Error)
+
+	err = ls.RestoreSecret(ctx, secret.ID)
+	require.Error(t, err)
+}
+
+func TestRestoreSecret_FinalUpdateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.SecretNode{})
+	ctx := context.Background()
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "restore-final-fail"})
+	require.NoError(t, err)
+	secret := &models.SecretNode{ProjectID: p.ID, EnvironmentID: 0, Name: "final-fail-secret", IsSecret: true}
+	require.NoError(t, ls.db.Create(secret).Error)
+	require.NoError(t, ls.db.Exec("UPDATE secret_nodes SET deleted_at = ? WHERE id = ?", time.Now().Add(-time.Hour), secret.ID).Error)
+
+	// query#1 = the initial secret lookup, query#2 = requireLiveProject's
+	// Count. Drop secret_nodes right after so the final Update fails.
+	dropTableAfterQueries(t, ls.db, 2, "secret_nodes")
+
+	err = ls.RestoreSecret(ctx, secret.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Storage operation failed")
+}
+
+// ---------------------------------------------------------------------------
+// ClearProjectSecretOwnership — DB error path
+// ---------------------------------------------------------------------------
+
+func TestClearProjectSecretOwnership_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	err := ls.ClearProjectSecretOwnership(context.Background(), 1, 1)
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// ListSecrets — Count error, Find error, and combined optional filters
+// ---------------------------------------------------------------------------
+
+func TestListSecrets_CountError(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, _, err := ls.ListSecrets(context.Background(), &storage.SecretFilter{})
+	require.Error(t, err)
+}
+
+func TestListSecrets_FindErrorAfterCountSucceeds(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{})
+	dropTableAfterQueries(t, ls.db, 1, "secret_nodes")
+
+	_, _, err := ls.ListSecrets(context.Background(), &storage.SecretFilter{})
+	require.Error(t, err)
+}
+
+func TestListSecrets_AllOptionalFilterBranches(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{}, &models.Environment{})
+
+	typ := "api_key"
+	createdBy := "bot"
+	createdAfter := time.Now().Add(-time.Hour)
+	createdBefore := time.Now().Add(time.Hour)
+	isSecret := true
+	parentID := uint(1)
+
+	secrets, total, err := ls.ListSecrets(context.Background(), &storage.SecretFilter{
+		Type:          &typ,
+		CreatedBy:     &createdBy,
+		CreatedAfter:  &createdAfter,
+		CreatedBefore: &createdBefore,
+		IsSecret:      &isSecret,
+		ParentID:      &parentID,
+		FolderOnly:    true,
+	})
+	require.NoError(t, err)
+	assert.Zero(t, total)
+	assert.Empty(t, secrets)
+}
+
+// ---------------------------------------------------------------------------
+// CountOrphanedSecretsByProject / CountExpiringSecretsByProject — DB errors
+// ---------------------------------------------------------------------------
+
+func TestCountOrphanedSecretsByProject_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.CountOrphanedSecretsByProject(context.Background(), []uint{1})
+	require.Error(t, err)
+}
+
+func TestCountExpiringSecretsByProject_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.CountExpiringSecretsByProject(context.Background(), []uint{1}, time.Now())
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// ListLiveSecretNamesByProject — truncation branch (real logic)
+// ---------------------------------------------------------------------------
+
+func TestListLiveSecretNamesByProject_Truncated(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.Environment{}, &models.SecretNode{})
+	ctx := context.Background()
+
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "trunc-proj"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{ProjectID: p.ID, Name: "prod"})
+	require.NoError(t, err)
+
+	for i := range 3 {
+		_, err := ls.CreateSecret(ctx, &models.SecretNode{
+			ProjectID: p.ID, EnvironmentID: env.ID,
+			Name: "secret-" + string(rune('a'+i)), IsSecret: true,
+		})
+		require.NoError(t, err)
+	}
+
+	rows, truncated, err := ls.ListLiveSecretNamesByProject(ctx, []uint{p.ID}, 2)
+	require.NoError(t, err)
+	assert.True(t, truncated)
+	assert.Len(t, rows, 2)
+
+	rows, truncated, err = ls.ListLiveSecretNamesByProject(ctx, []uint{p.ID}, 10)
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	assert.Len(t, rows, 3)
+}
+
+// ---------------------------------------------------------------------------
+// SetSecretTags — DB error paths at each of the 3 statements
+// ---------------------------------------------------------------------------
+
+func TestSetSecretTags_DeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	err := ls.SetSecretTags(context.Background(), 1, []string{"prod"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "clear tags")
+}
+
+func TestSetSecretTags_UpsertTagFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretTag{})
+	err := ls.SetSecretTags(context.Background(), 1, []string{"prod"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "upsert tag")
+}
+
+func TestSetSecretTags_LinkTagFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretTag{}, &models.Tag{})
+	// Same tag name twice: the 2nd iteration's FirstOrCreate resolves to the
+	// SAME tag row, so the 2nd SecretTag Create collides with the 1st on the
+	// composite primary key (secret_node_id, tag_id).
+	err := ls.SetSecretTags(context.Background(), 1, []string{"dup", "dup"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "link tag")
+}
+
+// ---------------------------------------------------------------------------
+// GetSecretAncestors — DB error path
+// ---------------------------------------------------------------------------
+
+func TestGetSecretAncestors_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetSecretAncestors(context.Background(), 1)
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_secrets_zero_coverage_test.go
+++ b/internal/storage/store/local_secrets_zero_coverage_test.go
@@ -1,0 +1,135 @@
+// local_secrets_zero_coverage_test.go covers local_secrets.go functions that
+// were still at 0%: GetProjectByName, ClearProjectSecretOwnership,
+// GetSecretAncestors.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func newSecretsZeroCoverageStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.SecretNode{}, &models.Environment{}))
+	return NewLocalStorage(db)
+}
+
+func TestGetProjectByName_CaseInsensitive(t *testing.T) {
+	ls := newSecretsZeroCoverageStore(t)
+	db := ls.DB()
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "MyProject"}).Error)
+
+	got, err := ls.GetProjectByName(context.Background(), "myproject")
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), got.ID)
+
+	got, err = ls.GetProjectByName(context.Background(), "MYPROJECT")
+	require.NoError(t, err)
+	assert.Equal(t, uint(1), got.ID)
+}
+
+func TestGetProjectByName_NotFound(t *testing.T) {
+	ls := newSecretsZeroCoverageStore(t)
+	project, err := ls.GetProjectByName(context.Background(), "nope")
+	require.Error(t, err)
+	assert.Nil(t, project)
+}
+
+func TestClearProjectSecretOwnership(t *testing.T) {
+	ls := newSecretsZeroCoverageStore(t)
+	ctx := context.Background()
+	db := ls.DB()
+
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, ProjectID: 1, EnvironmentID: 1, Name: "s1", IsSecret: true, Status: "active", OwnerID: 42}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 2, ProjectID: 1, EnvironmentID: 1, Name: "s2", IsSecret: true, Status: "active", OwnerID: 42}).Error)
+	// Different project, same owner -- must be untouched.
+	require.NoError(t, db.Create(&models.SecretNode{ID: 3, ProjectID: 2, EnvironmentID: 1, Name: "s3", IsSecret: true, Status: "active", OwnerID: 42}).Error)
+	// Same project, different owner -- must be untouched.
+	require.NoError(t, db.Create(&models.SecretNode{ID: 4, ProjectID: 1, EnvironmentID: 1, Name: "s4", IsSecret: true, Status: "active", OwnerID: 7}).Error)
+
+	require.NoError(t, ls.ClearProjectSecretOwnership(ctx, 42, 1))
+
+	var s1, s2, s3, s4 models.SecretNode
+	require.NoError(t, db.First(&s1, 1).Error)
+	require.NoError(t, db.First(&s2, 2).Error)
+	require.NoError(t, db.First(&s3, 3).Error)
+	require.NoError(t, db.First(&s4, 4).Error)
+
+	assert.Zero(t, s1.OwnerID)
+	assert.Zero(t, s2.OwnerID)
+	assert.Equal(t, uint(42), s3.OwnerID, "a different project's secret owned by the same user must be untouched")
+	assert.Equal(t, uint(7), s4.OwnerID, "a different owner's secret in the same project must be untouched")
+}
+
+func TestClearProjectSecretOwnership_NoMatchIsNoop(t *testing.T) {
+	ls := newSecretsZeroCoverageStore(t)
+	require.NoError(t, ls.ClearProjectSecretOwnership(context.Background(), 404, 404))
+}
+
+func TestGetSecretAncestors_WalksUpToRoot(t *testing.T) {
+	ls := newSecretsZeroCoverageStore(t)
+	ctx := context.Background()
+	db := ls.DB()
+
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, ProjectID: 1, EnvironmentID: 1, Name: "root", IsSecret: false, Status: "active"}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 2, ProjectID: 1, EnvironmentID: 1, Name: "mid", IsSecret: false, Status: "active", ParentID: uptr(1)}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 3, ProjectID: 1, EnvironmentID: 1, Name: "leaf", IsSecret: true, Status: "active", ParentID: uptr(2)}).Error)
+
+	ancestors, err := ls.GetSecretAncestors(ctx, 3)
+	require.NoError(t, err)
+	assert.Equal(t, []uint{2, 1}, ancestors)
+}
+
+func TestGetSecretAncestors_RootHasNoAncestors(t *testing.T) {
+	ls := newSecretsZeroCoverageStore(t)
+	ctx := context.Background()
+	db := ls.DB()
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, ProjectID: 1, EnvironmentID: 1, Name: "root", IsSecret: false, Status: "active"}).Error)
+
+	ancestors, err := ls.GetSecretAncestors(ctx, 1)
+	require.NoError(t, err)
+	assert.Empty(t, ancestors)
+}
+
+func TestGetSecretAncestors_MissingNodeStopsWalk(t *testing.T) {
+	ls := newSecretsZeroCoverageStore(t)
+	ancestors, err := ls.GetSecretAncestors(context.Background(), 999)
+	require.NoError(t, err)
+	assert.Empty(t, ancestors)
+}
+
+// A parent cycle (data corruption, or a defensive test of the guard itself)
+// must not hang the walk -- the visited-set cycle guard breaks out instead.
+func TestGetSecretAncestors_CycleGuardStopsInfiniteLoop(t *testing.T) {
+	ls := newSecretsZeroCoverageStore(t)
+	ctx := context.Background()
+	db := ls.DB()
+
+	require.NoError(t, db.Create(&models.SecretNode{ID: 1, ProjectID: 1, EnvironmentID: 1, Name: "a", IsSecret: false, Status: "active", ParentID: uptr(2)}).Error)
+	require.NoError(t, db.Create(&models.SecretNode{ID: 2, ProjectID: 1, EnvironmentID: 1, Name: "b", IsSecret: false, Status: "active", ParentID: uptr(1)}).Error)
+
+	done := make(chan struct{})
+	var ancestors []uint
+	var err error
+	go func() {
+		ancestors, err = ls.GetSecretAncestors(ctx, 1)
+		close(done)
+	}()
+	select {
+	case <-done:
+		require.NoError(t, err)
+		assert.NotEmpty(t, ancestors, "the cycle must be walked at least once before the guard breaks it")
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetSecretAncestors did not return -- the cycle guard failed to stop an infinite loop")
+	}
+}

--- a/internal/storage/store/local_sharing_cascade_sweep_test.go
+++ b/internal/storage/store/local_sharing_cascade_sweep_test.go
@@ -1,0 +1,291 @@
+// local_sharing_cascade_sweep_test.go — partial-coverage sweep for
+// local_sharing.go: the CreateShareRecord create-race recovery branches
+// (#136), and DB-error paths reached via newBrokenDB, partial migration, or
+// dropTableAfterQueries (shared helpers defined in
+// local_secrets_cascade_sweep_test.go, same package).
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func newSharingRaceStore(t *testing.T) (*LocalStorage, *models.Project, *models.Environment, *models.SecretNode, *models.User) {
+	t.Helper()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.Environment{}, &models.SecretNode{},
+		&models.ShareRecord{}, &models.User{}, &models.Group{})
+	// Mirrors ensureShareRecordUniqueIndex in production: without a real
+	// unique index, two identical share_records rows insert cleanly on
+	// SQLite and CreateShareRecord's race-recovery branch never triggers.
+	require.NoError(t, ls.db.Exec(
+		"CREATE UNIQUE INDEX IF NOT EXISTS uniq_share_records_active ON share_records(secret_id, recipient_id, is_group) WHERE deleted_at IS NULL").Error)
+	ctx := context.Background()
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "share-race-proj"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{ProjectID: p.ID, Name: "prod"})
+	require.NoError(t, err)
+	owner := &models.User{Username: "owner", UsernameFolded: "owner", EmailFolded: "owner@example.com"}
+	require.NoError(t, ls.db.Create(owner).Error)
+	secret, err := ls.CreateSecret(ctx, &models.SecretNode{
+		ProjectID: p.ID, EnvironmentID: env.ID, Name: "race-secret", IsSecret: true, OwnerID: owner.ID,
+	})
+	require.NoError(t, err)
+	recipient := &models.User{Username: "recipient", UsernameFolded: "recipient", EmailFolded: "recipient@example.com"}
+	require.NoError(t, ls.db.Create(recipient).Error)
+	return ls, p, env, secret, recipient
+}
+
+func TestCreateShareRecord_RaceRecoverySucceeds(t *testing.T) {
+	t.Parallel()
+	ls, _, _, secret, recipient := newSharingRaceStore(t)
+	ctx := context.Background()
+
+	calls := 0
+	require.NoError(t, ls.db.Callback().Query().After("gorm:query").Register("share-race-insert", func(_ *gorm.DB) {
+		calls++
+		if calls == 3 {
+			// Simulate a concurrent winner: insert the competing row right
+			// after CreateShareRecord's own existence check just missed it.
+			ls.db.Create(&models.ShareRecord{
+				SecretID: secret.ID, RecipientID: recipient.ID, IsGroup: false,
+				OwnerID: secret.OwnerID, Permission: "read",
+			})
+		}
+	}))
+
+	got, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secret.ID, RecipientID: recipient.ID, IsGroup: false,
+		OwnerID: secret.OwnerID, Permission: "write",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "write", got.Permission)
+}
+
+func TestCreateShareRecord_RaceRecoverySaveFails(t *testing.T) {
+	t.Parallel()
+	ls, _, _, secret, recipient := newSharingRaceStore(t)
+	ctx := context.Background()
+
+	calls := 0
+	require.NoError(t, ls.db.Callback().Query().After("gorm:query").Register("share-race-insert-then-drop", func(_ *gorm.DB) {
+		calls++
+		switch calls {
+		case 3:
+			ls.db.Create(&models.ShareRecord{
+				SecretID: secret.ID, RecipientID: recipient.ID, IsGroup: false,
+				OwnerID: secret.OwnerID, Permission: "read",
+			})
+		case 4:
+			ls.db.Exec("DROP TABLE share_records")
+		}
+	}))
+
+	_, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secret.ID, RecipientID: recipient.ID, IsGroup: false,
+		OwnerID: secret.OwnerID, Permission: "write",
+	})
+	require.Error(t, err)
+}
+
+func TestCreateShareRecord_CreateFailsGenericError(t *testing.T) {
+	t.Parallel()
+	ls, _, _, secret, recipient := newSharingRaceStore(t)
+	ctx := context.Background()
+
+	// Drop share_records right after the initial (not-found) existence check
+	// (the 3rd query-family call), so Create fails with "no such table" -- not
+	// a unique-constraint error, exercising the outer generic-error fallback.
+	dropTableAfterQueries(t, ls.db, 3, "share_records")
+
+	_, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secret.ID, RecipientID: recipient.ID, IsGroup: false,
+		OwnerID: secret.OwnerID, Permission: "write",
+	})
+	require.Error(t, err)
+}
+
+func TestCreateShareRecord_ExistingCheckGenericError(t *testing.T) {
+	t.Parallel()
+	// share_records intentionally absent: GetSecret and the recipient-existence
+	// check succeed, but the existing-share lookup fails with a non-not-found error.
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.User{})
+	ctx := context.Background()
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "no-share-table"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{ProjectID: p.ID, Name: "prod"})
+	require.NoError(t, err)
+	owner := &models.User{Username: "o2", UsernameFolded: "o2", EmailFolded: "o2@example.com"}
+	require.NoError(t, ls.db.Create(owner).Error)
+	secret, err := ls.CreateSecret(ctx, &models.SecretNode{
+		ProjectID: p.ID, EnvironmentID: env.ID, Name: "s2", IsSecret: true, OwnerID: owner.ID,
+	})
+	require.NoError(t, err)
+	recipient := &models.User{Username: "r2", UsernameFolded: "r2", EmailFolded: "r2@example.com"}
+	require.NoError(t, ls.db.Create(recipient).Error)
+
+	_, err = ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secret.ID, RecipientID: recipient.ID, IsGroup: false, OwnerID: owner.ID, Permission: "write",
+	})
+	require.Error(t, err)
+}
+
+func TestCreateShareRecord_UpdateExistingSaveFails(t *testing.T) {
+	t.Parallel()
+	ls, _, _, secret, recipient := newSharingRaceStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, ls.db.Create(&models.ShareRecord{
+		SecretID: secret.ID, RecipientID: recipient.ID, IsGroup: false, OwnerID: secret.OwnerID, Permission: "read",
+	}).Error)
+
+	// 3 query-family calls precede the Save: GetSecret, recipient Count, and
+	// the existing-share lookup (found this time). Drop share_records right after.
+	dropTableAfterQueries(t, ls.db, 3, "share_records")
+
+	_, err := ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secret.ID, RecipientID: recipient.ID, IsGroup: false, OwnerID: secret.OwnerID, Permission: "write",
+	})
+	require.Error(t, err)
+}
+
+func TestCreateShareRecord_GroupCountFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.User{})
+	ctx := context.Background()
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "grp-count-fail"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{ProjectID: p.ID, Name: "prod"})
+	require.NoError(t, err)
+	owner := &models.User{Username: "o3", UsernameFolded: "o3", EmailFolded: "o3@example.com"}
+	require.NoError(t, ls.db.Create(owner).Error)
+	secret, err := ls.CreateSecret(ctx, &models.SecretNode{
+		ProjectID: p.ID, EnvironmentID: env.ID, Name: "s3", IsSecret: true, OwnerID: owner.ID,
+	})
+	require.NoError(t, err)
+
+	// Group table intentionally absent.
+	_, err = ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secret.ID, RecipientID: 99, IsGroup: true, OwnerID: owner.ID, Permission: "read",
+	})
+	require.Error(t, err)
+}
+
+func TestCreateShareRecord_UserCountFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Project{}, &models.Environment{}, &models.SecretNode{})
+	ctx := context.Background()
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "usr-count-fail"})
+	require.NoError(t, err)
+	env, err := ls.CreateEnvironment(ctx, &models.Environment{ProjectID: p.ID, Name: "prod"})
+	require.NoError(t, err)
+	secret, err := ls.CreateSecret(ctx, &models.SecretNode{
+		ProjectID: p.ID, EnvironmentID: env.ID, Name: "s4", IsSecret: true, OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	// User table intentionally absent.
+	_, err = ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secret.ID, RecipientID: 99, IsGroup: false, OwnerID: 1, Permission: "read",
+	})
+	require.Error(t, err)
+}
+
+func TestGetShareRecord_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetShareRecord(context.Background(), 1)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "ErrorShareNotFound")
+}
+
+func TestUpdateShareRecord_SaveFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.ShareRecord{})
+	ctx := context.Background()
+	share := &models.ShareRecord{SecretID: 1, RecipientID: 2, OwnerID: 3, Permission: "read"}
+	require.NoError(t, ls.db.Create(share).Error)
+
+	dropTableAfterQueries(t, ls.db, 1, "share_records")
+
+	_, err := ls.UpdateShareRecord(ctx, &models.ShareRecord{ID: share.ID, Permission: "write"})
+	require.Error(t, err)
+}
+
+func TestDeleteShareRecord_DeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.ShareRecord{})
+	ctx := context.Background()
+	share := &models.ShareRecord{SecretID: 1, RecipientID: 2, OwnerID: 3, Permission: "read"}
+	require.NoError(t, ls.db.Create(share).Error)
+
+	dropTableAfterQueries(t, ls.db, 1, "share_records")
+
+	err := ls.DeleteShareRecord(ctx, share.ID)
+	require.Error(t, err)
+}
+
+func TestListSharedSecrets_DirectQueryBrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.ListSharedSecrets(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestListSharedSecrets_GroupQueryFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{}, &models.ShareRecord{}, &models.User{})
+	// groups/user_groups tables intentionally absent.
+	_, err := ls.ListSharedSecrets(context.Background(), 1)
+	require.Error(t, err)
+}
+
+func TestCheckSharePermission_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.CheckSharePermission(context.Background(), 1, 1)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "ErrorSecretNotFound")
+}
+
+func TestCheckSharePermission_OwnerActiveCountFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{})
+	ctx := context.Background()
+	secret := &models.SecretNode{ProjectID: 1, EnvironmentID: 1, Name: "owner-count-fail", IsSecret: true, OwnerID: 5}
+	require.NoError(t, ls.db.Create(secret).Error)
+
+	// users table intentionally absent.
+	_, err := ls.CheckSharePermission(ctx, secret.ID, 5)
+	require.Error(t, err)
+}
+
+func TestCheckSharePermission_DirectShareQueryFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{})
+	ctx := context.Background()
+	secret := &models.SecretNode{ProjectID: 1, EnvironmentID: 1, Name: "direct-fail", IsSecret: true, OwnerID: 0}
+	require.NoError(t, ls.db.Create(secret).Error)
+
+	// share_records/users tables intentionally absent, userID != OwnerID so the
+	// owner branch is skipped entirely.
+	_, err := ls.CheckSharePermission(ctx, secret.ID, 7)
+	require.Error(t, err)
+}
+
+func TestCheckSharePermission_GroupShareQueryFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{}, &models.ShareRecord{}, &models.User{})
+	ctx := context.Background()
+	secret := &models.SecretNode{ProjectID: 1, EnvironmentID: 1, Name: "group-fail", IsSecret: true, OwnerID: 0}
+	require.NoError(t, ls.db.Create(secret).Error)
+
+	// groups/user_groups tables intentionally absent; direct-share query
+	// succeeds (finds nothing) since share_records/users exist.
+	_, err := ls.CheckSharePermission(ctx, secret.ID, 9)
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_usage_cascade_sweep_test.go
+++ b/internal/storage/store/local_usage_cascade_sweep_test.go
@@ -1,0 +1,61 @@
+// local_usage_cascade_sweep_test.go — partial-coverage sweep for
+// local_usage.go's GetProjectUsageStats: each of its 3 sequential queries'
+// own DB-error branch, plus the real-logic branch where a project has read
+// activity but zero active secrets (so it's only ever seen via readRows, not
+// secretRows).
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetProjectUsageStats_SecretCountsQueryFails(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetProjectUsageStats(context.Background(), nil, 30)
+	require.Error(t, err)
+}
+
+func TestGetProjectUsageStats_ReadCountsQueryFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{})
+	_, err := ls.GetProjectUsageStats(context.Background(), nil, 30)
+	require.Error(t, err)
+}
+
+func TestGetProjectUsageStats_ProjectNamesQueryFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{}, &models.AuditEvent{})
+	require.NoError(t, ls.db.Create(&models.SecretNode{
+		ProjectID: 1, EnvironmentID: 1, Name: "active-secret", IsSecret: true,
+	}).Error)
+
+	_, err := ls.GetProjectUsageStats(context.Background(), nil, 30)
+	require.Error(t, err)
+}
+
+func TestGetProjectUsageStats_ReadOnlyProjectWithNoActiveSecrets(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.SecretNode{}, &models.AuditEvent{}, &models.Project{})
+	ctx := context.Background()
+	p, err := ls.CreateProject(ctx, &models.Project{Name: "read-only-proj"})
+	require.NoError(t, err)
+
+	success := true
+	require.NoError(t, ls.db.Create(&models.AuditEvent{
+		EventType: "secret.read", ProjectID: &p.ID, Success: &success, EventTime: time.Now(),
+	}).Error)
+
+	stats, err := ls.GetProjectUsageStats(ctx, nil, 30)
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+	assert.Equal(t, p.ID, stats[0].ProjectID)
+	assert.Equal(t, int64(0), stats[0].SecretCount)
+	assert.Equal(t, int64(1), stats[0].ReadsInWindow)
+}

--- a/internal/storage/store/local_users_cascade_sweep_test.go
+++ b/internal/storage/store/local_users_cascade_sweep_test.go
@@ -1,0 +1,267 @@
+// local_users_cascade_sweep_test.go — partial-coverage sweep for local_users.go:
+// genuine duplicate-email branches (unlike the analogous project-name case, SQLite
+// DOES name the email_folded column in its constraint-violation text, so these are
+// real, reachable branches — see isDuplicateEmailViolation's doc comment), plus
+// DB-error paths reached via newBrokenDB or the dropTableAfterQueries technique
+// from local_secrets_cascade_sweep_test.go (same package, reused here).
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// newUsersDBWithEmailIndex migrates User and creates the same partial unique
+// index migrateDatabase creates in production (uniq_users_email_folded_active),
+// so a genuine duplicate-email insert/update produces the real SQLite
+// constraint-violation text isDuplicateEmailViolation matches against.
+func newUsersDBWithEmailIndex(t *testing.T) *LocalStorage {
+	t.Helper()
+	ls := newPartialSecretsDB(t, &models.User{})
+	require.NoError(t, ls.db.Exec(
+		"CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_email_folded_active ON users(email_folded) WHERE deleted_at IS NULL AND email != ''").Error)
+	return ls
+}
+
+func TestCreateUser_DuplicateEmail(t *testing.T) {
+	t.Parallel()
+	ls := newUsersDBWithEmailIndex(t)
+	ctx := context.Background()
+
+	_, err := ls.CreateUser(ctx, &models.User{
+		Username: "alice", UsernameFolded: "alice", Email: "Alice@Example.com", EmailFolded: "alice@example.com",
+	})
+	require.NoError(t, err)
+
+	_, err = ls.CreateUser(ctx, &models.User{
+		Username: "alice2", UsernameFolded: "alice2", Email: "ALICE@example.com", EmailFolded: "alice@example.com",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrDuplicateEmail)
+}
+
+func TestCreateUserWithRoleGrants_DuplicateEmail(t *testing.T) {
+	t.Parallel()
+	ls := newUsersDBWithEmailIndex(t)
+	ctx := context.Background()
+
+	_, err := ls.CreateUser(ctx, &models.User{
+		Username: "bob", UsernameFolded: "bob", Email: "bob@example.com", EmailFolded: "bob@example.com",
+	})
+	require.NoError(t, err)
+
+	_, err = ls.CreateUserWithRoleGrants(ctx, &models.User{
+		Username: "bob2", UsernameFolded: "bob2", Email: "bob@example.com", EmailFolded: "bob@example.com",
+	}, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrDuplicateEmail)
+}
+
+func TestUpdateUser_DuplicateEmail(t *testing.T) {
+	t.Parallel()
+	ls := newUsersDBWithEmailIndex(t)
+	ctx := context.Background()
+
+	u1, err := ls.CreateUser(ctx, &models.User{
+		Username: "carl", UsernameFolded: "carl", Email: "carl@example.com", EmailFolded: "carl@example.com",
+	})
+	require.NoError(t, err)
+	u2, err := ls.CreateUser(ctx, &models.User{
+		Username: "dave", UsernameFolded: "dave", Email: "dave@example.com", EmailFolded: "dave@example.com",
+	})
+	require.NoError(t, err)
+
+	u2.EmailFolded = u1.EmailFolded
+	_, err = ls.UpdateUser(ctx, u2)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrDuplicateEmail)
+}
+
+func TestUpdateUserIfActiveStateMatches_DuplicateEmail(t *testing.T) {
+	t.Parallel()
+	ls := newUsersDBWithEmailIndex(t)
+	ctx := context.Background()
+
+	u1, err := ls.CreateUser(ctx, &models.User{
+		Username: "erin", UsernameFolded: "erin", Email: "erin@example.com", EmailFolded: "erin@example.com", IsActive: true,
+	})
+	require.NoError(t, err)
+	u2, err := ls.CreateUser(ctx, &models.User{
+		Username: "finn", UsernameFolded: "finn", Email: "finn@example.com", EmailFolded: "finn@example.com", IsActive: true,
+	})
+	require.NoError(t, err)
+
+	u2.EmailFolded = u1.EmailFolded
+	_, err = ls.UpdateUserIfActiveStateMatches(ctx, u2, true)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrDuplicateEmail)
+}
+
+func TestUpdateUserIfActiveStateMatches_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.UpdateUserIfActiveStateMatches(context.Background(), &models.User{ID: 1}, true)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, storage.ErrDuplicateEmail)
+}
+
+func TestGetUserByEmail_InvalidFold(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetUserByEmail(context.Background(), "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrUserNotFound)
+}
+
+func TestGetUserByUsername_InvalidFold(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetUserByUsername(context.Background(), "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrUserNotFound)
+}
+
+func TestGetUserGroupsAt_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.GetUserGroupsAt(context.Background(), 1, storage.Scope{ProjectID: 1})
+	require.Error(t, err)
+}
+
+func TestListAllUserGroupMemberships_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.ListAllUserGroupMemberships(context.Background())
+	require.Error(t, err)
+}
+
+func TestListInactiveUsers_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.ListInactiveUsers(context.Background(), time.Now())
+	require.Error(t, err)
+}
+
+func TestListUsers_FindErrorAfterCountSucceeds(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.User{})
+	dropTableAfterQueries(t, ls.db, 1, "users")
+
+	_, _, err := ls.ListUsers(context.Background(), &storage.UserFilter{})
+	require.Error(t, err)
+}
+
+func TestDeleteGroup_DeleteFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Group{})
+	ctx := context.Background()
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "g-delete-fail", NameFolded: "g-delete-fail"})
+	require.NoError(t, err)
+
+	dropTableAfterQueries(t, ls.db, 1, "groups")
+
+	err = ls.DeleteGroup(ctx, g.ID)
+	require.Error(t, err)
+}
+
+func TestDeleteGroup_RowsAffectedZero(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Group{})
+	ctx := context.Background()
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "g-race", NameFolded: "g-race"})
+	require.NoError(t, err)
+
+	// Race: soft-delete the row via a raw statement right after GetGroup's own
+	// read succeeds, so the subsequent GORM soft-delete Update (scoped to
+	// deleted_at IS NULL) matches zero rows.
+	require.NoError(t, ls.db.Callback().Query().After("gorm:query").Register("race-soft-delete-group", func(_ *gorm.DB) {
+		// Use the outer ls.db handle, not the callback's tx: calling
+		// Exec on tx mid-callback reuses/pollutes the in-flight SELECT's
+		// bound Statement.Vars and silently matches zero rows.
+		ls.db.Exec("UPDATE groups SET deleted_at = ? WHERE id = ?", time.Now(), g.ID)
+	}))
+
+	err = ls.DeleteGroup(ctx, g.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GroupNotFound")
+}
+
+func TestListGroupsPage_FindErrorAfterCountSucceeds(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Group{})
+	dropTableAfterQueries(t, ls.db, 1, "groups")
+
+	_, _, err := ls.ListGroupsPage(context.Background(), 0, 10)
+	require.Error(t, err)
+}
+
+func TestAddUserToGroup_MembershipLookupGenericError(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.User{}, &models.Group{})
+	ctx := context.Background()
+	u, err := ls.CreateUser(ctx, &models.User{Username: "gu", UsernameFolded: "gu", EmailFolded: "gu@example.com"})
+	require.NoError(t, err)
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "gg", NameFolded: "gg"})
+	require.NoError(t, err)
+
+	// user_groups table intentionally absent: the membership lookup fails with
+	// something other than gorm.ErrRecordNotFound.
+	err = ls.AddUserToGroup(ctx, u.ID, g.ID, 0)
+	require.Error(t, err)
+}
+
+func TestAddUserToGroup_CreateFails(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.User{}, &models.Group{}, &models.UserGroup{})
+	ctx := context.Background()
+	u, err := ls.CreateUser(ctx, &models.User{Username: "hu", UsernameFolded: "hu", EmailFolded: "hu@example.com"})
+	require.NoError(t, err)
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "hg", NameFolded: "hg"})
+	require.NoError(t, err)
+
+	// 3 query-family statements precede the Create: GetUser's First, GetGroup's
+	// First, and the membership-existence First (not-found). Drop user_groups
+	// right after so the Create fails.
+	dropTableAfterQueries(t, ls.db, 3, "user_groups")
+
+	err = ls.AddUserToGroup(ctx, u.ID, g.ID, 2)
+	require.Error(t, err)
+}
+
+func TestListGroupMembers_FindErrorAfterGetGroupSucceeds(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.Group{})
+	ctx := context.Background()
+	g, err := ls.CreateGroup(ctx, &models.Group{Name: "member-fail", NameFolded: "member-fail"})
+	require.NoError(t, err)
+
+	// users/user_groups tables intentionally absent.
+	_, err = ls.ListGroupMembers(ctx, g.ID)
+	require.Error(t, err)
+}
+
+func TestListGroupMembersAt_BrokenDB(t *testing.T) {
+	t.Parallel()
+	ls := newBrokenDB(t)
+	_, err := ls.ListGroupMembersAt(context.Background(), 1, storage.Scope{ProjectID: 1})
+	require.Error(t, err)
+}
+
+func TestPrunePasswordHistory_DeleteFailsAfterPluckSucceeds(t *testing.T) {
+	t.Parallel()
+	ls := newPartialSecretsDB(t, &models.PasswordHistory{})
+	ctx := context.Background()
+	require.NoError(t, ls.AddPasswordHistory(ctx, 1, "$2a$10$abc", time.Now()))
+
+	dropTableAfterQueries(t, ls.db, 1, "password_histories")
+
+	err := ls.PrunePasswordHistory(ctx, 1, 1)
+	require.Error(t, err)
+}

--- a/internal/storage/store/local_users_zero_coverage_test.go
+++ b/internal/storage/store/local_users_zero_coverage_test.go
@@ -40,7 +40,8 @@ func TestListInactiveUsers(t *testing.T) {
 	// Never logged in, created before threshold -- inactive.
 	u3 := &models.User{Username: "u3", UsernameFolded: "u3", Email: "u3@x.io", EmailFolded: "u3@x.io"}
 	require.NoError(t, db.Create(u3).Error)
-	require.NoError(t, db.Model(u3).Update("created_at", oldCreated).Error)
+	u3.CreatedAt = oldCreated
+	require.NoError(t, db.Save(u3).Error)
 	// Never logged in, created after threshold -- active (too new to judge).
 	require.NoError(t, db.Create(&models.User{Username: "u4", UsernameFolded: "u4", Email: "u4@x.io", EmailFolded: "u4@x.io"}).Error)
 

--- a/internal/storage/store/local_users_zero_coverage_test.go
+++ b/internal/storage/store/local_users_zero_coverage_test.go
@@ -1,0 +1,103 @@
+// local_users_zero_coverage_test.go covers local_users.go functions that
+// were still at 0%: ListInactiveUsers, GetUserGroupsAt, ListGroupMembersAt.
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func newUsersZeroCoverageStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Group{}, &models.UserGroup{}))
+	return NewLocalStorage(db)
+}
+
+func TestListInactiveUsers(t *testing.T) {
+	ls := newUsersZeroCoverageStore(t)
+	db := ls.DB()
+
+	threshold := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	oldLogin := threshold.Add(-48 * time.Hour)
+	recentLogin := threshold.Add(48 * time.Hour)
+	oldCreated := threshold.Add(-72 * time.Hour)
+
+	// Inactive: last login before threshold.
+	require.NoError(t, db.Create(&models.User{Username: "u1", UsernameFolded: "u1", Email: "u1@x.io", EmailFolded: "u1@x.io", LastLoginAt: &oldLogin}).Error)
+	// Active: last login after threshold.
+	require.NoError(t, db.Create(&models.User{Username: "u2", UsernameFolded: "u2", Email: "u2@x.io", EmailFolded: "u2@x.io", LastLoginAt: &recentLogin}).Error)
+	// Never logged in, created before threshold -- inactive.
+	u3 := &models.User{Username: "u3", UsernameFolded: "u3", Email: "u3@x.io", EmailFolded: "u3@x.io"}
+	require.NoError(t, db.Create(u3).Error)
+	require.NoError(t, db.Model(u3).Update("created_at", oldCreated).Error)
+	// Never logged in, created after threshold -- active (too new to judge).
+	require.NoError(t, db.Create(&models.User{Username: "u4", UsernameFolded: "u4", Email: "u4@x.io", EmailFolded: "u4@x.io"}).Error)
+
+	users, err := ls.ListInactiveUsers(context.Background(), threshold)
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, u := range users {
+		names[u.Username] = true
+	}
+	assert.True(t, names["u1"])
+	assert.False(t, names["u2"])
+	assert.True(t, names["u3"])
+	assert.False(t, names["u4"])
+}
+
+func TestGetUserGroupsAt(t *testing.T) {
+	ls := newUsersZeroCoverageStore(t)
+	ctx := context.Background()
+	db := ls.DB()
+
+	require.NoError(t, db.Create(&models.Group{ID: 1, Name: "global-group", NameFolded: "global-group"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 2, Name: "proj7-group", NameFolded: "proj7-group"}).Error)
+	require.NoError(t, db.Create(&models.Group{ID: 3, Name: "proj8-group", NameFolded: "proj8-group"}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 10, GroupID: 1, ProjectID: 0}).Error) // global
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 10, GroupID: 2, ProjectID: 7}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 10, GroupID: 3, ProjectID: 8}).Error)
+
+	groups, err := ls.GetUserGroupsAt(ctx, 10, storage.Scope{ProjectID: 7})
+	require.NoError(t, err)
+	ids := map[uint]bool{}
+	for _, g := range groups {
+		ids[g.ID] = true
+	}
+	assert.True(t, ids[1], "a global (project_id=0) membership must always be included")
+	assert.True(t, ids[2], "the project-7-scoped membership must be included at scope project 7")
+	assert.False(t, ids[3], "a different project's scoped membership must be excluded")
+}
+
+func TestListGroupMembersAt(t *testing.T) {
+	ls := newUsersZeroCoverageStore(t)
+	ctx := context.Background()
+	db := ls.DB()
+
+	require.NoError(t, db.Create(&models.User{ID: 20, Username: "member-global", UsernameFolded: "member-global", Email: "mg@x.io", EmailFolded: "mg@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 21, Username: "member-proj7", UsernameFolded: "member-proj7", Email: "mp7@x.io", EmailFolded: "mp7@x.io"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 22, Username: "member-proj8", UsernameFolded: "member-proj8", Email: "mp8@x.io", EmailFolded: "mp8@x.io"}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 20, GroupID: 5, ProjectID: 0}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 21, GroupID: 5, ProjectID: 7}).Error)
+	require.NoError(t, db.Create(&models.UserGroup{UserID: 22, GroupID: 5, ProjectID: 8}).Error)
+
+	users, err := ls.ListGroupMembersAt(ctx, 5, storage.Scope{ProjectID: 7})
+	require.NoError(t, err)
+	ids := map[uint]bool{}
+	for _, u := range users {
+		ids[u.ID] = true
+	}
+	assert.True(t, ids[20], "a global member must always be included")
+	assert.True(t, ids[21])
+	assert.False(t, ids[22], "a member scoped to a different project must be excluded")
+}

--- a/internal/storage/store/local_version_comments_test.go
+++ b/internal/storage/store/local_version_comments_test.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func newVersionCommentStore(t *testing.T) *LocalStorage {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.SecretVersionComment{}))
+	return NewLocalStorage(db)
+}
+
+func TestSecretVersionComment_CreateListDelete(t *testing.T) {
+	ls := newVersionCommentStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, ls.CreateSecretVersionComment(ctx, &models.SecretVersionComment{
+		SecretID: 1, VersionID: 10, UserID: 5, Username: "alice", Comment: "rotated for compliance",
+	}))
+	require.NoError(t, ls.CreateSecretVersionComment(ctx, &models.SecretVersionComment{
+		SecretID: 1, VersionID: 10, UserID: 6, Username: "bob", Comment: "confirmed",
+	}))
+	// Different version on the same secret -- must not show up in a VersionID=10 listing.
+	require.NoError(t, ls.CreateSecretVersionComment(ctx, &models.SecretVersionComment{
+		SecretID: 1, VersionID: 11, UserID: 5, Username: "alice", Comment: "other version",
+	}))
+	// Same VersionID, different secret (#G53 cross-tenant guard) -- must not leak in.
+	require.NoError(t, ls.CreateSecretVersionComment(ctx, &models.SecretVersionComment{
+		SecretID: 2, VersionID: 10, UserID: 5, Username: "alice", Comment: "different secret",
+	}))
+
+	comments, err := ls.ListSecretVersionComments(ctx, 1, 10)
+	require.NoError(t, err)
+	require.Len(t, comments, 2)
+	assert.Equal(t, "alice", comments[0].Username)
+	assert.Equal(t, "bob", comments[1].Username)
+
+	require.NoError(t, ls.DeleteSecretVersionComment(ctx, 1, 10, comments[0].ID))
+	comments, err = ls.ListSecretVersionComments(ctx, 1, 10)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	assert.Equal(t, "bob", comments[0].Username)
+}
+
+func TestSecretVersionComment_ListEmpty(t *testing.T) {
+	ls := newVersionCommentStore(t)
+	comments, err := ls.ListSecretVersionComments(context.Background(), 404, 404)
+	require.NoError(t, err)
+	assert.Empty(t, comments)
+}
+
+// A delete whose (secretID, versionID) doesn't match the comment's actual
+// parent must fail, not silently delete the wrong row's owner check (#G53).
+func TestSecretVersionComment_DeleteWrongParentFails(t *testing.T) {
+	ls := newVersionCommentStore(t)
+	ctx := context.Background()
+
+	c := &models.SecretVersionComment{SecretID: 1, VersionID: 10, UserID: 5, Username: "alice", Comment: "x"}
+	require.NoError(t, ls.CreateSecretVersionComment(ctx, c))
+
+	err := ls.DeleteSecretVersionComment(ctx, 999, 10, c.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	// The comment must still be there.
+	comments, err := ls.ListSecretVersionComments(ctx, 1, 10)
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+}
+
+func TestSecretVersionComment_DeleteMissingFails(t *testing.T) {
+	ls := newVersionCommentStore(t)
+	err := ls.DeleteSecretVersionComment(context.Background(), 1, 10, 9999)
+	require.Error(t, err)
+}

--- a/internal/storage/store/remote_access_review_campaigns_test.go
+++ b/internal/storage/store/remote_access_review_campaigns_test.go
@@ -221,7 +221,7 @@ func TestRemoteStorage_CreateAccessReviewItems(t *testing.T) {
 
 func TestRemoteStorage_CreateAccessReviewItems_Empty(t *testing.T) {
 	// Empty slice is a no-op — no HTTP call is made.
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.CreateAccessReviewItems(context.Background(), nil)

--- a/internal/storage/store/remote_audit_test.go
+++ b/internal/storage/store/remote_audit_test.go
@@ -43,7 +43,7 @@ func TestRemoteStorage_LogAuditEvent(t *testing.T) {
 // (no live caller under storage.type: remote), converted to an explicit stub.
 
 func TestRemoteStorage_CreateSecretAccessLog_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.CreateSecretAccessLog(context.Background(), &models.SecretAccessLog{})
@@ -56,7 +56,7 @@ func TestRemoteStorage_CreateSecretAccessLog_Unsupported(t *testing.T) {
 // — confirmed DEAD, converted to an explicit stub.
 
 func TestRemoteStorage_CountImpersonatedActions_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.CountImpersonatedActions(context.Background(), 1, 2, time.Now())
@@ -173,7 +173,7 @@ func TestRemoteStorage_GetRBACAuditLogs_WithFilter(t *testing.T) {
 // --- ListSecretAccessLogs (unsupported) ---
 
 func TestRemoteStorage_ListSecretAccessLogs_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.ListSecretAccessLogs(context.Background(), 1, time.Now())
@@ -183,7 +183,7 @@ func TestRemoteStorage_ListSecretAccessLogs_Unsupported(t *testing.T) {
 // --- CountSecretReadsBySecretIDs (unsupported) ---
 
 func TestRemoteStorage_CountSecretReadsBySecretIDs_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.CountSecretReadsBySecretIDs(context.Background(), []uint{1, 2}, time.Now())
@@ -193,7 +193,7 @@ func TestRemoteStorage_CountSecretReadsBySecretIDs_Unsupported(t *testing.T) {
 // --- PrincipalSecretFirstSeen (unsupported) ---
 
 func TestRemoteStorage_PrincipalSecretFirstSeen_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.PrincipalSecretFirstSeen(context.Background(), time.Now())
@@ -203,7 +203,7 @@ func TestRemoteStorage_PrincipalSecretFirstSeen_Unsupported(t *testing.T) {
 // --- MostAccessedSecrets (unsupported) ---
 
 func TestRemoteStorage_MostAccessedSecrets_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.MostAccessedSecrets(context.Background(), nil, nil, time.Now(), 10)
@@ -213,7 +213,7 @@ func TestRemoteStorage_MostAccessedSecrets_Unsupported(t *testing.T) {
 // --- UnusedSecrets (unsupported) ---
 
 func TestRemoteStorage_UnusedSecrets_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.UnusedSecrets(context.Background(), nil, nil, time.Now())
@@ -223,7 +223,7 @@ func TestRemoteStorage_UnusedSecrets_Unsupported(t *testing.T) {
 // --- CountUnusedSecretsByProject (unsupported) ---
 
 func TestRemoteStorage_CountUnusedSecretsByProject_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.CountUnusedSecretsByProject(context.Background(), []uint{1}, time.Now())
@@ -233,7 +233,7 @@ func TestRemoteStorage_CountUnusedSecretsByProject_Unsupported(t *testing.T) {
 // --- AuditRetentionStats (unsupported) ---
 
 func TestRemoteStorage_AuditRetentionStats_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.AuditRetentionStats(context.Background())
@@ -243,7 +243,7 @@ func TestRemoteStorage_AuditRetentionStats_Unsupported(t *testing.T) {
 // --- VerifyAuditChain (unsupported) ---
 
 func TestRemoteStorage_VerifyAuditChain_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.VerifyAuditChain(context.Background(), nil)
@@ -251,7 +251,7 @@ func TestRemoteStorage_VerifyAuditChain_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_MigrateAuditChainEncoding_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.MigrateAuditChainEncoding(context.Background(), true, nil)
@@ -261,7 +261,7 @@ func TestRemoteStorage_MigrateAuditChainEncoding_Unsupported(t *testing.T) {
 // --- CreateAuditCheckpoint (unsupported) ---
 
 func TestRemoteStorage_CreateAuditCheckpoint_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.CreateAuditCheckpoint(context.Background(), &models.AuditCheckpoint{})
@@ -271,7 +271,7 @@ func TestRemoteStorage_CreateAuditCheckpoint_Unsupported(t *testing.T) {
 // --- LatestAuditCheckpoint (unsupported) ---
 
 func TestRemoteStorage_LatestAuditCheckpoint_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.LatestAuditCheckpoint(context.Background())
@@ -281,7 +281,7 @@ func TestRemoteStorage_LatestAuditCheckpoint_Unsupported(t *testing.T) {
 // --- UpdateAuditCheckpointAnchor (unsupported) ---
 
 func TestRemoteStorage_UpdateAuditCheckpointAnchor_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.UpdateAuditCheckpointAnchor(context.Background(), 1, []byte("anchor"), time.Now(), "tsa-url")
@@ -291,7 +291,7 @@ func TestRemoteStorage_UpdateAuditCheckpointAnchor_Unsupported(t *testing.T) {
 // --- AuditEntryHashByID (unsupported) ---
 
 func TestRemoteStorage_AuditEntryHashByID_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, _, err = rs.AuditEntryHashByID(context.Background(), 1)
@@ -301,7 +301,7 @@ func TestRemoteStorage_AuditEntryHashByID_Unsupported(t *testing.T) {
 // --- GetSystemMetadata (unsupported) ---
 
 func TestRemoteStorage_GetSystemMetadata_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, _, err = rs.GetSystemMetadata(context.Background(), "key")
@@ -311,7 +311,7 @@ func TestRemoteStorage_GetSystemMetadata_Unsupported(t *testing.T) {
 // --- SetSystemMetadata (unsupported) ---
 
 func TestRemoteStorage_SetSystemMetadata_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.SetSystemMetadata(context.Background(), "key", "value")
@@ -321,7 +321,7 @@ func TestRemoteStorage_SetSystemMetadata_Unsupported(t *testing.T) {
 // --- CreateAnomalyAlert (unsupported) ---
 
 func TestRemoteStorage_CreateAnomalyAlert_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.CreateAnomalyAlert(context.Background(), &models.AnomalyAlert{})
@@ -331,7 +331,7 @@ func TestRemoteStorage_CreateAnomalyAlert_Unsupported(t *testing.T) {
 // --- ListAnomalyAlerts (unsupported) ---
 
 func TestRemoteStorage_ListAnomalyAlerts_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	acked := false
@@ -342,7 +342,7 @@ func TestRemoteStorage_ListAnomalyAlerts_Unsupported(t *testing.T) {
 // --- AcknowledgeAnomalyAlert (unsupported) ---
 
 func TestRemoteStorage_AcknowledgeAnomalyAlert_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.AcknowledgeAnomalyAlert(context.Background(), 1, 2, time.Now())
@@ -352,7 +352,7 @@ func TestRemoteStorage_AcknowledgeAnomalyAlert_Unsupported(t *testing.T) {
 // --- ListUnalertedAnomalyAlerts (unsupported) ---
 
 func TestRemoteStorage_ListUnalertedAnomalyAlerts_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.ListUnalertedAnomalyAlerts(context.Background())
@@ -362,7 +362,7 @@ func TestRemoteStorage_ListUnalertedAnomalyAlerts_Unsupported(t *testing.T) {
 // --- MarkAnomalyAlertAlerted (unsupported) ---
 
 func TestRemoteStorage_MarkAnomalyAlertAlerted_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.MarkAnomalyAlertAlerted(context.Background(), 1)
@@ -372,7 +372,7 @@ func TestRemoteStorage_MarkAnomalyAlertAlerted_Unsupported(t *testing.T) {
 // --- GetDistinctActiveUserIDs (unsupported) ---
 
 func TestRemoteStorage_GetDistinctActiveUserIDs_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.GetDistinctActiveUserIDs(context.Background(), time.Now())
@@ -382,7 +382,7 @@ func TestRemoteStorage_GetDistinctActiveUserIDs_Unsupported(t *testing.T) {
 // --- DeleteAuditLogsBefore (unsupported in remote mode) ---
 
 func TestRemoteStorage_DeleteAuditLogsBefore_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	n, anchor, err := rs.DeleteAuditLogsBefore(context.Background(), time.Now())

--- a/internal/storage/store/remote_auth_test.go
+++ b/internal/storage/store/remote_auth_test.go
@@ -125,7 +125,7 @@ func TestRemoteStorage_DeleteSession_Error(t *testing.T) {
 // pass — no matching route, zero callers in any topology; see
 // docs/adr-087-remote-storage-deletion-pass.md.
 func TestRemoteStorage_CleanupExpiredSessions_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.CleanupExpiredSessions(context.Background())

--- a/internal/storage/store/remote_coverage_test.go
+++ b/internal/storage/store/remote_coverage_test.go
@@ -58,7 +58,7 @@ func apiNotOK(code, message string) []byte {
 // TestRemoteCov_GetStats_Unsupported: #1511/G80 deletion pass — no matching
 // route, server-only caller; see docs/adr-087-remote-storage-deletion-pass.md.
 func TestRemoteCov_GetStats_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.GetStats(context.Background())

--- a/internal/storage/store/remote_group_a_error_sweep_test.go
+++ b/internal/storage/store/remote_group_a_error_sweep_test.go
@@ -1,0 +1,569 @@
+// remote_group_a_error_sweep_test.go — targeted coverage sweep for RemoteStorage
+// RPC-client thin proxies in remote_access_activity.go,
+// remote_access_review_campaigns.go, remote_audit.go, and remote_auth.go.
+//
+// Every method here follows the same three-branch shape: a transport-error
+// branch (rs.client.X returns err != nil — exercised with errHandler, which
+// writes a non-2xx status the HTTP client converts into a network-level
+// error before resp.Success is ever inspected), a !resp.Success branch
+// (exercised with apiNotOK, HTTP 200 + success:false), and — for methods that
+// decode resp.Data into a typed struct — a JSON-decode-error branch
+// (exercised with apiOK wrapping a JSON string, which cannot unmarshal into
+// the target struct/slice type).
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// remote_access_activity.go
+// ============================================================================
+
+func TestRemoteStorage_LastUserSecretActivity_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.LastUserSecretActivity(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get secret activity")
+}
+
+func TestRemoteStorage_LastUserSecretActivity_DecodeError_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("not-an-object"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.LastUserSecretActivity(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// TestRemoteStorage_LastUserSecretActivity_SkipsUnparseableUserID exercises
+// decodeAccessActivityResponse's per-key strconv.ParseUint failure branch: a
+// map key that isn't a valid uint is silently skipped rather than aborting
+// the whole decode.
+func TestRemoteStorage_LastUserSecretActivity_SkipsUnparseableUserID_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"activity": map[string]interface{}{
+				"5":          time.Now().UTC().Format(time.RFC3339),
+				"not-a-uint": time.Now().UTC().Format(time.RFC3339),
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.LastUserSecretActivity(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	_, ok := result[5]
+	assert.True(t, ok)
+}
+
+// ============================================================================
+// remote_access_review_campaigns.go
+// ============================================================================
+
+func TestRemoteStorage_CreateAccessReviewCampaign_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateAccessReviewCampaign(context.Background(), &models.AccessReviewCampaign{
+		ProjectID: 1, Name: "Q1", State: "open", CreatedBy: 1, CreatedAt: time.Now(),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create access-review campaign")
+}
+
+func TestRemoteStorage_GetAccessReviewCampaign_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "missing"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetAccessReviewCampaign(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get access-review campaign")
+}
+
+func TestRemoteStorage_ListAccessReviewCampaigns_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListAccessReviewCampaigns(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list access-review campaigns")
+}
+
+func TestRemoteStorage_ListAccessReviewCampaigns_NotSuccess_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "list failed upstream"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListAccessReviewCampaigns(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list access-review campaigns failed")
+}
+
+func TestRemoteStorage_ListAccessReviewCampaigns_DecodeError_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("not-an-object"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListAccessReviewCampaigns(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_GetOpenAccessReviewCampaign_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetOpenAccessReviewCampaign(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get open access-review campaign")
+}
+
+func TestRemoteStorage_GetOpenAccessReviewCampaign_NotSuccess_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "open lookup failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetOpenAccessReviewCampaign(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "get open access-review campaign failed")
+}
+
+func TestRemoteStorage_GetOpenAccessReviewCampaign_DecodeError_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("not-an-object"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetOpenAccessReviewCampaign(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_GetLatestClosedAccessReviewCampaign_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetLatestClosedAccessReviewCampaign(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get latest-closed access-review campaign")
+}
+
+func TestRemoteStorage_GetLatestClosedAccessReviewCampaign_NotSuccess_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "closed lookup failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetLatestClosedAccessReviewCampaign(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "get latest-closed access-review campaign failed")
+}
+
+func TestRemoteStorage_GetLatestClosedAccessReviewCampaign_DecodeError_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("not-an-object"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetLatestClosedAccessReviewCampaign(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_CreateAccessReviewItems_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateAccessReviewItems(context.Background(), []*models.AccessReviewItem{
+		{CampaignID: 1, PrincipalType: "user", PrincipalID: 3, Source: "role", AccessLevel: "read", EnvironmentID: 1, Decision: "pending"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create access-review items")
+}
+
+func TestRemoteStorage_CreateAccessReviewItems_NotSuccess_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "create items failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateAccessReviewItems(context.Background(), []*models.AccessReviewItem{
+		{CampaignID: 1, PrincipalType: "user", PrincipalID: 3, Source: "role", AccessLevel: "read", EnvironmentID: 1, Decision: "pending"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "create access-review items failed")
+}
+
+func TestRemoteStorage_ListAccessReviewItems_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListAccessReviewItems(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list access-review items")
+}
+
+func TestRemoteStorage_CountPendingAccessReviewItems_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountPendingAccessReviewItems(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to count pending access-review items")
+}
+
+func TestRemoteStorage_GetAccessReviewItem_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "missing"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetAccessReviewItem(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get access-review item")
+}
+
+func TestRemoteStorage_UpdateAccessReviewItem_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateAccessReviewItem(context.Background(), &models.AccessReviewItem{ID: 1, CampaignID: 1, Decision: "attested"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update access-review item")
+}
+
+// ============================================================================
+// remote_audit.go
+// ============================================================================
+
+func TestRemoteStorage_LogAuditEvent_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.LogAuditEvent(context.Background(), &models.AuditEvent{EventType: "test.event"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to log audit event")
+}
+
+func TestRemoteStorage_GetAuditLogs_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.GetAuditLogs(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get audit logs")
+}
+
+func TestRemoteStorage_GetAuditLogs_DecodeError_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("not-an-object"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.GetAuditLogs(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_GetRBACAuditLogs_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.GetRBACAuditLogs(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get RBAC audit logs")
+}
+
+func TestRemoteStorage_GetRBACAuditLogs_DecodeError_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("not-an-object"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.GetRBACAuditLogs(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// ============================================================================
+// remote_auth.go
+// ============================================================================
+
+func TestRemoteStorage_GetSession_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetSession(context.Background(), "tok")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get session")
+}
+
+func TestRemoteStorage_GetSession_DecodeError_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("not-a-session"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetSession(context.Background(), "tok")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_DeleteSession_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteSession(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete session")
+}
+
+func TestRemoteStorage_DeleteSessionsForUserExcept_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteSessionsForUserExcept(context.Background(), 1, 2)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete sessions for user")
+}
+
+func TestRemoteStorage_DeleteSessionsForUserExcept_NotSuccess_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "delete except failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteSessionsForUserExcept(context.Background(), 1, 2)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "delete sessions for user failed")
+}
+
+func TestRemoteStorage_RevokeAllPersonalAccessTokensForUser_TransportError_S1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.RevokeAllPersonalAccessTokensForUser(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to revoke personal access tokens for user")
+}
+
+func TestRemoteStorage_RevokeAllPersonalAccessTokensForUser_NotSuccess_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "revoke all failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.RevokeAllPersonalAccessTokensForUser(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "revoke personal access tokens for user failed")
+}
+
+func TestRemoteStorage_RevokeAllPersonalAccessTokensForUser_DecodeError_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("not-an-object"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.RevokeAllPersonalAccessTokensForUser(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_CreateSetupToken_NotSuccess_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "create setup token failed upstream"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateSetupToken(context.Background(), minimalSetupToken())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "create setup token failed")
+}
+
+func TestRemoteStorage_GetSetupTokenByHash_NotSuccess_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("NOT_FOUND", "setup token not found upstream"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetSetupTokenByHash(context.Background(), "deadbeef")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "get setup token failed")
+}
+
+func TestRemoteStorage_SupersedeActiveSetupTokens_NotSuccess_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "supersede failed upstream"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.SupersedeActiveSetupTokens(context.Background(), "account_setup", "user@example.com", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "supersede setup tokens failed")
+}
+
+func TestRemoteStorage_MarkSetupTokenExpired_NotSuccess_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("NOT_FOUND", "expire failed upstream"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.MarkSetupTokenExpired(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expire setup token failed")
+}
+
+func TestRemoteStorage_CountSetupTokensSince_NotSuccess_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "count failed upstream"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountSetupTokensSince(context.Background(), "account_setup", "user@example.com", time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "count setup tokens failed")
+}
+
+func TestRemoteStorage_CountSetupTokensSince_DecodeError_S1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("not-an-object"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountSetupTokensSince(context.Background(), "account_setup", "user@example.com", time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}

--- a/internal/storage/store/remote_group_b_break_glass_error_sweep_test.go
+++ b/internal/storage/store/remote_group_b_break_glass_error_sweep_test.go
@@ -1,0 +1,90 @@
+// remote_group_b_break_glass_error_sweep_test.go — closes the remaining
+// uncovered branches in remote_break_glass.go: the transport-error branch of
+// GetBreakGlassActivation, and the transport-error/!success/malformed-JSON
+// branches of ListBreakGlassActivations and RevokeBreakGlassActivation that
+// TestRemoteStorage_RevokeBreakGlassActivation_NotActive (remote_misc_test.go)
+// and TestRemoteCov_GetBreakGlassActivation_NotSuccess
+// (remote_coverage_policies_memberships_auth_test.go) don't reach: those exist
+// but cover the httpErr.ErrorType==breakGlassNotActiveCode branch and
+// GetBreakGlassActivation's !success branch respectively, not these.
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteStorage_GetBreakGlassActivation_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetBreakGlassActivation(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get break-glass activation")
+}
+
+func TestRemoteStorage_ListBreakGlassActivations_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListBreakGlassActivations(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list break-glass activations")
+}
+
+func TestRemoteStorage_ListBreakGlassActivations_NotSuccess_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "list failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListBreakGlassActivations(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list break-glass activations failed")
+}
+
+func TestRemoteStorage_ListBreakGlassActivations_MalformedJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListBreakGlassActivations(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_RevokeBreakGlassActivation_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.RevokeBreakGlassActivation(context.Background(), 9, 1, 0, time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to revoke break-glass activation")
+}
+
+func TestRemoteStorage_RevokeBreakGlassActivation_NotSuccess_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "revoke failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RevokeBreakGlassActivation(context.Background(), 9, 1, 0, time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "revoke break-glass activation failed")
+}

--- a/internal/storage/store/remote_group_b_dynamic_error_sweep_test.go
+++ b/internal/storage/store/remote_group_b_dynamic_error_sweep_test.go
@@ -1,0 +1,170 @@
+// remote_group_b_dynamic_error_sweep_test.go — closes the remaining uncovered
+// branches in remote_dynamic.go: the transport-error branch on every method
+// (remote_dynamic_test.go/remote_coverage_campaigns_dynamic_invitations_test.go
+// only exercise the success and !resp.Success branches, not transport error),
+// plus the !success/malformed-JSON branches of ListDynamicSecretConfigs,
+// ListDynamicSecretLeases, and ListExpiredActiveLeases, which had no error-path
+// tests at all before this file.
+//
+// GetDynamicSecretConfig's own validateEncryptedAdminDSNWireField error branch
+// (remote_dynamic.go:229, `return nil, err`) is deliberately NOT covered here:
+// validateEncryptedAdminDSNWireField is a documented permanent no-op ("_ =
+// dsnEnc; return nil") -- it can never return a non-nil error through any
+// caller-visible input, so that branch is dead code, not a reachable gap.
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteStorage_GetDynamicSecretConfig_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetDynamicSecretConfig(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get dynamic-secret config")
+}
+
+func TestRemoteStorage_ListDynamicSecretConfigs_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListDynamicSecretConfigs(context.Background(), 1, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list dynamic-secret configs")
+}
+
+func TestRemoteStorage_ListDynamicSecretConfigs_NotSuccess_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "list failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListDynamicSecretConfigs(context.Background(), 1, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list dynamic-secret configs failed")
+}
+
+func TestRemoteStorage_ListDynamicSecretConfigs_MalformedJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListDynamicSecretConfigs(context.Background(), 1, 0)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CountDynamicSecretConfigsByClassification_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CountDynamicSecretConfigsByClassification(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to count dynamic-secret configs by classification")
+}
+
+func TestRemoteStorage_GetDynamicSecretLease_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetDynamicSecretLease(context.Background(), "lease-xyz")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get dynamic-secret lease")
+}
+
+func TestRemoteStorage_ListDynamicSecretLeases_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListDynamicSecretLeases(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list dynamic-secret leases")
+}
+
+func TestRemoteStorage_ListDynamicSecretLeases_NotSuccess_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "list failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListDynamicSecretLeases(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list dynamic-secret leases failed")
+}
+
+func TestRemoteStorage_ListDynamicSecretLeases_MalformedJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListDynamicSecretLeases(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CountActiveLeases_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CountActiveLeases(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to count active dynamic-secret leases")
+}
+
+func TestRemoteStorage_ListExpiredActiveLeases_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListExpiredActiveLeases(context.Background(), time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list expired dynamic-secret leases")
+}
+
+func TestRemoteStorage_ListExpiredActiveLeases_NotSuccess_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "list failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListExpiredActiveLeases(context.Background(), time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list expired dynamic-secret leases failed")
+}
+
+func TestRemoteStorage_ListExpiredActiveLeases_MalformedJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListExpiredActiveLeases(context.Background(), time.Now())
+	assert.Error(t, err)
+}

--- a/internal/storage/store/remote_group_b_invitations_error_sweep_test.go
+++ b/internal/storage/store/remote_group_b_invitations_error_sweep_test.go
@@ -1,0 +1,168 @@
+// remote_group_b_invitations_error_sweep_test.go — closes the remaining
+// uncovered branches in remote_invitations.go: the transport-error branch on
+// every method (remote_invitations_test.go and
+// remote_coverage_campaigns_dynamic_invitations_test.go only exercise the
+// success and !resp.Success branches, not transport error), plus the
+// !success/malformed-JSON branches of ListProjectInvitations and
+// ListAccessRequests, which had no error-path tests at all before this file.
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteStorage_CreateProjectInvitation_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CreateProjectInvitation(context.Background(), &models.ProjectInvitation{
+		ProjectID: 10, Email: "bob@example.com", Role: "viewer", State: "pending", InvitedBy: 5,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create invitation")
+}
+
+func TestRemoteStorage_GetProjectInvitation_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetProjectInvitation(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get invitation")
+}
+
+func TestRemoteStorage_UpdateProjectInvitation_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateProjectInvitation(context.Background(), &models.ProjectInvitation{ID: 1, State: "accepted"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update invitation")
+}
+
+func TestRemoteStorage_ListProjectInvitations_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListProjectInvitations(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list invitations")
+}
+
+func TestRemoteStorage_ListProjectInvitations_NotSuccess_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "list failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListProjectInvitations(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list invitations failed")
+}
+
+func TestRemoteStorage_ListProjectInvitations_MalformedJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListProjectInvitations(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CreateAccessRequest_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CreateAccessRequest(context.Background(), &models.AccessRequest{
+		ProjectID: 10, UserID: 3, SuggestedRole: "editor", State: "pending",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create access request")
+}
+
+func TestRemoteStorage_GetAccessRequest_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetAccessRequest(context.Background(), 50)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get access request")
+}
+
+func TestRemoteStorage_UpdateAccessRequest_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateAccessRequest(context.Background(), &models.AccessRequest{ID: 50, State: "approved"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update access request")
+}
+
+func TestRemoteStorage_ListAccessRequests_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListAccessRequests(context.Background(), 10)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list access requests")
+}
+
+func TestRemoteStorage_ListAccessRequests_NotSuccess_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL", "list failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListAccessRequests(context.Background(), 10)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list access requests failed")
+}
+
+func TestRemoteStorage_ListAccessRequests_MalformedJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListAccessRequests(context.Background(), 10)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CreateAccessRequestApproval_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.CreateAccessRequestApproval(context.Background(), &models.AccessRequestApproval{RequestID: 50, ApproverID: 2})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create access request approval")
+}
+
+func TestRemoteStorage_ListAccessRequestApprovals_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListAccessRequestApprovals(context.Background(), 50)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list access request approvals")
+}

--- a/internal/storage/store/remote_group_b_legal_hold_login_error_sweep_test.go
+++ b/internal/storage/store/remote_group_b_legal_hold_login_error_sweep_test.go
@@ -1,0 +1,172 @@
+// remote_group_b_legal_hold_login_error_sweep_test.go — closes the remaining
+// uncovered branches in remote_legal_hold.go, remote_login_attempts.go, and
+// remote_login_verify.go:
+//   - remote_legal_hold.go: CreateLegalHold's generic transport-error fallback
+//     (distinct from the already-covered legalHoldAlreadyActiveCode branch) and
+//     malformed-JSON branch; GetActiveLegalHold's transport-error and
+//     malformed-JSON branches; UpdateLegalHold's transport-error branch. The
+//     !resp.Success branches for all three methods and CreateLegalHold's
+//     already-active branch are already covered by
+//     remote_coverage_policies_memberships_auth_test.go / remote_misc_test.go.
+//   - remote_login_attempts.go: the transport-error branch of all three
+//     methods, and the malformed-JSON branch of CountRecentLoginAttempts and
+//     PruneLoginAttempts (had no error-path tests at all before this file).
+//   - remote_login_verify.go: VerifyLoginCredentials' !resp.Success and
+//     malformed-JSON branches -- TestRemoteStorage_VerifyLoginCredentials_Failure
+//     (remote_misc_test.go) only reaches the transport-error branch (it writes
+//     a 401 status, which the HTTP client converts to a network-level error
+//     before resp is ever populated).
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- remote_legal_hold.go ---
+
+func TestRemoteStorage_CreateLegalHold_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CreateLegalHold(context.Background(), &models.LegalHold{Reason: "test", PlacedBy: 1})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create legal hold")
+}
+
+func TestRemoteStorage_CreateLegalHold_MalformedJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateLegalHold(context.Background(), &models.LegalHold{Reason: "test", PlacedBy: 1})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetActiveLegalHold_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetActiveLegalHold(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get active legal hold")
+}
+
+func TestRemoteStorage_GetActiveLegalHold_MalformedJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetActiveLegalHold(context.Background())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_UpdateLegalHold_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.UpdateLegalHold(context.Background(), &models.LegalHold{ID: 1, Reason: "test"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update legal hold")
+}
+
+// --- remote_login_attempts.go ---
+
+func TestRemoteStorage_RecordLoginAttempt_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.RecordLoginAttempt(context.Background(), "10.0.0.1", time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to record login attempt")
+}
+
+func TestRemoteStorage_CountRecentLoginAttempts_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CountRecentLoginAttempts(context.Background(), "10.0.0.1", time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to count login attempts")
+}
+
+func TestRemoteStorage_CountRecentLoginAttempts_MalformedJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountRecentLoginAttempts(context.Background(), "10.0.0.1", time.Now())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_PruneLoginAttempts_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.PruneLoginAttempts(context.Background(), time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to prune login attempts")
+}
+
+func TestRemoteStorage_PruneLoginAttempts_MalformedJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.PruneLoginAttempts(context.Background(), time.Now())
+	assert.Error(t, err)
+}
+
+// --- remote_login_verify.go ---
+
+func TestRemoteStorage_VerifyLoginCredentials_NotSuccess_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiNotOK("INVALID_CREDENTIALS", "wrong password"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.VerifyLoginCredentials(context.Background(), "alice", "wrong", "UA", "127.0.0.1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid credentials")
+}
+
+func TestRemoteStorage_VerifyLoginCredentials_MalformedJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK("{bad}"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.VerifyLoginCredentials(context.Background(), "alice", "s3cr3t", "UA", "127.0.0.1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid credentials")
+}

--- a/internal/storage/store/remote_group_c_machine_identities_error_sweep_test.go
+++ b/internal/storage/store/remote_group_c_machine_identities_error_sweep_test.go
@@ -1,0 +1,323 @@
+// remote_group_c_machine_identities_error_sweep_test.go — transport-error
+// (err != nil from rs.client.X) and decode-error sweep for
+// remote_machine_identities.go. store_s28_test.go already covers every
+// !resp.Success branch (HTTP 200 + success:false body) for this file; per
+// #501 any 4xx/5xx status collapses to a non-nil error at the client.Get/
+// Post/Put/Delete call site itself (see remote/client.go's makeRequest), so
+// errHandler's non-2xx status here specifically exercises the transport-
+// error branch, not !resp.Success.
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteStorage_CreateMachineIdentity_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateMachineIdentity(context.Background(), &models.MachineIdentity{Name: "ci"})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetMachineIdentity_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetMachineIdentity(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_LockMachineIdentityForUpdate_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.LockMachineIdentityForUpdate(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_TransitionMachineIdentityState_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.TransitionMachineIdentityState(context.Background(), &models.MachineIdentity{ID: 1}, "pending")
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListMachineIdentities_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListMachineIdentities(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListAllMachineIdentities_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListAllMachineIdentities(context.Background())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CountMachineIdentitiesByClassification_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountMachineIdentitiesByClassification(context.Background())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CreateMachineIdentityCredential_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateMachineIdentityCredential(context.Background(), &models.MachineIdentityCredential{MachineIdentityID: 1})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetMachineIdentityCredentialByHash_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetMachineIdentityCredentialByHash(context.Background(), "abc123")
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetMachineIdentityCredentialByHash_BadJSON_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("not-object"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetMachineIdentityCredentialByHash(context.Background(), "abc123")
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetMachineIdentityCredentialByID_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetMachineIdentityCredentialByID(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListMachineIdentityCredentials_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListMachineIdentityCredentials(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListActiveMachineIdentityCredentials_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListActiveMachineIdentityCredentials(context.Background())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_UpdateMachineIdentityCredential_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.UpdateMachineIdentityCredential(context.Background(), &models.MachineIdentityCredential{ID: 1})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CountMachineIdentityCredentialsByClassification_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountMachineIdentityCredentialsByClassification(context.Background())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_RevokeMachineIdentityCredential_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RevokeMachineIdentityCredential(context.Background(), 1, 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_TouchMachineIdentityCredential_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.TouchMachineIdentityCredential(context.Background(), 1, time.Now(), time.Hour)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_AssignMachineRole_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.AssignMachineRole(context.Background(), 1, 1, coreScope())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_RemoveMachineRole_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemoveMachineRole(context.Background(), 1, 1, coreScope())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetMachineRoleIDsAt_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetMachineRoleIDsAt(context.Background(), 1, coreScope())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetMachineRoles_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetMachineRoles(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CreateOIDCBinding_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateOIDCBinding(context.Background(), &models.MachineIdentityOIDCBinding{MachineIdentityID: 1})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetMachineByOIDCSubject_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetMachineByOIDCSubject(context.Background(), "https://issuer", "sub123")
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListOIDCBindings_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListOIDCBindings(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetOIDCBindingByID_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetOIDCBindingByID(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetOIDCBindingByID_BadJSON_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("not-object"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetOIDCBindingByID(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_DeleteOIDCBinding_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteOIDCBinding(context.Background(), 1)
+	assert.Error(t, err)
+}

--- a/internal/storage/store/remote_group_c_mfa_error_sweep_test.go
+++ b/internal/storage/store/remote_group_c_mfa_error_sweep_test.go
@@ -1,0 +1,302 @@
+// remote_group_c_mfa_error_sweep_test.go — remaining uncovered branches in
+// remote_memberships.go and remote_mfa.go: the transport-error (err != nil)
+// branch for methods store_s28/remote_coverage_mfa_rbac_secrets_test.go only
+// exercised with a 4xx/5xx status (which itself IS the transport-error
+// branch, per #501 — see remote_group_c_machine_identities_error_sweep_test.go's
+// package doc), the !resp.Success branch for methods that had no error test
+// at all, and a couple of decode-error / success-only branches that were
+// never reached.
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- remote_memberships.go ---
+
+func TestRemoteStorage_CreateProjectMembership_DuplicateActive_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"success":false,"error":"DUPLICATE_ACTIVE_MEMBERSHIP","message":"already active"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateProjectMembership(context.Background(), &models.ProjectMembership{ProjectID: 1, UserID: 1})
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, corestorage.ErrDuplicateActiveMembership)
+}
+
+func TestRemoteStorage_GetProjectMembership_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetProjectMembership(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListProjectMemberships_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListProjectMemberships(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListProjectMemberships_BadJSON_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK("bad"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListProjectMemberships(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetActiveProjectMembership_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetActiveProjectMembership(context.Background(), 1, 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetActiveProjectMembership_SuccessFalse_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL_ERROR", "failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetActiveProjectMembership(context.Background(), 1, 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListStaleInvitedMemberships_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListStaleInvitedMemberships(context.Background(), time.Now())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListUserProjectMemberships_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListUserProjectMemberships(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CountProjectMembershipsByUsers_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountProjectMembershipsByUsers(context.Background(), []uint{1})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CountProjectMembershipsByUsers_SuccessFalse_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL_ERROR", "failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountProjectMembershipsByUsers(context.Background(), []uint{1})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CountProjectMembershipsByUsers_BadJSON_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK([]int{1, 2, 3}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountProjectMembershipsByUsers(context.Background(), []uint{1})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CountProjectMembershipsByUsers_NullData_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.CountProjectMembershipsByUsers(context.Background(), []uint{1})
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+}
+
+// --- remote_mfa.go ---
+
+func TestRemoteStorage_GetMFASecret_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetMFASecret(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_MarkTOTPStepUsed_SuccessFalse_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL_ERROR", "failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.MarkTOTPStepUsed(context.Background(), 1, 12345)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_MarkTOTPStepUsed_Success_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{"fresh": true}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	fresh, err := rs.MarkTOTPStepUsed(context.Background(), 1, 12345)
+	require.NoError(t, err)
+	assert.True(t, fresh)
+}
+
+func TestRemoteStorage_CountUnusedMFARecoveryCodes_TransportError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CountUnusedMFARecoveryCodes(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ConsumeMFAChallenge_SuccessFalse_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL_ERROR", "failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ConsumeMFAChallenge(context.Background(), "hash", time.Now())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetActiveMFAChallenge_SuccessFalse_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL_ERROR", "failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetActiveMFAChallenge(context.Background(), "hash", time.Now())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_IssueMFAChallenge_SuccessFalse_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiNotOK("INTERNAL_ERROR", "failed"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.IssueMFAChallenge(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+// --- remote_mfa_stepup_grant.go ---
+
+// TestRemoteStorage_GetActiveMFAStepUpGrant_DecodeError_GroupC targets
+// decodeMFAStepUpGrantResponse's own parse-error branch specifically: the
+// data field must be syntactically valid JSON (so the outer envelope parses
+// and resp.Success is genuinely true) but the wrong shape for
+// mfaStepUpGrantWire, unlike a malformed-envelope body (e.g. embedding
+// literal `{bad json}` in "data"), which never reaches this function at all
+// -- the outer json.Unmarshal in remote/client.go's makeRequest fails first
+// and synthesizes a generic Success:false response instead.
+func TestRemoteStorage_GetActiveMFAStepUpGrant_DecodeError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK([]int{1, 2, 3}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetActiveMFAStepUpGrant(context.Background(), 1, time.Now().UTC())
+	assert.Error(t, err)
+}
+
+// TestRemoteStorage_PruneMFAStepUpGrants_DecodeError_GroupC: same reasoning
+// as above for PruneMFAStepUpGrants' own json.Unmarshal(resp.Data, &result)
+// branch -- valid outer JSON, wrong-shaped data.
+func TestRemoteStorage_PruneMFAStepUpGrants_DecodeError_GroupC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(apiOK([]int{1, 2, 3}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.PruneMFAStepUpGrants(context.Background(), time.Now().UTC())
+	assert.Error(t, err)
+}

--- a/internal/storage/store/remote_group_d_notifications_error_sweep_test.go
+++ b/internal/storage/store/remote_group_d_notifications_error_sweep_test.go
@@ -1,0 +1,105 @@
+// remote_group_d_notifications_error_sweep_test.go covers remote_notifications.go
+// branches left uncovered by remote_notifications_test.go /
+// remote_coverage_mfa_rbac_secrets_test.go: CreateNotification's generic
+// transport-error branch, its !resp.Success branch (a non-duplicate-reminder
+// failure), and the resp.Data decode-error branches for CreateNotification and
+// fetchNotifications (shared by ListNotifications/CountUnreadNotifications), plus
+// the transport-error branches of MarkNotificationRead/MarkAllNotificationsRead.
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- CreateNotification ---
+
+func TestRemoteStorage_CreateNotification_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateNotification(context.Background(), &models.Notification{UserID: 1})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create notification")
+}
+
+func TestRemoteStorage_CreateNotification_SuccessFalse_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "STORAGE_ERROR", "db unavailable"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateNotification(context.Background(), &models.Notification{UserID: 1})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "create notification failed")
+}
+
+func TestRemoteStorage_CreateNotification_BadJSON_GroupD(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateNotification(context.Background(), &models.Notification{UserID: 1})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// --- fetchNotifications (via ListNotifications) ---
+
+func TestRemoteStorage_ListNotifications_BadJSON_GroupD(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/notifications", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListNotifications(context.Background(), 0, false, 10)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// --- MarkNotificationRead / MarkAllNotificationsRead transport errors ---
+
+func TestRemoteStorage_MarkNotificationRead_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "notification not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.MarkNotificationRead(context.Background(), 42, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to mark notification read")
+}
+
+func TestRemoteStorage_MarkAllNotificationsRead_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "db down"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.MarkAllNotificationsRead(context.Background(), 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to mark all notifications read")
+}

--- a/internal/storage/store/remote_group_d_rbac_error_sweep_2_test.go
+++ b/internal/storage/store/remote_group_d_rbac_error_sweep_2_test.go
@@ -1,0 +1,290 @@
+// remote_group_d_rbac_error_sweep_2_test.go continues
+// remote_group_d_rbac_error_sweep_test.go's coverage of remote_rbac.go's
+// generic transport-error branches: Connect ref-grants, group role
+// assignments, and the project/environment catalog proxies, plus
+// RemoveGlobalAdminRoleGuarded's !resp.Success branch (its transport-error
+// and sentinel-translation branches are already covered by
+// store_s17_remote_test.go).
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- ListConnectRefGrantsByConnector ---
+
+func TestRemoteStorage_ListConnectRefGrantsByConnector_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListConnectRefGrantsByConnector(context.Background(), "connector-a")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list connect ref-grants by connector")
+}
+
+// --- ListConnectRefGrants ---
+
+func TestRemoteStorage_ListConnectRefGrants_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListConnectRefGrants(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list connect ref-grants")
+}
+
+// --- GetGroupRoles ---
+
+func TestRemoteStorage_GetGroupRoles_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetGroupRoles(context.Background(), 4)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get group roles")
+}
+
+// --- ListGroupRoleAssignments ---
+
+func TestRemoteStorage_ListGroupRoleAssignments_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListGroupRoleAssignments(context.Background(), 4)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list group role assignments")
+}
+
+// --- AssignRoleToGroup ---
+
+func TestRemoteStorage_AssignRoleToGroup_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.AssignRoleToGroup(context.Background(), 8, 2, corestorage.Scope{ProjectID: 5})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to assign role to group")
+}
+
+// --- RemoveRoleFromGroup ---
+
+func TestRemoteStorage_RemoveRoleFromGroup_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemoveRoleFromGroup(context.Background(), 8, 2, corestorage.Scope{ProjectID: 5, EnvironmentID: 3})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to remove role from group")
+}
+
+// --- ListProjects ---
+
+func TestRemoteStorage_ListProjects_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListProjects(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list projects")
+}
+
+// --- ListProjectsWithCounts ---
+
+func TestRemoteStorage_ListProjectsWithCounts_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListProjectsWithCounts(context.Background(), false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list projects with counts")
+}
+
+// --- GetProject ---
+
+func TestRemoteStorage_GetProject_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetProject(context.Background(), 3)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get project")
+}
+
+// --- DeleteProject ---
+
+func TestRemoteStorage_DeleteProject_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteProject(context.Background(), 3)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete project")
+}
+
+// --- DeleteProjectIfEmpty ---
+
+func TestRemoteStorage_DeleteProjectIfEmpty_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.DeleteProjectIfEmpty(context.Background(), 3)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete project if empty")
+}
+
+// --- ListEnvironments ---
+
+func TestRemoteStorage_ListEnvironments_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListEnvironments(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list environments")
+}
+
+// --- listEnvironmentsByProject (via ListEnvironmentsByProject) ---
+
+func TestRemoteStorage_ListEnvironmentsByProject_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListEnvironmentsByProject(context.Background(), 3)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list environments by project")
+}
+
+// --- GetEnvironment ---
+
+func TestRemoteStorage_GetEnvironment_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetEnvironment(context.Background(), 7)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get environment")
+}
+
+// --- DeleteEnvironment ---
+
+func TestRemoteStorage_DeleteEnvironment_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteEnvironment(context.Background(), 7)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete environment")
+}
+
+// --- ListProjectMembers ---
+
+func TestRemoteStorage_ListProjectMembers_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListProjectMembers(context.Background(), 3)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list project members")
+}
+
+// --- ListProjectRoleAssignments ---
+
+func TestRemoteStorage_ListProjectRoleAssignments_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListProjectRoleAssignments(context.Background(), 3)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list project role assignments")
+}
+
+// --- ListProjectMachineRoleAssignments ---
+
+func TestRemoteStorage_ListProjectMachineRoleAssignments_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListProjectMachineRoleAssignments(context.Background(), 3)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list project machine role assignments")
+}
+
+// --- RemoveGlobalAdminRoleGuarded: !resp.Success branch ---
+//
+// store_s17_remote_test.go already covers the err != nil branch (both
+// sentinel-translated and generic fallthrough, via non-2xx statuses). This
+// covers the remaining case: a 2xx response body carrying success:false with
+// neither sentinel error code set.
+func TestRemoteStorage_RemoveGlobalAdminRoleGuarded_SuccessFalse_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "UNEXPECTED", "something odd happened"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemoveGlobalAdminRoleGuarded(context.Background(), 10, 1, []uint{1, 2})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "remove global admin role failed")
+}

--- a/internal/storage/store/remote_group_d_rbac_error_sweep_test.go
+++ b/internal/storage/store/remote_group_d_rbac_error_sweep_test.go
@@ -1,0 +1,279 @@
+// remote_group_d_rbac_error_sweep_test.go covers remote_rbac.go's generic
+// transport-error branches (the `if err != nil` guard right after each
+// rs.client.Get/Post/Put/Delete call) that remote_rbac_test.go /
+// remote_rbac_completeness_test.go exercise for the !resp.Success and
+// decode-error branches but never for a raw 4xx/5xx transport failure.
+// Split across two files (this one: Roles / RBAC assignment / permissions);
+// see remote_group_d_rbac_error_sweep_2_test.go for Connect grants / groups /
+// projects / environments.
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- CreateRole ---
+
+func TestRemoteStorage_CreateRole_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	name, err := identity.NewFoldedName("admin")
+	require.NoError(t, err)
+	_, err = rs.CreateRole(context.Background(), name, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create role")
+}
+
+// --- GetRole ---
+
+func TestRemoteStorage_GetRole_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "role not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetRole(context.Background(), 5)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get role")
+}
+
+// --- GetRoleByName ---
+
+func TestRemoteStorage_GetRoleByName_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "role not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetRoleByName(context.Background(), "admin")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get role by name")
+}
+
+func TestRemoteStorage_GetRoleByName_BadJSON_GroupD(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetRoleByName(context.Background(), "admin")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// --- UpdateRole ---
+
+func TestRemoteStorage_UpdateRole_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateRole(context.Background(), &models.Role{ID: 5, Name: "editor"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update role")
+}
+
+// --- DeleteRole ---
+
+func TestRemoteStorage_DeleteRole_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteRole(context.Background(), 5)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete role")
+}
+
+// --- ListRoles ---
+
+func TestRemoteStorage_ListRoles_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListRoles(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list roles")
+}
+
+// --- GetGroupRoleGrants ---
+
+func TestRemoteStorage_GetGroupRoleGrants_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetGroupRoleGrants(context.Background(), 4)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get group role grants")
+}
+
+// --- AssignRoleWithExpiry ---
+
+func TestRemoteStorage_AssignRoleWithExpiry_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.AssignRoleWithExpiry(context.Background(), 10, 1, corestorage.Scope{ProjectID: 5}, time.Now().Add(time.Hour))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to assign role with expiry")
+}
+
+// --- AssignRoleToGroupWithExpiry ---
+
+func TestRemoteStorage_AssignRoleToGroupWithExpiry_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.AssignRoleToGroupWithExpiry(context.Background(), 3, 1, corestorage.Scope{ProjectID: 5}, time.Now().Add(time.Hour))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to assign role to group with expiry")
+}
+
+// --- DeleteExpiredRoleGrants ---
+
+func TestRemoteStorage_DeleteExpiredRoleGrants_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.DeleteExpiredRoleGrants(context.Background(), time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to purge expired role grants")
+}
+
+// --- RemoveAllProjectRoleGrants ---
+
+func TestRemoteStorage_RemoveAllProjectRoleGrants_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemoveAllProjectRoleGrants(context.Background(), 10, 5)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to remove all project role grants")
+}
+
+// --- GetUserRoles ---
+
+func TestRemoteStorage_GetUserRoles_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserRoles(context.Background(), 12)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get user roles")
+}
+
+// --- GetUserPermissions ---
+
+func TestRemoteStorage_GetUserPermissions_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserPermissions(context.Background(), 12)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get user permissions")
+}
+
+// --- ListPermissions ---
+
+func TestRemoteStorage_ListPermissions_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListPermissions(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list permissions")
+}
+
+// --- GetPermission ---
+
+func TestRemoteStorage_GetPermission_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetPermission(context.Background(), 9)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get permission")
+}
+
+// --- GetRolePermissions ---
+
+func TestRemoteStorage_GetRolePermissions_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetRolePermissions(context.Background(), 5)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get role permissions")
+}
+
+// --- RemovePermissionFromRole ---
+
+func TestRemoteStorage_RemovePermissionFromRole_TransportError_GroupD(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "boom"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemovePermissionFromRole(context.Background(), 5, 9)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to remove permission from role")
+}

--- a/internal/storage/store/remote_group_e_risk_rotation_error_sweep_test.go
+++ b/internal/storage/store/remote_group_e_risk_rotation_error_sweep_test.go
@@ -1,0 +1,213 @@
+// remote_group_e_risk_rotation_error_sweep_test.go — targeted coverage sweep
+// for remote_risk_exceptions.go and remote_rotation_policies.go: transport-error
+// (rs.client.X returns err != nil) and JSON-decode-error branches that had no
+// test, plus the ListRotationPolicies query-builder branch only reachable when
+// BOTH projectID and environmentID are non-nil.
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- remote_risk_exceptions.go ---
+
+func TestRemoteStorage_CreateRiskException_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CreateRiskException(context.Background(), &models.RiskException{
+		Title: "test", Category: "mfa", Justification: "needed", CreatedBy: 1,
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create risk exception")
+}
+
+func TestRemoteStorage_GetRiskException_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetRiskException(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get risk exception")
+}
+
+func TestRemoteStorage_ListRiskExceptions_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListRiskExceptions(context.Background(), false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list risk exceptions")
+}
+
+// TestRemoteStorage_ListRiskExceptions_NotSuccess_S36 exercises the
+// !resp.Success branch specifically: a 2xx round trip whose body says
+// success:false. A non-2xx status (errHandler) does NOT reach this branch —
+// makeRequest converts every 4xx/5xx into a non-nil transport error before
+// resp is ever populated (see remote/client.go's own doc comment), so it
+// would exercise the err != nil branch above instead.
+func TestRemoteStorage_ListRiskExceptions_NotSuccess_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiErr("INTERNAL_ERROR", "db down"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListRiskExceptions(context.Background(), false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list risk exceptions failed")
+}
+
+func TestRemoteStorage_ListRiskExceptions_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListRiskExceptions(context.Background(), false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// --- remote_rotation_policies.go ---
+
+func TestRemoteStorage_CreateRotationPolicy_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.CreateRotationPolicy(context.Background(), &models.RotationPolicy{Name: "daily", IntervalDays: 1, CreatedBy: "admin"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create rotation policy")
+}
+
+func TestRemoteStorage_CreateRotationPolicy_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateRotationPolicy(context.Background(), &models.RotationPolicy{Name: "daily", IntervalDays: 1, CreatedBy: "admin"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_GetRotationPolicy_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetRotationPolicy(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get rotation policy")
+}
+
+func TestRemoteStorage_GetRotationPolicy_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetRotationPolicy(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_ListRotationPolicies_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	pid := uint(1)
+	_, err = rs.ListRotationPolicies(context.Background(), &pid, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list rotation policies")
+}
+
+func TestRemoteStorage_ListRotationPolicies_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-array"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	pid := uint(1)
+	_, err = rs.ListRotationPolicies(context.Background(), &pid, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// TestRemoteStorage_ListRotationPolicies_BothParams_S36 exercises the
+// appendParam closure's "&key=val" (else) branch, only reached when a SECOND
+// query parameter is appended after the first — i.e. both projectID and
+// environmentID are non-nil. Every other existing test passes at most one.
+func TestRemoteStorage_ListRotationPolicies_BothParams_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/rotation-policies", r.URL.Path)
+		assert.Equal(t, "10", r.URL.Query().Get("project_id"))
+		assert.Equal(t, "20", r.URL.Query().Get("environment_id"))
+		_, _ = w.Write(apiOK([]map[string]any{}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	pid := uint(10)
+	eid := uint(20)
+	policies, err := rs.ListRotationPolicies(context.Background(), &pid, &eid)
+	require.NoError(t, err)
+	assert.Empty(t, policies)
+}
+
+func TestRemoteStorage_UpdateRotationPolicy_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.UpdateRotationPolicy(context.Background(), &models.RotationPolicy{ID: 1, Name: "daily", IntervalDays: 1, CreatedBy: "admin"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update rotation policy")
+}
+
+func TestRemoteStorage_UpdateRotationPolicy_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.UpdateRotationPolicy(context.Background(), &models.RotationPolicy{ID: 1, Name: "daily", IntervalDays: 1, CreatedBy: "admin"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_DeleteRotationPolicy_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.DeleteRotationPolicy(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete rotation policy")
+}

--- a/internal/storage/store/remote_group_e_secret_deps_error_sweep_test.go
+++ b/internal/storage/store/remote_group_e_secret_deps_error_sweep_test.go
@@ -1,0 +1,110 @@
+// remote_group_e_secret_deps_error_sweep_test.go — targeted coverage sweep for
+// remote_secret_dependencies.go: transport-error and decode-error branches for
+// GetSecretDependency/ListSecretDependenciesForProject, plus
+// CreateSecretDependencyExclusive's generic (non-duplicate/non-cycle)
+// transport-error fallback and its !resp.Success branch, none of which had a
+// test — only the success, duplicate, and cycle paths did.
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteStorage_GetSecretDependency_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetSecretDependency(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get secret dependency")
+}
+
+func TestRemoteStorage_ListSecretDependenciesForProject_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListSecretDependenciesForProject(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list secret dependencies")
+}
+
+// TestRemoteStorage_ListSecretDependenciesForProject_NotSuccess_S36 exercises
+// the !resp.Success branch specifically: a 2xx round trip whose body says
+// success:false. A non-2xx status (errHandler) does NOT reach this branch —
+// makeRequest converts every 4xx/5xx into a non-nil transport error before
+// resp is ever populated (see remote/client.go's own doc comment), so it
+// would exercise the err != nil branch above instead.
+func TestRemoteStorage_ListSecretDependenciesForProject_NotSuccess_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiErr("INTERNAL_ERROR", "db down"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListSecretDependenciesForProject(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list secret dependencies failed")
+}
+
+// TestRemoteStorage_ListSecretDependenciesForProject_BadJSON_S36 exercises
+// decodeSecretDependencyList's own JSON-decode-error branch, distinct from
+// the !resp.Success branch above.
+func TestRemoteStorage_ListSecretDependenciesForProject_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListSecretDependenciesForProject(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// TestRemoteStorage_CreateSecretDependencyExclusive_TransportError_S36 hits
+// the generic "failed to create secret dependency" fallback (the transport
+// error is a plain connection failure, not a *remote.HTTPError carrying a
+// duplicate/cycle ErrorType, so errors.As fails and execution falls through
+// to the final return in the err != nil branch).
+func TestRemoteStorage_CreateSecretDependencyExclusive_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CreateSecretDependencyExclusive(context.Background(), &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 2, DependsOnSecretID: 3,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create secret dependency")
+}
+
+// TestRemoteStorage_CreateSecretDependencyExclusive_NotSuccess_S36 exercises
+// the !resp.Success branch specifically: a 2xx round trip whose body says
+// success:false. A non-2xx status (errHandler) does NOT reach this branch —
+// it instead becomes a *remote.HTTPError, taking the err != nil path above.
+func TestRemoteStorage_CreateSecretDependencyExclusive_NotSuccess_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiErr("INTERNAL_ERROR", "db down"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateSecretDependencyExclusive(context.Background(), &models.SecretDependency{
+		ProjectID: 1, DependentSecretID: 2, DependsOnSecretID: 3,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "create secret dependency failed")
+}

--- a/internal/storage/store/remote_group_e_secrets_error_sweep_test.go
+++ b/internal/storage/store/remote_group_e_secrets_error_sweep_test.go
@@ -1,0 +1,142 @@
+// remote_group_e_secrets_error_sweep_test.go — targeted coverage sweep for
+// remote_secrets.go's transport-error (rs.client.X returns err != nil) and
+// decode-error branches across CreateSecret, GetSecretByName, UpdateSecret,
+// DeleteSecret, GetSecretIncludingDeleted, RestoreSecret, ListSecrets, and
+// ListSecretVersions, plus buildSecretFilterPath's nil-filter shortcut, none
+// of which had a test — only their !resp.Success/decode-error or success
+// paths did (see remote_secrets_test.go, remote_storage_test.go,
+// remote_coverage_mfa_rbac_secrets_test.go).
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteStorage_CreateSecret_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.CreateSecret(context.Background(), &models.SecretNode{Name: "s", Type: "password"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create secret")
+}
+
+func TestRemoteStorage_CreateSecret_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateSecret(context.Background(), &models.SecretNode{Name: "s", Type: "password"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_GetSecretByName_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetSecretByName(context.Background(), "s", 1, 2)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get secret by name")
+}
+
+func TestRemoteStorage_UpdateSecret_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateSecret(context.Background(), &models.SecretNode{ID: 1, Name: "s"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update secret")
+}
+
+func TestRemoteStorage_DeleteSecret_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.DeleteSecret(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete secret")
+}
+
+func TestRemoteStorage_GetSecretIncludingDeleted_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.GetSecretIncludingDeleted(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get secret including deleted")
+}
+
+func TestRemoteStorage_GetSecretIncludingDeleted_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetSecretIncludingDeleted(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_RestoreSecret_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.RestoreSecret(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to restore secret")
+}
+
+func TestRemoteStorage_ListSecrets_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, _, err = rs.ListSecrets(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list secrets")
+}
+
+// TestRemoteStorage_ListSecrets_NilFilter_S36 exercises
+// buildSecretFilterPath's `if filter == nil { return apiSecretsPath }`
+// shortcut — every other ListSecrets call in the package passes a non-nil
+// filter.
+func TestRemoteStorage_ListSecrets_NilFilter_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/secrets", r.URL.Path)
+		assert.Empty(t, r.URL.RawQuery)
+		_, _ = w.Write(apiOK(map[string]interface{}{"secrets": []map[string]interface{}{}, "total": 0}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	secrets, total, err := rs.ListSecrets(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, secrets)
+	assert.Zero(t, total)
+}
+
+func TestRemoteStorage_ListSecretVersions_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListSecretVersions(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list secret versions")
+}

--- a/internal/storage/store/remote_group_e_sharing_error_sweep_test.go
+++ b/internal/storage/store/remote_group_e_sharing_error_sweep_test.go
@@ -1,0 +1,202 @@
+// remote_group_e_sharing_error_sweep_test.go — targeted coverage sweep for
+// remote_sharing.go's transport-error (rs.client.X returns err != nil) and
+// decode-error branches across UpdateShareRecord, DeleteShareRecord,
+// ListSharesBySecret, ListSharesBySecretIDs, ListSharesByUser,
+// ListSharesByOwner, ListSharesByGroup, and DeleteExpiredShareRecords, plus
+// DeleteShareRecord's !resp.Success branch, none of which had a test — only
+// their success paths did (see remote_sharing_test.go).
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteStorage_UpdateShareRecord_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateShareRecord(context.Background(), &models.ShareRecord{ID: 1})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update share record")
+}
+
+func TestRemoteStorage_UpdateShareRecord_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateShareRecord(context.Background(), &models.ShareRecord{ID: 1})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_DeleteShareRecord_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.DeleteShareRecord(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete share record")
+}
+
+// TestRemoteStorage_DeleteShareRecord_NotSuccess_S36 exercises the
+// !resp.Success branch specifically: a 2xx round trip whose body says
+// success:false. A non-2xx status does NOT reach this branch — makeRequest
+// converts every 4xx/5xx into a non-nil transport error before resp is ever
+// populated (see remote/client.go's own doc comment), so it would exercise
+// the err != nil branch above instead.
+func TestRemoteStorage_DeleteShareRecord_NotSuccess_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiErr("INTERNAL_ERROR", "db down"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteShareRecord(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "delete share record failed")
+}
+
+func TestRemoteStorage_ListSharesBySecret_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListSharesBySecret(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list shares by secret")
+}
+
+func TestRemoteStorage_ListSharesBySecret_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-array"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListSharesBySecret(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// TestRemoteStorage_ListSharesBySecretIDs_PropagatesError_S36 exercises the
+// "list shares by secret %d: %w" wrap-and-return that fails the WHOLE batch
+// as soon as one underlying ListSharesBySecret call errors (by design — see
+// the method's own doc comment on why partial/degrade-to-empty is wrong
+// here).
+func TestRemoteStorage_ListSharesBySecretIDs_PropagatesError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListSharesBySecretIDs(context.Background(), []uint{1})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list shares by secret 1")
+}
+
+func TestRemoteStorage_ListSharesByUser_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListSharesByUser(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list shares by user")
+}
+
+func TestRemoteStorage_ListSharesByUser_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListSharesByUser(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_ListSharesByOwner_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListSharesByOwner(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list shares by owner")
+}
+
+func TestRemoteStorage_ListSharesByOwner_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListSharesByOwner(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_ListSharesByGroup_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.ListSharesByGroup(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list shares by group")
+}
+
+func TestRemoteStorage_ListSharesByGroup_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-array"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListSharesByGroup(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_DeleteExpiredShareRecords_TransportError_S36(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	_, err = rs.DeleteExpiredShareRecords(context.Background(), time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to purge expired share records")
+}
+
+func TestRemoteStorage_DeleteExpiredShareRecords_BadJSON_S36(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.DeleteExpiredShareRecords(context.Background(), time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}

--- a/internal/storage/store/remote_group_f_sod_sso_error_sweep_test.go
+++ b/internal/storage/store/remote_group_f_sod_sso_error_sweep_test.go
@@ -1,0 +1,160 @@
+// remote_group_f_sod_sso_error_sweep_test.go — closes the remaining coverage
+// gaps in remote_sod.go and remote_sso.go: the transport-error (err != nil
+// from rs.client.X) branch and the response-decode-error (json.Unmarshal on
+// resp.Data) branch for every method in both files. The !resp.Success
+// branches for these same methods are already covered by remote_coverage_test.go
+// (apiNotOK, HTTP 200 + success:false) — this file deliberately does not
+// duplicate those.
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// badDataHandler returns an HTTP 200 envelope with success:true but a `data`
+// value that cannot unmarshal into the target wire struct (a JSON string
+// instead of an object), exercising the json.Unmarshal error branch without
+// ever touching the transport-error or !resp.Success branches.
+func badDataHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":"not-an-object"}`))
+	}
+}
+
+// --- remote_sod.go ---
+
+func TestRemoteStorage_CreateSoDPolicy_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateSoDPolicy(context.Background(), &models.SoDPolicy{Name: "x"})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CreateSoDPolicy_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateSoDPolicy(context.Background(), &models.SoDPolicy{Name: "x"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_GetSoDPolicy_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetSoDPolicy(context.Background(), 5)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetSoDPolicy_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetSoDPolicy(context.Background(), 5)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_ListSoDPolicies_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListSoDPolicies(context.Background())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListSoDPolicies_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListSoDPolicies(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_DeleteSoDPolicy_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteSoDPolicy(context.Background(), 999)
+	assert.Error(t, err)
+}
+
+// --- remote_sso.go ---
+
+func TestRemoteStorage_CreateSSOLoginState_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateSSOLoginState(context.Background(), &models.SSOLoginState{State: "s1", Provider: "oidc"})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_CreateSSOLoginState_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateSSOLoginState(context.Background(), &models.SSOLoginState{State: "s1", Provider: "oidc"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_ConsumeSSOLoginState_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ConsumeSSOLoginState(context.Background(), "no-such-state")
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ConsumeSSOLoginState_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ConsumeSSOLoginState(context.Background(), "some-state")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}

--- a/internal/storage/store/remote_group_f_users_error_sweep_test.go
+++ b/internal/storage/store/remote_group_f_users_error_sweep_test.go
@@ -1,0 +1,451 @@
+// remote_group_f_users_error_sweep_test.go — closes the remaining coverage
+// gaps in remote_users.go: primarily the !resp.Success branches for methods
+// whose only existing error test used a 4xx/5xx status (which is consumed
+// entirely by the transport-error branch in rs.client.X, never reaching
+// !resp.Success — see remote_coverage_test.go's package doc), plus a handful
+// of response-decode-error branches and the groupWire.toModel() DeletedAt
+// branch and ListGroupMembersByGroupIDs's malformed-key `continue` branch
+// that no existing test reaches.
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Users: !resp.Success branches ---
+
+func TestRemoteStorage_CreateUser_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "CONFLICT", "user already exists"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateUser(context.Background(), &models.User{Username: "u1", Email: "u1@example.com"})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetUser_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "user not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetUser(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_LockUserForUpdate_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "user not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.LockUserForUpdate(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetUserByEmail_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "user not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserByEmail(context.Background(), "nobody@example.com")
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetUserByUsername_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "user not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserByUsername(context.Background(), "nobody")
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetUserByExternalID_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "user not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserByExternalID(context.Background(), "no-such-id")
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_UpdateUser_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "user not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateUser(context.Background(), &models.User{ID: 999, Username: "ghost"})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_DeleteUser_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "user not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteUser(context.Background(), 999)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_RestoreUser_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "user not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RestoreUser(context.Background(), 999)
+	assert.Error(t, err)
+}
+
+// --- ListUsers ---
+
+func TestRemoteStorage_ListUsers_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "INTERNAL", "db error"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.ListUsers(context.Background(), nil)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListUsers_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.ListUsers(context.Background(), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// --- ListUsersInStateBefore ---
+
+func TestRemoteStorage_ListUsersInStateBefore_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListUsersInStateBefore(context.Background(), "invited", time.Now())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListUsersInStateBefore_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "INTERNAL", "db error"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListUsersInStateBefore(context.Background(), "invited", time.Now())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListUsersInStateBefore_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListUsersInStateBefore(context.Background(), "invited", time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// --- GetUserGroups ---
+
+func TestRemoteStorage_GetUserGroups_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "user not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserGroups(context.Background(), 1)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetUserGroups_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetUserGroups(context.Background(), 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// --- Groups: !resp.Success and decode-error branches ---
+
+func TestRemoteStorage_CreateGroup_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "CONFLICT", "group already exists"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.CreateGroup(context.Background(), &models.Group{Name: "engineering"})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_GetGroup_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "group not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetGroup(context.Background(), 999)
+	assert.Error(t, err)
+}
+
+// GetGroup_DecodeErr also covers decodeGroupResponse's json.Unmarshal error
+// branch shared by CreateGroup/GetGroup/UpdateGroup.
+func TestRemoteStorage_GetGroup_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetGroup(context.Background(), 5)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// GetGroup_WithDeletedAt exercises groupWire.toModel()'s `if w.DeletedAt != nil`
+// branch — only reachable when the wire response carries a non-nil deleted_at.
+func TestRemoteStorage_GetGroup_WithDeletedAt_G1(t *testing.T) {
+	deletedAt := time.Now().Add(-24 * time.Hour).UTC().Truncate(time.Second)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		wire := minimalGroupWire(5, "retired-group")
+		wire["deleted_at"] = deletedAt.Format(time.RFC3339)
+		_, _ = w.Write(apiOK(wire))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	group, err := rs.GetGroup(context.Background(), 5)
+	require.NoError(t, err)
+	assert.True(t, group.DeletedAt.Valid, "expected DeletedAt.Valid=true for a soft-deleted group")
+	assert.WithinDuration(t, deletedAt, group.DeletedAt.Time, time.Second)
+}
+
+func TestRemoteStorage_UpdateGroup_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "group not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.UpdateGroup(context.Background(), &models.Group{ID: 999, Name: "ghost"})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_DeleteGroup_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "group not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteGroup(context.Background(), 999)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_RestoreGroup_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "group not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RestoreGroup(context.Background(), 999)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListGroups_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "INTERNAL", "db error"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListGroups(context.Background())
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListGroups_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListGroups(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_ListGroupsPage_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "INTERNAL", "db error"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.ListGroupsPage(context.Background(), 0, 10)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListGroupsPage_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, _, err = rs.ListGroupsPage(context.Background(), 0, 10)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_AddUserToGroup_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "CONFLICT", "already member"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.AddUserToGroup(context.Background(), 1, 5, 0)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_RemoveUserFromGroup_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "membership not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.RemoveUserFromGroup(context.Background(), 1, 999, 0)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListGroupMembers_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "group not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListGroupMembers(context.Background(), 999)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListGroupMembers_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListGroupMembers(context.Background(), 5)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// --- ListGroupMembersByGroupIDs ---
+
+func TestRemoteStorage_ListGroupMembersByGroupIDs_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListGroupMembersByGroupIDs(context.Background(), []uint{1, 2})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListGroupMembersByGroupIDs_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "INTERNAL", "db error"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListGroupMembersByGroupIDs(context.Background(), []uint{1, 2})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListGroupMembersByGroupIDs_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListGroupMembersByGroupIDs(context.Background(), []uint{1, 2})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// ListGroupMembersByGroupIDs_MalformedKey exercises the `continue` branch hit
+// when a response map key fails strconv.ParseUint — the malformed key's
+// members are silently dropped rather than erroring the whole call, while a
+// well-formed sibling key is still decoded normally.
+func TestRemoteStorage_ListGroupMembersByGroupIDs_MalformedKey_G1(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(apiOK(map[string]interface{}{
+			"not-a-uint": []interface{}{},
+			"3":          []interface{}{minimalUserWire(10, "alice", "alice@example.com")},
+		}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	result, err := rs.ListGroupMembersByGroupIDs(context.Background(), []uint{3})
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Len(t, result[3], 1)
+	assert.Equal(t, "alice", result[3][0].Username)
+}

--- a/internal/storage/store/remote_group_f_webauthn_error_sweep_test.go
+++ b/internal/storage/store/remote_group_f_webauthn_error_sweep_test.go
@@ -1,0 +1,178 @@
+// remote_group_f_webauthn_error_sweep_test.go — closes the remaining coverage
+// gaps in remote_webauthn.go: the transport-error branch, the response-decode-error
+// branch (including decodeWebAuthnCredentialResponse/decodeWebAuthnSessionResponse
+// and their propagation sites), and ConsumeWebAuthnSession's !resp.Success branch
+// (its only existing failure test uses a 4xx status, which is consumed entirely by
+// the transport-error branch, never reaching !resp.Success).
+package store_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GetWebAuthnCredentialByCredID decode error: exercises
+// decodeWebAuthnCredentialResponse's json.Unmarshal error branch.
+func TestRemoteStorage_GetWebAuthnCredentialByCredID_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetWebAuthnCredentialByCredID(context.Background(), []byte{0x01}, 7)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_GetWebAuthnCredentialByCredID_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.GetWebAuthnCredentialByCredID(context.Background(), []byte{0x01}, 7)
+	assert.Error(t, err)
+}
+
+// CreateWebAuthnSession decode error: exercises BOTH
+// decodeWebAuthnSessionResponse's json.Unmarshal error branch AND
+// CreateWebAuthnSession's own `if err != nil { return err }` propagation of it.
+func TestRemoteStorage_CreateWebAuthnSession_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateWebAuthnSession(context.Background(), &models.WebAuthnSession{
+		UserID: 7, TokenHash: "h", Purpose: "register",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_CreateWebAuthnSession_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.CreateWebAuthnSession(context.Background(), &models.WebAuthnSession{
+		UserID: 7, TokenHash: "h", Purpose: "register",
+	})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListWebAuthnCredentials_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListWebAuthnCredentials(context.Background(), 7)
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_ListWebAuthnCredentials_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ListWebAuthnCredentials(context.Background(), 7)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_UpdateWebAuthnCredential_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.UpdateWebAuthnCredential(context.Background(), &models.WebAuthnCredential{ID: 999})
+	assert.Error(t, err)
+}
+
+func TestRemoteStorage_AdvanceWebAuthnCredentialCounter_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	advanced, err := rs.AdvanceWebAuthnCredentialCounter(context.Background(),
+		[]byte{0xBE, 0xEF}, 7, []byte(`{}`), 10, time.Now())
+	assert.Error(t, err)
+	assert.False(t, advanced)
+}
+
+func TestRemoteStorage_AdvanceWebAuthnCredentialCounter_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	advanced, err := rs.AdvanceWebAuthnCredentialCounter(context.Background(),
+		[]byte{0xBE, 0xEF}, 7, []byte(`{}`), 10, time.Now())
+	assert.Error(t, err)
+	assert.False(t, advanced)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+func TestRemoteStorage_CountWebAuthnCredentials_TransportErr_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusNotFound, "NOT_FOUND", "not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	n, err := rs.CountWebAuthnCredentials(context.Background(), 7)
+	assert.Error(t, err)
+	assert.Zero(t, n)
+}
+
+func TestRemoteStorage_CountWebAuthnCredentials_DecodeErr_G1(t *testing.T) {
+	srv := httptest.NewServer(badDataHandler())
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	n, err := rs.CountWebAuthnCredentials(context.Background(), 7)
+	assert.Error(t, err)
+	assert.Zero(t, n)
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// ConsumeWebAuthnSession's !resp.Success branch is unreachable via a 4xx/5xx
+// status (that's consumed entirely by the transport-error branch above it —
+// see TestRemoteStorage_ConsumeWebAuthnSession_Failure in remote_webauthn_test.go,
+// which uses 422 and only ever exercises the transport-error branch). Only an
+// HTTP 200 + success:false body reaches it.
+func TestRemoteStorage_ConsumeWebAuthnSession_SuccessFalse_G1(t *testing.T) {
+	srv := httptest.NewServer(errHandler(http.StatusOK, "NOT_FOUND", "session not found"))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	_, err = rs.ConsumeWebAuthnSession(context.Background(), "some-hash", time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid or expired webauthn session")
+}

--- a/internal/storage/store/remote_misc_test.go
+++ b/internal/storage/store/remote_misc_test.go
@@ -604,7 +604,7 @@ func TestRemoteStorage_GetRiskException(t *testing.T) {
 // UpdateRiskExceptionProxy is not registered in router.go); zero production
 // callers. See docs/adr-087-remote-storage-deletion-pass.md.
 func TestRemoteStorage_UpdateRiskException_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.UpdateRiskException(context.Background(), &models.RiskException{ID: 6})

--- a/internal/storage/store/remote_rbac_test.go
+++ b/internal/storage/store/remote_rbac_test.go
@@ -129,7 +129,7 @@ func TestRemoteStorage_ListRoles(t *testing.T) {
 // TestRemoteStorage_AssignRole_Unsupported: #1511/G80 deletion pass — no
 // matching route; see docs/adr-087-remote-storage-deletion-pass.md.
 func TestRemoteStorage_AssignRole_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.AssignRole(context.Background(), 10, 1, corestorage.Scope{ProjectID: 0, EnvironmentID: 0})
@@ -140,7 +140,7 @@ func TestRemoteStorage_AssignRole_Unsupported(t *testing.T) {
 // TestRemoteStorage_RemoveRole_Unsupported: #1511/G80 deletion pass — no
 // matching route; see docs/adr-087-remote-storage-deletion-pass.md.
 func TestRemoteStorage_RemoveRole_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.RemoveRole(context.Background(), 10, 1, corestorage.Scope{ProjectID: 0, EnvironmentID: 0})
@@ -274,7 +274,7 @@ func TestRemoteStorage_GetUserPermissions(t *testing.T) {
 }
 
 func TestRemoteStorage_GetUserGroupPermissions_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.GetUserGroupPermissions(context.Background(), 1)
@@ -284,7 +284,7 @@ func TestRemoteStorage_GetUserGroupPermissions_Unsupported(t *testing.T) {
 // --- Permission management (unsupported in remote mode) ---
 
 func TestRemoteStorage_CreatePermission_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.CreatePermission(context.Background(), &models.Permission{Name: "test.read"})
@@ -292,7 +292,7 @@ func TestRemoteStorage_CreatePermission_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_AssignPermissionToRole_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.AssignPermissionToRole(context.Background(), 1, 2)
@@ -516,7 +516,7 @@ func TestRemoteStorage_RemoveRoleFromGroup_SendsScope(t *testing.T) {
 // --- Server-internal authorization primitives (unsupported in remote mode) ---
 
 func TestRemoteStorage_GetUserRoleIDsAt_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.GetUserRoleIDsAt(context.Background(), 1, corestorage.Scope{})
@@ -524,7 +524,7 @@ func TestRemoteStorage_GetUserRoleIDsAt_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_GetUserRoleIDsExact_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.GetUserRoleIDsExact(context.Background(), 1, corestorage.Scope{})
@@ -532,7 +532,7 @@ func TestRemoteStorage_GetUserRoleIDsExact_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_IsProjectMember_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.IsProjectMember(context.Background(), 1, 2)
@@ -540,7 +540,7 @@ func TestRemoteStorage_IsProjectMember_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_GetUserGroupRoleIDsAt_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.GetUserGroupRoleIDsAt(context.Background(), 1, corestorage.Scope{})
@@ -548,7 +548,7 @@ func TestRemoteStorage_GetUserGroupRoleIDsAt_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_GetUserRoleScopes_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.GetUserRoleScopes(context.Background(), 1)
@@ -556,7 +556,7 @@ func TestRemoteStorage_GetUserRoleScopes_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_RoleSetHasPermission_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.RoleSetHasPermission(context.Background(), []uint{1, 2}, "secrets.read")
@@ -566,7 +566,7 @@ func TestRemoteStorage_RoleSetHasPermission_Unsupported(t *testing.T) {
 // --- Project / Environment catalog ---
 
 func TestRemoteStorage_CreateProject_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.CreateProject(context.Background(), &models.Project{Name: "test"})
@@ -574,7 +574,7 @@ func TestRemoteStorage_CreateProject_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_CreateEnvironment_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.CreateEnvironment(context.Background(), &models.Environment{Name: "prod"})

--- a/internal/storage/store/remote_realimpl_zero_coverage_test.go
+++ b/internal/storage/store/remote_realimpl_zero_coverage_test.go
@@ -1,0 +1,164 @@
+package store_test
+
+// remote_realimpl_zero_coverage_test.go covers RemoteStorage methods that
+// were still at 0% but, unlike remote_stub_zero_coverage_test.go's targets,
+// are genuine HTTP-proxying implementations (they call rs.client and decode
+// a real response) rather than one-line unsupported stubs.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- remote_mfa_stepup_grant.go: PruneMFAStepUpGrants ---
+
+func TestRemoteStorage_PruneMFAStepUpGrants_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/mfa/stepup-grants/prune", r.URL.Path)
+		_, _ = w.Write(apiOK(map[string]interface{}{"deleted": 7}))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	deleted, err := rs.PruneMFAStepUpGrants(context.Background(), time.Now().UTC())
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), deleted)
+}
+
+func TestRemoteStorage_PruneMFAStepUpGrants_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(apiErr("STORAGE_ERROR", "db down"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	deleted, err := rs.PruneMFAStepUpGrants(context.Background(), time.Now().UTC())
+	require.Error(t, err)
+	assert.Zero(t, deleted)
+}
+
+func TestRemoteStorage_PruneMFAStepUpGrants_SuccessFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(apiErr("STORAGE_ERROR", "db down"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	deleted, err := rs.PruneMFAStepUpGrants(context.Background(), time.Now().UTC())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prune MFA step-up grants failed")
+	assert.Zero(t, deleted)
+}
+
+func TestRemoteStorage_PruneMFAStepUpGrants_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":{bad json}}`))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	deleted, err := rs.PruneMFAStepUpGrants(context.Background(), time.Now().UTC())
+	require.Error(t, err)
+	assert.Zero(t, deleted)
+}
+
+// --- remote_secret_acl.go: DeleteSecretACLsByUserAndProject ---
+
+func TestRemoteStorage_DeleteSecretACLsByUserAndProject_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/rbac/delete-secret-acls-by-user-and-project", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteSecretACLsByUserAndProject(context.Background(), 1, 2)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_DeleteSecretACLsByUserAndProject_TransportError(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.DeleteSecretACLsByUserAndProject(context.Background(), 1, 2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete secret ACLs by user and project")
+}
+
+func TestRemoteStorage_DeleteSecretACLsByUserAndProject_SuccessFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(apiErr("STORAGE_ERROR", "db down"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.DeleteSecretACLsByUserAndProject(context.Background(), 1, 2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete secret ACLs by user and project failed")
+}
+
+// --- remote_secrets.go: ClearProjectSecretOwnership ---
+
+func TestRemoteStorage_ClearProjectSecretOwnership_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/v1/system/rbac/clear-project-secret-ownership", r.URL.Path)
+		_, _ = w.Write(apiOK(nil))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.ClearProjectSecretOwnership(context.Background(), 1, 2)
+	require.NoError(t, err)
+}
+
+func TestRemoteStorage_ClearProjectSecretOwnership_TransportError(t *testing.T) {
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+
+	err = rs.ClearProjectSecretOwnership(context.Background(), 1, 2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to clear project secret ownership")
+}
+
+func TestRemoteStorage_ClearProjectSecretOwnership_SuccessFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(apiErr("STORAGE_ERROR", "db down"))
+	}))
+	defer srv.Close()
+
+	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
+	require.NoError(t, err)
+
+	err = rs.ClearProjectSecretOwnership(context.Background(), 1, 2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "clear project secret ownership failed")
+}

--- a/internal/storage/store/remote_secrets_test.go
+++ b/internal/storage/store/remote_secrets_test.go
@@ -193,7 +193,7 @@ func TestRemoteStorage_RestoreSecret(t *testing.T) {
 // PurgeDeletedSecretsBeforeProxy was deleted (#1593,
 // docs/adr-089-mfa-purge-relay-deletion.md) -- no live caller.
 func TestRemoteStorage_PurgeDeletedSecretsBefore_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.PurgeDeletedSecretsBefore(context.Background(), time.Now())
@@ -201,7 +201,7 @@ func TestRemoteStorage_PurgeDeletedSecretsBefore_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_ListProjectSecretsForDrift_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.ListProjectSecretsForDrift(context.Background(), 1)
@@ -209,7 +209,7 @@ func TestRemoteStorage_ListProjectSecretsForDrift_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_ListOrphanedSecrets_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.ListOrphanedSecrets(context.Background(), 1)
@@ -217,7 +217,7 @@ func TestRemoteStorage_ListOrphanedSecrets_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_CountOrphanedSecretsByProject_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.CountOrphanedSecretsByProject(context.Background(), []uint{1, 2})
@@ -225,7 +225,7 @@ func TestRemoteStorage_CountOrphanedSecretsByProject_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_CountExpiringSecretsByProject_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.CountExpiringSecretsByProject(context.Background(), []uint{1, 2}, time.Now())
@@ -233,7 +233,7 @@ func TestRemoteStorage_CountExpiringSecretsByProject_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_ListLiveSecretNamesByProject_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, _, err = rs.ListLiveSecretNamesByProject(context.Background(), []uint{1}, 100)
@@ -241,7 +241,7 @@ func TestRemoteStorage_ListLiveSecretNamesByProject_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_GetSecretTags_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.GetSecretTags(context.Background(), 1)
@@ -249,7 +249,7 @@ func TestRemoteStorage_GetSecretTags_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_SetSecretTags_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.SetSecretTags(context.Background(), 1, []string{"prod"})
@@ -257,7 +257,7 @@ func TestRemoteStorage_SetSecretTags_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_SetSecretCertNotAfter_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -266,7 +266,7 @@ func TestRemoteStorage_SetSecretCertNotAfter_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_TryIncrementSecretReadCount_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	ok, err := rs.TryIncrementSecretReadCount(context.Background(), 1, 5)
@@ -275,7 +275,7 @@ func TestRemoteStorage_TryIncrementSecretReadCount_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_TryIncrementSecretNodeReadCount_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	ok, err := rs.TryIncrementSecretNodeReadCount(context.Background(), 1, 5)
@@ -290,7 +290,7 @@ func TestRemoteStorage_TryIncrementSecretNodeReadCount_Unsupported(t *testing.T)
 // see docs/adr-087-remote-storage-deletion-pass.md); the method is now a
 // permanent stub, no HTTP server needed.
 func TestRemoteStorage_CreateSecretVersion_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.CreateSecretVersion(context.Background(), &models.SecretVersion{SecretNodeID: 42})
@@ -377,7 +377,7 @@ func TestRemoteStorage_GetSecretVersions(t *testing.T) {
 // intact; see docs/adr-087-remote-storage-deletion-pass.md); the method is
 // now a permanent stub.
 func TestRemoteStorage_GetLatestSecretVersion_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.GetLatestSecretVersion(context.Background(), 42)
@@ -390,7 +390,7 @@ func TestRemoteStorage_GetLatestSecretVersion_Unsupported(t *testing.T) {
 // route and zero callers anywhere in internal/core; see
 // docs/adr-087-remote-storage-deletion-pass.md.
 func TestRemoteStorage_IncrementSecretReadCount_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	err = rs.IncrementSecretReadCount(context.Background(), 100)

--- a/internal/storage/store/remote_sharing_test.go
+++ b/internal/storage/store/remote_sharing_test.go
@@ -45,7 +45,7 @@ func shareRecordData(id, secretID, ownerID, recipientID uint) map[string]interfa
 // TestRemoteStorage_CreateShareRecord_Unsupported: #1511/G80 deletion pass —
 // no matching route; see docs/adr-087-remote-storage-deletion-pass.md.
 func TestRemoteStorage_CreateShareRecord_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.CreateShareRecord(context.Background(), testShareRecord(0, 10, 2, 3))
@@ -58,7 +58,7 @@ func TestRemoteStorage_CreateShareRecord_Unsupported(t *testing.T) {
 // TestRemoteStorage_GetShareRecord_Unsupported: #1511/G80 deletion pass — no
 // matching route; see docs/adr-087-remote-storage-deletion-pass.md.
 func TestRemoteStorage_GetShareRecord_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.GetShareRecord(context.Background(), 1)
@@ -145,7 +145,7 @@ func TestRemoteStorage_ListSharesBySecretIDs(t *testing.T) {
 }
 
 func TestRemoteStorage_ListSharesBySecretIDs_Empty(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	results, err := rs.ListSharesBySecretIDs(context.Background(), nil)
@@ -224,7 +224,7 @@ func TestRemoteStorage_ListSharesByGroup(t *testing.T) {
 // TestRemoteStorage_ListSharedSecrets_Unsupported: #1511/G80 deletion pass —
 // no matching route; see docs/adr-087-remote-storage-deletion-pass.md.
 func TestRemoteStorage_ListSharedSecrets_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.ListSharedSecrets(context.Background(), 3)
@@ -238,7 +238,7 @@ func TestRemoteStorage_ListSharedSecrets_Unsupported(t *testing.T) {
 // — no matching route, and core.CheckSharePermission itself has zero callers
 // anywhere; see docs/adr-087-remote-storage-deletion-pass.md.
 func TestRemoteStorage_CheckSharePermission_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.CheckSharePermission(context.Background(), 10, 3)

--- a/internal/storage/store/remote_storage_test.go
+++ b/internal/storage/store/remote_storage_test.go
@@ -25,6 +25,21 @@ func testConfig(serverURL string) *remote.Config {
 	}
 }
 
+// testConfigNoRetry is testConfig with RetryAttempts: 0, for tests that
+// deliberately hit an unreachable target (e.g. "http://127.0.0.1:0") just to
+// exercise a transport-error (`err != nil`) return branch. HTTPClient.Request's
+// retry loop backs off attempt*attempt seconds between attempts
+// (internal/storage/remote/client.go), so testConfig's RetryAttempts: 3 burns a
+// full, unavoidable 1+4+9=14s per call against a target that can never succeed —
+// harmless for one test, but serial-additive across the many such tests in this
+// package. RetryAttempts: 0 makes exactly one attempt (no backoff), hitting the
+// identical code path in a few milliseconds instead.
+func testConfigNoRetry(serverURL string) *remote.Config {
+	cfg := testConfig(serverURL)
+	cfg.RetryAttempts = 0
+	return cfg
+}
+
 func apiOK(data interface{}) []byte {
 	type resp struct {
 		Success bool        `json:"success"`

--- a/internal/storage/store/remote_stub_zero_coverage_test.go
+++ b/internal/storage/store/remote_stub_zero_coverage_test.go
@@ -1,0 +1,569 @@
+package store_test
+
+// remote_stub_zero_coverage_test.go exercises every RemoteStorage method that
+// was still at 0% coverage as of the coverage-raising pass this file was
+// added in: one-line remoteUnsupported (or plain fmt.Errorf) stubs across
+// MFA step-up grants, secret ACLs, RBAC, WebAuthn, billing, connector-project
+// bindings, dynamic secrets, and several maintenance-sweep/lock proxies. Each
+// stub is documented at its own definition as intentionally unsupported in
+// remote (client) mode — see the corresponding remote_unsupported_registry_test.go
+// / remote_<feature>_completeness_test.go entries for the "why". This file's
+// job is narrower: actually CALL each stub (with zero-value/empty args, since
+// none of them touch rs.client or inspect their arguments before returning)
+// so the one line of real logic in each — "return the documented sentinel" —
+// is verified, not just asserted-to-exist by a static allowlist.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newStubTestRemoteStorage(t *testing.T) *store.RemoteStorage {
+	t.Helper()
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
+	require.NoError(t, err)
+	return rs
+}
+
+func assertRemoteUnsupported(t *testing.T, err error) {
+	t.Helper()
+	assert.True(t, errors.Is(err, store.ErrRemoteUnsupported), "expected ErrRemoteUnsupported, got %v", err)
+}
+
+// --- remote_access_review_campaigns.go ---
+
+func TestRemoteStorage_UpdateAccessReviewCampaign_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	matched, err := rs.UpdateAccessReviewCampaign(context.Background(), &models.AccessReviewCampaign{})
+	assert.False(t, matched)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_anomaly_config.go ---
+
+func TestRemoteStorage_GetAnomalyConfig_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	cfg, err := rs.GetAnomalyConfig(context.Background())
+	assert.Nil(t, cfg)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_SaveAnomalyConfig_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.SaveAnomalyConfig(context.Background(), &models.AnomalyConfigRecord{})
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_audit.go ---
+
+func TestRemoteStorage_GetSecretReadCounts_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	entries, err := rs.GetSecretReadCounts(context.Background(), 1, time.Now(), time.Now(), 10)
+	assert.Nil(t, entries)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_billing.go ---
+
+func TestRemoteStorage_GetBillingReport_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	report, err := rs.GetBillingReport(context.Background(), time.Now(), time.Now(), nil)
+	assert.Nil(t, report)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_bootstrap_lock.go ---
+
+func TestRemoteStorage_WithBootstrapLock_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	ran := false
+	err := rs.WithBootstrapLock(context.Background(), func() error {
+		ran = true
+		return nil
+	})
+	assertRemoteUnsupported(t, err)
+	assert.False(t, ran, "fn must never run — RemoteStorage has no cross-process guarantee to offer it")
+}
+
+// --- remote_break_glass.go ---
+
+func TestRemoteStorage_CreateBreakGlassActivation_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	activation, err := rs.CreateBreakGlassActivation(context.Background(), &models.BreakGlassActivation{})
+	assert.Nil(t, activation)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_ReconcileExpiredBreakGlassActivation_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.ReconcileExpiredBreakGlassActivation(context.Background(), 1, 2)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_UpdateBreakGlassActivation_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.UpdateBreakGlassActivation(context.Background(), &models.BreakGlassActivation{})
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_compliance.go ---
+
+func TestRemoteStorage_ListCompliancePostureSnapshots_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	snapshots, err := rs.ListCompliancePostureSnapshots(context.Background(), 10)
+	assert.Nil(t, snapshots)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_connector_project_bindings.go ---
+
+func TestRemoteStorage_GetConnectorProjectBinding_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	binding, err := rs.GetConnectorProjectBinding(context.Background(), "connector-1")
+	assert.Nil(t, binding)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_ListConnectorProjectBindings_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	bindings, err := rs.ListConnectorProjectBindings(context.Background())
+	assert.Nil(t, bindings)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_CreateConnectorProjectBinding_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	binding, err := rs.CreateConnectorProjectBinding(context.Background(), &models.ConnectorProjectBinding{})
+	assert.Nil(t, binding)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_dynamic.go ---
+
+func TestRemoteStorage_UpdateDynamicSecretConfig_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.UpdateDynamicSecretConfig(context.Background(), &models.DynamicSecretConfig{})
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_TransitionDynamicSecretConfigDisabled_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	matched, err := rs.TransitionDynamicSecretConfigDisabled(context.Background(), &models.DynamicSecretConfig{}, true)
+	assert.False(t, matched)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_CreateDynamicSecretLease_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	lease, err := rs.CreateDynamicSecretLease(context.Background(), &models.DynamicSecretLease{})
+	assert.Nil(t, lease)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_UpdateDynamicSecretLease_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.UpdateDynamicSecretLease(context.Background(), &models.DynamicSecretLease{})
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_inactivity_suspend.go ---
+
+func TestRemoteStorage_ListInactiveUsers_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	users, err := rs.ListInactiveUsers(context.Background(), time.Now())
+	assert.Nil(t, users)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_machine_identities.go ---
+
+func TestRemoteStorage_UpdateMachineIdentity_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.UpdateMachineIdentity(context.Background(), &models.MachineIdentity{})
+	assertRemoteUnsupported(t, err)
+}
+
+// GetMachineRoleScopes predates the remoteUnsupported/ErrRemoteUnsupported
+// convention and still returns a plain fmt.Errorf, so it's checked for a
+// non-nil error only, not the sentinel.
+func TestRemoteStorage_GetMachineRoleScopes_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	scopes, err := rs.GetMachineRoleScopes(context.Background(), 1)
+	assert.Nil(t, scopes)
+	require.Error(t, err)
+}
+
+// --- remote_memberships.go ---
+
+func TestRemoteStorage_UpdateProjectMembership_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.UpdateProjectMembership(context.Background(), &models.ProjectMembership{})
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_mfa.go ---
+
+func TestRemoteStorage_UpsertMFASecret_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.UpsertMFASecret(context.Background(), &models.MFASecret{})
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_mfa_stepup_grant.go ---
+
+func TestRemoteStorage_CreateMFAStepUpGrant_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.CreateMFAStepUpGrant(context.Background(), &models.MFAStepUpGrant{})
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_DeleteMFAStepUpGrantsFor_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.DeleteMFAStepUpGrantsFor(context.Background(), 1)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_named_lock.go ---
+//
+// Unlike the rest of this file, WithNamedLock is NOT a stub: it always runs
+// fn, passthrough (no distributed named-lock exists over HTTP; see the
+// method's own doc comment). Covered here for the same reason as the stubs —
+// it was still at 0% — but the assertion is the opposite: fn DOES run, and
+// its error/return value propagates untouched.
+func TestRemoteStorage_WithNamedLock_RunsFnAndPropagates(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	ran := false
+	err := rs.WithNamedLock(context.Background(), "some-lock", func(_ context.Context) error {
+		ran = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, ran)
+
+	sentinel := errors.New("boom")
+	err = rs.WithNamedLock(context.Background(), "some-lock", func(_ context.Context) error {
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+}
+
+// --- remote_rbac.go ---
+
+func TestRemoteStorage_SetRoleBypassesPermissionChecks_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.SetRoleBypassesPermissionChecks(context.Background(), 1, true)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_ListAllUserRoleGrants_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	grants, err := rs.ListAllUserRoleGrants(context.Background())
+	assert.Nil(t, grants)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_ListAllGroupRoleGrants_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	grants, err := rs.ListAllGroupRoleGrants(context.Background())
+	assert.Nil(t, grants)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_CreateConnectRefGrant_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	grant, err := rs.CreateConnectRefGrant(context.Background(), &models.ConnectRefGrant{})
+	assert.Nil(t, grant)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_DeleteConnectRefGrant_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.DeleteConnectRefGrant(context.Background(), 1)
+	assertRemoteUnsupported(t, err)
+}
+
+// IsGroupProjectScoped predates the remoteUnsupported convention too — plain
+// fmt.Errorf, same treatment as GetMachineRoleScopes above.
+func TestRemoteStorage_IsGroupProjectScoped_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	scoped, err := rs.IsGroupProjectScoped(context.Background(), 1, 2)
+	assert.False(t, scoped)
+	require.Error(t, err)
+}
+
+func TestRemoteStorage_RoleSetBypassesPermissionChecks_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	bypasses, err := rs.RoleSetBypassesPermissionChecks(context.Background(), []uint{1, 2})
+	assert.False(t, bypasses)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_GetProjectByName_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	project, err := rs.GetProjectByName(context.Background(), "proj")
+	assert.Nil(t, project)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_UpdateProject_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	project, err := rs.UpdateProject(context.Background(), &models.Project{})
+	assert.Nil(t, project)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_RestoreProject_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	envs, secrets, err := rs.RestoreProject(context.Background(), 1)
+	assert.Zero(t, envs)
+	assert.Zero(t, secrets)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_RestoreEnvironment_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.RestoreEnvironment(context.Background(), 1, 2)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_ListGlobalAdminAssignmentsForUpdate_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	assignments, err := rs.ListGlobalAdminAssignmentsForUpdate(context.Background(), []uint{1})
+	assert.Nil(t, assignments)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_role_expiry.go ---
+
+func TestRemoteStorage_ListExpiringUserRoles_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	roles, err := rs.ListExpiringUserRoles(context.Background(), time.Now())
+	assert.Nil(t, roles)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_scheduler_lock.go ---
+
+func TestRemoteStorage_WithSchedulerLock_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	ran := false
+	acquired, err := rs.WithSchedulerLock(context.Background(), 42, func() error {
+		ran = true
+		return nil
+	})
+	assert.False(t, acquired)
+	assertRemoteUnsupported(t, err)
+	assert.False(t, ran)
+}
+
+func TestRemoteStorage_TryAcquireSchedulerLock_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	acquired, err := rs.TryAcquireSchedulerLock(context.Background(), 42, "holder", time.Second)
+	assert.False(t, acquired)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_ReleaseSchedulerLock_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.ReleaseSchedulerLock(context.Background(), 42, "holder")
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_secret_acl.go ---
+
+func TestRemoteStorage_CreateOrUpdateSecretACL_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.CreateOrUpdateSecretACL(context.Background(), &models.SecretACL{})
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_ListSecretACLs_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	acls, err := rs.ListSecretACLs(context.Background(), 1)
+	assert.Nil(t, acls)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_ListSecretACLsByUser_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	acls, err := rs.ListSecretACLsByUser(context.Background(), 1)
+	assert.Nil(t, acls)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_GetSecretACL_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	acl, err := rs.GetSecretACL(context.Background(), 1, 2)
+	assert.Nil(t, acl)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_DeleteSecretACL_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.DeleteSecretACL(context.Background(), 1)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_GetSecretAncestors_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	ancestors, err := rs.GetSecretAncestors(context.Background(), 1)
+	assert.Nil(t, ancestors)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_secret_dependencies.go ---
+
+func TestRemoteStorage_CreateSecretDependency_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	dep, err := rs.CreateSecretDependency(context.Background(), &models.SecretDependency{})
+	assert.Nil(t, dep)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_ListSecretDependenciesForProjectForUpdate_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	deps, err := rs.ListSecretDependenciesForProjectForUpdate(context.Background(), 1)
+	assert.Nil(t, deps)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_DeleteSecretDependency_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.DeleteSecretDependency(context.Background(), 1)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_secrets.go (maintenance-sweep stubs) ---
+
+func TestRemoteStorage_DeleteAnomalyAlertsBefore_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	n, err := rs.DeleteAnomalyAlertsBefore(context.Background(), time.Now(), time.Now())
+	assert.Zero(t, n)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_DeleteClosedAccessReviewsBefore_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	campaigns, items, err := rs.DeleteClosedAccessReviewsBefore(context.Background(), time.Now())
+	assert.Zero(t, campaigns)
+	assert.Zero(t, items)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_DeleteExpiredBreakGlassBefore_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	n, err := rs.DeleteExpiredBreakGlassBefore(context.Background(), time.Now())
+	assert.Zero(t, n)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_DeleteResolvedAccessRequestsBefore_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	requests, approvals, err := rs.DeleteResolvedAccessRequestsBefore(context.Background(), time.Now())
+	assert.Zero(t, requests)
+	assert.Zero(t, approvals)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_stats.go ---
+
+func TestRemoteStorage_SaveDeploymentStatsSnapshot_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.SaveDeploymentStatsSnapshot(context.Background(), &models.DeploymentStatsSnapshot{})
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_GetPreviousDeploymentStatsSnapshot_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	snapshot, err := rs.GetPreviousDeploymentStatsSnapshot(context.Background())
+	assert.Nil(t, snapshot)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_usage.go ---
+
+func TestRemoteStorage_GetProjectUsageStats_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	stats, err := rs.GetProjectUsageStats(context.Background(), []uint{1}, 10)
+	assert.Nil(t, stats)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_users.go ---
+
+func TestRemoteStorage_UpdateLoginLockoutState_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	now := time.Now()
+	err := rs.UpdateLoginLockoutState(context.Background(), 1, 3, &now, &now, 5)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_ListAllUserGroupMemberships_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	memberships, err := rs.ListAllUserGroupMemberships(context.Background())
+	assert.Nil(t, memberships)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_GetUserGroupsAt_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	groups, err := rs.GetUserGroupsAt(context.Background(), 1, corestorage.Scope{})
+	assert.Nil(t, groups)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_ListGroupMembersAt_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	members, err := rs.ListGroupMembersAt(context.Background(), 1, corestorage.Scope{})
+	assert.Nil(t, members)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_version_comments.go ---
+
+func TestRemoteStorage_CreateSecretVersionComment_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.CreateSecretVersionComment(context.Background(), &models.SecretVersionComment{})
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_ListSecretVersionComments_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	comments, err := rs.ListSecretVersionComments(context.Background(), 1, 2)
+	assert.Nil(t, comments)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_DeleteSecretVersionComment_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.DeleteSecretVersionComment(context.Background(), 1, 2, 3)
+	assertRemoteUnsupported(t, err)
+}
+
+// --- remote_webauthn.go ---
+
+func TestRemoteStorage_CreateWebAuthnCredential_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.CreateWebAuthnCredential(context.Background(), &models.WebAuthnCredential{})
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_DeleteWebAuthnCredential_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.DeleteWebAuthnCredential(context.Background(), 1, 2)
+	assertRemoteUnsupported(t, err)
+}
+
+func TestRemoteStorage_SetUserWebAuthnEnabled_Unsupported(t *testing.T) {
+	rs := newStubTestRemoteStorage(t)
+	err := rs.SetUserWebAuthnEnabled(context.Background(), 1, true)
+	assertRemoteUnsupported(t, err)
+}

--- a/internal/storage/store/remote_users_test.go
+++ b/internal/storage/store/remote_users_test.go
@@ -415,7 +415,7 @@ func TestRemoteStorage_RestoreUser(t *testing.T) {
 // docs/adr-089-mfa-purge-relay-deletion.md -- no live caller) ---
 
 func TestRemoteStorage_PurgeDeletedUsersBefore_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.PurgeDeletedUsersBefore(context.Background(), time.Now())
@@ -423,7 +423,7 @@ func TestRemoteStorage_PurgeDeletedUsersBefore_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_PurgeDeletedProjectsBefore_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.PurgeDeletedProjectsBefore(context.Background(), time.Now())
@@ -431,7 +431,7 @@ func TestRemoteStorage_PurgeDeletedProjectsBefore_Unsupported(t *testing.T) {
 }
 
 func TestRemoteStorage_PurgeDeletedEnvironmentsBefore_Unsupported(t *testing.T) {
-	rs, err := store.NewRemoteStorage(testConfig("http://127.0.0.1:0"))
+	rs, err := store.NewRemoteStorage(testConfigNoRetry("http://127.0.0.1:0"))
 	require.NoError(t, err)
 
 	_, err = rs.PurgeDeletedEnvironmentsBefore(context.Background(), time.Now())

--- a/server/http/handlers/anomaly_config.go
+++ b/server/http/handlers/anomaly_config.go
@@ -9,6 +9,7 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
@@ -52,6 +53,19 @@ func UpdateAnomalyConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := coreService.UpdateAnomalyConfig(r.Context(), &cfg, updatedBy); err != nil {
+		// core.UpdateAnomalyConfig returns a plain (unwrapped) validation error
+		// from validateAnomalyConfig when a knob exceeds its ceiling (#G44) --
+		// e.g. "lookback_days exceeds the maximum of 365" -- before ever
+		// reaching storage. That's caller input error, not a server failure;
+		// treating it as 500 (as this used to, unconditionally) misreports a
+		// bad request as an internal error, same class of fix as
+		// secrets_bulk_rotate.go's BulkRotateSecrets/catalog.go's
+		// CloneEnvironment string-matching their own core layer's validation
+		// errors.
+		if strings.Contains(err.Error(), "exceeds the maximum") {
+			sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
+			return
+		}
 		sendError(w, "InternalError", "Failed to save anomaly config", http.StatusInternalServerError, nil)
 		return
 	}

--- a/server/http/handlers/anomaly_config_test.go
+++ b/server/http/handlers/anomaly_config_test.go
@@ -1,0 +1,213 @@
+// anomaly_config_test.go — coverage for GetAnomalyConfig/UpdateAnomalyConfig
+// (anomaly_config.go), previously untested (0% coverage). Both are
+// package-level functions using middleware.GetCoreServiceFromContext, whose
+// context key is unexported outside the middleware package — the established
+// convention for exercising the happy path (see
+// TestListAnomalyAlerts_WithCoreService_S7 in handlers_s7_test.go) is to wrap
+// the handler in middleware.Authentication(cs) behind a real httptest.Server
+// and authenticate with a bootstrapped session, rather than fabricate the
+// context directly.
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// newAnomalyConfigTestServer boots a real core, bootstraps an admin user, and
+// returns an httptest.Server wired with GetAnomalyConfig/UpdateAnomalyConfig
+// behind middleware.Authentication, plus a bearer token for that admin and
+// the core itself (so a caller can reach into storage, e.g. to force a
+// storage-error branch by closing the underlying DB after auth completes).
+func newAnomalyConfigTestServer(t *testing.T, name string) (*httptest.Server, string, *core.KeyorixCore) {
+	t.Helper()
+	cs := freshCoreS7(t)
+	mux := chi.NewRouter()
+	mux.Use(middleware.Authentication(cs))
+	mux.Get("/api/v1/admin/anomaly-config", GetAnomalyConfig)
+	mux.Put("/api/v1/admin/anomaly-config", UpdateAnomalyConfig)
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	cs.SetBootstrapToken(name + "-boot")
+	_, err := cs.BootstrapSystem(ctx, &core.BootstrapRequest{
+		Username: name,
+		Email:    name + "@example.com",
+		Password: "Kx#Vr9$Mn2!Zp4@Qw",
+		Token:    name + "-boot",
+	})
+	require.NoError(t, err)
+	session, _, err := cs.Login(ctx, &core.LoginRequest{Username: name, Password: "Kx#Vr9$Mn2!Zp4@Qw"})
+	require.NoError(t, err)
+
+	return ts, session.SessionToken, cs
+}
+
+func TestGetAnomalyConfig_NoCoreService(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/anomaly-config", nil)
+	w := httptest.NewRecorder()
+	GetAnomalyConfig(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestUpdateAnomalyConfig_NoCoreService(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/anomaly-config", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+	UpdateAnomalyConfig(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestGetAnomalyConfig_Success — no config has ever been saved, so the
+// storage layer's sensible defaults are returned (200).
+func TestGetAnomalyConfig_Success(t *testing.T) {
+	ts, token, _ := newAnomalyConfigTestServer(t, "s_anomalycfg_get")
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/admin/anomaly-config", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestUpdateAnomalyConfig_Success persists a within-bounds config and
+// confirms the round trip through GET reflects it.
+func TestUpdateAnomalyConfig_Success(t *testing.T) {
+	ts, token, _ := newAnomalyConfigTestServer(t, "s_anomalycfg_upd")
+
+	body := `{"lookback_days":14,"quarantine_hours":48,"ml_num_trees":50,"ml_sample_size":128}`
+	req, err := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/admin/anomaly-config", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestUpdateAnomalyConfig_BadJSON exercises the malformed-body 400 branch.
+func TestUpdateAnomalyConfig_BadJSON(t *testing.T) {
+	ts, token, _ := newAnomalyConfigTestServer(t, "s_anomalycfg_badjson")
+
+	req, err := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/admin/anomaly-config", strings.NewReader("{bad json}"))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestUpdateAnomalyConfig_ValidationError_S1546 exercises the ceiling
+// (#G44) rejection branch (lookback_days above the maximum of 365).
+//
+// Bug found and fixed alongside this coverage sweep: the handler used to map
+// EVERY UpdateAnomalyConfig error -- including this validation error, which
+// core.validateAnomalyConfig returns BEFORE ever touching storage -- to a
+// blanket 500 "InternalError". A caller submitting an out-of-range knob got
+// told the SERVER failed, not that ITS request was invalid; every sibling
+// handler in this package that distinguishes validation from storage errors
+// (secrets_bulk_rotate.go's BulkRotateSecrets, catalog.go's CloneEnvironment)
+// returns 400 for this class of error. Fixed by matching on the
+// "exceeds the maximum" substring validateAnomalyConfig's errors always
+// carry, same convention those siblings already use.
+func TestUpdateAnomalyConfig_ValidationError_S1546(t *testing.T) {
+	ts, token, _ := newAnomalyConfigTestServer(t, "s_anomalycfg_valerr")
+
+	body := `{"lookback_days":9999}`
+	req, err := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/admin/anomaly-config", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "an out-of-range knob is a bad request, not a server failure")
+}
+
+// TestGetAnomalyConfig_StorageError closes the underlying DB after auth
+// completes so coreService.GetAnomalyConfig's own storage read fails with a
+// genuine (non-record-not-found) error, exercising the handler's 500 branch.
+func TestGetAnomalyConfig_StorageError(t *testing.T) {
+	ts, token, cs := newAnomalyConfigTestServer(t, "s_anomalycfg_geterr")
+
+	newGetReq := func() *http.Request {
+		r, rerr := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/admin/anomaly-config", nil)
+		require.NoError(t, rerr)
+		r.Header.Set("Authorization", "Bearer "+token)
+		return r
+	}
+
+	// Warm-up request first: middleware.Authentication positive-caches a
+	// validated session token, so once cached, closing the DB below fails
+	// GetAnomalyConfig's own storage read without also failing session
+	// validation on the SAME request (which would produce a 401, not the 500
+	// this test targets).
+	warmup, err := ts.Client().Do(newGetReq())
+	require.NoError(t, err)
+	_ = warmup.Body.Close()
+	require.Equal(t, http.StatusOK, warmup.StatusCode)
+
+	ls, ok := cs.Storage().(*store.LocalStorage)
+	require.True(t, ok)
+	sqlDB, err := ls.DB().DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	resp, err := ts.Client().Do(newGetReq())
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+// TestUpdateAnomalyConfig_StorageError closes the underlying DB after auth
+// completes so a within-bounds config (passes validateAnomalyConfig, so the
+// #G44 400 branch is NOT taken) fails at the SaveAnomalyConfig write instead
+// -- the plain "InternalError" 500 branch.
+func TestUpdateAnomalyConfig_StorageError(t *testing.T) {
+	ts, token, cs := newAnomalyConfigTestServer(t, "s_anomalycfg_puterr")
+
+	// Warm-up GET first for the same reason as
+	// TestGetAnomalyConfig_StorageError: populate the session-token cache
+	// before the DB is closed, so the PUT below fails at SaveAnomalyConfig,
+	// not at session validation.
+	warmupReq, err := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/admin/anomaly-config", nil)
+	require.NoError(t, err)
+	warmupReq.Header.Set("Authorization", "Bearer "+token)
+	warmup, err := ts.Client().Do(warmupReq)
+	require.NoError(t, err)
+	_ = warmup.Body.Close()
+	require.Equal(t, http.StatusOK, warmup.StatusCode)
+
+	ls, ok := cs.Storage().(*store.LocalStorage)
+	require.True(t, ok)
+	sqlDB, err := ls.DB().DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	body := `{"lookback_days":14}`
+	req, err := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/admin/anomaly-config", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}

--- a/server/http/handlers/catalog_clone_environment_test.go
+++ b/server/http/handlers/catalog_clone_environment_test.go
@@ -1,0 +1,169 @@
+// catalog_clone_environment_test.go — coverage for CloneEnvironment
+// (catalog.go), previously untested (0% coverage). Uses freshCoreS12WithAdmin
+// (withUserCtx's UserID=1 wired to a global admin role) so CopySecret's
+// permission check inside CloneEnvironment passes via the RBAC fallback path
+// (CheckSecretPermission -> AuthorizePrincipal -> admin bypass) without
+// needing a separate per-project membership grant.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func TestCloneEnvironment_Unauthorized(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+	req := withChiParams(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/environments/1/clone", nil),
+		map[string]string{"id": "1", "envId": "1"})
+	w := httptest.NewRecorder()
+	h.CloneEnvironment(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestCloneEnvironment_InvalidProjectID(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+	req := withChiParams(httptest.NewRequest(http.MethodPost, "/api/v1/projects/abc/environments/1/clone", nil),
+		map[string]string{"id": "abc", "envId": "1"})
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.CloneEnvironment(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCloneEnvironment_InvalidEnvID(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+	req := withChiParams(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/environments/abc/clone", nil),
+		map[string]string{"id": "1", "envId": "abc"})
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.CloneEnvironment(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCloneEnvironment_BadJSON(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+	req := withChiParams(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/environments/1/clone",
+		bytes.NewReader([]byte("{bad json}"))), map[string]string{"id": "1", "envId": "1"})
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.CloneEnvironment(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCloneEnvironment_MissingDestination(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+	body, _ := json.Marshal(map[string]interface{}{})
+	req := withChiParams(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/environments/1/clone",
+		bytes.NewReader(body)), map[string]string{"id": "1", "envId": "1"})
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.CloneEnvironment(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestCloneEnvironment_CoreValidationError — same source and destination
+// environment ID: core.CloneEnvironment's own validation error ("must
+// differ"), mapped by the handler to 400 via its "must "/"belong"/"required"/
+// "validation" substring match.
+func TestCloneEnvironment_CoreValidationError(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+	body, _ := json.Marshal(map[string]interface{}{"destination_environment_id": 1})
+	req := withChiParams(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/environments/1/clone",
+		bytes.NewReader(body)), map[string]string{"id": "1", "envId": "1"})
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.CloneEnvironment(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestCloneEnvironment_SourceEnvNotFound exercises the errNotFound (404)
+// branch: core.CloneEnvironment wraps GetEnvironment's not-found error as
+// "Validation error: source environment: ...not found..." -- capital-V
+// "Validation" does NOT match the handler's lowercase "validation" substring
+// check, and none of "must "/"required"/"belong" match either, so this falls
+// through to the errNotFound ("not found") check instead of the 400 branch
+// above it.
+func TestCloneEnvironment_SourceEnvNotFound(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+	proj, err := cs.Storage().CreateProject(context.Background(), &models.Project{Name: "clone-notfound-proj"})
+	require.NoError(t, err)
+
+	body, _ := json.Marshal(map[string]interface{}{"destination_environment_id": 1})
+	req := withChiParams(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/environments/999999/clone",
+		bytes.NewReader(body)), map[string]string{"id": machineUintToStr(proj.ID), "envId": "999999"})
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.CloneEnvironment(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
+}
+
+// TestCloneEnvironment_StorageError closes the DB before the handler even
+// reaches core.CloneEnvironment's storage calls, so GetEnvironment fails with
+// a genuine connection error -- a message matching none of the 400/404
+// substring checks, landing on the handler's final else (500, clientSafe)
+// branch.
+func TestCloneEnvironment_StorageError(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	body, _ := json.Marshal(map[string]interface{}{"destination_environment_id": 2})
+	req := withChiParams(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/environments/1/clone",
+		bytes.NewReader(body)), map[string]string{"id": "1", "envId": "1"})
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.CloneEnvironment(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestCloneEnvironment_Success seeds a project with two environments and
+// three secrets in the source, then clones into the destination.
+func TestCloneEnvironment_Success(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+	ctx := context.Background()
+
+	proj, err := cs.Storage().CreateProject(ctx, &models.Project{Name: "clone-http-proj"})
+	require.NoError(t, err)
+	src, err := cs.Storage().CreateEnvironment(ctx, &models.Environment{Name: "src", ProjectID: proj.ID})
+	require.NoError(t, err)
+	dst, err := cs.Storage().CreateEnvironment(ctx, &models.Environment{Name: "dst", ProjectID: proj.ID})
+	require.NoError(t, err)
+
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		_, err := cs.CreateSecret(ctx, &core.CreateSecretRequest{
+			Name: name, Value: []byte("val-" + name),
+			ProjectID: proj.ID, EnvironmentID: src.ID,
+			Type: "generic", CreatedBy: "owner", OwnerID: 1,
+		})
+		require.NoError(t, err)
+	}
+
+	body, _ := json.Marshal(map[string]interface{}{"destination_environment_id": dst.ID})
+	req := withChiParams(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/environments/1/clone",
+		bytes.NewReader(body)), map[string]string{"id": machineUintToStr(proj.ID), "envId": machineUintToStr(src.ID)})
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.CloneEnvironment(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), `"SecretsCloned":3`)
+}

--- a/server/http/handlers/handlers_s7_test.go
+++ b/server/http/handlers/handlers_s7_test.go
@@ -99,6 +99,10 @@ func freshCoreS7(t *testing.T) *core.KeyorixCore {
 		&models.SecretAccessLog{},
 		// s7 addition: required for BootstrapSystem's initialized-state check.
 		&models.SystemMetadata{},
+		// coverage-sweep addition: required by anomaly_config_test.go's
+		// GetAnomalyConfig/UpdateAnomalyConfig real-server tests, and by
+		// BootstrapSystem's password-history write.
+		&models.AnomalyConfigRecord{}, &models.PasswordHistory{},
 	)
 	require.NoError(t, err)
 	return core.NewKeyorixCore(store.NewLocalStorage(db))

--- a/server/http/handlers/mfa_management_marktotp_test.go
+++ b/server/http/handlers/mfa_management_marktotp_test.go
@@ -1,0 +1,127 @@
+// mfa_management_marktotp_test.go — coverage for MarkTOTPStepUsedProxy
+// (mfa_management_proxy.go), previously untested (0% coverage): POST
+// /api/v1/system/mfa/totp-step-used.
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func TestMarkTOTPStepUsedProxy_BadJSON(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewAuthHandler(cs, false)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/totp-step-used",
+		bytes.NewReader([]byte("{bad json}")))
+	w := httptest.NewRecorder()
+	h.MarkTOTPStepUsedProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestMarkTOTPStepUsedProxy_MissingUserID(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewAuthHandler(cs, false)
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 0, "step": 5})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/totp-step-used",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.MarkTOTPStepUsedProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestMarkTOTPStepUsedProxy_StorageError(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h := NewAuthHandler(cs, false)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 1, "step": 5})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/totp-step-used",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.MarkTOTPStepUsedProxy(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestMarkTOTPStepUsedProxy_NoMatchingRow — no MFASecret row exists for the
+// user, so the conditional UPDATE matches zero rows: not an error, "fresh":false.
+func TestMarkTOTPStepUsedProxy_NoMatchingRow(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewAuthHandler(cs, false)
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 1, "step": 5})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/totp-step-used",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.MarkTOTPStepUsedProxy(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Fresh bool `json:"fresh"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.False(t, resp.Data.Fresh)
+}
+
+// TestMarkTOTPStepUsedProxy_FreshStep — an MFASecret row exists with no prior
+// used step, so the conditional UPDATE matches and "fresh":true is returned.
+func TestMarkTOTPStepUsedProxy_FreshStep(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h := NewAuthHandler(cs, false)
+	require.NoError(t, db.Create(&models.MFASecret{UserID: 1, SecretEnc: []byte("x"), SecretMeta: []byte("y")}).Error)
+
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 1, "step": 5})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/totp-step-used",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.MarkTOTPStepUsedProxy(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Fresh bool `json:"fresh"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.True(t, resp.Data.Fresh)
+}
+
+// TestMarkTOTPStepUsedProxy_ReplayedStep — a step at or below the stored
+// last-used step matches zero rows (anti-replay guard) — "fresh":false.
+func TestMarkTOTPStepUsedProxy_ReplayedStep(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h := NewAuthHandler(cs, false)
+	lastUsed := int64(10)
+	require.NoError(t, db.Create(&models.MFASecret{UserID: 1, SecretEnc: []byte("x"), SecretMeta: []byte("y"), LastUsedStep: &lastUsed}).Error)
+
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 1, "step": 5})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/totp-step-used",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.MarkTOTPStepUsedProxy(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Fresh bool `json:"fresh"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.False(t, resp.Data.Fresh)
+}

--- a/server/http/handlers/mfa_stepup_prune_test.go
+++ b/server/http/handlers/mfa_stepup_prune_test.go
@@ -1,0 +1,74 @@
+// mfa_stepup_prune_test.go — coverage for PruneMFAStepUpGrantsProxy
+// (mfa_stepup_proxy.go), previously untested (0% coverage): POST
+// /api/v1/system/mfa/stepup-grants/prune.
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPruneMFAStepUpGrantsProxy_BadJSON(t *testing.T) {
+	h, _ := freshCoreWithStepUpGrant(t, time.Now().UTC().Add(10*time.Minute))
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants/prune",
+		bytes.NewReader([]byte("{bad json}")))
+	w := httptest.NewRecorder()
+	h.PruneMFAStepUpGrantsProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPruneMFAStepUpGrantsProxy_MissingBefore(t *testing.T) {
+	h, _ := freshCoreWithStepUpGrant(t, time.Now().UTC().Add(10*time.Minute))
+	body, _ := json.Marshal(map[string]interface{}{})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants/prune",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.PruneMFAStepUpGrantsProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPruneMFAStepUpGrantsProxy_StorageError(t *testing.T) {
+	h, db := freshCoreWithStepUpGrant(t, time.Now().UTC().Add(10*time.Minute))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	body, _ := json.Marshal(map[string]interface{}{"before": time.Now().UTC()})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants/prune",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.PruneMFAStepUpGrantsProxy(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestPruneMFAStepUpGrantsProxy_Success — the seeded grant's expiry is far in
+// the future, so a "before" cutoff of now (clamped inside
+// core.PruneMFAStepUpGrants against the retention window) deletes nothing —
+// exercises the 200 success path with deleted:0 without depending on the
+// server's default retention window.
+func TestPruneMFAStepUpGrantsProxy_Success(t *testing.T) {
+	h, _ := freshCoreWithStepUpGrant(t, time.Now().UTC().Add(10*time.Minute))
+	body, _ := json.Marshal(map[string]interface{}{"before": time.Now().UTC()})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants/prune",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.PruneMFAStepUpGrantsProxy(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Deleted int64 `json:"deleted"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.Equal(t, int64(0), resp.Data.Deleted)
+}

--- a/server/http/handlers/project_memberships_proxy_transition_gaps_test.go
+++ b/server/http/handlers/project_memberships_proxy_transition_gaps_test.go
@@ -1,0 +1,120 @@
+// project_memberships_proxy_transition_gaps_test.go — remaining branch
+// coverage for TransitionMembershipProxy (project_memberships_proxy.go)
+// beyond project_memberships_proxy_transition_test.go's #1546 ceiling tests:
+// invalid path param, malformed body, missing target state, and the
+// #G42 lost-CAS-race ("matched":false) branch.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+func TestTransitionMembershipProxy_InvalidID(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+	req := httptest.NewRequest("PUT", "/", bytes.NewReader([]byte(`{}`)))
+	req = withChiParams(req, map[string]string{"id": "abc"})
+	w := httptest.NewRecorder()
+	h.TransitionMembershipProxy(w, req)
+	assert.Equal(t, 400, w.Code)
+}
+
+func TestTransitionMembershipProxy_BadJSON(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+	req := httptest.NewRequest("PUT", "/", bytes.NewReader([]byte("{bad json}")))
+	req = withChiParams(req, map[string]string{"id": "1"})
+	w := httptest.NewRecorder()
+	h.TransitionMembershipProxy(w, req)
+	assert.Equal(t, 400, w.Code)
+}
+
+func TestTransitionMembershipProxy_MissingTargetState(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewCatalogHandler(cs)
+	body, _ := json.Marshal(map[string]interface{}{
+		"membership": map[string]interface{}{"id": 1, "project_id": 1},
+	})
+	req := httptest.NewRequest("PUT", "/", bytes.NewReader(body))
+	req = withChiParams(req, map[string]string{"id": "1"})
+	w := httptest.NewRecorder()
+	h.TransitionMembershipProxy(w, req)
+	assert.Equal(t, 400, w.Code)
+}
+
+// raceLosingStorage wraps a real storage.Storage and forces
+// TransitionProjectMembershipState to report a lost CAS race (matched=false,
+// no error) — the #G42 branch that is otherwise only reachable via a genuine
+// concurrent second writer.
+type raceLosingStorage struct {
+	coreStorage.Storage
+}
+
+func (r *raceLosingStorage) TransitionProjectMembershipState(ctx context.Context, m *models.ProjectMembership, fromState string) (bool, error) {
+	return false, nil
+}
+
+// TestTransitionMembershipProxy_LostRace_MatchedFalse exercises the #G42
+// "another writer already moved this row" outcome: a legal transition
+// (provisioned -> revoked, no admin-role ceiling involved) whose conditional
+// write is forced to report zero rows matched. The wire contract treats this
+// as a normal 200 with matched:false, not a server error.
+func TestTransitionMembershipProxy_LostRace_MatchedFalse(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	ctx := context.Background()
+
+	project, err := cs.Storage().CreateProject(ctx, &models.Project{Name: "g42-race-project"})
+	require.NoError(t, err)
+	target, err := cs.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "g42-race-target", Email: "g42-race-target@example.com",
+		DisplayName: "G42 Race Target", Password: "NotArealpassword123!",
+	})
+	require.NoError(t, err)
+	membership, err := cs.Storage().CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: project.ID, UserID: target.ID, Role: "member", State: core.MembershipProvisioned,
+	})
+	require.NoError(t, err)
+
+	raceCore := core.NewKeyorixCore(&raceLosingStorage{Storage: cs.Storage()})
+	h := NewCatalogHandler(raceCore)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"membership": map[string]interface{}{"id": membership.ID, "project_id": membership.ProjectID, "state": core.MembershipRevoked},
+		"from_state": core.MembershipProvisioned,
+	})
+	req := httptest.NewRequest("PUT", "/", bytes.NewReader(body))
+	uc := &middleware.UserContext{UserID: 1}
+	req = req.WithContext(context.WithValue(req.Context(), middleware.GetUserContextKey(), uc))
+	req = withChiParams(req, map[string]string{"id": machineUintToStr(membership.ID)})
+	w := httptest.NewRecorder()
+	h.TransitionMembershipProxy(w, req)
+	require.Equal(t, 200, w.Code, w.Body.String())
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Matched bool `json:"matched"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.False(t, resp.Data.Matched)
+
+	// The row itself must be untouched by the lost-race branch (the fake
+	// never actually wrote anything).
+	reloaded, err := cs.Storage().GetProjectMembership(ctx, membership.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.MembershipProvisioned, reloaded.State)
+}

--- a/server/http/handlers/project_stats_test.go
+++ b/server/http/handlers/project_stats_test.go
@@ -1,0 +1,68 @@
+// project_stats_test.go — coverage for GetProjectStats (project_stats.go),
+// previously untested (0% coverage). Uses freshCoreS12WithAdmin rather than
+// project_health_handler_test.go's lighter fixture: core.GetProjectStats'
+// ListProjectRoleAssignments call unconditionally queries the user_roles/
+// group_roles tables, which the lighter fixture doesn't migrate.
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func newProjectStatsHandler(t *testing.T) *SecretHandler {
+	t.Helper()
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewSecretHandler(cs)
+	require.NoError(t, err)
+	return h
+}
+
+func TestGetProjectStats_Unauthorized(t *testing.T) {
+	h := newProjectStatsHandler(t)
+	req := withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/projects/1/stats", nil), "id", "1")
+	w := httptest.NewRecorder()
+	h.GetProjectStats(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestGetProjectStats_InvalidProjectID(t *testing.T) {
+	h := newProjectStatsHandler(t)
+	req := withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/projects/abc/stats", nil), "id", "abc")
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.GetProjectStats(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestGetProjectStats_NotFound — a well-formed but nonexistent project ID:
+// core.GetProjectStats' initial GetProject lookup fails, which the handler
+// maps to a generic 500 (no not-found branch of its own).
+func TestGetProjectStats_NotFound(t *testing.T) {
+	h := newProjectStatsHandler(t)
+	req := withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/projects/999/stats", nil), "id", "999")
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.GetProjectStats(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestGetProjectStats_Success(t *testing.T) {
+	h := newProjectStatsHandler(t)
+	proj, err := h.coreService.Storage().CreateProject(context.Background(), &models.Project{Name: "stats-proj"})
+	require.NoError(t, err)
+
+	req := withChiParam(httptest.NewRequest(http.MethodGet, "/api/v1/projects/1/stats", nil), "id", machineUintToStr(proj.ID))
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.GetProjectStats(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "total_secrets")
+}

--- a/server/http/handlers/rbac_secret_ownership_acl_proxy_test.go
+++ b/server/http/handlers/rbac_secret_ownership_acl_proxy_test.go
@@ -1,0 +1,136 @@
+// rbac_secret_ownership_acl_proxy_test.go — coverage for
+// ClearProjectSecretOwnershipProxy and DeleteSecretACLsByUserAndProjectProxy
+// (rbac_role_grants_proxy.go), previously untested (0% coverage): both are
+// thin passthroughs onto storage.Storage with no in-handler ceiling check
+// (authority is enforced by the /system route group's blanket system.write
+// gate, not by these handlers themselves — see the file's package doc).
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── ClearProjectSecretOwnershipProxy ────────────────────────────────────────
+
+func TestClearProjectSecretOwnershipProxy_BadJSON(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewRBACHandler(cs)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/rbac/clear-project-secret-ownership",
+		bytes.NewReader([]byte("{bad json}")))
+	w := httptest.NewRecorder()
+	h.ClearProjectSecretOwnershipProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestClearProjectSecretOwnershipProxy_MissingFields(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewRBACHandler(cs)
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 0, "project_id": 1})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/rbac/clear-project-secret-ownership",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ClearProjectSecretOwnershipProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestClearProjectSecretOwnershipProxy_StorageError(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h := NewRBACHandler(cs)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 1, "project_id": 1})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/rbac/clear-project-secret-ownership",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ClearProjectSecretOwnershipProxy(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestClearProjectSecretOwnershipProxy_Success(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewRBACHandler(cs)
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 1, "project_id": 1})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/rbac/clear-project-secret-ownership",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ClearProjectSecretOwnershipProxy(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Cleared bool `json:"cleared"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.True(t, resp.Data.Cleared)
+}
+
+// ── DeleteSecretACLsByUserAndProjectProxy ───────────────────────────────────
+
+func TestDeleteSecretACLsByUserAndProjectProxy_BadJSON(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewRBACHandler(cs)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/rbac/delete-secret-acls-by-user-and-project",
+		bytes.NewReader([]byte("{bad json}")))
+	w := httptest.NewRecorder()
+	h.DeleteSecretACLsByUserAndProjectProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDeleteSecretACLsByUserAndProjectProxy_MissingFields(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewRBACHandler(cs)
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 1, "project_id": 0})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/rbac/delete-secret-acls-by-user-and-project",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.DeleteSecretACLsByUserAndProjectProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDeleteSecretACLsByUserAndProjectProxy_StorageError(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h := NewRBACHandler(cs)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 1, "project_id": 1})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/rbac/delete-secret-acls-by-user-and-project",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.DeleteSecretACLsByUserAndProjectProxy(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestDeleteSecretACLsByUserAndProjectProxy_Success(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h := NewRBACHandler(cs)
+	body, _ := json.Marshal(map[string]interface{}{"user_id": 1, "project_id": 1})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/rbac/delete-secret-acls-by-user-and-project",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.DeleteSecretACLsByUserAndProjectProxy(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Deleted bool `json:"deleted"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.True(t, resp.Data.Deleted)
+}

--- a/server/http/handlers/rotation_dryrun_test.go
+++ b/server/http/handlers/rotation_dryrun_test.go
@@ -1,0 +1,68 @@
+// rotation_dryrun_test.go — coverage for SimulateRotation (rotation_dryrun.go),
+// previously untested (0% coverage).
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func TestSimulateRotation_Unauthorized(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/secrets/1/rotation/simulate", nil), "id", "1")
+	w := httptest.NewRecorder()
+	h.SimulateRotation(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestSimulateRotation_InvalidSecretID(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/secrets/abc/rotation/simulate", nil), "id", "abc")
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.SimulateRotation(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSimulateRotation_SecretNotFound(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/secrets/999/rotation/simulate", nil), "id", "999")
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.SimulateRotation(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestSimulateRotation_Success seeds a real secret (no rotation policy/backend
+// configured) and confirms the dry run returns 200 with an invalid (but
+// non-error) result -- SimulateRotation only errors when the secret itself
+// can't be found.
+func TestSimulateRotation_Success(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+	ctx := context.Background()
+	proj, err := h.coreService.Storage().CreateProject(ctx, &models.Project{Name: "dryrun-proj"})
+	require.NoError(t, err)
+	env, err := h.coreService.Storage().CreateEnvironment(ctx, &models.Environment{Name: "dryrun-env", ProjectID: proj.ID})
+	require.NoError(t, err)
+	secret, err := h.coreService.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "dryrun-secret", Value: []byte("val"),
+		ProjectID: proj.ID, EnvironmentID: env.ID,
+		Type: "generic", CreatedBy: "tester", OwnerID: 1,
+	})
+	require.NoError(t, err)
+
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/secrets/1/rotation/simulate", nil), "id", machineUintToStr(secret.ID))
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.SimulateRotation(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"valid":false`)
+}

--- a/server/http/handlers/secrets_bulk_rotate_test.go
+++ b/server/http/handlers/secrets_bulk_rotate_test.go
@@ -1,0 +1,81 @@
+// secrets_bulk_rotate_test.go — coverage for BulkRotateSecrets
+// (secrets_bulk_rotate.go), previously untested (0% coverage).
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBulkRotateSecrets_Unauthorized(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/secrets/bulk-rotate", nil), "id", "1")
+	w := httptest.NewRecorder()
+	h.BulkRotateSecrets(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestBulkRotateSecrets_InvalidProjectID(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/projects/abc/secrets/bulk-rotate", nil), "id", "abc")
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.BulkRotateSecrets(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestBulkRotateSecrets_BadJSON(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/secrets/bulk-rotate",
+		bytes.NewReader([]byte("{bad json}"))), "id", "1")
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.BulkRotateSecrets(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestBulkRotateSecrets_BatchTooLarge exercises the "exceeds the maximum
+// batch size" -> 400 branch (core.maxBulkRotateBatchSize is 500).
+func TestBulkRotateSecrets_BatchTooLarge(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+	ids := make([]uint, 501)
+	for i := range ids {
+		ids[i] = uint(i + 1)
+	}
+	body, _ := json.Marshal(map[string]interface{}{"secret_ids": ids})
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/secrets/bulk-rotate",
+		bytes.NewReader(body)), "id", "1")
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.BulkRotateSecrets(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestBulkRotateSecrets_Success — an empty project (no secrets, no explicit
+// secret_ids) is a legal project-wide rotation of zero secrets: 200 with an
+// empty Triggered/Failed result.
+func TestBulkRotateSecrets_Success(t *testing.T) {
+	h, _ := newProjectHealthHandler(t)
+	body, _ := json.Marshal(map[string]interface{}{})
+	req := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/projects/1/secrets/bulk-rotate",
+		bytes.NewReader(body)), "id", "1")
+	req = withUserCtx(req)
+	w := httptest.NewRecorder()
+	h.BulkRotateSecrets(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Total int `json:"total"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+}

--- a/server/http/handlers/users_credentials_proxy_test.go
+++ b/server/http/handlers/users_credentials_proxy_test.go
@@ -1,0 +1,157 @@
+// users_credentials_proxy_test.go — coverage for
+// RevokeAllPersonalAccessTokensForUserProxy and DeleteSessionsForUserExceptProxy
+// (users_credentials_proxy.go), previously untested (0% coverage). Unlike most
+// /system proxies, these DO enforce an in-handler ceiling
+// (requireUserCredentialsRevokeAuthority — users.write authority), so each gets
+// both an authorized and an unauthorized case.
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── RevokeAllPersonalAccessTokensForUserProxy ───────────────────────────────
+
+func TestRevokeAllPersonalAccessTokensForUserProxy_InvalidID(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	r := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/system/users/abc/personal-access-tokens/revoke-all", nil), "id", "abc")
+	r = withUserCtx(r)
+	w := httptest.NewRecorder()
+	h.RevokeAllPersonalAccessTokensForUserProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestRevokeAllPersonalAccessTokensForUserProxy_Unauthorized(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	// No user context at all: resolves to actorType "user", actorID 0 — no
+	// roles, requireUserCredentialsRevokeAuthority denies.
+	r := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/system/users/1/personal-access-tokens/revoke-all", nil), "id", "1")
+	w := httptest.NewRecorder()
+	h.RevokeAllPersonalAccessTokensForUserProxy(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "PERMISSION_DENIED")
+}
+
+func TestRevokeAllPersonalAccessTokensForUserProxy_StorageError(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	r := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/system/users/1/personal-access-tokens/revoke-all", nil), "id", "1")
+	r = withUserCtx(r)
+	w := httptest.NewRecorder()
+	h.RevokeAllPersonalAccessTokensForUserProxy(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestRevokeAllPersonalAccessTokensForUserProxy_Success(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	r := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/system/users/1/personal-access-tokens/revoke-all", nil), "id", "1")
+	r = withUserCtx(r)
+	w := httptest.NewRecorder()
+	h.RevokeAllPersonalAccessTokensForUserProxy(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Hashes []string `json:"hashes"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+}
+
+// ── DeleteSessionsForUserExceptProxy ────────────────────────────────────────
+
+func TestDeleteSessionsForUserExceptProxy_InvalidID(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	r := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/system/users/abc/sessions/delete-except", nil), "id", "abc")
+	r = withUserCtx(r)
+	w := httptest.NewRecorder()
+	h.DeleteSessionsForUserExceptProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDeleteSessionsForUserExceptProxy_BadJSON(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	r := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/system/users/1/sessions/delete-except",
+		bytes.NewReader([]byte("{bad json}"))), "id", "1")
+	r = withUserCtx(r)
+	w := httptest.NewRecorder()
+	h.DeleteSessionsForUserExceptProxy(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDeleteSessionsForUserExceptProxy_Unauthorized(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	body, _ := json.Marshal(map[string]interface{}{"except_session_id": 0})
+	r := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/system/users/1/sessions/delete-except",
+		bytes.NewReader(body)), "id", "1")
+	w := httptest.NewRecorder()
+	h.DeleteSessionsForUserExceptProxy(w, r)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "PERMISSION_DENIED")
+}
+
+func TestDeleteSessionsForUserExceptProxy_StorageError(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	body, _ := json.Marshal(map[string]interface{}{"except_session_id": 0})
+	r := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/system/users/1/sessions/delete-except",
+		bytes.NewReader(body)), "id", "1")
+	r = withUserCtx(r)
+	w := httptest.NewRecorder()
+	h.DeleteSessionsForUserExceptProxy(w, r)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestDeleteSessionsForUserExceptProxy_Success(t *testing.T) {
+	cs, _ := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	body, _ := json.Marshal(map[string]interface{}{"except_session_id": 0})
+	r := withChiParam(httptest.NewRequest(http.MethodPost, "/api/v1/system/users/1/sessions/delete-except",
+		bytes.NewReader(body)), "id", "1")
+	r = withUserCtx(r)
+	w := httptest.NewRecorder()
+	h.DeleteSessionsForUserExceptProxy(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Deleted bool `json:"deleted"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.True(t, resp.Data.Deleted)
+}


### PR DESCRIPTION
## Summary

Coverage-focused test additions across 8 packages identified as low- or zero-coverage in a repo-wide survey, plus 3 real bugs found and fixed while writing tests against the affected code paths (independently re-verified, not just self-reported by the agents that found them).

| Package | Before | After |
|---|---|---|
| `internal/storage/store` | 85.6% | 98.5% |
| `internal/cli/share` | 91.3% | 96.6% |
| `internal/core` | 89.0% | 89.9% (all 11 targeted authz/session-guard functions now 100%; WebAuthn `Finish*` flows raised via real crypto against W3C spec vectors) |
| `server/http/handlers` | 87.9% | 89.6% (all 13 targeted 0%-coverage proxy handlers now ~100%) |
| `internal/cli/secret` | 81.0% | 95.1% |
| `internal/cli/usage` | 73.2% | 96.4% |
| `internal/storage` | 82.5% | 85.5% (with live Postgres) / 82.6% (without) |
| `cmd/keyorix-k8s-sync` | 0% | 97.4% |

`internal/core` and `server/http/handlers` fall short of the 95% package-wide bar because both are large packages, and this sweep's scope was a specific, named set of functions rather than the whole file tree — everything targeted is now at or near 100%, the remaining gap is hundreds of pre-existing, unrelated functions across other subsystems never touched by this pass. `internal/storage`'s remaining gap is ~80 structurally-identical, already-guarded DDL error-wrap branches plus one line of dead code (documented in test comments) — not realistically closable without forcing low-value tests.

## Bugs found and fixed while writing tests

- **`internal/storage/store` — `GetBillingReport`**: `MachineReads` filtered `audit_events` on `actor_type = "machine"`, but every real machine-token caller writes `"machine_identity"` (ADR-023/ADR-030). `MachineReads` has reported 0 in every real deployment regardless of actual activity. One-line fix, caught because the function had 0% coverage before this pass.
- **`internal/storage/store` — `PruneMFAStepUpGrants`**: compared its cutoff to `expires_at` without normalizing to UTC first, while the column is always stored UTC-normalized — same bug class as a prior GORM/SQLite timezone incident (PR #1218) and G81. On any server not pinned to `TZ=UTC`, the maintenance sweep could prune the wrong set of grants.
- **`server/http/handlers/anomaly_config.go`**: `UpdateAnomalyConfig` mapped every error from `core.UpdateAnomalyConfig` — including request-validation errors (e.g. exceeding `lookback_days` max) — to a blanket `500 InternalError`. Now returns `400 BadRequest` for that class, matching the convention already used by sibling handlers.

(A suspected `ListShares`/`ListSharesBySecretIDs` expired-share bug from the initial survey turned out to be a false positive from a stale local checkout — already fixed on `main` via commit 6e5952c9 before this branch was cut. Verified directly: both tests pass cleanly against `origin/main`, no fix needed.)

## Test plan

- [x] `go build ./...` clean across the whole module
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] `go test ./...` — all green except `internal/securefiles`, which fails on a pre-existing, environment-specific local toolchain quirk unrelated to this change (`testlog.txt: file too large`; all assertions in that package still print PASS)
- [x] Every coverage number above independently re-measured against each branch before merging, not just self-reported by the agents that wrote the tests
- [x] `internal/storage/store`'s full suite now takes ~862s (up from ~80s) due to the volume of new tests — comparable to `server/http/handlers`' existing ~1200s CI budget, not unprecedented for this repo, but flagging for reviewer awareness