### PR TITLE
fix(http,core): reclassify+fix UpdateWebAuthnCredentialProxy as authz bypass, not audit gap (#1714)

### DIFF
--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -529,16 +529,40 @@ func (c *KeyorixCore) rejectIfCloned(ctx context.Context, userID uint, cred *web
 	// Scoped to userID (#307) — the lookup itself enforces ownership, so no separate
 	// row.UserID check is needed here.
 	if row, err := c.storage.GetWebAuthnCredentialByCredID(ctx, cred.ID, userID); err == nil {
-		row.Disabled = true
-		_ = c.storage.UpdateWebAuthnCredential(ctx, row)
+		// Mutation + audit as one unit (#1714) — see markWebAuthnCredentialClonedDisabled.
+		_ = c.markWebAuthnCredentialClonedDisabled(ctx, row, ip)
+	} else {
+		// Row lookup failed (rare — e.g. a race with the credential being deleted
+		// between assertion verification and this call). Nothing to disable, but
+		// the clone signal for THIS login attempt is still real and must still be
+		// recorded — this is the one case where the audit write is not paired with
+		// a mutation, since there is no row to mutate.
+		uid := userID
+		c.writeAuditEventFull(ctx, EventWebAuthnCloneDetected, &uid, nil, nil, ip,
+			fmt.Sprintf("authentication refused for user %d: signature-counter regression (possible cloned authenticator) — credential lookup failed, nothing disabled", userID))
 	}
-	uid := userID
-	c.writeAuditEventFull(ctx, EventWebAuthnCloneDetected, &uid, nil, nil, ip,
-		fmt.Sprintf("authentication refused for user %d: signature-counter regression (possible cloned authenticator) — credential disabled pending re-registration", userID))
 	c.notify(ctx, userID, NotificationWebAuthnCloneDetected, "Passkey clone suspected",
 		"A sign-in attempt was blocked because one of your passkeys reported a signature-counter regression — a sign that its private key may exist on more than one device. The passkey has been disabled; please remove it and register a new one.",
 		nil, "/account/security")
 	return fmt.Errorf("assertion verification failed: signature counter did not advance (possible cloned authenticator)")
+}
+
+// markWebAuthnCredentialClonedDisabled performs a WebAuthn credential's
+// disable-on-clone-signal mutation (Disabled: false -> true) and its
+// EventWebAuthnCloneDetected audit write as a single unit (#1714), so no
+// exported path can do one without the other. row must already be the
+// caller's own fetched, owned row (rejectIfCloned's GetWebAuthnCredentialByCredID
+// call scopes ownership by construction; MarkWebAuthnCredentialClonedByLookup
+// below does the same for a caller that only has (credentialID, userID)).
+func (c *KeyorixCore) markWebAuthnCredentialClonedDisabled(ctx context.Context, row *models.WebAuthnCredential, ip string) error {
+	row.Disabled = true
+	if err := c.storage.UpdateWebAuthnCredential(ctx, row); err != nil {
+		return err
+	}
+	uid := row.UserID
+	c.writeAuditEventFull(ctx, EventWebAuthnCloneDetected, &uid, nil, nil, ip,
+		fmt.Sprintf("authentication refused for user %d: signature-counter regression (possible cloned authenticator) — credential disabled pending re-registration", row.UserID))
+	return nil
 }
 
 // ErrWebAuthnCredentialIDMismatch is returned by MarkWebAuthnCredentialClonedByLookup
@@ -567,12 +591,7 @@ var ErrWebAuthnCredentialIDMismatch = errors.New("webauthn credential id does no
 // exchange for passing expectedID at all. Returns
 // ErrWebAuthnCredentialIDMismatch, unmutated, if the row's real ID doesn't
 // match.
-//
-// This is the authz half of #1714 (narrowing the write): it does NOT yet
-// audit its own mutation -- that unification with rejectIfCloned lands as
-// its own, independently-revertable commit (markWebAuthnCredentialClonedDisabled).
 func (c *KeyorixCore) MarkWebAuthnCredentialClonedByLookup(ctx context.Context, credentialID []byte, userID, expectedID uint, ip string) (*models.WebAuthnCredential, error) {
-	_ = ip // reserved for the audit write added by the follow-up commit
 	row, err := c.storage.GetWebAuthnCredentialByCredID(ctx, credentialID, userID)
 	if err != nil {
 		return nil, err
@@ -580,8 +599,7 @@ func (c *KeyorixCore) MarkWebAuthnCredentialClonedByLookup(ctx context.Context, 
 	if row.ID != expectedID {
 		return nil, ErrWebAuthnCredentialIDMismatch
 	}
-	row.Disabled = true
-	if err := c.storage.UpdateWebAuthnCredential(ctx, row); err != nil {
+	if err := c.markWebAuthnCredentialClonedDisabled(ctx, row, ip); err != nil {
 		return nil, err
 	}
 	return row, nil

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -541,6 +541,52 @@ func (c *KeyorixCore) rejectIfCloned(ctx context.Context, userID uint, cred *web
 	return fmt.Errorf("assertion verification failed: signature counter did not advance (possible cloned authenticator)")
 }
 
+// ErrWebAuthnCredentialIDMismatch is returned by MarkWebAuthnCredentialClonedByLookup
+// when (credentialID, userID) resolves to a real, owned row, but that row's ID
+// does not match the caller's expectedID. This is deliberately distinct from
+// "not found": the pair is real and does belong to userID, it just isn't the
+// SAME credential the caller is claiming to act on — a mismatch a caller must
+// never have silently coerced into acting on whichever row the lookup actually
+// named instead.
+var ErrWebAuthnCredentialIDMismatch = errors.New("webauthn credential id does not match (credential_id, user_id)")
+
+// MarkWebAuthnCredentialClonedByLookup explicitly disables a WebAuthn
+// credential on a clone-detection signal, identified by (credentialID,
+// userID) rather than an already-resolved row — the ONE thing
+// UpdateWebAuthnCredentialProxy (#1714) is allowed to do. The
+// GetWebAuthnCredentialByCredID lookup scopes ownership: a caller cannot
+// reach a credential it doesn't legitimately identify by both its own
+// credentialID and userID together, so there is no separate ownership check
+// needed here, matching rejectIfCloned's own "#307" reasoning.
+//
+// expectedID is checked BEFORE any mutation happens — never after. An
+// earlier draft of this fix fetched, mutated, and only THEN compared IDs,
+// which would disable the WRONG credential (the one (credentialID, userID)
+// actually named) before rejecting the request; that ordering is exactly the
+// "stored row is unchanged" property callers of this function get in
+// exchange for passing expectedID at all. Returns
+// ErrWebAuthnCredentialIDMismatch, unmutated, if the row's real ID doesn't
+// match.
+//
+// This is the authz half of #1714 (narrowing the write): it does NOT yet
+// audit its own mutation -- that unification with rejectIfCloned lands as
+// its own, independently-revertable commit (markWebAuthnCredentialClonedDisabled).
+func (c *KeyorixCore) MarkWebAuthnCredentialClonedByLookup(ctx context.Context, credentialID []byte, userID, expectedID uint, ip string) (*models.WebAuthnCredential, error) {
+	_ = ip // reserved for the audit write added by the follow-up commit
+	row, err := c.storage.GetWebAuthnCredentialByCredID(ctx, credentialID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if row.ID != expectedID {
+		return nil, ErrWebAuthnCredentialIDMismatch
+	}
+	row.Disabled = true
+	if err := c.storage.UpdateWebAuthnCredential(ctx, row); err != nil {
+		return nil, err
+	}
+	return row, nil
+}
+
 // persistUpdatedCredential writes back the credential's advanced signature counter
 // (and clone-warning flag) plus a last-used timestamp. Best-effort: a write error
 // must not fail an otherwise-valid login.

--- a/internal/core/webauthn_clone_disable_audit_test.go
+++ b/internal/core/webauthn_clone_disable_audit_test.go
@@ -1,0 +1,93 @@
+// webauthn_clone_disable_audit_test.go — #1714 invariant guard.
+//
+// UpdateWebAuthnCredentialProxy used to call storage.UpdateWebAuthnCredential
+// directly: any system.write holder could reassign a credential's ownership
+// or silently re-enable a clone-disabled one, with no audit trail either way.
+// The authz half of the fix is covered by
+// server/http/handlers/webauthn_proxy_1622_authz_test.go (rejection at the
+// HTTP layer, before any mutation). This file covers the audit half: the
+// fix is structural, not per-route -- markWebAuthnCredentialClonedDisabled is
+// the ONE place that performs the disable mutation and the
+// EventWebAuthnCloneDetected audit write as a single unit, and both exported
+// entry points -- rejectIfCloned's own login-time disable (unchanged
+// behavior, now delegating) and MarkWebAuthnCredentialClonedByLookup (which
+// UpdateWebAuthnCredentialProxy now calls) -- route through it.
+//
+// This test asserts the INVARIANT, not either route: disabling a credential
+// on a clone signal by ANY exported path produces exactly one
+// EventWebAuthnCloneDetected audit event, correctly attributed to the
+// calling actor via ctx (the auth middleware's WithActorType/WithMachineActor
+// tagging, read automatically by writeAuditEventFull -> emitAudit). A future
+// change that reintroduces a direct storage.UpdateWebAuthnCredential call in
+// either path -- bypassing markWebAuthnCredentialClonedDisabled -- fails this
+// test: temporarily rewriting markWebAuthnCredentialClonedDisabled to call
+// c.storage.UpdateWebAuthnCredential directly (skipping the audit write) was
+// confirmed to fail both subtests before this fix, with the audit event count
+// asserted at 0 instead of 1.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const invariantTestMachineID = uint(88)
+
+func TestDisableClonedWebAuthnCredential_Invariant_ExactlyOneAuditEventWithCorrectActor(t *testing.T) {
+	t.Run("login-time disable (rejectIfCloned)", func(t *testing.T) {
+		c, db := newWebAuthnTestCore(t, true)
+		credID := []byte("cred-invariant-login")
+		seedCredential(t, c, db, 1, string(credID))
+
+		actorCtx := WithMachineActor(WithActorType(context.Background(), ActorTypeMachine), invariantTestMachineID)
+		cred := &webauthn.Credential{ID: credID, Authenticator: webauthn.Authenticator{CloneWarning: true}}
+		err := c.rejectIfCloned(actorCtx, 1, cred, "203.0.113.9")
+		require.Error(t, err, "a regressed signature counter must still refuse the authentication")
+
+		var reloaded models.WebAuthnCredential
+		require.NoError(t, db.Where("credential_id = ?", credID).First(&reloaded).Error)
+		assert.True(t, reloaded.Disabled, "the credential must be disabled")
+
+		var events []models.AuditEvent
+		require.NoError(t, db.Where("event_type = ?", EventWebAuthnCloneDetected).Find(&events).Error)
+		require.Len(t, events, 1, "exactly one clone-detected audit event must be written")
+		assertCorrectMachineActor(t, events[0])
+	})
+
+	t.Run("explicit disable by lookup (MarkWebAuthnCredentialClonedByLookup)", func(t *testing.T) {
+		c, db := newWebAuthnTestCore(t, true)
+		credID := []byte("cred-invariant-lookup")
+		seedCredential(t, c, db, 1, string(credID))
+
+		var row models.WebAuthnCredential
+		require.NoError(t, db.Where("credential_id = ?", credID).First(&row).Error)
+
+		actorCtx := WithMachineActor(WithActorType(context.Background(), ActorTypeMachine), invariantTestMachineID)
+		_, err := c.MarkWebAuthnCredentialClonedByLookup(actorCtx, credID, 1, row.ID, "203.0.113.9")
+		require.NoError(t, err)
+
+		var reloaded models.WebAuthnCredential
+		require.NoError(t, db.Where("credential_id = ?", credID).First(&reloaded).Error)
+		assert.True(t, reloaded.Disabled, "the credential must be disabled")
+
+		var events []models.AuditEvent
+		require.NoError(t, db.Where("event_type = ?", EventWebAuthnCloneDetected).Find(&events).Error)
+		require.Len(t, events, 1, "exactly one clone-detected audit event must be written")
+		assertCorrectMachineActor(t, events[0])
+	})
+}
+
+func assertCorrectMachineActor(t *testing.T, ev models.AuditEvent) {
+	t.Helper()
+	assert.Equal(t, ActorTypeMachine, ev.ActorType,
+		"the audit event must be attributed to the calling actor's type from ctx")
+	require.NotNil(t, ev.MachineIdentityID,
+		"the calling actor's machine identity must be attached, not just ActorType")
+	assert.Equal(t, invariantTestMachineID, *ev.MachineIdentityID)
+	assert.Nil(t, ev.UserID, "a machine actor must not occupy UserID (ADR-092)")
+}

--- a/server/http/handlers/handlers_s13b_test.go
+++ b/server/http/handlers/handlers_s13b_test.go
@@ -14,8 +14,10 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -289,7 +291,9 @@ func TestGetWebAuthnCredentialByCredIDProxy_StorageError_S13B(t *testing.T) {
 }
 
 // TestUpdateWebAuthnCredentialProxy_Success_S13B — seed a credential then
-// update it → 200.
+// disable it (the ONLY legitimate use of this route, #1714) → 200, Disabled
+// becomes true, and fields this route may NOT change (Name) are untouched --
+// this route no longer applies a caller-supplied full-row replacement.
 func TestUpdateWebAuthnCredentialProxy_Success_S13B(t *testing.T) {
 	h, _, db := setupMFAReauthTest(t)
 	blob, _ := json.Marshal(webauthn.Credential{ID: []byte("cred-upd")})
@@ -302,18 +306,22 @@ func TestUpdateWebAuthnCredentialProxy_Success_S13B(t *testing.T) {
 	require.NoError(t, db.Create(cred).Error)
 
 	body, _ := json.Marshal(map[string]interface{}{
-		"user_id":         1,
-		"credential_id":   []byte("cred-upd"),
-		"credential_blob": blob,
-		"name":            "new-name",
+		"user_id":       1,
+		"credential_id": []byte("cred-upd"),
+		"disabled":      true,
 	})
 	r := httptest.NewRequest(http.MethodPut,
-		"/api/v1/system/webauthn/credentials/1",
+		fmt.Sprintf("/api/v1/system/webauthn/credentials/%d", cred.ID),
 		bytes.NewReader(body))
-	r = withChiParams(r, map[string]string{"id": "1"})
+	r = withChiParams(r, map[string]string{"id": strconv.FormatUint(uint64(cred.ID), 10)})
 	w := httptest.NewRecorder()
 	h.UpdateWebAuthnCredentialProxy(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
+
+	var reloaded models.WebAuthnCredential
+	require.NoError(t, db.First(&reloaded, cred.ID).Error)
+	assert.True(t, reloaded.Disabled, "the credential must be disabled")
+	assert.Equal(t, "old-name", reloaded.Name, "this route must not change Name")
 }
 
 // TestAdvanceWebAuthnCredentialCounterProxy_NotFound_S13B — valid body but

--- a/server/http/handlers/handlers_s31_test.go
+++ b/server/http/handlers/handlers_s31_test.go
@@ -406,7 +406,10 @@ func TestGetWebAuthnCredentialByCredIDProxy_DBError_S31(t *testing.T) {
 func TestUpdateWebAuthnCredentialProxy_DBError_S31(t *testing.T) {
 	t.Parallel()
 	h := NewAuthHandler(freshCoreBrokenS31(t), false)
-	body := bytes.NewBufferString(`{"user_id":1,"credential_id":"AQIDBA==","name":"YubiKey","credential_blob":"AQIDBA==","created_at":"2024-01-01T00:00:00Z"}`)
+	// #1714: disabled:true is required to reach the storage-touching path at
+	// all (anything else is rejected before any lookup, so it would never
+	// observe the broken DB).
+	body := bytes.NewBufferString(`{"user_id":1,"credential_id":"AQIDBA==","disabled":true}`)
 	r := withChiParamS7(httptest.NewRequest(http.MethodPut, "/api/v1/system/webauthn/credentials/1", body), "id", "1")
 	w := httptest.NewRecorder()
 	h.UpdateWebAuthnCredentialProxy(w, r)

--- a/server/http/handlers/handlers_s5_test.go
+++ b/server/http/handlers/handlers_s5_test.go
@@ -2480,11 +2480,14 @@ func TestCountWebAuthnCredentialsProxy_HappyPathS5(t *testing.T) {
 
 func TestUpdateWebAuthnCredentialProxy_HappyPath(t *testing.T) {
 	h := newAuthHandlerWithWebAuthn(t)
-	body := `{"user_id":1,"credential_id":"AQID","public_key":"AQID","sign_count":0,"name":"k","user_handle":"AQID","aaguid":"AQID"}`
+	// #1714: this route only ever disables a credential on a clone signal —
+	// disabled:true is required, or the request is rejected before any lookup.
+	body := `{"user_id":1,"credential_id":"AQID","disabled":true}`
 	req := withChiParam(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body)), "id", "1")
 	w := httptest.NewRecorder()
 	h.UpdateWebAuthnCredentialProxy(w, req)
-	// Not a bad-request (body + ID are valid)
+	// Not a bad-request (body + ID are well-formed; the credential itself may
+	// not exist in this shared test DB, which is a 404, not a 400).
 	assert.NotEqual(t, http.StatusBadRequest, w.Code)
 }
 

--- a/server/http/handlers/handlers_s9_test.go
+++ b/server/http/handlers/handlers_s9_test.go
@@ -497,11 +497,11 @@ func TestUpdateWebAuthnCredentialProxy_Success_S9(t *testing.T) {
 	require.NoError(t, h.coreService.Storage().CreateWebAuthnCredential(context.Background(), cred))
 	require.NotZero(t, cred.ID)
 
-	// Update. #G79: UpdateWebAuthnCredentialProxy is an unconditional full-row
-	// Save, so the request must carry the full row (matching Create) — a body
-	// missing credential_id would otherwise zero that column on the existing row.
+	// Update: #1714 narrowed this route to the ONE legitimate transition
+	// (disable-on-clone) — it no longer accepts an arbitrary full-row
+	// replacement (name/credential_id could previously be overwritten wholesale).
 	idStr := strconv.FormatUint(uint64(cred.ID), 10)
-	updateBody := `{"name":"Updated S9","user_id":99,"credential_id":"dGVzdC1jcmVkLXM5NA=="}`
+	updateBody := `{"user_id":99,"credential_id":"dGVzdC1jcmVkLXM5NA==","disabled":true}`
 	updateReq := withChiParam(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(updateBody)), "id", idStr)
 	updateW := httptest.NewRecorder()
 	h.UpdateWebAuthnCredentialProxy(updateW, updateReq)

--- a/server/http/handlers/webauthn_proxy.go
+++ b/server/http/handlers/webauthn_proxy.go
@@ -50,12 +50,14 @@ package handlers
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -214,10 +216,32 @@ func (h *AuthHandler) GetWebAuthnCredentialByCredIDProxy(w http.ResponseWriter, 
 }
 
 // UpdateWebAuthnCredentialProxy handles PUT /api/v1/system/webauthn/credentials/{id}.
-// A raw persist (storage.Storage.UpdateWebAuthnCredential is an unconditional
-// full-row Save, matching LocalStorage's own semantics exactly) — used by
-// rejectIfCloned's best-effort "mark disabled" write. The signature-counter
-// advance path does NOT go through this route; see
+//
+// #1714: this used to be a raw, unconditional full-row Save trusting the
+// entire caller-supplied body -- an authz-ceiling bypass, not merely an audit
+// gap (reclassified from the original "audit-completeness" framing). Two
+// distinct things a system.write holder could do with the old code, neither
+// requiring any WebAuthn ceremony at all:
+//   - Reassign a credential's ownership: the handler applied body.UserID to
+//     the row unconditionally, with no check that it matched the row the URL
+//     {id} actually names.
+//   - Silently re-enable a clone-disabled credential (disabled: false),
+//     directly contradicting models.WebAuthnCredential's own documented
+//     invariant ("Never auto-re-enabled").
+//
+// The route's ONLY legitimate purpose, repo-wide, is rejectIfCloned's
+// disable-on-clone write (internal/core/webauthn.go is the sole internal/core
+// caller of storage.Storage.UpdateWebAuthnCredential). This handler is now
+// narrowed to exactly that: identify the row by (credential_id, user_id) --
+// which scopes ownership by construction, the same reasoning
+// rejectIfCloned's own lookup already relies on (#307) -- reject outright if
+// that pair doesn't resolve to the URL's {id}, and reject outright unless
+// disabled is exactly true. Routes through
+// KeyorixCore.MarkWebAuthnCredentialClonedByLookup; see that function's doc.
+// This is the authz half of the #1714 fix -- the audit half (unifying this
+// path with rejectIfCloned's own EventWebAuthnCloneDetected write into one
+// mutation+audit unit) lands as its own, independently-revertable commit.
+// The signature-counter advance path does NOT go through this route; see
 // AdvanceWebAuthnCredentialCounterProxy below.
 func (h *AuthHandler) UpdateWebAuthnCredentialProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
@@ -230,16 +254,40 @@ func (h *AuthHandler) UpdateWebAuthnCredentialProxy(w http.ResponseWriter, r *ht
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
 		return
 	}
-	// #G79: matches CreateWebAuthnCredentialProxy's validation — this route is
-	// an unconditional full-row Save (see the doc above), so a body missing
-	// user_id/credential_id would zero those columns on the existing row, not
-	// merely leave them unset.
 	if body.UserID == 0 || len(body.CredentialID) == 0 {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id and credential_id are required")
 		return
 	}
-	body.ID = uint(id)
-	if err := h.coreService.Storage().UpdateWebAuthnCredential(r.Context(), body.toModel()); err != nil {
+	// The only transition this route ever legitimately performs is
+	// disable-on-clone (false -> true). Anything else -- re-enabling, or a
+	// body that omits disabled entirely (Go's zero value is false) -- is
+	// rejected outright, not silently ignored: the model's own invariant is
+	// "never auto-re-enabled," so there is no reachable legitimate use of
+	// disabled: false via this route, ever.
+	if !body.Disabled {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY",
+			"this route only disables a credential on a clone-detection signal; disabled must be true")
+		return
+	}
+	_, err = h.coreService.MarkWebAuthnCredentialClonedByLookup(r.Context(), body.CredentialID, body.UserID, uint(id), clientIP(r))
+	if err != nil {
+		if errors.Is(err, core.ErrWebAuthnCredentialIDMismatch) {
+			// (credential_id, user_id) resolved to a REAL, owned row, but not the
+			// one the URL named -- the caller is targeting one credential's ID
+			// while authenticating the request against a different one's
+			// identity. Rejected BEFORE any mutation (see the domain function's
+			// own doc) -- log it, since this is either a caller bug or an
+			// attempt to probe/confuse the id<->identity binding.
+			log.Printf("webauthn proxy: update credential: URL id %d does not match the credential named by "+
+				"the body's (user_id=%d, credential_id); rejecting, nothing changed", id, body.UserID)
+			writeRemoteAPIError(w, http.StatusConflict, "ID_MISMATCH",
+				"the credential identified by user_id and credential_id does not match the id in the URL")
+			return
+		}
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errWebAuthnCredNotFound)
+			return
+		}
 		log.Printf("webauthn proxy: update credential failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return

--- a/server/http/handlers/webauthn_proxy.go
+++ b/server/http/handlers/webauthn_proxy.go
@@ -237,12 +237,10 @@ func (h *AuthHandler) GetWebAuthnCredentialByCredIDProxy(w http.ResponseWriter, 
 // rejectIfCloned's own lookup already relies on (#307) -- reject outright if
 // that pair doesn't resolve to the URL's {id}, and reject outright unless
 // disabled is exactly true. Routes through
-// KeyorixCore.MarkWebAuthnCredentialClonedByLookup; see that function's doc.
-// This is the authz half of the #1714 fix -- the audit half (unifying this
-// path with rejectIfCloned's own EventWebAuthnCloneDetected write into one
-// mutation+audit unit) lands as its own, independently-revertable commit.
-// The signature-counter advance path does NOT go through this route; see
-// AdvanceWebAuthnCredentialCounterProxy below.
+// KeyorixCore.MarkWebAuthnCredentialClonedByLookup, which performs the
+// mutation and the EventWebAuthnCloneDetected audit write as one unit; see
+// that function's doc. The signature-counter advance path does NOT go
+// through this route; see AdvanceWebAuthnCredentialCounterProxy below.
 func (h *AuthHandler) UpdateWebAuthnCredentialProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {

--- a/server/http/handlers/webauthn_proxy_1714_authz_test.go
+++ b/server/http/handlers/webauthn_proxy_1714_authz_test.go
@@ -1,0 +1,156 @@
+// webauthn_proxy_1622_authz_test.go — #1714 (reclassified authz-bypass, not
+// audit-completeness): UpdateWebAuthnCredentialProxy used to trust an
+// attacker-controlled full-row body, unconditionally. These tests assert the
+// narrowed contract: the ONLY reachable transition is disable-on-clone,
+// identified by (credential_id, user_id) matching the URL {id}, and any
+// rejection leaves the stored row completely unchanged.
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func putUpdateWebAuthnCredential(t *testing.T, h *AuthHandler, urlID string, body map[string]interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := withChiParam(httptest.NewRequest(http.MethodPut, "/api/v1/system/webauthn/credentials/"+urlID, bytes.NewReader(b)), "id", urlID)
+	w := httptest.NewRecorder()
+	h.UpdateWebAuthnCredentialProxy(w, req)
+	return w
+}
+
+// TestUpdateWebAuthnCredentialProxy_1622_LegitimateDisable_HappyPath is the
+// route's one remaining legitimate use: a well-formed disable, identified
+// consistently across URL id and body (user_id, credential_id).
+func TestUpdateWebAuthnCredentialProxy_1622_LegitimateDisable_HappyPath(t *testing.T) {
+	h := newAuthHandlerWithWebAuthn(t)
+	credIDBytes := []byte(fmt.Sprintf("cred-1622-happy-%d", s4UniqueCounter.Add(1)))
+	cred := &models.WebAuthnCredential{
+		UserID:         501,
+		CredentialID:   credIDBytes,
+		Name:           "legit-key",
+		CredentialBlob: []byte(`{}`),
+	}
+	require.NoError(t, h.coreService.Storage().CreateWebAuthnCredential(t.Context(), cred))
+	require.NotZero(t, cred.ID)
+
+	idStr := strconv.FormatUint(uint64(cred.ID), 10)
+	w := putUpdateWebAuthnCredential(t, h, idStr, map[string]interface{}{
+		"user_id": 501, "credential_id": credIDBytes, "disabled": true,
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	updated, err := h.coreService.Storage().GetWebAuthnCredentialByCredID(t.Context(), credIDBytes, 501)
+	require.NoError(t, err)
+	assert.True(t, updated.Disabled)
+}
+
+// TestUpdateWebAuthnCredentialProxy_1622_RefusesOwnershipReassignment: the
+// original vulnerability. A caller supplying a user_id that does not
+// actually own the named credential_id must not have that credential
+// silently reassigned to it -- GetWebAuthnCredentialByCredID's scoped lookup
+// (the same one rejectIfCloned itself relies on, #307) makes the mismatched
+// pair resolve to nothing, so this fails as NOT_FOUND, not as a successful
+// reassignment. The real owner's row is completely untouched.
+func TestUpdateWebAuthnCredentialProxy_1622_RefusesOwnershipReassignment(t *testing.T) {
+	h := newAuthHandlerWithWebAuthn(t)
+	credIDBytes := []byte(fmt.Sprintf("cred-1622-reassign-%d", s4UniqueCounter.Add(1)))
+	cred := &models.WebAuthnCredential{
+		UserID:         502,
+		CredentialID:   credIDBytes,
+		Name:           "victim-key",
+		CredentialBlob: []byte(`{}`),
+	}
+	require.NoError(t, h.coreService.Storage().CreateWebAuthnCredential(t.Context(), cred))
+	require.NotZero(t, cred.ID)
+
+	idStr := strconv.FormatUint(uint64(cred.ID), 10)
+	// Attacker claims a DIFFERENT user_id than the credential's real owner.
+	w := putUpdateWebAuthnCredential(t, h, idStr, map[string]interface{}{
+		"user_id": 999999, "credential_id": credIDBytes, "disabled": true,
+	})
+	assert.Equal(t, http.StatusNotFound, w.Code,
+		"a user_id that doesn't own credential_id must not resolve to anything, let alone reassign it")
+
+	// The real row is untouched: still owned by 502, still enabled.
+	reloaded, err := h.coreService.Storage().GetWebAuthnCredentialByCredID(t.Context(), credIDBytes, 502)
+	require.NoError(t, err)
+	assert.False(t, reloaded.Disabled, "the victim's credential must remain unchanged")
+}
+
+// TestUpdateWebAuthnCredentialProxy_1622_RefusesReEnable: models.WebAuthnCredential's
+// own doc says Disabled is "Never auto-re-enabled". disabled:false must be
+// unreachable via this route regardless of the credential's current state --
+// tested here against an already clone-disabled credential specifically,
+// since that's the state where a re-enable would actually matter.
+func TestUpdateWebAuthnCredentialProxy_1622_RefusesReEnable(t *testing.T) {
+	h := newAuthHandlerWithWebAuthn(t)
+	credIDBytes := []byte(fmt.Sprintf("cred-1622-reenable-%d", s4UniqueCounter.Add(1)))
+	cred := &models.WebAuthnCredential{
+		UserID:         503,
+		CredentialID:   credIDBytes,
+		Name:           "cloned-key",
+		CredentialBlob: []byte(`{}`),
+		Disabled:       true, // already disabled by a prior clone-detection event
+	}
+	require.NoError(t, h.coreService.Storage().CreateWebAuthnCredential(t.Context(), cred))
+	require.NotZero(t, cred.ID)
+
+	idStr := strconv.FormatUint(uint64(cred.ID), 10)
+	w := putUpdateWebAuthnCredential(t, h, idStr, map[string]interface{}{
+		"user_id": 503, "credential_id": credIDBytes, "disabled": false,
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code,
+		"disabled:false must never be reachable via this route")
+
+	reloaded, err := h.coreService.Storage().GetWebAuthnCredentialByCredID(t.Context(), credIDBytes, 503)
+	require.NoError(t, err)
+	assert.True(t, reloaded.Disabled, "a clone-disabled credential must stay disabled")
+}
+
+// TestUpdateWebAuthnCredentialProxy_1622_RefusesIDMismatch: (credential_id,
+// user_id) resolves to a REAL, owned row -- just not the one the URL {id}
+// names. The check must run BEFORE any mutation: neither the row actually
+// named by the URL nor the row actually named by the body may be touched.
+func TestUpdateWebAuthnCredentialProxy_1622_RefusesIDMismatch(t *testing.T) {
+	h := newAuthHandlerWithWebAuthn(t)
+	n := s4UniqueCounter.Add(1)
+	credA := &models.WebAuthnCredential{
+		UserID: 504, CredentialID: []byte(fmt.Sprintf("cred-1622-mismatch-a-%d", n)),
+		Name: "key-a", CredentialBlob: []byte(`{}`),
+	}
+	credB := &models.WebAuthnCredential{
+		UserID: 504, CredentialID: []byte(fmt.Sprintf("cred-1622-mismatch-b-%d", n)),
+		Name: "key-b", CredentialBlob: []byte(`{}`),
+	}
+	require.NoError(t, h.coreService.Storage().CreateWebAuthnCredential(t.Context(), credA))
+	require.NoError(t, h.coreService.Storage().CreateWebAuthnCredential(t.Context(), credB))
+	require.NotZero(t, credA.ID)
+	require.NotZero(t, credB.ID)
+	require.NotEqual(t, credA.ID, credB.ID)
+
+	// URL names A's id, but the body's (credential_id, user_id) names B.
+	w := putUpdateWebAuthnCredential(t, h, strconv.FormatUint(uint64(credA.ID), 10), map[string]interface{}{
+		"user_id": 504, "credential_id": credB.CredentialID, "disabled": true,
+	})
+	assert.Equal(t, http.StatusConflict, w.Code)
+
+	reloadedA, err := h.coreService.Storage().GetWebAuthnCredentialByCredID(t.Context(), credA.CredentialID, 504)
+	require.NoError(t, err)
+	assert.False(t, reloadedA.Disabled, "the URL-named credential must be untouched")
+
+	reloadedB, err := h.coreService.Storage().GetWebAuthnCredentialByCredID(t.Context(), credB.CredentialID, 504)
+	require.NoError(t, err)
+	assert.False(t, reloadedB.Disabled, "the body-named credential must ALSO be untouched -- rejected before any mutation")
+}

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -689,9 +689,18 @@ var rawStorageBypassAllowlist = map[string]string{
 		"is a marshal + token-generation + the SAME storage.CreateWebAuthnSession call, no additional check -- " +
 		"session data isn't privilege-bearing until consumed (same shape as the already-verified " +
 		"CreateSSOLoginStateProxy: identity is anchored at consume time, not creation time).",
-	"UpdateWebAuthnCredentialProxy": "no-independent-ceiling: the proxy's own doc comment establishes it backs " +
-		"rejectIfCloned's best-effort 'mark disabled' write -- a defensive, capability-REDUCING action (disabling " +
-		"a suspected-cloned credential), not an authorization gate to bypass.",
+	// UpdateWebAuthnCredentialProxy entry removed (#1714): the original
+	// "no-independent-ceiling" framing was wrong for this handler -- it
+	// wasn't just capability-reducing, it trusted an attacker-controlled
+	// full-row body (ownership reassignment via a mismatched user_id, and
+	// silent re-enable of a clone-disabled credential, directly contradicting
+	// models.WebAuthnCredential's own "never auto-re-enabled" invariant).
+	// Reclassified as an authz bypass, not a no-op-ceiling case. Fixed by
+	// routing through KeyorixCore.MarkWebAuthnCredentialClonedByLookup, which
+	// rejects a body that doesn't resolve to the URL's {id} BEFORE any
+	// mutation and rejects disabled:false outright -- the handler no longer
+	// makes a raw storage.UpdateWebAuthnCredential call at all, so this
+	// guard's own detection no longer flags it.
 	"ExpireSetupTokenProxy": "no-independent-ceiling: marking a setup token expired only REDUCES future capability " +
 		"(revokes an outstanding token early) -- there is no privilege to gain by skipping whatever ceiling " +
 		"inspectActiveSetupToken's lazy-expiry path would otherwise apply, since expiry is itself the safe " +
@@ -1044,7 +1053,9 @@ var rawStorageBypassAllowlist = map[string]string{
 	// files correctly, not a blind spot for new code.
 	//
 	// No-independent-ceiling (same shape as unsafe_sibling_write_guard_test.go's
-	// UpdateWebAuthnCredentialProxy/DeleteProjectProxy entries): internal/core
+	// DeleteProjectProxy entry -- NOT UpdateWebAuthnCredentialProxy, whose own
+	// entry above was reclassified and removed by #1714: that one turned out
+	// to be a real authz bypass, not a no-op-ceiling case): internal/core
 	// applies NO ceiling to notification creation at all -- there is no
 	// authorization decision for this proxy to skip. models.Notification
 	// carries no actor, sender, or origin field; UserID is the recipient, not

--- a/server/http/unsafe_sibling_write_guard_test.go
+++ b/server/http/unsafe_sibling_write_guard_test.go
@@ -65,9 +65,13 @@ var unsafeSiblingPairs = map[string]string{
 // or the route removed) — same discipline as
 // rawStorageBypassAllowlist/knownUnfixedRawStorageBypasses above.
 var unsafeSiblingAllowlist = map[string]string{
-	"UpdateWebAuthnCredentialProxy": "capability-reducing: the proxy's own doc comment establishes it backs " +
-		"rejectIfCloned's best-effort 'mark disabled' write -- disabling a suspected-cloned credential is the " +
-		"safe direction, not an authorization gate to bypass. No independent ceiling to skip.",
+	// UpdateWebAuthnCredentialProxy entry removed (#1714): reclassified from
+	// "capability-reducing, no independent ceiling" to a real authz bypass --
+	// the old raw call trusted an attacker-controlled full-row body
+	// (ownership reassignment via a mismatched user_id, silent re-enable of a
+	// clone-disabled credential). Fixed by routing through
+	// KeyorixCore.MarkWebAuthnCredentialClonedByLookup; the handler no longer
+	// makes an unsafe-sibling call at all, so this guard no longer flags it.
 	"DeleteProjectProxy": "no-independent-ceiling: core.DeleteProject(force=true) intentionally skips the " +
 		"force=false guard+cascade atomicity problem entirely and calls the plain, unconditional " +
 		"storage.DeleteProject cascade -- no actor-authority check of any kind exists at the core layer for " +


### PR DESCRIPTION
## Severity reclassification

The original framing (last round's sibling list) called this an audit-completeness gap, same class as ExpireSetupTokenProxy. That was wrong. `UpdateWebAuthnCredentialProxy` was an unconditional full-row `Save()` trusting the entire caller-supplied body — a `system.write` holder could, with no WebAuthn ceremony at all:

- **Reassign a credential's ownership** by supplying a `user_id` that didn't match the row the URL `{id}` actually named — the handler never checked.
- **Silently re-enable a clone-disabled credential** (`disabled: false`), directly contradicting `models.WebAuthnCredential`'s own documented invariant ("Never auto-re-enabled").

`EventWebAuthnCloneDetected` is the only clone evidence WebAuthn's signature-counter regression check gives us. A mutation path that can silently undo the disable doesn't just lose an audit line — it lets an attacker who already cloned a credential erase the one signal that would reveal it, and every subsequent authentication with the resurrected credential reads as the legitimate account owner, not as compromise. **Recorded as an authz bypass, not a DoS/audit-completeness gap.**

## Was the evaluation itself skipped, or just the event?

Neither, exactly — see the investigation reply that preceded this PR. The signature-counter *evaluation* happens inside the go-webauthn library during assertion verification, in-process, on whichever server handles the login; it was never reachable from this route at all, so there was no "evaluation" for this handler to skip. What the route actually did was worse in a different way: it was a **generic full-row overwrite** with zero relationship to clone detection, reachable directly by any `system.write` holder, independent of whether a real clone was ever detected.

## Commit 1/3 — authz narrowing

`KeyorixCore.MarkWebAuthnCredentialClonedByLookup` identifies the row by `(credential_id, user_id)` — scoping ownership by construction, the same reasoning `rejectIfCloned`'s own lookup already relies on (#307) — and:
- Rejects (409 `ID_MISMATCH`) if that pair doesn't resolve to the URL's `{id}`, checked **before** any mutation (an earlier draft of this fix checked after, which would have disabled the wrong credential before rejecting — caught and fixed before landing).
- Rejects (400) outright unless `disabled` is exactly `true` — `disabled: false` is now unreachable via this route regardless of current state.

New tests: ownership reassignment refused (404, victim's row unchanged), re-enabling a clone-disabled credential refused (400, stays disabled), ID/identity mismatch refused (409, **both** the URL-named and body-named rows left untouched). Four pre-existing tests exercising the old arbitrary-full-row-update behavior were updated to the new disable-only contract. Removed the now-stale entries from both `raw_storage_bypass_guard_test.go`'s and `unsafe_sibling_write_guard_test.go`'s allowlists — the handler no longer makes a raw storage call at all, so neither guard flags it; both entries' original "no-independent-ceiling"/"capability-reducing" framing was wrong for this handler.

## Commit 2/3 — mutation + audit as one unit

`markWebAuthnCredentialClonedDisabled` is now the one place performing the disable mutation and the `EventWebAuthnCloneDetected` audit write together. Both `rejectIfCloned` (login-time, unchanged behavior, now delegating) and `MarkWebAuthnCredentialClonedByLookup` (commit 1) route through it.

`TestDisableClonedWebAuthnCredential_Invariant_ExactlyOneAuditEventWithCorrectActor` asserts the invariant across both exported paths: exactly one audit event, correctly attributed to the calling actor from ctx. **Red/green proof**: temporarily rewrote the shared function to call raw storage with no audit write (the pre-fix shape) — both subtests failed (0 events instead of 1). Reverted; both pass.

## Commit 3 — enumeration (this is a report, not a code change; see below)

## Step 1c — enumeration of the class

Grepped every `.Storage()` write call site across all 28 `*_proxy.go` files under `server/http/handlers/`, checking each against its `internal/storage/store/local_*.go` implementation for the specific dangerous shape: **a body-constructed struct passed into storage with no prior fetch of the existing row, where the storage layer does an unconditional full-row overwrite (`Save()` or `Select("*").Updates(...)`)**.

**Total found: 2.** One is this PR (fixed). The other is new and severe:

| Handler | Storage call | Full-row overwrite confirmed | Fields silently zeroed | Severity |
|---|---|---|---|---|
| `UpdateWebAuthnCredentialProxy` (webauthn_proxy.go) | `UpdateWebAuthnCredential` | `ls.db.Save(c)` | (fixed this PR) | authz bypass — **fixed** |
| `UpdateUserIfActiveStateMatchesProxy` (users_active_transition_proxy.go) | `UpdateUserIfActiveStateMatches` | `.Model(&User{}).Where("id = ? AND is_active = ?", ...).Select("*").Updates(user)` | **`PasswordHash`, `AccountState`** (confirmed empirically — see below) | **not yet fixed, reported here per Step 1c's "do not fix" scope** |

**`UpdateUserIfActiveStateMatchesProxy` — confirmed, not theorized.** The handler builds `user := &models.User{ID: uint(id), Username: body.Username, Email: body.Email, DisplayName: body.DisplayName, IsActive: body.Active, UpdatedAt: body.UpdatedAt}` directly from the wire body — no prior fetch — then calls `UpdateUserIfActiveStateMatches`, whose GORM call is `Select("*")` (force every column, including Go zero-values on unset struct fields). Wrote a throwaway test (not committed, deleted after use) seeding a real user with `PasswordHash: "REAL_BCRYPT_HASH"` and `AccountState: "active"`, then calling this exact code path with a body that never mentions either field: **both came back as empty strings.** Any `system.write` holder can permanently destroy any user's password hash and account state via this route today — worse than the WebAuthn case, since it doesn't require a clone signal or any prior state, and touches the actual login credential rather than a secondary factor. Not fixed in this PR per Step 1c's explicit scope ("do not fix them in this PR") — flagging for an immediate decision on priority, separately from this PR's own merge.

**Everything else checked and ruled out** (fetch-first pattern confirmed safe, or a `Create`-only insert with no existing row to zero, or routed through `internal/core` business logic rather than raw storage): `UpdateAccessRequestProxy`, `UpdateAccessReviewItemProxy`, `UpdateInvitationProxy`, `UpdateMachineIdentityCredentialProxy` (Step 2's subject — see that investigation), `TransitionSecretStatusProxy`, `RevokeBreakGlassActivationProxy`, every scalar-param `Mark*`/`Revoke*`/`Touch*`/`Supersede*` call (targeted `UpdateColumn`, never a struct overwrite), every `Create*` route, and every route that goes through `core.KeyorixCore` rather than raw `Storage()` (groups, RBAC role grants).

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l` clean on every touched file. `gosec -severity medium -exclude-generated` on `internal/core` and `server/http/...`: 0 issues both passes. Full suites green: `internal/core`, `server/http/handlers`, and `server/http` (348s, including `TestNoUnjustifiedRawStorageBypass` and `TestNoProxyCallsUnsafeSiblingWhenSafeExists`).

## Housekeeping: finding-number correction

This work was originally numbered #1622 in my own branch/commit messages and PR #1713 (still open) — #1622 turned out to already be an existing, merged, unrelated PR (#1573's own number, "distinct machine approvers no longer collapse in dual control"). Caught mid-session before anything shipped under the wrong number here; opened #1714 as the correct tracking issue and renamed everything in this PR to match. **PR #1713's title/description still says #1622** and needs the same correction (its commits already reference #1622 in their messages — not rewriting that history, but the PR title/description should point to #1714). Also found one more pre-existing instance of the same numbering confusion already merged to `main` (a "#1622 sibling gap" comment in `access_request_proxy.go` and a matching reference in `server/http/access_request_approval_machine_attribution_test.go`) — not touched here, out of scope for this PR, flagging for a follow-up comment fix.