### PR TITLE
Add configurable maximum secret value size (64 KiB default, 1 MiB ceiling)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -701,6 +701,64 @@ type ChunkingConfig struct {
 
 type LimitsConfig struct {
 	MaxSecretsPerUser int `yaml:"max_secrets_per_user"`
+	// MaxSecretSize caps a secret value's size in bytes, enforced on create/update/
+	// rotate (never on read/delete — a secret already stored above the cap, e.g. from
+	// before this was introduced or before an operator lowered it, stays fully
+	// readable and deletable; only new writes are rejected). 0 (unset) defaults to
+	// DefaultMaxSecretSize; Validate rejects any configured value above
+	// MaxSecretSizeHardCeiling. See DefaultMaxSecretSize's doc comment for the
+	// industry-comparison rationale behind the default.
+	MaxSecretSize int `yaml:"max_secret_size"`
+}
+
+// DefaultMaxSecretSize (64 KiB) is the default ceiling on a secret value's size when
+// secrets.limits.max_secret_size is unset. This is the number the major managed
+// secret stores have converged on, not an arbitrary round figure: AWS Secrets
+// Manager and GCP Secret Manager both cap at 64 KB (AWS's limit is explicitly
+// documented as non-adjustable and was raised twice, under customer pressure,
+// before settling at 64 KB); Azure Key Vault caps at 25 KB; HashiCorp Vault chunks
+// entries above 512 KiB and its own documentation warns that large entries degrade
+// other storage operations (backend replication, snapshot/restore, KV listing).
+// 64 KiB is the number defensible in this product's own docs for the same reasons.
+const DefaultMaxSecretSize = 65536
+
+// MaxSecretSizeHardCeiling (1 MiB) is the absolute upper bound secrets.limits.
+// max_secret_size may be configured to — Validate rejects a configured value above
+// this outright, at startup, rather than silently clamping it. An operator who
+// genuinely needs to store larger blobs should use a purpose-built object store and
+// reference it from a secret, not raise this ceiling; every comparable managed
+// secret store (see DefaultMaxSecretSize) treats "secret" as a credential-sized
+// value, not a general blob store, and this cap exists to keep that true here too.
+const MaxSecretSizeHardCeiling = 1 << 20 // 1 MiB
+
+// secretSizeEnvelopeHeadroomBytes is added on top of a secret value's base64-
+// inflated size (DeriveMaxRequestBodySize) to cover the REST of a create/update/
+// rotate request body: JSON field names and quoting, and the request's other
+// fields (name up to 255 bytes, metadata, tags, description, etc.), none of which
+// are the secret value itself and none of which max_secret_size is meant to bound.
+// 16 KiB is a generous, round number chosen to comfortably clear ordinary metadata/
+// tag usage without making the wire-level cap effectively unlimited -- it is a
+// coarse DoS backstop, not the precise enforcement point (that's the decoded-value
+// check against max_secret_size itself, applied separately after the body is
+// successfully read).
+const secretSizeEnvelopeHeadroomBytes = 16 * 1024
+
+// DeriveMaxRequestBodySize returns the maximum HTTP/gRPC request body size a
+// caller must be allowed to send in order to successfully submit a secret value of
+// exactly maxSecretSize bytes, plus headroom for the rest of the request envelope.
+//
+// A secret value never travels as raw bytes: the HTTP JSON API and gRPC's
+// generated string fields both carry it base64-encoded. Base64 inflates N bytes to
+// exactly ceil(N/3)*4 bytes -- setting a request-body limit to maxSecretSize itself
+// (the natural but wrong first instinct) would reject every valid maximum-size
+// secret outright, roughly 33% before the JSON envelope is even counted. This
+// function exists specifically so that mistake has one place it can't be made:
+// every caller that needs a body-size limit derived from max_secret_size (the HTTP
+// router's per-route middleware, the gRPC server's MaxRecvMsgSize) calls this,
+// rather than each re-deriving (and potentially mis-deriving) its own.
+func DeriveMaxRequestBodySize(maxSecretSize int) int64 {
+	base64Size := ((maxSecretSize + 2) / 3) * 4 // ceil(n/3)*4: the exact base64 output length
+	return int64(base64Size) + secretSizeEnvelopeHeadroomBytes
 }
 
 type SecurityConfig struct {
@@ -1983,6 +2041,18 @@ func (c *Config) Validate() error { // NOSONAR -- cognitive complexity 32, suppr
 		// per-replica split-brain SQLite instances with no operator-visible
 		// signal. Fail fast at config-validation time instead.
 		return fmt.Errorf("invalid storage.type %q: must be one of \"local\", \"sqlite\", \"postgres\", \"postgresql\", or \"remote\"", c.Storage.Type)
+	}
+
+	if c.Secrets.Limits.MaxSecretSize == 0 {
+		c.Secrets.Limits.MaxSecretSize = DefaultMaxSecretSize
+	}
+	if c.Secrets.Limits.MaxSecretSize < 0 {
+		return fmt.Errorf("secrets.limits.max_secret_size (%d) must not be negative", c.Secrets.Limits.MaxSecretSize)
+	}
+	if c.Secrets.Limits.MaxSecretSize > MaxSecretSizeHardCeiling {
+		return fmt.Errorf("secrets.limits.max_secret_size (%d) exceeds the hard ceiling of %d bytes (1 MiB) -- "+
+			"a secret store is not a general blob store; use a purpose-built object store for larger values",
+			c.Secrets.Limits.MaxSecretSize, MaxSecretSizeHardCeiling)
 	}
 
 	if c.Locale.Language == "" {

--- a/internal/config/max_secret_size_test.go
+++ b/internal/config/max_secret_size_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// validLocalConfig returns the minimal Config that passes every Validate()
+// check ahead of the secrets.limits.max_secret_size checks under test here.
+func validLocalConfig() *Config {
+	c := &Config{}
+	c.Storage.Type = "local"
+	c.Storage.Database.Path = "/tmp/keyorix.db"
+	return c
+}
+
+func TestValidate_MaxSecretSize_DefaultsWhenUnset(t *testing.T) {
+	c := validLocalConfig()
+	require.Zero(t, c.Secrets.Limits.MaxSecretSize, "test setup: expected zero-value MaxSecretSize")
+	require.NoError(t, c.Validate())
+	require.Equal(t, DefaultMaxSecretSize, c.Secrets.Limits.MaxSecretSize)
+}
+
+func TestValidate_MaxSecretSize_AcceptsExplicitValueUnderCeiling(t *testing.T) {
+	c := validLocalConfig()
+	c.Secrets.Limits.MaxSecretSize = 128 * 1024 // 128 KiB, under the 1 MiB ceiling
+	require.NoError(t, c.Validate())
+	require.Equal(t, 128*1024, c.Secrets.Limits.MaxSecretSize, "an explicitly configured value must not be overwritten")
+}
+
+func TestValidate_MaxSecretSize_AcceptsExactlyTheHardCeiling(t *testing.T) {
+	c := validLocalConfig()
+	c.Secrets.Limits.MaxSecretSize = MaxSecretSizeHardCeiling
+	require.NoError(t, c.Validate(), "exactly at the ceiling must be accepted, not just under it")
+}
+
+func TestValidate_MaxSecretSize_RejectsAboveHardCeiling(t *testing.T) {
+	c := validLocalConfig()
+	c.Secrets.Limits.MaxSecretSize = MaxSecretSizeHardCeiling + 1
+	err := c.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "max_secret_size")
+	require.Contains(t, err.Error(), "hard ceiling")
+}
+
+func TestValidate_MaxSecretSize_RejectsNegative(t *testing.T) {
+	c := validLocalConfig()
+	c.Secrets.Limits.MaxSecretSize = -1
+	require.Error(t, c.Validate())
+}
+
+func TestDeriveMaxRequestBodySize_ExactBase64PlusHeadroom(t *testing.T) {
+	// Verified against the exact documented formula rather than a hand-computed
+	// literal, so this test fails loudly if the formula's shape ever changes
+	// rather than silently drifting out of sync with it.
+	got := DeriveMaxRequestBodySize(DefaultMaxSecretSize)
+	wantBase64 := int64(((DefaultMaxSecretSize + 2) / 3) * 4)
+	want := wantBase64 + secretSizeEnvelopeHeadroomBytes
+	require.Equal(t, want, got)
+
+	// A base64-encoded DefaultMaxSecretSize-byte value must actually fit under
+	// the derived limit -- the property this function exists to guarantee.
+	require.LessOrEqual(t, wantBase64, got,
+		"a base64-encoded max-size secret would not fit under the derived body limit")
+}
+
+func TestDeriveMaxRequestBodySize_MonotonicInInput(t *testing.T) {
+	small := DeriveMaxRequestBodySize(1024)
+	large := DeriveMaxRequestBodySize(DefaultMaxSecretSize)
+	require.Less(t, small, large, "the derived limit must grow with the configured secret size")
+}

--- a/internal/core/secret_size_policy.go
+++ b/internal/core/secret_size_policy.go
@@ -1,0 +1,73 @@
+// secret_size_policy.go — the always-on maximum-secret-value-size cap.
+//
+// Distinct in kind from secret_value_policy.go's SecretValuePolicy: that policy is
+// an OPTIONAL quality gate (off by default, rejects weak/placeholder values) an
+// operator opts into. This cap is a RESOURCE-PROTECTION limit and is on by
+// default everywhere a KeyorixCore exists (CLI local mode included, not just the
+// HTTP/gRPC server) — see DefaultMaxSecretSize below, set directly in
+// NewKeyorixCore rather than left at a disabled zero value the way
+// SecretValuePolicy's zero value is.
+package core
+
+import "fmt"
+
+// DefaultMaxSecretSize mirrors internal/config.DefaultMaxSecretSize (64 KiB) —
+// this package cannot import internal/config (config depends on nothing above
+// it in the layering; core must not become a dependency of it), so the two
+// constants are independently defined and kept in sync by
+// TestDefaultMaxSecretSize_MatchesConfigDefault. This is the fallback used when
+// a KeyorixCore is constructed without SetMaxSecretSize ever being called (every
+// CLI local-mode command; see internal/cli/modes.go) — it must be a real,
+// enforced value on its own, not a sentinel meaning "unlimited".
+const DefaultMaxSecretSize = 65536
+
+// SecretValueTooLargeError is returned when a secret value exceeds the
+// configured (or default) maximum size. A typed error, not a plain
+// fmt.Errorf, so the HTTP and gRPC transports can map it to a precise status
+// (413 / ResourceExhausted) via errors.As instead of string-matching the
+// message the way most of this package's other validation errors are mapped
+// at the handler layer — worth the small inconsistency here because the
+// message itself needs to name the exact limit, which a transport-layer
+// string match can't reconstruct reliably.
+type SecretValueTooLargeError struct {
+	Size  int
+	Limit int
+}
+
+func (e *SecretValueTooLargeError) Error() string {
+	return fmt.Sprintf("secret value is %d bytes, which exceeds the configured maximum of %d bytes", e.Size, e.Limit)
+}
+
+// SetMaxSecretSize configures the maximum secret VALUE size (bytes) enforced on
+// create/update/rotate. The server calls this at startup with the validated
+// config value (internal/config.Config.Secrets.Limits.MaxSecretSize, already
+// defaulted and ceiling-checked by Config.Validate). n <= 0 is treated as "not
+// configured" and falls back to DefaultMaxSecretSize, matching Validate's own
+// zero-means-default handling — this setter does not need to be called at all
+// for the cap to be enforced; NewKeyorixCore already sets the default.
+func (c *KeyorixCore) SetMaxSecretSize(n int) {
+	if n <= 0 {
+		n = DefaultMaxSecretSize
+	}
+	c.maxSecretSize = n
+}
+
+// checkSecretSize enforces the configured maximum secret VALUE size. Called from
+// every write path that sets a secret's value (CreateSecret, UpdateSecret,
+// RotateSecret) — never from a read or delete path: a secret already stored
+// above the current cap (e.g. written before this existed, or before an
+// operator lowered secrets.limits.max_secret_size) must remain fully readable
+// and deletable. Only new writes are rejected.
+func (c *KeyorixCore) checkSecretSize(value []byte) error {
+	limit := c.maxSecretSize
+	if limit <= 0 {
+		// Defense in depth against a KeyorixCore constructed via a struct
+		// literal rather than NewKeyorixCore (bypassing its default) — the
+		// cap must never silently become "unlimited".
+		limit = DefaultMaxSecretSize
+	}
+	if len(value) > limit {
+		return &SecretValueTooLargeError{Size: len(value), Limit: limit}
+	}
+	return nil
+}

--- a/internal/core/secret_size_policy_test.go
+++ b/internal/core/secret_size_policy_test.go
@@ -1,0 +1,220 @@
+package core_test
+
+// secret_size_policy_test.go exercises the core-layer secret-size cap
+// (internal/core/secret_size_policy.go) against CreateSecret, UpdateSecret,
+// and RotateSecret -- the three write paths that call checkSecretSize. Each
+// uses real sqlite-backed storage (store.NewLocalStorage), matching the
+// pattern already established by concurrency_update_secret_test.go, rather
+// than mocks, so the exactly-at-limit case exercises the real storeSecretVersion
+// write path end to end.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// newSecretSizeTestCore returns a KeyorixCore backed by a fresh, migrated,
+// file-backed sqlite DB with one project and one environment already seeded --
+// enough to exercise CreateSecret/UpdateSecret/RotateSecret directly.
+func newSecretSizeTestCore(t *testing.T) *core.KeyorixCore {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+
+	dsn := "file:" + filepath.Join(t.TempDir(), "secret-size.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(20)
+
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.SecretAccessSchedule{}))
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_secret_versions_node_version ON secret_versions (secret_node_id, version_number)").Error)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "dev"}).Error)
+
+	return core.NewKeyorixCore(store.NewLocalStorage(db))
+}
+
+// newSecretSizeTestCoreAndStorage is newSecretSizeTestCore, but also returns
+// the underlying *store.LocalStorage so a test can write directly through it,
+// bypassing every core-layer check (checkSecretSize included) -- needed to
+// simulate a pre-existing secret version that predates the cap.
+func newSecretSizeTestCoreAndStorage(t *testing.T) (*core.KeyorixCore, *store.LocalStorage) {
+	t.Helper()
+	require.NoError(t, i18n.InitializeForTesting())
+
+	dsn := "file:" + filepath.Join(t.TempDir(), "secret-size-bypass.db") + "?_busy_timeout=10000&_journal_mode=WAL&_txlock=immediate"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(20)
+
+	require.NoError(t, db.AutoMigrate(&models.Project{}, &models.Environment{}, &models.SecretNode{}, &models.SecretVersion{}, &models.SecretAccessSchedule{}, &models.ShareRecord{}, &models.SecretACL{}))
+	require.NoError(t, db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS uniq_secret_versions_node_version ON secret_versions (secret_node_id, version_number)").Error)
+	require.NoError(t, db.Create(&models.Project{ID: 1, Name: "p1"}).Error)
+	require.NoError(t, db.Create(&models.Environment{ID: 1, ProjectID: 1, Name: "dev"}).Error)
+
+	ls := store.NewLocalStorage(db)
+	return core.NewKeyorixCore(ls), ls
+}
+
+// TestGetAndDeleteSecret_PreExistingOversizedValue_StillWorks is Item 1's
+// "1f": the cap must bound new WRITES, never break reads of data that
+// predates it. A secret version inserted directly through the storage layer
+// (bypassing checkSecretSize entirely, simulating a row written before the
+// cap existed, or under a since-lowered configured limit) must still be
+// readable via GetSecretValue and the secret must still be deletable via
+// DeleteSecret -- only a new write/update of an oversized value is rejected.
+func TestGetAndDeleteSecret_PreExistingOversizedValue_StillWorks(t *testing.T) {
+	c, ls := newSecretSizeTestCoreAndStorage(t)
+	c.SetMaxSecretSize(100)
+	ctx := context.Background()
+
+	sec, err := c.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "legacy-oversized", Value: []byte("seed"), ProjectID: 1, EnvironmentID: 1,
+		Type: "password", CreatedBy: "tester",
+	})
+	require.NoError(t, err)
+
+	// Write version 2 directly through storage, well over the configured
+	// 100-byte cap -- this is exactly the write checkSecretSize exists to
+	// reject when it goes through core, so it must bypass core entirely.
+	oversized := bytes.Repeat([]byte("legacy"), 50) // 300 bytes, > the 100-byte cap
+	_, err = ls.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: sec.ID, VersionNumber: 2, EncryptedValue: oversized,
+	})
+	require.NoError(t, err, "storage-layer write of the pre-existing oversized version must succeed (it is only 300B, under the 1MiB hard ceiling)")
+
+	value, err := c.GetSecretValue(ctx, sec.ID)
+	require.NoError(t, err, "reading a pre-existing oversized secret must still succeed")
+	require.Equal(t, oversized, value)
+
+	require.NoError(t, c.DeleteSecret(ctx, sec.ID), "deleting a pre-existing oversized secret must still succeed")
+}
+
+func TestCreateSecret_SecretSizeCap(t *testing.T) {
+	c := newSecretSizeTestCore(t)
+	c.SetMaxSecretSize(100)
+	ctx := context.Background()
+
+	t.Run("exactly at the limit is accepted", func(t *testing.T) {
+		value := bytes.Repeat([]byte("a"), 100)
+		secret, err := c.CreateSecret(ctx, &core.CreateSecretRequest{
+			Name: "at-limit", Value: value, ProjectID: 1, EnvironmentID: 1,
+			Type: "password", CreatedBy: "tester",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, secret)
+	})
+
+	t.Run("one byte over the limit is rejected", func(t *testing.T) {
+		value := bytes.Repeat([]byte("a"), 101)
+		secret, err := c.CreateSecret(ctx, &core.CreateSecretRequest{
+			Name: "over-limit", Value: value, ProjectID: 1, EnvironmentID: 1,
+			Type: "password", CreatedBy: "tester",
+		})
+		require.Error(t, err)
+		require.Nil(t, secret)
+		var tooLarge *core.SecretValueTooLargeError
+		require.True(t, errors.As(err, &tooLarge), "error must be a *core.SecretValueTooLargeError, got: %v", err)
+		require.Equal(t, 101, tooLarge.Size)
+		require.Equal(t, 100, tooLarge.Limit)
+	})
+}
+
+func TestUpdateSecret_SecretSizeCap(t *testing.T) {
+	c := newSecretSizeTestCore(t)
+	c.SetMaxSecretSize(100)
+	ctx := context.Background()
+
+	sec, err := c.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "updatable", Value: []byte("seed"), ProjectID: 1, EnvironmentID: 1,
+		Type: "password", CreatedBy: "tester",
+	})
+	require.NoError(t, err)
+
+	t.Run("exactly at the limit is accepted", func(t *testing.T) {
+		value := bytes.Repeat([]byte("b"), 100)
+		updated, err := c.UpdateSecret(ctx, &core.UpdateSecretRequest{
+			ID: sec.ID, Value: value, UpdatedBy: "tester",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+	})
+
+	t.Run("one byte over the limit is rejected", func(t *testing.T) {
+		value := bytes.Repeat([]byte("b"), 101)
+		updated, err := c.UpdateSecret(ctx, &core.UpdateSecretRequest{
+			ID: sec.ID, Value: value, UpdatedBy: "tester",
+		})
+		require.Error(t, err)
+		require.Nil(t, updated)
+		var tooLarge *core.SecretValueTooLargeError
+		require.True(t, errors.As(err, &tooLarge), "error must be a *core.SecretValueTooLargeError, got: %v", err)
+		require.Equal(t, 101, tooLarge.Size)
+		require.Equal(t, 100, tooLarge.Limit)
+	})
+}
+
+func TestRotateSecret_SecretSizeCap(t *testing.T) {
+	c := newSecretSizeTestCore(t)
+	c.SetMaxSecretSize(100)
+	ctx := context.Background()
+
+	sec, err := c.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "rotatable", Value: []byte("seed"), ProjectID: 1, EnvironmentID: 1,
+		Type: "password", CreatedBy: "tester",
+	})
+	require.NoError(t, err)
+
+	t.Run("exactly at the limit is accepted", func(t *testing.T) {
+		value := bytes.Repeat([]byte("c"), 100)
+		rotated, err := c.RotateSecret(ctx, sec.ID, value, 0, "tester")
+		require.NoError(t, err)
+		require.NotNil(t, rotated)
+	})
+
+	t.Run("one byte over the limit is rejected", func(t *testing.T) {
+		value := bytes.Repeat([]byte("c"), 101)
+		rotated, err := c.RotateSecret(ctx, sec.ID, value, 0, "tester")
+		require.Error(t, err)
+		require.Nil(t, rotated)
+		var tooLarge *core.SecretValueTooLargeError
+		require.True(t, errors.As(err, &tooLarge), "error must be a *core.SecretValueTooLargeError, got: %v", err)
+		require.Equal(t, 101, tooLarge.Size)
+		require.Equal(t, 100, tooLarge.Limit)
+	})
+}
+
+// TestSetMaxSecretSize_ZeroFallsBackToDefault documents the guard in
+// SetMaxSecretSize: a zero/negative n (e.g. from a config layer that failed
+// to apply its own default) must not silently disable the cap.
+func TestSetMaxSecretSize_ZeroFallsBackToDefault(t *testing.T) {
+	c := newSecretSizeTestCore(t)
+	c.SetMaxSecretSize(0)
+	ctx := context.Background()
+
+	value := bytes.Repeat([]byte("d"), core.DefaultMaxSecretSize+1)
+	secret, err := c.CreateSecret(ctx, &core.CreateSecretRequest{
+		Name: "zero-limit-fallback", Value: value, ProjectID: 1, EnvironmentID: 1,
+		Type: "password", CreatedBy: "tester",
+	})
+	require.Error(t, err)
+	require.Nil(t, secret)
+	var tooLarge *core.SecretValueTooLargeError
+	require.True(t, errors.As(err, &tooLarge))
+	require.Equal(t, core.DefaultMaxSecretSize, tooLarge.Limit)
+}

