### PR TITLE
test(http): structural guard against unfetched-struct full-row overwrites

### DIFF
--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -529,16 +529,40 @@ func (c *KeyorixCore) rejectIfCloned(ctx context.Context, userID uint, cred *web
 	// Scoped to userID (#307) — the lookup itself enforces ownership, so no separate
 	// row.UserID check is needed here.
 	if row, err := c.storage.GetWebAuthnCredentialByCredID(ctx, cred.ID, userID); err == nil {
-		row.Disabled = true
-		_ = c.storage.UpdateWebAuthnCredential(ctx, row)
+		// Mutation + audit as one unit (#1714) — see markWebAuthnCredentialClonedDisabled.
+		_ = c.markWebAuthnCredentialClonedDisabled(ctx, row, ip)
+	} else {
+		// Row lookup failed (rare — e.g. a race with the credential being deleted
+		// between assertion verification and this call). Nothing to disable, but
+		// the clone signal for THIS login attempt is still real and must still be
+		// recorded — this is the one case where the audit write is not paired with
+		// a mutation, since there is no row to mutate.
+		uid := userID
+		c.writeAuditEventFull(ctx, EventWebAuthnCloneDetected, &uid, nil, nil, ip,
+			fmt.Sprintf("authentication refused for user %d: signature-counter regression (possible cloned authenticator) — credential lookup failed, nothing disabled", userID))
 	}
-	uid := userID
-	c.writeAuditEventFull(ctx, EventWebAuthnCloneDetected, &uid, nil, nil, ip,
-		fmt.Sprintf("authentication refused for user %d: signature-counter regression (possible cloned authenticator) — credential disabled pending re-registration", userID))
 	c.notify(ctx, userID, NotificationWebAuthnCloneDetected, "Passkey clone suspected",
 		"A sign-in attempt was blocked because one of your passkeys reported a signature-counter regression — a sign that its private key may exist on more than one device. The passkey has been disabled; please remove it and register a new one.",
 		nil, "/account/security")
 	return fmt.Errorf("assertion verification failed: signature counter did not advance (possible cloned authenticator)")
+}
+
+// markWebAuthnCredentialClonedDisabled performs a WebAuthn credential's
+// disable-on-clone-signal mutation (Disabled: false -> true) and its
+// EventWebAuthnCloneDetected audit write as a single unit (#1714), so no
+// exported path can do one without the other. row must already be the
+// caller's own fetched, owned row (rejectIfCloned's GetWebAuthnCredentialByCredID
+// call scopes ownership by construction; MarkWebAuthnCredentialClonedByLookup
+// below does the same for a caller that only has (credentialID, userID)).
+func (c *KeyorixCore) markWebAuthnCredentialClonedDisabled(ctx context.Context, row *models.WebAuthnCredential, ip string) error {
+	row.Disabled = true
+	if err := c.storage.UpdateWebAuthnCredential(ctx, row); err != nil {
+		return err
+	}
+	uid := row.UserID
+	c.writeAuditEventFull(ctx, EventWebAuthnCloneDetected, &uid, nil, nil, ip,
+		fmt.Sprintf("authentication refused for user %d: signature-counter regression (possible cloned authenticator) — credential disabled pending re-registration", row.UserID))
+	return nil
 }
 
 // ErrWebAuthnCredentialIDMismatch is returned by MarkWebAuthnCredentialClonedByLookup
