### PR TITLE
fix(storage): ROOT CAUSE 1/2 -- backfill blank account_state, add Postgres CHECK constraint

### DIFF
--- a/internal/storage/account_state_backfill.go
+++ b/internal/storage/account_state_backfill.go
@@ -1,0 +1,120 @@
+package storage
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// accountStateBackfilledLabel is the explicit value a blank/unset
+// users.account_state is backfilled to. Matches core.AccountActive
+// (internal/storage cannot import internal/core -- core imports storage --
+// so this is the same literal core.NormalizeAccountState's own "" -> active
+// mapping already treats blank as meaning).
+const accountStateBackfilledLabel = "active"
+
+// backfillBlankAccountState finds every live user row whose account_state is
+// blank, unset, or all-whitespace and sets it to an explicit "active"
+// (ADR-025 root-cause fix).
+//
+// This closes a real, confirmed authentication-bypass chain: core.
+// AccountLoginBlocked (the single choke point every login/session/PAT/SSO/
+// WebAuthn/MFA-step-up/impersonation-target path calls) is a deny-list keyed
+// on NormalizeAccountState(state), which maps "" to "active" -- so a
+// suspended or deprovisioned account whose account_state was ever written as
+// blank reads as NOT blocked. The write-path fix that stops NEW blanks from
+// being introduced only closes the ONE call site it was found at; any row
+// that was ALREADY blank before that landed -- from that bug, or from any
+// other path that ever wrote an empty string -- stays a live landmine until
+// backfilled explicitly. This function is that backfill: idempotent (a no-op
+// once no blank rows remain, like every other backfill* helper in this
+// package), and loud about what it found -- the row count is logged
+// unconditionally so an operator upgrading a real database SEES the number,
+// not just a silent success.
+//
+// Deliberately does NOT change any code-level behavior
+// (NormalizeAccountState/AccountLoginBlocked stay exactly as they are): the
+// fail-open-to-fail-closed behavior change is its own, later deploy --
+// flipping the default before every existing blank row is confirmed
+// backfilled would lock out any account this migration hasn't reached yet,
+// which is worse than the bug it fixes.
+func backfillBlankAccountState(db *gorm.DB) error {
+	type row struct {
+		ID    uint
+		State string
+	}
+	var rows []row
+	if err := db.Table("users").Select("id, account_state AS state").
+		Where(sqlWhereNotDeleted).
+		Find(&rows).Error; err != nil {
+		return fmt.Errorf("failed to read users for account_state backfill: %w", err)
+	}
+
+	var blankIDs []uint
+	for _, r := range rows {
+		if strings.TrimSpace(r.State) == "" {
+			blankIDs = append(blankIDs, r.ID)
+		}
+	}
+	if len(blankIDs) == 0 {
+		return nil
+	}
+
+	// Loud on purpose: this is the number an operator upgrading a real
+	// database needs to see, not just a silent success. A large count here
+	// confirms blank-as-legacy-active was real, live production state, not a
+	// theoretical edge case.
+	log.Printf("SECURITY: backfilling account_state for %d user row(s) with a blank/unset value -- "+
+		"each was reading as NOT login-blocked regardless of any suspension/deprovisioning ever recorded "+
+		"for it; setting explicitly to %q", len(blankIDs), accountStateBackfilledLabel)
+
+	if err := db.Table("users").Where("id IN ?", blankIDs).
+		Update("account_state", accountStateBackfilledLabel).Error; err != nil {
+		return fmt.Errorf("failed to backfill account_state for %d user row(s): %w", len(blankIDs), err)
+	}
+	return nil
+}
+
+// guardAccountStateNotBlank adds a database-level CHECK constraint refusing
+// any future write of an empty users.account_state, on Postgres. This is the
+// schema-level half of the fix: even before NormalizeAccountState/
+// AccountLoginBlocked are changed to fail closed on an unrecognized value (a
+// separate, later behavior change -- see backfillBlankAccountState's own
+// doc), a write path that tries to blank this column again (a resurgence of
+// the exact bug the write-path containment fix closed at one call site, or a
+// new site nobody has found yet) fails loudly at the database instead of
+// silently succeeding.
+//
+// Postgres only: SQLite's ALTER TABLE cannot add a CHECK constraint to an
+// existing table without a full table rebuild (copy to a new table, drop,
+// rename) -- a materially riskier operation for a boot-time, idempotent
+// migration than this fix is worth, especially since ADR-039 already
+// documents SQLite as single-instance/development only, never the
+// production-HA backend this constraint most needs to protect. The portable,
+// both-dialect backstop is the later code-level fail-closed change to
+// NormalizeAccountState/AccountLoginBlocked -- this constraint is
+// defense-in-depth specifically for Postgres production, not a substitute
+// for it.
+func guardAccountStateNotBlank(db *gorm.DB) error {
+	if db.Dialector.Name() != "postgres" {
+		return nil
+	}
+	const constraintName = "chk_users_account_state_not_blank"
+	var exists bool
+	if err := db.Raw(
+		"SELECT EXISTS (SELECT 1 FROM information_schema.table_constraints WHERE constraint_name = ? AND table_name = 'users')",
+		constraintName,
+	).Scan(&exists).Error; err != nil {
+		return fmt.Errorf("failed to check for existing %s constraint: %w", constraintName, err)
+	}
+	if exists {
+		return nil
+	}
+	if err := db.Exec("ALTER TABLE users ADD CONSTRAINT " + constraintName +
+		" CHECK (btrim(account_state) <> '')").Error; err != nil {
+		return fmt.Errorf("failed to add %s constraint: %w", constraintName, err)
+	}
+	return nil
+}

