### PR TITLE
fix(web): close GlobalInviteUserModal clipboard bypass + missing SENSITIVE_GC_TIME

### DIFF
--- a/web/src/features/admin/__tests__/api.test.ts
+++ b/web/src/features/admin/__tests__/api.test.ts
@@ -247,6 +247,24 @@ describe('useAdminCreateUser', () => {
         expect(users.create).toHaveBeenCalledWith(body);
         expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['admin-users'] });
     });
+
+    // G28: the response can carry a one-time setup-link/OTP credential. Without a
+    // short gcTime override, react-query's MutationCache would retain it for the
+    // default 5 minutes after the last observer unmounts.
+    it('does not retain the created-user response in the MutationCache once the component unmounts', async () => {
+        users.create.mockResolvedValueOnce({ id: 1, setup_link: { link_for_admin: 'https://k/x/abc' } });
+        const { wrapper, queryClient } = createWrapper();
+        const { result, unmount } = renderHook(() => useAdminCreateUser(), { wrapper });
+
+        act(() => {
+            result.current.mutate({ username: 'bob', email: 'bob@x.com', display_name: 'Bob' });
+        });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(queryClient.getMutationCache().getAll()).toHaveLength(1);
+
+        unmount();
+        await waitFor(() => expect(queryClient.getMutationCache().getAll()).toHaveLength(0));
+    });
 });
 
 describe('useAdminUpdateUser', () => {
@@ -412,6 +430,29 @@ describe('useResendSetupLink', () => {
         expect(users.resendSetupLink).toHaveBeenCalledWith(4);
         expect(result.current.data).toEqual({ email: 'a@b.com', channel: 'smtp', delivered: true });
         expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['stale-accounts'] });
+    });
+
+    // G28: the response carries a one-time setup-link credential. Without a short
+    // gcTime override, react-query's MutationCache would retain it for the default
+    // 5 minutes after the last observer unmounts.
+    it('does not retain the resent setup link in the MutationCache once the component unmounts', async () => {
+        users.resendSetupLink.mockResolvedValueOnce({
+            email: 'a@b.com',
+            channel: 'out_of_band',
+            delivered: false,
+            link_for_admin: 'https://k/x/resend',
+        });
+        const { wrapper, queryClient } = createWrapper();
+        const { result, unmount } = renderHook(() => useResendSetupLink(), { wrapper });
+
+        act(() => {
+            result.current.mutate(4);
+        });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(queryClient.getMutationCache().getAll()).toHaveLength(1);
+
+        unmount();
+        await waitFor(() => expect(queryClient.getMutationCache().getAll()).toHaveLength(0));
     });
 });
 

--- a/web/src/features/admin/api.ts
+++ b/web/src/features/admin/api.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../../services/client';
 import { adminApi } from '../../services/admin';
 import { usersApi, type ProjectAssignment } from '../../services/users';
-import { queryKeys } from '../../lib/queryClient';
+import { queryKeys, SENSITIVE_GC_TIME } from '../../lib/queryClient';
 import { useAuthStore } from '../../store/authStore';
 
 // ── Admin stats / roles / audit (admin-specific endpoints) ─────────────────
@@ -91,6 +91,9 @@ export const useAdminCreateUser = () => {
             project_assignments?: ProjectAssignment[];
         }) => usersApi.create(body),
         onSuccess: () => queryClient.invalidateQueries({ queryKey: ['admin-users'] }),
+        // G28: the response can carry a one-time setup-link/OTP credential -- don't
+        // let react-query's MutationCache retain it for the default 5 minutes.
+        gcTime: SENSITIVE_GC_TIME,
     });
 };
 
@@ -147,6 +150,9 @@ export const useResendSetupLink = () => {
     return useMutation({
         mutationFn: (id: number) => usersApi.resendSetupLink(id),
         onSuccess: () => queryClient.invalidateQueries({ queryKey: ['stale-accounts'] }),
+        // G28: the response carries a one-time setup-link credential -- don't let
+        // react-query's MutationCache retain it for the default 5 minutes.
+        gcTime: SENSITIVE_GC_TIME,
     });
 };
 

