### PR TITLE
ci: add security-closure verification guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,17 @@ jobs:
       - name: Assert every docs/adr-NNN-*.md number is unique
         run: ./scripts/check-adr-numbers.sh
 
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Self-test the closure guard (must be able to go red)
+        run: ./scripts/check-closures.sh --self-test
+
+      - name: Verify every security closure claim names a passing test
+        run: ./scripts/check-closures.sh
+
   # Backstop for the actionlint pre-commit hook (.pre-commit-config.yaml) --
   # not a replacement for it. That hook is the PRIMARY guard: it runs on the
   # contributor's own machine before a broken workflow file is ever pushed,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,3 +222,15 @@ Reasoning and incidents behind these: `docs/g80-remediation-notes.md`.
   off the upstream server's own storage and asserts one exists — the only
   assertion that could have told `CreateNotification` was a permanently-
   failing stub from `CreateNotification` genuinely working.
+
+## Closing a security fix
+
+- Add a row to `docs/security-closures.tsv`: claim id, package, proving test, commit.
+  `scripts/check-closures.sh` fails the build if the named test does not exist,
+  skips, or fails. Verify by test, never by commit — this repo squash-merges.
+- If the root cause has sibling call sites, the fix is an invariant test, not a
+  site patch. Extend an existing registry test
+  (`TestEveryDirectRoleGrantChecksAuthority`, `remote_reachability_registry_test.go`)
+  rather than adding a one-off.
+- Reasoning and the failures behind these:
+  `keyorix-private/adversarial-review/LESSONS-LEARNED.md` and `SECURITY-INVARIANTS.md`.

--- a/docs/security-closures.tsv
+++ b/docs/security-closures.tsv
@@ -1,0 +1,26 @@
+# Security closure ledger. Verified by scripts/check-closures.sh, which fails the
+# build if a named test does not exist, skips, or fails.
+#
+# claim_id	package	proving_test	landed_commit	note
+#
+# landed_commit is INFORMATIONAL. This repo squash-merges, so ancestry checks
+# return false for every correctly landed PR. Closure is verified by test.
+
+G01	./internal/core	TestCheckGroupPermissions_ProjectScopedMembershipDoesNotCrossProjects	e6f018a0	project-scoped group membership must not grant cross-project secret read
+FIX-2-primitive	./internal/core	TestRemoveUserRole_RefusesLastProjectAdminAtThePrimitive	6b512b90	last-admin refused at the primitive, not only at entry points
+FIX-2-sso	./internal/core	TestReconcileSSOGroups_RefusesStrandingLastProjectAdmin	6b512b90	the SSO path must not bypass the group guards
+FIX-3-1551	./server/http	TestRemoteStorageMachineIdentities_RevokeCredential_UnauthorizedCallerRejected_RealServer	6b512b90	#1551 cross-tenant credential revoke must be refused
+FIX-3-1572	./server/http/handlers	TestUpdateUserIfActiveStateMatchesProxy_DeactivationRevokesCredentialsEvenWithoutUsersWrite_RealServer	6b512b90	#1572 deactivation must not leave tokens live
+FIX-4-sentinel	./server/grpc/services	TestMapRoleError_ValidationTextWithoutSentinel_NotEchoed	6b512b90	#1668/#1669 sentinel must survive adjacent commits
+FIX-5-namedlock	./internal/storage/store	TestWithNamedLock_NestedDifferentKey_StillSerializesAgainstOtherHolder	fca6d401	reentrancy guard keys on lockKey, not "any lock held"
+FIX-6-sod-oracle	./internal/core	TestDeleteSoDPolicy_NonAdmin_NonExistentAndNonOwned_IdenticalDenial	6b512b90	403/404 split must not be an existence oracle
+FIX-7-breakglass	./internal/storage/store	TestDeleteExpiredBreakGlassBefore_ReconciledRowStillRevocable	d1b93444	purge must not hard-delete a row mid-reconciliation
+FIX-8-csv	./internal/core	TestCSVWriters_EncodeAgainstFormulaInjection	d1b93444	structural: every CSV writer applies an encoder
+INV-1-grant-authority	./server/http	TestEveryDirectRoleGrantChecksAuthority	pre-existing	structural: every direct role grant checks authority
+
+# NOT LISTED, deliberately:
+#   FIX-1 actorID==0 fast-path (internal/core/authz.go:614). The eight-site reroute
+#   landed (#68e5116c) and actorIsMachine is threaded rather than hardcoded, but the
+#   fast-path itself remains and is now DOCUMENTED as the local-CLI path. A documented
+#   exception is a claim, not a fact -- 3 of 13 were false last time. It belongs in the
+#   documented-exception sweep, not in this ledger, until a test settles it.