--- a/internal/storage/account_state_backfill_postgres_test.go
+++ b/internal/storage/account_state_backfill_postgres_test.go
@@ -1,0 +1,42 @@
+package storage
+
+// account_state_backfill_postgres_test.go — the real-Postgres counterpart to
+// account_state_backfill_test.go's TestGuardAccountStateNotBlank_NoOpOnSQLite:
+// proves the CHECK constraint actually rejects a blank write on the one
+// dialect it's meant to protect. Skips (KEYORIX_TEST_PG_DSN unset) when no
+// real Postgres server is available, same convention as
+// factory_rbac_pk_rebuild_postgres_test.go.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGuardAccountStateNotBlank_Postgres_RejectsBlankWrite(t *testing.T) {
+	base := pgTestDSN(t)
+	db := pgRawOpen(t, pgIsolatedDatabaseDSN(t, base))
+
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, account_state TEXT)`).Error)
+	require.NoError(t, guardAccountStateNotBlank(db))
+
+	// A non-blank write still succeeds.
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'active')`).Error)
+
+	// An empty-string write is refused at the database.
+	err := db.Exec(`INSERT INTO users VALUES (2, '')`).Error
+	require.Error(t, err, "an empty account_state must be refused by the CHECK constraint")
+	assert.Contains(t, err.Error(), "chk_users_account_state_not_blank")
+
+	// A whitespace-only write is ALSO refused (the constraint uses btrim,
+	// matching backfillBlankAccountState's own strings.TrimSpace definition
+	// of "blank").
+	err = db.Exec(`INSERT INTO users VALUES (3, '   ')`).Error
+	require.Error(t, err, "a whitespace-only account_state must also be refused")
+
+	// Re-applying the guard on a database that already has the constraint is
+	// a no-op, not an error (idempotent, matching every other ensure*/guard*
+	// migration helper in this package).
+	require.NoError(t, guardAccountStateNotBlank(db))
+}

