### PR TITLE
fix(deploy,hardening): re-land Guaranteed-QoS default + ADR-100 evidence (#1679)

### DIFF
--- a/deploy/helm/keyorix/templates/server-deployment.yaml
+++ b/deploy/helm/keyorix/templates/server-deployment.yaml
@@ -95,9 +95,11 @@ spec:
             {{- if .Values.server.resources }}
             {{- toYaml .Values.server.resources | nindent 12 }}
             {{- else }}
+            # Kept in sync with values.yaml's own server.resources default --
+            # see its comment for the Guaranteed-QoS/measurement derivation.
             requests:
-              cpu: 50m
-              memory: 128Mi
+              cpu: 1000m
+              memory: 512Mi
               ephemeral-storage: 64Mi
             limits:
               cpu: 1000m

--- a/deploy/helm/keyorix/values.yaml
+++ b/deploy/helm/keyorix/values.yaml
@@ -45,10 +45,36 @@ server:
     size: 1Gi
     storageClass: ""
     accessMode: ReadWriteOnce
+  # requests == limits for both cpu and memory (Guaranteed QoS -- see
+  # docs/adr-100-mlockall-removal-deployment-swap-control.md): under Kubernetes'
+  # NodeSwap, only Burstable-QoS pods are eligible for swap at all -- Guaranteed
+  # (and BestEffort) pods receive zero swap unconditionally
+  # (github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md:
+  # "Swap access is granted only for pods of Burstable QoS"). Since mlockall was
+  # removed, this is now the ONLY control preventing decrypted secret memory from
+  # being swapped to disk on a cluster where a node opts into swap -- a
+  # requests==limits mismatch here silently reopens exactly the gap ADR-100 closed.
+  # ephemeral-storage is NOT part of QoS classification and is left as before.
+  #
+  # memory: 512Mi is unchanged from before mlockall removal, but re-derived from
+  # measurement rather than inherited: the real server binary
+  # (server/Dockerfile, linux/arm64 via this environment's Docker backend --
+  # see ADR-100's own environment caveat) measured VmRSS at rest ~22.5MB, peak
+  # (VmHWM) ~82MB after creating 50 secrets (20 * 500KB + 30 * 2MB payloads) via
+  # the real HTTP API -- 512Mi is ~6.4x that observed peak, headroom for
+  # larger production bulk operations (bigger secret exports, wider audit
+  # queries) this synthetic load didn't exercise.
+  #
+  # cpu: previously 100m request / 1 limit (Burstable). Request raised to match
+  # the existing limit -- the trade-off: every server pod now permanently
+  # reserves a full CPU core from the node's allocatable capacity, even at
+  # idle, instead of bursting into it opportunistically. Not re-derived from
+  # measurement (no CPU load test was run); kept at the existing limit value
+  # rather than picked arbitrarily.
   resources:
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 1
+      memory: 512Mi
       ephemeral-storage: 64Mi
     limits:
       cpu: 1

--- a/docs/adr-100-mlockall-removal-deployment-swap-control.md
+++ b/docs/adr-100-mlockall-removal-deployment-swap-control.md
@@ -314,10 +314,12 @@ described here).
   scenario above and arguably the more concerning finding. It is **not a
   permanent leak**: 5 minutes after the driver stopped entirely, `VmRSS` had
   fallen to 59276 kB, close to the true cold-boot baseline (~23 MB) — the
