### PR TITLE
fix(http,grpc): wire OwnerMachineIdentityID into CreateSecret entry points (#1625)

### DIFF
--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -66,6 +66,16 @@ func (s *SecretGRPCService) CreateSecret(ctx context.Context, req *pb.CreateSecr
 		CreatedBy:     user.Username,
 		OwnerID:       user.UserID,
 	}
+	// #1625 (#1573 machine-actor attribution family, Part 2 continuation
+	// finding): mirrors the HTTP CreateSecret handler's identical fix --
+	// OwnerMachineIdentityID exists on CreateSecretRequest and is threaded
+	// through to the persisted model, but this gRPC entry point never
+	// populated it, so a machine caller's secret creation over gRPC landed
+	// with zero identifying information (same gap as the HTTP path, just
+	// unfixed here too).
+	if user.ActorType == core.ActorTypeMachine {
+		coreReq.OwnerMachineIdentityID = user.MachineIdentityID
+	}
 	if req.ParentId != nil && req.GetParentId() != 0 {
 		pID := uint(req.GetParentId())
 		coreReq.ParentID = &pID

--- a/server/grpc/services/secret_service_machine_attribution_test.go
+++ b/server/grpc/services/secret_service_machine_attribution_test.go
@@ -1,0 +1,56 @@
+// secret_service_machine_attribution_test.go — #1625 gRPC counterpart to
+// server/http/handlers/secrets_crud_machine_attribution_test.go: the gRPC
+// CreateSecret RPC had the identical unwired-OwnerMachineIdentityID gap as
+// the HTTP handler. Drives the real gRPC service (not core.CreateSecret
+// directly), matching the finding's own call-out that the original PR's test
+// bypassed both real entry points.
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/grpc/interceptors"
+	pb "github.com/keyorixhq/keyorix/server/proto/pb"
+)
+
+// machineAuthCtx returns a context carrying a machine principal, as the auth
+// interceptor would populate it for a real machine token (see
+// server/middleware/auth.go's machineUserContext for the equivalent HTTP
+// shape: Username set to the machine identity's own Name).
+func machineAuthCtx(machineID uint, name string) context.Context {
+	return context.WithValue(context.Background(), interceptors.GetUserContextKey(),
+		&interceptors.UserContext{ActorType: core.ActorTypeMachine, MachineIdentityID: machineID, Username: name})
+}
+
+// TestSecretService_CreateSecret_MachineActor_AttributedToOwnerMachineIdentityID
+// drives the real gRPC CreateSecret RPC as an authorized machine principal
+// and confirms the persisted secret's OwnerMachineIdentityID is populated.
+func TestSecretService_CreateSecret_MachineActor_AttributedToOwnerMachineIdentityID(t *testing.T) {
+	r := newSecretTestRig(t)
+
+	const machineID = uint(50)
+	require.NoError(t, r.db.Create(&models.MachineIdentity{
+		ID: machineID, ProjectID: 1, Name: "ci-runner-grpc", State: "active",
+	}).Error)
+	require.NoError(t, r.db.Create(&models.MachineIdentityRole{
+		MachineIdentityID: machineID, RoleID: writerRoleID, ProjectID: 1, EnvironmentID: 0,
+	}).Error)
+
+	ctx := machineAuthCtx(machineID, "ci-runner-grpc")
+	sec, err := r.svc.CreateSecret(ctx, &pb.CreateSecretRequest{
+		Name: "machine-created-secret-grpc", Value: "s3cr3t", ProjectId: 1, EnvironmentId: 1, Type: "password",
+	})
+	require.NoError(t, err)
+
+	var created models.SecretNode
+	require.NoError(t, r.db.Where("name = ?", "machine-created-secret-grpc").First(&created).Error)
+	assert.Equal(t, uint(0), created.OwnerID, "a machine caller's UserID is 0 by convention (ADR-030) -- must not collide with a real user ID")
+	assert.Equal(t, machineID, created.OwnerMachineIdentityID, "#1625: a machine-created secret over gRPC must record WHICH machine created it, not leave both owner columns at zero")
+	assert.Equal(t, uint32(0), sec.GetOwnerId())
+}

--- a/server/grpc/services/secret_service_test.go
+++ b/server/grpc/services/secret_service_test.go
@@ -49,6 +49,7 @@ func newSecretTestRig(t *testing.T) *secretTestRig {
 		&models.Permission{}, &models.RolePermission{}, &models.UserRole{},
 		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
 		&models.DynamicSecretConfig{}, &models.SecretACL{}, &models.SecretAccessSchedule{},
+		&models.MachineIdentity{}, &models.MachineIdentityRole{},
 	))
 	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "default"}).Error)
 	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "development"}).Error)

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -81,6 +81,17 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 		CreatedBy:      userCtx.Username,
 		OwnerID:        userCtx.UserID,
 	}