--- a/web/src/features/invitations/GlobalInviteUserModal.tsx
+++ b/web/src/features/invitations/GlobalInviteUserModal.tsx
@@ -7,6 +7,7 @@ import { SYSTEM_ROLES } from '../../services/users';
 import type { ProjectAssignment, SetupLinkResult } from '../../services/users';
 import { useCreateGlobalInvitation } from './api';
 import { inviteErrorMessage } from './inviteErrorMessage';
+import { copyToClipboard } from '../../utils';
 
 interface GlobalInviteUserModalProps {
     isOpen: boolean;
@@ -53,9 +54,9 @@ export const GlobalInviteUserModal: React.FC<GlobalInviteUserModalProps> = ({ is
         onClose();
     }
 
-    function handleCopy() {
+    async function handleCopy() {
         if (!result?.link_for_admin) return;
-        navigator.clipboard?.writeText(result.link_for_admin);
+        await copyToClipboard(result.link_for_admin);
         setCopied(true);
     }
 

--- a/web/src/features/invitations/__tests__/GlobalInviteUserModal.test.tsx
+++ b/web/src/features/invitations/__tests__/GlobalInviteUserModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, act } from '../../../test/test-utils';
+import { render, screen, fireEvent, act, waitFor } from '../../../test/test-utils';
 import { GlobalInviteUserModal } from '../GlobalInviteUserModal';
 
 const mutate = vi.fn();
@@ -8,6 +8,18 @@ let isPending = false;
 vi.mock('../api', () => ({
     useCreateGlobalInvitation: () => ({ mutate, isPending }),
 }));
+
+// The copy button must route through the shared copyToClipboard() util (which
+// clears the clipboard again after a timeout) rather than calling
+// navigator.clipboard.writeText() directly -- mock it so the assertion below can
+// tell the two apart. A regression back to the raw call would leave this spy
+// uncalled even though "Copied" still renders (the raw call sets copied state
+// too), which is why asserting on the label alone doesn't catch the bypass.
+const copyToClipboard = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../../utils', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../../utils')>();
+    return { ...actual, copyToClipboard: (...args: unknown[]) => copyToClipboard(...args) };
+});
 
 // The Headless UI Modal shell isn't the unit under test (and needs an
 // IntersectionObserver constructor the jsdom setup doesn't provide) — render its
@@ -41,6 +53,7 @@ const onClose = vi.fn();
 beforeEach(() => {
     mutate.mockReset();
     onClose.mockReset();
+    copyToClipboard.mockClear();
     isPending = false;
 });
 
@@ -164,7 +177,7 @@ describe('GlobalInviteUserModal', () => {
         expect(onClose).not.toHaveBeenCalled();
     });
 