--- a/scripts/check-closures.sh
+++ b/scripts/check-closures.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# check-closures.sh — fails if any security closure claim lacks a proving test
+# that actually runs and passes.
+#
+# Caught missing: G01 was recorded in REMEDIATION-STATUS.md as "merged, fully
+# addressed — 8 of 8 members" for three weeks. Five members had landed; the other
+# three sat on an unmerged branch (112b64ff). An adversarial review later
+# re-exploited the gap live, spending a full exploit build to learn what this
+# check learns in one second.
+#
+# Two design rules, each from a failure:
+#
+#   1. Verify by test, not by commit. This repo squash-merges, so
+#      `git merge-base --is-ancestor <branch> origin/main` returns false for
+#      every correctly landed PR — a check that always fails is as useless as one
+#      that always passes, and more corrosive, because it teaches people to
+#      ignore it. The landed_commit column is informational only.
+#
+#   2. PASS is not "did not fail". `go test -run` over a name that matches
+#      nothing EXITS ZERO, and a gated test with no DSN does not appear in output
+#      at all, not even as SKIP — that is how 13 Postgres lock sites stayed
+#      "verified" for months on the path where every one is a no-op. So this
+#      requires a literal `--- PASS: <name>` line and reports SKIP, no-match and
+#      unrecognised output as three distinct failures.
+#
+# Usage:
+#   ./scripts/check-closures.sh              # verify every row in the ledger
+#   ./scripts/check-closures.sh --self-test  # prove the check can go red
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LEDGER="${CLOSURE_LEDGER:-$REPO_ROOT/docs/security-closures.tsv}"
+fail=0
+checked=0
+die()  { echo "FAIL: $*" >&2; fail=1; }
+note() { echo "  $*"; }
+
+if [ ! -f "$LEDGER" ]; then
+    echo "FAIL: closure ledger not found at $LEDGER" >&2; exit 1
+fi
+
+rows=$(grep -vE '^[[:space:]]*(#|$)' "$LEDGER" || true)
+if [ -z "$rows" ]; then
+    echo "FAIL: closure ledger is empty — a ledger with no rows cannot fail, and" >&2
+    echo "      a check that cannot fail is not a check." >&2
+    exit 1
+fi
+
+dupes=$(cut -f1 <<<"$rows" | sort | uniq -d || true)
+if [ -n "$dupes" ]; then
+    die "duplicate claim_id in ledger:"; for d in $dupes; do note "$d"; done
+fi
+
+while IFS=$'\t' read -r claim pkg test commit rest; do
+    [ -z "${claim:-}" ] && continue
+    if [ -z "${pkg:-}" ] || [ -z "${test:-}" ]; then
+        die "$claim: missing package or proving_test — a closure without a citation is not a closure"
+    fi
+    [ -z "${commit:-}" ] && die "$claim: missing landed_commit"
+done <<<"$rows"
+[ "$fail" -eq 0 ] || exit 1
+
+for pkg in $(cut -f2 <<<"$rows" | sort -u); do
+    tests=$(awk -F'\t' -v p="$pkg" '$2==p {print $3}' <<<"$rows")
+    pattern=$(paste -sd'|' - <<<"$tests")
+    echo "==> $pkg"
+    set +e
+    out=$(cd "$REPO_ROOT" && go test -count=1 -v -run "^(${pattern})\$" "$pkg" 2>&1); rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+        die "$pkg: go test exited $rc"; sed -n '1,40p' <<<"$out" | sed 's/^/      /'; continue
+    fi
+    while IFS= read -r test; do
+        [ -z "$test" ] && continue
+        checked=$((checked + 1))
+        claim=$(awk -F'\t' -v p="$pkg" -v t="$test" '$2==p && $3==t {print $1}' <<<"$rows")
+        if grep -qE "^--- PASS: ${test}([[:space:]]|$)" <<<"$out"; then
+            note "ok   $claim -> $test"
+        elif grep -qE "^--- SKIP: ${test}([[:space:]]|$)" <<<"$out"; then
+            die "$claim: proving test $test SKIPPED, not passed."
+            note "     A skipped test proves nothing. If it needs a DSN or build tag,"
+            note "     CI must supply it, or this closure has no evidence."
+        elif grep -q "no tests to run" <<<"$out"; then
+            die "$claim: proving test $test DOES NOT EXIST (go test matched nothing, exited 0)."
+            note "     The false-green case: a renamed, deleted or never-written test"
+            note "     still reports success."
+        else
+            die "$claim: proving test $test produced no PASS line and no recognised failure."
+            sed -n '1,20p' <<<"$out" | sed 's/^/      /'
+        fi
+    done <<<"$tests"
+done
+
+if [ "${1:-}" = "--self-test" ]; then
+    echo; echo "==> self-test: the check must reject a closure naming a nonexistent test"
+    tmp=$(mktemp)
+    printf 'SELF-TEST\t./internal/core\tTestThisNameDoesNotExistAnywhere\tdeadbeef\tcalibration row\n' > "$tmp"
+    set +e
+    CLOSURE_LEDGER="$tmp" "$0" >/dev/null 2>&1; selfrc=$?
+    set -e
+    rm -f "$tmp"
+    if [ "$selfrc" -eq 0 ]; then
+        echo "FAIL: self-test PASSED when it must fail — this check cannot detect a" >&2
+        echo "      missing proving test and is therefore worthless." >&2
+        exit 1
+    fi
+    echo "  ok: self-test correctly went red (exit $selfrc)"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "ok: $checked closure claim(s) verified — each names a test that ran and passed"
+else
+    echo "CLOSURE VERIFICATION FAILED — do not treat the ledger as accurate" >&2; exit 1
+fi