+	// #1625 (#1573 machine-actor attribution family, Part 2 continuation
+	// finding): CreateSecretRequest.OwnerMachineIdentityID exists and is
+	// threaded through to the persisted model (core/secrets.go), matching
+	// every sibling model this PR family touched -- but this real entry point
+	// never populated it. Without this, a machine identity's secret creation
+	// lands with OwnerID=0 AND OwnerMachineIdentityID=0, indistinguishable
+	// from an orphaned/legacy row for exactly the incident-response/
+	// compliance-audit use case the discriminator-field pattern exists for.
+	if userCtx.MachineIdentityID != nil {
+		req.OwnerMachineIdentityID = *userCtx.MachineIdentityID
+	}
 
 	response, err := h.coreService.CreateSecret(r.Context(), req)
 	if err != nil {

--- a/server/http/handlers/secrets_crud_machine_attribution_test.go
+++ b/server/http/handlers/secrets_crud_machine_attribution_test.go
@@ -1,0 +1,151 @@
+// secrets_crud_machine_attribution_test.go — #1625 (#1573 machine-actor
+// attribution family, Part 2 continuation finding, 2026-09-04): every other
+// model CreateSecretRequest's sibling PR touched (invitations, machine
+// identities, break-glass, access-review campaigns, secret dependencies,
+// setup tokens) got its own *MachineIdentityID companion field AND had its
+// real production entry points updated to populate it. SecretNode.
+// OwnerMachineIdentityID got the model column and the request-struct field --
+// the full shape of a completed fix -- but neither real production entry
+// point (this HTTP handler, nor the gRPC CreateSecret RPC) was ever updated
+// to set it. The original PR's own regression test called core.CreateSecret
+// directly, bypassing both real handlers entirely, so it gave no assurance
+// the shipped endpoints worked -- this test drives the real HTTP handler
+// instead, the exact gap the finding called out.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+// seedMachineWriteRole creates a Role with secrets.write and grants it to
+// machineID at projectID scope via MachineIdentityRole -- the write-side
+// counterpart to secrets_list_machine_authz_test.go's seedMachineReadRole.
+func seedMachineWriteRole(t *testing.T, db *gorm.DB, roleName string, machineID, projectID uint) uint {
+	t.Helper()
+
+	role := &models.Role{Name: roleName}
+	require.NoError(t, db.Create(role).Error)
+
+	perm := &models.Permission{}
+	if err := db.Where("name = ?", permSecretsWrite).First(perm).Error; err != nil {
+		perm = &models.Permission{Name: permSecretsWrite, Resource: "secrets", Action: "write"}
+		require.NoError(t, db.Create(perm).Error)
+	}
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: role.ID, PermissionID: perm.ID}).Error)
+
+	require.NoError(t, db.Create(&models.MachineIdentityRole{
+		MachineIdentityID: machineID,
+		RoleID:            role.ID,
+		ProjectID:         projectID,
+		EnvironmentID:     0,
+	}).Error)
+	return role.ID
+}
+
+// TestCreateSecret_MachineActor_AttributedToOwnerMachineIdentityID drives the
+// real HTTP CreateSecret handler as an authorized machine principal and
+// confirms the persisted secret's OwnerMachineIdentityID is populated, not
+// left at 0 alongside a zero OwnerID (the pre-fix, unattributable shape).
+func TestCreateSecret_MachineActor_AttributedToOwnerMachineIdentityID(t *testing.T) {
+	h, db := freshMachineAuthzFixture(t)
+
+	proj := &models.Project{Name: "proj-machine-create"}
+	require.NoError(t, db.Create(proj).Error)
+	env := &models.Environment{Name: "env-machine-create", ProjectID: proj.ID}
+	require.NoError(t, db.Create(env).Error)
+
+	const machineID = uint(41)
+	require.NoError(t, db.Create(&models.MachineIdentity{
+		ID: machineID, ProjectID: proj.ID, Name: "ci-runner-41", State: "active",
+	}).Error)
+	seedMachineWriteRole(t, db, "machine_writer_create", machineID, proj.ID)
+
+	body, err := json.Marshal(map[string]any{
+		"name":           "machine-created-secret",
+		"value":          "s3cr3t",
+		"project_id":     proj.ID,
+		"environment_id": env.ID,
+		"type":           "static",
+	})
+	require.NoError(t, err)
+
+	// withMachineCtxID doesn't set Username (its own callers don't need
+	// CreatedBy) -- real production machine auth does (machineUserContext,
+	// server/middleware/auth.go, Username: m.Name), and CreateSecret's own
+	// validation requires CreatedBy non-empty, so replicate that here rather
+	// than change the shared helper's behavior for its other callers.
+	mid := uint(machineID)
+	req := withMachineCtxID(httptest.NewRequest(http.MethodPost, "/api/v1/secrets", bytes.NewReader(body)), machineID)
+	req = req.WithContext(context.WithValue(req.Context(), middleware.GetUserContextKey(), &middleware.UserContext{
+		UserID: 0, ActorType: core.ActorTypeMachine, MachineIdentityID: &mid, Username: "ci-runner-41",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateSecret(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "authorized machine token should be able to create a secret: %s", w.Body.String())
+
+	var created models.SecretNode
+	require.NoError(t, db.Where("name = ?", "machine-created-secret").First(&created).Error)
+	assert.Equal(t, uint(0), created.OwnerID, "a machine caller's UserID is 0 by convention (ADR-030) -- must not collide with a real user ID")
+	assert.Equal(t, machineID, created.OwnerMachineIdentityID, "#1625: a machine-created secret must record WHICH machine created it, not leave both owner columns at zero")
+}
+
+// TestCreateSecret_UserActor_OwnerMachineIdentityIDStaysZero is the
+// counterpart: an ordinary user-created secret must NOT get a nonzero
+// OwnerMachineIdentityID -- the discriminator fields are mutually exclusive.
+func TestCreateSecret_UserActor_OwnerMachineIdentityIDStaysZero(t *testing.T) {
+	h, db := freshMachineAuthzFixture(t)
+
+	proj := &models.Project{Name: "proj-user-create"}
+	require.NoError(t, db.Create(proj).Error)
+	env := &models.Environment{Name: "env-user-create", ProjectID: proj.ID}
+	require.NoError(t, db.Create(env).Error)
+
+	user := &models.User{Username: "creator", Email: "creator@example.com"}
+	require.NoError(t, db.Create(user).Error)
+
+	role := &models.Role{Name: "user_writer_create"}
+	require.NoError(t, db.Create(role).Error)
+	perm := &models.Permission{}
+	if err := db.Where("name = ?", permSecretsWrite).First(perm).Error; err != nil {
+		perm = &models.Permission{Name: permSecretsWrite, Resource: "secrets", Action: "write"}
+		require.NoError(t, db.Create(perm).Error)
+	}
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: role.ID, PermissionID: perm.ID}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: user.ID, RoleID: role.ID, ProjectID: proj.ID}).Error)
+
+	body, err := json.Marshal(map[string]any{
+		"name":           "user-created-secret",
+		"value":          "s3cr3t",
+		"project_id":     proj.ID,
+		"environment_id": env.ID,
+		"type":           "static",
+	})
+	require.NoError(t, err)
+
+	req := withUserCtxID(httptest.NewRequest(http.MethodPost, "/api/v1/secrets", bytes.NewReader(body)), user.ID, "creator")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateSecret(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "authorized user should be able to create a secret: %s", w.Body.String())
+
+	var created models.SecretNode
+	require.NoError(t, db.Where("name = ?", "user-created-secret").First(&created).Error)
+	assert.Equal(t, user.ID, created.OwnerID)
+	assert.Equal(t, uint(0), created.OwnerMachineIdentityID, "a user-created secret must not have a nonzero OwnerMachineIdentityID")
+}


