### PR TITLE
fix(storage): self-certifiable gates for the account-state fail-closed flip (G1-G3)

### DIFF
--- a/internal/storage/account_state_backfill.go
+++ b/internal/storage/account_state_backfill.go
@@ -77,31 +77,85 @@ func backfillBlankAccountState(db *gorm.DB) error {
 	return nil
 }
 
-// guardAccountStateNotBlank adds a database-level CHECK constraint refusing
-// any future write of an empty users.account_state, on Postgres. This is the
-// schema-level half of the fix: even before NormalizeAccountState/
-// AccountLoginBlocked are changed to fail closed on an unrecognized value (a
-// separate, later behavior change -- see backfillBlankAccountState's own
-// doc), a write path that tries to blank this column again (a resurgence of
-// the exact bug the write-path containment fix closed at one call site, or a
-// new site nobody has found yet) fails loudly at the database instead of
-// silently succeeding.
+// ValidAccountStateSQLValues is the SQL-literal form of every ADR-025 account
+// state, for guardAccountStateValid's CHECK constraint. Deliberately
+// duplicated as literals rather than imported from internal/core: this
+// package (internal/storage) cannot import internal/core, since core already
+// imports storage (see accountStateBackfilledLabel's own comment for the
+// identical constraint). TestValidAccountStateSQLValues_MatchesCoreRegistry
+// (account_state_backfill_core_sync_test.go, an external storage_test
+// package, which CAN import core without an import cycle) fails CI if this
+// list ever drifts from core's own AccountXxx constants.
+var ValidAccountStateSQLValues = []string{
+	"active",
+	"pending_first_login",
+	"password_reset_required",
+	"suspended",
+	"deprovisioned",
+}
+
+// guardAccountStateValid adds a database-level CHECK constraint refusing any
+// future write of a users.account_state value outside the ADR-025 canonical
+// set, on Postgres. This is the schema-level half of the fix: even before
+// core.AccountLoginBlocked is changed to fail closed on an unrecognized value
+// (a separate, later behavior change -- see backfillBlankAccountState's own
+// doc), a write path that tries to persist blank OR any other non-canonical
+// value (a resurgence of the exact bug the write-path containment fix closed
+// at one call site, a typo, or a new site nobody has found yet) fails loudly
+// at the database instead of silently succeeding.
+//
+// An ENUM allow-list, not merely a non-empty check: a plain `<> ”` check
+// (this constraint's first version) stops a blank write but does nothing
+// about a garbage non-blank value reaching the column, which is exactly the
+// gap core.AccountLoginBlocked's fail-closed-on-unrecognized behavior needs
+// covered at the schema level too. Supersedes and replaces the narrower
+// chk_users_account_state_not_blank constraint from that first version.
+//
+// This constraint does NOT make the Go-level fail-closed check in
+// core.AccountLoginBlocked redundant -- that function is a pure function
+// over a string, not a query result. A User struct can carry an arbitrary
+// value from a session cache entry, an API request body deserialized before
+// any write, a test fixture, or (once storage.type: remote / a non-Postgres
+// backend is in play) a database this constraint was never applied to at
+// all. This constraint is defense-in-depth specifically for Postgres
+// production, not a substitute for the code-level check.
 //
 // Postgres only: SQLite's ALTER TABLE cannot add a CHECK constraint to an
 // existing table without a full table rebuild (copy to a new table, drop,
