### PR TITLE
docs(adr-102): re-land second misattribution instance (UpdateUserIfActiveStateMatchesProxy)

### DIFF
--- a/docs/adr-102-system-write-blast-radius.md
+++ b/docs/adr-102-system-write-blast-radius.md
@@ -98,6 +98,64 @@ capability of the permission as currently scoped, exercised through routes
 that (before #1622, and possibly others — see #1622's sibling list) do not all
 audit their own use.
 
+### A second instance: actor misattribution via `UpdateUserIfActiveStateMatchesProxy`
+
+The "user account state" bullet above names `UpdateUserIfActiveStateMatchesProxy`
+as one of the 148 routes a flat `system.write` grant reaches. A closer look at
+that one route shows the same flat-capability design producing a second,
+independent instance of actor misattribution, not just an over-broad grant —
+this time going past an unaudited action to a full account-takeover chain,
+already confirmed end to end.
+
+`UpdateUserIfActiveStateMatchesProxy` is a RemoteStorage HTTP-relay proxy
+route. It used to build its storage-layer struct directly from the request
+body, with no fetch of the existing row first, and hand that struct straight
+to `UpdateUserIfActiveStateMatches` — a `Select("*")` full-row overwrite.
+Every field the route's wire format doesn't carry, including `PasswordHash`
+and `AccountState`, was silently zeroed on any call, whether or not the
+caller intended to touch either one.
+
+`AccountLoginBlocked` — the single choke point every login/session/PAT/SSO/
+WebAuthn/MFA-step-up/impersonation-target path in this codebase calls to
+decide whether an account may authenticate — is written as a deny-list: it
+blocks only the recognized `suspended`/`deprovisioned` states, not an
+allow-list requiring an explicit "permitted" value. A blanked `AccountState`
+therefore read as not blocked, silently reactivating a disabled account.
+Chained with the setup-token/password-reset completion flow
+(`completePasswordSetup`, which itself gates only on `AccountLoginBlocked`),
+this produced a full, empirically-confirmed account-takeover chain: a
+`system.write` holder blanks the target's `AccountState` via this route,
+obtains or mints a setup token for that account, completes setup with an
+attacker-chosen password, and receives a real, valid session — for the
+target's account, not their own. Every subsequent action that session takes
+is attributed to the account it belongs to, not to the `system.write` holder
+who actually controls it.
+
+The victim class this reactivates is not arbitrary. `suspended` and
+`deprovisioned` are the two states an admin (or SCIM/IdP deactivation)
+deliberately put an account into — in practice, terminated employees. That is
+what makes this a real security-incident class rather than a theoretical
+gap: the account a blanked `AccountState` reactivates is, definitionally, one
+an admin already decided should no longer have access.
+
+This is a second instance, within this ADR, of `system.write`'s flat design
+producing actor misattribution rather than merely an over-broad grant. The
+audit-trail case above left an action's actor unrecorded entirely; this one
+goes further, actively reassigning the resulting session — and every action
+taken through it — to a different, innocent identity. Both are evidence for
+the same question this ADR poses, not resolutions of it: whether (a) or (b)
+is the right model determines whether the fix for this class of finding is
+alerting on the pattern or narrowing the grant that makes the pattern
+possible.
+
+This specific chain is already closed on the reactivation-mechanics side: the
+route now fetches the existing row before writing, so a request that doesn't
+carry `PasswordHash`/`AccountState` no longer zeroes them. Closing
+`AccountLoginBlocked`'s fail-open itself — the account-state gate's deny-list
+shape — is a separate, still-in-progress migration. It is recorded here as
+evidence of what the flat capability already demonstrated once fixed, not as
+an open, exploitable path.
+
 ## The two candidate positions
 
 **(a) `system.write` is break-glass / root-equivalent.** If that is the


### PR DESCRIPTION
## Summary

Re-lands #1730's payload, which was correctly reviewed but auto-closed by
GitHub when its base branch (`fix-1622-expire-setup-token-audit-gap`, PR
#1713's branch) was deleted on squash-merge — the same stacked-branch
failure mode as #1726 (see that PR's description), just a smaller instance:
a single, isolated, additive documentation commit with nothing else stacked
on top of it and no code/test implications.

Adds one new subsection to `docs/adr-102-system-write-blast-radius.md`'s
Context section, recording `UpdateUserIfActiveStateMatchesProxy` as a
second, independent instance — within this same ADR — of the flat
`system.write` capability producing actor misattribution: the route built
its storage struct directly from the request body without fetching the
existing row first, and the underlying storage method is a `Select("*")`
full-row overwrite, so any call silently zeroed `PasswordHash` and
`AccountState`. Because `AccountLoginBlocked` (the account-state gate on
every login/session/PAT/SSO/WebAuthn/MFA-step-up/impersonation-target path)
is a deny-list rather than an allow-list, a blanked `AccountState` read as
not blocked, reactivating a suspended or deprovisioned account. Chained
with the setup-token completion flow, this was confirmed end-to-end as a
full account-takeover chain whose resulting session is attributed to the
victim, not the attacker who controls it.

Recorded as evidence only — the reactivation mechanics are already fixed
(fetch-first, landed via #1722) and the account-state fail-open is a
separate, still-in-progress migration (#1723). Does not change ADR-102's
Proposed status or choose between its two candidate positions.

## Test plan
- Documentation-only change, no code touched.
- Verified by content: `docs/adr-102-system-write-blast-radius.md` diff is
  exactly the 58-line addition from the original #1730 commit, cherry-picked
  cleanly onto current `main` with no conflicts.