### PR TITLE
fix(web): close clipboard auto-clear bypass + login open-redirect precursor

### DIFF
--- a/web/src/features/dynamic-secrets/LeasesPanel.tsx
+++ b/web/src/features/dynamic-secrets/LeasesPanel.tsx
@@ -6,6 +6,7 @@ import { Alert } from '../../components/ui/Alert';
 import { IssuedCredential } from '../../services/dynamicSecrets';
 import { useDynamicLeases, useIssueLease, useRevokeLease, useRevokeAllLeases } from './api';
 import { useAutoClearOnIdle } from '../../hooks/useAutoClearOnIdle';
+import { copyToClipboard } from '../../utils';
 
 const leaseStatusStyle = (status: string): React.CSSProperties => {
     switch (status) {
@@ -29,8 +30,8 @@ const fieldLabel = (key: string): string => {
 
 const CopyRow: React.FC<{ label: string; value: string }> = ({ label, value }) => {
     const [copied, setCopied] = useState(false);
-    const copy = () => {
-        navigator.clipboard?.writeText(value);
+    const copy = async () => {
+        await copyToClipboard(value);
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
     };

--- a/web/src/features/dynamic-secrets/__tests__/LeasesPanel.test.tsx
+++ b/web/src/features/dynamic-secrets/__tests__/LeasesPanel.test.tsx
@@ -338,14 +338,18 @@ describe('LeasesPanel', () => {
         issueMutate.mockImplementation((_vars, opts) =>
             opts.onSuccess({ leaseId: 'lease-copy', username: 'app_user', password: 'super-secret' })
         );
-        vi.useFakeTimers();
+        // shouldAdvanceTime: copy() now routes through the async copyToClipboard
+        // util, so the label flip lands on a microtask after the click, not
+        // synchronously -- waitFor's internal polling needs real timer ticks to
+        // observe that, even though the timers below are otherwise faked.
+        vi.useFakeTimers({ shouldAdvanceTime: true });
 
         render(<LeasesPanel configId={5} canManage />);
         fireEvent.click(screen.getByRole('button', { name: /issue credential/i }));
 
         const copyButtons = screen.getAllByRole('button', { name: 'Copy' });
         fireEvent.click(copyButtons[0]);
-        expect(screen.getAllByRole('button', { name: 'Copied' })).toHaveLength(1);
+        await waitFor(() => expect(screen.getAllByRole('button', { name: 'Copied' })).toHaveLength(1));
 
         await act(async () => {
             await vi.advanceTimersByTimeAsync(2000);

--- a/web/src/features/machine-identities/MachineTokensPanel.tsx
+++ b/web/src/features/machine-identities/MachineTokensPanel.tsx
@@ -7,6 +7,7 @@ import { IssuedMachineToken } from '../../services/machineIdentities';
 import { classificationMeta, CLASSIFICATION_LEVELS } from '../secrets/classification';
 import { useMachineTokens, useIssueMachineToken, useRevokeMachineToken, useClassifyMachineToken } from './api';
 import { useAutoClearOnIdle } from '../../hooks/useAutoClearOnIdle';
+import { copyToClipboard } from '../../utils';
 
 /**
  * Machine-token credentials for one machine identity (ADR-030): issue an opaque
@@ -52,9 +53,9 @@ export const MachineTokensPanel: React.FC<{
         );
     };
 
-    const copy = () => {
+    const copy = async () => {
         if (!issued) return;
-        navigator.clipboard?.writeText(issued.token);
+        await copyToClipboard(issued.token);
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
     };

--- a/web/src/features/machine-identities/__tests__/MachineTokensPanel.test.tsx
+++ b/web/src/features/machine-identities/__tests__/MachineTokensPanel.test.tsx
@@ -136,7 +136,7 @@ describe('MachineTokensPanel', () => {
             vi.useRealTimers();
         });
 
-        it('reverts the Copy button label back to "Copy" after the timeout elapses', () => {
+        it('reverts the Copy button label back to "Copy" after the timeout elapses', async () => {
             issueMutate.mockImplementation((_vars, opts) => {
                 opts.onSuccess({
                     token: 'kx_machine_copy_secret',
@@ -145,14 +145,18 @@ describe('MachineTokensPanel', () => {
                     classification: '',
                 });
             });
-            vi.useFakeTimers();
+            // shouldAdvanceTime: copy() now routes through the async copyToClipboard
+            // util, so the label flip lands on a microtask after the click, not
+            // synchronously -- waitFor's internal polling needs real timer ticks to
+            // observe that, even though the timers below are otherwise faked.
+            vi.useFakeTimers({ shouldAdvanceTime: true });
 
             render(<MachineTokensPanel projectId={3} machineId={7} canManage />);
             fireEvent.change(screen.getByPlaceholderText('Token name…'), { target: { value: 'copy-test' } });
             fireEvent.click(screen.getByRole('button', { name: /issue token/i }));
 
             fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
-            expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+            await waitFor(() => expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument());
 
             act(() => {
                 vi.advanceTimersByTime(2000);

--- a/web/src/pages/auth/LoginPage.tsx
+++ b/web/src/pages/auth/LoginPage.tsx
@@ -4,6 +4,7 @@ import { LoginForm, PasswordResetForm, useAuth } from '../../features/auth';
 import { authService } from '../../services/auth';
 import { LoginFormData, PasswordResetRequest } from '../../types';
 import { ROUTES } from '../../constants';
+import { isSafeReturnTo } from '../../utils/routing';
 
 type AuthMode = 'login' | 'reset' | 'reset-success';
 
@@ -34,17 +35,20 @@ export const LoginPage: React.FC = () => {
         };
     }, []);
 
-    // Where to land after SSO — preserve the originally-requested route.
-    const ssoReturnTo = (location.state as any)?.from?.pathname || ROUTES.DASHBOARD;
+    // Where to land after SSO — preserve the originally-requested route. Validated
+    // the same way SSOCompletePage validates its own return_to on the way back
+    // (isSafeReturnTo), so a crafted `from` can't be smuggled through either leg.
+    const requestedFrom = (location.state as any)?.from?.pathname;
+    const safeFrom = requestedFrom && isSafeReturnTo(requestedFrom) ? requestedFrom : ROUTES.DASHBOARD;
+    const ssoReturnTo = safeFrom;
     const ssoHref = (name: string) =>
         `/auth/sso/${encodeURIComponent(name)}/login?return_to=${encodeURIComponent(ssoReturnTo)}`;
 
     useEffect(() => {
         if (isAuthenticated) {
-            const from = (location.state as any)?.from?.pathname || ROUTES.DASHBOARD;
-            navigate(from, { replace: true });
+            navigate(safeFrom, { replace: true });
         }
-    }, [isAuthenticated, navigate, location]);
+    }, [isAuthenticated, navigate, safeFrom]);
 
     useEffect(() => {
         clearError();

--- a/web/src/pages/auth/__tests__/LoginPage.test.tsx
+++ b/web/src/pages/auth/__tests__/LoginPage.test.tsx
@@ -149,6 +149,16 @@ describe('LoginPage', () => {
         expect(navigateMock).toHaveBeenCalledWith('/secrets', { replace: true });
     });
 
+    it('falls back to the dashboard rather than navigating to an unsafe protocol-relative from-path', () => {
+        window.history.pushState({ usr: { from: { pathname: '//evil.example.com/phish' } } }, '', '/login');
+        authState.isAuthenticated = true;
+        authState.isLoading = false;
+        render(<LoginPage />);
+
+        expect(navigateMock).toHaveBeenCalledWith('/dashboard', { replace: true });
+        expect(navigateMock).not.toHaveBeenCalledWith('//evil.example.com/phish', expect.anything());
+    });
+
     it('shows an SSO error banner from the sso_error query param', () => {
         window.history.pushState({}, '', '/login?sso_error=access_denied');
         render(<LoginPage />);
@@ -184,6 +194,15 @@ describe('LoginPage', () => {
 
         const oktaLink = screen.getByRole('link', { name: 'Sign in with okta' });
         expect(oktaLink).toHaveAttribute('href', '/auth/sso/okta/login?return_to=%2Fdashboard');
+    });
+
+    it('falls back to the dashboard in the SSO return_to param for an unsafe protocol-relative from-path', async () => {
+        window.history.pushState({ usr: { from: { pathname: '//evil.example.com/phish' } } }, '', '/login');
+        getSSOProvidersMock.mockResolvedValue(['google']);
+        render(<LoginPage />);
+
+        const googleLink = await screen.findByRole('link', { name: 'Sign in with google' });
+        expect(googleLink).toHaveAttribute('href', '/auth/sso/google/login?return_to=%2Fdashboard');
     });
 
     it('preserves the originally-requested route in the SSO return_to param', async () => {


### PR DESCRIPTION
## Summary
Two findings from an earlier unreviewed-modules security sweep (frontend) were re-verified against current `main` and found still open, while their siblings from the same sweep had already been fixed:

- **Clipboard auto-clear bypass**: `MachineTokensPanel` (machine token copy) and `LeasesPanel` (dynamic-secret lease credential copy) called `navigator.clipboard.writeText()` directly instead of the shared `copyToClipboard()` util, so the copied value never got cleared from the clipboard on a timeout — every other secret-copy surface in the app already does this correctly.
- **Login open-redirect precursor**: `LoginPage`'s post-login redirect uses `location.state`'s `from.pathname` directly with no validation, while its SSO sibling (`SSOCompletePage`) already validates via `isSafeReturnTo`. A protocol-relative path (`//evil.example.com/...`) reaches `navigate()` and the SSO `return_to` param unvalidated. The validation helper (`isSafeReturnTo`) already existed in `utils/routing.ts` for exactly this but was never wired into the regular login path.

## Fix
- Route both copy buttons through `copyToClipboard`.
- Validate `LoginPage`'s `from` (both the direct `navigate()` call and the SSO `return_to` param) through `isSafeReturnTo`, falling back to the dashboard on an unsafe path.

## Test plan
- [x] `pnpm type-check`, `pnpm lint`, `pnpm format:check`, `pnpm build` all clean
- [x] Full `pnpm test --run` green (3154 tests)
- [x] `MachineTokensPanel`/`LeasesPanel` copy-reset tests updated for the now-async `copy()` (label flip lands on a microtask under fake timers)
- [x] 2 new `LoginPage` regression tests (direct redirect + SSO `return_to`) asserting a protocol-relative `from` path falls back to the dashboard — red/green verified against the pre-fix code