-// rename) -- a materially riskier operation for a boot-time, idempotent
-// migration than this fix is worth, especially since ADR-039 already
-// documents SQLite as single-instance/development only, never the
-// production-HA backend this constraint most needs to protect. The portable,
-// both-dialect backstop is the later code-level fail-closed change to
-// NormalizeAccountState/AccountLoginBlocked -- this constraint is
-// defense-in-depth specifically for Postgres production, not a substitute
-// for it.
-func guardAccountStateNotBlank(db *gorm.DB) error {
+// rename). For the `users` table specifically -- referenced by sessions,
+// PATs, group/user role grants, secret ownership, machine-identity
+// CreatedBy, webauthn credentials, and audit rows -- doing that rebuild
+// inside a boot-time, always-on, every-restart idempotent migration is a
+// materially riskier operation than the value justifies now that the
+// Go-level check is the actual, dialect-independent enforcement mechanism;
+// ADR-039 already documents SQLite as single-instance/development only,
+// never the production-HA backend this constraint most needs to protect.
+// Explicit, deliberate gap -- not silent: SQLite installs rely entirely on
+// core.AccountLoginBlocked's fail-closed behavior for this protection, with
+// no schema-level backstop.
+func guardAccountStateValid(db *gorm.DB) error {
 	if db.Dialector.Name() != "postgres" {
 		return nil
 	}
-	const constraintName = "chk_users_account_state_not_blank"
+	const constraintName = "chk_users_account_state_valid"
+	const oldConstraintName = "chk_users_account_state_not_blank"
+
+	var oldExists bool
+	if err := db.Raw(
+		"SELECT EXISTS (SELECT 1 FROM information_schema.table_constraints WHERE constraint_name = ? AND table_name = 'users')",
+		oldConstraintName,
+	).Scan(&oldExists).Error; err != nil {
+		return fmt.Errorf("failed to check for existing %s constraint: %w", oldConstraintName, err)
+	}
+	if oldExists {
+		// Subsumed by the new, stricter allow-list constraint below -- keeping
+		// both would be redundant, and Postgres has no "ALTER CONSTRAINT
+		// definition" so replacing it means drop-then-add.
+		if err := db.Exec("ALTER TABLE users DROP CONSTRAINT " + oldConstraintName).Error; err != nil {
+			return fmt.Errorf("failed to drop superseded %s constraint: %w", oldConstraintName, err)
+		}
+	}
+
 	var exists bool
 	if err := db.Raw(
 		"SELECT EXISTS (SELECT 1 FROM information_schema.table_constraints WHERE constraint_name = ? AND table_name = 'users')",
@@ -112,8 +166,41 @@ func guardAccountStateNotBlank(db *gorm.DB) error {
 	if exists {
 		return nil
 	}
+
+	quoted := make([]string, len(ValidAccountStateSQLValues))
+	for i, v := range ValidAccountStateSQLValues {
+		quoted[i] = "'" + v + "'"
+	}
+	inList := strings.Join(quoted, ",")
+	checkExpr := "account_state IN (" + inList + ")"
 	if err := db.Exec("ALTER TABLE users ADD CONSTRAINT " + constraintName +
-		" CHECK (btrim(account_state) <> '')").Error; err != nil {
+		" CHECK (" + checkExpr + ")").Error; err != nil {
+		// This constraint is stricter than the blank-only guard it replaces --
+		// backfillBlankAccountState only ever fixes BLANK rows, so an existing
+		// row already holding a non-blank, non-canonical value (a typo, manual
+		// DB edit, or some unrelated historical bug -- NOT the account-takeover
+		// vulnerability this whole fix closes, which was specifically about
+		// blank) makes this ADD CONSTRAINT fail with Postgres's own generic
+		// "violated by some row" error, naming no row. Since this failure is
+		// already fatal to server startup (migrateDatabase's caller aborts via
+		// log.Fatalf -- see this function's own doc), a bare Postgres error
+		// here would leave an operator with a dead server and no idea which
+		// row(s) to fix. Look them up and name them.
+		var offenders []struct {
+			ID    uint
+			State string
+		}
+		if scanErr := db.Raw("SELECT id, account_state AS state FROM users WHERE account_state NOT IN (" +
+			inList + ")").Scan(&offenders).Error; scanErr == nil && len(offenders) > 0 {
+			details := make([]string, len(offenders))
+			for i, o := range offenders {
+				details[i] = fmt.Sprintf("user %d has account_state %q", o.ID, o.State)
+			}
+			return fmt.Errorf("failed to add %s constraint: %d existing row(s) hold a non-canonical "+
+				"account_state value that must be corrected by an administrator before this version can "+
+				"start (backfillBlankAccountState only fixes blank values, not typos/garbage): %s: %w",
+				constraintName, len(offenders), strings.Join(details, "; "), err)
+		}
 		return fmt.Errorf("failed to add %s constraint: %w", constraintName, err)
 	}
 	return nil

--- a/internal/storage/account_state_backfill_core_sync_test.go
+++ b/internal/storage/account_state_backfill_core_sync_test.go
@@ -1,0 +1,35 @@
+// account_state_backfill_core_sync_test.go — external storage_test package
+// (not the production storage package, which cannot import internal/core:
+// core already imports storage) guarding against ValidAccountStateSQLValues
+// drifting from core's own ADR-025 account-state registry. If a new account
+// state is ever added to internal/core/account_state.go without updating
+// guardAccountStateValid's SQL list, this fails CI instead of silently
+// leaving Postgres's CHECK constraint rejecting a value the Go code
+// considers perfectly valid.
+package storage_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/storage"
+)
+
+func TestValidAccountStateSQLValues_MatchesCoreRegistry(t *testing.T) {
+	coreSideList := []string{
+		core.AccountActive,
+		core.AccountPendingFirstLogin,
+		core.AccountPasswordResetRequired,
+		core.AccountSuspended,
+		core.AccountDeprovisioned,
+	}
+	storageSideList := append([]string(nil), storage.ValidAccountStateSQLValues...)
+	sort.Strings(coreSideList)
+	sort.Strings(storageSideList)
+	assert.Equal(t, coreSideList, storageSideList,
+		"internal/storage/account_state_backfill.go's ValidAccountStateSQLValues must list exactly "+
+			"core's AccountXxx constants -- update both together")
+}

--- a/internal/storage/account_state_backfill_postgres_test.go
+++ b/internal/storage/account_state_backfill_postgres_test.go
@@ -1,10 +1,10 @@
 package storage
 
 // account_state_backfill_postgres_test.go — the real-Postgres counterpart to
-// account_state_backfill_test.go's TestGuardAccountStateNotBlank_NoOpOnSQLite:
-// proves the CHECK constraint actually rejects a blank write on the one
-// dialect it's meant to protect. Skips (KEYORIX_TEST_PG_DSN unset) when no
-// real Postgres server is available, same convention as
+// account_state_backfill_test.go's TestGuardAccountStateValid_NoOpOnSQLite:
+// proves the CHECK constraint actually rejects blank and non-canonical writes
+// on the one dialect it's meant to protect. Skips (KEYORIX_TEST_PG_DSN unset)
+// when no real Postgres server is available, same convention as
 // factory_rbac_pk_rebuild_postgres_test.go.
 
 import (
@@ -14,29 +14,91 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGuardAccountStateNotBlank_Postgres_RejectsBlankWrite(t *testing.T) {
+func TestGuardAccountStateValid_Postgres_RejectsBlankAndGarbageWrites(t *testing.T) {
 	base := pgTestDSN(t)
 	db := pgRawOpen(t, pgIsolatedDatabaseDSN(t, base))
 
 	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, account_state TEXT)`).Error)
-	require.NoError(t, guardAccountStateNotBlank(db))
+	require.NoError(t, guardAccountStateValid(db))
 
-	// A non-blank write still succeeds.
-	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'active')`).Error)
+	// Every canonical value still succeeds.
+	for i, v := range ValidAccountStateSQLValues {
+		require.NoError(t, db.Exec(`INSERT INTO users VALUES (?, ?)`, i+1, v).Error, "canonical value %q must be accepted", v)
+	}
 
 	// An empty-string write is refused at the database.
-	err := db.Exec(`INSERT INTO users VALUES (2, '')`).Error
+	err := db.Exec(`INSERT INTO users VALUES (100, '')`).Error
 	require.Error(t, err, "an empty account_state must be refused by the CHECK constraint")
-	assert.Contains(t, err.Error(), "chk_users_account_state_not_blank")
+	assert.Contains(t, err.Error(), "chk_users_account_state_valid")
 
-	// A whitespace-only write is ALSO refused (the constraint uses btrim,
-	// matching backfillBlankAccountState's own strings.TrimSpace definition
-	// of "blank").
-	err = db.Exec(`INSERT INTO users VALUES (3, '   ')`).Error
+	// A whitespace-only write is ALSO refused (not a member of the enum list).
+	err = db.Exec(`INSERT INTO users VALUES (101, '   ')`).Error
 	require.Error(t, err, "a whitespace-only account_state must also be refused")
+
+	// A non-blank but non-canonical (garbage/typo) value is refused too --
+	// the entire reason for the enum allow-list over a plain non-empty check.
+	err = db.Exec(`INSERT INTO users VALUES (102, 'Active')`).Error
+	require.Error(t, err, "a non-canonical value (wrong casing) must be refused")
+	err = db.Exec(`INSERT INTO users VALUES (103, 'deleted')`).Error
+	require.Error(t, err, "a non-canonical value (made-up state) must be refused")
 
 	// Re-applying the guard on a database that already has the constraint is
 	// a no-op, not an error (idempotent, matching every other ensure*/guard*
 	// migration helper in this package).
-	require.NoError(t, guardAccountStateNotBlank(db))
+	require.NoError(t, guardAccountStateValid(db))
+}
+
+// TestGuardAccountStateValid_Postgres_ReplacesSupersededConstraint proves the
+// upgrade path from the first version of this constraint
+// (chk_users_account_state_not_blank, a plain non-empty check) to the current
+// enum allow-list: a database that already has the old constraint (and no
+// data that would violate the new one) gets it dropped and replaced, not left
+// in place alongside the new one.
+func TestGuardAccountStateValid_Postgres_ReplacesSupersededConstraint(t *testing.T) {
+	base := pgTestDSN(t)
+	db := pgRawOpen(t, pgIsolatedDatabaseDSN(t, base))
+
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, account_state TEXT)`).Error)
+	require.NoError(t, db.Exec(`ALTER TABLE users ADD CONSTRAINT chk_users_account_state_not_blank CHECK (btrim(account_state) <> '')`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'active')`).Error)
+
+	require.NoError(t, guardAccountStateValid(db))
+
+	var oldExists bool
+	require.NoError(t, db.Raw(
+		"SELECT EXISTS (SELECT 1 FROM information_schema.table_constraints WHERE constraint_name = 'chk_users_account_state_not_blank' AND table_name = 'users')",
+	).Scan(&oldExists).Error)
+	assert.False(t, oldExists, "the superseded constraint must be dropped, not left in place")
+
+	// The new constraint governs writes now -- a value that would have passed
+	// the old one is refused.
+	err := db.Exec(`INSERT INTO users VALUES (2, 'another-garbage-value')`).Error
+	require.Error(t, err, "the new enum constraint must govern writes after the upgrade")
+	assert.Contains(t, err.Error(), "chk_users_account_state_valid")
+}
+
+// TestGuardAccountStateValid_Postgres_FailsLoudlyOnPreexistingGarbageRow
+// covers the case the previous test deliberately avoids: an existing row
+// already holds a non-blank, non-canonical value (a typo or some unrelated
+// historical bug -- backfillBlankAccountState only ever fixes BLANK rows, so
+// this is untouched by it) when the enum constraint is first added. Postgres
+// refuses the ADD CONSTRAINT outright; this proves the resulting error names
+// the offending row/value instead of surfacing Postgres's own generic
+// "violated by some row" message, which names nothing an operator could act
+// on. This failure is intentional and fatal (migrateDatabase's caller aborts
+// server startup on it) -- better a clearly-diagnosable refusal to start than
+// silently leaving the schema-level guarantee unenforced.
+func TestGuardAccountStateValid_Postgres_FailsLoudlyOnPreexistingGarbageRow(t *testing.T) {
+	base := pgTestDSN(t)
+	db := pgRawOpen(t, pgIsolatedDatabaseDSN(t, base))
+
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, account_state TEXT)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, 'active')`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (42, 'some-garbage-value')`).Error)
+
+	err := guardAccountStateValid(db)
+	require.Error(t, err, "a pre-existing non-canonical row must fail the constraint add, not be silently ignored")
+	assert.Contains(t, err.Error(), "user 42")
+	assert.Contains(t, err.Error(), "some-garbage-value")
+	assert.Contains(t, err.Error(), "administrator")
 }