-  memory is reclaimable, just not reclaimed fast enough relative to the
-  sustained allocation rate for Go's default GC pacing (`GOGC=100`, no
-  `GOMEMLIMIT`) to keep the process anywhere near its steady-state minimum
-  while load continues.
+  memory is reclaimable once the underlying cause (below) stops adding
+  pressure faster than it clears, not gone for good the way a genuine leak
+  would be. This is NOT primarily a GC-pacing problem that a soft memory
+  limit would fix — see "Sustained load is not a memory-sizing problem"
+  below, correcting this ADR's own earlier claim that `GOMEMLIMIT` closes
+  this gap.
 
   **Leading cause identified, not just observed:** the server log for this
   run contains 704 occurrences of `SECURITY: failed to persist audit event
@@ -419,11 +421,15 @@ multi-user load, not an attack.
 **Recommended: raise `server.resources.requests/limits.memory` to 768Mi**,
 keeping `requests == limits` (Guaranteed QoS, unchanged rationale). Headroom
 math: the single-burst worst case measured (100 concurrent × 2MB,
-uncapped) peaked at 582 MB; 768Mi (805,306,368 bytes) is ~1.4x that. This
-does **not** cover the sustained-pass peak (723 MB) with real margin on its
-own — see the `GOMEMLIMIT` recommendation below, which is what actually
-closes that gap, not a larger static number chasing an unbounded sustained
-scenario.
+uncapped) peaked at 582 MB; 768Mi (805,306,368 bytes) is ~1.4x that. **This
+number is sized for bursts. It does not cover the sustained-load finding,
+and no static memory number should try to** — 768Mi is only ~1.06x the
+sustained pass's own peak (723 MB), and that run had not plateaued when it
+stopped at 30 minutes; a longer run could plausibly have exceeded 768Mi too.
+See "Sustained load is not a memory-sizing problem" below (correcting this
+ADR's earlier claim that `GOMEMLIMIT` closes this gap — it does not) for
+why the sustained case needs a different fix entirely, not a bigger number
+here.
 
 **What this trades off:** every default install now permanently reserves
 768Mi instead of 512Mi — 256Mi of additional capacity every customer holds
@@ -433,16 +439,29 @@ matrix demonstrated) is not a real option once the risk is measured, not
 assumed — a Guaranteed-QoS pod that gets OOM-killed under ordinary
 concurrent use fails the exact goal (surviving ordinary load without
 disruption) the QoS change in the first follow-up was made for. This
-number is **not** sized to survive the sustained-load scenario indefinitely
-at 25-concurrency — see below for why that is deliberately a `GOMEMLIMIT`
-problem instead of an ever-larger static reservation.
+raise is scoped to bursts, deliberately: see below for why chasing the
+sustained scenario with an ever-larger static reservation is the wrong
+tool for that specific problem.
 
 **Not implemented in this pass** — `deploy/helm/keyorix/values.yaml` still
 reads 512Mi as of this write-up; this is a recommendation for the next
 follow-up PR, stated here so the measurement and the decision aren't
 separated in time.
 
-## `GOMEMLIMIT`: recommended, ~85% of the container limit
+## `GOMEMLIMIT`: recommended for bursts, ~85% of the container limit — corrected 2026-09-04
+
+**Correction to this section's original text**, made before anyone acted on
+it: the original version claimed `GOMEMLIMIT` is "what actually closes th[e]
+gap" for the sustained-load finding. **That is wrong.** `GOMEMLIMIT` is a
+*soft* limit — Go responds to approaching it by spending more CPU on GC,
+not by staying under the ceiling. It is a real, useful mitigation for
+*bounded* memory pressure (a burst that will subside once the requests
+finish). It is the wrong tool against the sustained-load finding
+specifically, because that growth was traced (see "Leading cause
+identified" above, and the #1679 follow-up round's Step 1 audit-persist
+investigation) to **structurally unbounded** causes — an un-checkpointed
+WAL and SQLite write-lock contention under sustained concurrent load, not a
+bounded working set GC can shrink by working harder.
 
 **Recommend setting `GOMEMLIMIT` to approximately 85% of
 `server.resources.limits.memory`** (e.g. `GOMEMLIMIT=650MiB` against a 768Mi
@@ -451,35 +470,55 @@ per the Go team's own guidance for using `GOMEMLIMIT` as a backstop
 alongside percentage-based GC, not a replacement for it), set as an
 environment variable on the server container (no code change needed — the
 Go runtime reads it directly; `internal/config`/`server/main.go` need no
-new field).
+new field). **Scope this recommendation to bursts** — the single-burst
+worst case (582 MB, concurrency=100) is bounded: once those requests
+finish, allocation pressure stops and GC can catch up. `GOMEMLIMIT` genuinely
+helps there: it makes GC work harder as heap approaches the limit during
+the burst's peak, instead of the runtime pacing purely off heap growth with
+no awareness a cgroup ceiling exists at all (confirmed zero
+`GOMEMLIMIT`/`SetMemoryLimit` references anywhere in this repo, `git grep -n
+"GOMEMLIMIT\|SetMemoryLimit" -- '*.go' '*.yaml' '*Dockerfile*'`).
 
-**Why:** the sustained-load finding above is exactly the failure mode
-`GOMEMLIMIT` exists for. Go's default GC (`GOGC=100`, no memory limit
-awareness at all when `GOMEMLIMIT` is unset — confirmed by `git grep -n
-"GOMEMLIMIT\|SetMemoryLimit" -- '*.go' '*.yaml' '*Dockerfile*'` returning
-zero hits anywhere in this repo, both before and after this pass) paces
-collection off heap *growth*, not proximity to any external ceiling — it has
-no way to know a hard cgroup limit exists at all, let alone that it is
-approaching one. Under the sustained scenario measured, RSS climbed for 30
-straight minutes with no sign of slowing down on its own; the only reason it
-didn't end in an OOM-kill is that the container had no cap during that
-specific run. With `GOMEMLIMIT` set, the runtime is required to run
-additional GC cycles as live heap approaches the configured limit — trading
-CPU (more frequent, harder-working collections) for staying alive, changing
-the failure mode from "hard kill, mid-request, no warning" to "degraded
-throughput/latency, visible in metrics, process stays up." This is a
-strictly better outcome for the exact scenario this pass measured, at the
-cost of GC CPU overhead under sustained pressure — not measured directly in
-this pass (would require comparing sustained-load CPU utilization with and
-without `GOMEMLIMIT` set, a follow-up measurement, not inferred here).
+## Sustained load is not a memory-sizing problem
 
-**Not a substitute for the base container limit being large enough for
-ordinary bursts.** `GOMEMLIMIT` makes the GC work harder as the heap
-approaches it; it does not create memory the process doesn't have. A
-container limit sized for the single-burst worst case (the 768Mi
-recommendation above) still matters — `GOMEMLIMIT` is what keeps a
-*sustained* load from reaching that ceiling in the first place, not a way to
-shrink the ceiling itself.
+**Against genuinely unbounded growth, `GOMEMLIMIT` does not fail safely —
+it produces a GC death spiral, which is operationally worse than a clean
+OOM-kill.** If the underlying cause keeps producing new live-reachable-looking
+pressure faster than GC can reclaim (a WAL that never gets checkpointed,
+writers piling up behind lock contention that never clears), the runtime
+does exactly what `GOMEMLIMIT` tells it to: run more GC cycles, more often,
+harder. Heap keeps climbing toward the limit anyway, because the cause was
+never memory the GC could actually free — it was on-disk WAL growth and
+in-flight contended writers backing up, both invisible to the Go garbage
+collector's own view of "live heap." The practical result: CPU spent
+almost entirely on GC, request throughput collapsing toward zero, `/health`
+possibly still returning 200 (it doesn't check GC pressure or request
+latency), no crash, no restart — a pod that LOOKS alive to Kubernetes and
+IS unusable, indefinitely, until someone notices and intervenes by hand.
+Kubernetes has no automatic response to this failure mode the way it does
+to an OOM-kill (pod dies → rescheduled → alerting fires on the restart
+count, a well-understood, well-instrumented signal every operator already
+watches for). A clean OOM-kill is the *better* outcome here, not the one to
+engineer around.
+
+**The sizing math already shows this doesn't close the gap even optimistically:**
+768Mi is ~1.4x the single-burst worst case (582 MB) but only ~1.06x the
+sustained pass's own observed peak (723 MB) — and that 30-minute run had
+not plateaued. Reaching for a bigger static number instead doesn't fix
+this either: the growth pattern gives no evidence of where (or whether) it
+stops on its own; sizing a "safe" ceiling for it requires knowing that
+ceiling exists, which this measurement pass specifically did not establish.
+
+**This has no memory-limit fix — bounded or soft.** The actual fix is
+closing the unbounded-growth cause at its source: WAL checkpointing (the
+`.db-wal` file grew to 59.5 MB over the sustained run without being
+checkpointed back into the main database file) and tighter write
+serialization under concurrent load (the same contention responsible for
+the 704 dropped audit-persist writes the #1679 follow-up round's Step 1
+audit investigated). That work is tracked as its own item, referencing
+Step 1's findings directly — not proposed or scoped here, since it's a
+correctness/durability fix to the storage layer, not a resource-sizing
+decision.
 
 **Not implemented in this pass**, same status as the memory-limit
 recommendation above — stated here for the next follow-up PR to carry out.

--- a/docs/adr-100-mlockall-removal-deployment-swap-control.md
+++ b/docs/adr-100-mlockall-removal-deployment-swap-control.md
@@ -20,7 +20,21 @@ mode worth gating behind config, and no relationship to the problem below.
 
 Swap protection for decrypted secret memory is now a **deployment-level**
 concern: disable swap on the node, or in the container runtime, rather than
-locking memory pages in-process.
+locking memory pages in-process. This is not left as operator best-effort
+guidance alone: `deploy/helm/keyorix/values.yaml`'s default `server.resources`
+now sets `requests == limits` for both `cpu` and `memory`, which places the
+server pod in Kubernetes' **Guaranteed** QoS class. Under `NodeSwap`
+(Kubernetes' opt-in swap-on-Linux-nodes feature), the `LimitedSwap` behavior
+grants swap access **only to Burstable-QoS pods**
+([KEP-2400](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md):
+"Swap access is granted only for pods of Burstable QoS") — a Guaranteed pod
+receives zero swap unconditionally, on a cluster that has opted into
+`NodeSwap` or not. This closes a real gap in this ADR's first version, which
+documented "disable swap on the node" as operator guidance without the
+shipped chart's own default actually landing in the QoS class that
+guarantee depends on (the previous default, `requests.memory: 128Mi` against
+`limits.memory: 512Mi`, is Burstable — precisely the class `NodeSwap` permits
+to swap).
 
 ## Why mlockall does not work here
 
@@ -81,6 +95,19 @@ Three independent findings, each sufficient on its own:
   as intended is worse than the control's absence, because it invites an
   operator to believe they have a working guarantee by setting it.
 - `server/main.go`'s call site no longer reads `cfg.Security.Mlock.*`.
+- `deploy/helm/keyorix/values.yaml`'s `server.resources` default changes from
+  `requests: {cpu: 100m, memory: 128Mi}` / `limits: {cpu: 1, memory: 512Mi}`
+  (Burstable) to `requests == limits == {cpu: 1, memory: 512Mi}` (Guaranteed).
+  `memory` is unchanged from before this ADR — see "Verification" below for
+  why 512Mi is still the right number, now re-derived from measurement rather
+  than inherited. `cpu`'s *request* is raised to match the pre-existing
+  *limit* — see "Verification" for the trade-off this costs. `web` (the
+  bundled nginx reverse proxy + static UI) and the bundled `postgresql` are
+  deliberately left Burstable/unchanged: neither ever held decrypted secret
+  material in its own process memory (`mlockall` was only ever called from
+  `server/main.go`; Postgres stores and serves ciphertext only, encryption
+  happens in the Go server before a write and after a read), so neither was
+  ever in this control's scope.
 
 ## What does not change
 
@@ -96,13 +123,22 @@ Three independent findings, each sufficient on its own:
 
 ## Operator guidance: deployment-level swap control
 
-Swap protection for a Keyorix server deployment should now be provided by
-the environment, not the process:
+Swap protection for a Keyorix server deployment is now provided by the
+environment, not the process — and, for the shipped Helm chart, by the
+chart's own default resource shape, not by operator diligence alone:
 
-- **Kubernetes:** nodes run with swap disabled by default; this is normally
-  already the case and requires no chart change. If a cluster has opted
-  into `NodeSwap`, exclude the nodes running Keyorix server pods from swap,
-  or pin the deployment to a node pool with swap disabled.
+- **Kubernetes, using this chart's defaults:** the server pod's Guaranteed
+  QoS class (see "What changes" above) means it receives zero swap under
+  `NodeSwap`'s `LimitedSwap` behavior regardless of whether the cluster or
+  node has opted into swap — no additional operator action is required
+  beyond leaving `server.resources.requests == server.resources.limits`
+  intact if `server.resources` is overridden. Overriding `server.resources`
+  to break that equality silently reopens this gap; there is no code-level
+  guard against a values.yaml override doing this (a `helm template` /
+  `helm lint` custom check could catch it, but is not implemented here).
+- **Kubernetes, nodes without `NodeSwap` at all:** the common case today —
+  nodes run with swap disabled by default, so this is already true
+  regardless of pod QoS class.
 - **systemd / bare metal / VM:** disable swap at the host level (`swapoff
   -a` and remove the relevant `swap` entry from `/etc/fstab`, or set
   `vm.swappiness=0` combined with no swap device at all for a stronger
@@ -147,14 +183,303 @@ the environment, not the process:
 
 ## Verification
 
+**Follow-up pass (2026-09-04, superseded again same day): observed values,
+real binary, real Linux container.** The original version of this ADR
+asserted the measurements above from a companion evidence document rather
+than from commands run in this ADR's own verification pass. A first
+follow-up (below, now itself superseded) closed that gap but used a single
+narrow scenario (50 secrets, one client) to size a Guaranteed-QoS
+reservation — insufficient, because `requests == limits` means the chosen
+number is capacity every install permanently withholds from its node. This
+section replaces that narrow measurement with a fuller matrix: secret count
+and client concurrency varied independently, the bundled deployment-wide CSV
+export and audit-log export surfaces exercised at the largest count tier,
+one memory-capped run to directly test for an OOM-kill at the limit
+`values.yaml` set, and one 30-minute sustained-load pass. All commands run
+directly against `server/Dockerfile`'s image, `linux/arm64` via this
+environment's Docker backend (OrbStack — not the `linux/amd64` architecture
+the shipped `ghcr.io/keyorixhq/keyorix-server` image and most production
+Kubernetes nodes run; not independently re-measured on `amd64` from this
+pass). Method: `docker exec <container> cat /proc/6/status` (PID 6 is the
+real server process; PID 1 is `entrypoint.sh`), reading `VmRSS`/`VmHWM`
+(peak-ever resident set for the process's lifetime so far);
+`docker inspect -f '{{.State.OOMKilled}}'` for the OOM check; load generated
+via real HTTP calls (`/auth/login` then `POST /api/v1/secrets`,
+`GET /api/v1/secrets`, `GET /api/v1/secrets/{id}` — not synthetic in-process
+allocation) using a small Python `ThreadPoolExecutor`-based driver
+(`.scratch/measure.py`, `.scratch/sustained.py`, not committed — throwaway
+per this repo's `.scratch/` convention, reproducible from the commands
+described here).
+
+- **`VmLck` is 0 at rest, confirming mlockall is genuinely gone** — the
+  literal line from `/proc/<pid>/status` inside the running container, no
+  special capability granted:
+  ```
+  VmLck:	       0 kB
+  ```
+- **Secret-count axis, concurrency held at 1** (sequential, one client),
+  cumulative on one running instance — 50 secrets at ~500KB (matching the
+  original narrow test, kept for continuity), then 950 more at a realistic
+  ~200B (typical API-key/password size) to reach 1,000, then 9,000 more at
+  ~200B to reach 10,000:
+  | Point | `VmRSS` | `VmHWM` (peak) |
+  |---|---|---|
+  | At rest | 23148 kB | 51192 kB |
+  | 50 secrets (50×~500KB) | 59084 kB | 61096 kB |
+  | 1,000 secrets (+950×~200B) | 44904 kB | 61096 kB (unchanged) |
+  | 10,000 secrets (+9,000×~200B) | 48040 kB | 61096 kB (unchanged) |
+
+  **Row count alone, at realistic per-secret size, does not drive memory.**
+  Growing the store 200x (50 → 10,000 rows) via small sequential writes
+  never raised the peak past what the original 50×500KB burst had already
+  set — each request's working set is independent and reclaimed before the
+  next.
+- **Bulk endpoints at the 10,000-row tier** (the scenario this matrix was
+  specifically designed to exercise — a large count meeting a bulk read):
+  | Endpoint | Response size | `VmRSS` after | `VmHWM` (peak) |
+  |---|---|---|---|
+  | `GET /api/v1/secrets?...&page_size=100` (paginated list) | 85029 B | 69236 kB | 69236 kB |
+  | `GET /api/v1/secrets/inventory.csv` (deployment-wide, **unbounded** — no `LIMIT`) | 746706 B (10,050 rows) | 57928 kB | 68288 kB |
+  | `GET /api/v1/audit/export.csv?limit=10000` (bounded, `csvExportMaxRows` cap) | 1221918 B (10,000 rows) | 48296 kB | 68288 kB (unchanged) |
+
+  **Also negligible.** The unbounded deployment-wide inventory export
+  materializes all 10,050 rows into memory before writing a single CSV byte
+  (`server/http/handlers/secrets_inventory_deployment_csv.go`) but each row
+  is metadata only (name, id, project, classification, owner, timestamps —
+  never a secret value), so 10k rows costs single-digit MB, not the
+  "row count becomes resident memory" risk this test was built to catch. Row
+  count is not the dominant cost driver for this dataset shape; concurrency
+  and per-request payload size are (below).
+- **Concurrency axis, secret count and size held fixed** (100 secrets per
+  burst, added on top of the running 10k-row instance), isolating
+  concurrency's own effect:
+  | Concurrency | Secret size | `VmHWM` (peak) after burst |
+  |---|---|---|
+  | 1 | 100KB | 68288 kB (unchanged) |
+  | 25 | 100KB | 85304 kB |
+  | 100 | 100KB | 128728 kB |
+  | 100 | 500KB | 237248 kB |
+  | 100 | 2MB | **581864 kB — exceeds the 512Mi (524288 KiB) limit** |
+
+  **Concurrency is the dominant driver, not count.** Throughput barely
+  changed between concurrency 1/25/100 at the same 100-secret/100KB size
+  (111 → 102 → 97.5 req/s — consistent with SQLite's single-writer lock
+  serializing the actual writes), but peak memory rose monotonically and
+  steeply (68 → 85 → 129 MB) purely from more requests being held in flight
+  simultaneously, with no corresponding throughput benefit. Combined with
+  payload size the effect compounds: 100 concurrent × 2MB secrets peaked at
+  568 MB, already past the shipped 512Mi limit, in an UNCAPPED container —
+  a smaller reservation would not have "handled" this more gracefully, it
+  would have been killed before reaching this reading.
+- **5-minute idle after the 2MB/concurrency=100 peak:** `VmRSS` fell from
+  the 332564 kB reading taken immediately after the burst to 36632 kB —
+  reclaimed almost completely once load actually stops. The peak is
+  transient, but it still has to be survived in the moment it happens.
+- **OOM-kill test, at the exact limit `values.yaml` sets.** Fresh container,
+  `docker run --memory=512m` (matching `server.resources.limits.memory:
+  512Mi` verbatim):
+  - Replaying the identical 100×2MB/concurrency=100 burst: peaked at 500864
+    kB (95.5% of the 524288 KiB cap) — survived, but by a margin thin enough
+    that GC-timing luck, not design headroom, is the reason it didn't tip
+    over (the uncapped run of the same scenario read 581864 kB — above the
+    cap — showing this is not a stable, repeatable "safe" number).
+  - Escalating to 200×2MB/concurrency=200 on the same capped container: the
+    process was killed. `docker inspect -f '{{.State.OOMKilled}}'` → `true`,
+    exit code 137. **The current 512Mi default is empirically not safe
+    against a plausible concurrent-large-secret burst.**
+- **30-minute sustained pass, moderate concurrency (25), mixed realistic
+  workload** (random per-iteration choice of create-a-~300B-secret /
+  paginated-list / list-then-fetch-one, real HTTP calls throughout, fresh
+  container):
+  | t | Iterations | `VmRSS` | `VmHWM` (peak) |
+  |---|---|---|---|
+  | start | 0 | 119948 kB | 198492 kB |
+  | +2min | 4,989 | 265104 kB | 298924 kB |
+  | +10min | 14,514 | 468256 kB | 506724 kB |
+  | +18min | 19,503 | 576680 kB | 618552 kB |
+  | +26min | 24,249 | 685712 kB | 713616 kB |
+  | +30min (test end) | 26,263 | 655172 kB | **723336 kB** |
+  | +5min further idle (test fully stopped) | — | 59276 kB | 723336 kB (unchanged) |
+
+  (The `start` reading is elevated above true cold-boot baseline — an
+  earlier, interrupted launch attempt of this same driver had already sent
+  some requests to this container before being killed and restarted; the
+  trend from `+2min` onward is unaffected and is what matters here.)
+
+  **RSS climbs steadily for the full 30 minutes and does not plateau** —
+  every 2-minute sample is higher than the last, right through the end of
+  the run, peaking at 723336 kB (**~1.4x the 512Mi limit**, achieved under
+  only *moderate* concurrency doing a realistic mixed workload, not an
+  adversarial burst). This is a lower bar to trigger than the burst
+  scenario above and arguably the more concerning finding. It is **not a
+  permanent leak**: 5 minutes after the driver stopped entirely, `VmRSS` had
+  fallen to 59276 kB, close to the true cold-boot baseline (~23 MB) — the
+  memory is reclaimable, just not reclaimed fast enough relative to the
+  sustained allocation rate for Go's default GC pacing (`GOGC=100`, no
+  `GOMEMLIMIT`) to keep the process anywhere near its steady-state minimum
+  while load continues.
+
+  **Leading cause identified, not just observed:** the server log for this
+  run contains 704 occurrences of `SECURITY: failed to persist audit event
+  "..." ... database is locked (SQLITE_BUSY)` out of 27,351 iterations
+  (~2.6%) — SQLite's single-writer lock rejecting concurrent audit-event
+  inserts under this load (logged and dropped, not silently — a real,
+  separate finding: audit events are lost under write contention on the
+  shipped default backend, worth its own follow-up, out of scope here). The
+  `.db-wal` file also grew to 59.5 MB over the run without being
+  checkpointed. Neither fact alone accounts for the full ~600 MB of growth,
+  but both point the same direction: **this is concurrent write contention
+  against the bundled SQLite backend under sustained load, not a Go-level
+  memory leak** — the growth's shape (steady climb, then full reclaim once
+  load stops) matches GC pacing lagging a sustained allocation rate, not an
+  accumulating retained data structure.
+- **Core dump suppression, red and green, via the real `ApplyMemoryHardening`
+  code path** (not a unit test in isolation): a throwaway harness
+  (`internal/hardening.ApplyMemoryHardening()` then a deliberate nil-pointer
+  dereference) built and run inside `golang:1.26-bookworm` (matching
+  ADR-098's own container choice), `GOTRACEBACK=crash`, `ulimit -c
+  unlimited`:
+  - **Red (baseline, hardening NOT called):** `panic: runtime error: invalid
+    memory address or nil pointer dereference` / `[signal SIGSEGV:
+    segmentation violation code=0x1 addr=0x0 pc=0xb0858]`, ending
+    `Aborted (core dumped)` — a 39.9 MB `core` file present afterward.
+  - **Green (hardening called first):** identical panic and SIGSEGV,
+    preceded by the real log line `hardening: core dumps disabled
+    (RLIMIT_CORE=0)`, ending `Aborted` (no `(core dumped)` suffix) — no
+    `core` file present afterward.
+- **`helm template` with default `values.yaml`: confirmed Guaranteed QoS.**
+  The rendered `server` Deployment's container resources:
+  ```yaml
+  resources:
+    limits:
+      cpu: 1
+      ephemeral-storage: 256Mi
+      memory: 512Mi
+    requests:
+      cpu: 1
+      ephemeral-storage: 64Mi
+      memory: 512Mi
+  ```
+  `cpu` and `memory` both have `requests == limits` for every field
+  Kubernetes' QoS classification actually considers (`ephemeral-storage`
+  requests/limits differ and this is fine — ephemeral-storage is not part of
+  QoS classification: "Containers in a Pod can request other resources (not
+  CPU or memory) and still be classified as `BestEffort`",
+  [kubernetes.io/docs/concepts/workloads/pods/pod-qos](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/)).
+  The bundled `postgresql` and `web` Deployments remain Burstable
+  (`requests != limits`), confirmed unchanged in the same rendered output —
+  intentional, see "What changes" above for why.
+- **Guaranteed-QoS/`NodeSwap` premise, confirmed against current upstream
+  docs, not assumed:**
+  [kubernetes.io/docs/concepts/workloads/pods/pod-qos](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/)
+  ("To be `Guaranteed`... Every Container in the Pod must have a memory
+  limit and a memory request, and they must be the same. Every Container in
+  the Pod must have a CPU limit and a CPU request, and they must be the
+  same." — memory alone does not suffice, which is why `cpu` requests were
+  also raised here, not just `memory`) and
+  [KEP-2400](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md)
+  ("Swap access is granted only for pods of Burstable QoS... Guaranteed QoS
+  pods are usually higher-priority pods, therefore we want to avoid swap's
+  performance penalty for them" — Guaranteed and Best-Effort pods are both
+  excluded). `NodeSwap` targeted GA in Kubernetes 1.32 per that KEP's
+  implementation history; this pass did not independently re-verify GA
+  landed exactly on schedule against a specific cluster version, only that
+  the QoS-eligibility rule itself is what the KEP and docs state.
+- **Could not verify:** a real production Kubernetes node's containerd/CRI-O
+  behavior end-to-end under an actual `NodeSwap`-enabled cluster (this
+  environment has no such cluster available) — the verification above is
+  the documented, specified behavior per Kubernetes' own KEP and docs, not
+  an end-to-end observed test against a live swap-enabled node.
 - `internal/hardening/memlock_test.go`: `TestApplyMemoryHardening_DisablesCoreDumps`
   and `TestApplyMemoryHardening_CoreDumpDisableFailureIsFatal` cover the two
   remaining branches of `ApplyMemoryHardening` (success, `setrlimit`
   failure) via the same injected-syscall pattern ADR-098 established, now
   without the mlockall-specific branches this change removes.
+- `internal/hardening/mlockall_removal_guard_test.go`: repo-wide guard
+  confirming no tracked or untracked-but-not-ignored `*.go` file references
+  the `Mlockall` identifier, with its own red/green self-test proving the
+  scan mechanism actually detects a deliberately reintroduced
+  `unix.Mlockall` call rather than passing vacuously.
 - `go build ./...`, `go vet`, `gofmt -l`, and `gosec -severity medium
   -exclude-generated` all clean on every package this change touches
   (`internal/hardening`, `internal/config`, `server`).
 - Confirmed no other reference to `MlockConfig`, `mlockallFn`, or
   `security.mlock.*` remains anywhere in the repository (`git grep`, not
   `grep -r`, across `*.go`/`*.yaml`/`*.yml`/`*.md`).
+
+## Sizing recommendation (2026-09-04 follow-up — not yet implemented)
+
+**The matrix above shows 512Mi is not a safe Guaranteed-QoS reservation.**
+It was OOM-killed under a directly-reproduced burst scenario, and a separate
+30-minute moderate-concurrency sustained run peaked at 723 MB (1.4x the
+limit) without plateauing. Neither is a contrived adversarial case — 100-200
+concurrent clients and 25 concurrent clients sustained are both ordinary
+multi-user load, not an attack.
+
+**Recommended: raise `server.resources.requests/limits.memory` to 768Mi**,
+keeping `requests == limits` (Guaranteed QoS, unchanged rationale). Headroom
+math: the single-burst worst case measured (100 concurrent × 2MB,
+uncapped) peaked at 582 MB; 768Mi (805,306,368 bytes) is ~1.4x that. This
+does **not** cover the sustained-pass peak (723 MB) with real margin on its
+own — see the `GOMEMLIMIT` recommendation below, which is what actually
+closes that gap, not a larger static number chasing an unbounded sustained
+scenario.
+
+**What this trades off:** every default install now permanently reserves
+768Mi instead of 512Mi — 256Mi of additional capacity every customer holds
+whether or not they ever approach it, on a product positioned as
+lightweight. The alternative (leave 512Mi and accept the OOM risk this
+matrix demonstrated) is not a real option once the risk is measured, not
+assumed — a Guaranteed-QoS pod that gets OOM-killed under ordinary
+concurrent use fails the exact goal (surviving ordinary load without
+disruption) the QoS change in the first follow-up was made for. This
+number is **not** sized to survive the sustained-load scenario indefinitely
+at 25-concurrency — see below for why that is deliberately a `GOMEMLIMIT`
+problem instead of an ever-larger static reservation.
+
+**Not implemented in this pass** — `deploy/helm/keyorix/values.yaml` still
+reads 512Mi as of this write-up; this is a recommendation for the next
+follow-up PR, stated here so the measurement and the decision aren't
+separated in time.
+
+## `GOMEMLIMIT`: recommended, ~85% of the container limit
+
+**Recommend setting `GOMEMLIMIT` to approximately 85% of
+`server.resources.limits.memory`** (e.g. `GOMEMLIMIT=650MiB` against a 768Mi
+container limit — leaving `GOGC` at its default rather than disabling it,
+per the Go team's own guidance for using `GOMEMLIMIT` as a backstop
+alongside percentage-based GC, not a replacement for it), set as an
+environment variable on the server container (no code change needed — the
+Go runtime reads it directly; `internal/config`/`server/main.go` need no
+new field).
+
+**Why:** the sustained-load finding above is exactly the failure mode
+`GOMEMLIMIT` exists for. Go's default GC (`GOGC=100`, no memory limit
+awareness at all when `GOMEMLIMIT` is unset — confirmed by `git grep -n
+"GOMEMLIMIT\|SetMemoryLimit" -- '*.go' '*.yaml' '*Dockerfile*'` returning
+zero hits anywhere in this repo, both before and after this pass) paces
+collection off heap *growth*, not proximity to any external ceiling — it has
+no way to know a hard cgroup limit exists at all, let alone that it is
+approaching one. Under the sustained scenario measured, RSS climbed for 30
+straight minutes with no sign of slowing down on its own; the only reason it
+didn't end in an OOM-kill is that the container had no cap during that
+specific run. With `GOMEMLIMIT` set, the runtime is required to run
+additional GC cycles as live heap approaches the configured limit — trading
+CPU (more frequent, harder-working collections) for staying alive, changing
+the failure mode from "hard kill, mid-request, no warning" to "degraded
+throughput/latency, visible in metrics, process stays up." This is a
+strictly better outcome for the exact scenario this pass measured, at the
+cost of GC CPU overhead under sustained pressure — not measured directly in
+this pass (would require comparing sustained-load CPU utilization with and
+without `GOMEMLIMIT` set, a follow-up measurement, not inferred here).
+
+**Not a substitute for the base container limit being large enough for
+ordinary bursts.** `GOMEMLIMIT` makes the GC work harder as the heap
+approaches it; it does not create memory the process doesn't have. A
+container limit sized for the single-burst worst case (the 768Mi
+recommendation above) still matters — `GOMEMLIMIT` is what keeps a
+*sustained* load from reaching that ceiling in the first place, not a way to
+shrink the ceiling itself.
+
+**Not implemented in this pass**, same status as the memory-limit
+recommendation above — stated here for the next follow-up PR to carry out.

--- a/internal/hardening/mlockall_removal_guard_test.go
+++ b/internal/hardening/mlockall_removal_guard_test.go
@@ -1,0 +1,141 @@
+/*
+Keyorix Server - Enterprise Secret Management System
+Copyright (C) 2025 Keyorix Contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+// mlockall_removal_guard_test.go asserts ADR-100's removal of mlockall stays
+// removed: nothing in this repo's tracked Go source reaches the mlockall
+// syscall from process startup. This is the "cannot be silently undone" half
+// of ADR-100's closure -- a future contributor re-adding `unix.Mlockall` (to
+// "fix" a swap-related incident, for example) would reintroduce exactly the
+// unbounded, non-shrinking RSS growth ADR-100 measured and removed, without
+// necessarily reading ADR-100 or ADR-098 first. A guard that fails loudly at
+// review/CI time is cheaper than that repeating in production.
+package hardening
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// scanRepoForMlockall reports every *.go file (repo-relative path)
+// containing the literal identifier "Mlockall", excluding this guard file
+// itself -- which necessarily spells out that identifier in the string
+// literals below and would otherwise self-match on every run regardless of
+// whether the real syscall is actually gone. Mirrors
+// server/http/g80_triage_doc_closure_guard_test.go's repoContains, scoped to
+// list every match rather than a single found/not-found bool (so a failure
+// message can name the offending file(s) directly), and additionally passes
+// --untracked --no-exclude-standard so a locally-created-but-not-yet-staged
+// reintroduction is caught too, not just one already added to the index --
+// confirmed empirically these two flags are both required: plain `git grep`
+// is invisible to files under .scratch/ (gitignored), which is exactly
+// where TestMlockallRemovalGuard_FiresOnADeliberateReintroduction below
+// plants its synthetic violation.
+func scanRepoForMlockall(t *testing.T, root string) []string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", root, "grep", "-l", "-F", "--untracked", "--no-exclude-standard", "Mlockall", "--",
+		"*.go", ":!internal/hardening/mlockall_removal_guard_test.go").CombinedOutput()
+	if err == nil {
+		return strings.Split(strings.TrimSpace(string(out)), "\n")
+	}
+	// git grep exits 1 (not an error) when nothing matches -- distinguish
+	// that from a real failure (e.g. not a git repo, bad pathspec) by
+	// checking for output; a real error with no output is unexpected here
+	// and should fail loud rather than be silently read as "no matches".
+	if len(out) == 0 {
+		return nil
+	}
+	t.Fatalf("git grep failed unexpectedly while scanning for Mlockall: %v (%s)", err, string(out))
+	return nil
+}
+
+// TestMlockallRemovalGuard_NoMlockallSyscallReachableFromStartup is the
+// green case: confirms the current working tree contains no reference to
+// unix.Mlockall (or any other identifier literally named "Mlockall")
+// anywhere in tracked Go source. If this ever fails, ADR-100's removal has
+// been reverted or reintroduced elsewhere and needs the same design
+// discussion ADR-100 itself required, not a silent re-add.
+func TestMlockallRemovalGuard_NoMlockallSyscallReachableFromStartup(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+	matches := scanRepoForMlockall(t, "../..")
+	if len(matches) > 0 {
+		t.Errorf("found %d file(s) referencing Mlockall -- ADR-100 removed this syscall from the startup path "+
+			"(unbounded, non-shrinking RSS growth measured against the shipped Helm chart's memory limit); "+
+			"re-adding it needs the same design decision ADR-100 required, not a silent reintroduction: %v",
+			len(matches), matches)
+	}
+}
+
+// TestMlockallRemovalGuard_FiresOnADeliberateReintroduction is the red case:
+// proves scanRepoForMlockall actually detects the identifier it exists to
+// catch, using a real (untracked, git-ignored by .scratch/ convention)
+// throwaway file written to and immediately removed from the repo root --
+// not just an assertion that today's tree is clean, which would pass
+// identically even if the scan itself were broken (e.g. a typo'd pathspec
+// that matches nothing).
+func TestMlockallRemovalGuard_FiresOnADeliberateReintroduction(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available on PATH")
+	}
+	repoRoot, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	if err != nil {
+		t.Fatalf("resolving repo root: %v (%s)", err, string(repoRoot))
+	}
+	root := strings.TrimSpace(string(repoRoot))
+
+	// .scratch/ is gitignored and, unlike a tracked directory, is not
+	// guaranteed to exist in a fresh checkout (e.g. CI, or any clone that
+	// hasn't already written a scratch file some other way) -- os.WriteFile
+	// does not create parent directories, so without this the write below
+	// fails with ENOENT on exactly that fresh-checkout case. Confirmed this
+	// was masked on a dev machine that already had .scratch/ from prior,
+	// unrelated scratch-file use, and reproduced the CI failure locally by
+	// running against a checkout with no .scratch/ directory at all.
+	scratchDir := root + "/.scratch"
+	if err := os.MkdirAll(scratchDir, 0700); err != nil {
+		t.Fatalf("creating .scratch/ directory: %v", err)
+	}
+
+	violationPath := scratchDir + "/mlockall_reintroduction_synthetic_test.go"
+	violationSrc := "package scratch\n\nimport \"golang.org/x/sys/unix\"\n\nfunc poison() error {\n\treturn unix.Mlockall(unix.MCL_CURRENT)\n}\n"
+	if err := os.WriteFile(violationPath, []byte(violationSrc), 0600); err != nil {
+		t.Fatalf("writing synthetic violation file: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(violationPath) })
+
+	// git grep only sees files git itself is aware of; -F/-l against an
+	// untracked file still matches because `git grep` (unlike `git log`
+	// based commands) searches the working tree by default, not just
+	// committed content -- confirmed by this test actually passing below,
+	// not assumed.
+	matches := scanRepoForMlockall(t, root)
+	found := false
+	for _, m := range matches {
+		if strings.HasSuffix(m, ".scratch/mlockall_reintroduction_synthetic_test.go") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("scanRepoForMlockall did not flag a deliberately reintroduced unix.Mlockall call -- "+
+			"the guard above would not catch a real reintroduction either; matches seen: %v", matches)
+	}
+}


### PR DESCRIPTION
## Summary

Re-lands PR #1709's payload, which was correctly reviewed and squash-merged
but landed on the stacked base branch `fix/1679-mlock-removal-base` instead
of `main` (that branch was itself already fully merged into `main` via #1707,
so the squash target was effectively a dead end). This PR cherry-picks
#1709's squash commit onto current `main`, verified byte-for-byte identical
in scope, plus one addition:

- **Helm `requests==limits` Guaranteed-QoS default** (`deploy/helm/keyorix`):
  unchanged from #1709 — confirmed via `helm template` that the server
  container renders `limits.cpu == requests.cpu == 1` and
  `limits.memory == requests.memory == 512Mi`.
- **`internal/hardening/mlockall_removal_guard_test.go`**: unchanged from
  #1709 — the anti-regression guard against `Mlockall` being silently
  reintroduced after #1707's removal.
- **ADR-100 correction** (new commit, not part of #1709's original squash):
  the ADR's own GOMEMLIMIT section was mid-edit — corrected but never
  committed — when #1709 was squashed. That correction was found uncommitted
  in the original PR worktree and is applied here as its own commit. It
  retracts the ADR's earlier claim that `GOMEMLIMIT` "closes the gap" for
  the sustained-load memory growth this ADR measured: `GOMEMLIMIT` is a
  *soft* limit, and against the unbounded cause actually identified (WAL
  growth + SQLite write-lock contention under sustained concurrency),
  forcing more GC work as heap approaches the ceiling produces a GC death
  spiral — CPU consumed by GC, throughput collapsing toward zero, no crash,
  `/health` still 200 — which is operationally *worse* than a clean
  OOM-kill. Adds a "Sustained load is not a memory-sizing problem" section
  concluding the real fix is closing the growth at its source (WAL
  checkpointing, write serialization), tracked separately.

Context: #1707 removed `mlockall` (issue/PR #1679) after measuring it pinned
`VmLck` at ~2.6x the shipped memory limit. #1709 closed the gap that removal
left open — the shipped Helm chart's Burstable-QoS default meant
`mlockall`'s replacement (node-level swap-disable guidance) wasn't backed by
a QoS class that actually gets zero swap under Kubernetes' `NodeSwap`.

Not included here: the audit-persist-loss reproduction test and the
memory-measurement harness discovered alongside the orphaned ADR edit —
those are out of scope for this recovery and will land separately (see
`wip/1709-followup-preservation` for the preserved originals).

## Test plan
- [x] `gofmt -l` clean on touched Go file
- [x] `go vet ./internal/hardening/...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/hardening/... -v` — all 4 tests pass, including the
      guard's own red/green mutation self-test
      (`TestMlockallRemovalGuard_FiresOnADeliberateReintroduction`)
- [x] `gosec -severity medium -exclude-generated` on `internal/hardening/...`
      — 0 issues
- [x] `helm lint` — 0 charts failed
- [x] `helm template` — confirmed rendered server resources are
      `requests == limits` for both cpu and memory