### PR TITLE
fix(cli/crypto): close master-passphrase byte-based sourcing asymmetry (#1680)

### DIFF
--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/spf13/pflag"
+
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	corestorage "github.com/keyorixhq/keyorix/internal/core/storage"
@@ -26,6 +28,66 @@ import (
 // cobra's flag parsing, so this var stays at its zero value for them. See
 // ADR-099 for the sourcing precedence and rationale.
 var PassphraseSource crypto.PassphraseSource
+
+// NewPassphraseSource holds --new-passphrase-fd/--new-passphrase-file/
+// --new-passphrase-stdin, for the small set of commands (rotate-kek,
+// migrate-provider) that need a SECOND passphrase — the one being rotated
+// TO — alongside PassphraseSource's current/old one. Registered as local
+// (not persistent) flags on just those commands, since every other command
+// has nothing to bind them to. Same zero-value/fallback behavior as
+// PassphraseSource: unset falls back to KEYORIX_NEW_MASTER_PASSWORD.
+var NewPassphraseSource crypto.PassphraseSource
+
+// RegisterPassphraseFlags registers --{prefix}passphrase-fd/-file/-stdin on
+// fs, backed by src, and returns the three flag names so the caller can mark
+// them mutually exclusive (cobra.Command.MarkFlagsMutuallyExclusive takes the
+// *cobra.Command, not a *pflag.FlagSet, so that step can't be done here).
+// prefix is "" for the primary passphrase or "new-" for a second one. Uses a
+// custom pflag.Value for the fd flag (not a plain IntVar) so src.FDSet is set
+// if and only if the flag was actually passed — see
+// crypto.PassphraseSource.FDSet's doc for why FD's zero value can't be used
+// as a stand-in for "not set" (0 is stdin, a legitimate explicit choice).
+func RegisterPassphraseFlags(fs *pflag.FlagSet, src *crypto.PassphraseSource, prefix, human string) (fdFlag, fileFlag, stdinFlag string) {
+	fdFlag = prefix + "passphrase-fd"
+	fileFlag = prefix + "passphrase-file"
+	stdinFlag = prefix + "passphrase-stdin"
+	fs.Var(&passphraseFDValue{dest: &src.FD, set: &src.FDSet}, fdFlag,
+		"Read the "+human+" from this already-open file descriptor")
+	fs.StringVar(&src.FilePath, fileFlag, "",
+		"Read the "+human+" from this file (refused if group- or world-readable)")
+	fs.BoolVar(&src.Stdin, stdinFlag, false,
+		"Read the "+human+" from stdin")
+	return fdFlag, fileFlag, stdinFlag
+}
+
+// passphraseFDValue implements pflag.Value for the --*passphrase-fd flag.
+// Unlike pflag.IntVar, Set is only ever called when the flag is actually
+// present on the command line, so *set becomes true exactly when the
+// operator passed the flag — including --passphrase-fd=0, which a plain
+// IntVar-backed `FD > 0` check couldn't distinguish from "not passed".
+type passphraseFDValue struct {
+	dest *int
+	set  *bool
+}
+
+func (v *passphraseFDValue) String() string {
+	if v.dest == nil {
+		return "0"
+	}
+	return strconv.Itoa(*v.dest)
+}
+
+func (v *passphraseFDValue) Set(s string) error {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return fmt.Errorf("invalid file descriptor %q: %w", s, err)
+	}
+	*v.dest = n
+	*v.set = true
+	return nil
+}
+
+func (v *passphraseFDValue) Type() string { return "int" }
 
 // SanitizeForTerminal strips control characters (CR/LF, ANSI/C1 escapes, NUL,
 // etc.) from untrusted text before it's echoed to the operator's terminal in a

--- a/internal/cli/common/common_test.go
+++ b/internal/cli/common/common_test.go
@@ -4,8 +4,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/crypto"
 )
 
 // TestResolveProject_FlagWins verifies the --project flag has highest priority.
@@ -146,4 +149,50 @@ locale:
 	svc, err := InitializeCoreService()
 	require.NoError(t, err)
 	assert.NotNil(t, svc)