-    it('copies the setup link and shows "Copied"', () => {
+    it('copies the setup link via the shared copyToClipboard util and shows "Copied"', async () => {
         mutate.mockImplementation((_vars, opts) =>
             opts.onSuccess({
                 invitation: { id: 12 },
@@ -176,16 +189,22 @@ describe('GlobalInviteUserModal', () => {
                 },
             })
         );
-        const writeText = vi.fn();
-        Object.assign(navigator, { clipboard: { writeText } });
 
         render(<GlobalInviteUserModal isOpen onClose={onClose} />);
         fireEvent.change(screen.getByPlaceholderText('jane@example.com'), { target: { value: 'carol@x.io' } });
         fireEvent.click(screen.getByRole('button', { name: /send invitation/i }));
         fireEvent.click(screen.getByRole('button', { name: /^copy$/i }));
 
-        expect(writeText).toHaveBeenCalledWith('https://k/x/abc');
-        expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument();
+        // The load-bearing assertion: a regression back to a raw
+        // navigator.clipboard.writeText() call would still flip the label to
+        // "Copied" (that state update doesn't depend on which copy path ran), so
+        // asserting on the label alone can't tell the two apart -- only this
+        // spy can.
+        expect(copyToClipboard).toHaveBeenCalledWith('https://k/x/abc');
+        // handleCopy now routes through the async copyToClipboard util, so the
+        // "Copied" label flip lands on a microtask after the click, not
+        // synchronously -- wait for it rather than asserting immediately.
+        await waitFor(() => expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument());
     });
 
     it('shows the email-delivery success copy (no link_for_admin) with the channel', () => {

--- a/web/src/features/invitations/__tests__/api.test.ts
+++ b/web/src/features/invitations/__tests__/api.test.ts
@@ -92,6 +92,27 @@ describe('useCreateGlobalInvitation', () => {
         expect(mock.createGlobal).toHaveBeenCalledWith('carol@example.com', 'system_viewer', assignments);
         expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: INVITATION_KEYS.all });
     });
+
+    // G28: the response carries a one-time setup-link credential. Without a short
+    // gcTime override, react-query's MutationCache would retain it for the default
+    // 5 minutes after the last observer unmounts.
+    it('does not retain the setup link in the MutationCache once the component unmounts', async () => {
+        mock.createGlobal.mockResolvedValueOnce({
+            invitation: { id: 10 },
+            setup_link: { link_for_admin: 'https://k/x/global' },
+        });
+        const { wrapper, queryClient } = createWrapper();
+        const { result, unmount } = renderHook(() => useCreateGlobalInvitation(), { wrapper });
+
+        act(() => {
+            result.current.mutate({ email: 'carol@example.com', role: 'system_viewer', assignments: [] });
+        });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(queryClient.getMutationCache().getAll()).toHaveLength(1);
+
+        unmount();
+        await waitFor(() => expect(queryClient.getMutationCache().getAll()).toHaveLength(0));
+    });
 });
 
 describe('useRevokeInvitation', () => {

--- a/web/src/features/invitations/api.ts
+++ b/web/src/features/invitations/api.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { projectInvitationsApi } from '../../services/projectInvitations';
 import { PROJECT_KEYS } from '../projects/api';
+import { SENSITIVE_GC_TIME } from '../../lib/queryClient';
 
 // ADR-024 query keys, namespaced per project.
 export const INVITATION_KEYS = {
@@ -46,6 +47,9 @@ export function useCreateGlobalInvitation() {
             assignments: { project_id: number; role: string }[];
         }) => projectInvitationsApi.createGlobal(email, role, assignments),
         onSuccess: () => queryClient.invalidateQueries({ queryKey: INVITATION_KEYS.all }),
+        // G28: the response carries a one-time setup-link credential -- don't let
+        // react-query's MutationCache retain it for the default 5 minutes.
+        gcTime: SENSITIVE_GC_TIME,
     });
 }
 


### PR DESCRIPTION
## Summary
Two more MEDIUM/LOW findings from a follow-up frontend security pass (this is a continuation of the same sweep that produced #1729):

- **Clipboard auto-clear bypass**: `GlobalInviteUserModal.tsx`'s copy button called `navigator.clipboard.writeText()` directly for a one-time account-setup-link token, instead of the shared `copyToClipboard()` util every other one-time-credential surface uses (including the machine-token/lease-credential copy buttons fixed in #1729) — a direct sibling of that same bug, in a modal the earlier fix didn't touch.
- **Missing `SENSITIVE_GC_TIME`**: `useAdminCreateUser`, `useResendSetupLink`, and `useCreateGlobalInvitation` all return one-time plaintext setup-link/OTP credentials but didn't set `gcTime: SENSITIVE_GC_TIME`, unlike every other one-time-credential mutation in the app, per the app's own documented convention in `lib/queryClient.ts`.

(A third finding from this pass — CSV/formula-injection escaping in `AuditLogPage.tsx` — turned out to already be fixed on `main` by an earlier, independent commit; verified directly, no change needed, not included here.)

## Test plan
- [x] `pnpm type-check`, `pnpm lint`, `pnpm format:check`, `pnpm test --run`, `pnpm build` all clean
- [x] New/updated regression tests for both fixes, red/green verified (temporarily reverted each fix, confirmed the corresponding test fails, restored and confirmed green)