### PR TITLE
fix(core,http): close UpdateMachineIdentityCredentialProxy audit-trail gap (#1714)

### DIFF
--- a/internal/core/machine_credential_classify_audit_test.go
+++ b/internal/core/machine_credential_classify_audit_test.go
@@ -1,0 +1,82 @@
+// machine_credential_classify_audit_test.go — #1714 invariant guard.
+//
+// UpdateMachineIdentityCredentialProxy (server/http/handlers/machine_identities_proxy.go)
+// used to call storage.UpdateMachineIdentityCredential directly after a raw
+// fetch+patch-Classification-only: no authz-ceiling issue (already narrowed,
+// G80 overnight campaign), but zero audit trail -- a system.write holder could
+// silently reclassify a machine credential's data-sensitivity label with no
+// record of the change. The fix routes the proxy through
+// ClassifyMachineTokenByID, which performs the fetch, the mutation, and the
+// machine_identity.token_classified audit write as one unit.
+//
+// This test asserts the invariant directly against ClassifyMachineTokenByID,
+// the ONLY route into this mutation for a caller that has just a credential
+// ID: a real classification change produces exactly one audit event, and a
+// no-op (new value equals the current one) produces none, matching
+// ClassifyMachineToken's own no-op short-circuit.
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyMachineTokenByID_RealChange_WritesOneAuditEvent(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	ctx := context.Background()
+
+	const machineID = uint(9)
+	const projectID = uint(3)
+	cred := &models.MachineIdentityCredential{ID: 55, MachineIdentityID: machineID, Classification: "internal"}
+	machine := &models.MachineIdentity{ID: machineID, ProjectID: projectID}
+
+	ms.On("GetMachineIdentityCredentialByID", ctx, cred.ID).Return(cred, nil)
+	ms.On("GetMachineIdentity", ctx, machineID).Return(machine, nil)
+	ms.On("UpdateMachineIdentityCredential", ctx, mock.MatchedBy(func(c *models.MachineIdentityCredential) bool {
+		return c.Classification == "confidential"
+	})).Return(nil)
+
+	var captured *models.AuditEvent
+	ms.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).
+		Run(func(args mock.Arguments) { captured = args.Get(1).(*models.AuditEvent) }).
+		Return(nil)
+
+	require.NoError(t, c.ClassifyMachineTokenByID(ctx, cred.ID, "confidential"))
+
+	ms.AssertNumberOfCalls(t, "UpdateMachineIdentityCredential", 1)
+	ms.AssertNumberOfCalls(t, "LogAuditEvent", 1)
+	require.NotNil(t, captured, "reclassifying a machine credential must write an audit event")
+	assert.Equal(t, "machine_identity.token_classified", captured.EventType)
+	require.NotNil(t, captured.ProjectID)
+	assert.Equal(t, projectID, *captured.ProjectID)
+}
+
+func TestClassifyMachineTokenByID_NoOp_WritesNoAuditEvent(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	ctx := context.Background()
+
+	cred := &models.MachineIdentityCredential{ID: 56, MachineIdentityID: 9, Classification: "internal"}
+	ms.On("GetMachineIdentityCredentialByID", ctx, cred.ID).Return(cred, nil)
+
+	require.NoError(t, c.ClassifyMachineTokenByID(ctx, cred.ID, "internal"))
+
+	ms.AssertNumberOfCalls(t, "UpdateMachineIdentityCredential", 0)
+	ms.AssertNumberOfCalls(t, "LogAuditEvent", 0)
+}
+
+func TestClassifyMachineTokenByID_InvalidClassification_Rejected(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	ctx := context.Background()
+
+	err := c.ClassifyMachineTokenByID(ctx, 1, "super-secret")
+	require.Error(t, err)
+	ms.AssertNotCalled(t, "GetMachineIdentityCredentialByID", mock.Anything, mock.Anything)
+}

--- a/internal/core/machine_token.go
+++ b/internal/core/machine_token.go
@@ -238,6 +238,44 @@ func (c *KeyorixCore) ClassifyMachineToken(ctx context.Context, projectID, machi
 	return cred, nil
 }
 