--- a/internal/storage/account_state_backfill_test.go
+++ b/internal/storage/account_state_backfill_test.go
@@ -1,0 +1,90 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBackfillBlankAccountState_BackfillsBlankNullAndWhitespace covers all
+// three shapes a "legacy unset" account_state can take -- empty string, SQL
+// NULL, and whitespace-only (a value that would pass a naive `= ”` check but
+// still normalizes to blank under strings.TrimSpace, and reads as blank to
+// NormalizeAccountState's own switch since it's not any recognized state
+// string either) -- plus a genuinely-set control row that must be left alone.
+func TestBackfillBlankAccountState_BackfillsBlankNullAndWhitespace(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "account-state-blank-null-ws.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, account_state TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, NULL, NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (3, '   ', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (4, 'suspended', NULL)`).Error)
+
+	require.NoError(t, backfillBlankAccountState(db))
+
+	type row struct {
+		ID           uint
+		AccountState string
+	}
+	var rows []row
+	require.NoError(t, db.Table("users").Order("id").Find(&rows).Error)
+	require.Len(t, rows, 4)
+	assert.Equal(t, "active", rows[0].AccountState, "empty string must be backfilled")
+	assert.Equal(t, "active", rows[1].AccountState, "NULL must be backfilled")
+	assert.Equal(t, "active", rows[2].AccountState, "whitespace-only must be backfilled")
+	assert.Equal(t, "suspended", rows[3].AccountState, "an already-set state must be left completely alone")
+}
+
+// TestBackfillBlankAccountState_ExcludesSoftDeletedRows: a soft-deleted user's
+// blank account_state is not a live login-eligibility landmine (DeleteUser
+// already blocks login independently via deleted_at), so it's intentionally
+// left alone rather than rewritten -- matches the deleted_at-scoping every
+// other backfill* helper in this file uses.
+func TestBackfillBlankAccountState_ExcludesSoftDeletedRows(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "account-state-softdeleted.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, account_state TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, '', '2026-01-01 00:00:00')`).Error)
+
+	require.NoError(t, backfillBlankAccountState(db))
+
+	var state string
+	require.NoError(t, db.Table("users").Select("account_state").Where("id = 1").Scan(&state).Error)
+	assert.Equal(t, "", state, "a soft-deleted row's account_state is not touched")
+}
+
+// TestBackfillBlankAccountState_NoOpWhenNothingBlank proves the idempotency
+// every other backfill* helper in this package guarantees: re-running finds
+// nothing to do and touches nothing.
+func TestBackfillBlankAccountState_NoOpWhenNothingBlank(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "account-state-noop.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, account_state TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'active', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, 'pending_first_login', NULL)`).Error)
+
+	require.NoError(t, backfillBlankAccountState(db))
+
+	var state1, state2 string
+	require.NoError(t, db.Table("users").Select("account_state").Where("id = 1").Scan(&state1).Error)
+	require.NoError(t, db.Table("users").Select("account_state").Where("id = 2").Scan(&state2).Error)
+	assert.Equal(t, "active", state1)
+	assert.Equal(t, "pending_first_login", state2)
+}
+
+// TestGuardAccountStateNotBlank_NoOpOnSQLite: the CHECK constraint is
+// Postgres-only (see the function's own doc for why) -- on SQLite this must
+// be a clean no-op, not an error, since every local/dev/test database in
+// this repo runs on SQLite.
+func TestGuardAccountStateNotBlank_NoOpOnSQLite(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "account-state-guard-sqlite.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, account_state TEXT)`).Error)
+	require.NoError(t, guardAccountStateNotBlank(db))
+	// A blank write must still succeed on SQLite -- confirms no constraint
+	// was (incorrectly) applied here.
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, '')`).Error)
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1798,6 +1798,18 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	if err := ensureUserExternalIDIndex(db); err != nil {
 		return err
 	}
+	// ADR-025 account-state root-cause fix: backfill any blank/unset
+	// account_state to an explicit "active" before adding the constraint
+	// that refuses to let a NEW blank land -- see backfillBlankAccountState's
+	// own doc for why this matters (AccountLoginBlocked treats blank the
+	// same as active, silently reactivating a suspended/deprovisioned
+	// account for login).
+	if err := backfillBlankAccountState(db); err != nil {
+		return err
+	}
+	if err := guardAccountStateNotBlank(db); err != nil {
+		return err
+	}
 	if err := ensureProjectNameIndex(db); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Scope: data migration + schema constraint only

This is deploy 1 of 2 for the root-cause fix, per the agreed sequencing: **the code-level fail-closed behavior change (making `NormalizeAccountState`/`AccountLoginBlocked` deny an unrecognized value, and switching `completePasswordSetup` from a deny-list to an allow-list) is a separate, later PR**, gated on this one having run and confirmed zero blanks remain. Flipping the default before every existing blank row is backfilled would lock out any account this migration hasn't reached yet — worse than the bug it fixes.

## Why

`core.AccountLoginBlocked` — the single choke point every login/session/PAT/SSO/WebAuthn/MFA-step-up/impersonation-target path calls — is a deny-list keyed on `NormalizeAccountState(state)`, which maps `""` to `"active"` (documented legacy shorthand). Any user row whose `account_state` was ever written blank — from the `UpdateUserIfActiveStateMatchesProxy` bug fixed in a separate PR, or any other path that ever wrote an empty string — reads as **not** login-blocked regardless of any suspension/deprovisioning actually recorded for it.

## The count you asked to see before anything migrates

**I have no access to any deployed database — dev, staging, or production.** I can't report a real row count myself. What I've built instead: `backfillBlankAccountState` counts the blank rows and logs the number unconditionally at `SECURITY` level, *before* writing anything, the moment this code runs against a real database (every server boot, same as every other `backfill*` helper in this package — additive, idempotent, a no-op once nothing is blank). If the number is large on your actual databases, you'll see it in the boot log the first time this ships. I verified the counting and backfill logic itself is correct via synthetic test fixtures (below), which is not a substitute for a real count — flagging that distinction explicitly rather than implying I have one.

## What's in this PR

- **`backfillBlankAccountState`**: finds every live (non-deleted) user row with a blank, unset, or whitespace-only `account_state` and sets it to an explicit `"active"` — matching what blank has always meant to `NormalizeAccountState`. Wired into `migrateDatabase`.
- **`guardAccountStateNotBlank`**: adds a CHECK constraint refusing any future blank write, **Postgres only**. SQLite's `ALTER TABLE` can't add a CHECK constraint to an existing table without a full table rebuild (copy, drop, rename) — materially riskier for a boot-time idempotent migration than this is worth, and ADR-039 already documents SQLite as single-instance/development only, never the production-HA backend this constraint most needs to protect. This is defense-in-depth for Postgres specifically; the portable, both-dialect backstop is the code-level fail-closed change landing in the next PR.

## Tests

Blank/NULL/whitespace-only all backfilled; an already-set state left completely untouched; soft-deleted rows excluded (a soft-deleted user's blank state isn't a live landmine — `deleted_at` already blocks login independently); idempotent re-run is a no-op. **The Postgres CHECK constraint is verified against a real, running Postgres instance** (`KEYORIX_TEST_PG_DSN`, same convention as `factory_rbac_pk_rebuild_postgres_test.go`) — confirmed to actually reject an empty write and a whitespace-only write, not just asserted to exist. Skips cleanly (not a failure) when no Postgres is available, matching the existing convention.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l` clean. `gosec -severity medium -exclude-generated` on `internal/storage`: 0 issues. Full `internal/storage` package suite green (all pre-existing `TestMigrateDatabase_*`/`TestCreateStorage_*` tests unaffected — no regression from the new migration step).