### PR TITLE
ci: give internal/storage/store its own pinned test-suite leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,22 @@ jobs:
           - leg: core
             timeout: 1800
             coverage-file: coverage_core.out
+          # storage-store (internal/storage/store, re-pinned out of root-4's
+          # catch-all 2026-09-04) -- same trigger as core's own split above: a
+          # real CI run (main, commit b971ed36) found root-4's `go test` step
+          # at 1363s against its 1800s timeout (76% of budget, only ~437s
+          # headroom) -- well past the ~569s root-4 measured at when that
+          # budget was last calibrated. Isolating internal/storage/store alone
+          # locally (go test -timeout 20m, no -race, single run) took 867.818s
+          # BY ITSELF, confirming it as the dominant contributor: the package
+          # picked up a large batch of new *_cascade_sweep_test.go/
+          # *_error_sweep_test.go coverage files since root-4's budget was
+          # last measured. 1800s here for the same reason every other leg
+          # uses it -- generous headroom so a healthy-but-slow run never
+          # trips it, not tuned tight to the observed duration.
+          - leg: storage-store
+            timeout: 1800
+            coverage-file: coverage_storage_store.out
           # handlers (server/http/handlers, one package, 167 test files, 5151
           # top-level tests, all already t.Parallel()) measured at 911s in CI
           # -- vs. 15s wall / 37s summed-per-test locally without -race. That
@@ -767,7 +783,13 @@ jobs:
           source scripts/ci-test-legs.sh
           grep_args=()
           while IFS= read -r pattern; do grep_args+=(-e "$pattern"); done < <(coverage_floor_grep_patterns)
-          tail -q -n +2 coverage_root1.out coverage_root2.out coverage_root3.out coverage_root4.out coverage_handlers1.out coverage_handlers2.out coverage_handlers3.out coverage_handlers4.out coverage_http1.out coverage_http2.out coverage_http3.out coverage_http4.out coverage_http5.out coverage_http6.out | grep -v "${grep_args[@]}" >> coverage_merged.out
+          # coverage_core.out is deliberately NOT in this list -- a pre-existing
+          # gap this PR found but did not fix (out of scope for a CI-sharding
+          # change; internal/core's coverage silently isn't counted toward the
+          # floor). coverage_storage_store.out below is included: it's THIS
+          # leg's own new file, and omitting it would just be reproducing that
+          # same gap in new code rather than inheriting an unrelated one.
+          tail -q -n +2 coverage_root1.out coverage_root2.out coverage_root3.out coverage_root4.out coverage_storage_store.out coverage_handlers1.out coverage_handlers2.out coverage_handlers3.out coverage_handlers4.out coverage_http1.out coverage_http2.out coverage_http3.out coverage_http4.out coverage_http5.out coverage_http6.out | grep -v "${grep_args[@]}" >> coverage_merged.out
           mv coverage_merged.out coverage.out
 
       - name: Check coverage floor (≥${{ env.COVERAGE_FLOOR }}%)

--- a/scripts/ci-test-legs.sh
+++ b/scripts/ci-test-legs.sh
@@ -225,12 +225,31 @@ core_pkgs() {
   echo "github.com/keyorixhq/keyorix/internal/core"
 }
 
+# storage_store_pkgs: internal/storage/store gets its own pinned leg (added
+# 2026-09-04) for the same reason internal/core did -- it grew large enough in
+# root-4's catch-all to threaten that leg's timeout budget. Measured directly:
+# a real CI run (main, commit b971ed36) had root-4's own `go test` step take
+# 1363s against its 1800s timeout (76% of budget, ~437s headroom) -- well past
+# the ~569s root-4 measured at when that budget was last calibrated (see the
+# root-1/2/3/4 comment block below). Isolating internal/storage/store alone
+# (go test -timeout 20m ./internal/storage/store/..., no -race, single local
+# run) took 867.818s BY ITSELF, confirming it as the dominant contributor
+# growing root-4 past its old baseline -- the package picked up a large batch
+# of new *_cascade_sweep_test.go/*_error_sweep_test.go coverage files since
+# root-4 was last measured. Same treatment as core: its own 1800s-timeout leg
+# rather than tuned tight to the observed duration, so a healthy-but-slow run
+# never trips it (see the "unused headroom costs nothing" reasoning in the
+# root-1/2/3/4 comment block below, which applies identically here).
+storage_store_pkgs() {
+  echo "github.com/keyorixhq/keyorix/internal/storage/store"
+}
+
 # root_4_pkgs: the dynamic catch-all -- every root_base() package not pinned
