### PR TITLE
fix(hardening): remove mlockall, move swap protection to deployment level (#1679)

### DIFF
--- a/deploy/helm/keyorix/README.md
+++ b/deploy/helm/keyorix/README.md
@@ -57,3 +57,9 @@ helm test keyorix
 - **Backups:** back up both the database and the `*-server-keys` PVC. You need
   both (plus the master password) to recover.
 - **TLS:** terminate at the ingress (`ingress.tls` + cert-manager annotations).
+- **Swap:** run the nodes backing this deployment with swap disabled (the
+  Kubernetes default). Decrypted secret memory is not locked against swap
+  in-process (see `docs/adr-100-mlockall-removal-deployment-swap-control.md`
+  for why an in-process lock was tried and removed) — this is now a
+  deployment-level control, not something the chart or server configures for
+  you.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -168,6 +168,10 @@ Groups:
 3. **Network Segmentation**: Deploy in secure network segments
 4. **Regular Updates**: Keep system and dependencies updated
 5. **Monitoring**: Implement security monitoring and alerting
+6. **Disable swap**: run the node/host with swap disabled (Kubernetes' default) so
+   decrypted secret memory cannot be written to disk under memory pressure. This is a
+   deployment-level control, not something the server process configures — see
+   `docs/adr-100-mlockall-removal-deployment-swap-control.md`.
 
 ### Configuration Security
 ```yaml

--- a/docs/adr-098-process-memory-hardening.md
+++ b/docs/adr-098-process-memory-hardening.md
@@ -2,7 +2,23 @@
 
 ## Status
 
-**Accepted (2026-09-02).** Follow-up to the 2026-09 security review
+**Partially superseded (2026-09-04) — see
+[ADR-100](adr-100-mlockall-removal-deployment-swap-control.md).** The
+`mlockall` half of this decision is removed: measured against the real
+server binary and the shipped Helm chart's default memory limit, it pins an
+ever-growing, never-shrinking floor of locked memory (`VmLck`) that already
+exceeds that default at rest, and cannot deliver its intended protection in
+a garbage-collected runtime regardless of tuning (the GC moves and copies
+memory a locked address does not follow). **Core dump suppression
+(`RLIMIT_CORE=0`) is unaffected and remains exactly as documented below** —
+only the mlockall-specific content in this document (the Summary's item 1,
+the "mlockall is opt-out" design decision, and the Operator prerequisites
+section) describes a mechanism no longer in the code; everything else here
+is still accurate. This document is kept as the historical record of why
+mlockall was originally adopted and how it was verified at the time — see
+ADR-100 for the removal decision and its own verification.
+
+**Originally accepted (2026-09-02).** Follow-up to the 2026-09 security review
 (`docs/security-review-2026-09.md`), specifically its memory-zeroization
 finding: `internal/crypto`'s wipe-after-use discipline closes the transient
 in-process exposure of decrypted secret values (three unwiped heap copies,
@@ -16,7 +32,7 @@ Two independent hardening steps are applied once, at server startup, before
 any key material or decrypted secret value is allocated
 (`internal/hardening.ApplyMemoryHardening`, called from `server/main.go`):
 
-1. **`mlockall(MCL_CURRENT | MCL_FUTURE)`** — locks the process's already-
+1. **[Superseded by ADR-100 — removed.] `mlockall(MCL_CURRENT | MCL_FUTURE)`** — locks the process's already-
    mapped pages, and every page mapped for the rest of the process's
    lifetime, into physical RAM. The kernel can never swap a locked page to
    disk, so a decrypted secret value can no longer survive in a swap file or
@@ -63,7 +79,9 @@ a container runtime) that explicitly sets `LimitCORE=` or `ulimit -c` before
 before this code ever runs, and is out of this code's control — see
 Operator prerequisites below.
 
-**mlockall is opt-out (`security.mlock.disabled`, default false — attempted
+**[Superseded by ADR-100 — mlockall and this config are removed from the
+code; kept here only as the historical record of the original design.]**
+mlockall is opt-out (`security.mlock.disabled`, default false — attempted
 by default), and its failure mode is config-driven
 (`security.mlock.require_success`, default false — warn and continue).**
 `mlockall` requires `CAP_IPC_LOCK` or a raised `RLIMIT_MEMLOCK`, and many
@@ -112,6 +130,10 @@ it does **not** protect against:
 - **The CLI process** (see Scope above).
 
 ## Operator prerequisites
+
+**[Superseded by ADR-100 — mlockall is removed; this section no longer
+applies. See ADR-100's "Operator guidance: deployment-level swap control"
+for the current recommendation.]**
 
 `mlockall` needs one of:
 

--- a/docs/adr-100-mlockall-removal-deployment-swap-control.md
+++ b/docs/adr-100-mlockall-removal-deployment-swap-control.md
@@ -1,0 +1,160 @@
+# ADR-100: Remove mlockall; move swap protection to deployment-level control
+
+## Status
+
+**Accepted (2026-09-04).** Supersedes the `mlockall` half of
+[ADR-098](adr-098-process-memory-hardening.md) — that ADR's core dump
+suppression (`RLIMIT_CORE=0`) is unaffected and remains in effect exactly as
+originally documented; only the memory-locking mechanism is removed. See
+ADR-098 for the historical record of why `mlockall` was originally adopted
+and how it was verified at the time.
+
+## Summary
+
+`internal/hardening.ApplyMemoryHardening` no longer calls
+`mlockall(MCL_CURRENT | MCL_FUTURE)`. `config.MlockConfig`
+(`security.mlock.disabled` / `security.mlock.require_success`) is removed
+entirely — there is no config flag or opt-in for the removed control. Core
+dump suppression is untouched: it has no operator prerequisite, no failure
+mode worth gating behind config, and no relationship to the problem below.
+
+Swap protection for decrypted secret memory is now a **deployment-level**
+concern: disable swap on the node, or in the container runtime, rather than
+locking memory pages in-process.
+
+## Why mlockall does not work here
+
+Three independent findings, each sufficient on its own:
+
+1. **Measured, not estimated: the real server binary pins `VmLck` ≈ 1.33 GiB
+   at rest**, on a healthy process that has served nothing beyond a
+   readiness probe — already **~2.6×** the shipped Helm chart's default
+   512Mi memory *limit* (`deploy/helm/keyorix/values.yaml`), before a single
+   API request. `VmLck` grows further under ordinary request load (secret
+   creation) and does not shrink afterward, even after an idle period long
+   enough for garbage collection to run and `debug.FreeOSMemory()` to
+   execute — `mlockall`'s locked pages cannot be reclaimed by
+   `madvise(MADV_DONTNEED/MADV_FREE)`, the mechanism the Go runtime's
+   scavenger uses to return freed memory to the OS. The shipped chart's own
+   `securityContext.capabilities.drop: ["ALL"]` (with no `add:` list, and no
+   `values.yaml` knob to add one back) means the *only* thing standing
+   between "mlockall silently degrades to a no-op-equivalent warning" and
+   "mlockall succeeds and pins an ever-growing, non-shrinking floor toward
+   an OOM-kill" is the container runtime's default `RLIMIT_MEMLOCK` — a
+   value this chart does not control, does not document, and cannot rely on
+   being small enough to fail safely.
+2. **This is not a tuning problem — `mlockall` cannot deliver the intended
+   protection in a garbage-collected runtime.** The Go garbage collector
+   moves and copies memory during normal operation; locking a specific
+   buffer's virtual address protects that address, not the copies the
+   runtime scatters elsewhere as it compacts and reallocates. This is a
+   structural mismatch between the mechanism and the language runtime it
+   was applied in, not a configuration or scoping choice — scoping the lock
+   to a smaller set of addresses narrows the pinned footprint but does not
+   fix this mismatch, so it is not implemented here as a middle ground.
+3. **The field has moved away from process-wide mlock.** OpenBao (the
+   post-fork continuation of the exact tool this repo's original design
+   modeled itself on) removed `mlock` entirely
+   ([openbao/openbao#363](https://github.com/openbao/openbao/issues/363);
+   design rationale: [RFC](https://openbao.org/community/rfcs/mlock-removal/)).
+   HashiCorp's own Vault Helm chart dropped `IPC_LOCK` from its default
+   deployment in 2020
+   ([hashicorp/vault-helm#198](https://github.com/hashicorp/vault-helm/pull/198)).
+   HashiCorp's production-hardening guidance treats disabling swap at the
+   host level as the baseline, and in-process `mlock` as an additional
+   trade-off on top of that baseline, not a replacement for it. Kubernetes
+   nodes run with swap disabled by default; `NodeSwap` (opt-in swap support)
+   only reached GA recently. The premise this repo's chart already runs on
+   swapless nodes in the common case — this ADR makes that premise the
+   documented, primary control instead of a redundant in-process backstop
+   that actively works against the memory limit on the deployments that
+   don't.
+
+## What changes
+
+- `internal/hardening.ApplyMemoryHardening` takes no arguments and only
+  disables core dumps. The `mlockallFn` syscall indirection, `MCL_CURRENT`/
+  `MCL_FUTURE`, and every log line specific to the mlockall attempt are
+  removed.
+- `config.MlockConfig` and `SecurityConfig.Mlock` are removed. There is
+  deliberately no replacement flag: a knob for a control that does not work
+  as intended is worse than the control's absence, because it invites an
+  operator to believe they have a working guarantee by setting it.
+- `server/main.go`'s call site no longer reads `cfg.Security.Mlock.*`.
+
+## What does not change
+
+- **Core dump suppression (`RLIMIT_CORE = {0, 0}`) is unaffected**, still
+  unconditional, still called from the same place, still logs its own line.
+  Everything ADR-098 says about it — no operator prerequisite, `Max` lowered
+  alongside `Cur`, verified by triggering a real crash — remains accurate.
+- The transient in-process exposure of decrypted secret values (the "three
+  unwiped heap copies" gap documented alongside ADR-098 and in
+  `docs/security-review-2026-09.md`) was never something `mlockall`
+  protected against, and remains exactly as it was: unchanged, out of scope
+  here, tracked separately.
+
+## Operator guidance: deployment-level swap control
+
+Swap protection for a Keyorix server deployment should now be provided by
+the environment, not the process:
+
+- **Kubernetes:** nodes run with swap disabled by default; this is normally
+  already the case and requires no chart change. If a cluster has opted
+  into `NodeSwap`, exclude the nodes running Keyorix server pods from swap,
+  or pin the deployment to a node pool with swap disabled.
+- **systemd / bare metal / VM:** disable swap at the host level (`swapoff
+  -a` and remove the relevant `swap` entry from `/etc/fstab`, or set
+  `vm.swappiness=0` combined with no swap device at all for a stronger
+  guarantee than a swappiness tunable alone).
+- This guidance is recorded in `deploy/helm/keyorix/README.md`'s Production
+  notes and `docs/SECURITY.md`'s deployment security checklist.
+
+## Alternatives considered
+
+- **Scope the lock to secret-bearing buffers only, instead of the whole
+  process.** Rejected — see point 2 above: this does not fix the underlying
+  GC-copies-memory mismatch, it only shrinks the pinned footprint while
+  leaving the same structural gap in place (any address the GC copies a
+  locked buffer's contents to is unlocked). It was also independently
+  assessed as a large refactor on its own merits — the bounded key material
+  (~128 bytes: DEK, DEK snapshot, evidence-signing key, audit-checkpoint
+  key) is trivial to scope-lock, but decrypted secret VALUES are smeared
+  across at least three unwiped heap copies by construction of
+  `encoding/json` and Go's immutable strings, per
+  `docs/security-review-2026-09.md`'s own prior finding — scoping the lock
+  to that traffic would mean threading `[]byte`-only plaintext through the
+  entire read path and abandoning string-based serialization for secret
+  fields, a change with a far larger blast radius than this ADR's scope.
+- **Add a soft memory ceiling (`GOMEMLIMIT` / `debug.SetMemoryLimit`) below
+  the cgroup limit, keep `mlockall`.** Rejected as the primary fix — it
+  would only bound how large the *unreclaimable* pinned floor can grow, not
+  prevent the floor from being unreclaimable in the first place; the
+  process would still hit degraded GC behavior (more frequent, less
+  effective collection cycles as it fights to stay under the soft limit
+  while `mlockall`'s prior high-water mark can never shrink). Nothing here
+  precludes adding `GOMEMLIMIT` as an independent, unrelated improvement to
+  general memory behavior in the future — it just isn't a substitute for
+  removing `mlockall`.
+- **Just raise the default Helm chart memory limit above the pinned-RSS
+  floor.** Rejected as the fix, though operators who override the default
+  today are free to size their own limits however they like: it papers over
+  the mismatch for the shipped default only, does nothing for the
+  underlying "grows forever, never shrinks" behavior, and every future MB
+  of legitimate peak load (larger secret exports, wider audit queries)
+  permanently ratchets the floor higher regardless of what the limit is set
+  to.
+
+## Verification
+
+- `internal/hardening/memlock_test.go`: `TestApplyMemoryHardening_DisablesCoreDumps`
+  and `TestApplyMemoryHardening_CoreDumpDisableFailureIsFatal` cover the two
+  remaining branches of `ApplyMemoryHardening` (success, `setrlimit`
+  failure) via the same injected-syscall pattern ADR-098 established, now
+  without the mlockall-specific branches this change removes.
+- `go build ./...`, `go vet`, `gofmt -l`, and `gosec -severity medium
+  -exclude-generated` all clean on every package this change touches
+  (`internal/hardening`, `internal/config`, `server`).
+- Confirmed no other reference to `MlockConfig`, `mlockallFn`, or
+  `security.mlock.*` remains anywhere in the repository (`git grep`, not
+  `grep -r`, across `*.go`/`*.yaml`/`*.yml`/`*.md`).

--- a/docs/security-review-2026-09.md
+++ b/docs/security-review-2026-09.md
@@ -227,22 +227,27 @@ that edits its own past claims without a visible trail is exactly the failure mo
   `TestBreakGlassReads_NeverPersistState` proves neither read function ever writes. Every changed behavior was
   verified by mutation (revert the fix, confirm the specific test goes red) before landing. #1653 reopened on
   GitHub with the full account, not closed with a note — its premise was falsified, not refined.
-- **Memory zeroization's durable half — swap and core dumps — closed (ADR-098).** The memory-zeroization entry
-  above deliberately scoped itself to the transient in-process exposure and left the durable exposure (plaintext
-  surviving in swap across a reboot, or in a core file after a crash) as future work, not a decision. Closed via
-  `internal/hardening.ApplyMemoryHardening`, called at server startup before any key material or decrypted secret
-  is allocated: `mlockall(MCL_CURRENT|MCL_FUTURE)` locks the process's memory against swap (opt-out via
-  `security.mlock.disabled`, default attempted; failure is a loud `WARNING` by default or fatal with
-  `security.mlock.require_success=true`, mirroring HashiCorp Vault's own mlock behavior), and `RLIMIT_CORE` is
-  unconditionally set to `{Cur:0, Max:0}`, disabling core dumps with no config gate and no operator prerequisite.
-  Verified functionally, not just by reading the config back: `mlockall` success confirmed by quoting a non-zero
-  `VmLck` from `/proc/self/status` in a real Linux container; failure confirmed to warn (not silently no-op) when
-  `CAP_IPC_LOCK`/`RLIMIT_MEMLOCK` are absent, and to be fatal when `require_success=true`; core dump suppression
-  confirmed by actually triggering a crash (`GOTRACEBACK=crash`, deliberate nil dereference) and observing no
-  core file is written even though the parent shell had `ulimit -c unlimited` — versus a 46 MB core file produced
-  by the identical crash without the hardening applied. This narrows, not closes, the zeroization gap: the
-  transient in-process exposure documented above remains, unchanged, by design — see ADR-098's "What this does
-  not protect against" section for the full boundary.
+- **Memory zeroization's durable half — swap and core dumps — closed (ADR-098), swap half later reversed
+  (ADR-100).** The memory-zeroization entry above deliberately scoped itself to the transient in-process exposure
+  and left the durable exposure (plaintext surviving in swap across a reboot, or in a core file after a crash) as
+  future work, not a decision. Initially closed via `internal/hardening.ApplyMemoryHardening`, called at server
+  startup before any key material or decrypted secret is allocated: `mlockall(MCL_CURRENT|MCL_FUTURE)` locked the
+  process's memory against swap, and `RLIMIT_CORE` is unconditionally set to `{Cur:0, Max:0}`, disabling core
+  dumps with no config gate and no operator prerequisite. At the time, verified functionally, not just by reading
+  the config back: `mlockall` success confirmed by quoting a non-zero `VmLck` from `/proc/self/status` in a real
+  Linux container; failure confirmed to warn (not silently no-op) when `CAP_IPC_LOCK`/`RLIMIT_MEMLOCK` were
+  absent; core dump suppression confirmed by actually triggering a crash (`GOTRACEBACK=crash`, deliberate nil
+  dereference) and observing no core file is written even though the parent shell had `ulimit -c unlimited` —
+  versus a 46 MB core file produced by the identical crash without the hardening applied.
+  **`mlockall` was removed 2026-09-04 (ADR-100):** measured against the real server binary, it pinned `VmLck` at
+  ~2.6× the shipped Helm chart's default 512Mi memory limit at rest, growing further under ordinary load and never
+  shrinking — a real availability regression (risk of cgroup OOM-kill under legitimate traffic) on exactly the
+  deployments that followed this control's own guidance, and structurally incapable of working as intended in a
+  garbage-collected runtime regardless of tuning. Swap protection is now a deployment-level concern (disable swap
+  on the node / in the container runtime) rather than in-process. **Core dump suppression is unaffected and
+  remains in effect exactly as verified above.** This narrows, not closes, the zeroization gap: the transient
+  in-process exposure documented above remains, unchanged, by design — see ADR-098's "What this does not protect
+  against" section and ADR-100 for the full current boundary.
 - **Master passphrase sourcing fixed; the wiping gap stays open by design (ADR-099).** The memory-zeroization
   entry above also documented that `KEYORIX_MASTER_PASSWORD` "is string-shaped from `os.Getenv` onward and, like
   any Go string, structurally cannot be wiped at all." Fixed the *sourcing* half: the server and CLI now accept

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -724,31 +724,6 @@ type SecurityConfig struct {
 	// common, supported deployment), but when off the server logs a prominent warning if
 	// it serves cleartext, so the exposure is never silent.
 	RequireTransportTLS bool `yaml:"require_transport_tls"`
-	// Mlock configures process-memory hardening applied once at startup
-	// (mlockall + core dump suppression). See ADR-098. It narrows, not
-	// closes, the memory-zeroization gap: it protects decrypted secret
-	// plaintext from surviving a reboot (swap) or a crash (core file), not
-	// from the transient in-memory exposure of a live, healthy process.
-	Mlock MlockConfig `yaml:"mlock"`
-}
-
-// MlockConfig controls whether the process locks its memory pages against
-// swap (mlockall) at startup, and how an mlockall failure is handled. Core
-// dump suppression (RLIMIT_CORE=0) is unconditional and not gated by this
-// struct — see ADR-098 for why.
-type MlockConfig struct {
-	// Disabled opts out of mlockall(MCL_CURRENT|MCL_FUTURE) at startup.
-	// mlockall is attempted by default (mirroring HashiCorp Vault's own
-	// mlock default); set this when the host/container cannot grant
-	// CAP_IPC_LOCK or a raised RLIMIT_MEMLOCK and the resulting startup
-	// warning is unwanted noise.
-	Disabled bool `yaml:"disabled"`
-	// RequireSuccess makes a failed mlockall attempt fatal at startup
-	// instead of a logged warning. Default false: mlockall failure is
-	// warned and startup continues (matching Vault's default). Set true to
-	// fail closed when swap-exposure must be guaranteed closed rather than
-	// best-effort.
-	RequireSuccess bool `yaml:"require_success"`
 }
 
 // parseDurationDefault parses a Go duration string, returning def when empty or

--- a/internal/hardening/memlock.go
+++ b/internal/hardening/memlock.go
@@ -17,11 +17,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
 // Package hardening applies process-level memory hardening at server
-// startup: locking pages against swap (mlockall) and disabling core dumps
-// (RLIMIT_CORE=0). See docs/adr-098-process-memory-hardening.md for the
-// design rationale and, importantly, what this does NOT protect against —
-// the transient in-process exposure of decrypted secret values documented
-// alongside #1653 remains, unchanged, by design.
+// startup: disabling core dumps (RLIMIT_CORE=0). See
+// docs/adr-098-process-memory-hardening.md for the original design (mlock +
+// core dump suppression) and docs/adr-100-mlockall-removal-deployment-swap-control.md
+// for why the mlockall half was removed (measured to pin gigabytes of RSS
+// with no ceiling on the shipped 512Mi Helm default, and to be structurally
+// incompatible with a garbage-collected runtime — the GC moves and copies
+// memory, so locking one buffer's address does not protect the copies the
+// runtime scatters elsewhere). Core dump suppression is unaffected: it has
+// no such gap and stays.
 package hardening
 
 import (
@@ -31,77 +35,29 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// mlockallFn and setrlimitFn are indirections over the real syscalls, swapped
-// out in tests so every branch below (success, failure-warns,
-// failure-is-fatal, disabled) is exercised deterministically regardless of
-// the test host's actual capabilities -- CI's CAP_IPC_LOCK/RLIMIT_MEMLOCK
-// posture is not something a unit test should depend on.
-var (
-	mlockallFn  = unix.Mlockall
-	setrlimitFn = unix.Setrlimit
-)
+// setrlimitFn is an indirection over the real syscall, swapped out in tests
+// so the failure branch is exercised deterministically regardless of the
+// test host's actual limits posture.
+var setrlimitFn = unix.Setrlimit
 
-// MemoryConfig is the subset of config.MlockConfig this package needs. It is
-// a plain struct (not config.MlockConfig itself) so this package stays
-// independently testable without importing internal/config.
-type MemoryConfig struct {
-	// Disabled opts out of the mlockall attempt. Core dump suppression is
-	// unaffected by this field — see ApplyMemoryHardening's doc comment.
-	Disabled bool
-	// RequireSuccess makes a failed mlockall attempt fatal (ApplyMemoryHardening
-	// returns a non-nil error) instead of a logged warning.
-	RequireSuccess bool
-}
-
-// ApplyMemoryHardening disables core dumps and, unless disabled, locks the
-// process's memory pages against swap. It must run once, as early as
-// possible in process startup — before any key material or decrypted
-// secret value is allocated — since mlockall(MCL_FUTURE) only covers pages
-// mapped AFTER the call, and a core dump captures whatever is resident at
+// ApplyMemoryHardening disables core dumps. It must run once, as early as
+// possible in process startup — before any key material or decrypted secret
+// value is allocated — since a core dump captures whatever is resident at
 // the moment of the crash regardless of when RLIMIT_CORE was lowered.
 //
-// Core dump suppression is unconditional: lowering RLIMIT_CORE has no
-// operator prerequisite and, unlike mlockall, essentially cannot fail for a
-// process operating on its own limits, so there is no reason to gate it
-// behind config. mlockall DOES have a real operator prerequisite
-// (CAP_IPC_LOCK or a raised RLIMIT_MEMLOCK) and can fail on hosts that
-// don't grant it — many containers don't — so it is opt-out via cfg.Disabled,
-// and its failure mode (warn vs. fatal) is controlled by cfg.RequireSuccess,
-// mirroring HashiCorp Vault's own mlock behavior (warn by default, can be
-// configured to refuse to start).
-//
-// Every outcome — success, skipped-by-config, or failure — produces exactly
-// one startup log line, so the operator never has to infer whether secret
-// memory is protected: silent failure is the one unacceptable outcome here.
-func ApplyMemoryHardening(cfg MemoryConfig) error {
+// Lowering RLIMIT_CORE has no operator prerequisite and, unlike the mlockall
+// step this function previously also performed (see the package doc
+// comment), essentially cannot fail for a process operating on its own
+// limits — so failure here is always fatal, not a warning.
+func ApplyMemoryHardening() error {
 	if err := disableCoreDumps(); err != nil {
 		// Lowering a limit the process already holds essentially never
-		// fails; if it does, that's a real, actionable misconfiguration
-		// (not a missing-capability case like mlockall) — fail loud rather
-		// than let the operator believe core dumps are off when they
-		// aren't.
+		// fails; if it does, that's a real, actionable misconfiguration —
+		// fail loud rather than let the operator believe core dumps are
+		// off when they aren't.
 		return fmt.Errorf("hardening: disable core dumps: %w", err)
 	}
 	log.Printf("hardening: core dumps disabled (RLIMIT_CORE=0)")
-
-	if cfg.Disabled {
-		log.Printf("hardening: mlock disabled by config (security.mlock.disabled=true) -- " +
-			"decrypted secret memory CAN be swapped to disk")
-		return nil
-	}
-
-	if err := mlockallFn(unix.MCL_CURRENT | unix.MCL_FUTURE); err != nil {
-		msg := fmt.Sprintf("hardening: mlockall failed (%v) -- decrypted secret memory CAN be swapped "+
-			"to disk. Grant CAP_IPC_LOCK or raise RLIMIT_MEMLOCK (systemd unit: LimitMEMLOCK=infinity) "+
-			"to fix, or set security.mlock.disabled=true to silence this warning", err)
-		if cfg.RequireSuccess {
-			return fmt.Errorf("%s (refusing to start: security.mlock.require_success=true)", msg)
-		}
-		log.Printf("WARNING: %s", msg)
-		return nil
-	}
-
-	log.Printf("hardening: mlockall succeeded -- process memory locked against swap")
 	return nil
 }
 

--- a/internal/hardening/memlock_test.go
+++ b/internal/hardening/memlock_test.go
@@ -27,92 +27,33 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// withFakeSyscalls swaps mlockallFn/setrlimitFn for the duration of the test
-// and restores the real ones on cleanup -- these tests must never depend on
-// the CI host's actual CAP_IPC_LOCK/RLIMIT_MEMLOCK posture, which is
-// unpredictable and would make the failure-path branches flaky.
-func withFakeSyscalls(t *testing.T, mlockall func(int) error, setrlimit func(int, *unix.Rlimit) error) {
+// withFakeSetrlimit swaps setrlimitFn for the duration of the test and
+// restores the real one on cleanup -- this must never depend on the CI
+// host's actual limits posture.
+func withFakeSetrlimit(t *testing.T, setrlimit func(int, *unix.Rlimit) error) {
 	t.Helper()
-	origMlockall, origSetrlimit := mlockallFn, setrlimitFn
-	mlockallFn, setrlimitFn = mlockall, setrlimit
-	t.Cleanup(func() { mlockallFn, setrlimitFn = origMlockall, origSetrlimit })
+	orig := setrlimitFn
+	setrlimitFn = setrlimit
+	t.Cleanup(func() { setrlimitFn = orig })
 }
 
-func TestApplyMemoryHardening_CoreDumpsAlwaysDisabledRegardlessOfMlockConfig(t *testing.T) {
-	for _, cfg := range []MemoryConfig{
-		{Disabled: false, RequireSuccess: false},
-		{Disabled: true, RequireSuccess: false},
-		{Disabled: true, RequireSuccess: true},
-	} {
-		var gotResource int
-		var gotRlimit unix.Rlimit
-		withFakeSyscalls(t,
-			func(int) error { return nil },
-			func(resource int, rlim *unix.Rlimit) error {
-				gotResource, gotRlimit = resource, *rlim
-				return nil
-			},
-		)
+func TestApplyMemoryHardening_DisablesCoreDumps(t *testing.T) {
+	var gotResource int
+	var gotRlimit unix.Rlimit
+	withFakeSetrlimit(t, func(resource int, rlim *unix.Rlimit) error {
+		gotResource, gotRlimit = resource, *rlim
+		return nil
+	})
 
-		require.NoError(t, ApplyMemoryHardening(cfg))
-		assert.Equal(t, unix.RLIMIT_CORE, gotResource, "cfg=%+v", cfg)
-		assert.Equal(t, unix.Rlimit{Cur: 0, Max: 0}, gotRlimit, "cfg=%+v -- Max must also be 0, not just Cur, or a later privileged action can raise it back", cfg)
-	}
+	require.NoError(t, ApplyMemoryHardening())
+	assert.Equal(t, unix.RLIMIT_CORE, gotResource)
+	assert.Equal(t, unix.Rlimit{Cur: 0, Max: 0}, gotRlimit, "Max must also be 0, not just Cur, or a later privileged action can raise it back")
 }
 
-func TestApplyMemoryHardening_CoreDumpDisableFailureIsAlwaysFatal(t *testing.T) {
-	withFakeSyscalls(t,
-		func(int) error {
-			t.Fatal("mlockall must not be attempted when core-dump suppression itself failed")
-			return nil
-		},
-		func(int, *unix.Rlimit) error { return errors.New("setrlimit boom") },
-	)
+func TestApplyMemoryHardening_CoreDumpDisableFailureIsFatal(t *testing.T) {
+	withFakeSetrlimit(t, func(int, *unix.Rlimit) error { return errors.New("setrlimit boom") })
 
-	err := ApplyMemoryHardening(MemoryConfig{Disabled: true})
+	err := ApplyMemoryHardening()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "setrlimit boom")
-}
-
-func TestApplyMemoryHardening_DisabledSkipsMlockallEntirely(t *testing.T) {
-	mlockallCalled := false
-	withFakeSyscalls(t,
-		func(int) error { mlockallCalled = true; return nil },
-		func(int, *unix.Rlimit) error { return nil },
-	)
-
-	require.NoError(t, ApplyMemoryHardening(MemoryConfig{Disabled: true}))
-	assert.False(t, mlockallCalled, "security.mlock.disabled=true must skip the mlockall attempt entirely, not just ignore its result")
-}
-
-func TestApplyMemoryHardening_SuccessLocksWithCurrentAndFuture(t *testing.T) {
-	var gotFlags int
-	withFakeSyscalls(t,
-		func(flags int) error { gotFlags = flags; return nil },
-		func(int, *unix.Rlimit) error { return nil },
-	)
-
-	require.NoError(t, ApplyMemoryHardening(MemoryConfig{Disabled: false}))
-	assert.Equal(t, unix.MCL_CURRENT|unix.MCL_FUTURE, gotFlags, "must lock both already-mapped pages (MCL_CURRENT) and pages mapped after this call (MCL_FUTURE) -- decrypted secret values are allocated throughout the process lifetime, not just at startup")
-}
-
-func TestApplyMemoryHardening_FailureWarnsAndContinuesByDefault(t *testing.T) {
-	withFakeSyscalls(t,
-		func(int) error { return errors.New("operation not permitted") },
-		func(int, *unix.Rlimit) error { return nil },
-	)
-
-	err := ApplyMemoryHardening(MemoryConfig{Disabled: false, RequireSuccess: false})
-	assert.NoError(t, err, "mlockall failure must not be fatal when require_success is unset -- matches Vault's default of warn, not refuse")
-}
-
-func TestApplyMemoryHardening_FailureIsFatalWhenRequireSuccessSet(t *testing.T) {
-	withFakeSyscalls(t,
-		func(int) error { return errors.New("operation not permitted") },
-		func(int, *unix.Rlimit) error { return nil },
-	)
-
-	err := ApplyMemoryHardening(MemoryConfig{Disabled: false, RequireSuccess: true})
-	require.Error(t, err, "mlockall failure must be fatal when require_success=true -- the whole point of the setting is to refuse to run with plaintext swappable")
-	assert.Contains(t, err.Error(), "operation not permitted")
 }

--- a/server/main.go
+++ b/server/main.go
@@ -114,15 +114,16 @@ func main() { // NOSONAR -- cognitive complexity 22, suppress go:S3776
 		log.Fatalf("startup validation: %v", err)
 	}
 
-	// Lock process memory against swap and disable core dumps before any key material
-	// or decrypted secret value is ever allocated (ADR-098). Narrows, not closes, the
-	// memory-zeroization gap: it protects the durable paths (swap survival across a
-	// reboot, a core file surviving a crash), not the transient in-memory exposure of a
+	// Disable core dumps before any key material or decrypted secret value is ever
+	// allocated (ADR-098). Narrows, not closes, the memory-zeroization gap: it protects
+	// a core file from surviving a crash, not the transient in-memory exposure of a
 	// live, healthy process documented alongside #1653's "three unwiped heap copies".
-	if err := hardening.ApplyMemoryHardening(hardening.MemoryConfig{
-		Disabled:       cfg.Security.Mlock.Disabled,
-		RequireSuccess: cfg.Security.Mlock.RequireSuccess,
-	}); err != nil {
+	// This package previously also called mlockall to protect against swap; that was
+	// removed (ADR-100) — it pinned RSS well above the shipped Helm chart's default
+	// memory limit with no ceiling, and cannot work as intended in a garbage-collected
+	// runtime. Swap exposure is now addressed at the deployment level (disable swap on
+	// the node / in the container runtime) rather than in-process.
+	if err := hardening.ApplyMemoryHardening(); err != nil {
 		log.Fatalf("memory hardening: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

Removes `mlockall(MCL_CURRENT|MCL_FUTURE)` from `internal/hardening.ApplyMemoryHardening` and `config.MlockConfig` entirely. Core dump suppression (`RLIMIT_CORE=0`) is unaffected.

**Why:** measured against the real `keyorix-server` binary, `mlockall` pins `VmLck` at ~2.6x the shipped Helm chart's default 512Mi memory limit at rest — before a single request beyond the readiness probe — and grows further under ordinary secret-creation load without ever shrinking (`madvise`-based reclamation cannot free `VM_LOCKED` pages). The shipped chart's `capabilities.drop: ["ALL"]` (no add-back path) means the only thing standing between "silently degraded to a no-op warning" and "pins an unbounded, ever-growing floor toward an OOM-kill" is the container runtime's default `RLIMIT_MEMLOCK`, which this chart doesn't control.

Scoping the lock to specific buffers instead of the whole process is not a viable middle ground: Go's garbage collector moves and copies memory, so locking one buffer's address doesn't protect the copies the runtime scatters elsewhere — the same reason Vault (the design this originally followed) used `mlockall` rather than per-buffer locking. The field has since moved away from process-wide mlock entirely: OpenBao removed it ([openbao/openbao#363](https://github.com/openbao/openbao/issues/363)), HashiCorp's own Vault Helm chart dropped `IPC_LOCK` in 2020, and Kubernetes nodes run swapless by default.

No config flag, no opt-in for the removed control — a knob for a control that doesn't work as intended is worse than its absence.

**Full rationale, measured evidence, and alternatives considered:** [`docs/adr-100-mlockall-removal-deployment-swap-control.md`](https://github.com/keyorixhq/keyorix/blob/fix-1679-mlock-removal/docs/adr-100-mlockall-removal-deployment-swap-control.md) (new). ADR-098 is marked partially superseded (mlockall half only); `docs/security-review-2026-09.md`'s prior claim is updated; operator guidance (disable swap at the deployment level) added to the Helm chart README and `docs/SECURITY.md`.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `gofmt -l` clean on all touched files
- [x] `gosec -severity medium -exclude-generated` clean on all touched packages
- [x] `internal/hardening`, `internal/config` suites green; `TestApplyMemoryHardening_DisablesCoreDumps` / `_CoreDumpDisableFailureIsFatal` cover the two remaining branches via the same injected-syscall pattern ADR-098 established
- [x] Confirmed via `git grep` (not `grep -r`) that no reference to `MlockConfig`, `mlockallFn`, or `security.mlock.*` remains anywhere in the repo outside historical doc comments explaining the removal
- [x] `scripts/check-adr-numbers.sh` passes with the new ADR-100