### PR TITLE
fix(http): CONTAINMENT -- close full account-takeover chain in UpdateUserIfActiveStateMatchesProxy

### DIFF
--- a/server/http/handlers/users_active_transition_proxy.go
+++ b/server/http/handlers/users_active_transition_proxy.go
@@ -11,13 +11,32 @@
 // system.write RBAC permission every other RemoteStorage-primitive proxy in
 // this package already needs — no new privilege class).
 //
-// This is a thin passthrough onto the SAME storage.Storage.
-// UpdateUserIfActiveStateMatches primitive internal/core/users.go's UpdateUser
-// already calls against a local backend — no update-request validation
-// (uniqueness checks, which fields the original caller actually meant to
-// change) is made here; that stays entirely in the CALLING server's own
-// internal/core.KeyorixCore, exactly as it does against a local backend. This
-// handler only persists the row it's given, conditionally.
+// This is NOT a thin passthrough of a caller-supplied row (it used to be, and
+// that was an authentication-bypass bug -- see below): storage.Storage.
+// UpdateUserIfActiveStateMatches is a `Select("*")` full-row overwrite, and
+// this route's own wire body (userActiveTransitionProxyBody) only carries
+// username/email/display_name/active/updated_at -- it structurally cannot
+// carry PasswordHash, AccountState, or any other models.User field. A
+// caller-constructed struct built directly from that body therefore left
+// every OTHER field at its Go zero value, and Select("*") persisted those
+// zeros over the real, existing values -- confirmed to blank PasswordHash and
+// AccountState on every call, and blanking AccountState reactivates a
+// suspended/deprovisioned account for login (AccountLoginBlocked treats an
+// unrecognized/empty state as NOT blocked), chaining into full account
+// takeover via any subsequent setup-token/password-reset completion. This is
+// reachable from a genuinely benign, storage.type: remote spoke relay just as
+// easily as from a malicious direct call to this route -- PasswordHash never
+// crosses the wire at all (models.User.PasswordHash is json:"-"), so ANY
+// legitimate profile-edit relayed through this route already zeroed it,
+// independent of intent.
+//
+// Fixed: this handler now fetches the existing row first and patches only
+// the fields the wire body actually carries onto it, so every field this
+// route was never meant to touch survives unchanged. No update-request
+// validation (uniqueness checks, which fields the original caller actually
+// meant to change) beyond that is made here; that stays entirely in the
+// CALLING server's own internal/core.KeyorixCore, exactly as it does against
+// a local backend.
 //
 // Deliberately NOT the human-facing PUT /api/v1/users/{id} route
 // (users_crud.go's UserHandler.UpdateUser): that route re-runs the UPSTREAM
@@ -48,7 +67,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/identity"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // userActiveTransitionProxyBody mirrors RemoteStorage's
@@ -95,7 +113,15 @@ func (h *UserHandler) UpdateUserIfActiveStateMatchesProxy(w http.ResponseWriter,
 		return
 	}
 	var body userActiveTransitionProxyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	dec := json.NewDecoder(r.Body)
+	// Reject a body carrying any field this route doesn't declare (e.g.
+	// password_hash, account_state) rather than silently ignoring it -- a
+	// caller trying to smuggle a security-critical field through this route
+	// should get a 400, not a request that quietly succeeds having done
+	// nothing with the extra field. See the containment fix below for why
+	// this route must never accept those fields at all.
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&body); err != nil {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
@@ -151,17 +177,31 @@ func (h *UserHandler) UpdateUserIfActiveStateMatchesProxy(w http.ResponseWriter,
 			return
 		}
 	}
