### PR TITLE
fix(storage): wire roles.name_folded and secret_nodes NFC normalization into existing-DB upgrades

### DIFF
--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1648,6 +1648,42 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 		}
 	}
 
+	// #1642: roles.name_folded and secret_nodes' NFC-normalized name were only
+	// ever wired into the fresh-DB tail below, never into this additive,
+	// existing-DB-safe path -- unlike every sibling *_folded/normalized column
+	// above (groups.name_folded, users.username_folded/email_folded), which is
+	// called from both here AND the fresh-DB tail. Since migrateDatabase
+	// returns early below once projectsExists is true (an already-initialized
+	// database), the fresh-DB-only call site never ran on any upgrade: the
+	// roles table never gained name_folded, while models.Role and
+	// CreateRole/UpdateRole unconditionally reference that column in every
+	// generated INSERT/UPDATE -- breaking role creation/update outright on
+	// every real upgrade the first time either is called. Mirrors
+	// ensureUserNameIndex's tableExists guard above exactly. Additive +
+	// idempotent; the full AutoMigrate below covers fresh DBs.
+	if tableExists(db, "roles") {
+		// ensureRoleNameIndex/backfillFoldedColumn assume name_folded already
+		// exists (true on a fresh install, where AutoMigrate added it from
+		// models.Role's struct tag) -- they only backfill and index an
+		// EXISTING column, they never ALTER TABLE ADD COLUMN it themselves.
+		// On an existing install AutoMigrate never runs, so this ADD COLUMN
+		// step -- mirroring the groups.DeletedAt AddColumn immediately above
+		// this comment block -- is what actually has to add it here.
+		if m := db.Migrator(); !m.HasColumn(&models.Role{}, "NameFolded") {
+			if err := m.AddColumn(&models.Role{}, "NameFolded"); err != nil {
+				return fmt.Errorf("failed to add roles.name_folded column: %w", err)
+			}
+		}
+		if err := ensureRoleNameIndex(db); err != nil {
+			return err
+		}
+	}
+	if tableExists(db, "secret_nodes") {
+		if err := ensureSecretNodeNameNFC(db); err != nil {
+			return err
+		}
+	}
+
 	// Close the share-create race (#136): a partial unique index on live rows so two
 	// concurrent CreateShareRecord calls for the same (secret, recipient, is_group)
 	// can no longer both succeed as separate rows. Additive + idempotent; the full