### PR DESCRIPTION
## Summary

Every other model the #1573 machine-actor attribution family touched (invitations, machine identities, break-glass, access-review campaigns, secret dependencies, setup tokens) got its own `*MachineIdentityID` companion field **and** had its real production entry points updated to populate it. `SecretNode.OwnerMachineIdentityID` got the model column and the `CreateSecretRequest` field — the full shape of a completed fix — but neither real production entry point (`server/http/handlers/secrets_crud.go`'s `CreateSecret`, `server/grpc/services/secret_service.go`'s `CreateSecret` RPC) was ever updated to set it.

Verified directly: both call sites' `core.CreateSecretRequest{}` literals only set `OwnerID` from the human `UserID`, never `MachineIdentityID`. The original PR's own regression test called `core.CreateSecret` directly, bypassing both real handlers, so it gave no assurance the shipped endpoints worked. A machine identity's secret creation landed with `OwnerID=0 AND OwnerMachineIdentityID=0` — indistinguishable from an orphaned/legacy row for exactly the incident-response/compliance-audit use case the discriminator-field pattern exists for.

Part 2 continuation finding, `keyorix-private`'s `RUN-META.md` — independent review session, mechanical fix not yet implemented.

## Changes

- `server/http/handlers/secrets_crud.go`: `CreateSecret` now sets `req.OwnerMachineIdentityID` from `userCtx.MachineIdentityID` when present.
- `server/grpc/services/secret_service.go`: `CreateSecret` RPC now sets `coreReq.OwnerMachineIdentityID` from `user.MachineIdentityID` when `user.ActorType == core.ActorTypeMachine`.

## Test plan

- [x] New tests drive the **real** HTTP handler and gRPC service (not `core.CreateSecret` directly) — the exact gap the finding called out — confirming a machine-created secret gets `OwnerID=0, OwnerMachineIdentityID=<machine ID>`, and a user-created secret stays at `OwnerMachineIdentityID=0`.
- [x] Both new tests red/green-verified (temporarily removed each fix, confirmed the corresponding test fails with the exact predicted symptom, restored, confirmed green).
- [x] `go build ./...` clean; `gofmt -l` / `gosec -severity medium -exclude-generated` clean on both changed packages.
- [x] Full `server/grpc/...` suite green; full `server/http/handlers` suite green (34.9s, no collateral breakage).