--- a/internal/storage/account_state_backfill_test.go
+++ b/internal/storage/account_state_backfill_test.go
@@ -56,6 +56,45 @@ func TestBackfillBlankAccountState_ExcludesSoftDeletedRows(t *testing.T) {
 	assert.Equal(t, "", state, "a soft-deleted row's account_state is not touched")
 }
 
+// TestBackfillBlankAccountState_IdempotentOnSecondRunAfterRealBackfill is
+// distinct from TestBackfillBlankAccountState_NoOpWhenNothingBlank: that test
+// only proves re-running is a no-op when nothing was EVER blank. This proves
+// the stronger, actually-load-bearing property -- run the backfill once
+// against rows that genuinely need it, then run it AGAIN against the
+// now-fixed database, and confirm the second run neither errors nor changes
+// anything. migrateDatabase calls this on every boot (not just once), so a
+// backfill that isn't safe to re-run would corrupt or error on every restart
+// of an already-upgraded install, not just the first one.
+func TestBackfillBlankAccountState_IdempotentOnSecondRunAfterRealBackfill(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "account-state-idempotent-real.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, account_state TEXT, deleted_at DATETIME)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, '', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (2, NULL, NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (3, '   ', NULL)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users VALUES (4, 'suspended', NULL)`).Error)
+
+	require.NoError(t, backfillBlankAccountState(db), "first run must backfill the 3 blank rows")
+
+	type row struct {
+		ID           uint
+		AccountState string
+	}
+	var afterFirst []row
+	require.NoError(t, db.Table("users").Order("id").Find(&afterFirst).Error)
+	require.Len(t, afterFirst, 4)
+	for _, r := range afterFirst[:3] {
+		assert.Equal(t, "active", r.AccountState)
+	}
+	assert.Equal(t, "suspended", afterFirst[3].AccountState)
+
+	require.NoError(t, backfillBlankAccountState(db), "second run against an already-fixed database must not error")
+
+	var afterSecond []row
+	require.NoError(t, db.Table("users").Order("id").Find(&afterSecond).Error)
+	assert.Equal(t, afterFirst, afterSecond, "second run must leave every row byte-for-byte unchanged")
+}
+
 // TestBackfillBlankAccountState_NoOpWhenNothingBlank proves the idempotency
 // every other backfill* helper in this package guarantees: re-running finds
 // nothing to do and touches nothing.