@@ -1826,7 +1862,14 @@ func ensureRoleNameIndex(db *gorm.DB) error {
 // never holds two different Unicode representations of what a human reads as
 // the same address.
 func ensureSecretNodeNameNFC(db *gorm.DB) error {
-	return normalizeColumnInPlace(db, "secret_nodes", "id", "name", sqlWhereNotDeleted, normalizeAddress)
+	// Scoped by (project_id, environment_id): secret_nodes.name is only
+	// unique WITHIN that scope (uniq_secret_nodes_project_env_name_active),
+	// not globally -- two secrets legitimately named "DATABASE_URL" in two
+	// different projects are not a collision. Passing this unscoped would
+	// make normalizeColumnInPlace group by name alone and falsely refuse to
+	// migrate any installation with the same secret name reused across
+	// projects, an extremely common pattern.
+	return normalizeColumnInPlace(db, "secret_nodes", "id", "name", sqlWhereNotDeleted, "project_id, environment_id", normalizeAddress)
 }
 
 // ensureShareRecordUniqueIndex creates a partial unique index on share_records

--- a/internal/storage/factory_role_secretnode_migration_wiring_test.go
+++ b/internal/storage/factory_role_secretnode_migration_wiring_test.go
@@ -1,0 +1,84 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRoleNameFoldedColumn_AddedOnUpgrade pins a critical regression:
+// ensureRoleNameIndex (#1642, roles.name_folded) was only ever wired into
+// migrateDatabase's fresh-install tail block, never into the additive,
+// existing-DB-safe path every sibling *_folded column (groups.name_folded,
+// users.username_folded/email_folded) correctly uses. Since migrateDatabase
+// returns early once the projects table already exists, an upgrade of any
+// real pre-existing installation never ran ensureRoleNameIndex at all --
+// roles.name_folded was never added -- while models.Role and
+// LocalStorage.CreateRole/UpdateRole unconditionally reference that column
+// in every generated INSERT/UPDATE, breaking role creation/update outright
+// with a "no such column" error the first time either was called after
+// upgrading. Mirrors TestCompanionIndexes_CreatedOnUpgrade's established
+// simulate-an-upgrade pattern: boot fresh (creates the column via the
+// fresh-DB tail, matching a real fresh install), remove it to stand in for
+// "this install predates the fix", then re-run migrateDatabase exactly as a
+// real second process boot does and confirm it re-converges.
+func TestRoleNameFoldedColumn_AddedOnUpgrade(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "role-name-folded-upgrade.db")
+	db, err := gormOpenForTest(t, dbPath)
+	require.NoError(t, err)
+
+	f := &DefaultStorageFactory{}
+
+	// First boot: genuinely fresh database. projects doesn't exist yet, so
+	// the full AutoMigrate block + fresh-DB tail run, adding name_folded.
+	require.NoError(t, f.migrateDatabase(db))
+	require.True(t, columnExists(db, "roles", "name_folded"), "fresh install must have name_folded via the AutoMigrate+fresh-tail path")
+
+	// Remove it, standing in for an install that upgraded through an older
+	// binary that predates this fix (roles table present, name_folded never
+	// added because the wiring bug skipped ensureRoleNameIndex entirely).
+	require.NoError(t, db.Exec("DROP INDEX IF EXISTS uniq_roles_name_folded").Error)
+	require.NoError(t, db.Exec("ALTER TABLE roles DROP COLUMN name_folded").Error)
+	require.False(t, columnExists(db, "roles", "name_folded"), "name_folded must actually be gone before re-running the migration")
+
+	// Second run: mirrors exactly what a real process boot does on an
+	// existing (projects table present) database.
+	require.NoError(t, f.migrateDatabase(db))
+
+	assert.True(t, columnExists(db, "roles", "name_folded"), "name_folded must be re-added on an upgraded install, not just a fresh one")
+	assert.True(t, indexExists(db, "uniq_roles_name_folded"), "the unique index on name_folded must be re-created on an upgraded install too")
+}
+
+// TestSecretNodeNameNFC_NormalizedOnUpgrade is the sibling regression test
+// for ensureSecretNodeNameNFC, which had the identical wiring gap:
+// secret_nodes.name was never NFC-normalized on an upgrade of an existing
+// installation, only on a fresh install.
+func TestSecretNodeNameNFC_NormalizedOnUpgrade(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "secretnode-nfc-upgrade.db")
+	db, err := gormOpenForTest(t, dbPath)
+	require.NoError(t, err)
+
+	f := &DefaultStorageFactory{}
+
+	// Fresh boot to get the real, fully-migrated schema (all tables/columns
+	// present), matching a genuine fresh install.
+	require.NoError(t, f.migrateDatabase(db))
+
+	// Simulate an existing installation with a pre-#1642 secret whose name
+	// was stored in NFD form (the exact scenario ensureSecretNodeNameNFC
+	// exists to fix). Requires a real project/environment row to satisfy
+	// secret_nodes' foreign keys.
+	require.NoError(t, db.Exec(`INSERT INTO projects (id, name, created_at, updated_at) VALUES (1, 'p', datetime('now'), datetime('now'))`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO environments (id, project_id, name, created_at, updated_at) VALUES (1, 1, 'e', datetime('now'), datetime('now'))`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO secret_nodes (id, project_id, environment_id, name, type, created_at, updated_at) VALUES (1, 1, 1, ?, 'static', datetime('now'), datetime('now'))`, nfdCafe).Error)
+
+	// Re-run migrateDatabase exactly as a real second process boot does
+	// against this now-existing (projects table present) database.
+	require.NoError(t, f.migrateDatabase(db))
+
+	var got string
+	require.NoError(t, db.Table("secret_nodes").Where("id = 1").Select("name").Scan(&got).Error)
+	assert.Equal(t, nfcCafe, got, "a pre-existing NFD secret name must be NFC-normalized on an upgraded install, not just a fresh one")
+}

