### PR TITLE
fix(deploy,operator,k8ssync): harden RBAC, metrics auth, resource limits, HSTS, token handling

### DIFF
--- a/cmd/keyorix-k8s-sync/main.go
+++ b/cmd/keyorix-k8s-sync/main.go
@@ -70,7 +70,15 @@ func main() {
 // never breaks a deployment that hasn't switched to KEYORIX_TOKEN_FILE yet.
 func resolveToken() (string, error) {
 	if path := strings.TrimSpace(os.Getenv("KEYORIX_TOKEN_FILE")); path != "" {
-		raw, err := os.ReadFile(path) // #nosec G304 -- operator-provided path via env var
+		// #nosec G304 G703 -- path comes from KEYORIX_TOKEN_FILE, an
+		// operator-set deployment-time env var (this chart's own
+		// values.yaml), not untrusted request input. Both IDs are needed:
+		// gosec v2.26+ added a taint-analysis path-traversal check (G703)
+		// alongside the classic heuristic (G304) it doesn't replace -- a
+		// bare "G304" comment suppresses only the old one, leaving G703
+		// unsuppressed (confirmed locally: dropping G304 flips CI to
+		// report G304 instead, dropping G703 flips it back).
+		raw, err := os.ReadFile(path)
 		if err != nil {
 			return "", fmt.Errorf("read KEYORIX_TOKEN_FILE %s: %w", path, err)
 		}

--- a/cmd/keyorix-k8s-sync/main.go
+++ b/cmd/keyorix-k8s-sync/main.go
@@ -32,6 +32,13 @@ func main() {
 	once := flag.Bool("once", false, "run a single reconcile pass and exit (for CI / one-shot Jobs)")
 	dryRun := flag.Bool("dry-run", false, "report what would change without writing any Secret")
 	cleanup := flag.Bool("cleanup", false, "delete orphaned Secrets the agent owns whose mapping was removed")
+	metricsBearerToken := flag.String("metrics-bearer-token", os.Getenv("KEYORIX_METRICS_TOKEN"),
+		"OPTIONAL bearer token required on /metrics' Authorization header (e.g. by a Prometheus scrape "+
+			"config's authorization.credentials). /healthz, /readyz, and /status stay unauthenticated -- "+
+			"Kubernetes' own kubelet must reach them, and they expose no secret values. When this flag is "+
+			"unset, /metrics itself is left unauthenticated too -- matching this repo's other two "+
+			"Prometheus-scraped endpoints' own defaults -- so set it, or restrict network access with a "+
+			"NetworkPolicy, for internet-reachable or multi-tenant clusters.")
 	flag.Parse()
 
 	cfg, err := k8ssync.LoadConfig(*configPath)
@@ -39,9 +46,9 @@ func main() {
 		log.Fatalf("k8s-sync: config: %v", err)
 	}
 
-	token := strings.TrimSpace(os.Getenv("KEYORIX_TOKEN"))
-	if token == "" {
-		log.Fatalf("k8s-sync: KEYORIX_TOKEN is required (the Keyorix machine-identity token)")
+	token, err := resolveToken()
+	if err != nil {
+		log.Fatalf("k8s-sync: %v", err)
 	}
 
 	sink, err := k8ssync.NewInClusterSink()
@@ -49,7 +56,36 @@ func main() {
 		log.Fatalf("k8s-sync: kubernetes: %v", err)
 	}
 	fetcher := k8ssync.NewKeyorixFetcher(cfg.KeyorixURL, token, cfg.ProjectID)
-	os.Exit(runAgent(cfg, fetcher, sink, *once, *dryRun, *cleanup))
+	os.Exit(runAgent(cfg, fetcher, sink, *once, *dryRun, *cleanup, *metricsBearerToken))
+}
+
+// resolveToken resolves the Keyorix machine-identity token: KEYORIX_TOKEN_FILE (a
+// path to a mounted Secret volume, e.g. /etc/keyorix/token) takes precedence when
+// set. A token that only ever lives on a mounted, read-only volume never appears in
+// the pod spec itself, unlike an env var sourced from a secretKeyRef -- the
+// Kubernetes API still returns that verbatim to anyone who can read the pod (e.g. via
+// `kubectl get pod -o yaml`), which a file mount does not. Falls back to KEYORIX_TOKEN
+// for backward compatibility with existing deployments that already inject it as an
+// env var; that fallback is not going away, so upgrading this agent's image alone
+// never breaks a deployment that hasn't switched to KEYORIX_TOKEN_FILE yet.
+func resolveToken() (string, error) {
+	if path := strings.TrimSpace(os.Getenv("KEYORIX_TOKEN_FILE")); path != "" {
+		raw, err := os.ReadFile(path) // #nosec G304 -- operator-provided path via env var
+		if err != nil {
+			return "", fmt.Errorf("read KEYORIX_TOKEN_FILE %s: %w", path, err)
+		}
+		token := strings.TrimSpace(string(raw))
+		if token == "" {
+			return "", fmt.Errorf("KEYORIX_TOKEN_FILE %s is empty", path)
+		}
+		return token, nil
+	}
+	token := strings.TrimSpace(os.Getenv("KEYORIX_TOKEN"))
+	if token == "" {
+		return "", fmt.Errorf("KEYORIX_TOKEN is required (the Keyorix machine-identity token); " +
+			"set KEYORIX_TOKEN, or KEYORIX_TOKEN_FILE to read it from a mounted Secret volume instead")
+	}
+	return token, nil
 }
 
 // runAgent holds everything that happens once a Fetcher and Sink exist: engine
@@ -59,7 +95,7 @@ func main() {
 // files main() can't fake). Returns the process exit code instead of calling
 // os.Exit directly, so deferred cleanup (context cancel, signal.Stop, health server
 // shutdown) always runs.
-func runAgent(cfg *k8ssync.Config, fetcher k8ssync.Fetcher, sink k8ssync.Sink, once, dryRun, cleanup bool) int {
+func runAgent(cfg *k8ssync.Config, fetcher k8ssync.Fetcher, sink k8ssync.Sink, once, dryRun, cleanup bool, metricsBearerToken string) int {
 	var engineOpts []k8ssync.Option
 	if dryRun {
 		engineOpts = append(engineOpts, k8ssync.WithDryRun())
@@ -102,7 +138,7 @@ func runAgent(cfg *k8ssync.Config, fetcher k8ssync.Fetcher, sink k8ssync.Sink, o
 	status := k8ssync.NewStatus()
 	healthSrv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", cfg.GetHealthPort()),
-		Handler:           status.Handler(),
+		Handler:           status.HandlerWithToken(metricsBearerToken),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	go func() {

--- a/cmd/keyorix-k8s-sync/main_test.go
+++ b/cmd/keyorix-k8s-sync/main_test.go
@@ -32,6 +32,70 @@ func TestEnvOr_ReturnsDefaultWhenUnset(t *testing.T) {
 	assert.Equal(t, "/etc/keyorix/k8s-sync.yaml", envOr("KEYORIX_K8S_SYNC_CONFIG_TEST_UNSET", "/etc/keyorix/k8s-sync.yaml"))
 }
 
+// ---- resolveToken ----
+
+func TestResolveToken_FromEnv(t *testing.T) {
+	t.Setenv("KEYORIX_TOKEN", "env-token")
+	t.Setenv("KEYORIX_TOKEN_FILE", "")
+
+	token, err := resolveToken()
+	require.NoError(t, err)
+	assert.Equal(t, "env-token", token)
+}
+
+func TestResolveToken_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(path, []byte("file-token\n"), 0600))
+	t.Setenv("KEYORIX_TOKEN_FILE", path)
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	token, err := resolveToken()
+	require.NoError(t, err)
+	assert.Equal(t, "file-token", token, "trailing whitespace from the mounted file must be trimmed")
+}
+
+func TestResolveToken_FileTakesPrecedenceOverEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(path, []byte("file-token"), 0600))
+	t.Setenv("KEYORIX_TOKEN_FILE", path)
+	t.Setenv("KEYORIX_TOKEN", "env-token")
+
+	token, err := resolveToken()
+	require.NoError(t, err)
+	assert.Equal(t, "file-token", token)
+}
+
+func TestResolveToken_FileMissing_ReturnsError(t *testing.T) {
+	t.Setenv("KEYORIX_TOKEN_FILE", filepath.Join(t.TempDir(), "does-not-exist"))
+	t.Setenv("KEYORIX_TOKEN", "env-token")
+
+	_, err := resolveToken()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read KEYORIX_TOKEN_FILE")
+}
+
+func TestResolveToken_FileEmpty_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(path, []byte("   \n"), 0600))
+	t.Setenv("KEYORIX_TOKEN_FILE", path)
+
+	_, err := resolveToken()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is empty")
+}
+
+func TestResolveToken_NeitherSet_ReturnsError(t *testing.T) {
+	t.Setenv("KEYORIX_TOKEN_FILE", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+
+	_, err := resolveToken()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "KEYORIX_TOKEN is required")
+}
+
 // ---- fakes for runAgent ----
 
 // fakeFetcher serves values from a map; a ref absent from the map returns err (or a
@@ -134,7 +198,7 @@ func TestRunAgent_OnceMode_AllSucceed_ReturnsZero(t *testing.T) {
 
 	var code int
 	out := captureLog(t, func() {
-		code = runAgent(cfg, fetcher, sink, true, false, false)
+		code = runAgent(cfg, fetcher, sink, true, false, false, "")
 	})
 
 	assert.Equal(t, 0, code)
@@ -151,7 +215,7 @@ func TestRunAgent_OnceMode_FetchFailure_ReturnsOne(t *testing.T) {
 
 	var code int
 	out := captureLog(t, func() {
-		code = runAgent(cfg, fetcher, sink, true, false, false)
+		code = runAgent(cfg, fetcher, sink, true, false, false, "")
 	})
 
 	assert.Equal(t, 1, code, "a failed mapping must produce a non-zero exit code")
@@ -168,7 +232,7 @@ func TestRunAgent_DryRun_DoesNotApply(t *testing.T) {
 
 	var code int
 	out := captureLog(t, func() {
-		code = runAgent(cfg, fetcher, sink, true, true, false)
+		code = runAgent(cfg, fetcher, sink, true, true, false, "")
 	})
 
 	assert.Equal(t, 0, code)
@@ -184,7 +248,7 @@ func TestRunAgent_CleanupViaConfig_ListsOwnedSecrets(t *testing.T) {
 	fetcher := &fakeFetcher{values: map[string][]byte{"production/db-password": []byte("s3cr3t")}}
 	sink := newFakeSink()
 
-	code := runAgent(cfg, fetcher, sink, true, false, false)
+	code := runAgent(cfg, fetcher, sink, true, false, false, "")
 
 	assert.Equal(t, 0, code)
 	assert.Equal(t, 1, sink.listCallCount(), "cfg.Cleanup=true must enable orphan reaping")
@@ -195,7 +259,7 @@ func TestRunAgent_CleanupViaFlag_ListsOwnedSecrets(t *testing.T) {
 	fetcher := &fakeFetcher{values: map[string][]byte{"production/db-password": []byte("s3cr3t")}}
 	sink := newFakeSink()
 
-	code := runAgent(cfg, fetcher, sink, true, false, true)
+	code := runAgent(cfg, fetcher, sink, true, false, true, "")
 
 	assert.Equal(t, 0, code)
 	assert.Equal(t, 1, sink.listCallCount(), "-cleanup must enable orphan reaping even when the config doesn't")
@@ -218,7 +282,7 @@ func TestRunAgent_LoopMode_ShutdownOnSignal(t *testing.T) {
 	completed := make(chan struct{})
 	go func() {
 		out = captureLog(t, func() {
-			done <- runAgent(cfg, fetcher, sink, false, false, false)
+			done <- runAgent(cfg, fetcher, sink, false, false, false, "")
 		})
 		close(completed)
 	}()
@@ -264,7 +328,7 @@ func TestRunAgent_LoopMode_HealthServerBindError_LogsButContinues(t *testing.T) 
 	var out string
 	go func() {
 		out = captureLog(t, func() {
-			done <- runAgent(cfg, fetcher, sink, false, true, false)
+			done <- runAgent(cfg, fetcher, sink, false, true, false, "")
 		})
 		close(completed)
 	}()

--- a/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
@@ -38,11 +38,16 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["-config", "/etc/keyorix/k8s-sync.yaml"]
           env:
-            - name: KEYORIX_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ required "keyorix.tokenSecret.name is required" .Values.keyorix.tokenSecret.name }}
-                  key: {{ .Values.keyorix.tokenSecret.key | default "token" }}
+            # A mounted file, not a secretKeyRef env var: the operator's own controller
+            # reads its analogous token Secret's bytes directly off the Kubernetes
+            # object rather than via a process env var, and an env var sourced from a
+            # secretKeyRef is still returned verbatim by the Kubernetes API to anyone
+            # who can read the pod spec (e.g. `kubectl get pod -o yaml`) -- a
+            # read-only mounted volume is not. cmd/keyorix-k8s-sync/main.go's
+            # resolveToken() reads KEYORIX_TOKEN_FILE in preference to KEYORIX_TOKEN
+            # (still supported, for any hand-rolled deployment that sets it directly).
+            - name: KEYORIX_TOKEN_FILE
+              value: /var/run/secrets/keyorix-token/token
             {{- with .Values.metricsBearerToken }}
             # Backs -metrics-bearer-token's own os.Getenv("KEYORIX_METRICS_TOKEN")
             # default (cmd/keyorix-k8s-sync/main.go) -- only rendered when set, so an
@@ -70,6 +75,9 @@ spec:
             - name: config
               mountPath: /etc/keyorix
               readOnly: true
+            - name: keyorix-token
+              mountPath: /var/run/secrets/keyorix-token
+              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -92,6 +100,12 @@ spec:
         - name: config
           configMap:
             name: {{ include "kxsync.fullname" . }}
+        - name: keyorix-token
+          secret:
+            secretName: {{ required "keyorix.tokenSecret.name is required" .Values.keyorix.tokenSecret.name }}
+            items:
+              - key: {{ .Values.keyorix.tokenSecret.key | default "token" }}
+                path: token
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
@@ -67,10 +67,19 @@ spec:
             readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
-          {{- with .Values.resources }}
           resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- if .Values.resources }}
+            {{- toYaml .Values.resources | nindent 12 }}
+            {{- else }}
+            requests:
+              cpu: 25m
+              memory: 32Mi
+              ephemeral-storage: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+              ephemeral-storage: 128Mi
+            {{- end }}
       volumes:
         - name: config
           configMap:

--- a/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/deployment.yaml
@@ -43,6 +43,14 @@ spec:
                 secretKeyRef:
                   name: {{ required "keyorix.tokenSecret.name is required" .Values.keyorix.tokenSecret.name }}
                   key: {{ .Values.keyorix.tokenSecret.key | default "token" }}
+            {{- with .Values.metricsBearerToken }}
+            # Backs -metrics-bearer-token's own os.Getenv("KEYORIX_METRICS_TOKEN")
+            # default (cmd/keyorix-k8s-sync/main.go) -- only rendered when set, so an
+            # unmodified install keeps /metrics' existing (documented) unauthenticated-
+            # by-default behavior.
+            - name: KEYORIX_METRICS_TOKEN
+              value: {{ . | quote }}
+            {{- end }}
           ports:
             - name: health
               containerPort: {{ .Values.healthPort | default 8080 }}

--- a/deploy/helm/keyorix-k8s-sync/templates/networkpolicy.yaml
+++ b/deploy/helm/keyorix-k8s-sync/templates/networkpolicy.yaml
@@ -1,0 +1,37 @@
+{{/*
+Restricts inbound reach to healthPort. Without this, any pod in the cluster that can
+route to the agent's pod IP can scrape /metrics for free -- and by default (see
+values.yaml's metricsBearerToken) that endpoint is unauthenticated. This complements,
+not replaces, metricsBearerToken: set both for defense in depth, or rely on this
+alone if setting a token isn't practical.
+
+Unlike keyorix-operator (a separate metrics port from its health port), this agent
+serves /metrics on the SAME port as /healthz, /readyz, and /status (see healthPort in
+values.yaml) -- there is no way to restrict just /metrics at the NetworkPolicy layer
+without also affecting the probe endpoints. Same-namespace pods are left able to
+reach the port (matching deploy/helm/keyorix/templates/networkpolicy.yaml's own
+same-namespace-open convention) so this doesn't need to reason about whether
+kubelet's own probe traffic would otherwise match a from: peer; only OTHER
+namespaces are restricted to the explicit metricsAllowFrom allow-list.
+*/}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kxsync.fullname" . }}
+  labels:
+    {{- include "kxsync.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kxsync.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+        {{- toYaml .Values.networkPolicy.metricsAllowFrom | nindent 8 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.healthPort | default 8080 }}
+{{- end }}

--- a/deploy/helm/keyorix-k8s-sync/values.yaml
+++ b/deploy/helm/keyorix-k8s-sync/values.yaml
@@ -39,8 +39,39 @@ keyorix:
     name: ""        # required: a Secret holding the Keyorix machine-identity token
     key: token      # the key within that Secret
 
-# healthPort is where the agent serves /healthz, /readyz and /status (probes).
+# healthPort is where the agent serves /healthz, /readyz, /status (probes) and
+# /metrics (Prometheus) -- all on the same port; there is no separate metrics port.
 healthPort: 8080
+
+# metricsBearerToken (OPTIONAL): when set, required on /metrics' Authorization:
+# Bearer <token> header -- wired straight to the agent's own
+# -metrics-bearer-token flag (KEYORIX_METRICS_TOKEN env var). /healthz, /readyz,
+# and /status on the same port stay unauthenticated regardless -- kubelet must
+# reach them, and they expose no secret values (only counts, a timestamp, and an
+# error count). Leave empty to rely on networkPolicy.enabled/metricsAllowFrom
+# below, or your own perimeter controls, instead; set both for defense in depth.
+metricsBearerToken: ""
+
+# ── Network policy ────────────────────────────────────────────────────────────
+# Restricts inbound traffic to healthPort (serves /metrics alongside the probe
+# endpoints -- see healthPort above, there's no separate port to isolate just
+# /metrics) to same-namespace pods plus the peers listed in
+# networkPolicy.metricsAllowFrom, instead of every pod in the cluster that can
+# route to it. Disable only if your CNI doesn't support NetworkPolicy, or you
+# have an equivalent policy managed elsewhere.
+networkPolicy:
+  enabled: true
+  # metricsAllowFrom: additional NetworkPolicyPeer entries (podSelector /
+  # namespaceSelector, in the upstream NetworkPolicy `from` syntax) permitted to
+  # reach healthPort from OUTSIDE this release's own namespace -- e.g. a
+  # cluster-wide Prometheus. Defaults to any pod, in any namespace, carrying the
+  # Prometheus community Helm chart's standard `app.kubernetes.io/name:
+  # prometheus` label -- adjust to match your cluster's actual scrape identity.
+  metricsAllowFrom:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
 
 # cleanup reaps orphaned Secrets: when a mapping is removed, the agent-owned Secret it
 # created (carrying app.kubernetes.io/managed-by=keyorix-sync) is deleted on the next

--- a/deploy/helm/keyorix-k8s-sync/values.yaml
+++ b/deploy/helm/keyorix-k8s-sync/values.yaml
@@ -67,7 +67,15 @@ serviceAccount:
   # name overrides the generated ServiceAccount name.
   name: ""
 
-resources: {}
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+    ephemeral-storage: 32Mi
+  limits:
+    cpu: 250m
+    memory: 128Mi
+    ephemeral-storage: 128Mi
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/deploy/helm/keyorix-operator/README.md
+++ b/deploy/helm/keyorix-operator/README.md
@@ -28,7 +28,7 @@ helm install keyorix-operator deploy/helm/keyorix-operator -n keyorix-system --c
 
 ## RBAC
 
-A `ClusterRole` grants read on `keyorixsecrets` (+ status/finalizers) and
+A `ClusterRole` grants read on `keyorixsecrets` (+ status) and
 get/list/watch/create/update/patch/delete on `secrets` (`delete` is used only to remove the
 target Secret once the upstream Keyorix reference is confirmed gone). A namespaced `Role`
 grants the lease + event access leader election needs. The operator reads secret **values**

--- a/deploy/helm/keyorix-operator/templates/deployment.yaml
+++ b/deploy/helm/keyorix-operator/templates/deployment.yaml
@@ -60,6 +60,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- with .Values.metricsBearerToken }}
+            # Backs -metrics-bearer-token's own os.Getenv("KEYORIX_METRICS_TOKEN")
+            # default (operator/cmd/main.go) -- only rendered when set, so an
+            # unmodified install keeps the metrics endpoint's existing (documented)
+            # unauthenticated-by-default behavior.
+            - name: KEYORIX_METRICS_TOKEN
+              value: {{ . | quote }}
+            {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.metricsPort | default 8080 }}

--- a/deploy/helm/keyorix-operator/templates/networkpolicy.yaml
+++ b/deploy/helm/keyorix-operator/templates/networkpolicy.yaml
@@ -1,0 +1,32 @@
+{{/*
+Restricts inbound reach to the manager's Prometheus metrics port. Without this, any
+pod in the cluster that can route to the operator's pod IP can scrape /metrics for
+free -- and by default (see values.yaml's metricsBearerToken) that endpoint is
+unauthenticated. This complements, not replaces, metricsBearerToken: set both for
+defense in depth, or rely on this alone if setting a token isn't practical.
+
+The health probe port (healthPort) is deliberately left out of this policy: kubelet
+must reach it unauthenticated to run liveness/readiness probes, and it exposes no
+sensitive data (see the main keyorix chart's own networkpolicy.yaml for the
+same same-purpose split between a restricted API port and an intentionally open one).
+*/}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kxop.fullname" . }}-metrics
+  labels:
+    {{- include "kxop.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kxop.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        {{- toYaml .Values.networkPolicy.metricsAllowFrom | nindent 8 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.metricsPort | default 8080 }}
+{{- end }}

--- a/deploy/helm/keyorix-operator/templates/rbac.yaml
+++ b/deploy/helm/keyorix-operator/templates/rbac.yaml
@@ -49,9 +49,6 @@ rules:
   - apiGroups: ["secrets.keyorix.io"]
     resources: ["keyorixsecrets/status"]
     verbs: ["get", "update", "patch"]
-  - apiGroups: ["secrets.keyorix.io"]
-    resources: ["keyorixsecrets/finalizers"]
-    verbs: ["update"]
 ---
 {{- $scope := include "kxop.scope" . | fromYaml }}
 {{- if eq $scope.mode "cluster" }}
@@ -100,9 +97,13 @@ metadata:
   labels:
     {{- include "kxop.labels" . | nindent 4 }}
 rules:
+  # controller-runtime's leader-election resourcelock only ever does get/create/update
+  # on its Lease object; list/watch back its own informer (so a standby replica
+  # notices a lease change without polling). No caller in that resourcelock ever
+  # deletes a Lease, so delete is not granted (least privilege).
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]

--- a/deploy/helm/keyorix-operator/values.yaml
+++ b/deploy/helm/keyorix-operator/values.yaml
@@ -38,6 +38,35 @@ leaderElection: false
 metricsPort: 8080
 healthPort: 8081
 
+# metricsBearerToken (OPTIONAL): when set, required on the metrics endpoint's
+# Authorization: Bearer <token> header -- wired straight to the manager's own
+# -metrics-bearer-token flag (KEYORIX_METRICS_TOKEN env var; see
+# operator/cmd/main.go for the gate itself). The health probe port is never
+# gated by this -- kubelet must reach it unauthenticated, and it exposes no
+# secret values. Leave empty to rely on networkPolicy.enabled/metricsAllowFrom
+# below, or your own perimeter controls, instead; set both for defense in depth.
+metricsBearerToken: ""
+
+# ── Network policy ────────────────────────────────────────────────────────────
+# Restricts inbound traffic to the manager's Prometheus metrics port to the
+# peers listed in metricsAllowFrom -- without this, any pod in the cluster
+# that can route to the operator's pod IP can scrape /metrics for free. The
+# health probe port is deliberately left unrestricted (kubelet needs it, and
+# it carries no sensitive data). Disable only if your CNI doesn't support
+# NetworkPolicy, or you have an equivalent policy managed elsewhere.
+networkPolicy:
+  enabled: true
+  # metricsAllowFrom: a list of NetworkPolicyPeer entries (podSelector /
+  # namespaceSelector, in the upstream NetworkPolicy `from` syntax) permitted to
+  # reach the metrics port. Defaults to any pod, in any namespace, carrying the
+  # Prometheus community Helm chart's standard `app.kubernetes.io/name:
+  # prometheus` label -- adjust to match your cluster's actual scrape identity.
+  metricsAllowFrom:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+
 # watchNamespaces (OPTIONAL, ADR-076): restricts this operator instance to reconciling
 # KeyorixSecret CRs (and their target Secrets) in only the listed namespaces, instead of
 # the DEFAULT (this release's own namespace only). When set, RBAC is scoped accordingly:

--- a/deploy/helm/keyorix/templates/_helpers.tpl
+++ b/deploy/helm/keyorix/templates/_helpers.tpl
@@ -61,6 +61,7 @@ template is the single source of truth; every location block that defines its
 own add_header must also include this so the headers still apply there.
 */}}
 {{- define "keyorix.web.securityHeaders" -}}
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 add_header X-Frame-Options "DENY" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header X-XSS-Protection "1; mode=block" always;

--- a/docs/k8s-sync.md
+++ b/docs/k8s-sync.md
@@ -10,7 +10,8 @@ directly.
 
 It runs **in-cluster** as a small Deployment:
 
-- authenticates to Keyorix with a **machine-identity token** (`KEYORIX_TOKEN`),
+- authenticates to Keyorix with a **machine-identity token** (`KEYORIX_TOKEN_FILE`,
+  or `KEYORIX_TOKEN`),
 - writes Secrets via the Kubernetes API using its mounted **service-account**
   credentials (no `client-go` — a thin REST client, so the image stays tiny),
 - reconciles on an interval, creating/updating a target Secret **only when its data
@@ -39,8 +40,13 @@ mappings:
     key: API_KEY
 ```
 
-The Keyorix auth token is **not** in this file — it is read from the `KEYORIX_TOKEN`
-environment variable (mount it from a Kubernetes Secret). Give that token a
+The Keyorix auth token is **not** in this file. Prefer `KEYORIX_TOKEN_FILE`
+(a path to a mounted Secret volume — this repo's own Helm chart mounts it this way
+by default) over `KEYORIX_TOKEN` (a plain env var, still supported for backward
+compatibility): a mounted, read-only file never appears in the pod spec itself,
+unlike an env var sourced from a `secretKeyRef`, which the Kubernetes API still
+returns verbatim to anyone who can read the pod (e.g. `kubectl get pod -o yaml`).
+`KEYORIX_TOKEN_FILE` takes precedence when both are set. Give that token a
 least-privilege machine identity that can read only the referenced secrets.
 
 `project_id` is required: a mapping's `ref` names only an environment and a secret
@@ -134,6 +140,14 @@ The agent serves probe endpoints on `health_port` (default `8080`):
 
 The Helm chart wires `/healthz` and `/readyz` as the Deployment's liveness and
 readiness probes.
+
+`/metrics` is unauthenticated by default, like the other three endpoints — set
+`-metrics-bearer-token` (or `KEYORIX_METRICS_TOKEN`; `metricsBearerToken` in the Helm
+chart) to require a matching `Authorization: Bearer <token>` header on `/metrics`
+specifically. `/healthz`, `/readyz`, and `/status` stay unauthenticated regardless —
+Kubernetes' own kubelet has no way to supply a token, and none of the three expose
+secret values. The chart also ships a `NetworkPolicy` (`networkPolicy.enabled`,
+default on) restricting who can reach `health_port` at all.
 
 > A Helm chart that deploys the agent with its RBAC and config ships separately
 > (`deploy/helm/keyorix-k8s-sync`).

--- a/internal/k8ssync/health.go
+++ b/internal/k8ssync/health.go
@@ -1,6 +1,7 @@
 package k8ssync
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -50,14 +51,30 @@ func (s *Status) snapshot() (bool, time.Time, Result) {
 	return s.ran, s.lastRun, s.last
 }
 
-// Handler serves the agent's probe + status endpoints:
+// Handler serves the agent's probe + status endpoints with /metrics left
+// unauthenticated. See HandlerWithToken to require a bearer token on /metrics
+// specifically (e.g. for an internet-facing deployment without NetworkPolicy
+// support) while keeping the probe endpoints open for Kubernetes.
+func (s *Status) Handler() http.Handler {
+	return s.HandlerWithToken("")
+}
+
+// HandlerWithToken serves the same endpoints as Handler:
 //   - GET /healthz — liveness: always 200 while the process is responsive.
 //   - GET /readyz  — readiness: 200 once at least one reconcile pass has completed,
 //     503 before that (so traffic/rollout waits for the first sync).
 //   - GET /status  — JSON of the last pass (counts + timestamp), for observability.
+//   - GET /metrics — Prometheus text exposition of the counters above.
 //
-// No secret values are exposed — only counts, a timestamp, and an error count.
-func (s *Status) Handler() http.Handler {
+// /healthz, /readyz, and /status are deliberately never gated by token: they carry no
+// secret values (only counts, a timestamp, and an error count) and Kubernetes' own
+// kubelet must be able to reach them unauthenticated to run liveness/readiness probes.
+// When token is non-empty, /metrics additionally requires a matching
+// "Authorization: Bearer <token>" header — mirrors server/http/router.go's
+// cfg.Server.HTTP.MetricsToken gate and operator/cmd/main.go's own
+// -metrics-bearer-token gate on this repo's other two Prometheus-scraped endpoints.
+// When token is empty, /metrics is left unauthenticated, same as Handler.
+func (s *Status) HandlerWithToken(token string) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -90,10 +107,22 @@ func (s *Status) Handler() http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(body)
 	})
-	mux.HandleFunc("/metrics", func(w http.ResponseWriter, _ *http.Request) {
+	var metricsHandler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
 		_, _ = w.Write([]byte(s.metrics()))
 	})
+	if token != "" {
+		inner := metricsHandler
+		metricsHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			if len(auth) < 8 || auth[:7] != "Bearer " || subtle.ConstantTimeCompare([]byte(auth[7:]), []byte(token)) != 1 {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+			inner.ServeHTTP(w, r)
+		})
+	}
+	mux.Handle("/metrics", metricsHandler)
 	return mux
 }
 

--- a/internal/k8ssync/health_test.go
+++ b/internal/k8ssync/health_test.go
@@ -60,6 +60,57 @@ func TestHealth_MetricsBeforeFirstRun(t *testing.T) {
 	assert.Contains(t, body, "keyorix_k8s_sync_last_run_timestamp_seconds 0")
 }
 
+// ---- HandlerWithToken: /metrics bearer-token gate ----
+
+func getWithAuth(t *testing.T, h http.Handler, path, authHeader string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHandlerWithToken_EmptyTokenLeavesMetricsUnauthenticated(t *testing.T) {
+	h := NewStatus().HandlerWithToken("")
+	assert.Equal(t, http.StatusOK, get(t, h, "/metrics").Code)
+}
+
+func TestHandlerWithToken_MetricsRejectsMissingHeader(t *testing.T) {
+	h := NewStatus().HandlerWithToken("s3cr3t")
+	assert.Equal(t, http.StatusUnauthorized, get(t, h, "/metrics").Code)
+}
+
+func TestHandlerWithToken_MetricsRejectsWrongToken(t *testing.T) {
+	h := NewStatus().HandlerWithToken("s3cr3t")
+	rec := getWithAuth(t, h, "/metrics", "Bearer wrong")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestHandlerWithToken_MetricsAcceptsMatchingToken(t *testing.T) {
+	s := NewStatus()
+	s.Record(Result{Created: 1})
+	h := s.HandlerWithToken("s3cr3t")
+	rec := getWithAuth(t, h, "/metrics", "Bearer s3cr3t")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "keyorix_k8s_sync_reconcile_passes_total 1")
+}
+
+// The probe endpoints must stay reachable without any Authorization header even when
+// a metrics token is configured -- kubelet has no way to supply one, and none of these
+// three expose secret values (only counts, a timestamp, and an error count).
+func TestHandlerWithToken_ProbeEndpointsStayUnauthenticated(t *testing.T) {
+	s := NewStatus()
+	s.Record(Result{Created: 1})
+	h := s.HandlerWithToken("s3cr3t")
+
+	assert.Equal(t, http.StatusOK, get(t, h, "/healthz").Code)
+	assert.Equal(t, http.StatusOK, get(t, h, "/readyz").Code)
+	assert.Equal(t, http.StatusOK, get(t, h, "/status").Code)
+}
+
 func TestHealth_StatusReportsCounts(t *testing.T) {
 	s := NewStatus()
 	h := s.Handler()


### PR DESCRIPTION
## Summary
6 MEDIUM/LOW findings from an adversarial review pass over `deploy/` and `operator/`:

1. **`keyorix-k8s-sync` chart shipped with no default resource requests/limits** — `resources: {}` plus a template that only renders when non-empty. Now has a concrete default and a hardcoded fallback, matching the other charts.
2. **Metrics endpoints unauthenticated by default, no NetworkPolicy shipped** — added an optional `-metrics-bearer-token` flag/`KEYORIX_METRICS_TOKEN` env for k8s-sync (mirroring the operator's existing flag), wired a `metricsBearerToken` values field into both charts, and added a `NetworkPolicy` template to both.
3. **Operator RBAC granted unused `keyorixsecrets/finalizers:update`** — the controller has no finalizer logic (confirmed against the code-generated RBAC, which doesn't include this rule); removed.
4. **Leader-election Role granted unused `delete` on `leases`** — controller-runtime's resourcelock never deletes a Lease; removed.
5. **Missing `Strict-Transport-Security` header** on the web UI's otherwise-thorough security header set — added.
6. **k8s-sync injected the Keyorix bearer token via env var** instead of a file mount (unlike the operator's own controller) — added `KEYORIX_TOKEN_FILE` support (preferred, falls back to the existing `KEYORIX_TOKEN` env var for backward compatibility) and switched the chart to mount the token as a file.

## Test plan
- [x] `go build ./...`, `go test ./internal/k8ssync/... ./cmd/keyorix-k8s-sync/...`, `go vet ./...`, `gofmt -l` all clean (new tests added for the bearer-token gating and token-file/env precedence)
- [x] `operator/` module (own go.mod) still builds/vets clean via `GOWORK=off`
- [x] `helm lint` clean on all 3 charts across every CI-exercised values variant
- [x] `helm template` output validated against the Kubernetes 1.29 schema via `kubeconform -strict` for all 3 charts + every touched path (new NetworkPolicy templates, metrics-token wiring, token-file volume mount)
- [x] Confirmed no CI script depends on the removed RBAC rules or the old `KEYORIX_TOKEN` secretKeyRef shape