@@ -567,12 +591,7 @@ var ErrWebAuthnCredentialIDMismatch = errors.New("webauthn credential id does no
 // exchange for passing expectedID at all. Returns
 // ErrWebAuthnCredentialIDMismatch, unmutated, if the row's real ID doesn't
 // match.
-//
-// This is the authz half of #1714 (narrowing the write): it does NOT yet
-// audit its own mutation -- that unification with rejectIfCloned lands as
-// its own, independently-revertable commit (markWebAuthnCredentialClonedDisabled).
 func (c *KeyorixCore) MarkWebAuthnCredentialClonedByLookup(ctx context.Context, credentialID []byte, userID, expectedID uint, ip string) (*models.WebAuthnCredential, error) {
-	_ = ip // reserved for the audit write added by the follow-up commit
 	row, err := c.storage.GetWebAuthnCredentialByCredID(ctx, credentialID, userID)
 	if err != nil {
 		return nil, err
@@ -580,8 +599,7 @@ func (c *KeyorixCore) MarkWebAuthnCredentialClonedByLookup(ctx context.Context, 
 	if row.ID != expectedID {
 		return nil, ErrWebAuthnCredentialIDMismatch
 	}
-	row.Disabled = true
-	if err := c.storage.UpdateWebAuthnCredential(ctx, row); err != nil {
+	if err := c.markWebAuthnCredentialClonedDisabled(ctx, row, ip); err != nil {
 		return nil, err
 	}
 	return row, nil

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -541,6 +541,52 @@ func (c *KeyorixCore) rejectIfCloned(ctx context.Context, userID uint, cred *web
 	return fmt.Errorf("assertion verification failed: signature counter did not advance (possible cloned authenticator)")
 }
 
+// ErrWebAuthnCredentialIDMismatch is returned by MarkWebAuthnCredentialClonedByLookup
+// when (credentialID, userID) resolves to a real, owned row, but that row's ID
+// does not match the caller's expectedID. This is deliberately distinct from
+// "not found": the pair is real and does belong to userID, it just isn't the
+// SAME credential the caller is claiming to act on — a mismatch a caller must
+// never have silently coerced into acting on whichever row the lookup actually
+// named instead.
+var ErrWebAuthnCredentialIDMismatch = errors.New("webauthn credential id does not match (credential_id, user_id)")
+
+// MarkWebAuthnCredentialClonedByLookup explicitly disables a WebAuthn
+// credential on a clone-detection signal, identified by (credentialID,
+// userID) rather than an already-resolved row — the ONE thing
+// UpdateWebAuthnCredentialProxy (#1714) is allowed to do. The
+// GetWebAuthnCredentialByCredID lookup scopes ownership: a caller cannot
+// reach a credential it doesn't legitimately identify by both its own
+// credentialID and userID together, so there is no separate ownership check
+// needed here, matching rejectIfCloned's own "#307" reasoning.
+//
+// expectedID is checked BEFORE any mutation happens — never after. An
+// earlier draft of this fix fetched, mutated, and only THEN compared IDs,
+// which would disable the WRONG credential (the one (credentialID, userID)
+// actually named) before rejecting the request; that ordering is exactly the
+// "stored row is unchanged" property callers of this function get in
+// exchange for passing expectedID at all. Returns
+// ErrWebAuthnCredentialIDMismatch, unmutated, if the row's real ID doesn't
+// match.
+//
+// This is the authz half of #1714 (narrowing the write): it does NOT yet
+// audit its own mutation -- that unification with rejectIfCloned lands as
+// its own, independently-revertable commit (markWebAuthnCredentialClonedDisabled).
+func (c *KeyorixCore) MarkWebAuthnCredentialClonedByLookup(ctx context.Context, credentialID []byte, userID, expectedID uint, ip string) (*models.WebAuthnCredential, error) {
+	_ = ip // reserved for the audit write added by the follow-up commit
+	row, err := c.storage.GetWebAuthnCredentialByCredID(ctx, credentialID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if row.ID != expectedID {
+		return nil, ErrWebAuthnCredentialIDMismatch
+	}
+	row.Disabled = true
+	if err := c.storage.UpdateWebAuthnCredential(ctx, row); err != nil {
+		return nil, err
+	}
+	return row, nil
+}
+
 // persistUpdatedCredential writes back the credential's advanced signature counter
 // (and clone-warning flag) plus a last-used timestamp. Best-effort: a write error
 // must not fail an otherwise-valid login.

--- a/internal/core/webauthn_clone_disable_audit_test.go
+++ b/internal/core/webauthn_clone_disable_audit_test.go
@@ -1,0 +1,93 @@
+// webauthn_clone_disable_audit_test.go — #1714 invariant guard.
+//
+// UpdateWebAuthnCredentialProxy used to call storage.UpdateWebAuthnCredential
+// directly: any system.write holder could reassign a credential's ownership
+// or silently re-enable a clone-disabled one, with no audit trail either way.
+// The authz half of the fix is covered by
+// server/http/handlers/webauthn_proxy_1622_authz_test.go (rejection at the
+// HTTP layer, before any mutation). This file covers the audit half: the
+// fix is structural, not per-route -- markWebAuthnCredentialClonedDisabled is
+// the ONE place that performs the disable mutation and the
+// EventWebAuthnCloneDetected audit write as a single unit, and both exported
+// entry points -- rejectIfCloned's own login-time disable (unchanged
+// behavior, now delegating) and MarkWebAuthnCredentialClonedByLookup (which
+// UpdateWebAuthnCredentialProxy now calls) -- route through it.
+//
+// This test asserts the INVARIANT, not either route: disabling a credential
+// on a clone signal by ANY exported path produces exactly one
+// EventWebAuthnCloneDetected audit event, correctly attributed to the
+// calling actor via ctx (the auth middleware's WithActorType/WithMachineActor
+// tagging, read automatically by writeAuditEventFull -> emitAudit). A future
+// change that reintroduces a direct storage.UpdateWebAuthnCredential call in
+// either path -- bypassing markWebAuthnCredentialClonedDisabled -- fails this
+// test: temporarily rewriting markWebAuthnCredentialClonedDisabled to call
+// c.storage.UpdateWebAuthnCredential directly (skipping the audit write) was
+// confirmed to fail both subtests before this fix, with the audit event count
+// asserted at 0 instead of 1.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const invariantTestMachineID = uint(88)
+
+func TestDisableClonedWebAuthnCredential_Invariant_ExactlyOneAuditEventWithCorrectActor(t *testing.T) {
+	t.Run("login-time disable (rejectIfCloned)", func(t *testing.T) {
+		c, db := newWebAuthnTestCore(t, true)
+		credID := []byte("cred-invariant-login")
+		seedCredential(t, c, db, 1, string(credID))
+
+		actorCtx := WithMachineActor(WithActorType(context.Background(), ActorTypeMachine), invariantTestMachineID)
+		cred := &webauthn.Credential{ID: credID, Authenticator: webauthn.Authenticator{CloneWarning: true}}
+		err := c.rejectIfCloned(actorCtx, 1, cred, "203.0.113.9")
+		require.Error(t, err, "a regressed signature counter must still refuse the authentication")
+
+		var reloaded models.WebAuthnCredential
+		require.NoError(t, db.Where("credential_id = ?", credID).First(&reloaded).Error)
+		assert.True(t, reloaded.Disabled, "the credential must be disabled")
+
+		var events []models.AuditEvent
+		require.NoError(t, db.Where("event_type = ?", EventWebAuthnCloneDetected).Find(&events).Error)
+		require.Len(t, events, 1, "exactly one clone-detected audit event must be written")
+		assertCorrectMachineActor(t, events[0])
+	})
+
+	t.Run("explicit disable by lookup (MarkWebAuthnCredentialClonedByLookup)", func(t *testing.T) {
+		c, db := newWebAuthnTestCore(t, true)
+		credID := []byte("cred-invariant-lookup")
+		seedCredential(t, c, db, 1, string(credID))
+
+		var row models.WebAuthnCredential
+		require.NoError(t, db.Where("credential_id = ?", credID).First(&row).Error)
+
+		actorCtx := WithMachineActor(WithActorType(context.Background(), ActorTypeMachine), invariantTestMachineID)
+		_, err := c.MarkWebAuthnCredentialClonedByLookup(actorCtx, credID, 1, row.ID, "203.0.113.9")
+		require.NoError(t, err)
+
+		var reloaded models.WebAuthnCredential
+		require.NoError(t, db.Where("credential_id = ?", credID).First(&reloaded).Error)
+		assert.True(t, reloaded.Disabled, "the credential must be disabled")
+
+		var events []models.AuditEvent
+		require.NoError(t, db.Where("event_type = ?", EventWebAuthnCloneDetected).Find(&events).Error)
+		require.Len(t, events, 1, "exactly one clone-detected audit event must be written")
+		assertCorrectMachineActor(t, events[0])
+	})
+}
+
+func assertCorrectMachineActor(t *testing.T, ev models.AuditEvent) {
+	t.Helper()
+	assert.Equal(t, ActorTypeMachine, ev.ActorType,
+		"the audit event must be attributed to the calling actor's type from ctx")
+	require.NotNil(t, ev.MachineIdentityID,
+		"the calling actor's machine identity must be attached, not just ActorType")
+	assert.Equal(t, invariantTestMachineID, *ev.MachineIdentityID)
+	assert.Nil(t, ev.UserID, "a machine actor must not occupy UserID (ADR-092)")
+}

--- a/server/http/full_row_overwrite_guard_test.go
+++ b/server/http/full_row_overwrite_guard_test.go
@@ -1,0 +1,387 @@
+// full_row_overwrite_guard_test.go — structural guard closing the class of
+// bug UpdateUserIfActiveStateMatchesProxy and UpdateWebAuthnCredentialProxy
+// both turned out to have: a caller-facing handler builds a *models.X struct
+// LITERAL directly from a request body (a fresh, never-fetched struct with
+// every field the request doesn't carry left at Go's zero value) and passes
+// it straight into a storage-layer method that does an unconditional
+// full-row overwrite (Select("*").Updates(...) or a plain Save(...)). Every
+// field the request doesn't carry gets silently zeroed on persist -- this
+// was PasswordHash and AccountState in the confirmed instance, and account
+// takeover, not just data loss, once AccountState was one of them.
+//
+// Population derivation (a full repo sweep, not just this package's own
+// prior narrower one): every internal/storage/store method whose GORM call
+// combines Select("*") with .Updates(...), plus every method whose GORM call
+// is a plain, unconditional .Save(...) on a caller-supplied struct -- 9 of
+// the former, ~15 of the latter (three of those, UpdateProjectMembership/
+// UpdateMachineIdentity/UpdateRiskException, are dead code with zero live
+// callers and excluded here; they're covered by unsafeSiblingPairs above
+// instead). Every current caller of every one of these methods, repo-wide,
+// was individually read and confirmed fetch-first (SAFE) except exactly one:
+// UpdateAnomalyConfig, an already-accepted, documented, non-security-critical
+// design tradeoff (see anomaly_config.go's own comment) -- NOT caught by this
+// guard's own detection; see "What this guard does not catch" below for why.
+//
+// Scope: server/http/handlers/*.go and server/grpc/services/*.go -- the
+// caller-facing boundary layer where untrusted wire input first becomes a
+// Go struct, which is where both real instances of this bug were found.
+//
+// Detection: a call of the form X.Storage().Method(ctx, &models.Y{...}) (or
+// the "storage := ...Storage()" aliased form handlerBodyStorageCalls above
+// already recognizes) where the argument is a composite-literal address
+// expression, not an identifier -- UpdateWebAuthnCredentialProxy's and
+// UpdateUserIfActiveStateMatchesProxy's original, real shape: a fresh
+// &models.X{...} literal built directly from a decoded request body, passed
+// straight into a full-row-overwrite call. A fetched-then-patched row is
+// NEVER built as a literal at the call site -- it's always a variable
+// (existing/row/etc.) by the time it reaches the call. Verified zero false
+// positives against the current, fully-fixed tree.
+//
+// What this guard does NOT catch, and why not: an earlier draft also tried
+// to flag a bare-identifier argument whenever the enclosing function
+// contained no Get-/Find-/List-prefixed storage call anywhere in its own
+// body (aimed at UpdateAnomalyConfig's shape: cfg arrives as a parameter,
+// decoded from the wire two calls up, never fetched anywhere in the chain).
+// That heuristic produced 7 false positives on the first real run --
+// ClassifyMachineIdentity, ExtendExpiringSecrets, UpdateRole,
+// expireInvitationIfOverdue, finalizeAccessRequestApproval,
+// markWebAuthnCredentialClonedDisabled, revertFailedActivation -- every one
+// a legitimate small helper that receives an ALREADY-fetched row as a
+// parameter from a caller elsewhere in the same file that fetched it first.
+// Distinguishing "helper receiving a caller's already-fetched row" from
+// "wrapper blindly relaying an unfetched wire value" requires real call-graph
+// tracing (does ANY caller, at any depth, fetch before calling this
+// function?), not a single-function-body syntactic check -- exactly the kind
+// of unreliable heuristic CLAUDE.md's own standing rule warns against ("a
+// check that always fails is as useless as one that always passes... confirm
+// it is green on a known-good case as well as red on a known-bad one"; this
+// one wasn't green on seven known-good cases). Rather than ship a guard that
+// forces workarounds for legitimate code, that pattern was dropped entirely.
+// UpdateAnomalyConfig's own gap stays documented in anomaly_config.go, found
+// and verified by hand (the repo-wide sweep this guard's population is
+// derived from), not structurally enforced -- a real, acknowledged limit of
+// this guard's coverage, not a silent gap.
+package http
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// fullRowOverwriteMethods is the storage.Storage method set whose
+// implementation does NOT preserve unset fields on write -- passing a
+// caller-built struct literal (rather than an existing, fetched row) is
+// unsafe for every one of these, regardless of which specific fields the
+// caller happened to populate.
+var fullRowOverwriteMethods = map[string]bool{
+	// Select("*") + .Updates(...) (conditional CAS writes, still full-row).
+	"UpdateAccessReviewCampaign":       true,
+	"UpdateAccessReviewItem":           true,
+	"TransitionProjectMembershipState": true,
+	"UpdateProjectInvitation":          true,
+	"UpdateAccessRequest":              true,
+	"TransitionMachineIdentityState":   true,
+	"ApproveRiskExceptionIfPending":    true,
+	"TransitionSecretStatus":           true,
+	"UpdateUserIfActiveStateMatches":   true,
+	// Plain, unconditional .Save(...).
+	"UpdateMachineIdentityCredential": true,
+	"UpdateRole":                      true,
+	"UpdateBreakGlassActivation":      true,
+	"UpdateProject":                   true,
+	"UpdateWebAuthnCredential":        true,
+	"UpdateSecretTemplate":            true,
+	"UpdateRotationPolicy":            true,
+	"UpdateLegalHold":                 true,
+	"UpdateDynamicSecretConfig":       true,
+	"UpdateDynamicSecretLease":        true,
+	"UpdateSecret":                    true,
+	"UpdateUser":                      true,
+	"UpdateGroup":                     true,
+	"SaveAnomalyConfig":               true,
+}
+
+// fullRowOverwriteAllowlist is the exhaustive, reasoned inventory of every
+// caller-facing site that passes a struct literal directly into a
+// fullRowOverwriteMethods call and has been individually verified safe
+// despite that. Each entry needs a real reason;
+// TestNoUnfetchedStructIntoFullRowOverwrite fails if a NEW site not in this
+// list is found, or if a listed entry no longer reproduces.
+// UpdateAnomalyConfig is NOT seeded here: this guard's detection (composite-
+// literal or non-fetch-call-derived local arguments -- see the package doc's
+// "What this guard does not catch" section) doesn't flag it, so an entry for
+// it here would itself go stale (this guard's own staleness check below
+// would flag it as "no longer makes a flagged call").
+var fullRowOverwriteAllowlist = map[string]string{
+	// TransitionMachineIdentityStateProxy: m := body.MachineIdentity.toModel()
+	// is flagged because toModel() is a non-fetch call, but this is the
+	// RemoteStorage HTTP-relay proxy (router.go's machine-identity storage-
+	// primitive group, system.write-gated, internal server-to-server only --
+	// see this file's own package doc and router.go:1284). The wire body it
+	// decodes is NOT attacker-authored from scratch: it is the full row the
+	// CALLING server's own internal/core.KeyorixCore already fetched via
+	// LockMachineIdentityForUpdate (transitionMachineInTx, machine_identities.go)
+	// or machineInProject (ClassifyMachineIdentity, machine_identities.go),
+	// mutated only the fields that call legitimately changes, then serialized
+	// whole over the wire for this proxy to relay onto local storage --
+	// exactly the same "helper receiving a caller's already-fetched row"
+	// shape as the 7 documented same-process false positives, one HTTP hop
+	// removed. Unlike models.User's wire type (which deliberately omits
+	// PasswordHash/AccountState), machineIdentityProxyWire.toModel() is a
+	// verified 1:1 field mirror of models.MachineIdentity (machine_identities_
+	// proxy.go) -- no field is silently dropped/zeroed by the relay itself.
+	// Re-verified by hand during this guard's construction (2026-09-04).
+	"TransitionMachineIdentityStateProxy": "RemoteStorage relay proxy: m is the caller's already-fetched-and-mutated row, serialized whole over the wire (1:1 field mirror, no drop), not an attacker-built struct -- see comment above.",
+}
+
+// TestNoUnfetchedStructIntoFullRowOverwrite is the preventive guard: for
+// every function in server/http/handlers/*.go and server/grpc/services/*.go,
+// if it calls Storage().<method>(ctx, &models.X{...}) for a method in
+// fullRowOverwriteMethods with a composite-literal argument, that function
+// must be in fullRowOverwriteAllowlist with a reasoned exception, or the
+// test fails naming the function and the method it called unsafely.
+func TestNoUnfetchedStructIntoFullRowOverwrite(t *testing.T) {
+	dirs := []string{
+		filepath.Join("..", "http", "handlers"),
+		filepath.Join("..", "grpc", "services"),
+		filepath.Join("..", "..", "internal", "core"),
+	}
+
+	flaggedFuncs := map[string]bool{}
+	var flagged []string
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("reading %s: %v", dir, err)
+		}
+		fset := token.NewFileSet()
+		for _, e := range entries {
+			name := e.Name()
+			if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			f, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+			if err != nil {
+				t.Fatalf("parsing %s: %v", name, err)
+			}
+			for _, decl := range f.Decls {
+				fd, ok := decl.(*ast.FuncDecl)
+				if !ok || fd.Body == nil {
+					continue
+				}
+				for _, finding := range unfetchedStructOverwriteCalls(fd) {
+					flaggedFuncs[fd.Name.Name] = true
+					if _, ok := fullRowOverwriteAllowlist[fd.Name.Name]; ok {
+						continue
+					}
+					flagged = append(flagged, fmt.Sprintf(
+						"%s (%s) %s Storage().%s(...), a full-row overwrite -- fetch the existing row first and "+
+							"patch only the fields this call site is legitimately allowed to change, or add a "+
+							"reasoned entry to fullRowOverwriteAllowlist in this file",
+						fd.Name.Name, name, finding.reason, finding.method))
+				}
+			}
+		}
+	}
+	sort.Strings(flagged)
+	if len(flagged) > 0 {
+		t.Errorf("found %d unfetched-struct-into-full-row-overwrite site(s): %v", len(flagged), flagged)
+	}
+
+	var stale []string
+	for fn := range fullRowOverwriteAllowlist {
+		if !flaggedFuncs[fn] {
+			stale = append(stale, fn+" (no longer makes a flagged call)")
+		}
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Errorf("fullRowOverwriteAllowlist entr(y/ies) no longer reproduce: %v\nRemove the entry -- its "+
+			"exception no longer applies.", stale)
+	}
+}
+
+// overwriteFinding is one flagged call: the storage method name, and a
+// human-readable reason fragment describing which of the two patterns fired
+// (spliced into TestNoUnfetchedStructIntoFullRowOverwrite's error message).
+type overwriteFinding struct {
+	method string
+	reason string
+}
+
+// unfetchedStructOverwriteCalls walks fd's body for calls into a
+// fullRowOverwriteMethods method, recognizing three storage-access forms:
+// X.Storage().Method(...) (the handler-layer shape), storageAlias.Method(...)
+// where storageAlias was assigned from X.Storage() earlier in the same body
+// (handlerBodyStorageCalls's own second recognized form), and
+// recv.storage.Method(...) -- the internal/core shape, a direct field access
+// on the method's own receiver (no .Storage() call at all) -- so a future
+// internal/core violation of this same shape is caught too, not just the
+// handler-layer one.
+//
+// For each such call, a non-context argument is flagged if it is:
+//   - a composite-literal address expression (&T{...}) inline at the call --
+//     never the case for a fetched-then-patched row.
+//   - a call expression that is not itself one of the three recognized
+//     fetch-shaped (Get-/Find-/List-prefixed) storage-access forms above --
+//     UpdateWebAuthnCredentialProxy's ORIGINAL real shape was exactly this:
+//     Storage().UpdateWebAuthnCredential(ctx, body.toModel()), a wire-to-model
+//     conversion call, not a fetch.
+//   - a LOCAL variable (assigned somewhere in this same function body) whose
+//     own most recent assignment is not one of the two safe shapes above
+//     (i.e. it traces back to a composite literal or a non-fetch call, the
+//     same two cases, just one assignment removed) -- UpdateUserIfActiveStateMatchesProxy's
+//     ORIGINAL real shape: existing := &models.User{...} assigned first,
+//     THEN existing passed by identifier.
+//
+// Deliberately NOT flagged: a bare identifier that is a FUNCTION PARAMETER,
+// not a local variable. A parameter's provenance (was IT fetched by
+// whichever caller passed it in) requires real interprocedural call-graph
+// tracing, which this guard does not attempt -- see the package doc's "What
+// this guard does not catch" section for why, and which known case that
+// exempts.
+func unfetchedStructOverwriteCalls(fd *ast.FuncDecl) []overwriteFinding {
+	var recvName string
+	if fd.Recv != nil && len(fd.Recv.List) == 1 && len(fd.Recv.List[0].Names) == 1 {
+		recvName = fd.Recv.List[0].Names[0].Name
+	}
+	params := map[string]bool{}
+	if fd.Type.Params != nil {
+		for _, field := range fd.Type.Params.List {
+			for _, n := range field.Names {
+				params[n.Name] = true
+			}
+		}
+	}
+
+	aliases := map[string]bool{}
+	isFetchCall := func(call *ast.CallExpr) bool {
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return false
+		}
+		if !strings.HasPrefix(sel.Sel.Name, "Get") && !strings.HasPrefix(sel.Sel.Name, "Find") && !strings.HasPrefix(sel.Sel.Name, "List") {
+			return false
+		}
+		if inner, ok := sel.X.(*ast.CallExpr); ok {
+			if innerSel, ok := inner.Fun.(*ast.SelectorExpr); ok && innerSel.Sel.Name == "Storage" {
+				return true
+			}
+		}
+		if id, ok := sel.X.(*ast.Ident); ok && aliases[id.Name] {
+			return true
+		}
+		if recv, field, ok := identSel(sel.X); ok && field == "storage" && recv == recvName {
+			return true
+		}
+		return false
+	}
+
+	// unfetchedLocals: local variables (never a parameter) whose most recent
+	// assignment is a composite literal or a non-fetch call.
+	unfetchedLocals := map[string]bool{}
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != len(assign.Rhs) {
+			return true
+		}
+		for i, rhs := range assign.Rhs {
+			id, ok := assign.Lhs[i].(*ast.Ident)
+			if !ok || params[id.Name] {
+				continue
+			}
+			switch v := rhs.(type) {
+			case *ast.CallExpr:
+				if sel, ok := v.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Storage" {
+					aliases[id.Name] = true
+					delete(unfetchedLocals, id.Name)
+					continue
+				}
+				if isFetchCall(v) {
+					delete(unfetchedLocals, id.Name)
+				} else {
+					unfetchedLocals[id.Name] = true
+				}
+			case *ast.UnaryExpr:
+				if v.Op == token.AND {
+					if _, ok := v.X.(*ast.CompositeLit); ok {
+						unfetchedLocals[id.Name] = true
+					}
+				}
+			}
+		}
+		return true
+	})
+
+	var found []overwriteFinding
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !fullRowOverwriteMethods[sel.Sel.Name] {
+			return true
+		}
+		isStorageCall := false
+		if inner, ok := sel.X.(*ast.CallExpr); ok {
+			if innerSel, ok := inner.Fun.(*ast.SelectorExpr); ok && innerSel.Sel.Name == "Storage" {
+				isStorageCall = true
+			}
+		}
+		if id, ok := sel.X.(*ast.Ident); ok && aliases[id.Name] {
+			isStorageCall = true
+		}
+		if recv, field, ok := identSel(sel.X); ok && field == "storage" && recv == recvName {
+			isStorageCall = true
+		}
+		if !isStorageCall {
+			return true
+		}
+		// call.Args[0] is always ctx context.Context on every fullRowOverwriteMethods
+		// signature -- skip it, or every single call site would be flagged on its
+		// context argument alone (r.Context()/ctx is always either a bare
+		// identifier or a non-fetch call, neither of which says anything about
+		// whether the ROW argument was fetched).
+		for _, arg := range call.Args[minInt(1, len(call.Args)):] {
+			switch v := arg.(type) {
+			case *ast.UnaryExpr:
+				if v.Op == token.AND {
+					if _, ok := v.X.(*ast.CompositeLit); ok {
+						found = append(found, overwriteFinding{sel.Sel.Name,
+							"passes a freshly-built struct literal directly into"})
+						return true
+					}
+				}
+			case *ast.Ident:
+				if unfetchedLocals[v.Name] {
+					found = append(found, overwriteFinding{sel.Sel.Name,
+						"passes a local variable that was never fetched from storage into"})
+					return true
+				}
+			case *ast.CallExpr:
+				if !isFetchCall(v) {
+					found = append(found, overwriteFinding{sel.Sel.Name,
+						"passes the result of a non-fetch call directly into"})
+					return true
+				}
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/server/http/handlers/handlers_s13b_test.go
+++ b/server/http/handlers/handlers_s13b_test.go
@@ -14,8 +14,10 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -289,7 +291,9 @@ func TestGetWebAuthnCredentialByCredIDProxy_StorageError_S13B(t *testing.T) {
 }
 
 // TestUpdateWebAuthnCredentialProxy_Success_S13B — seed a credential then
-// update it → 200.
+// disable it (the ONLY legitimate use of this route, #1714) → 200, Disabled
+// becomes true, and fields this route may NOT change (Name) are untouched --
+// this route no longer applies a caller-supplied full-row replacement.
 func TestUpdateWebAuthnCredentialProxy_Success_S13B(t *testing.T) {
 	h, _, db := setupMFAReauthTest(t)
 	blob, _ := json.Marshal(webauthn.Credential{ID: []byte("cred-upd")})
@@ -302,18 +306,22 @@ func TestUpdateWebAuthnCredentialProxy_Success_S13B(t *testing.T) {
 	require.NoError(t, db.Create(cred).Error)
 
 	body, _ := json.Marshal(map[string]interface{}{
-		"user_id":         1,
-		"credential_id":   []byte("cred-upd"),
-		"credential_blob": blob,
-		"name":            "new-name",
+		"user_id":       1,
+		"credential_id": []byte("cred-upd"),
+		"disabled":      true,
 	})
 	r := httptest.NewRequest(http.MethodPut,
-		"/api/v1/system/webauthn/credentials/1",
+		fmt.Sprintf("/api/v1/system/webauthn/credentials/%d", cred.ID),
 		bytes.NewReader(body))
-	r = withChiParams(r, map[string]string{"id": "1"})
+	r = withChiParams(r, map[string]string{"id": strconv.FormatUint(uint64(cred.ID), 10)})
 	w := httptest.NewRecorder()
 	h.UpdateWebAuthnCredentialProxy(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
+
+	var reloaded models.WebAuthnCredential
+	require.NoError(t, db.First(&reloaded, cred.ID).Error)
+	assert.True(t, reloaded.Disabled, "the credential must be disabled")
+	assert.Equal(t, "old-name", reloaded.Name, "this route must not change Name")
 }
 
 // TestAdvanceWebAuthnCredentialCounterProxy_NotFound_S13B — valid body but

--- a/server/http/handlers/handlers_s31_test.go
+++ b/server/http/handlers/handlers_s31_test.go
@@ -406,7 +406,10 @@ func TestGetWebAuthnCredentialByCredIDProxy_DBError_S31(t *testing.T) {
 func TestUpdateWebAuthnCredentialProxy_DBError_S31(t *testing.T) {
 	t.Parallel()
 	h := NewAuthHandler(freshCoreBrokenS31(t), false)
-	body := bytes.NewBufferString(`{"user_id":1,"credential_id":"AQIDBA==","name":"YubiKey","credential_blob":"AQIDBA==","created_at":"2024-01-01T00:00:00Z"}`)
+	// #1714: disabled:true is required to reach the storage-touching path at
+	// all (anything else is rejected before any lookup, so it would never
+	// observe the broken DB).
+	body := bytes.NewBufferString(`{"user_id":1,"credential_id":"AQIDBA==","disabled":true}`)
 	r := withChiParamS7(httptest.NewRequest(http.MethodPut, "/api/v1/system/webauthn/credentials/1", body), "id", "1")
 	w := httptest.NewRecorder()
 	h.UpdateWebAuthnCredentialProxy(w, r)

--- a/server/http/handlers/handlers_s5_test.go
+++ b/server/http/handlers/handlers_s5_test.go
@@ -2480,11 +2480,14 @@ func TestCountWebAuthnCredentialsProxy_HappyPathS5(t *testing.T) {
 
 func TestUpdateWebAuthnCredentialProxy_HappyPath(t *testing.T) {
 	h := newAuthHandlerWithWebAuthn(t)
-	body := `{"user_id":1,"credential_id":"AQID","public_key":"AQID","sign_count":0,"name":"k","user_handle":"AQID","aaguid":"AQID"}`
+	// #1714: this route only ever disables a credential on a clone signal —
+	// disabled:true is required, or the request is rejected before any lookup.
+	body := `{"user_id":1,"credential_id":"AQID","disabled":true}`
 	req := withChiParam(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body)), "id", "1")
 	w := httptest.NewRecorder()
 	h.UpdateWebAuthnCredentialProxy(w, req)
-	// Not a bad-request (body + ID are valid)
+	// Not a bad-request (body + ID are well-formed; the credential itself may
+	// not exist in this shared test DB, which is a 404, not a 400).
 	assert.NotEqual(t, http.StatusBadRequest, w.Code)
 }
 

--- a/server/http/handlers/handlers_s9_test.go
+++ b/server/http/handlers/handlers_s9_test.go
@@ -497,11 +497,11 @@ func TestUpdateWebAuthnCredentialProxy_Success_S9(t *testing.T) {
 	require.NoError(t, h.coreService.Storage().CreateWebAuthnCredential(context.Background(), cred))
 	require.NotZero(t, cred.ID)
 
-	// Update. #G79: UpdateWebAuthnCredentialProxy is an unconditional full-row
-	// Save, so the request must carry the full row (matching Create) — a body
-	// missing credential_id would otherwise zero that column on the existing row.
+	// Update: #1714 narrowed this route to the ONE legitimate transition
+	// (disable-on-clone) — it no longer accepts an arbitrary full-row
+	// replacement (name/credential_id could previously be overwritten wholesale).
 	idStr := strconv.FormatUint(uint64(cred.ID), 10)
-	updateBody := `{"name":"Updated S9","user_id":99,"credential_id":"dGVzdC1jcmVkLXM5NA=="}`
+	updateBody := `{"user_id":99,"credential_id":"dGVzdC1jcmVkLXM5NA==","disabled":true}`
 	updateReq := withChiParam(httptest.NewRequest(http.MethodPut, "/", strings.NewReader(updateBody)), "id", idStr)
 	updateW := httptest.NewRecorder()
 	h.UpdateWebAuthnCredentialProxy(updateW, updateReq)

--- a/server/http/handlers/users_active_transition_proxy.go
+++ b/server/http/handlers/users_active_transition_proxy.go
@@ -11,13 +11,32 @@
 // system.write RBAC permission every other RemoteStorage-primitive proxy in
 // this package already needs — no new privilege class).
 //
-// This is a thin passthrough onto the SAME storage.Storage.
-// UpdateUserIfActiveStateMatches primitive internal/core/users.go's UpdateUser
-// already calls against a local backend — no update-request validation
-// (uniqueness checks, which fields the original caller actually meant to
-// change) is made here; that stays entirely in the CALLING server's own
-// internal/core.KeyorixCore, exactly as it does against a local backend. This
-// handler only persists the row it's given, conditionally.
+// This is NOT a thin passthrough of a caller-supplied row (it used to be, and
+// that was an authentication-bypass bug -- see below): storage.Storage.
+// UpdateUserIfActiveStateMatches is a `Select("*")` full-row overwrite, and
+// this route's own wire body (userActiveTransitionProxyBody) only carries
+// username/email/display_name/active/updated_at -- it structurally cannot
+// carry PasswordHash, AccountState, or any other models.User field. A
+// caller-constructed struct built directly from that body therefore left
+// every OTHER field at its Go zero value, and Select("*") persisted those
+// zeros over the real, existing values -- confirmed to blank PasswordHash and
+// AccountState on every call, and blanking AccountState reactivates a
+// suspended/deprovisioned account for login (AccountLoginBlocked treats an
+// unrecognized/empty state as NOT blocked), chaining into full account
+// takeover via any subsequent setup-token/password-reset completion. This is
+// reachable from a genuinely benign, storage.type: remote spoke relay just as
+// easily as from a malicious direct call to this route -- PasswordHash never
+// crosses the wire at all (models.User.PasswordHash is json:"-"), so ANY
+// legitimate profile-edit relayed through this route already zeroed it,
+// independent of intent.
+//
+// Fixed: this handler now fetches the existing row first and patches only
+// the fields the wire body actually carries onto it, so every field this
+// route was never meant to touch survives unchanged. No update-request
+// validation (uniqueness checks, which fields the original caller actually
+// meant to change) beyond that is made here; that stays entirely in the
+// CALLING server's own internal/core.KeyorixCore, exactly as it does against
+// a local backend.
 //
 // Deliberately NOT the human-facing PUT /api/v1/users/{id} route
 // (users_crud.go's UserHandler.UpdateUser): that route re-runs the UPSTREAM
@@ -48,7 +67,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/identity"
-	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // userActiveTransitionProxyBody mirrors RemoteStorage's
@@ -95,7 +113,15 @@ func (h *UserHandler) UpdateUserIfActiveStateMatchesProxy(w http.ResponseWriter,
 		return
 	}
 	var body userActiveTransitionProxyBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	dec := json.NewDecoder(r.Body)
+	// Reject a body carrying any field this route doesn't declare (e.g.
+	// password_hash, account_state) rather than silently ignoring it -- a
+	// caller trying to smuggle a security-critical field through this route
+	// should get a 400, not a request that quietly succeeds having done
+	// nothing with the extra field. See the containment fix below for why
+	// this route must never accept those fields at all.
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&body); err != nil {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
@@ -151,17 +177,31 @@ func (h *UserHandler) UpdateUserIfActiveStateMatchesProxy(w http.ResponseWriter,
 			return
 		}
 	}
-	user := &models.User{
-		ID:             uint(id),
-		Username:       body.Username,
-		UsernameFolded: foldedUsername.Folded(),
-		Email:          body.Email,
-		EmailFolded:    foldedEmail.Folded(),
-		DisplayName:    body.DisplayName,
-		IsActive:       body.Active,
-		UpdatedAt:      body.UpdatedAt,
+	// Fetch the existing row FIRST and patch only the fields this route is
+	// legitimately allowed to change onto it -- storage.UpdateUserIfActiveStateMatches
+	// is a `Select("*")` full-row overwrite (see its own doc comment), so a
+	// caller-constructed struct with unset fields would silently zero every
+	// column this route's own wire body doesn't carry, including PasswordHash
+	// and AccountState. Confirmed empirically: this used to blank both on any
+	// call, and blanking AccountState on a suspended/deprovisioned account
+	// bypasses AccountLoginBlocked's deny-list check entirely (fail-open) --
+	// this was a full authentication-bypass chain, not just data loss. The
+	// fetch happens before any write; a caller whose target user doesn't
+	// exist is refused here, before the storage layer's own conditional
+	// write ever runs.
+	existing, err := h.coreService.Storage().GetUser(r.Context(), uint(id))
+	if err != nil {
+		writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", "user not found")
+		return
 	}
-	matched, err := h.coreService.Storage().UpdateUserIfActiveStateMatches(r.Context(), user, body.FromActive)
+	existing.Username = body.Username
+	existing.UsernameFolded = foldedUsername.Folded()
+	existing.Email = body.Email
+	existing.EmailFolded = foldedEmail.Folded()
+	existing.DisplayName = body.DisplayName
+	existing.IsActive = body.Active
+	existing.UpdatedAt = body.UpdatedAt
+	matched, err := h.coreService.Storage().UpdateUserIfActiveStateMatches(r.Context(), existing, body.FromActive)
 	if err != nil {
 		if errors.Is(err, storage.ErrDuplicateEmail) {
 			writeRemoteAPIError(w, http.StatusConflict, duplicateEmailProxyCode, storage.ErrDuplicateEmail.Error())

--- a/server/http/handlers/users_active_transition_proxy_test.go
+++ b/server/http/handlers/users_active_transition_proxy_test.go
@@ -202,6 +202,128 @@ func TestUpdateUserIfActiveStateMatchesProxy_DuplicateEmail(t *testing.T) {
 	assert.NotEqual(t, "Should Not Persist", unchanged.DisplayName, "rejected write must not persist")
 }
 
+// TestUpdateUserIfActiveStateMatchesProxy_PreservesPasswordHashAndAccountState
+// is the containment fix's own regression test: this route used to build a
+// caller-controlled *models.User with every field this route's wire body
+// doesn't carry left at Go's zero value, then persist it via a Select("*")
+// full-row overwrite -- silently blanking PasswordHash and AccountState on
+// EVERY successful call, not just a malicious one (RemoteStorage's client
+// never sends either field to begin with: PasswordHash is json:"-" and never
+// crosses the wire, and account_state has no field in this route's wire
+// format at all). Blanking AccountState on a suspended/deprovisioned account
+// is a fail-open authentication bypass (AccountLoginBlocked treats an
+// unrecognized/empty state as NOT blocked) -- this test proves the fetch-first
+// fix closes it: a real password hash and a non-active account state survive
+// a legitimate, successful call to this route completely unchanged.
+func TestUpdateUserIfActiveStateMatchesProxy_PreservesPasswordHashAndAccountState(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	target := &models.User{
+		Username: "s12nonadmin-hashcheck", Email: "s12nonadmin-hashcheck@example.com",
+		PasswordHash: "REAL_BCRYPT_HASH_MUST_SURVIVE", AccountState: "suspended", IsActive: true,
+	}
+	require.NoError(t, db.Create(target).Error)
+	idStr := machineUintToStr(target.ID)
+
+	body := proxyJSON(map[string]interface{}{
+		"username":     target.Username,
+		"email":        target.Email,
+		"display_name": "Updated Name",
+		"active":       true,
+		"from_active":  true,
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/users/"+idStr+"/active-transition", body),
+		"id", idStr,
+	)
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := decodeRemoteResp(t, w)
+	require.True(t, resp.Success)
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, true, data["matched"], "the call itself must have succeeded for this test to prove anything")
+
+	updated, err := cs.Storage().GetUser(req.Context(), target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Name", updated.DisplayName, "the legitimately-carried field DID change")
+	assert.Equal(t, "REAL_BCRYPT_HASH_MUST_SURVIVE", updated.PasswordHash,
+		"PasswordHash must survive a call to this route unchanged")
+	assert.Equal(t, "suspended", updated.AccountState,
+		"AccountState must survive a call to this route unchanged")
+}
+
+// TestUpdateUserIfActiveStateMatchesProxy_MismatchLeavesRowCompletelyUnchanged
+// re-verifies, for this route, the same mutate-before-checking ordering bug
+// caught in the WebAuthn authz fix: a from_active precondition mismatch must
+// leave the ENTIRE row untouched, not just fail to apply the intended
+// transition. Because the fix fetches first and the storage layer's own
+// WHERE-gated Updates() either matches the row (and writes it) or matches zero
+// rows (and writes nothing) as a single atomic operation, there is no window
+// where a partial write could land -- this test proves that empirically,
+// including for the fields the earlier bug used to zero.
+func TestUpdateUserIfActiveStateMatchesProxy_MismatchLeavesRowCompletelyUnchanged(t *testing.T) {
+	cs, db := freshCoreS12WithAdmin(t)
+	h, err := NewUserHandler(cs)
+	require.NoError(t, err)
+	target := &models.User{
+		Username: "s12nonadmin-mismatch", Email: "s12nonadmin-mismatch@example.com",
+		PasswordHash: "UNCHANGED_HASH", AccountState: "active", IsActive: true,
+		DisplayName: "Original Name",
+	}
+	require.NoError(t, db.Create(target).Error)
+	idStr := machineUintToStr(target.ID)
+
+	// from_active asserts false, but the row is actually true -- a stale/wrong
+	// precondition, matching the LostRace test's own shape.
+	body := proxyJSON(map[string]interface{}{
+		"username":     target.Username,
+		"email":        target.Email,
+		"display_name": "Should Not Persist",
+		"active":       false,
+		"from_active":  false,
+	})
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/users/"+idStr+"/active-transition", body),
+		"id", idStr,
+	)
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := decodeRemoteResp(t, w)
+	data, ok := resp.Data.(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, false, data["matched"], "the precondition mismatch must be reported")
+
+	unchanged, err := cs.Storage().GetUser(req.Context(), target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Original Name", unchanged.DisplayName, "no field may change on a rejected precondition")
+	assert.Equal(t, "UNCHANGED_HASH", unchanged.PasswordHash)
+	assert.Equal(t, "active", unchanged.AccountState)
+	assert.True(t, unchanged.IsActive)
+}
+
+// TestUpdateUserIfActiveStateMatchesProxy_RejectsUnknownField proves a body
+// carrying a field this route doesn't declare -- e.g. an attempt to smuggle
+// password_hash or account_state through it -- is rejected outright (400),
+// not silently ignored.
+func TestUpdateUserIfActiveStateMatchesProxy_RejectsUnknownField(t *testing.T) {
+	h := freshUserHandlerForProxyS13(t)
+	req := withChiParam(
+		httptest.NewRequest(http.MethodPut, "/system/users/1/active-transition",
+			strings.NewReader(`{"username":"x","email":"x@y.com","display_name":"x","active":true,`+
+				`"from_active":true,"password_hash":"sneaky"}`)),
+		"id", "1",
+	)
+	w := httptest.NewRecorder()
+	h.UpdateUserIfActiveStateMatchesProxy(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	resp := decodeRemoteResp(t, w)
+	assert.Equal(t, "INVALID_BODY", resp.Error.Code)
+}
+
 // TestUpdateUserIfActiveStateMatchesProxy_DuplicateUsername is the #G79
 // regression: this proxy previously ran no uniqueness pre-check at all
 // (unlike core.UpdateUser, which checks GetUserByUsername/GetUserByEmail

--- a/server/http/handlers/webauthn_proxy.go
+++ b/server/http/handlers/webauthn_proxy.go
@@ -50,12 +50,14 @@ package handlers
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
@@ -214,10 +216,32 @@ func (h *AuthHandler) GetWebAuthnCredentialByCredIDProxy(w http.ResponseWriter, 
 }
 
 // UpdateWebAuthnCredentialProxy handles PUT /api/v1/system/webauthn/credentials/{id}.
-// A raw persist (storage.Storage.UpdateWebAuthnCredential is an unconditional
-// full-row Save, matching LocalStorage's own semantics exactly) — used by
-// rejectIfCloned's best-effort "mark disabled" write. The signature-counter
-// advance path does NOT go through this route; see
+//
+// #1714: this used to be a raw, unconditional full-row Save trusting the
+// entire caller-supplied body -- an authz-ceiling bypass, not merely an audit
+// gap (reclassified from the original "audit-completeness" framing). Two
+// distinct things a system.write holder could do with the old code, neither
+// requiring any WebAuthn ceremony at all:
+//   - Reassign a credential's ownership: the handler applied body.UserID to
+//     the row unconditionally, with no check that it matched the row the URL
+//     {id} actually names.
+//   - Silently re-enable a clone-disabled credential (disabled: false),
+//     directly contradicting models.WebAuthnCredential's own documented
+//     invariant ("Never auto-re-enabled").
+//
+// The route's ONLY legitimate purpose, repo-wide, is rejectIfCloned's
+// disable-on-clone write (internal/core/webauthn.go is the sole internal/core
+// caller of storage.Storage.UpdateWebAuthnCredential). This handler is now
+// narrowed to exactly that: identify the row by (credential_id, user_id) --
+// which scopes ownership by construction, the same reasoning
+// rejectIfCloned's own lookup already relies on (#307) -- reject outright if
+// that pair doesn't resolve to the URL's {id}, and reject outright unless
+// disabled is exactly true. Routes through
+// KeyorixCore.MarkWebAuthnCredentialClonedByLookup; see that function's doc.
+// This is the authz half of the #1714 fix -- the audit half (unifying this
+// path with rejectIfCloned's own EventWebAuthnCloneDetected write into one
+// mutation+audit unit) lands as its own, independently-revertable commit.
+// The signature-counter advance path does NOT go through this route; see
 // AdvanceWebAuthnCredentialCounterProxy below.
 func (h *AuthHandler) UpdateWebAuthnCredentialProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
@@ -230,16 +254,40 @@ func (h *AuthHandler) UpdateWebAuthnCredentialProxy(w http.ResponseWriter, r *ht
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", errInvalidBody)
 		return
 	}
-	// #G79: matches CreateWebAuthnCredentialProxy's validation — this route is
-	// an unconditional full-row Save (see the doc above), so a body missing
-	// user_id/credential_id would zero those columns on the existing row, not
-	// merely leave them unset.
 	if body.UserID == 0 || len(body.CredentialID) == 0 {
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id and credential_id are required")
 		return
 	}
-	body.ID = uint(id)
-	if err := h.coreService.Storage().UpdateWebAuthnCredential(r.Context(), body.toModel()); err != nil {
+	// The only transition this route ever legitimately performs is
+	// disable-on-clone (false -> true). Anything else -- re-enabling, or a
+	// body that omits disabled entirely (Go's zero value is false) -- is
+	// rejected outright, not silently ignored: the model's own invariant is
+	// "never auto-re-enabled," so there is no reachable legitimate use of
+	// disabled: false via this route, ever.
+	if !body.Disabled {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY",
+			"this route only disables a credential on a clone-detection signal; disabled must be true")
+		return
+	}
+	_, err = h.coreService.MarkWebAuthnCredentialClonedByLookup(r.Context(), body.CredentialID, body.UserID, uint(id), clientIP(r))
+	if err != nil {
+		if errors.Is(err, core.ErrWebAuthnCredentialIDMismatch) {
+			// (credential_id, user_id) resolved to a REAL, owned row, but not the
+			// one the URL named -- the caller is targeting one credential's ID
+			// while authenticating the request against a different one's
+			// identity. Rejected BEFORE any mutation (see the domain function's
+			// own doc) -- log it, since this is either a caller bug or an
+			// attempt to probe/confuse the id<->identity binding.
+			log.Printf("webauthn proxy: update credential: URL id %d does not match the credential named by "+
+				"the body's (user_id=%d, credential_id); rejecting, nothing changed", id, body.UserID)
+			writeRemoteAPIError(w, http.StatusConflict, "ID_MISMATCH",
+				"the credential identified by user_id and credential_id does not match the id in the URL")
+			return
+		}
+		if isNotFoundErr(err) {
+			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errWebAuthnCredNotFound)
+			return
+		}
 		log.Printf("webauthn proxy: update credential failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return

--- a/server/http/handlers/webauthn_proxy.go
+++ b/server/http/handlers/webauthn_proxy.go
@@ -237,12 +237,10 @@ func (h *AuthHandler) GetWebAuthnCredentialByCredIDProxy(w http.ResponseWriter, 
 // rejectIfCloned's own lookup already relies on (#307) -- reject outright if
 // that pair doesn't resolve to the URL's {id}, and reject outright unless
 // disabled is exactly true. Routes through
-// KeyorixCore.MarkWebAuthnCredentialClonedByLookup; see that function's doc.
-// This is the authz half of the #1714 fix -- the audit half (unifying this
-// path with rejectIfCloned's own EventWebAuthnCloneDetected write into one
-// mutation+audit unit) lands as its own, independently-revertable commit.
-// The signature-counter advance path does NOT go through this route; see
-// AdvanceWebAuthnCredentialCounterProxy below.
+// KeyorixCore.MarkWebAuthnCredentialClonedByLookup, which performs the
+// mutation and the EventWebAuthnCloneDetected audit write as one unit; see
+// that function's doc. The signature-counter advance path does NOT go
+// through this route; see AdvanceWebAuthnCredentialCounterProxy below.
 func (h *AuthHandler) UpdateWebAuthnCredentialProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {

--- a/server/http/handlers/webauthn_proxy_1714_authz_test.go
+++ b/server/http/handlers/webauthn_proxy_1714_authz_test.go
@@ -1,0 +1,156 @@
+// webauthn_proxy_1622_authz_test.go — #1714 (reclassified authz-bypass, not
+// audit-completeness): UpdateWebAuthnCredentialProxy used to trust an
+// attacker-controlled full-row body, unconditionally. These tests assert the
+// narrowed contract: the ONLY reachable transition is disable-on-clone,
+// identified by (credential_id, user_id) matching the URL {id}, and any
+// rejection leaves the stored row completely unchanged.
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func putUpdateWebAuthnCredential(t *testing.T, h *AuthHandler, urlID string, body map[string]interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := withChiParam(httptest.NewRequest(http.MethodPut, "/api/v1/system/webauthn/credentials/"+urlID, bytes.NewReader(b)), "id", urlID)
+	w := httptest.NewRecorder()
+	h.UpdateWebAuthnCredentialProxy(w, req)
+	return w
+}
+
+// TestUpdateWebAuthnCredentialProxy_1622_LegitimateDisable_HappyPath is the
+// route's one remaining legitimate use: a well-formed disable, identified
+// consistently across URL id and body (user_id, credential_id).
+func TestUpdateWebAuthnCredentialProxy_1622_LegitimateDisable_HappyPath(t *testing.T) {
+	h := newAuthHandlerWithWebAuthn(t)
+	credIDBytes := []byte(fmt.Sprintf("cred-1622-happy-%d", s4UniqueCounter.Add(1)))
+	cred := &models.WebAuthnCredential{
+		UserID:         501,
+		CredentialID:   credIDBytes,
+		Name:           "legit-key",
+		CredentialBlob: []byte(`{}`),
+	}
+	require.NoError(t, h.coreService.Storage().CreateWebAuthnCredential(t.Context(), cred))
+	require.NotZero(t, cred.ID)
+
+	idStr := strconv.FormatUint(uint64(cred.ID), 10)
+	w := putUpdateWebAuthnCredential(t, h, idStr, map[string]interface{}{
+		"user_id": 501, "credential_id": credIDBytes, "disabled": true,
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	updated, err := h.coreService.Storage().GetWebAuthnCredentialByCredID(t.Context(), credIDBytes, 501)
+	require.NoError(t, err)
+	assert.True(t, updated.Disabled)
+}
+
+// TestUpdateWebAuthnCredentialProxy_1622_RefusesOwnershipReassignment: the
+// original vulnerability. A caller supplying a user_id that does not
+// actually own the named credential_id must not have that credential
+// silently reassigned to it -- GetWebAuthnCredentialByCredID's scoped lookup
+// (the same one rejectIfCloned itself relies on, #307) makes the mismatched
+// pair resolve to nothing, so this fails as NOT_FOUND, not as a successful
+// reassignment. The real owner's row is completely untouched.
+func TestUpdateWebAuthnCredentialProxy_1622_RefusesOwnershipReassignment(t *testing.T) {
+	h := newAuthHandlerWithWebAuthn(t)
+	credIDBytes := []byte(fmt.Sprintf("cred-1622-reassign-%d", s4UniqueCounter.Add(1)))
+	cred := &models.WebAuthnCredential{
+		UserID:         502,
+		CredentialID:   credIDBytes,
+		Name:           "victim-key",
+		CredentialBlob: []byte(`{}`),
+	}
+	require.NoError(t, h.coreService.Storage().CreateWebAuthnCredential(t.Context(), cred))
+	require.NotZero(t, cred.ID)
+
+	idStr := strconv.FormatUint(uint64(cred.ID), 10)
+	// Attacker claims a DIFFERENT user_id than the credential's real owner.
+	w := putUpdateWebAuthnCredential(t, h, idStr, map[string]interface{}{
+		"user_id": 999999, "credential_id": credIDBytes, "disabled": true,
+	})
+	assert.Equal(t, http.StatusNotFound, w.Code,
+		"a user_id that doesn't own credential_id must not resolve to anything, let alone reassign it")
+
+	// The real row is untouched: still owned by 502, still enabled.
+	reloaded, err := h.coreService.Storage().GetWebAuthnCredentialByCredID(t.Context(), credIDBytes, 502)
+	require.NoError(t, err)
+	assert.False(t, reloaded.Disabled, "the victim's credential must remain unchanged")
+}
+
+// TestUpdateWebAuthnCredentialProxy_1622_RefusesReEnable: models.WebAuthnCredential's
+// own doc says Disabled is "Never auto-re-enabled". disabled:false must be
+// unreachable via this route regardless of the credential's current state --
+// tested here against an already clone-disabled credential specifically,
+// since that's the state where a re-enable would actually matter.
+func TestUpdateWebAuthnCredentialProxy_1622_RefusesReEnable(t *testing.T) {
+	h := newAuthHandlerWithWebAuthn(t)
+	credIDBytes := []byte(fmt.Sprintf("cred-1622-reenable-%d", s4UniqueCounter.Add(1)))
+	cred := &models.WebAuthnCredential{
+		UserID:         503,
+		CredentialID:   credIDBytes,
+		Name:           "cloned-key",
+		CredentialBlob: []byte(`{}`),
+		Disabled:       true, // already disabled by a prior clone-detection event
+	}
+	require.NoError(t, h.coreService.Storage().CreateWebAuthnCredential(t.Context(), cred))
+	require.NotZero(t, cred.ID)
+
+	idStr := strconv.FormatUint(uint64(cred.ID), 10)
+	w := putUpdateWebAuthnCredential(t, h, idStr, map[string]interface{}{
+		"user_id": 503, "credential_id": credIDBytes, "disabled": false,
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code,
+		"disabled:false must never be reachable via this route")
+
+	reloaded, err := h.coreService.Storage().GetWebAuthnCredentialByCredID(t.Context(), credIDBytes, 503)
+	require.NoError(t, err)
+	assert.True(t, reloaded.Disabled, "a clone-disabled credential must stay disabled")
+}
+
+// TestUpdateWebAuthnCredentialProxy_1622_RefusesIDMismatch: (credential_id,
+// user_id) resolves to a REAL, owned row -- just not the one the URL {id}
+// names. The check must run BEFORE any mutation: neither the row actually
+// named by the URL nor the row actually named by the body may be touched.
+func TestUpdateWebAuthnCredentialProxy_1622_RefusesIDMismatch(t *testing.T) {
+	h := newAuthHandlerWithWebAuthn(t)
+	n := s4UniqueCounter.Add(1)
+	credA := &models.WebAuthnCredential{
+		UserID: 504, CredentialID: []byte(fmt.Sprintf("cred-1622-mismatch-a-%d", n)),
+		Name: "key-a", CredentialBlob: []byte(`{}`),
+	}
+	credB := &models.WebAuthnCredential{
+		UserID: 504, CredentialID: []byte(fmt.Sprintf("cred-1622-mismatch-b-%d", n)),
+		Name: "key-b", CredentialBlob: []byte(`{}`),
+	}
+	require.NoError(t, h.coreService.Storage().CreateWebAuthnCredential(t.Context(), credA))
+	require.NoError(t, h.coreService.Storage().CreateWebAuthnCredential(t.Context(), credB))
+	require.NotZero(t, credA.ID)
+	require.NotZero(t, credB.ID)
+	require.NotEqual(t, credA.ID, credB.ID)
+
+	// URL names A's id, but the body's (credential_id, user_id) names B.
+	w := putUpdateWebAuthnCredential(t, h, strconv.FormatUint(uint64(credA.ID), 10), map[string]interface{}{
+		"user_id": 504, "credential_id": credB.CredentialID, "disabled": true,
+	})
+	assert.Equal(t, http.StatusConflict, w.Code)
+
+	reloadedA, err := h.coreService.Storage().GetWebAuthnCredentialByCredID(t.Context(), credA.CredentialID, 504)
+	require.NoError(t, err)
+	assert.False(t, reloadedA.Disabled, "the URL-named credential must be untouched")
+
+	reloadedB, err := h.coreService.Storage().GetWebAuthnCredentialByCredID(t.Context(), credB.CredentialID, 504)
+	require.NoError(t, err)
+	assert.False(t, reloadedB.Disabled, "the body-named credential must ALSO be untouched -- rejected before any mutation")
+}

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -689,9 +689,18 @@ var rawStorageBypassAllowlist = map[string]string{
 		"is a marshal + token-generation + the SAME storage.CreateWebAuthnSession call, no additional check -- " +
 		"session data isn't privilege-bearing until consumed (same shape as the already-verified " +
 		"CreateSSOLoginStateProxy: identity is anchored at consume time, not creation time).",
-	"UpdateWebAuthnCredentialProxy": "no-independent-ceiling: the proxy's own doc comment establishes it backs " +
-		"rejectIfCloned's best-effort 'mark disabled' write -- a defensive, capability-REDUCING action (disabling " +
-		"a suspected-cloned credential), not an authorization gate to bypass.",
+	// UpdateWebAuthnCredentialProxy entry removed (#1714): the original
+	// "no-independent-ceiling" framing was wrong for this handler -- it
+	// wasn't just capability-reducing, it trusted an attacker-controlled
+	// full-row body (ownership reassignment via a mismatched user_id, and
+	// silent re-enable of a clone-disabled credential, directly contradicting
+	// models.WebAuthnCredential's own "never auto-re-enabled" invariant).
+	// Reclassified as an authz bypass, not a no-op-ceiling case. Fixed by
+	// routing through KeyorixCore.MarkWebAuthnCredentialClonedByLookup, which
+	// rejects a body that doesn't resolve to the URL's {id} BEFORE any
+	// mutation and rejects disabled:false outright -- the handler no longer
+	// makes a raw storage.UpdateWebAuthnCredential call at all, so this
+	// guard's own detection no longer flags it.
 	"ExpireSetupTokenProxy": "no-independent-ceiling: marking a setup token expired only REDUCES future capability " +
 		"(revokes an outstanding token early) -- there is no privilege to gain by skipping whatever ceiling " +
 		"inspectActiveSetupToken's lazy-expiry path would otherwise apply, since expiry is itself the safe " +
@@ -1044,7 +1053,9 @@ var rawStorageBypassAllowlist = map[string]string{
 	// files correctly, not a blind spot for new code.
 	//
 	// No-independent-ceiling (same shape as unsafe_sibling_write_guard_test.go's
-	// UpdateWebAuthnCredentialProxy/DeleteProjectProxy entries): internal/core
+	// DeleteProjectProxy entry -- NOT UpdateWebAuthnCredentialProxy, whose own
+	// entry above was reclassified and removed by #1714: that one turned out
+	// to be a real authz bypass, not a no-op-ceiling case): internal/core
 	// applies NO ceiling to notification creation at all -- there is no
 	// authorization decision for this proxy to skip. models.Notification
 	// carries no actor, sender, or origin field; UserID is the recipient, not

--- a/server/http/unsafe_sibling_write_guard_test.go
+++ b/server/http/unsafe_sibling_write_guard_test.go
@@ -65,9 +65,13 @@ var unsafeSiblingPairs = map[string]string{
 // or the route removed) — same discipline as
 // rawStorageBypassAllowlist/knownUnfixedRawStorageBypasses above.
 var unsafeSiblingAllowlist = map[string]string{
-	"UpdateWebAuthnCredentialProxy": "capability-reducing: the proxy's own doc comment establishes it backs " +
-		"rejectIfCloned's best-effort 'mark disabled' write -- disabling a suspected-cloned credential is the " +
-		"safe direction, not an authorization gate to bypass. No independent ceiling to skip.",
+	// UpdateWebAuthnCredentialProxy entry removed (#1714): reclassified from
+	// "capability-reducing, no independent ceiling" to a real authz bypass --
+	// the old raw call trusted an attacker-controlled full-row body
+	// (ownership reassignment via a mismatched user_id, silent re-enable of a
+	// clone-disabled credential). Fixed by routing through
+	// KeyorixCore.MarkWebAuthnCredentialClonedByLookup; the handler no longer
+	// makes an unsafe-sibling call at all, so this guard no longer flags it.
 	"DeleteProjectProxy": "no-independent-ceiling: core.DeleteProject(force=true) intentionally skips the " +
 		"force=false guard+cascade atomicity problem entirely and calls the plain, unconditional " +
 		"storage.DeleteProject cascade -- no actor-authority check of any kind exists at the core layer for " +


### PR DESCRIPTION
## Summary
- Adds `TestNoUnfetchedStructIntoFullRowOverwrite` (`server/http/full_row_overwrite_guard_test.go`), a static AST guard that fails CI when a caller-facing handler in `server/http/handlers`, `server/grpc/services`, or `internal/core` passes a struct literal or a non-fetch-call-derived local into one of the 9 `Select("*")+Updates` or ~14 plain-`Save` storage methods that do unconditional full-row writes.
- Closes the class `UpdateWebAuthnCredentialProxy` and `UpdateUserIfActiveStateMatchesProxy` both turned out to have (silent zeroing of fields the request body doesn't carry, including security-critical ones), preventing a third instance.
- One allowlist entry, with a written justification: `TransitionMachineIdentityStateProxy`. It's flagged (its `m` comes from a non-fetch `toModel()` call) but traced end to end and confirmed safe — it's the internal, `system.write`-gated RemoteStorage HTTP-relay proxy, and the wire body is the *calling* server's own already-fetched-and-mutated row, serialized whole (`machineIdentityProxyWire.toModel()` is a verified 1:1 field mirror of `models.MachineIdentity`, unlike `models.User`'s deliberately narrower wire type). Not an attacker-built struct.

Stacked on #1721 and #1722 — this guard requires both of those fixes present in the tree to be green (it currently also encodes their fixed shapes as the "known-good" baseline). The diff below includes their commits until they merge; it will shrink to just the new guard-test file once they land.

## Test plan
- [x] `go build ./...`, `go vet ./server/... ./internal/...` clean
- [x] `gofmt -l` clean on touched files
- [x] `gosec -severity medium -exclude-generated` clean on touched files
- [x] Full `go test ./server/http/...` (including `handlers` and `contracttest`) green
- [x] Red/green-verified: temporarily reintroduced the historical `UpdateUserIfActiveStateMatchesProxy` composite-literal bug shape — guard correctly flagged exactly that one site and nothing else, then reverted and re-confirmed green