@@ -75,15 +114,37 @@ func TestBackfillBlankAccountState_NoOpWhenNothingBlank(t *testing.T) {
 	assert.Equal(t, "pending_first_login", state2)
 }
 
-// TestGuardAccountStateNotBlank_NoOpOnSQLite: the CHECK constraint is
+// TestMigrateDatabase_FreshInstallBootsCleanlyWithAccountStateGuards proves
+// the account-state backfill/guard pair doesn't regress the fresh-install
+// path: a brand new database with no pre-existing users table at all (no
+// legacy rows, nothing to backfill) must migrate successfully through the
+// FULL migrateDatabase chain, not just the isolated backfill/guard functions.
+// A row-count-based guard (as opposed to one keyed on recorded migration
+// state) would be the wrong design specifically because it could behave
+// differently on an empty table than a populated one -- this test is what
+// catches that class of bug if it's ever introduced.
+func TestMigrateDatabase_FreshInstallBootsCleanlyWithAccountStateGuards(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "account-state-fresh-install.db"))
+	require.NoError(t, err)
+
+	require.NoError(t, (&DefaultStorageFactory{}).migrateDatabase(db),
+		"a fresh install with no legacy users table must migrate cleanly")
+
+	var count int64
+	require.NoError(t, db.Table("users").Where("account_state = '' OR account_state IS NULL").
+		Count(&count).Error)
+	assert.Zero(t, count, "a fresh install must never end up with a blank account_state row")
+}
+
+// TestGuardAccountStateValid_NoOpOnSQLite: the CHECK constraint is
 // Postgres-only (see the function's own doc for why) -- on SQLite this must
 // be a clean no-op, not an error, since every local/dev/test database in
 // this repo runs on SQLite.