-	user := &models.User{
-		ID:             uint(id),
-		Username:       body.Username,
-		UsernameFolded: foldedUsername.Folded(),
-		Email:          body.Email,
-		EmailFolded:    foldedEmail.Folded(),
-		DisplayName:    body.DisplayName,
-		IsActive:       body.Active,
-		UpdatedAt:      body.UpdatedAt,
+	// Fetch the existing row FIRST and patch only the fields this route is
+	// legitimately allowed to change onto it -- storage.UpdateUserIfActiveStateMatches
+	// is a `Select("*")` full-row overwrite (see its own doc comment), so a
+	// caller-constructed struct with unset fields would silently zero every
+	// column this route's own wire body doesn't carry, including PasswordHash
+	// and AccountState. Confirmed empirically: this used to blank both on any
+	// call, and blanking AccountState on a suspended/deprovisioned account
+	// bypasses AccountLoginBlocked's deny-list check entirely (fail-open) --
+	// this was a full authentication-bypass chain, not just data loss. The
+	// fetch happens before any write; a caller whose target user doesn't
+	// exist is refused here, before the storage layer's own conditional
+	// write ever runs.
+	existing, err := h.coreService.Storage().GetUser(r.Context(), uint(id))
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "user not found")
+		return
 	}
-	matched, err := h.coreService.Storage().UpdateUserIfActiveStateMatches(r.Context(), user, body.FromActive)
+	existing.Username = body.Username
+	existing.UsernameFolded = foldedUsername.Folded()
+	existing.Email = body.Email
+	existing.EmailFolded = foldedEmail.Folded()
+	existing.DisplayName = body.DisplayName
+	existing.IsActive = body.Active
+	existing.UpdatedAt = body.UpdatedAt
+	matched, err := h.coreService.Storage().UpdateUserIfActiveStateMatches(r.Context(), existing, body.FromActive)
 	if err != nil {
 		if errors.Is(err, storage.ErrDuplicateEmail) {
 			writeRemoteAPIError(w, http.StatusConflict, duplicateEmailProxyCode, storage.ErrDuplicateEmail.Error())

--- a/server/http/handlers/users_active_transition_proxy_test.go
+++ b/server/http/handlers/users_active_transition_proxy_test.go
@@ -202,6 +202,128 @@ func TestUpdateUserIfActiveStateMatchesProxy_DuplicateEmail(t *testing.T) {
 	assert.NotEqual(t, "Should Not Persist", unchanged.DisplayName, "rejected write must not persist")
 }
 
+// TestUpdateUserIfActiveStateMatchesProxy_PreservesPasswordHashAndAccountState
+// is the containment fix's own regression test: this route used to build a
+// caller-controlled *models.User with every field this route's wire body
+// doesn't carry left at Go's zero value, then persist it via a Select("*")
+// full-row overwrite -- silently blanking PasswordHash and AccountState on
+// EVERY successful call, not just a malicious one (RemoteStorage's client
+// never sends either field to begin with: PasswordHash is json:"-" and never
+// crosses the wire, and account_state has no field in this route's wire
+// format at all). Blanking AccountState on a suspended/deprovisioned account
+// is a fail-open authentication bypass (AccountLoginBlocked treats an
+// unrecognized/empty state as NOT blocked) -- this test proves the fetch-first
+// fix closes it: a real password hash and a non-active account state survive
+// a legitimate, successful call to this route completely unchanged.
+func TestUpdateUserIfActiveStateMatchesProxy_PreservesPasswordHashAndAccountState(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	target := &models.User{
+		Username: "s12nonadmin-hashcheck", Email: "s12nonadmin-hashcheck@example.com",
+		PasswordHash: "REAL_BCRYPT_HASH_MUST_SURVIVE", AccountState: "suspended", IsActive: true,
+	}
+	require.NoError(t, db.Create(target).Error)
+	idStr := machineUintToStr(target.ID)
+
+	body := proxyJSON(map[string]interface{}{
+		"username":     target.Username,
+		"email":        target.Email,
+		"display_name": "Updated Name",
+		"active":       true,
+		"from_active":  true,
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/users/"+idStr+"/active-transition", body),
+		"id", idStr,
+	)
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := decodeRemoteResp(t, w)
+	require.True(t, resp.Success)
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, true, data["matched"], "the call itself must have succeeded for this test to prove anything")
+
+	updated, err := cs.Storage().GetUser(req.Context(), target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Name", updated.DisplayName, "the legitimately-carried field DID change")
+	assert.Equal(t, "REAL_BCRYPT_HASH_MUST_SURVIVE", updated.PasswordHash,
+		"PasswordHash must survive a call to this route unchanged")
+	assert.Equal(t, "suspended", updated.AccountState,
+		"AccountState must survive a call to this route unchanged")
+}
+
+// TestUpdateUserIfActiveStateMatchesProxy_MismatchLeavesRowCompletelyUnchanged
+// re-verifies, for this route, the same mutate-before-checking ordering bug
+// caught in the WebAuthn authz fix: a from_active precondition mismatch must
+// leave the ENTIRE row untouched, not just fail to apply the intended
+// transition. Because the fix fetches first and the storage layer's own
+// WHERE-gated Updates() either matches the row (and writes it) or matches zero
+// rows (and writes nothing) as a single atomic operation, there is no window
+// where a partial write could land -- this test proves that empirically,
+// including for the fields the earlier bug used to zero.
+func TestUpdateUserIfActiveStateMatchesProxy_MismatchLeavesRowCompletelyUnchanged(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	target := &models.User{
+		Username: "s12nonadmin-mismatch", Email: "s12nonadmin-mismatch@example.com",
+		PasswordHash: "UNCHANGED_HASH", AccountState: "active", IsActive: true,
+		DisplayName: "Original Name",
+	}
+	require.NoError(t, db.Create(target).Error)
+	idStr := machineUintToStr(target.ID)
+
+	// from_active asserts false, but the row is actually true -- a stale/wrong
+	// precondition, matching the LostRace test's own shape.
+	body := proxyJSON(map[string]interface{}{
+		"username":     target.Username,
+		"email":        target.Email,
+		"display_name": "Should Not Persist",
+		"active":       false,
+		"from_active":  false,
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/users/"+idStr+"/active-transition", body),
+		"id", idStr,
+	)
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := decodeRemoteResp(t, w)
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, false, data["matched"], "the precondition mismatch must be reported")
+
+	unchanged, err := cs.Storage().GetUser(req.Context(), target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Original Name", unchanged.DisplayName, "no field may change on a rejected precondition")
+	assert.Equal(t, "UNCHANGED_HASH", unchanged.PasswordHash)
+	assert.Equal(t, "active", unchanged.AccountState)
+	assert.True(t, unchanged.IsActive)
+}
+
+// TestUpdateUserIfActiveStateMatchesProxy_RejectsUnknownField proves a body
+// carrying a field this route doesn't declare -- e.g. an attempt to smuggle
+// password_hash or account_state through it -- is rejected outright (400),
+// not silently ignored.
+func TestUpdateUserIfActiveStateMatchesProxy_RejectsUnknownField(t *testing.T) {
+	h := freshUserHandlerForProxyS13(t)
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/users/1/active-transition",
+			strings.NewReader(`{"username":"x","email":"x@y.com","display_name":"x","active":true,`+
+				`"from_active":true,"password_hash":"sneaky"}`)),
+		"id", "1",
+	)
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+}
+
 // TestUpdateUserIfActiveStateMatchesProxy_DuplicateUsername is the #G79
 // regression: this proxy previously ran no uniqueness pre-check at all
 // (unlike core.UpdateUser, which checks GetUserByUsername/GetUserByEmail


### PR DESCRIPTION
## Severity: Critical — full account takeover, not data corruption

`UpdateUserIfActiveStateMatchesProxy` built a `*models.User` directly from its own wire body (`username`/`email`/`display_name`/`active`/`updated_at`/`from_active` — the only fields it declares) and passed it straight into `storage.UpdateUserIfActiveStateMatches`, a `Select("*")` full-row overwrite. Every field this route's wire format doesn't carry — `PasswordHash`, `AccountState`, everything else on `models.User` — was silently zeroed on **every** call.

## Blast radius (Step A findings)

**(a) PasswordHash — fail-closed for password login specifically.** `bcrypt.CompareHashAndPassword` on an empty hash always errors (confirmed directly: `hashedSecret too short to be a bcrypted password`). No code path anywhere checks `PasswordHash == ""` to route to a setup/reset flow instead of failing verification.

**(b) AccountState — fail-open, confirmed.** `AccountLoginBlocked` — the single choke point every login/session/PAT/SSO/WebAuthn/MFA-step-up/impersonation-target path calls — is a deny-list: `switch NormalizeAccountState(state) { case Suspended, Deprovisioned: return true; default: return false }`. `NormalizeAccountState("")` returns `AccountActive` (documented legacy shorthand). Confirmed directly: `AccountLoginBlocked("") == false`.

**(c) The chain is reachable end-to-end, and it's account takeover, not just reactivation.** `completePasswordSetup` (completes an `account_setup`/`password_reset_link` setup token) gates explicitly on `AccountLoginBlocked(user.AccountState)`. Blank the state first via this route, and that gate passes. Confirmed end-to-end in a throwaway test (not committed): seed a **suspended** user, blank their `AccountState` via this route, then complete a setup token against them with an **attacker-chosen password** — `CompleteSetup` returns `err=nil`, mints a real session, and the attacker's password passes `bcrypt.CompareHashAndPassword` against the stored hash afterward.

**The victim class here is accounts deliberately suspended or deprovisioned — i.e. terminated employees.** Any `system.write` holder (a permission this same campaign's ADR-102 investigation found gates 148 routes behind one flat boolean) can take over a terminated employee's account, set a password of their choosing, and be logged in as that employee — with the resulting session and every subsequent action attributed to the victim, not the attacker.

**(d) Not just a malicious-actor bug.** `models.User.PasswordHash` is `json:"-"` and never crosses the wire at all. Under `storage.type: remote`, a spoke's own `core.UpdateUser` relaying *any* legitimate profile edit (changing a display name, for instance) through this exact route already zeroed the hub's real `PasswordHash` on receipt — independent of attacker intent, independent of what the spoke's caller actually changed. Any deployment using this topology and this admin flow in normal operation may already have corrupted user records.

## Fix

Fetch the existing row first, patch only the fields this route legitimately carries onto it, leave everything else exactly as fetched. `DisallowUnknownFields()` on the JSON decoder so a body carrying `password_hash`/`account_state` (or anything outside the declared six fields) is rejected with 400, not silently ignored.

## Tests

- `PasswordHash`/`AccountState` survive a legitimate, successful call unchanged.
- A `from_active` precondition mismatch leaves the row completely untouched — noted honestly in the test's own doc comment that this property holds *with or without* this fix (the storage layer's `WHERE`-gated `Updates()` was already atomic on that axis), so it's not overclaimed as newly fixed.
- An unknown JSON field (`password_hash` smuggled in) is rejected outright.

**Red/green proof**: temporarily reintroduced the unfetched-struct version of the handler and re-ran the PasswordHash/AccountState-preservation test — failed (both fields came back empty). Reverted; passes.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l` clean. `gosec -severity medium -exclude-generated` on `server/http/handlers`: 0 issues. Full `server/http/handlers` suite green, plus `TestNoUnjustifiedRawStorageBypass` and `TestNoProxyCallsUnsafeSiblingWhenSafeExists` (unaffected — this route legitimately calls raw storage by design, no wrapping core method exists for this primitive).

## Scope note

This is containment only, per the agreed 3-PR sequence. Root cause (making a blank/unrecognized `AccountState` fail closed everywhere, not just here) is PR 2, in two separate migrate-then-flip deploys. A structural guard preventing a third instance of this shape is PR 3.