+// ClassifyMachineTokenByID sets a machine credential's data-classification label by
+// credential ID alone, with no project/machine ownership check. This is the ONLY
+// route into this mutation for a caller that has just a credential ID -- in
+// particular server/http/handlers' UpdateMachineIdentityCredentialProxy (backing a
+// RemoteStorage peer's own credential-classification path, #1714), which must not
+// call storage.UpdateMachineIdentityCredential directly since that mutates state
+// with no audit write. Unlike ClassifyMachineToken (the human-facing, project-scoped
+// API), this performs no project/machine authorization: exactly like every other
+// genuine passthrough in machine_identities_proxy.go, the CALLING server's own
+// internal/core already authorized its actor before deciding to relay this write --
+// this route makes no state-machine-legality or authorization decision, only
+// records that the classification changed (see that file's package doc).
+func (c *KeyorixCore) ClassifyMachineTokenByID(ctx context.Context, credentialID uint, level string) error {
+	if !IsValidClassification(level) {
+		return fmt.Errorf("classification must be one of public, internal, confidential, restricted (or empty to clear)")
+	}
+	cred, err := c.storage.GetMachineIdentityCredentialByID(ctx, credentialID)
+	if err != nil {
+		return err
+	}
+	if cred.Classification == level {
+		return nil // no-op
+	}
+	old := cred.Classification
+	cred.Classification = level
+	if err := c.storage.UpdateMachineIdentityCredential(ctx, cred); err != nil {
+		return err
+	}
+	var pid *uint
+	if m, err := c.storage.GetMachineIdentity(ctx, cred.MachineIdentityID); err == nil {
+		pid = &m.ProjectID
+	}
+	diff := fmt.Sprintf(`{"classification":{"before":%q,"after":%q}}`, old, level)
+	c.writeAuditEventDiff(ctx, "machine_identity.token_classified", nil, nil, pid, "",
+		fmt.Sprintf("machine credential %d (machine %d) classification set to %q", cred.ID, cred.MachineIdentityID, level), diff)
+	return nil
+}
+
 // ValidateMachineToken resolves a raw machine token to its identity, granted
 // role names, network restriction, and the credential's row id. It rejects
 // revoked/expired credentials and any machine not in the active state. The