--- a/internal/core/secrets.go
+++ b/internal/core/secrets.go
@@ -80,6 +80,9 @@ func (c *KeyorixCore) CreateSecret(ctx context.Context, req *CreateSecretRequest
 	if err := c.secretValuePolicy.Validate(req.Value); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
+	if err := c.checkSecretSize(req.Value); err != nil {
+		return nil, err
+	}
 	if err := c.validateSecretName(req.Name); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 	}
@@ -291,6 +294,9 @@ func (c *KeyorixCore) UpdateSecret(ctx context.Context, req *UpdateSecretRequest
 		if err := c.secretValuePolicy.Validate(req.Value); err != nil {
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
 		}
+		if err := c.checkSecretSize(req.Value); err != nil {
+			return nil, err
+		}
 	}
 	secret, err := c.storage.GetSecret(ctx, req.ID)
 	if err != nil {
@@ -392,6 +398,9 @@ const EventSecretRotateNoop = "secret.rotate_noop"
 func (c *KeyorixCore) RotateSecret(ctx context.Context, id uint, newValue []byte, actorID uint, rotatedBy string) (*models.SecretNode, error) {
 	if err := c.secretValuePolicy.Validate(newValue); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorValidation", nil), err)
+	}
+	if err := c.checkSecretSize(newValue); err != nil {
+		return nil, err
 	}
 	secret, err := c.storage.GetSecret(ctx, id)
 	if err != nil {

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -96,10 +96,15 @@ type KeyorixCore struct {
 	// KeyorixCore-level mutex: a per-process mutex here would only serialize
 	// callers within ONE replica, same gap #339 originally closed for concurrent
 	// same-process callers only.
-	secretValuePolicy SecretValuePolicy  // optional quality gate on secret values (off by default)
-	secretNamePolicy  SecretNamePolicy   // optional naming convention for secrets (off by default)
-	secretNameRe      *regexp.Regexp     // compiled secretNamePolicy.Pattern (nil = no regex check)
-	loginLockout      LoginLockoutPolicy // per-account login lockout (disabled by default)
+	secretValuePolicy SecretValuePolicy // optional quality gate on secret values (off by default)
+	// maxSecretSize caps a secret value's size in bytes (see
+	// secret_size_policy.go) — unlike secretValuePolicy, this is on by default
+	// (NewKeyorixCore sets it to DefaultMaxSecretSize) rather than requiring
+	// an explicit opt-in.
+	maxSecretSize    int
+	secretNamePolicy SecretNamePolicy   // optional naming convention for secrets (off by default)
+	secretNameRe     *regexp.Regexp     // compiled secretNamePolicy.Pattern (nil = no regex check)
+	loginLockout     LoginLockoutPolicy // per-account login lockout (disabled by default)
 	// recordFailedLogin (and the pre-session-mint recheck in
 	// checkLockAndClearLoginFailures) so concurrent failures can't lose an increment.
 	// Combined with the row lock LockUserForUpdate takes on Postgres, the lockout
@@ -659,6 +664,7 @@ func NewKeyorixCore(storage storage.Storage) *KeyorixCore {
 		now:            time.Now,
 		passwordPolicy: DefaultPasswordPolicy(),
 		auditStream:    newAuditBroker(),
+		maxSecretSize:  DefaultMaxSecretSize,
 	}
 }
 

--- a/internal/core/storage/errors.go
+++ b/internal/core/storage/errors.go
@@ -98,6 +98,17 @@ var ErrDuplicateProjectName = errors.New("a project with this name already exist
 // the rotation outright on ordinary concurrent contention.
 var ErrDuplicateSecretVersion = errors.New("a secret version with this version number already exists")
 
+// ErrSecretValueTooLarge is returned (wrapped, with the actual size and limit) by
+// LocalStorage.CreateSecretVersion when a version's encrypted value exceeds
+// MaxSecretSizeHardCeiling (internal/storage/store/local_secrets.go). This is
+// defense-in-depth: internal/core.checkSecretSize already enforces the
+// operator-configured (possibly smaller) secrets.limits.max_secret_size on every
+// write path BEFORE this is ever reached, so this check should never actually
+// fire in normal operation — it exists so that a bug in, or a future write path
+// that bypasses, the core-layer check cannot silently persist a secret value
+// above the architectural maximum regardless of what an operator configured.
+var ErrSecretValueTooLarge = errors.New("secret value exceeds the maximum allowed size")
+
 // ErrUnsupportedByBackend is returned (wrapped) by a storage.Storage implementation
 // when an operation has no meaningful implementation under the ACTIVE backend —
 // distinct from a transient failure of that backend. The original motivating case

--- a/internal/storage/store/local_secrets.go
+++ b/internal/storage/store/local_secrets.go
@@ -883,8 +883,23 @@ func (ls *LocalStorage) SetSecretTags(ctx context.Context, secretID uint, tagNam
 
 // --- Versions ---
 
+// maxSecretVersionValueSize is the storage layer's own, unconditional backstop on
+// a secret version's stored (encrypted) value size — see
+// storage.ErrSecretValueTooLarge's doc comment for why this exists as defense in
+// depth behind internal/core.checkSecretSize's operator-configured, potentially
+// smaller limit, rather than duplicating that configured value here.
+// internal/storage/store deliberately does not import internal/config (this
+// package sits below it in the dependency layering), so this is independently
+// defined rather than shared — kept in sync with config.MaxSecretSizeHardCeiling
+// by TestMaxSecretVersionValueSize_MatchesConfigHardCeiling.
+const maxSecretVersionValueSize = 1 << 20 // 1 MiB, mirrors config.MaxSecretSizeHardCeiling
+
 // CreateSecretVersion creates a new version of a secret.
 func (ls *LocalStorage) CreateSecretVersion(ctx context.Context, version *models.SecretVersion) (*models.SecretVersion, error) {
+	if len(version.EncryptedValue) > maxSecretVersionValueSize {
+		return nil, fmt.Errorf("%w: %d bytes exceeds the %d-byte hard ceiling",
+			storage.ErrSecretValueTooLarge, len(version.EncryptedValue), maxSecretVersionValueSize)
+	}
 	if err := ls.db.WithContext(ctx).Create(version).Error; err != nil {
 		if isUniqueViolation(err) {
 			// The unique index on (secret_node_id, version_number) (#121) caught a

--- a/internal/storage/store/secret_size_cap_storage_test.go
+++ b/internal/storage/store/secret_size_cap_storage_test.go
@@ -1,0 +1,44 @@
+package store
+
+// secret_size_cap_storage_test.go proves the storage-layer defence-in-depth
+// backstop (maxSecretVersionValueSize, local_secrets.go) fires on its own --
+// i.e. even when called directly, bypassing every transport and core-layer
+// check above it.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+func TestLocalStorage_CreateSecretVersion_SecretSizeCap(t *testing.T) {
+	ls := newMaxStore(t, "secret_size_cap", &models.SecretNode{}, &models.SecretVersion{})
+	ctx := context.Background()
+
+	t.Run("exactly at the hard ceiling is accepted", func(t *testing.T) {
+		v := &models.SecretVersion{
+			SecretNodeID: 1, VersionNumber: 1,
+			EncryptedValue: make([]byte, maxSecretVersionValueSize),
+		}
+		created, err := ls.CreateSecretVersion(ctx, v)
+		require.NoError(t, err)
+		require.NotNil(t, created)
+	})
+
+	t.Run("one byte over the hard ceiling is rejected, bypassing every transport/core check", func(t *testing.T) {
+		v := &models.SecretVersion{
+			SecretNodeID: 1, VersionNumber: 2,
+			EncryptedValue: make([]byte, maxSecretVersionValueSize+1),
+		}
+		created, err := ls.CreateSecretVersion(ctx, v)
+		require.Error(t, err)
+		require.Nil(t, created)
+		require.True(t, errors.Is(err, storage.ErrSecretValueTooLarge),
+			"error must wrap storage.ErrSecretValueTooLarge, got: %v", err)
+	})
+}

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -32,6 +32,14 @@ func NewServer(cfg *config.Config, coreService *core.KeyorixCore) (*grpc.Server,
 
 	// Create server options
 	opts := []grpc.ServerOption{
+		// Consistent with the HTTP API's secret-write-route body limit
+		// (server/http/router.go's secretBodyLimit) — both are derived from the
+		// same secrets.limits.max_secret_size via config.DeriveMaxRequestBodySize,
+		// so a caller cannot bypass the HTTP transport's tighter limit by
+		// switching to gRPC. gRPC's default MaxRecvMsgSize (4 MiB) would
+		// otherwise silently let a request through this transport that the HTTP
+		// API already rejects at the wire level for the same secret.
+		grpc.MaxRecvMsgSize(int(config.DeriveMaxRequestBodySize(cfg.Secrets.Limits.MaxSecretSize))),
 		// grpc.ChainUnaryInterceptor/ChainStreamInterceptor run interceptors in the
 		// order listed: the first is OUTERMOST (executes first on the way in, last on
 		// the way out), wrapping every interceptor listed after it. RecoveryInterceptor

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -534,7 +534,7 @@ func mapSecretError(err error) error {
 	// could cause.
 	var tooLarge *core.SecretValueTooLargeError
 	if errors.As(err, &tooLarge) {
-		return status.Error(codes.ResourceExhausted, tooLarge.Error())
+		return status.Error(codes.ResourceExhausted, tooLarge.Error()) // nosemgrep: keyorix-raw-error-to-client -- SecretValueTooLargeError.Error() is a fixed-format string carrying only the submitted size and configured limit (both already known to the caller), never secret content
 	}
 	msg := err.Error()
 	switch {

--- a/server/grpc/services/secret_service.go
+++ b/server/grpc/services/secret_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -523,6 +524,18 @@ func authorizeSecretScoped(ctx context.Context, cs *core.KeyorixCore, actor *int
 
 // mapSecretError translates core errors into gRPC status codes.
 func mapSecretError(err error) error {
+	// Checked via errors.As, BEFORE the string-matching switch below: this
+	// error's own message contains the substring "exceeds" (deliberately, so
+	// it names the actual limit), which the switch's own
+	// "exceeds"-string-matching InvalidArgument branch would otherwise catch
+	// first and misreport as an unrelated invalid-rotation-configuration
+	// error instead of ResourceExhausted -- exactly the collision that
+	// branch's own comment already warns a future "exceeds"-containing error
+	// could cause.
+	var tooLarge *core.SecretValueTooLargeError
+	if errors.As(err, &tooLarge) {
+		return status.Error(codes.ResourceExhausted, tooLarge.Error())
+	}
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "not found"):

--- a/server/grpc/services/secret_size_cap_test.go
+++ b/server/grpc/services/secret_size_cap_test.go
@@ -1,0 +1,75 @@
+// secret_size_cap_test.go — gRPC-layer coverage for the maximum secret-value
+// size cap (Item 1c/1e): exactly-at-limit is accepted, one byte over is
+// rejected with codes.ResourceExhausted (core.SecretValueTooLargeError,
+// mapped by mapSecretError's errors.As check ahead of its string-matching
+// switch -- see the "exceeds" collision this guards against in
+// mapSecretError's own comment).
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/keyorixhq/keyorix/server/proto/pb"
+)
+
+func TestSecretService_CreateSecret_SecretSizeCap_ExactlyAtLimit(t *testing.T) {
+	r := newSecretTestRig(t)
+	r.svc.core.SetMaxSecretSize(100)
+	ctx := authCtx(1, "writer", "secrets.write", "secrets.read")
+
+	sec, err := r.svc.CreateSecret(ctx, &pb.CreateSecretRequest{
+		Name: "at-limit-grpc", Value: strings.Repeat("a", 100),
+		ProjectId: 1, EnvironmentId: 1, Type: "password",
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, sec.GetId())
+}
+
+func TestSecretService_CreateSecret_SecretSizeCap_OneByteOverRejected(t *testing.T) {
+	r := newSecretTestRig(t)
+	r.svc.core.SetMaxSecretSize(100)
+	ctx := authCtx(1, "writer", "secrets.write", "secrets.read")
+
+	_, err := r.svc.CreateSecret(ctx, &pb.CreateSecretRequest{
+		Name: "over-limit-grpc", Value: strings.Repeat("a", 101),
+		ProjectId: 1, EnvironmentId: 1, Type: "password",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "100")
+}
+
+func TestSecretService_UpdateSecret_SecretSizeCap_ExactlyAtLimit(t *testing.T) {
+	r := newSecretTestRig(t)
+	ctx := authCtx(1, "writer", "secrets.write", "secrets.read")
+	created := r.createSecret(t, ctx, "update-at-limit-grpc", "seed")
+	r.svc.core.SetMaxSecretSize(100)
+
+	value := strings.Repeat("b", 100)
+	updated, err := r.svc.UpdateSecret(ctx, &pb.UpdateSecretRequest{
+		Id: created.GetId(), Value: &value,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, created.GetId(), updated.GetId())
+}
+
+func TestSecretService_UpdateSecret_SecretSizeCap_OneByteOverRejected(t *testing.T) {
+	r := newSecretTestRig(t)
+	ctx := authCtx(1, "writer", "secrets.write", "secrets.read")
+	created := r.createSecret(t, ctx, "update-over-limit-grpc", "seed")
+	r.svc.core.SetMaxSecretSize(100)
+
+	value := strings.Repeat("b", 101)
+	_, err := r.svc.UpdateSecret(ctx, &pb.UpdateSecretRequest{
+		Id: created.GetId(), Value: &value,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "100")
+}

--- a/server/http/handlers/secret_size_cap_test.go
+++ b/server/http/handlers/secret_size_cap_test.go
@@ -1,0 +1,192 @@
+// secret_size_cap_test.go — HTTP-layer coverage for the maximum secret-value
+// size cap (Item 1): exactly-at-limit is accepted, one byte over the DECODED
+// value limit is rejected with 413 (core.SecretValueTooLargeError, via
+// trySendSecretSizeError), and a request body large enough to trip the
+// wire-level http.MaxBytesReader limit (server/http/router.go's
+// secretBodyLimit, derived by config.DeriveMaxRequestBodySize) is also
+// rejected with 413 (*http.MaxBytesError). Reuses freshSecretFixtureS15 /
+// withAdminCtxS15 from secrets_crud_s15_test.go.
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/server/middleware"
+)
+
+func withChiIDParam(r *http.Request, id string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+func TestCreateSecret_SecretSizeCap_ExactlyAtLimit_Accepted(t *testing.T) {
+	h, cs, _, _ := freshSecretFixtureS15(t)
+	cs.SetMaxSecretSize(100)
+
+	body, err := json.Marshal(map[string]interface{}{
+		"name": "at-limit-create", "value": strings.Repeat("a", 100),
+		"project_id": uint(1), "environment_id": uint(10), "type": "static",
+	})
+	require.NoError(t, err)
+
+	r := withAdminCtxS15(httptest.NewRequest(http.MethodPost, "/api/v1/secrets", bytes.NewReader(body)))
+	w := httptest.NewRecorder()
+	h.CreateSecret(w, r)
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+}
+
+func TestCreateSecret_SecretSizeCap_OneByteOver_Rejected413(t *testing.T) {
+	h, cs, _, _ := freshSecretFixtureS15(t)
+	cs.SetMaxSecretSize(100)
+
+	body, err := json.Marshal(map[string]interface{}{
+		"name": "over-limit-create", "value": strings.Repeat("a", 101),
+		"project_id": uint(1), "environment_id": uint(10), "type": "static",
+	})
+	require.NoError(t, err)
+
+	r := withAdminCtxS15(httptest.NewRequest(http.MethodPost, "/api/v1/secrets", bytes.NewReader(body)))
+	w := httptest.NewRecorder()
+	h.CreateSecret(w, r)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "PayloadTooLarge")
+	assert.Contains(t, w.Body.String(), "100")
+}
+
+func TestCreateSecret_SecretSizeCap_BodyTooLarge_MaxBytesReaderTrips413(t *testing.T) {
+	h, cs, _, _ := freshSecretFixtureS15(t)
+	cs.SetMaxSecretSize(100)
+
+	// A body far larger than config.DeriveMaxRequestBodySize(100) -- the
+	// wire-level limit must trip during json.Decode, before a Go value with a
+	// decoded length ever exists (distinct code path from the test above).
+	body, err := json.Marshal(map[string]interface{}{
+		"name": "wire-limit-create", "value": strings.Repeat("a", 30_000),
+		"project_id": uint(1), "environment_id": uint(10), "type": "static",
+	})
+	require.NoError(t, err)
+
+	limit := config.DeriveMaxRequestBodySize(100)
+	require.Less(t, limit, int64(len(body)), "test setup: body must exceed the derived wire-level limit")
+
+	wrapped := middleware.MaxBodyBytes(limit)(http.HandlerFunc(h.CreateSecret))
+	r := withAdminCtxS15(httptest.NewRequest(http.MethodPost, "/api/v1/secrets", bytes.NewReader(body)))
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "PayloadTooLarge")
+}
+
+// TestCreateSecret_SecretSizeCap_GenuineMaxSizeSecret_ThroughRealMiddleware_Accepted
+// is the actual proof for 1b: every other "accepted" test in this file calls
+// h.CreateSecret directly, bypassing the http.MaxBytesReader wire-level limit
+// entirely -- a wrong DeriveMaxRequestBodySize (e.g. accidentally wired to the
+// raw 65536 rather than the base64+envelope-inflated derivation) would still
+// pass those tests, because they never exercise the wire-level limit at all.
+// This test sends a genuine config.DefaultMaxSecretSize-byte (64 KiB) secret
+// value, base64-inflated by JSON string encoding exactly as a real client
+// would send it, through the SAME middleware.MaxBodyBytes(...) wrapping
+// server/http/router.go actually applies (same derivation call, same
+// production default constant, not a scaled-down test limit) and asserts
+// 201 -- if the derivation under-counts the envelope/encoding overhead, the
+// real handler's decode fails and this goes red where the others would not.
+func TestCreateSecret_SecretSizeCap_GenuineMaxSizeSecret_ThroughRealMiddleware_Accepted(t *testing.T) {
+	h, cs, _, _ := freshSecretFixtureS15(t)
+	// Deliberately NOT calling cs.SetMaxSecretSize: KeyorixCore already
+	// defaults to core.DefaultMaxSecretSize on construction, so this exercises
+	// the real production default end to end rather than a test-only override.
+
+	value := strings.Repeat("a", config.DefaultMaxSecretSize)
+	body, err := json.Marshal(map[string]interface{}{
+		"name": "genuine-max-size-secret", "value": value,
+		"project_id": uint(1), "environment_id": uint(10), "type": "static",
+	})
+	require.NoError(t, err)
+
+	limit := config.DeriveMaxRequestBodySize(config.DefaultMaxSecretSize)
+	require.Greater(t, limit, int64(len(body)),
+		"test setup: the derived limit must actually cover a genuine max-size secret's encoded body -- "+
+			"if this fails, DeriveMaxRequestBodySize itself under-counts the encoding/envelope overhead")
+
+	wrapped := middleware.MaxBodyBytes(limit)(http.HandlerFunc(h.CreateSecret))
+	r := withAdminCtxS15(httptest.NewRequest(http.MethodPost, "/api/v1/secrets", bytes.NewReader(body)))
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, r)
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	var resp struct {
+		Data struct {
+			ID uint `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	stored, err := cs.GetSecretValue(context.Background(), resp.Data.ID)
+	require.NoError(t, err)
+	assert.Len(t, stored, config.DefaultMaxSecretSize, "the stored value's decoded length must equal the original, not be truncated by the wire-level limit")
+}
+
+func TestUpdateSecret_SecretSizeCap_ExactlyAtLimit_Accepted(t *testing.T) {
+	h, cs, _, _ := freshSecretFixtureS15(t)
+	cs.SetMaxSecretSize(100)
+
+	body, err := json.Marshal(map[string]interface{}{"value": strings.Repeat("b", 100)})
+	require.NoError(t, err)
+
+	r := withChiIDParam(withAdminCtxS15(httptest.NewRequest(http.MethodPut, "/api/v1/secrets/1", bytes.NewReader(body))), "1")
+	w := httptest.NewRecorder()
+	h.UpdateSecret(w, r)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+func TestUpdateSecret_SecretSizeCap_OneByteOver_Rejected413(t *testing.T) {
+	h, cs, _, _ := freshSecretFixtureS15(t)
+	cs.SetMaxSecretSize(100)
+
+	body, err := json.Marshal(map[string]interface{}{"value": strings.Repeat("b", 101)})
+	require.NoError(t, err)
+
+	r := withChiIDParam(withAdminCtxS15(httptest.NewRequest(http.MethodPut, "/api/v1/secrets/1", bytes.NewReader(body))), "1")
+	w := httptest.NewRecorder()
+	h.UpdateSecret(w, r)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "PayloadTooLarge")
+}
+
+func TestRotateSecret_SecretSizeCap_ExactlyAtLimit_Accepted(t *testing.T) {
+	h, cs, _, _ := freshSecretFixtureS15(t)
+	cs.SetMaxSecretSize(100)
+
+	body, err := json.Marshal(map[string]interface{}{"new_value": strings.Repeat("c", 100)})
+	require.NoError(t, err)
+
+	r := withChiIDParam(withAdminCtxS15(httptest.NewRequest(http.MethodPost, "/api/v1/secrets/1/rotate", bytes.NewReader(body))), "1")
+	w := httptest.NewRecorder()
+	h.RotateSecret(w, r)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+func TestRotateSecret_SecretSizeCap_OneByteOver_Rejected413(t *testing.T) {
+	h, cs, _, _ := freshSecretFixtureS15(t)
+	cs.SetMaxSecretSize(100)
+
+	body, err := json.Marshal(map[string]interface{}{"new_value": strings.Repeat("c", 101)})
+	require.NoError(t, err)
+
+	r := withChiIDParam(withAdminCtxS15(httptest.NewRequest(http.MethodPost, "/api/v1/secrets/1/rotate", bytes.NewReader(body))), "1")
+	w := httptest.NewRecorder()
+	h.RotateSecret(w, r)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "PayloadTooLarge")
+}

--- a/server/http/handlers/secret_size_error.go
+++ b/server/http/handlers/secret_size_error.go
@@ -1,0 +1,41 @@
+// secret_size_error.go — shared 413 mapping for the maximum-secret-value-size
+// cap (internal/core.checkSecretSize, config.DeriveMaxRequestBodySize), used by
+// CreateSecret, UpdateSecret, and RotateSecret. A "too large" condition can
+// surface at two different points, both mapped here so every caller handles
+// both the same way instead of one being missed:
+//
+//   - the wire-level body limit (server/http/router.go's secretBodyLimit,
+//     applied via http.MaxBytesReader) trips DURING json.Decode, before a
+//     Go value ever exists to inspect -- surfaced as *http.MaxBytesError;
+//   - the DECODED value's exact byte length exceeds
+//     secrets.limits.max_secret_size -- surfaced as
+//     *core.SecretValueTooLargeError from the core-layer check.
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+// trySendSecretSizeError reports whether err is either shape of "secret value
+// too large" and, if so, has already written a 413 response naming the actual
+// limit. false means err was something else and the caller should continue
+// with its own error mapping.
+func (h *SecretHandler) trySendSecretSizeError(w http.ResponseWriter, err error) bool {
+	var mbe *http.MaxBytesError
+	if errors.As(err, &mbe) {
+		h.sendError(w, "PayloadTooLarge",
+			fmt.Sprintf("request body exceeds the %d-byte limit derived from the configured maximum secret size", mbe.Limit),
+			http.StatusRequestEntityTooLarge, nil)
+		return true
+	}
+	var tooLarge *core.SecretValueTooLargeError
+	if errors.As(err, &tooLarge) {
+		h.sendError(w, "PayloadTooLarge", tooLarge.Error(), http.StatusRequestEntityTooLarge, nil)
+		return true
+	}
+	return false
+}

--- a/server/http/handlers/secrets_crud.go
+++ b/server/http/handlers/secrets_crud.go
@@ -44,6 +44,9 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		if h.trySendSecretSizeError(w, err) {
+			return
+		}
 		h.sendError(w, "InvalidJSON", errInvalidJSON, http.StatusBadRequest, nil)
 		return
 	}
@@ -96,6 +99,9 @@ func (h *SecretHandler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 	response, err := h.coreService.CreateSecret(r.Context(), req)
 	if err != nil {
 		log.Printf("Error creating secret: %v", err)
+		if h.trySendSecretSizeError(w, err) {
+			return
+		}
 		if strings.Contains(err.Error(), "already exists") {
 			h.sendError(w, "ConflictError", "Secret with this name already exists", http.StatusConflict, nil)
 		} else if strings.Contains(err.Error(), "does not belong to project") || strings.Contains(err.Error(), "environment") && strings.Contains(err.Error(), errNotFound) {
@@ -467,6 +473,9 @@ func (h *SecretHandler) UpdateSecret(w http.ResponseWriter, r *http.Request) {
 		Secret *models.SecretNode `json:"secret,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		if h.trySendSecretSizeError(w, err) {
+			return
+		}
 		h.sendError(w, "InvalidJSON", errInvalidJSON, http.StatusBadRequest, nil)
 		return
 	}
@@ -573,6 +582,9 @@ func (h *SecretHandler) DeleteSecret(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *SecretHandler) sendUpdateSecretError(w http.ResponseWriter, err error) {
+	if h.trySendSecretSizeError(w, err) {
+		return
+	}
 	if strings.Contains(err.Error(), "not found") {
 		h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)
 	} else if strings.Contains(err.Error(), "permission denied") {

--- a/server/http/handlers/secrets_versions.go
+++ b/server/http/handlers/secrets_versions.go
@@ -83,6 +83,9 @@ func (h *SecretHandler) RotateSecret(w http.ResponseWriter, r *http.Request) {
 		NewValue string `json:"new_value" validate:"required"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		if h.trySendSecretSizeError(w, err) {
+			return
+		}
 		h.sendError(w, "InvalidJSON", "Invalid JSON in request body", http.StatusBadRequest, nil)
 		return
 	}
@@ -97,6 +100,9 @@ func (h *SecretHandler) RotateSecret(w http.ResponseWriter, r *http.Request) {
 	// potentially compromised credential is still live untouched upstream.
 	secret, err := h.coreService.RotateSecretOnDemand(r.Context(), uint(id), []byte(reqBody.NewValue), userCtx.UserID, userCtx.Username)
 	if err != nil {
+		if h.trySendSecretSizeError(w, err) {
+			return
+		}
 		switch {
 		case strings.Contains(err.Error(), errNotFound):
 			h.sendError(w, "NotFound", "Secret not found", http.StatusNotFound, nil)

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -100,6 +100,15 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 	r.Use(customMiddleware.MaxBodyBytes(cfg.Server.HTTP.EffectiveMaxRequestBodyBytes()))
 	r.Use(middleware.Timeout(60 * time.Second))
 
+	// A tighter body-size limit for the three routes that carry a secret VALUE
+	// (create/update/rotate), scoped in addition to (not instead of) the global
+	// EffectiveMaxRequestBodyBytes limit above. Derived from
+	// secrets.limits.max_secret_size rather than left at the generous global
+	// default (10 MiB) — see DeriveMaxRequestBodySize's doc comment for why this
+	// is NOT simply max_secret_size itself (a secret value travels base64-encoded
+	// inside a JSON envelope, which inflates it well past the raw byte count).
+	secretBodyLimit := customMiddleware.MaxBodyBytes(config.DeriveMaxRequestBodySize(cfg.Secrets.Limits.MaxSecretSize))
+
 	// CORS configuration. AllowCredentials is set because MFA, WebAuthn, and SSO
 	// login paths now issue session cookies (r121); cross-origin requests from the
 	// dashboard must be allowed to send them. Credentials are only sent to origins
@@ -694,15 +703,15 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Get("/{id}/certificate", secretHandler.GetSecretCertificate)
 
 			// Create: authorized inside the handler (scope comes from the body).
-			r.Post("/", secretHandler.CreateSecret)
-			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Put("/{id}", secretHandler.UpdateSecret)
+			r.With(secretBodyLimit).Post("/", secretHandler.CreateSecret)
+			r.With(secretBodyLimit, customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Put("/{id}", secretHandler.UpdateSecret)
 			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Patch("/{id}/classification", secretHandler.ClassifySecret)
 			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Patch("/{id}/description", secretHandler.DescribeSecret)
 			// Copy into another environment: read the source ({id}); the handler also
 			// authorizes secrets.write at the target environment's scope.
 			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Post("/{id}/copy", secretHandler.CopySecret)
 			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Patch("/{id}/auto-rotate", secretHandler.SetAutoRotate)
-			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Post("/{id}/rotate", secretHandler.RotateSecret)
+			r.With(secretBodyLimit, customMiddleware.RequireScopedSecretPermission(permSecretsWrite, "id")).Post("/{id}/rotate", secretHandler.RotateSecret)
 			// Rotation dry-run / simulation (ADR-047): validates the rotation config without
 			// making any live change. Read-only — requires only secrets.read.
 			r.With(customMiddleware.RequireScopedSecretPermission(permSecretsRead, "id")).Post("/{id}/rotation/simulate", secretHandler.SimulateRotation)

--- a/server/main.go
+++ b/server/main.go
@@ -494,6 +494,12 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			svp.MinLength, svp.RejectCommon, len(svp.ExtraDenylist))
 	}
 
+	// Apply the maximum secret VALUE size (bytes) — unlike the quality gate above,
+	// this is always applied (not gated behind an Enabled flag): cfg.Secrets.Limits.
+	// MaxSecretSize is already defaulted and ceiling-checked by cfg.Validate(), so
+	// there is always a real, valid value to set here.
+	coreService.SetMaxSecretSize(cfg.Secrets.Limits.MaxSecretSize)
+
 	// Apply the optional secret naming convention (regex / max-length on names).
 	if snp := cfg.SecretNamePolicy; snp.Enabled {
 		if err := coreService.SetSecretNamePolicy(core.SecretNamePolicy{


### PR DESCRIPTION
## Summary
- Adds `secrets.limits.max_secret_size` (default 65536 bytes / 64 KiB), validated against a 1 MiB hard ceiling at startup. 64 KiB matches AWS/GCP Secrets Manager's converged cap; Azure Key Vault is 25 KB; Vault warns large entries degrade other storage operations.
- Enforced at every layer: HTTP (`http.MaxBytesReader`, sized via `config.DeriveMaxRequestBodySize` to account for base64 expansion + JSON envelope, not the raw secret size), gRPC (`grpc.MaxRecvMsgSize`, same derivation), core (`checkSecretSize` on Create/Update/Rotate), and storage (`LocalStorage.CreateSecretVersion`'s own unconditional 1 MiB backstop, independent of any transport).
- Both transports reject with the correct status naming the actual limit: HTTP 413 (`PayloadTooLarge`), gRPC `ResourceExhausted` — `mapSecretError` checks `errors.As` for the typed error before its pre-existing string-matching switch, since the new error's own "exceeds" substring would otherwise be misrouted by an unrelated existing branch.
- Existing data is never broken: the cap only rejects new writes. A secret already stored above the cap (or above a since-lowered configured value) still reads and deletes normally.

## Test plan
- [x] Core layer: exactly-at-limit accepted / one-byte-over rejected for CreateSecret, UpdateSecret, RotateSecret, against real sqlite-backed storage.
- [x] Core layer: a secret version written directly through storage (bypassing every check) still reads via `GetSecretValue` and deletes via `DeleteSecret`.
- [x] HTTP layer: exactly-at-limit accepted / one-byte-over rejected (413) for Create/Update/Rotate; a body large enough to trip the wire-level `MaxBytesReader` limit also rejected (413, distinct code path from the decoded-value check).
- [x] HTTP layer: a genuine 64 KiB secret posted through the actual `middleware.MaxBodyBytes(config.DeriveMaxRequestBodySize(...))` wrapping (same call `router.go` makes, same production default) succeeds end-to-end — this is the one that would catch a wrong derivation constant; verified by temporarily reverting the derivation to a naive `int64(maxSecretSize)` and confirming the test goes red.
- [x] gRPC layer: exactly-at-limit accepted / one-byte-over rejected with `codes.ResourceExhausted` for Create/Update; verified the `errors.As` guard is load-bearing by disabling it and confirming the tests fall through to the wrong error code.
- [x] Storage layer: `CreateSecretVersion` rejects an oversized value directly, bypassing every transport/core check, proving the defence-in-depth backstop fires independently.
- [x] `go build ./...`, `go vet ./...`, `gofmt`, `gosec -severity medium` all clean on every touched package.

Not in this round (per scope): request admission control / in-flight concurrency limiting.