-# to root-1/2/3/core above, so a newly added package always lands somewhere
-# (root-4) rather than silently running nowhere.
+# to root-1/2/3/core/storage-store above, so a newly added package always
+# lands somewhere (root-4) rather than silently running nowhere.
 root_4_pkgs() {
   local pinned
-  pinned=$(cat <(root_1_pkgs) <(root_2_pkgs) <(root_3_pkgs) <(core_pkgs) | sort -u)
+  pinned=$(cat <(root_1_pkgs) <(root_2_pkgs) <(root_3_pkgs) <(core_pkgs) <(storage_store_pkgs) | sort -u)
   comm -23 <(root_base | sort -u) <(echo "$pinned")
 }
 
@@ -727,6 +746,7 @@ pkgs_for_leg() {
     root-3) root_3_pkgs ;;
     core) core_pkgs ;;
     root-4) root_4_pkgs ;;
+    storage-store) storage_store_pkgs ;;
     handlers-1|handlers-2|handlers-3|handlers-4) handlers_pkg ;;
     http-1|http-2|http-3|http-4|http-5|http-6) http_pkg ;;
     *) echo "pkgs_for_leg: unknown leg '$1'" >&2; return 1 ;;
@@ -743,6 +763,7 @@ root-2
 root-3
 root-4
 core
+storage-store
 handlers-1
 handlers-2
 handlers-3


### PR DESCRIPTION
## Summary

`internal/storage/store` currently falls into `root-4`'s dynamic catch-all rather than having its own pinned CI leg. That's become a real risk:

- A real CI run on `main` (commit `b971ed36`) had `root-4`'s actual `go test` step take **1363s against its 1800s timeout — 76% of budget, only ~437s (7.3 min) headroom left.**
- That's well past the **~569s** figure `ci.yml`'s own comments record from when `root-4`'s timeout was last calibrated.
- Isolating `internal/storage/store` alone locally (`go test -timeout 20m ./internal/storage/store/...`, no `-race`, single run) took **867.818s by itself** — confirming it as the dominant contributor. The package picked up a large batch of new `*_cascade_sweep_test.go`/`*_error_sweep_test.go` coverage files since `root-4`'s budget was last measured.

`ci.yml`'s own comments explicitly warn that tuning a leg close to its observed duration "risks exactly the intermittent-red outcome" the repo has hit before — that's the exact reasoning that got `internal/core` (previously in `root-4`'s catch-all too, at a *smaller* 605s figure) split into its own pinned leg. This PR gives `internal/storage/store` the same treatment.

## Changes

- `scripts/ci-test-legs.sh`: new `storage_store_pkgs()` function (single package), excluded from `root_4_pkgs()`'s catch-all computation, added to `pkgs_for_leg()` and `all_leg_names()`.
- `.github/workflows/ci.yml`: new `storage-store` matrix leg, 1800s timeout (matching every other leg's generous-headroom precedent, not tuned tight to the observed duration).
- Wired `coverage_storage_store.out` into the coverage-floor merge step. Along the way, found that `coverage_core.out` is notably **not** in that same merge list — a separate, pre-existing gap (internal/core's coverage silently isn't counted toward the floor). Out of scope for a CI-scheduling change, not fixed here, flagging for a separate follow-up.

## Verification

- [x] `shellcheck scripts/ci-test-legs.sh` — clean
- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] `assert_leg_completeness` (sourced locally) — passes, every non-excluded package still covered by exactly one leg
- [x] Confirmed `pkgs_for_leg storage-store` returns `internal/storage/store` and `root_4_pkgs` no longer includes it (no double-run)
- [x] This is a workflow/script-only change — no Go source touched, so `go build`/`go vet` are unaffected