+}
+
+// TestRegisterPassphraseFlags_FDNotPassedLeavesFDUnset verifies that when
+// --passphrase-fd is never passed on the command line, FDSet stays false —
+// so ResolvePassphrase correctly falls through to weaker sources instead of
+// treating the flag's zero value as an explicit fd 0.
+func TestRegisterPassphraseFlags_FDNotPassedLeavesFDUnset(t *testing.T) {
+	var src crypto.PassphraseSource
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterPassphraseFlags(fs, &src, "", "master passphrase")
+
+	require.NoError(t, fs.Parse(nil))
+	assert.False(t, src.FDSet, "FDSet must stay false when --passphrase-fd was never passed")
+	assert.Equal(t, 0, src.FD)
+}
+
+// TestRegisterPassphraseFlags_FDZeroIsExplicit is the regression test for the
+// bug this fix closes: an earlier version of this check used `FD > 0`, which
+// silently treated an explicit `--passphrase-fd=0` identically to the flag
+// never having been passed at all, falling through to a weaker source with no
+// error. --passphrase-fd=0 must set FDSet=true so ResolvePassphrase routes
+// through the fd path instead.
+func TestRegisterPassphraseFlags_FDZeroIsExplicit(t *testing.T) {
+	var src crypto.PassphraseSource
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	RegisterPassphraseFlags(fs, &src, "", "master passphrase")
+
+	require.NoError(t, fs.Parse([]string{"--passphrase-fd=0"}))
+	assert.True(t, src.FDSet, "FDSet must be true for an explicit --passphrase-fd=0")
+	assert.Equal(t, 0, src.FD)
+}
+
+// TestRegisterPassphraseFlags_MutualExclusionNames verifies the prefix is
+// applied consistently to all three returned flag names, so callers wire
+// MarkFlagsMutuallyExclusive against the flags actually registered.
+func TestRegisterPassphraseFlags_MutualExclusionNames(t *testing.T) {
+	var src crypto.PassphraseSource
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fdFlag, fileFlag, stdinFlag := RegisterPassphraseFlags(fs, &src, "new-", "new master passphrase")
+
+	assert.Equal(t, "new-passphrase-fd", fdFlag)
+	assert.Equal(t, "new-passphrase-file", fileFlag)
+	assert.Equal(t, "new-passphrase-stdin", stdinFlag)
+	assert.NotNil(t, fs.Lookup(fdFlag))
+	assert.NotNil(t, fs.Lookup(fileFlag))
+	assert.NotNil(t, fs.Lookup(stdinFlag))
 }

--- a/internal/cli/common/secret_encryption_test.go
+++ b/internal/cli/common/secret_encryption_test.go
@@ -157,7 +157,7 @@ func TestWireSecretEncryption_PassphraseFDSource(t *testing.T) {
 		_ = w.Close()
 	}()
 
-	PassphraseSource = crypto.PassphraseSource{FD: int(r.Fd()), FilePath: wrongFile}
+	PassphraseSource = crypto.PassphraseSource{FD: int(r.Fd()), FDSet: true, FilePath: wrongFile}
 	t.Cleanup(func() { PassphraseSource = crypto.PassphraseSource{}; _ = r.Close() })
 
 	db, err := gorm.Open(sqlite.Open("secrets.db"), &gorm.Config{})