### PR DESCRIPTION
## Summary

Fails the build if a security-fix closure claim names a proving test that does not exist, is skipped, or fails.

Catches the shape of gap that let G01 sit recorded as "merged, fully addressed — 8 of 8 members" for three weeks while three of its eight members were actually still on an unmerged branch — an adversarial review later re-exploited the gap live, spending a full exploit build to learn what this check learns in one second.

## Two design rules, each from a real failure

1. **Verify by test, not by commit ancestry.** This repo squash-merges every PR, so `git merge-base --is-ancestor <branch> origin/main` returns false for every correctly landed PR — a check that always fails is as useless as one that always passes, and worse, because it teaches people to ignore it. `landed_commit` in the ledger is informational only.
2. **PASS is not "did not fail."** `go test -run` over a name matching nothing exits zero, and a gated test with no DSN doesn't appear in output at all, not even as SKIP — that is how 13 Postgres lock sites stayed "verified" for months on the path where every one of them is a no-op. The script requires a literal `--- PASS: <name>` line and treats SKIP, no-match, and unrecognised output as three distinct failures.

## Landing notes

- **Ledger path matters.** It lives at `docs/security-closures.tsv`, **not** `security/closures.tsv` — the latter is gitignored (`.gitignore:149`), which would make the guard present in the pipeline and silently inert (checked: `git check-ignore -v docs/security-closures.tsv` returns no match).
- Fixed one real issue found while landing: the drafted `actions/setup-go@v5` CI step used a mutable tag; every other `setup-go` use in this same file pins to `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0` — repinned to match.
- Fixed one mode regression: `scripts/check-closures.sh` had lost its executable bit somewhere between drafting and this landing pass (755 → 644) — restored before committing; confirmed `100755` in the final tree.
- Seeded with 11 rows: G01, FIX-2 through FIX-8, and the pre-existing `TestEveryDirectRoleGrantChecksAuthority` invariant test.
- CI wiring: two new steps in the `adr-numbers` job (self-test first, then the real verification), after the existing ADR-number-uniqueness check — that job had no Go setup before, so the added `setup-go` step is genuinely needed, not redundant.
- Landed alone — nothing else in this PR — so its own self-test is the only thing being judged the first time it runs.

## Verification (by hand, not just CI)

`./scripts/check-closures.sh --self-test`:

```
==> ./internal/core
  ok   G01 -> TestCheckGroupPermissions_ProjectScopedMembershipDoesNotCrossProjects
  ok   FIX-2-primitive -> TestRemoveUserRole_RefusesLastProjectAdminAtThePrimitive
  ok   FIX-2-sso -> TestReconcileSSOGroups_RefusesStrandingLastProjectAdmin
  ok   FIX-6-sod-oracle -> TestDeleteSoDPolicy_NonAdmin_NonExistentAndNonOwned_IdenticalDenial
  ok   FIX-8-csv -> TestCSVWriters_EncodeAgainstFormulaInjection
==> ./internal/storage/store
  ok   FIX-5-namedlock -> TestWithNamedLock_NestedDifferentKey_StillSerializesAgainstOtherHolder
  ok   FIX-7-breakglass -> TestDeleteExpiredBreakGlassBefore_ReconciledRowStillRevocable
==> ./server/grpc/services
  ok   FIX-4-sentinel -> TestMapRoleError_ValidationTextWithoutSentinel_NotEchoed
==> ./server/http
  ok   FIX-3-1551 -> TestRemoteStorageMachineIdentities_RevokeCredential_UnauthorizedCallerRejected_RealServer
  ok   INV-1-grant-authority -> TestEveryDirectRoleGrantChecksAuthority
==> ./server/http/handlers
  ok   FIX-3-1572 -> TestUpdateUserIfActiveStateMatchesProxy_DeactivationRevokesCredentialsEvenWithoutUsersWrite_RealServer

==> self-test: the check must reject a closure naming a nonexistent test
  ok: self-test correctly went red (exit 1)

ok: 11 closure claim(s) verified -- each names a test that ran and passed
```

`./scripts/check-closures.sh` (plain, against the seeded ledger): identical output minus the self-test block, exit 0. Both runs use `-count=1` (baked into the script), so this is not a cached result.

**Neither Go test path had ever actually executed before this landing pass** (drafted in a shell without Go available) — this was the first real run. All 11 seeded rows are genuinely green; zero red rows to report.

- [x] `shellcheck --severity=warning` clean (one info-level SC2013 style note left as-is — not a defect, and this is a landing task, not a design task)
- [x] `actionlint` clean
- [x] `git check-ignore -v docs/security-closures.tsv` — no match
- [x] `--self-test` observed going red on an injected nonexistent-test row
- [x] Real run against all 11 seeded rows observed green, twice (pre- and post-rebase onto current main)
