### PR TITLE
fix(storage): reclaim namedLockRegistry entries after use (#1690)

### DIFF
--- a/internal/storage/store/local_named_lock.go
+++ b/internal/storage/store/local_named_lock.go
@@ -69,7 +69,7 @@ func (r *namedLockRegistry) acquire(lockKey string) *namedLockEntry {
 	e.refs++
 	r.mu.Unlock()
 	e.mu.Lock()
-	return e
+	return e // nosemgrep: trailofbits.go.missing-unlock-before-return.missing-unlock-before-return -- intentional lock handoff: e.mu is returned still locked BY DESIGN, unlocked by the paired release(lockKey, e) call the caller is contractually required to make (see doc comment above); tested under -race in TestWithNamedLock_ConcurrentSameKey_MutualExclusionSurvivesReclamation
 }
 
 // release unlocks e and, if no other caller is currently holding or waiting

--- a/internal/storage/store/local_named_lock.go
+++ b/internal/storage/store/local_named_lock.go
@@ -22,29 +22,67 @@ import (
 // (old, wrong) silently skipping it, or (a naive per-key reentrancy fix atop
 // the OLD single shared mutex) self-deadlocking by re-locking the same mutex
 // the outer call already holds.
+//
+// #1690 regression (Part 2 regression audit, 2026-09-04): FIX-5's own map
+// (originally map[string]*sync.Mutex) never deleted an entry once created --
+// lockKey's key space is per-entity (sodGrantLockKey("user"/"group", ID),
+// projectAdminGuardLockKey(projectID)), so on a long-uptime SQLite/
+// single-process deployment the map grows by one entry per distinct
+// user/group/project ID ever role-managed and never shrinks: an unbounded
+// memory-growth surface the old single-mutex design had no way to exhibit,
+// by construction. Fixed with a refcounted entry: acquire increments refs
+// under r.mu before locking the entry's own mutex; release decrements refs
+// (also under r.mu) after unlocking it and deletes the map entry only once
+// refs reaches zero -- i.e. only once no goroutine anywhere in the process is
+// still holding or waiting on that specific entry. A racing acquire for the
+// same key between another caller's unlock and its release either sees the
+// entry still in the map (bumps refs, reuses the SAME mutex object -- no
+// correctness gap) or finds it already deleted (creates a fresh one for a
+// genuinely uncontended key) -- there is never a window where two different
+// mutex objects are live for the same key at once.
+type namedLockEntry struct {
+	mu   sync.Mutex
+	refs int // guarded by namedLockRegistry.mu, not by mu above
+}
+
 type namedLockRegistry struct {
 	mu    sync.Mutex
-	locks map[string]*sync.Mutex
+	locks map[string]*namedLockEntry
 }
 
 func newNamedLockRegistry() *namedLockRegistry {
-	return &namedLockRegistry{locks: make(map[string]*sync.Mutex)}
+	return &namedLockRegistry{locks: make(map[string]*namedLockEntry)}
 }
 
-// forKey returns the mutex for lockKey, creating it if this is the first
-// caller to ever name it. The registry's own mu only guards the map lookup
-// itself, not the returned mutex's Lock/Unlock -- callers hold the returned
-// mutex for the duration of their critical section, same as before this type
-// existed.
-func (r *namedLockRegistry) forKey(lockKey string) *sync.Mutex {
+// acquire locks and returns the entry for lockKey, creating it if this is the
+// first caller to ever name it (or if a prior entry was already reclaimed).
+// The caller MUST pass the returned entry to release(lockKey, entry) exactly
+// once, after its critical section, to unlock it and let the registry
+// reclaim it once no one else is using it.
+func (r *namedLockRegistry) acquire(lockKey string) *namedLockEntry {
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	m, ok := r.locks[lockKey]
+	e, ok := r.locks[lockKey]
 	if !ok {
-		m = &sync.Mutex{}
-		r.locks[lockKey] = m
+		e = &namedLockEntry{}
+		r.locks[lockKey] = e
 	}
-	return m
+	e.refs++
+	r.mu.Unlock()
+	e.mu.Lock()
+	return e
+}
+
+// release unlocks e and, if no other caller is currently holding or waiting
+// on it, removes lockKey's entry from the registry so its memory is
+// reclaimed rather than retained for the rest of the process's lifetime.
+func (r *namedLockRegistry) release(lockKey string, e *namedLockEntry) {
+	e.mu.Unlock()
+	r.mu.Lock()
+	e.refs--
+	if e.refs == 0 {
+		delete(r.locks, lockKey)
+	}
+	r.mu.Unlock()
 }
 
 // namedLockKey derives a stable int64 advisory-lock key from an arbitrary lockKey
@@ -150,9 +188,8 @@ func (ls *LocalStorage) WithNamedLock(ctx context.Context, lockKey string, fn fu
 	ctx = context.WithValue(ctx, namedLockHeldCtxKey{}, next)
 
 	if ls.db.Dialector.Name() != "postgres" {
-		mu := ls.namedLockMu.forKey(lockKey)
-		mu.Lock()
-		defer mu.Unlock()
+		entry := ls.namedLockMu.acquire(lockKey)
+		defer ls.namedLockMu.release(lockKey, entry)
 		return fn(ctx)
 	}
 

--- a/internal/storage/store/local_named_lock_test.go
+++ b/internal/storage/store/local_named_lock_test.go
@@ -2,10 +2,13 @@ package store
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
@@ -136,4 +139,77 @@ func TestNamedLockKey_StableAndKeyDependent(t *testing.T) {
 	require.NotEqual(t, namedLockKey("key-A"), namedLockKey("key-B"),
 		"different lockKey strings should (in practice) hash to different keys")
 	require.NotEqual(t, int64(0), namedLockKey(""), "even an empty lockKey must produce a deterministic, usable key")
+}
+
+// TestWithNamedLock_RegistryReclaimsEntriesAfterUse is the #1690 regression
+// pin (Part 2 regression audit, 2026-09-04): FIX-5's namedLockRegistry map
+// grew by one entry per distinct lockKey ever seen and never shrank -- an
+// unbounded-memory-growth surface on any long-uptime SQLite/single-process
+// deployment (lockKey's key space is per-entity: one lock per user/group/
+// project ID ever role-managed). After each WithNamedLock call fully
+// completes and no other caller is contending for that same key, the
+// registry must not still be holding that key's entry.
+func TestWithNamedLock_RegistryReclaimsEntriesAfterUse(t *testing.T) {
+	ls := newNamedLockTestStore(t)
+	ctx := context.Background()
+
+	for i := 0; i < 500; i++ {
+		key := fmt.Sprintf("entity-%d", i)
+		require.NoError(t, ls.WithNamedLock(ctx, key, func(ctx context.Context) error {
+			return nil
+		}))
+	}
+
+	ls.namedLockMu.mu.Lock()
+	size := len(ls.namedLockMu.locks)
+	ls.namedLockMu.mu.Unlock()
+	assert.Equal(t, 0, size, "the registry must reclaim each key's entry once its last holder releases it, not retain one entry per distinct key forever")
+}
+
+// TestWithNamedLock_ConcurrentSameKey_MutualExclusionSurvivesReclamation
+// proves the refcounted-reclamation fix (#1690) did not reopen the mutual-
+// exclusion guarantee WithNamedLock exists for: many goroutines racing
+// acquire/release on the SAME key, including races that land exactly on a
+// reclaim-and-recreate boundary, must never observe two goroutines inside the
+// critical section at once. Run with -race to also catch a data race on the
+// shared counter if two goroutines ever held two DIFFERENT mutex objects for
+// what should be one logical key.
+func TestWithNamedLock_ConcurrentSameKey_MutualExclusionSurvivesReclamation(t *testing.T) {
+	ls := newNamedLockTestStore(t)
+
+	const goroutines = 50
+	const itersPerGoroutine = 20
+	var inCriticalSection int32
+	var overlapDetected bool
+	var mu sync.Mutex // guards overlapDetected only
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < itersPerGoroutine; i++ {
+				err := ls.WithNamedLock(context.Background(), "shared-key", func(ctx context.Context) error {
+					n := inCriticalSection + 1
+					inCriticalSection = n
+					if n != 1 {
+						mu.Lock()
+						overlapDetected = true
+						mu.Unlock()
+					}
+					inCriticalSection--
+					return nil
+				})
+				assert.NoError(t, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.False(t, overlapDetected, "two goroutines observed inside WithNamedLock's critical section for the same key at once -- reclamation raced ahead of an active holder")
+
+	ls.namedLockMu.mu.Lock()
+	size := len(ls.namedLockMu.locks)
+	ls.namedLockMu.mu.Unlock()
+	assert.Equal(t, 0, size, "the registry must end empty once every goroutine has released the shared key")
 }


### PR DESCRIPTION
## Summary

Fixes the last remaining open finding from the adversarial-review campaign's Part 2 regression audit batch 4 (#1701's "not yet covered" list, and independently reconfirmed by a second concurrent review session in `keyorix-private/adversarial-review/RUN-META.md`).

PR #1690 (FIX-5) correctly closed a real bug: `namedLockRegistry`'s reentrancy guard used to be a single untyped "any lock held" boolean, so a nested `WithNamedLock` call under a DIFFERENT key from the one already held silently skipped acquiring its own lock — losing cross-replica SoD/admin-ceiling serialization for call chains like `SetProjectMemberRole` (holding `projectAdminGuardLockKey`) calling `AssignUserRole` (needing its own `sodGrantLockKey`). FIX-5's own re-keying of the guard on `lockKey` is sound.

The regression is in how the fix obtains the per-key mutex on the non-Postgres (SQLite/single-process) fallback path: `namedLockRegistry.forKey` lazily created a `*sync.Mutex` per distinct `lockKey` the first time it was seen and stored it in `r.locks[lockKey]` — and nothing ever deleted an entry. `lockKey`'s key space is per-entity (`sodGrantLockKey("user"/"group", ID)`, `projectAdminGuardLockKey(projectID)`), so on a long-uptime SQLite/single-process deployment the map grows by one entry for every distinct user/group/project ID ever role-managed and never shrinks — an unbounded-memory-growth surface the old single-mutex design had no way to exhibit, by construction. Not directly attacker-triggerable at unbounded scale by an unprivileged actor, but any legitimate high-churn tenant (frequent onboarding/offboarding, JIT grants, SCIM-driven group sync) accumulates one `*sync.Mutex` + map entry permanently per distinct ID touched, with no cap or reclamation short of a process restart.

## Fix

Replaced the plain map with a refcounted entry: `acquire` increments `refs` under the registry's own mutex before locking the entry's mutex; `release` decrements `refs` (also under the registry mutex) after unlocking it and deletes the map entry only once `refs` reaches zero — i.e. only once no goroutine anywhere in the process is still holding or waiting on that specific entry. A racing acquire for the same key between another caller's unlock and its release either reuses the still-live entry (refs bumped, same mutex object — no correctness gap) or creates a fresh one (prior entry already reclaimed) — there is never a window where two different mutex objects are live for the same key at once.

## Test plan

- [x] `go build ./...` clean
- [x] `gofmt -l` / `gosec -severity medium -exclude-generated` clean
- [x] `TestWithNamedLock_RegistryReclaimsEntriesAfterUse` — 500 distinct keys acquired/released sequentially, registry ends empty
- [x] `TestWithNamedLock_ConcurrentSameKey_MutualExclusionSurvivesReclamation` — 50 goroutines × 20 iterations racing acquire/release on the same key under `-race`, no overlap detected, registry ends empty
- [x] Both new tests red/green-verified (temporarily removed the `delete` on zero-refcount, confirmed both fail with the exact predicted symptom, restored, confirmed green)
- [x] Full `internal/storage/store` and `internal/core` suites green (this registry underpins SoD/admin-ceiling serialization used broadly)
- [x] Existing FIX-5 reentrancy/nested-different-key tests still pass unmodified