--- a/internal/storage/normalize_backfill.go
+++ b/internal/storage/normalize_backfill.go
@@ -111,15 +111,45 @@ func backfillFoldedColumn(db *gorm.DB, table, idColumn, sourceColumn, foldColumn
 // columns do. Only rows whose normalized form actually differs from the
 // stored value are written, so this is a no-op for an already-normalized
 // database. Same fail-loud collision refusal as backfillFoldedColumn: if two
-// existing rows normalize to the same value, nothing is written and the
-// error lists every colliding pair for manual resolution.
-func normalizeColumnInPlace(db *gorm.DB, table, idColumn, column, whereClause string, normalize func(string) (string, error)) error {
+// existing rows normalize to the same value WITHIN THE SAME scopeColumns
+// tuple, nothing is written and the error lists every colliding pair for
+// manual resolution.
+//
+// scopeColumns is a comma-separated list of column names (or "" for no
+// scoping) that participate in the column's own real uniqueness constraint.
+// This matters because not every normalized column is globally unique the
+// way roles.name_folded/users.username_folded are: secret_nodes.name is only
+// unique within (project_id, environment_id) — see
+// uniq_secret_nodes_project_env_name_active — so two secrets legitimately
+// named "DATABASE_URL" in different projects are not a collision and must
+// not be grouped together. Passing "" preserves the original global-grouping
+// behavior for callers whose column genuinely has no scope (the *_folded
+// columns).
+func normalizeColumnInPlace(db *gorm.DB, table, idColumn, column, whereClause, scopeColumns string, normalize func(string) (string, error)) error {
 	type row struct {
 		ID     uint
 		Source string
+		Scope  string
 	}
 	var rows []row
-	q := db.Table(table).Select(idColumn + " AS id, " + column + " AS source")
+	// scopeColumns is a comma-separated raw column-name list (matching
+	// warnIfDuplicatesExist's keyExpr convention elsewhere in this package),
+	// combined here into one delimited string via the portable CAST(...AS
+	// TEXT) || sep || ... form (both SQLite and Postgres support TEXT casts
+	// and the || concatenation operator identically) rather than any
+	// dialect-specific tuple/ROW syntax. \x1f (ASCII unit separator) can't
+	// appear in an integer column's textual representation, so it can't be
+	// spoofed into a false cross-scope match.
+	scopeExpr := "''"
+	if scopeColumns != "" {
+		cols := strings.Split(scopeColumns, ",")
+		parts := make([]string, len(cols))
+		for i, c := range cols {
+			parts[i] = "CAST(" + strings.TrimSpace(c) + " AS TEXT)"
+		}
+		scopeExpr = strings.Join(parts, " || '\x1f' || ")
+	}
+	q := db.Table(table).Select(idColumn + " AS id, " + column + " AS source, (" + scopeExpr + ") AS scope")
 	if whereClause != "" {
 		q = q.Where(whereClause)
 	}
@@ -135,22 +165,34 @@ func normalizeColumnInPlace(db *gorm.DB, table, idColumn, column, whereClause st
 		new string
 	}
 	var changes []change
-	idsByNormalized := make(map[string][]uint, len(rows))
+	// Keyed on scope+"\x00"+normalized so two rows only collide when they
+	// share BOTH the same scope tuple and the same normalized value — a
+	// NUL byte can't appear in either half (scope is numeric column values
+	// joined by SQL concatenation; normalized is a validated identity/
+	// address string), so this can't be spoofed into a false match.
+	idsByScopeAndNormalized := make(map[string][]uint, len(rows))
+	keyLabel := make(map[string]string, len(rows))
 	for _, r := range rows {
 		normalized, err := normalize(r.Source)
 		if err != nil {
 			return fmt.Errorf("failed to normalize %s.%s=%q (id=%d): %w", table, column, r.Source, r.ID, err)
 		}
-		idsByNormalized[normalized] = append(idsByNormalized[normalized], r.ID)
+		key := r.Scope + "\x00" + normalized
+		idsByScopeAndNormalized[key] = append(idsByScopeAndNormalized[key], r.ID)
+		if scopeColumns != "" {
+			keyLabel[key] = fmt.Sprintf("%q (scope %s=%s)", normalized, scopeColumns, r.Scope)
+		} else {
+			keyLabel[key] = fmt.Sprintf("%q", normalized)
+		}
 		if normalized != r.Source {
 			changes = append(changes, change{id: r.ID, new: normalized})
 		}
 	}
 
 	var collisions []string
-	for normalized, ids := range idsByNormalized {
+	for key, ids := range idsByScopeAndNormalized {
 		if len(ids) > 1 {
-			collisions = append(collisions, fmt.Sprintf("%q shared by %s row id(s) %v", normalized, table, ids))
+			collisions = append(collisions, fmt.Sprintf("%s shared by %s row id(s) %v", keyLabel[key], table, ids))
 		}
 	}
 	if len(collisions) > 0 {

--- a/internal/storage/normalize_backfill_test.go
+++ b/internal/storage/normalize_backfill_test.go
@@ -88,7 +88,7 @@ func TestNormalizeColumnInPlace_RefusesOnCollision(t *testing.T) {
 	require.NoError(t, db.Exec(`INSERT INTO secret_nodes VALUES (1, ?, NULL)`, nfcCafe).Error)
 	require.NoError(t, db.Exec(`INSERT INTO secret_nodes VALUES (2, ?, NULL)`, nfdCafe).Error)
 
-	err = normalizeColumnInPlace(db, "secret_nodes", "id", "name", "", normalizeAddress)
+	err = normalizeColumnInPlace(db, "secret_nodes", "id", "name", "", "", normalizeAddress)
 	require.Error(t, err, "two rows normalizing to the same NFC form must refuse the entire pass")
 	assert.Contains(t, err.Error(), "cannot normalize secret_nodes.name")
 
@@ -99,6 +99,46 @@ func TestNormalizeColumnInPlace_RefusesOnCollision(t *testing.T) {
 	require.NoError(t, db2.Exec(`CREATE TABLE secret_nodes (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`).Error)
 	require.NoError(t, db2.Exec(`INSERT INTO secret_nodes VALUES (1, 'PROD_KEY', NULL)`).Error)
 	require.NoError(t, db2.Exec(`INSERT INTO secret_nodes VALUES (2, 'prod_key', NULL)`).Error)
-	require.NoError(t, normalizeColumnInPlace(db2, "secret_nodes", "id", "name", "", normalizeAddress),
+	require.NoError(t, normalizeColumnInPlace(db2, "secret_nodes", "id", "name", "", "", normalizeAddress),
 		"case-distinct secret names must not be treated as colliding")
+}
+
+// TestNormalizeColumnInPlace_ScopedCollision_DifferentProjectsNotAColliding
+// proves the fix for a real regression: secret_nodes.name is only unique
+// within (project_id, environment_id) -- uniq_secret_nodes_project_env_name_active
+// -- not globally, so two secrets legitimately named the same address in two
+// different projects/environments must NOT be reported as a collision, and
+// each row's own scope-local normalization must still be applied.
+func TestNormalizeColumnInPlace_ScopedCollision_DifferentProjectsNotAColliding(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "normalize-scoped.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE secret_nodes (id INTEGER PRIMARY KEY, project_id INTEGER, environment_id INTEGER, name TEXT, deleted_at DATETIME)`).Error)
+	// Same NFD-form address in two different projects: legitimate, must not collide.
+	require.NoError(t, db.Exec(`INSERT INTO secret_nodes VALUES (1, 1, 1, ?, NULL)`, nfdCafe).Error)
+	require.NoError(t, db.Exec(`INSERT INTO secret_nodes VALUES (2, 2, 1, ?, NULL)`, nfdCafe).Error)
+
+	require.NoError(t, normalizeColumnInPlace(db, "secret_nodes", "id", "name", "", "project_id, environment_id", normalizeAddress),
+		"the same secret name in two different projects must not be reported as a collision")
+
+	var got1, got2 string
+	require.NoError(t, db.Table("secret_nodes").Where("id = 1").Select("name").Scan(&got1).Error)
+	require.NoError(t, db.Table("secret_nodes").Where("id = 2").Select("name").Scan(&got2).Error)
+	assert.Equal(t, nfcCafe, got1, "row 1 must still be NFC-normalized despite sharing a name with row 2")
+	assert.Equal(t, nfcCafe, got2, "row 2 must still be NFC-normalized despite sharing a name with row 1")
+}
+
+// TestNormalizeColumnInPlace_ScopedCollision_SameProjectStillCollides proves
+// the scoped collision check still catches a REAL collision: two rows
+// sharing both the same scope AND the same normalized name must still be
+// refused.
+func TestNormalizeColumnInPlace_ScopedCollision_SameProjectStillCollides(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "normalize-scoped-collide.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE secret_nodes (id INTEGER PRIMARY KEY, project_id INTEGER, environment_id INTEGER, name TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO secret_nodes VALUES (1, 1, 1, ?, NULL)`, nfcCafe).Error)
+	require.NoError(t, db.Exec(`INSERT INTO secret_nodes VALUES (2, 1, 1, ?, NULL)`, nfdCafe).Error)
+
+	err = normalizeColumnInPlace(db, "secret_nodes", "id", "name", "", "project_id, environment_id", normalizeAddress)
+	require.Error(t, err, "two rows in the SAME project+environment normalizing to the same NFC form must still refuse")
+	assert.Contains(t, err.Error(), "cannot normalize secret_nodes.name")
 }


### PR DESCRIPTION
## Summary

Two findings from this session's adversarial-review Part 2 continuation (regression audit of PR #1661, the #1642 normalization-boundary work). Both verified by direct code reading against `origin/main`, not just inferred from the review.

- **CRITICAL** — `ensureRoleNameIndex`/`ensureSecretNodeNameNFC` were only ever wired into `migrateDatabase`'s fresh-install tail block, never into the additive, existing-DB-safe path every sibling `*_folded` column (`groups.name_folded`, `users.username_folded`/`email_folded`) correctly uses from both places. Since `migrateDatabase` returns early once the `projects` table already exists, **the fresh-DB-only call site never ran on any upgrade**: `roles.name_folded` was never added to an existing installation's schema, while `models.Role` and `LocalStorage.CreateRole`/`UpdateRole` unconditionally reference that column in every generated INSERT/UPDATE — **breaking role creation/update outright with a "no such column" error on every real upgrade**, the first time either was called.
- **HIGH** — `normalizeColumnInPlace`'s collision detection (used by `ensureSecretNodeNameNFC`) grouped colliding rows by normalized value alone, table-wide. `secret_nodes.name` is only unique within `(project_id, environment_id)` — unlike roles/users/groups, whose folded names are genuinely globally unique — so two legitimate, non-colliding secrets sharing a name in different projects (e.g. every project having its own `DATABASE_URL`) would report a false-positive collision and fail the whole migration. Latent until the critical fix above made it reachable.

## Fix

- Added the missing `tableExists`-guarded additive call sites (mirroring `ensureUserNameIndex`'s pattern) plus the `ALTER TABLE ADD COLUMN` step `ensureRoleNameIndex` itself assumes already happened (mirroring `groups.DeletedAt`'s `AddColumn` immediately above in the same function).
- Added an optional `scopeColumns` parameter to `normalizeColumnInPlace`, portable across SQLite/Postgres via `CAST(...AS TEXT) ||` concatenation (matching `warnIfDuplicatesExist`'s existing `keyExpr` convention), passing `"project_id, environment_id"` from the one real caller.

## Test plan

- [x] 4 new regression tests: 2 mirror `TestCompanionIndexes_CreatedOnUpgrade`'s established simulate-an-upgrade pattern (boot fresh, remove what the fix restores, re-run `migrateDatabase`, confirm re-convergence) for both `roles.name_folded` and secret_nodes NFC normalization; 2 prove the scoping fix directly (same name in different projects does not collide; same name in the same project still does)
- [x] All 4 red/green-verified — temporarily disabled the fix and confirmed each test fails with the exact symptom described above, then restored
- [x] `go build`/`vet`/`gofmt` clean
- [x] Full `internal/storage/...` suite green (`internal/storage`, `models`, `remote`, `sqlitedialect`, `store`)