### PR TITLE
test: cover GenerateBillingReport, config roundtrip, notification proxy

### DIFF
--- a/internal/config/roundtrip_test.go
+++ b/internal/config/roundtrip_test.go
@@ -1,0 +1,367 @@
+package config
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// readYAMLMap re-reads path and decodes it into a generic map for assertions on
+// individual keys, independent of the Config struct's own field set (SaveFields
+// operates on arbitrary YAML key paths, not just ones Config happens to declare).
+func readYAMLMap(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &m))
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// IsNotExist
+// ---------------------------------------------------------------------------
+
+// TestIsNotExist_TrueForWrappedFsErrNotExist confirms the documented contract:
+// unlike os.IsNotExist, IsNotExist must see through fmt.Errorf's %w wrapping.
+func TestIsNotExist_TrueForWrappedFsErrNotExist(t *testing.T) {
+	err := fmt.Errorf("failed to read config file %q: %w", "x.yaml", fs.ErrNotExist)
+	assert.True(t, IsNotExist(err))
+}
+
+// TestIsNotExist_TrueForRealMissingFileOpen exercises the actual stdlib error
+// shape (a *fs.PathError from os.Open on a missing path), not just a hand-built
+// fs.ErrNotExist wrap.
+func TestIsNotExist_TrueForRealMissingFileOpen(t *testing.T) {
+	dir := t.TempDir()
+	_, err := os.Open(filepath.Join(dir, "does-not-exist.yaml"))
+	require.Error(t, err)
+	assert.True(t, IsNotExist(err))
+}
+
+// TestIsNotExist_TrueThroughLoadWrapping mirrors the real production call chain:
+// Load wraps securefiles' not-found error in its own "failed to read config file"
+// message. IsNotExist exists specifically because that wrapping breaks
+// os.IsNotExist; confirm it survives the actual wrap Load performs, not just a
+// synthetic one.
+func TestIsNotExist_TrueThroughLoadWrapping(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := Load(filepath.Join(dir, "missing.yaml"))
+	require.Error(t, err)
+	assert.True(t, IsNotExist(err), "Load's wrapped not-exist error must satisfy IsNotExist")
+}
+
+// TestIsNotExist_FalseForParseError is the read-side counterpart of #1644: a
+// config file that EXISTS but fails to parse must never be mistaken for one that
+// doesn't exist. A caller that gets this wrong falls back to save-the-defaults
+// and silently destroys the file's real content.
+func TestIsNotExist_FalseForParseError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("a: [1, 2\n"), 0o600))
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.False(t, IsNotExist(err), "a parse/decode failure must NOT be mistaken for not-exist")
+}
+
+// TestIsNotExist_FalseForNil confirms the zero-value / no-error case.
+func TestIsNotExist_FalseForNil(t *testing.T) {
+	assert.False(t, IsNotExist(nil))
+}
+
+// ---------------------------------------------------------------------------
+// SaveFields
+// ---------------------------------------------------------------------------
+
+// TestSaveFields_CreatesNewFile validates the fresh-install path: when the
+// target file doesn't exist yet, SaveFields creates one containing only the
+// given fields.
+func TestSaveFields_CreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyorix.yaml")
+
+	require.NoError(t, SaveFields(path, map[string]any{
+		"environment": "prod",
+	}))
+
+	m := readYAMLMap(t, path)
+	assert.Equal(t, map[string]any{"environment": "prod"}, m)
+}
+
+// TestSaveFields_PreservesOtherKeys is the core #1644 regression test: writing
+// one named field via SaveFields must leave every other pre-existing top-level
+// key's value completely untouched -- this is exactly the property Save (full
+// struct remarshal) violated.
+func TestSaveFields_PreservesOtherKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyorix.yaml")
+
+	original := "" +
+		"environment: dev\n" +
+		"security:\n" +
+		"  require_transport_tls: true\n" +
+		"  other_flag: false\n" +
+		"storage:\n" +
+		"  type: local\n"
+	require.NoError(t, os.WriteFile(path, []byte(original), 0o600))
+
+	require.NoError(t, SaveFields(path, map[string]any{
+		"environment": "prod",
+	}))
+
+	m := readYAMLMap(t, path)
+	assert.Equal(t, "prod", m["environment"], "the named field must be updated")
+
+	security, ok := m["security"].(map[string]any)
+	require.True(t, ok, "security mapping must survive untouched")
+	assert.Equal(t, true, security["require_transport_tls"], "unrelated security setting must not be reverted -- this is the exact #1644 failure mode")
+	assert.Equal(t, false, security["other_flag"])
+
+	storage, ok := m["storage"].(map[string]any)
+	require.True(t, ok, "storage mapping must survive untouched")
+	assert.Equal(t, "local", storage["type"])
+}
+
+// TestSaveFields_InvalidYAMLLeavesFileUnchanged asserts the "a parse failure is
+// not licence to replace the file" invariant the SaveFields doc comment states
+// explicitly: against a file that exists but contains invalid YAML, SaveFields
+// must return an error AND leave the on-disk bytes byte-for-byte unchanged.
+func TestSaveFields_InvalidYAMLLeavesFileUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyorix.yaml")
+
+	invalid := "a: [1, 2\n" // unterminated flow sequence -- invalid YAML
+	require.NoError(t, os.WriteFile(path, []byte(invalid), 0o600))
+
+	before, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	err = SaveFields(path, map[string]any{"environment": "prod"})
+	require.Error(t, err)
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "SaveFields must not modify the file on a parse failure")
+}
+
+// TestSaveFields_NestedDotPathOnFreshFile validates that a multi-segment dot
+// path (e.g. "storage.remote.base_url") creates the necessary intermediate
+// mapping nodes when starting from nothing.
+func TestSaveFields_NestedDotPathOnFreshFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyorix.yaml")
+
+	require.NoError(t, SaveFields(path, map[string]any{
+		"storage.remote.base_url": "https://example.com",
+	}))
+
+	m := readYAMLMap(t, path)
+	storage, ok := m["storage"].(map[string]any)
+	require.True(t, ok)
+	remote, ok := storage["remote"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "https://example.com", remote["base_url"])
+}
+
+// TestSaveFields_NestedDotPathPreservesSiblings validates that setting a nested
+// field on a mapping that already has OTHER keys at every level doesn't clobber
+// any of those siblings -- the multi-level analogue of
+// TestSaveFields_PreservesOtherKeys.
+func TestSaveFields_NestedDotPathPreservesSiblings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyorix.yaml")
+
+	original := "" +
+		"storage:\n" +
+		"  type: remote\n" +
+		"  remote:\n" +
+		"    api_key: secret-value\n" +
+		"    timeout: 30\n"
+	require.NoError(t, os.WriteFile(path, []byte(original), 0o600))
+
+	require.NoError(t, SaveFields(path, map[string]any{
+		"storage.remote.base_url": "https://example.com",
+	}))
+
+	m := readYAMLMap(t, path)
+	storage, ok := m["storage"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "remote", storage["type"], "sibling of the intermediate mapping must survive")
+
+	remote, ok := storage["remote"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "secret-value", remote["api_key"], "sibling of the leaf key must survive")
+	assert.Equal(t, 30, remote["timeout"], "sibling of the leaf key must survive")
+	assert.Equal(t, "https://example.com", remote["base_url"], "the newly-set leaf key must be present")
+}
+
+// TestSaveFields_DefaultsPathWhenEmpty mirrors Save's own empty-path handling:
+// SaveFields("", fields) must write to appRootDir/keyorix.yaml rather than
+// erroring.
+func TestSaveFields_DefaultsPathWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	require.NoError(t, SaveFields("", map[string]any{"environment": "default-path-test"}))
+
+	m := readYAMLMap(t, filepath.Join(dir, "keyorix.yaml"))
+	assert.Equal(t, "default-path-test", m["environment"])
+}
+
+// TestSaveFields_ReadErrorOtherThanNotExist exercises the "default" branch of
+// SaveFields' read-error switch: a read failure that is NOT fs.ErrNotExist
+// (here, the securefiles traversal guard rejecting a path that escapes
+// appRootDir) must be surfaced as a real error, not silently treated as
+// "file doesn't exist yet."
+func TestSaveFields_ReadErrorOtherThanNotExist(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	err := SaveFields("../escape.yaml", map[string]any{"environment": "prod"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read config file")
+
+	_, statErr := os.Stat(filepath.Join(filepath.Dir(dir), "escape.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "SaveFields must not write outside its base directory")
+}
+
+// TestSaveFields_RootNotAMapping validates that an existing file whose YAML
+// content parses but is not a mapping at its root (e.g. a bare list) is
+// rejected with a clear error rather than panicking or silently discarding
+// the file's structure.
+func TestSaveFields_RootNotAMapping(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyorix.yaml")
+	original := "- one\n- two\n"
+	require.NoError(t, os.WriteFile(path, []byte(original), 0o600))
+
+	err := SaveFields(path, map[string]any{"environment": "prod"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not contain a YAML mapping")
+
+	after, rerr := os.ReadFile(path)
+	require.NoError(t, rerr)
+	assert.Equal(t, original, string(after), "file must be left untouched when the root isn't a mapping")
+}
+
+// TestSaveFields_WriteErrorPropagates exercises the write-side error branch:
+// when the underlying secure write fails (here, the target directory has no
+// write permission), SaveFields must propagate that error rather than
+// reporting success.
+func TestSaveFields_WriteErrorPropagates(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory write permissions")
+	}
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.Mkdir(sub, 0o700))
+	require.NoError(t, os.Chmod(sub, 0o500)) // read+execute only, no write
+	t.Cleanup(func() { _ = os.Chmod(sub, 0o700) })
+
+	path := filepath.Join(sub, "keyorix.yaml")
+	err := SaveFields(path, map[string]any{"environment": "prod"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write config file")
+}
+
+// TestSaveFields_HonorsAbsolutePath mirrors TestSaveHonorsAbsolutePath: an
+// absolute path must be written exactly there, rooted at its own directory,
+// not mis-joined against appRootDir.
+func TestSaveFields_HonorsAbsolutePath(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	elsewhere := t.TempDir()
+	absPath := filepath.Join(elsewhere, "keyorix.yaml")
+
+	require.NoError(t, SaveFields(absPath, map[string]any{"environment": "prod-abs-path-test"}))
+
+	m := readYAMLMap(t, absPath)
+	assert.Equal(t, "prod-abs-path-test", m["environment"])
+
+	entries, err := os.ReadDir(cwd)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "cwd must remain untouched when SaveFields is given an absolute path")
+}
+
+// ---------------------------------------------------------------------------
+// yamlSetField (unexported, tested directly from within the package)
+// ---------------------------------------------------------------------------
+
+// parseMappingRoot parses a small YAML document and returns its root mapping
+// node, for driving yamlSetField directly without going through SaveFields'
+// file I/O.
+func parseMappingRoot(t *testing.T, src string) *yaml.Node {
+	t.Helper()
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &doc))
+	require.Equal(t, yaml.DocumentNode, doc.Kind)
+	require.NotEmpty(t, doc.Content)
+	root := doc.Content[0]
+	require.Equal(t, yaml.MappingNode, root.Kind)
+	return root
+}
+
+// decodeNode marshals a yaml.Node back out and decodes it into a generic map,
+// so assertions can be made on values rather than node internals.
+func decodeNode(t *testing.T, node *yaml.Node) map[string]any {
+	t.Helper()
+	out, err := yaml.Marshal(node)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, yaml.Unmarshal(out, &m))
+	return m
+}
+
+// TestYamlSetField_OverwritesExistingScalar validates the simple single-segment
+// case: an existing key's value is replaced.
+func TestYamlSetField_OverwritesExistingScalar(t *testing.T) {
+	root := parseMappingRoot(t, "environment: dev\nother: unchanged\n")
+
+	require.NoError(t, yamlSetField(root, []string{"environment"}, "prod"))
+
+	m := decodeNode(t, root)
+	assert.Equal(t, "prod", m["environment"])
+	assert.Equal(t, "unchanged", m["other"], "sibling key must be untouched")
+}
+
+// TestYamlSetField_AddsNewKey validates that a key not previously present is
+// appended rather than requiring pre-existence.
+func TestYamlSetField_AddsNewKey(t *testing.T) {
+	root := parseMappingRoot(t, "existing: value\n")
+
+	require.NoError(t, yamlSetField(root, []string{"brand_new"}, "hello"))
+
+	m := decodeNode(t, root)
+	assert.Equal(t, "value", m["existing"])
+	assert.Equal(t, "hello", m["brand_new"])
+}
+
+// TestYamlSetField_OverwritesNonMappingIntermediate exercises the documented
+// edge case: "overwrites (rather than merges into) any existing non-mapping
+// node found along an intermediate segment." Path a.b.c where a.b currently
+// holds a scalar (not a mapping) must have that scalar replaced by a mapping
+// so c can be set underneath it -- not error out, and not silently no-op.
+func TestYamlSetField_OverwritesNonMappingIntermediate(t *testing.T) {
+	root := parseMappingRoot(t, "a:\n  b: i-am-a-scalar\n  sibling: keep-me\n")
+
+	require.NoError(t, yamlSetField(root, []string{"a", "b", "c"}, "value"))
+
+	m := decodeNode(t, root)
+	a, ok := m["a"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "keep-me", a["sibling"], "sibling of the overwritten intermediate must survive")
+
+	b, ok := a["b"].(map[string]any)
+	require.True(t, ok, "b must have been converted from scalar to mapping")
+	assert.Equal(t, "value", b["c"])
+}

--- a/internal/core/billing_test.go
+++ b/internal/core/billing_test.go
@@ -1,0 +1,162 @@
+package core
+
+import (
+	"context"
+	"crypto/ed25519"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/license"
+	"github.com/keyorixhq/keyorix/internal/trust"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// billingLicensedGate builds a license gate that grants license.FeatureBilling,
+// mirroring gateWithExpiry (license_expiry_test.go) but for the billing feature
+// specifically rather than an expiry scenario.
+func billingLicensedGate(t *testing.T) *license.Gate {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	token, err := license.Issue(license.License{
+		Licensee: "ACME GmbH", Plan: "enterprise", Features: []string{license.FeatureBilling},
+		IssuedAt: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(365 * 24 * time.Hour), KeyID: "license-billing",
+	}, priv)
+	require.NoError(t, err)
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeLicense, "license-billing", pub))
+	return license.NewGate(token, reg, "", time.Hour)
+}
+
+func TestGenerateBillingReport_Unlicensed_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms) // no gate set → nil gate → community baseline, no features
+
+	from := time.Now().Add(-24 * time.Hour)
+	to := time.Now()
+
+	report, err := c.GenerateBillingReport(ctx, from, to, nil)
+	require.Error(t, err)
+	assert.Nil(t, report)
+	assert.Contains(t, err.Error(), "commercial license")
+	ms.AssertNotCalled(t, "GetBillingReport", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenerateBillingReport_FromEqualsTo_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.SetLicenseGate(billingLicensedGate(t))
+
+	same := time.Now()
+
+	report, err := c.GenerateBillingReport(ctx, same, same, nil)
+	require.Error(t, err)
+	assert.Nil(t, report)
+	assert.Contains(t, err.Error(), "must be before")
+	ms.AssertNotCalled(t, "GetBillingReport", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenerateBillingReport_FromAfterTo_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.SetLicenseGate(billingLicensedGate(t))
+
+	from := time.Now()
+	to := from.Add(-time.Hour) // inverted
+
+	report, err := c.GenerateBillingReport(ctx, from, to, nil)
+	require.Error(t, err)
+	assert.Nil(t, report)
+	assert.Contains(t, err.Error(), "must be before")
+	ms.AssertNotCalled(t, "GetBillingReport", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenerateBillingReport_WindowExceedsMax_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.SetLicenseGate(billingLicensedGate(t))
+
+	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := from.Add(366*24*time.Hour + time.Nanosecond) // just over the max
+
+	report, err := c.GenerateBillingReport(ctx, from, to, nil)
+	require.Error(t, err)
+	assert.Nil(t, report)
+	assert.Contains(t, err.Error(), "exceeds the maximum")
+	ms.AssertNotCalled(t, "GetBillingReport", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenerateBillingReport_WindowExactly366Days_Allowed(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.SetLicenseGate(billingLicensedGate(t))
+
+	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := from.Add(366 * 24 * time.Hour) // exactly the boundary, not over
+
+	want := &storage.BillingReport{From: from, To: to}
+	ms.On("GetBillingReport", ctx, from, to, []uint(nil)).Return(want, nil)
+
+	got, err := c.GenerateBillingReport(ctx, from, to, nil)
+	require.NoError(t, err)
+	assert.Same(t, want, got)
+	ms.AssertExpectations(t)
+}
+
+func TestGenerateBillingReport_Delegates_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.SetLicenseGate(billingLicensedGate(t))
+
+	// Deliberately use a non-UTC location to confirm the core layer normalizes
+	// to UTC before delegating to storage, per the function's doc comment.
+	loc := time.FixedZone("UTC-5", -5*60*60)
+	from := time.Date(2025, 6, 1, 10, 0, 0, 0, loc)
+	to := time.Date(2025, 6, 8, 10, 0, 0, 0, loc)
+	projectIDs := []uint{1, 2, 3}
+
+	want := &storage.BillingReport{
+		From:     from.UTC(),
+		To:       to.UTC(),
+		Projects: []storage.BillingProjectStat{{ProjectID: 1}},
+	}
+	ms.On("GetBillingReport", ctx, from.UTC(), to.UTC(), projectIDs).Return(want, nil)
+
+	got, err := c.GenerateBillingReport(ctx, from, to, projectIDs)
+	require.NoError(t, err)
+	assert.Same(t, want, got)
+	ms.AssertExpectations(t)
+
+	// The call the mock recorded must have received UTC-normalized times, not
+	// the original non-UTC location.
+	call := ms.Calls[0]
+	assert.Equal(t, time.UTC, call.Arguments.Get(1).(time.Time).Location())
+	assert.Equal(t, time.UTC, call.Arguments.Get(2).(time.Time).Location())
+}
+
+func TestGenerateBillingReport_PropagatesStorageError(t *testing.T) {
+	ctx := context.Background()
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	c.SetLicenseGate(billingLicensedGate(t))
+
+	from := time.Now().Add(-24 * time.Hour)
+	to := time.Now()
+
+	storageErr := assert.AnError
+	ms.On("GetBillingReport", ctx, from.UTC(), to.UTC(), []uint(nil)).Return(nil, storageErr)
+
+	got, err := c.GenerateBillingReport(ctx, from, to, nil)
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.ErrorIs(t, err, storageErr)
+}

--- a/server/http/handlers/notification_proxy_test.go
+++ b/server/http/handlers/notification_proxy_test.go
@@ -1,0 +1,278 @@
+// notification_proxy_test.go — regression coverage for CreateNotificationProxy
+// (notification_proxy.go, #1589): before this handler existed,
+// storage.type: remote deployments silently, permanently dropped every
+// notification because CreateNotification was an unconditional stub, and
+// notify()/notifyWithSeverity() (internal/core/notifications.go) swallow the
+// error by design — nothing surfaced the failure. This file is the
+// regression guard: it exercises the full wire<->model round-trip
+// (including the deliberate IsRead=false invariant on create) and both
+// storage-error branches (duplicate reminder -> 409, generic -> 500) so a
+// future refactor that reopens #1589 fails a test instead of failing silently.
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	sqlite "github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+var notifProxyDBCounter atomic.Int64
+
+// freshCoreNotifProxy creates a brand-new in-memory SQLite DB migrated for
+// models.Notification, plus the same partial unique reminder-dedup index
+// production installs via internal/storage/factory.go's
+// ensureReminderNotificationDedupIndex ("uniq_notifications_unread_reminder"
+// on (user_id, type, project_id) WHERE is_read = false AND type IN
+// ('rotation.reminder', 'secret.expiry_reminder')) — without this index,
+// CreateNotification can never return storage.ErrDuplicateReminderNotification
+// and the 409 branch would be untestable. Returns both the gorm handle (so a
+// test can close the underlying *sql.DB to force a generic storage error) and
+// the KeyorixCore built on top of it.
+func freshCoreNotifProxy(t *testing.T) (*gorm.DB, *core.KeyorixCore) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+	n := notifProxyDBCounter.Add(1)
+	dsn := fmt.Sprintf("file:kxhandlers_notifproxy_%d?mode=memory&cache=shared&_timeout=30000", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Notification{}))
+	require.NoError(t, db.Exec(
+		"CREATE UNIQUE INDEX IF NOT EXISTS uniq_notifications_unread_reminder "+
+			"ON notifications (user_id, type, project_id) "+
+			"WHERE is_read = false AND type IN ('rotation.reminder', 'secret.expiry_reminder')",
+	).Error)
+	cs := core.NewKeyorixCore(store.NewLocalStorage(db))
+	return db, cs
+}
+
+func newNotifProxyRequest(t *testing.T, body interface{}) *http.Request {
+	t.Helper()
+	var raw []byte
+	switch v := body.(type) {
+	case []byte:
+		raw = v
+	case string:
+		raw = []byte(v)
+	default:
+		var err error
+		raw, err = json.Marshal(v)
+		require.NoError(t, err)
+	}
+	return httptest.NewRequest(http.MethodPost, "/api/v1/system/notifications", bytes.NewReader(raw))
+}
+
+// ── missing/zero UserID -> 400 ──────────────────────────────────────────────
+
+func TestCreateNotificationProxy_ZeroUserID(t *testing.T) {
+	_, cs := freshCoreNotifProxy(t)
+	h := NewCatalogHandler(cs)
+	req := newNotifProxyRequest(t, notificationProxyWire{
+		UserID:  0,
+		Type:    "secret.shared",
+		Title:   "hi",
+		Message: "hello",
+	})
+	w := httptest.NewRecorder()
+	h.CreateNotificationProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.False(t, resp.Success)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+	assert.Equal(t, "user_id is required", resp.Error.Message)
+}
+
+func TestCreateNotificationProxy_MissingUserIDField(t *testing.T) {
+	_, cs := freshCoreNotifProxy(t)
+	h := NewCatalogHandler(cs)
+	req := newNotifProxyRequest(t, `{"type":"secret.shared","title":"hi","message":"hello"}`)
+	w := httptest.NewRecorder()
+	h.CreateNotificationProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+}
+
+// ── bad JSON body -> 400 ────────────────────────────────────────────────────
+
+func TestCreateNotificationProxy_BadJSON(t *testing.T) {
+	_, cs := freshCoreNotifProxy(t)
+	h := NewCatalogHandler(cs)
+	req := newNotifProxyRequest(t, "{not valid json")
+	w := httptest.NewRecorder()
+	h.CreateNotificationProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.False(t, resp.Success)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+	assert.Equal(t, errInvalidBody, resp.Error.Message)
+}
+
+// ── success: full field round-trip, including the IsRead=false invariant ──
+
+func TestCreateNotificationProxy_Success_FullRoundTrip(t *testing.T) {
+	db, cs := freshCoreNotifProxy(t)
+	h := NewCatalogHandler(cs)
+
+	secretNodeID := uint(42)
+	projectID := uint(7)
+	createdAt := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	body := map[string]interface{}{
+		"user_id":        99,
+		"secret_node_id": secretNodeID,
+		"project_id":     projectID,
+		"type":           "rotation.reminder",
+		"title":          "Rotate your secret",
+		"message":        "This secret is due for rotation.",
+		"link":           "/projects/7/secrets/42",
+		"severity":       int(models.NotificationSeverityCritical),
+		// Adversarial: a caller-supplied is_read=true must NOT survive to
+		// the created record — creation always forces IsRead=false per the
+		// handler's own documented invariant.
+		"is_read":    true,
+		"created_at": createdAt,
+	}
+
+	req := newNotifProxyRequest(t, body)
+	w := httptest.NewRecorder()
+	h.CreateNotificationProxy(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := decodeRemoteResp(t, w)
+	require.True(t, resp.Success)
+
+	dataBytes, err := json.Marshal(resp.Data)
+	require.NoError(t, err)
+	var wire notificationProxyWire
+	require.NoError(t, json.Unmarshal(dataBytes, &wire))
+
+	assert.NotZero(t, wire.ID, "ID must be assigned by the database, not trusted from the wire")
+	assert.Equal(t, uint(99), wire.UserID)
+	require.NotNil(t, wire.SecretNodeID)
+	assert.Equal(t, secretNodeID, *wire.SecretNodeID)
+	require.NotNil(t, wire.ProjectID)
+	assert.Equal(t, projectID, *wire.ProjectID)
+	assert.Equal(t, "rotation.reminder", wire.Type)
+	assert.Equal(t, "Rotate your secret", wire.Title)
+	assert.Equal(t, "This secret is due for rotation.", wire.Message)
+	assert.Equal(t, "/projects/7/secrets/42", wire.Link)
+	assert.Equal(t, int(models.NotificationSeverityCritical), wire.Severity)
+	assert.False(t, wire.IsRead, "creation must always force IsRead=false regardless of what the wire body requested")
+
+	// Confirm the invariant landed in storage too, not just the response.
+	var stored models.Notification
+	require.NoError(t, db.First(&stored, wire.ID).Error)
+	assert.False(t, stored.IsRead)
+}
+
+// ── success: nil pointer fields round-trip as nil, not zero ────────────────
+
+func TestCreateNotificationProxy_Success_NilOptionalFields(t *testing.T) {
+	_, cs := freshCoreNotifProxy(t)
+	h := NewCatalogHandler(cs)
+
+	body := notificationProxyWire{
+		UserID:  5,
+		Type:    "secret.shared",
+		Title:   "A secret was shared with you",
+		Message: "See details.",
+	}
+	req := newNotifProxyRequest(t, body)
+	w := httptest.NewRecorder()
+	h.CreateNotificationProxy(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := decodeRemoteResp(t, w)
+	require.True(t, resp.Success)
+
+	dataBytes, err := json.Marshal(resp.Data)
+	require.NoError(t, err)
+	var wire notificationProxyWire
+	require.NoError(t, json.Unmarshal(dataBytes, &wire))
+
+	assert.Nil(t, wire.SecretNodeID)
+	assert.Nil(t, wire.ProjectID)
+	assert.False(t, wire.IsRead)
+	assert.Equal(t, int(models.NotificationSeverityNone), wire.Severity)
+}
+
+// ── duplicate reminder -> 409 with the documented error code ───────────────
+
+func TestCreateNotificationProxy_DuplicateReminder(t *testing.T) {
+	_, cs := freshCoreNotifProxy(t)
+	h := NewCatalogHandler(cs)
+
+	first := notificationProxyWire{
+		UserID:    11,
+		ProjectID: uintPtrNotifProxy(3),
+		Type:      "rotation.reminder",
+		Title:     "Rotate now",
+		Message:   "first reminder",
+	}
+	req1 := newNotifProxyRequest(t, first)
+	w1 := httptest.NewRecorder()
+	h.CreateNotificationProxy(w1, req1)
+	require.Equal(t, http.StatusOK, w1.Code, "body: %s", w1.Body.String())
+
+	// Second unread reminder of the same (user, type, project) must hit the
+	// partial unique dedup index (#488) and surface as
+	// storage.ErrDuplicateReminderNotification via errors.Is.
+	second := notificationProxyWire{
+		UserID:    11,
+		ProjectID: uintPtrNotifProxy(3),
+		Type:      "rotation.reminder",
+		Title:     "Rotate now (again)",
+		Message:   "duplicate reminder",
+	}
+	req2 := newNotifProxyRequest(t, second)
+	w2 := httptest.NewRecorder()
+	h.CreateNotificationProxy(w2, req2)
+
+	assert.Equal(t, http.StatusConflict, w2.Code)
+	resp := decodeRemoteResp(t, w2)
+	assert.False(t, resp.Success)
+	assert.Equal(t, notificationDuplicateReminderCode, resp.Error.Code)
+	assert.Equal(t, "DUPLICATE_REMINDER_NOTIFICATION", resp.Error.Code)
+}
+
+// ── generic storage error -> 500 STORAGE_ERROR ──────────────────────────────
+
+func TestCreateNotificationProxy_GenericStorageError(t *testing.T) {
+	db, cs := freshCoreNotifProxy(t)
+	h := NewCatalogHandler(cs)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.Close())
+
+	req := newNotifProxyRequest(t, notificationProxyWire{
+		UserID:  1,
+		Type:    "secret.shared",
+		Title:   "t",
+		Message: "m",
+	})
+	w := httptest.NewRecorder()
+	h.CreateNotificationProxy(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.False(t, resp.Success)
+	assert.Equal(t, "STORAGE_ERROR", resp.Error.Code)
+}
+
+func uintPtrNotifProxy(v uint) *uint { return &v }


### PR DESCRIPTION
## Summary
Three previously 0%-covered paths that survived the #1700 coverage sweep, picked because each guards a specific past incident rather than for the coverage number alone:

- `internal/core/billing.go:GenerateBillingReport` — license gate + window-validation branches (inverted/equal/>366d/exactly-366d), UTC-normalized delegation into storage.
- `internal/config/roundtrip.go` (`IsNotExist`/`SaveFields`/`yamlSetField`) — regression coverage for #1644 (a config re-save that silently reverted `security.require_transport_tls` and destroyed every other setting). Verified the new tests actually catch that failure mode by temporarily reintroducing the bug and confirming red before reverting.
- `server/http/handlers/notification_proxy.go` — regression coverage for #1589 (remote-mode notification creation was an unconditional stub, silently and permanently dropping every notification under `storage.type: remote`). Covers the dedup-conflict branch, the always-`IsRead=false` invariant, and the wire↔model round-trip.

No production code changed; no bugs found in any of the three.

## Test plan
- [x] `go vet ./internal/config/... ./internal/core/... ./server/http/handlers/...` clean
- [x] `go test ./internal/config/...` — pass
- [x] `go test ./internal/core/...` — pass (full suite, no regressions)
- [x] `go test ./server/http/handlers/...` — pass (full suite, no regressions)
- [x] Target functions confirmed at 100% coverage post-change