--- a/server/http/handlers/machine_identities_proxy.go
+++ b/server/http/handlers/machine_identities_proxy.go
@@ -716,6 +716,13 @@ func (h *CatalogHandler) ListActiveMachineIdentityCredentialsProxy(w http.Respon
 // caller-side concern already satisfied by whichever server's core initiated
 // the relayed call) -- deliberately not re-derived here for the same reason
 // TransitionMachineIdentityStateProxy's cross-project guard isn't either.
+// #1714: routed through KeyorixCore.ClassifyMachineTokenByID, not
+// h.coreService.Storage().UpdateMachineIdentityCredential directly -- the raw
+// storage call mutates state with no audit trail, so any system.write holder
+// could silently reclassify a machine credential's data-sensitivity label with
+// no record of the change. ClassifyMachineTokenByID performs the fetch, the
+// mutation, and the machine_identity.token_classified audit write as one unit;
+// see its own doc.
 func (h *CatalogHandler) UpdateMachineIdentityCredentialProxy(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 32)
 	if err != nil {
@@ -732,18 +739,11 @@ func (h *CatalogHandler) UpdateMachineIdentityCredentialProxy(w http.ResponseWri
 			"classification must be one of public, internal, confidential, restricted (or empty to clear)")
 		return
 	}
-	existing, err := h.coreService.Storage().GetMachineIdentityCredentialByID(r.Context(), uint(id))
-	if err != nil {
+	if err := h.coreService.ClassifyMachineTokenByID(r.Context(), uint(id), body.Classification); err != nil {
 		if isNotFoundErr(err) {
 			writeRemoteAPIError(w, http.StatusNotFound, "NOT_FOUND", errMachineCredentialNotFound)
 			return
 		}
-		log.Printf("machine-credentials proxy: update lookup failed: %v", err)
-		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
-		return
-	}
-	existing.Classification = body.Classification
-	if err := h.coreService.Storage().UpdateMachineIdentityCredential(r.Context(), existing); err != nil {
 		log.Printf("machine-credentials proxy: update failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return

--- a/server/http/raw_storage_bypass_guard_test.go
+++ b/server/http/raw_storage_bypass_guard_test.go
@@ -993,22 +993,18 @@ var rawStorageBypassAllowlist = map[string]string{
 	"TransitionMachineIdentityStateProxy": "FIXED: preceded by core.IsValidMachineTransition -- see the FIXED " +
 		"comment immediately above this entry for the full reasoning (kept as a map comment, not a value, since " +
 		"Go doesn't support per-key doc comments on map literals).",
-	// FIXED 2026-08-24 (G80 overnight campaign, Tier 1 Group A #2, was in
-	// knownUnfixedRawStorageBypasses): the raw call is still here, but it no longer
-	// accepts a full caller-supplied replacement row. The handler now fetches the
-	// EXISTING credential and applies only Classification from the wire body,
-	// matching core.ClassifyMachineToken's actual behavior exactly (confirmed the
-	// ONLY exported core caller of this storage primitive by grep before this fix
-	// landed -- it never touches TokenHash/Revoked/ExpiresAt). No RemoteStorage
-	// wire-protocol change was needed: the only real caller only ever sends a
-	// classification change, so narrowing what the hub acts on breaks nothing
-	// (verified in the overnight session's RemoteStorage impact check). The route
-	// carries no caller-asserted project/machine scope to re-derive
-	// ClassifyMachineToken's own machineInProject check against -- same reasoning as
-	// TransitionMachineIdentityStateProxy's cross-project guard above; that check is
-	// a caller-side concern already satisfied before the relayed call reached here.
-	"UpdateMachineIdentityCredentialProxy": "FIXED: narrowed to fetch-existing + apply-Classification-only -- see " +
-		"the FIXED comment immediately above this entry for the full reasoning.",
+	// UpdateMachineIdentityCredentialProxy entry removed (#1714): the previous
+	// FIXED entry here only closed the authz-ceiling question (narrowed to
+	// fetch-existing + apply-Classification-only, matching
+	// core.ClassifyMachineToken's own field scope). #1714 found a separate,
+	// narrower defect the ceiling framing didn't cover: the raw
+	// storage.UpdateMachineIdentityCredential call skipped the
+	// machine_identity.token_classified AUDIT write entirely. Fixed
+	// structurally, not by adding a ceiling check: the handler now goes
+	// through KeyorixCore.ClassifyMachineTokenByID, which performs the fetch,
+	// the mutation, and the audit write as one unit -- no raw storage call
+	// remains in the handler, so this guard's own detection no longer flags
+	// it.
 	// FIXED 2026-08-24 (G80 Phase 2, #1529 re-triage): CreateInvitationProxy now
 	// re-derives InviteToProject's/InviteGlobal's own requireAuthorityForRole
 	// escalation-by-proxy ceiling for every role the wire body can carry (the


### PR DESCRIPTION
## Summary
- `UpdateMachineIdentityCredentialProxy` used to call `storage.UpdateMachineIdentityCredential` directly after a fetch+patch-Classification-only narrow (already closed, no authz-ceiling issue) — but with zero audit trail, so any `system.write` holder could silently reclassify a machine credential's data-sensitivity label with no record of the change.
- Adds `KeyorixCore.ClassifyMachineTokenByID`, which performs the fetch, the mutation, and the `machine_identity.token_classified` audit write as one unit (mirroring the existing project-scoped `ClassifyMachineToken`, minus the project/machine ownership check that doesn't apply to this proxy-relay route).
- Routes the proxy handler through it instead of raw storage.
- Removes the now-stale `rawStorageBypassAllowlist` entry in `server/http/raw_storage_bypass_guard_test.go`: the handler no longer makes a raw storage call at all, matching the `ExpireSetupTokenProxy`/`UpdateWebAuthnCredentialProxy` precedent already in that guard test.

Closes #1714 (the remaining item in that finding family — `ExpireSetupTokenProxy` and `UpdateWebAuthnCredentialProxy` were already fixed by prior PRs).

## Test plan
- [x] `go test ./internal/core/... -run TestClassifyMachineTokenByID` — new tests: real-change writes exactly one audit event, no-op writes none, invalid classification rejected before any storage call
- [x] `go test ./server/http/handlers/... -run MachineIdentityCredential` — existing handler tests (happy path, bad ID/body, DB error, ignores-attacker-fields) all green
- [x] `go test ./server/http/ -run TestNoUnjustifiedRawStorageBypass` — guard test green with the entry removed