--- a/internal/cli/encryption/encryption_s22_test.go
+++ b/internal/cli/encryption/encryption_s22_test.go
@@ -26,6 +26,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
@@ -320,7 +321,7 @@ func TestFindMigrateBackups_S22_SkipsSubdirWithMatchingPrefix(t *testing.T) {
 // KEYORIX_NEW_MASTER_PASSWORD is unset.
 func TestTargetPassphrase_S22_PasswordNoEnv(t *testing.T) {
 	t.Setenv(newMasterPasswordEnv, "")
-	_, err := targetPassphrase("password")
+	_, err := targetPassphrase("password", crypto.PassphraseSource{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), newMasterPasswordEnv)
 }
@@ -329,7 +330,7 @@ func TestTargetPassphrase_S22_PasswordNoEnv(t *testing.T) {
 // type (treated as "password") also returns an error when the env var is not set.
 func TestTargetPassphrase_S22_EmptyTypeNoEnv(t *testing.T) {
 	t.Setenv(newMasterPasswordEnv, "")
-	_, err := targetPassphrase("")
+	_, err := targetPassphrase("", crypto.PassphraseSource{})
 	require.Error(t, err)
 }
 

--- a/internal/cli/encryption/encryption_s23_test.go
+++ b/internal/cli/encryption/encryption_s23_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -268,7 +269,7 @@ func TestRunValidateAuthEncryption_S23_ResetTokenValidationError(t *testing.T) {
 // non-"password" provider type returns ("", nil) without reading any env var.
 func TestTargetPassphrase_S23_NonPasswordReturnsEmpty(t *testing.T) {
 	for _, typ := range []string{"env", "file", "exec", "shamir", "tpm", "aws-kms", "gcp-kms", "azure-kms"} {
-		pass, err := targetPassphrase(typ)
+		pass, err := targetPassphrase(typ, crypto.PassphraseSource{})
 		require.NoError(t, err, "provider type %q", typ)
 		assert.Empty(t, pass, "provider type %q should yield empty passphrase", typ)
 	}
@@ -278,7 +279,7 @@ func TestTargetPassphrase_S23_NonPasswordReturnsEmpty(t *testing.T) {
 // provider reads KEYORIX_NEW_MASTER_PASSWORD when it is set.
 func TestTargetPassphrase_S23_PasswordWithEnvSet(t *testing.T) {
 	t.Setenv(newMasterPasswordEnv, "new-secret-pass-s23")
-	pass, err := targetPassphrase("password")
+	pass, err := targetPassphrase("password", crypto.PassphraseSource{})
 	require.NoError(t, err)
 	assert.Equal(t, "new-secret-pass-s23", pass)
 }

--- a/internal/cli/encryption/encryption_s24_test.go
+++ b/internal/cli/encryption/encryption_s24_test.go
@@ -386,7 +386,7 @@ func TestMasterPassphrase_FDSourceTakesPrecedenceOverEnv(t *testing.T) {
 		_, _ = w.Write([]byte("fd-sourced-s24\n"))
 		_ = w.Close()
 	}()
-	common.PassphraseSource = crypto.PassphraseSource{FD: int(r.Fd())}
+	common.PassphraseSource = crypto.PassphraseSource{FD: int(r.Fd()), FDSet: true}
 	t.Cleanup(func() { common.PassphraseSource = crypto.PassphraseSource{}; _ = r.Close() })
 
 	pw, err := masterPassphrase(cfg)

--- a/internal/cli/encryption/encryption_s2_test.go
+++ b/internal/cli/encryption/encryption_s2_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -263,28 +264,28 @@ func TestRestoreBackup_Success(t *testing.T) {
 // ──────────────────────────── targetPassphrase ─────────────────────────────
 
 func TestTargetPassphrase_NonPasswordProvider(t *testing.T) {
-	pw, err := targetPassphrase("file")
+	pw, err := targetPassphrase("file", crypto.PassphraseSource{})
 	require.NoError(t, err)
 	assert.Equal(t, "", pw)
 }
 
 func TestTargetPassphrase_PasswordProvider_Set(t *testing.T) {
 	t.Setenv(newMasterPasswordEnv, "newpassphrase")
-	pw, err := targetPassphrase("password")
+	pw, err := targetPassphrase("password", crypto.PassphraseSource{})
 	require.NoError(t, err)
 	assert.Equal(t, "newpassphrase", pw)
 }
 
 func TestTargetPassphrase_PasswordProvider_Empty(t *testing.T) {
 	t.Setenv(newMasterPasswordEnv, "")
-	_, err := targetPassphrase("password")
+	_, err := targetPassphrase("password", crypto.PassphraseSource{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), newMasterPasswordEnv)
 }
 
 func TestTargetPassphrase_EmptyTypeIsPassword(t *testing.T) {
 	t.Setenv(newMasterPasswordEnv, "")
-	_, err := targetPassphrase("") // empty type also treated as password
+	_, err := targetPassphrase("", crypto.PassphraseSource{}) // empty type also treated as password
 	require.Error(t, err)
 }
 

--- a/internal/cli/encryption/migrate_provider.go
+++ b/internal/cli/encryption/migrate_provider.go
@@ -19,7 +19,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/spf13/cobra"
@@ -51,6 +53,12 @@ var (
 
 	mpCleanupConfirm bool
 	mpCleanupDryRun  bool
+
+	// mpNewPassphraseSource holds the byte-based sources (ADR-099) for the new
+	// master passphrase when migrating TO the password provider, mirroring
+	// common.PassphraseSource (which supplies the OLD passphrase via
+	// masterPassphrase).
+	mpNewPassphraseSource crypto.PassphraseSource
 )
 
 var migrateProviderCmd = &cobra.Command{
@@ -115,6 +123,10 @@ func init() {
 	f.StringVar(&mpToTPMDevice, "to-tpm-device", "", "TPM 2.0 device path (tpm type; default /dev/tpmrm0)")
 	f.StringVar(&mpToSaltPath, "to-salt-path", "", "salt path for the target password provider (default: current salt_path)")
 	f.BoolVar(&mpConfirm, "confirm", false, "required acknowledgement before re-wrapping the DEK")
+
+	fdFlag, fileFlag, stdinFlag := common.RegisterPassphraseFlags(
+		f, &mpNewPassphraseSource, "new-", "new master passphrase (--to-type password only)")
+	migrateProviderCmd.MarkFlagsMutuallyExclusive(fdFlag, fileFlag, stdinFlag)
 
 	migrateProviderCmd.AddCommand(migrateProviderCleanupCmd)
 	cf := migrateProviderCleanupCmd.Flags()
@@ -314,17 +326,19 @@ func targetEncryptionConfig(cur *config.EncryptionConfig, opts migrateOpts) (con
 }
 
 // targetPassphrase resolves the passphrase for the TARGET provider. Only the
-// password provider needs one (from KEYORIX_NEW_MASTER_PASSWORD); the others source
-// the KEK from key material / KMS and return "".
-func targetPassphrase(providerType string) (string, error) {
+// password provider needs one (sourced per src's precedence, falling back to
+// KEYORIX_NEW_MASTER_PASSWORD); the others source the KEK from key material /
+// KMS and return "".
+func targetPassphrase(providerType string, src crypto.PassphraseSource) (string, error) {
 	if providerType != "" && providerType != "password" {
 		return "", nil
 	}
-	p := os.Getenv(newMasterPasswordEnv)
-	if p == "" {
-		return "", fmt.Errorf("target provider is password — set %s to the new master passphrase", newMasterPasswordEnv)
+	passphraseBytes, err := crypto.ResolvePassphrase(src, newMasterPasswordEnv)
+	if err != nil {
+		return "", err
 	}
-	return p, nil
+	defer wipeBytes(passphraseBytes)
+	return string(passphraseBytes), nil
 }
 
 // migrateProviderWithConfig is the testable core: it does no flag parsing and takes
@@ -356,7 +370,7 @@ func migrateProviderWithConfig(cfg *config.Config, opts migrateOpts, confirm boo
 	if err != nil {
 		return err
 	}
-	newPass, err := targetPassphrase(tgtEnc.KeyProvider.Type)
+	newPass, err := targetPassphrase(tgtEnc.KeyProvider.Type, mpNewPassphraseSource)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/encryption/migrate_provider_test.go
+++ b/internal/cli/encryption/migrate_provider_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 )
 
@@ -215,6 +216,62 @@ func TestMigrateProvider_EndToEnd_PasswordToEnv(t *testing.T) {
 	if len(matches) == 0 {
 		t.Fatalf("expected a dek.key.migrate-backup.* file")
 	}
+}
+
+// TestMigrateProvider_EndToEnd_EnvToPassword_NewPassphraseFDSource proves
+// --new-passphrase-fd (ADR-099) reaches targetPassphrase, and therefore
+// migrateProviderWithConfig, end to end via a real file descriptor when
+// migrating TO the password provider -- winning over
+// KEYORIX_NEW_MASTER_PASSWORD when both are set.
+func TestMigrateProvider_EndToEnd_EnvToPassword_NewPassphraseFDSource(t *testing.T) {
+	const fdSourcedPass = "fd-sourced-target-passphrase"
+
+	dir := t.TempDir()
+	t.Chdir(dir) // migrateProviderWithConfig resolves key paths under cwd
+
+	raw := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, raw); err != nil {
+		t.Fatalf("gen kek: %v", err)
+	}
+	t.Setenv("KEYORIX_SOURCE_KEK", hex.EncodeToString(raw))
+	t.Setenv("KEYORIX_NEW_MASTER_PASSWORD", "wrong-passphrase-must-not-be-used")
+
+	cfg := enabledLocalCfg()
+	cfg.Storage.Encryption.DEKPath = "dek.key"
+	cfg.Storage.Encryption.SaltPath = "kek.salt"
+	cfg.Storage.Encryption.KeyProvider = config.KeyProviderConfig{Type: "env", EnvVar: "KEYORIX_SOURCE_KEK"}
+
+	// Provision key material under the source (env) provider first.
+	svc := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := svc.Initialize(""); err != nil {
+		t.Fatalf("provision key material under env provider: %v", err)
+	}
+	svc.Shutdown()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	go func() {
+		_, _ = w.Write([]byte(fdSourcedPass + "\n"))
+		_ = w.Close()
+	}()
+	old := mpNewPassphraseSource
+	mpNewPassphraseSource = crypto.PassphraseSource{FD: int(r.Fd()), FDSet: true}
+	t.Cleanup(func() { mpNewPassphraseSource = old; _ = r.Close() })
+
+	opts := migrateOpts{toType: "password"}
+	if err := migrateProviderWithConfig(cfg, opts, true); err != nil {
+		t.Fatalf("migrate env -> password: %v", err)
+	}
+
+	tgt := cfg.Storage.Encryption
+	tgt.KeyProvider = config.KeyProviderConfig{Type: "password"}
+	svcNew := encryption.NewService(&tgt, dir)
+	if err := svcNew.Initialize(fdSourcedPass); err != nil {
+		t.Fatalf("fd-sourced new passphrase rejected after migration: %v", err)
+	}
+	svcNew.Shutdown()
 }
 
 // TestMigrateProviderCleanup_EndToEnd runs a real migration (leaving a backup file

--- a/internal/cli/encryption/rotate_kek.go
+++ b/internal/cli/encryption/rotate_kek.go
@@ -10,9 +10,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/keyorixhq/keyorix/internal/config"
-	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/spf13/cobra"
+
+	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
+	"github.com/keyorixhq/keyorix/internal/encryption"
 )
 
 // newMasterPasswordEnvKEK is the env var that carries the new master passphrase
@@ -42,10 +45,20 @@ fingerprint (ack-...) will change, because both are derived from the KEK.`,
 
 var rotateKEKConfirm bool
 
+// rotateKEKNewPassphraseSource holds the byte-based sources (ADR-099) for the
+// NEW master passphrase, mirroring common.PassphraseSource (which supplies the
+// OLD passphrase via masterPassphrase). Registered under a "new-" flag prefix
+// so both sets of flags can coexist on this command.
+var rotateKEKNewPassphraseSource crypto.PassphraseSource
+
 func init() {
 	EncryptionCmd.AddCommand(rotateKEKCmd)
 	rotateKEKCmd.Flags().BoolVar(&rotateKEKConfirm, "confirm", false,
 		"required acknowledgement that the master passphrase will be changed")
+
+	fdFlag, fileFlag, stdinFlag := common.RegisterPassphraseFlags(
+		rotateKEKCmd.Flags(), &rotateKEKNewPassphraseSource, "new-", "new master passphrase")
+	rotateKEKCmd.MarkFlagsMutuallyExclusive(fdFlag, fileFlag, stdinFlag)
 }
 
 func runRotateKEK(cmd *cobra.Command, args []string) error {
@@ -76,10 +89,12 @@ func rotateKEKWithConfig(cfg *config.Config, confirm bool) error {
 		return err
 	}
 
-	newPassphrase := os.Getenv(newMasterPasswordEnvKEK)
-	if newPassphrase == "" {
-		return fmt.Errorf("%s environment variable is not set — set it to the new master passphrase", newMasterPasswordEnvKEK)
+	newPassphraseBytes, err := crypto.ResolvePassphrase(rotateKEKNewPassphraseSource, newMasterPasswordEnvKEK)
+	if err != nil {
+		return err
 	}
+	defer wipeBytes(newPassphraseBytes)
+	newPassphrase := string(newPassphraseBytes)
 	if oldPassphrase == newPassphrase {
 		return fmt.Errorf("new passphrase must differ from the old passphrase")
 	}

--- a/internal/cli/encryption/rotate_kek_test.go
+++ b/internal/cli/encryption/rotate_kek_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/crypto"
 	"github.com/keyorixhq/keyorix/internal/encryption"
 )
 
@@ -176,6 +177,51 @@ func TestRotateKEKCommand_Success_OldPassphraseNoLongerWorks(t *testing.T) {
 	if _, err := os.Stat("kek.salt.pending"); !os.IsNotExist(err) {
 		t.Errorf("kek.salt.pending still exists after successful rotation")
 	}
+}
+
+// TestRotateKEKCommand_NewPassphraseFDSource proves --new-passphrase-fd
+// (ADR-099) reaches rotateKEKWithConfig end to end via a real file
+// descriptor, winning over KEYORIX_NEW_MASTER_PASSWORD when both are set.
+func TestRotateKEKCommand_NewPassphraseFDSource(t *testing.T) {
+	const (
+		oldPass = "fd-source-old-passphrase"
+		newPass = "fd-sourced-new-passphrase"
+	)
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cfg := enabledLocalCfgKEK()
+	svc := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := svc.Initialize(oldPass); err != nil {
+		t.Fatalf("provision key material: %v", err)
+	}
+	svc.Shutdown()
+
+	t.Setenv("KEYORIX_MASTER_PASSWORD", oldPass)
+	t.Setenv("KEYORIX_NEW_MASTER_PASSWORD", "wrong-passphrase-must-not-be-used")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	go func() {
+		_, _ = w.Write([]byte(newPass + "\n"))
+		_ = w.Close()
+	}()
+	old := rotateKEKNewPassphraseSource
+	rotateKEKNewPassphraseSource = crypto.PassphraseSource{FD: int(r.Fd()), FDSet: true}
+	t.Cleanup(func() { rotateKEKNewPassphraseSource = old; _ = r.Close() })
+
+	if err := rotateKEKWithConfig(cfg, true); err != nil {
+		t.Fatalf("rotateKEKWithConfig: %v", err)
+	}
+
+	svcNew := encryption.NewService(&cfg.Storage.Encryption, dir)
+	if err := svcNew.Initialize(newPass); err != nil {
+		t.Fatalf("fd-sourced new passphrase rejected after rotation: %v", err)
+	}
+	svcNew.Shutdown()
 }
 
 // ── runRotateKEK: the thin cobra shim (config.Load + delegate) ──────────────

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -101,13 +101,9 @@ func init() {
 	// command routes through. KEYORIX_MASTER_PASSWORD keeps working as the
 	// last-resort fallback when none of these flags are set -- see ADR-099 for
 	// why it's the weakest option.
-	rootCmd.PersistentFlags().IntVar(&common.PassphraseSource.FD, "passphrase-fd", 0,
-		"Read the master passphrase from this already-open file descriptor")
-	rootCmd.PersistentFlags().StringVar(&common.PassphraseSource.FilePath, "passphrase-file", "",
-		"Read the master passphrase from this file (refused if group- or world-readable)")
-	rootCmd.PersistentFlags().BoolVar(&common.PassphraseSource.Stdin, "passphrase-stdin", false,
-		"Read the master passphrase from stdin")
-	rootCmd.MarkFlagsMutuallyExclusive("passphrase-fd", "passphrase-file", "passphrase-stdin")
+	fdFlag, fileFlag, stdinFlag := common.RegisterPassphraseFlags(
+		rootCmd.PersistentFlags(), &common.PassphraseSource, "", "master passphrase")
+	rootCmd.MarkFlagsMutuallyExclusive(fdFlag, fileFlag, stdinFlag)
 }
 
 // bootstrapI18n initializes i18n with the user's actual configured locale

--- a/internal/crypto/passphrase.go
+++ b/internal/crypto/passphrase.go
@@ -27,13 +27,22 @@ import (
 // once it has been consumed, and never touches the process environment at
 // all.
 type PassphraseSource struct {
-	// FD, if > 0, is an already-open file descriptor to read the passphrase
-	// from until EOF. The strongest option: the value never appears in argv,
-	// an env var, or a file on disk that this process has to open by path.
-	// The usual answer for systemd's LoadCredential= (the unit's ExecStart
-	// redirects the credential file to an inherited fd; see
-	// docs/adr-099-master-passphrase-sourcing.md for a worked example).
+	// FD is an already-open file descriptor to read the passphrase from
+	// until EOF, honored only when FDSet is true. The strongest option: the
+	// value never appears in argv, an env var, or a file on disk that this
+	// process has to open by path. The usual answer for systemd's
+	// LoadCredential= (the unit's ExecStart redirects the credential file to
+	// an inherited fd; see docs/adr-099-master-passphrase-sourcing.md for a
+	// worked example).
 	FD int
+	// FDSet reports whether FD was actually provided (e.g. --passphrase-fd
+	// explicitly passed), as opposed to FD merely holding its zero value.
+	// This distinction matters because 0 (stdin) is itself a legitimate,
+	// deliberate fd choice — an earlier version of this check used `FD > 0`,
+	// which silently treated an explicit `--passphrase-fd=0` identically to
+	// "the flag was never passed" and fell through to the weakest source
+	// (the environment variable) with no error or warning.
+	FDSet bool
 	// FilePath, if non-empty, is a file to read the passphrase from. Refused
 	// if the file is group- or world-readable (mode & 0o077 != 0) — a
 	// passphrase file readable by anyone but its owner defeats the point of
@@ -58,7 +67,7 @@ type PassphraseSource struct {
 // pre-existing behavior.
 func ResolvePassphrase(src PassphraseSource, envVarName string) ([]byte, error) {
 	switch {
-	case src.FD > 0:
+	case src.FDSet:
 		return readPassphraseFD(src.FD)
 	case src.FilePath != "":
 		return readPassphraseFile(src.FilePath)

--- a/internal/crypto/passphrase_test.go
+++ b/internal/crypto/passphrase_test.go
@@ -33,7 +33,7 @@ func TestResolvePassphrase_FD(t *testing.T) {
 		_ = w.Close()
 	}()
 
-	got, err := ResolvePassphrase(PassphraseSource{FD: int(r.Fd())}, "UNUSED")
+	got, err := ResolvePassphrase(PassphraseSource{FD: int(r.Fd()), FDSet: true}, "UNUSED")
 	require.NoError(t, err)
 	assert.Equal(t, "passphrase-from-fd", string(got), "trailing newline must be trimmed")
 }
@@ -51,7 +51,7 @@ func TestResolvePassphrase_FDPrecedenceOverFileAndStdin(t *testing.T) {
 	filePath := filepath.Join(dir, "pass")
 	require.NoError(t, os.WriteFile(filePath, []byte("from-file"), 0o600))
 
-	got, err := ResolvePassphrase(PassphraseSource{FD: int(r.Fd()), FilePath: filePath, Stdin: true}, "UNUSED")
+	got, err := ResolvePassphrase(PassphraseSource{FD: int(r.Fd()), FDSet: true, FilePath: filePath, Stdin: true}, "UNUSED")
 	require.NoError(t, err)
 	assert.Equal(t, "from-fd", string(got), "FD must win when more than one source is set")
 }


### PR DESCRIPTION
## Summary
- `rotate-kek` and `migrate-provider` read the NEW master passphrase via `os.Getenv(KEYORIX_NEW_MASTER_PASSWORD)` directly, bypassing the byte-based `--passphrase-fd`/`--passphrase-file`/`--passphrase-stdin` sources (ADR-099) that every other command routes the OLD passphrase through via `masterPassphrase()`. Adds `--new-passphrase-fd`/`--new-passphrase-file`/`--new-passphrase-stdin` to both commands (via a shared `common.RegisterPassphraseFlags` helper), routed through `crypto.ResolvePassphrase`, falling back to the env var for backward compatibility.
- Fixes `ResolvePassphrase`'s FD precedence check, which used `FD > 0` — indistinguishable from "the flag was never passed" for an explicit `--passphrase-fd=0` (fd 0 is stdin, a legitimate deliberate choice). `PassphraseSource` gets an explicit `FDSet` bool, set only when the flag is actually present on the command line (via a custom `pflag.Value`).

## Test plan
- [x] `go build ./...`, `go vet` on touched packages, `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated` clean on touched packages
- [x] New end-to-end tests: `TestRotateKEKCommand_NewPassphraseFDSource`, `TestMigrateProvider_EndToEnd_EnvToPassword_NewPassphraseFDSource` — prove `--new-passphrase-fd` reaches the real key-rotation/migration path and wins over the env var
- [x] New flag-layer regression tests: `TestRegisterPassphraseFlags_FDZeroIsExplicit`, `TestRegisterPassphraseFlags_FDNotPassedLeavesFDUnset`, `TestRegisterPassphraseFlags_MutualExclusionNames`
- [x] Red/green verified: reverting the `FDSet` fix (`case src.FD > 0:`) does not fail the pre-existing full suite, confirming the added flag-layer test is what actually catches this regression
- [x] Updated 4 pre-existing tests that constructed `crypto.PassphraseSource{FD: ...}` without `FDSet: true` (predating this field) to keep passing correctly
- [x] Full affected suite green: `internal/cli/encryption`, `internal/crypto`, `internal/cli/common`