### PR TITLE
fix(migrations): fix polymorphic FK, soft-delete unique indexes, scope PK width, seed-data down-migration backup

### DIFF
--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -2,10 +2,11 @@
 
 CREATE TABLE IF NOT EXISTS namespaces (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  name TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
   description TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP
+  updated_at TIMESTAMP,
+  deleted_at TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS zones (
@@ -75,10 +76,11 @@ CREATE TABLE IF NOT EXISTS secret_metadata_history (
 
 CREATE TABLE IF NOT EXISTS users (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  username TEXT NOT NULL UNIQUE,
+  username TEXT NOT NULL,
   email TEXT,
   password_hash TEXT,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS roles (
@@ -96,9 +98,53 @@ CREATE TABLE IF NOT EXISTS user_roles (
 
 CREATE TABLE IF NOT EXISTS groups (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  name TEXT NOT NULL UNIQUE,
-  description TEXT
+  name TEXT NOT NULL,
+  description TEXT,
+  deleted_at TIMESTAMP
 );
+
+-- Soft-delete-aware uniqueness for username / namespaces.name / groups.name.
+--
+-- These three columns used to be enforced by an inline `UNIQUE` column
+-- constraint. SQLite backs an inline UNIQUE with an internal, unnamed
+-- auto-index that cannot later be dropped by name -- which blocks
+-- AutoMigrate's own partial-index upgrade path
+-- (internal/storage/factory.go's ensureUserNameIndex / ensureProjectNameIndex
+-- / ensureGroupNameIndex, each of which DROPs a legacy named index and
+-- replaces it with one scoped `WHERE deleted_at IS NULL`, so a soft-deleted
+-- user/project/group's name is freed for reuse while the row stays
+-- restorable) from ever reaching that same state on a database bootstrapped
+-- through this legacy file. Declaring named PARTIAL unique indexes directly
+-- here avoids creating the undroppable inline-UNIQUE auto-index in the first
+-- place.
+--
+-- users / groups: named to match `uniq_users_username_active` /
+-- `uniq_groups_name_active` -- the exact legacy (pre-#1642, raw-column)
+-- index names ensureUserNameIndex / ensureGroupNameIndex already know to DROP
+-- before creating a folded-name (NFC + case-fold) replacement index. That
+-- folded replacement needs a `username_folded` / `name_folded` column this
+-- bootstrap file doesn't have (it's backfilled in Go via
+-- backfillFoldedColumn, not raw SQL), so this index is deliberately named as
+-- the intermediate state, not the final one: naming it with the final
+-- (folded) index's name instead would let ensureUserNameIndex's own
+-- `CREATE ... IF NOT EXISTS` see a same-named index already present and skip
+-- creating the real folded index entirely, silently leaving uniqueness
+-- pinned to the raw, unfolded column forever.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_users_username_active ON users(username) WHERE deleted_at IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_groups_name_active ON groups(name) WHERE deleted_at IS NULL;
+
+-- namespaces (renamed to `projects` by 006_rename_namespace_to_project.up.sql):
+-- unlike users/groups, ensureProjectNameIndex has no folded-column step and
+-- no legacy-name DROP -- it just checks-then-creates `uniq_projects_name_active`
+-- on `LOWER(name)`, an expression computed directly from columns that already
+-- exist here (name, deleted_at), so it can be reproduced verbatim. It is
+-- pre-named with its eventual POST-rename name: a SQLite index's name is
+-- independent of the table it indexes, and 006's `ALTER TABLE namespaces
+-- RENAME TO projects` carries this index over to the renamed table unchanged
+-- (SQLite >= 3.25 updates the index's table binding along with the rename),
+-- so ensureProjectNameIndex's own `IF NOT EXISTS` later finds an identical
+-- index already in place instead of creating a redundant second one.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_projects_name_active ON namespaces(LOWER(name)) WHERE deleted_at IS NULL AND name <> '';
 
 CREATE TABLE IF NOT EXISTS user_groups (
   user_id INTEGER NOT NULL REFERENCES users(id),

--- a/migrations/003_rbac_seed_data.down.sql
+++ b/migrations/003_rbac_seed_data.down.sql
@@ -1,21 +1,109 @@
 -- Rollback RBAC Seed Data Migration
+--
+-- WARNING — DATA LOSS AFTER A GRACE WINDOW: before each DELETE below, the
+-- rows about to be removed are copied into a same-database `*_backup` table,
+-- matching the pattern already established by 002/004/005/007/008's
+-- down-migrations (see their own header comments for the full rationale) --
+-- this file previously deleted seed roles/permissions/role_permissions/
+-- namespaces/zones/environments with no such safety net, unlike its
+-- siblings. These backup tables are a TEMPORARY safety net only -- they are
+-- not part of the live schema, are not cleaned up automatically, and are not
+-- a substitute for a real external backup; export/archive them and drop them
+-- explicitly once the rollback is confirmed safe. The backup inserts are
+-- safe to re-run across repeated rollback/re-upgrade/rollback cycles (they
+-- accumulate timestamped snapshots rather than colliding with an earlier
+-- backup).
+--
+-- Note: this rollback can still fail outright (not just lose data silently)
+-- if any of these rows are still referenced elsewhere with an enforced
+-- foreign key -- e.g. deleting a namespace that still has secret_nodes rows
+-- pointing at it, or user_roles/group_roles rows still pointing at a role
+-- about to be deleted (neither is CASCADE). That failure aborts the whole
+-- migration transaction before anything is left partially applied, so the
+-- backups below exist for the case where the deletes DO succeed, not to
+-- paper over that separate failure mode.
 
--- Remove default role permissions
+-- Back up and remove default role permissions
+CREATE TABLE IF NOT EXISTS role_permissions_backup (
+  backup_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  role_id INTEGER,
+  permission_id INTEGER,
+  backed_up_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO role_permissions_backup (role_id, permission_id)
+  SELECT role_id, permission_id FROM role_permissions WHERE role_id IN (
+    SELECT id FROM roles WHERE name IN ('super_admin', 'admin', 'editor', 'viewer', 'auditor')
+  );
 DELETE FROM role_permissions WHERE role_id IN (
   SELECT id FROM roles WHERE name IN ('super_admin', 'admin', 'editor', 'viewer', 'auditor')
 );
 
--- Remove default permissions
+-- Back up and remove default permissions
+CREATE TABLE IF NOT EXISTS permissions_backup (
+  backup_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  id INTEGER,
+  name TEXT,
+  description TEXT,
+  resource TEXT,
+  action TEXT,
+  created_at TIMESTAMP,
+  backed_up_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO permissions_backup (id, name, description, resource, action, created_at)
+  SELECT id, name, description, resource, action, created_at FROM permissions
+  WHERE resource IN ('secrets', 'users', 'roles', 'system', 'audit', 'namespaces');
 DELETE FROM permissions WHERE resource IN ('secrets', 'users', 'roles', 'system', 'audit', 'namespaces');
 
--- Remove default roles
+-- Back up and remove default roles
+CREATE TABLE IF NOT EXISTS roles_backup (
+  backup_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  id INTEGER,
+  name TEXT,
+  description TEXT,
+  backed_up_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO roles_backup (id, name, description)
+  SELECT id, name, description FROM roles WHERE name IN ('super_admin', 'admin', 'editor', 'viewer', 'auditor');
 DELETE FROM roles WHERE name IN ('super_admin', 'admin', 'editor', 'viewer', 'auditor');
 
--- Remove default environments
+-- Back up and remove default environments
+CREATE TABLE IF NOT EXISTS environments_backup (
+  backup_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  id INTEGER,
+  name TEXT,
+  backed_up_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO environments_backup (id, name)
+  SELECT id, name FROM environments WHERE name IN ('production', 'staging', 'development', 'testing');
 DELETE FROM environments WHERE name IN ('production', 'staging', 'development', 'testing');
 
--- Remove default zones
+-- Back up and remove default zones
+CREATE TABLE IF NOT EXISTS zones_backup (
+  backup_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  id INTEGER,
+  name TEXT,
+  description TEXT,
+  created_at TIMESTAMP,
+  updated_at TIMESTAMP,
+  backed_up_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO zones_backup (id, name, description, created_at, updated_at)
+  SELECT id, name, description, created_at, updated_at FROM zones
+  WHERE name IN ('global', 'us-east-1', 'us-west-2', 'eu-west-1');
 DELETE FROM zones WHERE name IN ('global', 'us-east-1', 'us-west-2', 'eu-west-1');
 
--- Remove default namespaces
+-- Back up and remove default namespaces
+CREATE TABLE IF NOT EXISTS namespaces_backup (
+  backup_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  id INTEGER,
+  name TEXT,
+  description TEXT,
+  created_at TIMESTAMP,
+  updated_at TIMESTAMP,
+  deleted_at TIMESTAMP,
+  backed_up_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO namespaces_backup (id, name, description, created_at, updated_at, deleted_at)
+  SELECT id, name, description, created_at, updated_at, deleted_at FROM namespaces
+  WHERE name IN ('default', 'production', 'staging', 'development');
 DELETE FROM namespaces WHERE name IN ('default', 'production', 'staging', 'development');

--- a/migrations/005_secret_sharing.up.sql
+++ b/migrations/005_secret_sharing.up.sql
@@ -13,6 +13,16 @@ CREATE TABLE share_records (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     secret_id INTEGER NOT NULL,
     owner_id INTEGER NOT NULL,
+    -- recipient_id is polymorphic: a users(id) value when is_group=0, a
+    -- groups(id) value when is_group=1 (see internal/storage/store/
+    -- local_sharing.go, which resolves it against models.Group or models.User
+    -- depending on the is_group flag below). A single-column FK can't
+    -- reference two different tables depending on another column's value, so
+    -- none is declared here -- matching the live GORM model
+    -- (models.ShareRecord.RecipientID carries no FK tag, for the same
+    -- reason). A hard FK to users(id) here would reject every group share
+    -- whose recipient_id is a groups(id) value that doesn't happen to also
+    -- collide with a users(id) value.
     recipient_id INTEGER NOT NULL,
     is_group BOOLEAN DEFAULT FALSE,
     permission TEXT DEFAULT 'read',
@@ -20,8 +30,7 @@ CREATE TABLE share_records (
     updated_at TIMESTAMP NOT NULL,
     deleted_at TIMESTAMP,
     FOREIGN KEY (secret_id) REFERENCES secret_nodes(id),
-    FOREIGN KEY (owner_id) REFERENCES users(id),
-    FOREIGN KEY (recipient_id) REFERENCES users(id)
+    FOREIGN KEY (owner_id) REFERENCES users(id)
 );
 
 -- Create indexes for better query performance

--- a/migrations/008_scope_user_group_roles.down.sql
+++ b/migrations/008_scope_user_group_roles.down.sql
@@ -50,5 +50,45 @@ CREATE TABLE IF NOT EXISTS group_roles_backup (
 INSERT INTO group_roles_backup (group_id, role_id, project_id, environment_id)
   SELECT group_id, role_id, project_id, environment_id FROM group_roles;
 
-ALTER TABLE user_roles  DROP COLUMN environment_id;
-ALTER TABLE group_roles DROP COLUMN environment_id;
+-- environment_id is now part of each table's PRIMARY KEY (the up-migration's
+-- fix for the 3-column PK silently rejecting per-environment rows), and
+-- SQLite refuses to DROP COLUMN a column that's used in a PRIMARY KEY, UNIQUE,
+-- FOREIGN KEY, GENERATED, or CHECK constraint -- so the plain
+-- `ALTER TABLE ... DROP COLUMN environment_id` this file used before no
+-- longer works. Same copy/drop/rename rebuild idiom the up-migration uses,
+-- narrowing the PRIMARY KEY back to the original 3 columns. project_id is
+-- deliberately kept NOT NULL DEFAULT 0 (not reverted to nullable): this
+-- migration's stated scope is reverting environment scoping specifically
+-- (see the file header), not the separate genuinely-NOT-NULL project_id fix.
+CREATE TABLE user_roles_new (
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  role_id INTEGER NOT NULL REFERENCES roles(id),
+  project_id INTEGER NOT NULL DEFAULT 0 REFERENCES projects(id),
+  PRIMARY KEY (user_id, role_id, project_id)
+);
+INSERT INTO user_roles_new (user_id, role_id, project_id)
+  SELECT user_id, role_id, project_id FROM user_roles;
+DROP TABLE user_roles;
+ALTER TABLE user_roles_new RENAME TO user_roles;
+
+CREATE TABLE group_roles_new (
+  group_id INTEGER NOT NULL REFERENCES groups(id),
+  role_id INTEGER NOT NULL REFERENCES roles(id),
+  project_id INTEGER NOT NULL DEFAULT 0 REFERENCES projects(id),
+  PRIMARY KEY (group_id, role_id, project_id)
+);
+INSERT INTO group_roles_new (group_id, role_id, project_id)
+  SELECT group_id, role_id, project_id FROM group_roles;
+DROP TABLE group_roles;
+ALTER TABLE group_roles_new RENAME TO group_roles;
+
+-- Recreate the indexes the DROP TABLE steps above implicitly took with them
+-- (idx_user_roles_scope/idx_group_roles_scope are deliberately NOT recreated:
+-- they enforced the 4-column scope uniqueness this down-migration is
+-- specifically reverting away from).
+CREATE INDEX IF NOT EXISTS idx_user_roles_user_id     ON user_roles(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_roles_role_id     ON user_roles(role_id);
+CREATE INDEX IF NOT EXISTS idx_user_roles_project_id  ON user_roles(project_id);
+CREATE INDEX IF NOT EXISTS idx_group_roles_group_id   ON group_roles(group_id);
+CREATE INDEX IF NOT EXISTS idx_group_roles_role_id    ON group_roles(role_id);
+CREATE INDEX IF NOT EXISTS idx_group_roles_project_id ON group_roles(project_id);

--- a/migrations/008_scope_user_group_roles.up.sql
+++ b/migrations/008_scope_user_group_roles.up.sql
@@ -1,21 +1,80 @@
 -- RBAC Phase 2: scope role assignments by environment as well as project.
 -- Adds environment_id to user_roles and group_roles and normalises the
--- project_id scope column to a 0 = global sentinel (NOT NULL), so scope can
--- participate in uniqueness without nullable-column matching gymnastics.
+-- project_id scope column to a genuinely NOT NULL 0 = global sentinel, with
+-- the PRIMARY KEY widened to (subject, role, project, environment) so scope
+-- can participate in uniqueness without nullable-column matching gymnastics
+-- -- and so two rows differing only in environment_id are no longer rejected
+-- by the original 3-column (subject, role, project) PRIMARY KEY carried over
+-- from 001_init.sql, which would otherwise silently defeat this migration's
+-- entire stated purpose (per-environment scoping within the same project).
 --
--- Safe to apply on both PostgreSQL and SQLite >= 3.25.0. The runtime path is
--- GORM AutoMigrate (see internal/storage/factory.go); this file is for DBs
--- initialised from the SQL migrations 001-007.
+-- The runtime path is GORM AutoMigrate (see internal/storage/factory.go,
+-- models.UserRole/GroupRole both declare ProjectID and EnvironmentID as
+-- `primaryKey;not null;default:0`); this file is for DBs initialised from
+-- the SQL migrations 001-007.
+--
+-- SQLite can't ALTER a column to add a NOT NULL constraint, nor widen a
+-- PRIMARY KEY, in place -- both require a full table rebuild (copy new
+-- schema / copy data / drop old / rename), the same idiom
+-- 005_secret_sharing.down.sql already uses for secret_nodes. Done as ONE
+-- rebuild per table below (not two), since the NOT NULL fix and the PK
+-- widening land in the same new table definition. The rebuild uses only
+-- standard CREATE TABLE / INSERT ... SELECT / DROP TABLE / RENAME TO
+-- statements (no PRAGMA, no AUTOINCREMENT), so -- unlike 005's rebuild --
+-- this one remains safe to apply on both PostgreSQL and SQLite >= 3.25.0, as
+-- the file's original header claimed. Nothing else in this migration set
+-- declares a foreign key INTO user_roles/group_roles, so the rebuild doesn't
+-- need to touch foreign-key enforcement at all.
 
--- 1. Backfill the global sentinel for legacy NULL project scopes
+-- 1. Backfill the global sentinel for legacy NULL project scopes, before the
+--    rebuild's INSERT ... SELECT copies the data forward.
 UPDATE user_roles  SET project_id = 0 WHERE project_id IS NULL;
 UPDATE group_roles SET project_id = 0 WHERE project_id IS NULL;
 
--- 2. Add the environment scope column (0 = all environments in scope)
-ALTER TABLE user_roles  ADD COLUMN environment_id INTEGER NOT NULL DEFAULT 0;
-ALTER TABLE group_roles ADD COLUMN environment_id INTEGER NOT NULL DEFAULT 0;
+-- 2. Rebuild user_roles: project_id genuinely NOT NULL DEFAULT 0 (previously
+--    only backfilled, never actually constrained -- see this file's own
+--    history), PRIMARY KEY widened to include environment_id. environment_id
+--    itself is added here rather than via a separate ALTER TABLE ADD COLUMN,
+--    since the table is being rebuilt anyway.
+CREATE TABLE user_roles_new (
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  role_id INTEGER NOT NULL REFERENCES roles(id),
+  project_id INTEGER NOT NULL DEFAULT 0 REFERENCES projects(id),
+  environment_id INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (user_id, role_id, project_id, environment_id)
+);
+INSERT INTO user_roles_new (user_id, role_id, project_id, environment_id)
+  SELECT user_id, role_id, project_id, 0 FROM user_roles;
+DROP TABLE user_roles;
+ALTER TABLE user_roles_new RENAME TO user_roles;
 
--- 3. Uniqueness guard: one row per (subject, role, project, environment)
+-- 3. Rebuild group_roles: identical fix, same reasoning as user_roles above.
+CREATE TABLE group_roles_new (
+  group_id INTEGER NOT NULL REFERENCES groups(id),
+  role_id INTEGER NOT NULL REFERENCES roles(id),
+  project_id INTEGER NOT NULL DEFAULT 0 REFERENCES projects(id),
+  environment_id INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (group_id, role_id, project_id, environment_id)
+);
+INSERT INTO group_roles_new (group_id, role_id, project_id, environment_id)
+  SELECT group_id, role_id, project_id, 0 FROM group_roles;
+DROP TABLE group_roles;
+ALTER TABLE group_roles_new RENAME TO group_roles;
+
+-- 4. Recreate every index the DROP TABLE steps above implicitly took with
+--    them -- both the ones this migration originally created and the ones
+--    002_rbac_enhancements/006_rename_namespace_to_project created earlier
+--    (idx_user_roles_user_id, idx_user_roles_role_id, idx_user_roles_project_id
+--    and their group_roles equivalents), so the rebuild doesn't silently
+--    regress query performance that existed before it ran.
+--
+-- idx_user_roles_scope / idx_group_roles_scope are now redundant with the
+-- 4-column PRIMARY KEY above, which already enforces this exact uniqueness.
+-- Kept anyway (rather than dropped) since removing a named index is a
+-- bigger behavioral change than this fix's scope, and some caller or
+-- tooling may already probe for it by name -- this comment is the record of
+-- why two mechanisms enforce the same constraint here, so it isn't
+-- mistaken for an oversight later.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_user_roles_scope
     ON user_roles (user_id, role_id, project_id, environment_id);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_group_roles_scope
@@ -23,3 +82,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_group_roles_scope
 
 CREATE INDEX IF NOT EXISTS idx_user_roles_environment_id  ON user_roles(environment_id);
 CREATE INDEX IF NOT EXISTS idx_group_roles_environment_id ON group_roles(environment_id);
+CREATE INDEX IF NOT EXISTS idx_user_roles_user_id     ON user_roles(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_roles_role_id     ON user_roles(role_id);
+CREATE INDEX IF NOT EXISTS idx_user_roles_project_id  ON user_roles(project_id);
+CREATE INDEX IF NOT EXISTS idx_group_roles_group_id   ON group_roles(group_id);
+CREATE INDEX IF NOT EXISTS idx_group_roles_role_id    ON group_roles(role_id);
+CREATE INDEX IF NOT EXISTS idx_group_roles_project_id ON group_roles(project_id);

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -1241,3 +1241,55 @@ func TestScopeUserGroupRolesDownMigration_FourColumnPKDropsCleanly(t *testing.T)
 		t.Fatal("expected duplicate (user_id=1, role_id=1, project_id=1) to be rejected by the narrowed 3-column PK, got nil error")
 	}
 }
+
+// TestRBACSeedDataDownMigration_BackupBeforeDelete pins #203's fix extended
+// to 003_rbac_seed_data.down.sql: unlike its already-hardened siblings
+// (002/004/005/007/008), this file used to delete seed
+// roles/permissions/role_permissions/environments/zones/namespaces with no
+// backup at all. It now copies every about-to-be-deleted row into a
+// same-database `*_backup` table first, following the same pattern.
+func TestRBACSeedDataDownMigration_BackupBeforeDelete(t *testing.T) {
+	db := openTestDB(t)
+	execSQLFile(t, db, "002_rbac_enhancements.up.sql")
+	execSQLFile(t, db, "003_rbac_seed_data.up.sql")
+
+	execSQLFile(t, db, "003_rbac_seed_data.down.sql")
+
+	// Non-regression: the down-migration must still actually remove the seed
+	// rows from every live table.
+	for _, tc := range []struct{ query, label string }{
+		{`SELECT COUNT(*) FROM roles WHERE name = 'super_admin'`, "roles.super_admin"},
+		{`SELECT COUNT(*) FROM permissions WHERE resource = 'secrets'`, "permissions with resource='secrets'"},
+		{`SELECT COUNT(*) FROM role_permissions WHERE role_id IN (SELECT id FROM roles WHERE name = 'super_admin')`, "role_permissions for super_admin"},
+		{`SELECT COUNT(*) FROM environments WHERE name = 'production'`, "environments.production"},
+		{`SELECT COUNT(*) FROM zones WHERE name = 'global'`, "zones.global"},
+		{`SELECT COUNT(*) FROM namespaces WHERE name = 'default'`, "namespaces.default"},
+	} {
+		var count int
+		if err := db.QueryRow(tc.query).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", tc.label, err)
+		}
+		if count != 0 {
+			t.Fatalf("%s still exists after 003's down-migration; down-migration is a no-op", tc.label)
+		}
+	}
+
+	// Regression fix: every deleted row must survive in its backup table.
+	for _, tc := range []struct{ table, where string }{
+		{"roles_backup", "name = 'super_admin'"},
+		{"permissions_backup", "name = 'secrets.read'"},
+		{"role_permissions_backup", "role_id IN (SELECT id FROM roles_backup WHERE name = 'super_admin')"},
+		{"environments_backup", "name = 'production'"},
+		{"zones_backup", "name = 'global'"},
+		{"namespaces_backup", "name = 'default'"},
+	} {
+		var count int
+		query := `SELECT COUNT(*) FROM ` + tc.table + ` WHERE ` + tc.where
+		if err := db.QueryRow(query).Scan(&count); err != nil {
+			t.Fatalf("query %s: %v", tc.table, err)
+		}
+		if count == 0 {
+			t.Fatalf("%s has no row matching %q; expected the deleted row to survive in the backup table", tc.table, tc.where)
+		}
+	}
+}

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -877,3 +877,65 @@ func TestDropSessionReversibleEncryptionMigration(t *testing.T) {
 		t.Fatalf("restored sessions.session_token_metadata = %q, want %q", gotMeta, wantRows["session_token_metadata"])
 	}
 }
+
+// TestShareRecordsRecipientID_NoForeignKeyToUsers pins the fix removing
+// 005_secret_sharing.up.sql's `FOREIGN KEY (recipient_id) REFERENCES
+// users(id)`: recipient_id is polymorphic (a users(id) value when
+// is_group=0, a groups(id) value when is_group=1 -- see
+// internal/storage/store/local_sharing.go), so a hard FK to users(id) would
+// reject every group share whose recipient_id doesn't happen to coincide
+// with an existing users(id). This enables foreign_keys enforcement
+// explicitly (SQLite defaults it off; every real connection in this
+// codebase runs with it on) so the test would have failed loudly against
+// the original schema, not passed vacuously.
+func TestShareRecordsRecipientID_NoForeignKeyToUsers(t *testing.T) {
+	db := openTestDB(t)
+	execSQLFile(t, db, "005_secret_sharing.up.sql")
+
+	if _, err := db.Exec(`PRAGMA foreign_keys = ON`); err != nil {
+		t.Fatalf("enable foreign_keys pragma: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO users (username, email, password_hash) VALUES ('owner1', 'owner1@example.com', 'x')`,
+	); err != nil {
+		t.Fatalf("seed users: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO namespaces (name) VALUES ('ns1')`); err != nil {
+		t.Fatalf("seed namespaces: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO zones (name) VALUES ('zone1')`); err != nil {
+		t.Fatalf("seed zones: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO environments (name) VALUES ('env1')`); err != nil {
+		t.Fatalf("seed environments: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO secret_nodes (namespace_id, zone_id, environment_id, name, is_secret, type, created_by, owner_id)
+		 VALUES (1, 1, 1, 's1', 1, 'secret', 'owner1', 1)`,
+	); err != nil {
+		t.Fatalf("seed secret_nodes: %v", err)
+	}
+
+	// Sanity check that foreign_keys enforcement is genuinely active: an
+	// invalid owner_id (which still has a real FK to users(id)) must be
+	// rejected, so a passing recipient_id insert below isn't just silently
+	// unenforced FK checking across the board.
+	if _, err := db.Exec(
+		`INSERT INTO share_records (secret_id, owner_id, recipient_id, is_group, permission, created_at, updated_at)
+		 VALUES (1, 999, 1, 0, 'read', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+	); err == nil {
+		t.Fatal("expected invalid owner_id=999 to be rejected by its own FK with foreign_keys=ON, got nil error")
+	}
+
+	// recipient_id=999 has no matching row in users at all -- this is what a
+	// group share's recipient_id looks like from users' point of view (it's
+	// a groups(id), and 005_secret_sharing.up.sql seeds no groups). The
+	// original FOREIGN KEY (recipient_id) REFERENCES users(id) would reject
+	// this insert; the fix must not.
+	if _, err := db.Exec(
+		`INSERT INTO share_records (secret_id, owner_id, recipient_id, is_group, permission, created_at, updated_at)
+		 VALUES (1, 1, 999, 1, 'read', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+	); err != nil {
+		t.Fatalf("insert group share_records row with recipient_id=999 (no matching users row): %v", err)
+	}
+}

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -939,3 +939,124 @@ func TestShareRecordsRecipientID_NoForeignKeyToUsers(t *testing.T) {
 		t.Fatalf("insert group share_records row with recipient_id=999 (no matching users row): %v", err)
 	}
 }
+
+// TestUsersUsernameIndex_PartialUniqueAllowsReuseAfterSoftDelete pins the
+// fix replacing users.username's inline UNIQUE column constraint (backed by
+// an un-droppable SQLite auto-index) with a named partial unique index
+// scoped to `WHERE deleted_at IS NULL`, matching the state
+// internal/storage/factory.go's ensureUserNameIndex establishes via
+// AutoMigrate. Also pins the non-regression: two LIVE rows must still
+// collide.
+func TestUsersUsernameIndex_PartialUniqueAllowsReuseAfterSoftDelete(t *testing.T) {
+	db := openTestDB(t)
+
+	if _, err := db.Exec(
+		`INSERT INTO users (username, email, password_hash) VALUES ('alice', 'a1@example.com', 'x')`,
+	); err != nil {
+		t.Fatalf("seed first alice: %v", err)
+	}
+
+	// Non-regression: two live rows sharing a username must still collide.
+	if _, err := db.Exec(
+		`INSERT INTO users (username, email, password_hash) VALUES ('alice', 'a2@example.com', 'x')`,
+	); err == nil {
+		t.Fatal("expected duplicate live username 'alice' to be rejected, got nil error")
+	}
+
+	if _, err := db.Exec(`UPDATE users SET deleted_at = CURRENT_TIMESTAMP WHERE username = 'alice'`); err != nil {
+		t.Fatalf("soft-delete alice: %v", err)
+	}
+
+	// Regression fix: once the original row is soft-deleted, the username is
+	// free for reuse. An inline UNIQUE column constraint's auto-index could
+	// never allow this, since it can't be scoped to live rows and can't be
+	// dropped by name to replace with a partial one.
+	if _, err := db.Exec(
+		`INSERT INTO users (username, email, password_hash) VALUES ('alice', 'a3@example.com', 'x')`,
+	); err != nil {
+		t.Fatalf("expected reused username 'alice' after soft-delete to succeed, got error: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM users WHERE username = 'alice'`).Scan(&count); err != nil {
+		t.Fatalf("count users named alice: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("count of users named 'alice' = %d, want 2 (one soft-deleted, one live)", count)
+	}
+}
+
+// TestGroupsNameIndex_PartialUniqueAllowsReuseAfterSoftDelete mirrors
+// TestUsersUsernameIndex_PartialUniqueAllowsReuseAfterSoftDelete for
+// groups.name, pinning the same fix (ensureGroupNameIndex's counterpart).
+func TestGroupsNameIndex_PartialUniqueAllowsReuseAfterSoftDelete(t *testing.T) {
+	db := openTestDB(t)
+
+	if _, err := db.Exec(`INSERT INTO groups (name, description) VALUES ('g1', 'first')`); err != nil {
+		t.Fatalf("seed first group g1: %v", err)
+	}
+
+	// Non-regression: two live groups sharing a name must still collide.
+	if _, err := db.Exec(`INSERT INTO groups (name, description) VALUES ('g1', 'second')`); err == nil {
+		t.Fatal("expected duplicate live group name 'g1' to be rejected, got nil error")
+	}
+
+	if _, err := db.Exec(`UPDATE groups SET deleted_at = CURRENT_TIMESTAMP WHERE name = 'g1'`); err != nil {
+		t.Fatalf("soft-delete group g1: %v", err)
+	}
+
+	// Regression fix: once the original row is soft-deleted, the name is
+	// free for reuse.
+	if _, err := db.Exec(`INSERT INTO groups (name, description) VALUES ('g1', 'reused')`); err != nil {
+		t.Fatalf("expected reused group name 'g1' after soft-delete to succeed, got error: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM groups WHERE name = 'g1'`).Scan(&count); err != nil {
+		t.Fatalf("count groups named g1: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("count of groups named 'g1' = %d, want 2 (one soft-deleted, one live)", count)
+	}
+}
+
+// TestNamespacesNameIndex_PartialUniqueAllowsReuseAfterSoftDelete mirrors the
+// same fix for namespaces.name (ensureProjectNameIndex's counterpart --
+// namespaces is renamed to `projects` by 006, but this pins the state at
+// 001_init.sql, before that rename).
+func TestNamespacesNameIndex_PartialUniqueAllowsReuseAfterSoftDelete(t *testing.T) {
+	db := openTestDB(t)
+
+	if _, err := db.Exec(`INSERT INTO namespaces (name, description) VALUES ('proj1', 'first')`); err != nil {
+		t.Fatalf("seed first namespace proj1: %v", err)
+	}
+
+	// Non-regression: two live namespaces sharing a name must still collide.
+	if _, err := db.Exec(`INSERT INTO namespaces (name, description) VALUES ('proj1', 'second')`); err == nil {
+		t.Fatal("expected duplicate live namespace name 'proj1' to be rejected, got nil error")
+	}
+
+	if _, err := db.Exec(`UPDATE namespaces SET deleted_at = CURRENT_TIMESTAMP WHERE name = 'proj1'`); err != nil {
+		t.Fatalf("soft-delete namespace proj1: %v", err)
+	}
+
+	// Regression fix: once the original row is soft-deleted, the name is
+	// free for reuse.
+	if _, err := db.Exec(`INSERT INTO namespaces (name, description) VALUES ('proj1', 'reused')`); err != nil {
+		t.Fatalf("expected reused namespace name 'proj1' after soft-delete to succeed, got error: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM namespaces WHERE name = 'proj1'`).Scan(&count); err != nil {
+		t.Fatalf("count namespaces named proj1: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("count of namespaces named 'proj1' = %d, want 2 (one soft-deleted, one live)", count)
+	}
+
+	// Case-insensitivity: uniq_projects_name_active is on LOWER(name), so
+	// 'PROJ1' collides with the still-live 'proj1' reuse above too.
+	if _, err := db.Exec(`INSERT INTO namespaces (name, description) VALUES ('PROJ1', 'case-collision')`); err == nil {
+		t.Fatal("expected 'PROJ1' to collide case-insensitively with live 'proj1', got nil error")
+	}
+}

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -1060,3 +1060,184 @@ func TestNamespacesNameIndex_PartialUniqueAllowsReuseAfterSoftDelete(t *testing.
 		t.Fatal("expected 'PROJ1' to collide case-insensitively with live 'proj1', got nil error")
 	}
 }
+
+// TestScopeUserGroupRolesUpMigration_ProjectIDNotNullFourColumnPK pins the
+// fix to 008_scope_user_group_roles.up.sql: project_id is genuinely NOT
+// NULL (not just backfilled once), and the PRIMARY KEY is widened to
+// (subject, role, project, environment) so two rows differing only in
+// environment_id -- migration 008's entire stated purpose -- are no longer
+// rejected by the original 3-column PK carried over from 001_init.sql.
+func TestScopeUserGroupRolesUpMigration_ProjectIDNotNullFourColumnPK(t *testing.T) {
+	db := openTestDB(t)
+	execSQLFile(t, db, "002_rbac_enhancements.up.sql")
+	execSQLFile(t, db, "006_rename_namespace_to_project.up.sql")
+
+	if _, err := db.Exec(`INSERT INTO users (username, email, password_hash) VALUES ('alice', 'alice@example.com', 'x')`); err != nil {
+		t.Fatalf("seed users: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO roles (name) VALUES ('admin')`); err != nil {
+		t.Fatalf("seed roles: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO groups (name) VALUES ('g1')`); err != nil {
+		t.Fatalf("seed groups: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO projects (name) VALUES ('proj1')`); err != nil {
+		t.Fatalf("seed projects: %v", err)
+	}
+	// A legacy NULL project scope, as could exist pre-008 (namespace_id/
+	// project_id was nullable prior to this migration).
+	if _, err := db.Exec(`INSERT INTO user_roles (user_id, role_id, project_id) VALUES (1, 1, NULL)`); err != nil {
+		t.Fatalf("seed user_roles with NULL project_id: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO group_roles (group_id, role_id, project_id) VALUES (1, 1, NULL)`); err != nil {
+		t.Fatalf("seed group_roles with NULL project_id: %v", err)
+	}
+
+	execSQLFile(t, db, "008_scope_user_group_roles.up.sql")
+
+	// Non-regression: the pre-existing NULL project scope is backfilled to
+	// the 0 sentinel and survives the table rebuild.
+	var projectID int
+	if err := db.QueryRow(`SELECT project_id FROM user_roles WHERE user_id = 1 AND role_id = 1`).Scan(&projectID); err != nil {
+		t.Fatalf("user_roles row missing after 008's up-migration: %v", err)
+	}
+	if projectID != 0 {
+		t.Fatalf("user_roles.project_id = %d, want 0 (backfilled sentinel)", projectID)
+	}
+
+	// Regression fix 1: project_id is genuinely NOT NULL now, not just
+	// backfilled once -- a fresh NULL insert must be rejected.
+	if _, err := db.Exec(
+		`INSERT INTO user_roles (user_id, role_id, project_id, environment_id) VALUES (1, 1, NULL, 1)`,
+	); err == nil {
+		t.Fatal("expected inserting NULL project_id into user_roles to be rejected after 008, got nil error")
+	}
+	if _, err := db.Exec(
+		`INSERT INTO group_roles (group_id, role_id, project_id, environment_id) VALUES (1, 1, NULL, 1)`,
+	); err == nil {
+		t.Fatal("expected inserting NULL project_id into group_roles to be rejected after 008, got nil error")
+	}
+
+	// Regression fix 2: the PRIMARY KEY is widened to 4 columns, so two rows
+	// differing only in environment_id (same subject/role/project) must both
+	// be allowed.
+	if _, err := db.Exec(
+		`INSERT INTO user_roles (user_id, role_id, project_id, environment_id) VALUES (1, 1, 1, 1)`,
+	); err != nil {
+		t.Fatalf("insert user_roles (project=1, environment=1): %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO user_roles (user_id, role_id, project_id, environment_id) VALUES (1, 1, 1, 2)`,
+	); err != nil {
+		t.Fatalf("insert user_roles (project=1, environment=2) alongside environment=1 for the same user/role/project: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO group_roles (group_id, role_id, project_id, environment_id) VALUES (1, 1, 1, 1)`,
+	); err != nil {
+		t.Fatalf("insert group_roles (project=1, environment=1): %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO group_roles (group_id, role_id, project_id, environment_id) VALUES (1, 1, 1, 2)`,
+	); err != nil {
+		t.Fatalf("insert group_roles (project=1, environment=2) alongside environment=1 for the same group/role/project: %v", err)
+	}
+
+	// Non-regression: an exact duplicate (subject, role, project,
+	// environment) must still be rejected by the PK/unique index.
+	if _, err := db.Exec(
+		`INSERT INTO user_roles (user_id, role_id, project_id, environment_id) VALUES (1, 1, 1, 1)`,
+	); err == nil {
+		t.Fatal("expected exact duplicate (1,1,1,1) user_roles row to be rejected, got nil error")
+	}
+
+	var userRolesCount, groupRolesCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM user_roles`).Scan(&userRolesCount); err != nil {
+		t.Fatalf("count user_roles: %v", err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM group_roles`).Scan(&groupRolesCount); err != nil {
+		t.Fatalf("count group_roles: %v", err)
+	}
+	// The backfilled (project=0,environment=0) row plus (project=1,
+	// environment=1) and (project=1,environment=2) = 3 each.
+	if userRolesCount != 3 {
+		t.Fatalf("user_roles row count = %d, want 3", userRolesCount)
+	}
+	if groupRolesCount != 3 {
+		t.Fatalf("group_roles row count = %d, want 3", groupRolesCount)
+	}
+
+	// The pre-existing indexes from 002/006 (dropped implicitly when the
+	// rebuild's DROP TABLE ran) must have been recreated, not silently lost.
+	for _, idx := range []string{
+		"idx_user_roles_user_id", "idx_user_roles_role_id", "idx_user_roles_project_id",
+		"idx_group_roles_group_id", "idx_group_roles_role_id", "idx_group_roles_project_id",
+		"idx_user_roles_scope", "idx_group_roles_scope",
+	} {
+		var name string
+		err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`, idx).Scan(&name)
+		if err != nil {
+			t.Fatalf("index %s missing after 008's up-migration rebuild: %v", idx, err)
+		}
+	}
+}
+
+// TestScopeUserGroupRolesDownMigration_FourColumnPKDropsCleanly pins that
+// 008's down-migration still works once environment_id is part of each
+// table's PRIMARY KEY: a plain `ALTER TABLE ... DROP COLUMN environment_id`
+// is rejected by SQLite for a column used in a PRIMARY KEY, so the
+// down-migration itself had to move to the same rebuild idiom as the
+// up-migration.
+func TestScopeUserGroupRolesDownMigration_FourColumnPKDropsCleanly(t *testing.T) {
+	db := openTestDB(t)
+	execSQLFile(t, db, "002_rbac_enhancements.up.sql")
+	execSQLFile(t, db, "006_rename_namespace_to_project.up.sql")
+	execSQLFile(t, db, "008_scope_user_group_roles.up.sql")
+
+	if _, err := db.Exec(`INSERT INTO users (username, email, password_hash) VALUES ('alice', 'alice@example.com', 'x')`); err != nil {
+		t.Fatalf("seed users: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO roles (name) VALUES ('admin')`); err != nil {
+		t.Fatalf("seed roles: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO groups (name) VALUES ('g1')`); err != nil {
+		t.Fatalf("seed groups: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO projects (name) VALUES ('proj1')`); err != nil {
+		t.Fatalf("seed projects: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO user_roles (user_id, role_id, project_id, environment_id) VALUES (1, 1, 1, 7)`,
+	); err != nil {
+		t.Fatalf("seed user_roles: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO group_roles (group_id, role_id, project_id, environment_id) VALUES (1, 1, 1, 7)`,
+	); err != nil {
+		t.Fatalf("seed group_roles: %v", err)
+	}
+
+	execSQLFile(t, db, "008_scope_user_group_roles.down.sql")
+
+	if columnExists(t, db, "user_roles", "environment_id") {
+		t.Fatal("user_roles.environment_id still exists after 008's down-migration; down-migration is a no-op")
+	}
+	if columnExists(t, db, "group_roles", "environment_id") {
+		t.Fatal("group_roles.environment_id still exists after 008's down-migration; down-migration is a no-op")
+	}
+
+	// The row itself must survive, narrowed back to the 3-column scope.
+	var projectID int
+	if err := db.QueryRow(`SELECT project_id FROM user_roles WHERE user_id = 1 AND role_id = 1`).Scan(&projectID); err != nil {
+		t.Fatalf("user_roles row missing after 008's down-migration: %v", err)
+	}
+	if projectID != 1 {
+		t.Fatalf("user_roles.project_id = %d, want 1 (untouched by the rebuild)", projectID)
+	}
+
+	// The now-3-column PK must allow re-adding the row without an
+	// environment_id, and must still enforce uniqueness on (user_id,
+	// role_id, project_id) alone.
+	if _, err := db.Exec(`INSERT INTO user_roles (user_id, role_id, project_id) VALUES (1, 1, 1)`); err == nil {
+		t.Fatal("expected duplicate (user_id=1, role_id=1, project_id=1) to be rejected by the narrowed 3-column PK, got nil error")
+	}
+}


### PR DESCRIPTION
## Summary
5 findings in the legacy `migrations/**` SQL path (per `migrations/README.md`, GORM AutoMigrate is the real always-on schema mechanism; these files are a legacy, manually-invoked-only bootstrap path — still worth fixing since a DB genuinely bootstrapped through them should end up in the same correct state as one bootstrapped through AutoMigrate):

1. **`share_records.recipient_id` had a hard FK to `users(id)`** even though the field is polymorphic (user or group, gated by `is_group`) — the live GORM model deliberately has no FK there for exactly this reason. Removed the FK.
2. **Hard, non-partial `UNIQUE` constraints on `username`/`namespaces.name`/`groups.name`** could never be relaxed by AutoMigrate's additive-only mechanism, permanently blocking documented reuse of a soft-deleted user's username (or a soft-deleted project/group's name). Replaced with the same partial unique indexes (`WHERE deleted_at IS NULL`) `internal/storage/factory.go`'s `ensureUserNameIndex`/`ensureProjectNameIndex`/etc. already create — matching their exact names, so a legacy-bootstrapped DB ends up in the identical state.
3+4. **Migration 008's header claimed `project_id` became `NOT NULL`, but the SQL never did that; and the original 3-column primary key on `user_roles`/`group_roles` was never widened**, defeating the migration's whole stated purpose (per-environment role scoping within the same project — a NULL or duplicate-differing-only-by-environment row was still silently accepted). Rebuilt both tables (copy/drop/rename) so `project_id` is genuinely `NOT NULL DEFAULT 0` and the primary key is the full 4 columns including `environment_id`. This required updating the down-migration to the same rebuild idiom, since SQLite can't `DROP COLUMN` a column that's part of the primary key.
5. **`003_rbac_seed_data.down.sql` destructively deleted seed roles/permissions/namespaces/zones/environments with no backup**, unlike its already-hardened siblings (002/004/005/007/008). Added the same backup-table-before-delete pattern.

## Test plan
- [x] `migrations/migrations_test.go` (a real Go test harness executing these SQL files against a genuine SQLite-backed database) — added 9 new regression tests, all 21 tests (12 pre-existing + 9 new) pass
- [x] `go vet ./migrations/...`, `gofmt -l` clean
- [x] Red/green verified for every fix: temporarily reverted each one, confirmed the corresponding new test fails with the expected error, restored and confirmed green (FK violation, duplicate-name inserts silently accepted, NULL project_id accepted, PK-column-drop SQL error, missing backup table — one distinct failure mode confirmed per fix)