-func TestGuardAccountStateNotBlank_NoOpOnSQLite(t *testing.T) {
+func TestGuardAccountStateValid_NoOpOnSQLite(t *testing.T) {
 	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "account-state-guard-sqlite.db"))
 	require.NoError(t, err)
 	require.NoError(t, db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, account_state TEXT)`).Error)
-	require.NoError(t, guardAccountStateNotBlank(db))
+	require.NoError(t, guardAccountStateValid(db))
 	// A blank write must still succeed on SQLite -- confirms no constraint
 	// was (incorrectly) applied here.
 	require.NoError(t, db.Exec(`INSERT INTO users VALUES (1, '')`).Error)

--- a/internal/storage/account_state_fatal_migration_guard_test.go
+++ b/internal/storage/account_state_fatal_migration_guard_test.go
@@ -1,0 +1,102 @@
+// account_state_fatal_migration_guard_test.go — a structural guard, in the
+// same family as server/http's raw_storage_bypass_guard_test.go, proving
+// migrateDatabase's calls to backfillBlankAccountState and
+// guardAccountStateValid are wired so a failure aborts migrateDatabase
+// itself (`if err := X(db); err != nil { return ... }`), not merely logged
+// and continued past.
+//
+// This is the actual enforcement of "fail closed on migration state": this
+// codebase has no separate migration-ledger table to check at startup --
+// migrateDatabase already runs synchronously, on every boot, before storage
+// becomes usable, and its caller chain (createLocalStorage/
+// createPostgresStorage -> CreateStorage -> server/main.go's log.Fatalf) is
+// already fatal on any error migrateDatabase returns (confirmed by direct
+// reading of factory.go:359-361, factory.go:382-384, and server/main.go's
+// call site, which panics the process via log.Fatalf, itself calling
+// os.Exit -- not independently re-provable in a unit test without killing
+// the test binary). The one link in that chain this repo CAN keep honest via
+// CI is this one: that migrateDatabase's own body never starts silently
+// swallowing one of these two calls' errors. If it ever did, a real
+// migration failure (e.g. the pre-existing-garbage-row case
+// TestGuardAccountStateValid_Postgres_FailsLoudlyOnPreexistingGarbageRow
+// covers) would leave migrateDatabase reporting success while the schema
+// invariant it's supposed to guarantee silently didn't hold.
+package storage
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestMigrateDatabase_AccountStateCallsAbortOnError(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "factory.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing factory.go: %v", err)
+	}
+
+	var migrateDatabaseDecl *ast.FuncDecl
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if ok && fd.Name.Name == "migrateDatabase" {
+			migrateDatabaseDecl = fd
+			break
+		}
+	}
+	if migrateDatabaseDecl == nil {
+		t.Fatal("could not find migrateDatabase's declaration in factory.go")
+	}
+
+	for _, target := range []string{"backfillBlankAccountState", "guardAccountStateValid"} {
+		if !callAbortsOnError(migrateDatabaseDecl, target) {
+			t.Errorf("migrateDatabase's call to %s(...) must be wired as "+
+				"`if err := %s(db); err != nil { return ... }` -- a failure here must abort "+
+				"migrateDatabase, not be logged/ignored and continued past", target, target)
+		}
+	}
+}
+
+// callAbortsOnError reports whether fd's body contains an if-statement of the
+// shape `if err := <target>(...); err != nil { <block containing a return> }`.
+func callAbortsOnError(fd *ast.FuncDecl, target string) bool {
+	found := false
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok || ifStmt.Init == nil {
+			return true
+		}
+		assign, ok := ifStmt.Init.(*ast.AssignStmt)
+		if !ok || len(assign.Rhs) != 1 {
+			return true
+		}
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok || ident.Name != target {
+			return true
+		}
+		// Confirm the if's condition checks err != nil (the assigned variable).
+		cond, ok := ifStmt.Cond.(*ast.BinaryExpr)
+		if !ok || cond.Op != token.NEQ {
+			return true
+		}
+		// Confirm the if-body contains a return statement (aborts the function)
+		// rather than e.g. only a log call.
+		hasReturn := false
+		ast.Inspect(ifStmt.Body, func(bn ast.Node) bool {
+			if _, ok := bn.(*ast.ReturnStmt); ok {
+				hasReturn = true
+			}
+			return true
+		})
+		if hasReturn {
+			found = true
+		}
+		return true
+	})
+	return found
+}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1826,7 +1826,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	if err := backfillBlankAccountState(db); err != nil {
 		return err
 	}
-	if err := guardAccountStateNotBlank(db); err != nil {
+	if err := guardAccountStateValid(db); err != nil {
 		return err
 	}
 	if err := ensureProjectNameIndex(db); err != nil {


### PR DESCRIPTION
## Summary
Replaces the "confirm zero blanks in production" gate the fail-closed `AccountLoginBlocked` flip was previously held on. That gate can never be satisfied as framed: Keyorix is on-premise with no production database any session controls, and every customer applies migrations on their own schedule — "the backfill ran once, somewhere" is not evidence any given deployment has run it. Three self-certifiable gates instead, each provable in CI with no DB access:

**G1 — migration correctness and idempotency.** Adds the missing "idempotent after a REAL backfill" test — the existing test only proved idempotency when nothing was ever blank to begin with. While writing the Postgres upgrade test for G2, found and fixed a real gap: a pre-existing non-canonical row would make the new CHECK constraint's `ADD CONSTRAINT` fail with Postgres's own generic "violated by some row" error, naming nothing. Now the wrapped error names the offending row id and value, with actionable guidance.

**G2 — schema-level constraint widened from a plain non-empty check to a full ENUM allow-list** (`CHECK (account_state IN (...))`), so a non-blank garbage value is refused at the database too, not just blank. Postgres only — same reasoning as before for the SQLite gap (ADR-039: dev-only, and the Go-level check is now the actual, dialect-independent enforcement — see the function's updated doc for why the DB constraint doesn't make it redundant). A cross-package test (external `storage_test`, which can import `internal/core` without the cycle `internal/storage`'s production code can't take) fails CI if the SQL literal list ever drifts from `core`'s own account-state registry.

**G3 — this codebase has no separate migration-ledger table.** `migrateDatabase` already runs synchronously on every boot before storage becomes usable, and a failure already propagates through `createLocalStorage`/`createPostgresStorage`/`CreateStorage` to `server/main.go`'s `log.Fatalf` (verified by direct reading, file:line references in the new code comments). Adds a structural (AST-based) test proving `migrateDatabase`'s calls to the backfill/guard functions stay wired as fatal (`if err != nil { return }`), not silently logged-and-continued in some future edit, plus an explicit fresh-install-boots-cleanly test.

Does **not** change `AccountLoginBlocked`'s behavior — that flip (G4) is a separate PR once these are in place and merged.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated` clean
- [x] Full `internal/storage/...` suite green (including the ~14min `store` package suite), `internal/core/...` green
- [x] New Postgres tests run against a real local Postgres container (not just SQLite): rejects blank/whitespace/garbage writes, cleanly replaces the superseded constraint, and fails loudly+actionably on a pre-existing garbage row
- [x] Red/green verified the new AST structural test by temporarily swallowing the backfill error (logged-and-continued instead of returned) — confirmed it fails, then restored and confirmed green