### PR TITLE
fix(core): flip AccountLoginBlocked to fail closed on blank/unrecognized state (G4)

### DIFF
--- a/internal/core/account_state.go
+++ b/internal/core/account_state.go
@@ -22,6 +22,8 @@ package core
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
@@ -106,21 +108,75 @@ func AccountRestricted(state string) bool {
 // funnels through here, so a deprovisioned account is refused everywhere a suspended
 // one is, with no per-path change.
 //
-// Unlike AccountRestricted, this deliberately keeps a fail-OPEN default (false, not
-// blocked) for an unrecognized state. Blocking login outright has no self-healing
-// path — a fully blocked user can never reach the password-change flow to fix
-// anything — so failing closed here would risk permanently locking out an already-
-// legitimate user over a merely malformed value (e.g. a stale data migration, or a
-// value from a since-removed state) with no recovery short of direct DB/admin
-// intervention. AccountRestricted's fail-closed default already guarantees an
-// unrecognized value can never grant full unrestricted access; that is the correct
-// place for the defense-in-depth backstop, not here.
-func AccountLoginBlocked(state string) bool {
-	switch NormalizeAccountState(state) {
+// Fails CLOSED on blank, whitespace-only, and any other unrecognized value — this is
+// a change from this function's original design, which deliberately chose fail-OPEN
+// here (see git history for the prior reasoning: blocking login outright has no
+// self-healing path, so failing closed on a merely malformed value risked permanently
+// locking out an already-legitimate user with no recovery short of direct DB/admin
+// intervention).
+//
+// That reasoning was correct in general — it is exactly why AccountRestricted (a
+// state that still authenticates but forces a password change) keeps a fail-closed
+// default while THIS function, which refuses login outright, did not. But it weighed
+// wrongful-lockout and wrongful-access as comparable costs, and at this specific
+// call site they are not. For a secrets-management platform: a lockout is
+// admin-recoverable in minutes and loudly visible (ReactivateUser, an audited action,
+// with the operator informed exactly why via the log line and metric below); an
+// authentication bypass through this exact gate is how a suspended/deprovisioned
+// account got fully reactivated for login in a real, confirmed incident (a full-row
+// storage overwrite silently blanked account_state, which this function's old
+// fail-open default then read as "not blocked") — unrecoverable once exploited, and
+// may never be detected. At an authentication boundary specifically, the integrity
+// argument wins. This does NOT generalize to the rest of the codebase; it is a
+// property of this one call site, which is why AccountRestricted's own default is
+// untouched.
+//
+// Four things make failing closed here safe rather than a new blast radius:
+//  1. internal/storage/account_state_backfill.go's guardAccountStateValid adds a
+//     Postgres CHECK constraint restricting account_state to exactly the ADR-025
+//     canonical set — no other value can be newly WRITTEN, on that backend. (This
+//     function is still the one enforcement this constraint doesn't reach: it's a
+//     pure function over a string, not a query result. A User struct can carry an
+//     arbitrary value from a session-cache entry, an API request body deserialized
+//     before any write, a test fixture, or a non-Postgres backend the constraint was
+//     never applied to at all — SQLite has no equivalent, by design; see that
+//     function's doc. The constraint is defense-in-depth for one backend, not a
+//     substitute for the check below.)
+//  2. TestAccountLoginBlocked_ExhaustsStateRegistry (account_state_exhaustiveness_
+//     guard_test.go) statically asserts every AccountXxx constant declared in this
+//     file is explicitly listed in this switch's case clauses — adding a new account
+//     state without handling it here fails CI, which is what makes "a future state
+//     not yet in this switch" (the original comment's main scenario) impossible to
+//     ship silently.
+//  3. Every existing blank row was backfilled to an explicit "active" before this
+//     change shipped (internal/storage/account_state_backfill.go's
+//     backfillBlankAccountState, proven idempotent and correct for every blank shape
+//     — empty, NULL, whitespace-only — by its own test suite), so this flip does not
+//     retroactively lock out any account that was blank for a benign reason.
+//  4. The failure is LOUD, never silent: every fail-closed hit below logs the exact
+//     value and the affected user ID at security level and increments
+//     accountStateUnrecognizedTotal (account_state_metrics.go), so a lockout this
+//     causes is immediately diagnosable from a single log line and alertable via the
+//     metric — never a mysterious, undiagnosable "why can't I log in".
+//
+// Release ordering: the backfill (item 3) is backward-compatible — old code reads
+// the explicit "active" value exactly the same as it read blank — so it can ship in
+// a release ahead of this fail-closed change without any coordination requirement
+// beyond "the backfill's release is deployed first". See ADR-025 for the account of
+// why a live-database confirmation gate was replaced with these four self-certifiable
+// preconditions.
+func AccountLoginBlocked(userID uint, state string) bool {
+	switch strings.TrimSpace(state) {
+	case AccountActive, AccountPendingFirstLogin, AccountPasswordResetRequired:
+		return false
 	case AccountSuspended, AccountDeprovisioned:
 		return true
 	default:
-		return false
+		accountStateUnrecognizedTotal.Inc()
+		log.Printf("SECURITY: user %d has a blank or unrecognized account_state %q -- failing closed "+
+			"(login blocked). Recovery: an administrator must explicitly reactivate this account "+
+			"(ReactivateUser) to set it to a valid state.", userID, state)
+		return true
 	}
 }
 
@@ -230,7 +286,7 @@ func (c *KeyorixCore) setAccountState(ctx context.Context, adminID, userID uint,
 		// accounts as a slow-path backstop, but the cache fast path bypasses it — so
 		// evict here too. Revoked PAT hashes are folded into sessionHashes so they're
 		// evicted from the auth cache alongside the session hashes after commit.
-		if AccountLoginBlocked(state) {
+		if AccountLoginBlocked(userID, state) {
 			_ = tx.DeleteSessionsForUserExcept(ctx, userID, 0)
 			if hashes, herr := tx.RevokeAllPersonalAccessTokensForUser(ctx, userID); herr == nil {
 				sessionHashes = append(sessionHashes, hashes...)

--- a/internal/core/account_state_exhaustiveness_guard_test.go
+++ b/internal/core/account_state_exhaustiveness_guard_test.go
@@ -1,0 +1,130 @@
+// account_state_exhaustiveness_guard_test.go — a structural guard, in the
+// same family as server/http's raw_storage_bypass_guard_test.go, statically
+// proving every ADR-025 account-state constant declared in account_state.go
+// is explicitly listed in AccountLoginBlocked's switch statement.
+//
+// This is what makes "a future account state added without updating this
+// switch" (the scenario AccountLoginBlocked's own doc names as the reason a
+// blanket fail-open default used to seem safer) impossible to ship silently:
+// a state that falls through to AccountLoginBlocked's default case gets
+// blocked, not silently allowed -- but ONLY if a developer actually intended
+// that. This test forces the decision to be explicit and visible in the
+// diff, not an accident of switch-statement omission.
+package core
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestAccountLoginBlocked_ExhaustsStateRegistry parses account_state.go,
+// collects every top-level `AccountXxx = "..."` constant declared there, then
+// confirms each one is referenced as a case value somewhere in
+// AccountLoginBlocked's switch statement (either the "not blocked" or the
+// "blocked" case group). Adding a new AccountXxx constant without adding it
+// to one of those two groups fails this test.
+func TestAccountLoginBlocked_ExhaustsStateRegistry(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "account_state.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing account_state.go: %v", err)
+	}
+
+	constants := accountStateConstants(f)
+	if len(constants) == 0 {
+		t.Fatal("found zero AccountXxx constants in account_state.go -- the const-collection logic itself is broken")
+	}
+
+	switchCases := accountLoginBlockedSwitchCaseIdents(f)
+	if switchCases == nil {
+		t.Fatal("could not find AccountLoginBlocked's switch statement in account_state.go")
+	}
+
+	var missing []string
+	for _, c := range constants {
+		if !switchCases[c] {
+			missing = append(missing, c)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("AccountLoginBlocked's switch does not explicitly list: %v -- add each to either the "+
+			"not-blocked or blocked case group (never rely on the default case for a real, valid state)", missing)
+	}
+}
+
+// accountStateConstants returns every top-level constant identifier declared
+// in f whose name starts with "Account" (matching AccountActive,
+// AccountSuspended, etc.) and whose value is a string literal.
+func accountStateConstants(f *ast.File) []string {
+	var names []string
+	for _, decl := range f.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if len(vs.Values) <= i {
+					continue
+				}
+				if _, ok := vs.Values[i].(*ast.BasicLit); !ok {
+					continue
+				}
+				if len(name.Name) > 7 && name.Name[:7] == "Account" {
+					names = append(names, name.Name)
+				}
+			}
+		}
+	}
+	return names
+}
+
+// accountLoginBlockedSwitchCaseIdents finds AccountLoginBlocked's func decl
+// and returns the set of identifier names referenced in any of its switch
+// statement's (non-default) case clauses. Returns nil if the function or its
+// switch statement can't be found.
+func accountLoginBlockedSwitchCaseIdents(f *ast.File) map[string]bool {
+	var fd *ast.FuncDecl
+	for _, decl := range f.Decls {
+		cand, ok := decl.(*ast.FuncDecl)
+		if ok && cand.Name.Name == "AccountLoginBlocked" {
+			fd = cand
+			break
+		}
+	}
+	if fd == nil {
+		return nil
+	}
+
+	var sw *ast.SwitchStmt
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		if s, ok := n.(*ast.SwitchStmt); ok {
+			sw = s
+			return false
+		}
+		return true
+	})
+	if sw == nil {
+		return nil
+	}
+
+	idents := map[string]bool{}
+	for _, stmt := range sw.Body.List {
+		cc, ok := stmt.(*ast.CaseClause)
+		if !ok || cc.List == nil { // nil List is the default case
+			continue
+		}
+		for _, expr := range cc.List {
+			if id, ok := expr.(*ast.Ident); ok {
+				idents[id.Name] = true
+			}
+		}
+	}
+	return idents
+}

--- a/internal/core/account_state_metrics.go
+++ b/internal/core/account_state_metrics.go
@@ -1,0 +1,27 @@
+// account_state_metrics.go — Prometheus instrumentation for
+// AccountLoginBlocked's fail-closed path (ADR-025), matching the
+// package-per-counter-file convention internal/notifychan/notify_metrics.go
+// establishes.
+//
+// A blank or unrecognized users.account_state should never occur once the
+// backfill (internal/storage/account_state_backfill.go) and the Postgres
+// enum CHECK constraint have both run -- if this counter is ever non-zero,
+// either that backfill missed a row, a non-Postgres backend has no
+// schema-level backstop (SQLite, by design -- see guardAccountStateValid's
+// doc), or something wrote a value outside the ADR-025 canonical set through
+// a path this fix didn't anticipate. Any of those is worth a page, not a
+// silent log line nobody watches.
+package core
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// accountStateUnrecognizedTotal counts every AccountLoginBlocked call that
+// fell through to the fail-closed default case: a blank, whitespace-only, or
+// otherwise unrecognized account_state value.
+var accountStateUnrecognizedTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "keyorix_account_state_unrecognized_total",
+	Help: "Count of AccountLoginBlocked calls against a blank or unrecognized users.account_state value, failed closed.",
+})

--- a/internal/core/account_state_test.go
+++ b/internal/core/account_state_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -21,8 +22,8 @@ func TestAccountStateHelpers(t *testing.T) {
 	assert.False(t, AccountRestricted(AccountActive))
 	assert.False(t, AccountRestricted("")) // legacy → active
 
-	assert.True(t, AccountLoginBlocked(AccountSuspended))
-	assert.False(t, AccountLoginBlocked(AccountActive))
+	assert.True(t, AccountLoginBlocked(1, AccountSuspended))
+	assert.False(t, AccountLoginBlocked(1, AccountActive))
 
 	// A restricted state clears to active on password change; others unchanged.
 	assert.Equal(t, AccountActive, clearRestrictionOnPasswordChange(AccountPasswordResetRequired))
@@ -43,34 +44,78 @@ func TestIsValidAccountState(t *testing.T) {
 }
 
 // TestAccountState_UnrecognizedValueFailsClosed proves #334's defense-in-depth
-// backstop: an unrecognized account_state value (e.g. one persisted before the
-// write-path validation shipped) is treated as restricted — never as fully
-// active/unrestricted — while still not being an outright login block, since a
-// restricted session can self-heal via a password change.
+// backstop (AccountRestricted) AND AccountLoginBlocked's own fail-closed
+// posture (see that function's doc for the asymmetry reasoning): an
+// unrecognized account_state value is treated as restricted by
+// AccountRestricted (never as fully active/unrestricted), AND refused
+// outright by AccountLoginBlocked — both fail closed, just to different
+// degrees of severity, matching what each function protects.
 func TestAccountState_UnrecognizedValueFailsClosed(t *testing.T) {
 	garbage := "not-a-real-state"
 
 	assert.True(t, AccountRestricted(garbage), "unrecognized state must fail closed to restricted")
-	assert.False(t, AccountLoginBlocked(garbage), "unrecognized state must not hard-lock out login (no self-heal path)")
+	assert.True(t, AccountLoginBlocked(1, garbage), "unrecognized state must also fail closed to login-blocked")
 
 	// An unrecognized-but-restricted state still self-heals to active on the
 	// next password change, exactly like the canonical restricted states.
+	// (Moot in practice for login itself, since AccountLoginBlocked now refuses
+	// it before a session is ever minted -- but clearRestrictionOnPasswordChange
+	// is also called from paths that already hold an authenticated session, e.g.
+	// an admin-initiated password change, so this must still self-heal.)
 	assert.Equal(t, AccountActive, clearRestrictionOnPasswordChange(garbage))
 
-	// The canonical, previously-tested behaviors are unchanged by the new default.
+	// The canonical, previously-tested behaviors are unchanged.
 	assert.True(t, AccountRestricted(AccountPendingFirstLogin))
 	assert.True(t, AccountRestricted(AccountPasswordResetRequired))
 	assert.False(t, AccountRestricted(AccountActive))
 	assert.False(t, AccountRestricted(AccountSuspended))
 	assert.False(t, AccountRestricted(AccountDeprovisioned))
+	// AccountRestricted's behavior for blank is genuinely unchanged by this fix:
+	// NormalizeAccountState still maps "" to AccountActive (write-time-defaulting
+	// semantics used elsewhere, e.g. CreateUser's "no state specified" path --
+	// see AccountLoginBlocked's own doc for why that function deliberately does
+	// NOT route through NormalizeAccountState instead), so AccountRestricted("")
+	// still resolves to AccountActive's case (not restricted) exactly as before.
+	// This is moot in practice: AccountLoginBlocked now refuses a blank state
+	// outright, so restriction-checking is never reached for it at all.
 	assert.False(t, AccountRestricted(""))
 
-	assert.True(t, AccountLoginBlocked(AccountSuspended))
-	assert.True(t, AccountLoginBlocked(AccountDeprovisioned))
-	assert.False(t, AccountLoginBlocked(AccountActive))
-	assert.False(t, AccountLoginBlocked(AccountPendingFirstLogin))
-	assert.False(t, AccountLoginBlocked(AccountPasswordResetRequired))
-	assert.False(t, AccountLoginBlocked(""))
+	assert.True(t, AccountLoginBlocked(1, AccountSuspended))
+	assert.True(t, AccountLoginBlocked(1, AccountDeprovisioned))
+	assert.False(t, AccountLoginBlocked(1, AccountActive))
+	assert.False(t, AccountLoginBlocked(1, AccountPendingFirstLogin))
+	assert.False(t, AccountLoginBlocked(1, AccountPasswordResetRequired))
+}
+
+// TestAccountLoginBlocked_FailsClosedOnBlankAndWhitespace is the regression
+// test for the actual vulnerability this fix closes: a blank or whitespace-
+// only account_state (the shape a full-row storage overwrite silently
+// produced in a real, confirmed incident) must be refused, not read as "not
+// blocked" the way this function's original fail-open default did.
+func TestAccountLoginBlocked_FailsClosedOnBlankAndWhitespace(t *testing.T) {
+	for _, s := range []string{"", " ", "\t", "   "} {
+		assert.True(t, AccountLoginBlocked(1, s), "blank/whitespace state %q must block login", s)
+	}
+}
+
+// TestAccountLoginBlocked_MetricAndLogOnFailClosed proves P3's "loud, never
+// silent" requirement: hitting the fail-closed default increments the
+// unrecognized-state counter (the routine Suspended/Deprovisioned path must
+// NOT increment it -- that's expected, not anomalous).
+func TestAccountLoginBlocked_MetricAndLogOnFailClosed(t *testing.T) {
+	before := testutil.ToFloat64(accountStateUnrecognizedTotal)
+
+	assert.True(t, AccountLoginBlocked(1, AccountSuspended))
+	assert.True(t, AccountLoginBlocked(1, AccountDeprovisioned))
+	assert.False(t, AccountLoginBlocked(1, AccountActive))
+	assert.Equal(t, before, testutil.ToFloat64(accountStateUnrecognizedTotal),
+		"routine suspended/deprovisioned/active checks must not touch the anomalous-state counter")
+
+	assert.True(t, AccountLoginBlocked(1, ""))
+	assert.Equal(t, before+1, testutil.ToFloat64(accountStateUnrecognizedTotal))
+
+	assert.True(t, AccountLoginBlocked(1, "some-garbage-value"))
+	assert.Equal(t, before+2, testutil.ToFloat64(accountStateUnrecognizedTotal))
 }
 
 func newAccountCore(store *MockStorage) *KeyorixCore {
@@ -105,7 +150,7 @@ func TestAdminAccountTransitions(t *testing.T) {
 			// (#r125-H2: password_reset_required previously skipped PAT eviction).
 			store.On("ListPersonalAccessTokensByUser", ctx, uint(2)).Return([]*models.PersonalAccessToken{}, nil)
 			// A login-blocking transition (suspend) must purge the user's sessions AND PATs.
-			if AccountLoginBlocked(tc.wantState) {
+			if AccountLoginBlocked(1, tc.wantState) {
 				store.On("DeleteSessionsForUserExcept", ctx, uint(2), uint(0)).Return(nil)
 				store.On("RevokeAllPersonalAccessTokensForUser", ctx, uint(2)).Return([]string{}, nil)
 			}
@@ -119,7 +164,7 @@ func TestAdminAccountTransitions(t *testing.T) {
 
 			require.NoError(t, tc.call(c, ctx))
 			store.AssertExpectations(t)
-			if !AccountLoginBlocked(tc.wantState) {
+			if !AccountLoginBlocked(1, tc.wantState) {
 				store.AssertNotCalled(t, "DeleteSessionsForUserExcept", mock.Anything, mock.Anything, mock.Anything)
 			}
 		})

--- a/internal/core/auth.go
+++ b/internal/core/auth.go
@@ -143,7 +143,7 @@ func (c *KeyorixCore) VerifyPasswordCredentials(ctx context.Context, username, p
 	// A suspended account is refused login outright (ADR-025). Restricted states
 	// (pending_first_login / password_reset_required) still log in, but the auth
 	// middleware confines the session to the password-change allowlist.
-	if AccountLoginBlocked(user.AccountState) {
+	if AccountLoginBlocked(user.ID, user.AccountState) {
 		return nil, fmt.Errorf("account suspended")
 	}
 	return user, nil
@@ -397,7 +397,7 @@ func (c *KeyorixCore) RefreshSession(ctx context.Context, token string) (*models
 	if err != nil {
 		return nil, fmt.Errorf("user not found")
 	}
-	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
+	if !user.IsActive || AccountLoginBlocked(user.ID, user.AccountState) {
 		_ = c.storage.DeleteSession(ctx, old.ID)
 		return nil, fmt.Errorf("account is not active")
 	}
@@ -562,7 +562,7 @@ func (c *KeyorixCore) ValidateSessionToken(ctx context.Context, token string) (*
 	// Reject sessions whose account has since been deactivated or suspended, so an
 	// admin's suspend/deactivate takes effect on already-issued tokens rather than
 	// lingering until expiry. Mirrors the active-state check in ValidatePATToken.
-	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
+	if !user.IsActive || AccountLoginBlocked(user.ID, user.AccountState) {
 		return nil, nil, fmt.Errorf("account is not active")
 	}
 	// For an impersonation session (acting AS session.UserID on behalf of an admin),
@@ -646,7 +646,7 @@ func (c *KeyorixCore) AccountStillUsable(ctx context.Context, userID uint) (bool
 	if err != nil {
 		return false, err
 	}
-	return user.IsActive && !AccountLoginBlocked(user.AccountState), nil
+	return user.IsActive && !AccountLoginBlocked(user.ID, user.AccountState), nil
 }
 
 // RequestPasswordReset issues a password-reset link for the given email and
@@ -673,7 +673,7 @@ func (c *KeyorixCore) RequestPasswordReset(ctx context.Context, email string) er
 		return nil // Don't reveal whether the email exists.
 	}
 	// Never send a reset to a login-blocked (e.g. suspended) account.
-	if AccountLoginBlocked(user.AccountState) {
+	if AccountLoginBlocked(user.ID, user.AccountState) {
 		return nil
 	}
 	// Refuse for externally-managed identities (SSO/SCIM): issuing a local password

--- a/internal/core/core_s27_test.go
+++ b/internal/core/core_s27_test.go
@@ -513,15 +513,15 @@ func TestNormalizeAccountState_Known(t *testing.T) {
 // ── AccountLoginBlocked ───────────────────────────────────────────────────────
 
 func TestAccountLoginBlocked_Active(t *testing.T) {
-	assert.False(t, AccountLoginBlocked("active"))
+	assert.False(t, AccountLoginBlocked(1, "active"))
 }
 
 func TestAccountLoginBlocked_Deprovisioned(t *testing.T) {
-	assert.True(t, AccountLoginBlocked(AccountDeprovisioned))
+	assert.True(t, AccountLoginBlocked(1, AccountDeprovisioned))
 }
 
 func TestAccountLoginBlocked_Suspended(t *testing.T) {
-	assert.True(t, AccountLoginBlocked(AccountSuspended))
+	assert.True(t, AccountLoginBlocked(1, AccountSuspended))
 }
 
 // ── versions.go — getSecretValueForUser branches ─────────────────────────────

--- a/internal/core/impersonation.go
+++ b/internal/core/impersonation.go
@@ -81,7 +81,7 @@ func (c *KeyorixCore) StartImpersonation(ctx context.Context, adminID, targetID 
 	// Don't mint a session for a target who cannot log in: it would be dead on arrival
 	// (ValidateSessionToken rejects blocked/inactive accounts on every request) and would
 	// only produce a misleading impersonation.start audit event.
-	if !target.IsActive || AccountLoginBlocked(target.AccountState) {
+	if !target.IsActive || AccountLoginBlocked(target.ID, target.AccountState) {
 		c.writeImpersonationDeniedEvent(ctx, adminID, &targetID, ip,
 			fmt.Sprintf("%s attempted to impersonate %s, but the target is suspended or inactive", admin.Username, target.Username))
 		return nil, nil, fmt.Errorf("cannot impersonate a suspended or inactive user")
@@ -202,7 +202,7 @@ func (c *KeyorixCore) ReauthorizeImpersonation(ctx context.Context, adminID, tar
 	if err != nil {
 		return fmt.Errorf("impersonating account not found")
 	}
-	if !admin.IsActive || AccountLoginBlocked(admin.AccountState) {
+	if !admin.IsActive || AccountLoginBlocked(admin.ID, admin.AccountState) {
 		return fmt.Errorf("impersonating account is not active")
 	}
 	if err := c.cachedImpersonationCeiling(ctx, adminID, targetID); err != nil {

--- a/internal/core/impersonation_test.go
+++ b/internal/core/impersonation_test.go
@@ -39,7 +39,7 @@ func TestStartImpersonation_Success(t *testing.T) {
 	ctx := context.Background()
 
 	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin"}, nil)
-	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "alice", IsActive: true}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "alice", IsActive: true, AccountState: AccountActive}, nil)
 	// The target-rank guard discovers every scope the target holds a role at (it
 	// holds none here), so no per-scope admin comparison ever runs.
 	store.On("GetUserRoleScopes", ctx, uint(2)).Return([]Scope{}, nil)
@@ -133,7 +133,7 @@ func TestStartImpersonation_AllowsSessionAuth(t *testing.T) {
 	c := newImpersonationCore(store)
 	ctx := WithSessionAuth(context.Background(), true)
 	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin"}, nil)
-	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "alice", IsActive: true}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "alice", IsActive: true, AccountState: AccountActive}, nil)
 	store.On("GetUserRoleScopes", ctx, uint(2)).Return([]Scope{}, nil)
 	store.On("CreateSession", ctx, mock.Anything).Return(&models.Session{ID: 1, UserID: 2, SessionToken: "tok"}, nil)
 	store.On("LogAuditEvent", ctx, mock.Anything).Return(nil)
@@ -173,7 +173,7 @@ func TestStartImpersonation_RejectsAdminTargetForNonAdminCaller(t *testing.T) {
 	c := newImpersonationCore(store)
 	ctx := context.Background()
 	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "helpdesk"}, nil)
-	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "root", IsActive: true}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "root", IsActive: true, AccountState: AccountActive}, nil)
 	// Target (id 2) holds the admin role globally; caller (id 1) holds nothing.
 	store.On("GetRoleByName", ctx, mock.Anything).Return(&models.Role{ID: 7, Name: "admin"}, nil)
 	store.On("GetUserRoleScopes", ctx, uint(2)).Return([]Scope{{}}, nil)
@@ -209,7 +209,7 @@ func TestStartImpersonation_RejectsProjectScopedAdminTargetForNonAdminCaller(t *
 	ctx := context.Background()
 	projScope := Scope{ProjectID: 7}
 	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "helpdesk"}, nil)
-	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "proj-admin", IsActive: true}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "proj-admin", IsActive: true, AccountState: AccountActive}, nil)
 	// Target (id 2) holds project_admin at project 7 only; caller (id 1) holds nothing.
 	store.On("GetRoleByName", ctx, mock.Anything).Return(&models.Role{ID: 8, Name: "project_admin"}, nil)
 	store.On("GetUserRoleScopes", ctx, uint(2)).Return([]Scope{projScope}, nil)
@@ -237,7 +237,7 @@ func TestStartImpersonation_AllowsProjectScopedAdminTargetForSameScopeAdminCalle
 	ctx := context.Background()
 	projScope := Scope{ProjectID: 7}
 	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "other-proj-admin"}, nil)
-	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "proj-admin", IsActive: true}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "proj-admin", IsActive: true, AccountState: AccountActive}, nil)
 	// ADR-084: role 8 (project_admin) bypasses via the structural flag now.
 	store.On("RoleSetBypassesPermissionChecks", ctx, []uint{8}).Return(true, nil)
 	store.On("GetUserRoleScopes", ctx, uint(2)).Return([]Scope{projScope}, nil)
@@ -268,7 +268,7 @@ func TestStartImpersonation_RejectsCustomAdminTierRoleTargetForNonAdminCaller(t 
 	c := newImpersonationCore(store)
 	ctx := context.Background()
 	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "helpdesk"}, nil)
-	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "secops", IsActive: true}, nil)
+	store.On("GetUser", ctx, uint(2)).Return(&models.User{ID: 2, Username: "secops", IsActive: true, AccountState: AccountActive}, nil)
 	// Target (id 2) holds a custom "secops" role (id 9) at global scope, bundling
 	// system.write — the role has no ADR-084 bypass flag set, so
 	// roleSetContainsAdmin(target) would have returned false and the old
@@ -301,7 +301,7 @@ func TestReauthorizeImpersonation_RevokedImpersonatePermission(t *testing.T) {
 	store := new(MockStorage)
 	c := newImpersonationCore(store)
 	ctx := context.Background()
-	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin", IsActive: true}, nil)
+	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin", IsActive: true, AccountState: AccountActive}, nil)
 	// Admin (1) no longer holds users.impersonate: RoleSetHasPermission returns
 	// false for it, but the admin otherwise still outranks the target (2, no
 	// roles at all) — isolates the missing per-permission re-check from the
@@ -322,7 +322,7 @@ func TestReauthorizeImpersonation_StillAuthorized(t *testing.T) {
 	store := new(MockStorage)
 	c := newImpersonationCore(store)
 	ctx := context.Background()
-	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin", IsActive: true}, nil)
+	store.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: "admin", IsActive: true, AccountState: AccountActive}, nil)
 	store.On("GetUserRoleIDsAt", ctx, uint(1), Scope{}).Return([]uint{5}, nil)
 	store.On("GetUserGroupRoleIDsAt", ctx, uint(1), Scope{}).Return([]uint{}, nil)
 	store.On("RoleSetBypassesPermissionChecks", ctx, []uint{5}).Return(false, nil)

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -317,7 +317,7 @@ func (c *KeyorixCore) VerifyMFACredentials(ctx context.Context, challenge, code 
 	// issued (password step passed) just before an admin suspended the account, and
 	// nothing rechecks the state between the two steps. Mirrors the password,
 	// session, PAT, and passwordless-WebAuthn gates.
-	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
+	if !user.IsActive || AccountLoginBlocked(user.ID, user.AccountState) {
 		return nil, false, fmt.Errorf("account is not active")
 	}
 	// Per-account lockout also gates the second factor. The per-IP rate limiter is

--- a/internal/core/mfa_stepup.go
+++ b/internal/core/mfa_stepup.go
@@ -24,7 +24,7 @@ func (c *KeyorixCore) VerifyMFAStepUp(ctx context.Context, userID uint, code str
 	if err != nil {
 		return fmt.Errorf("user not found")
 	}
-	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
+	if !user.IsActive || AccountLoginBlocked(user.ID, user.AccountState) {
 		return fmt.Errorf("account is not active")
 	}
 	if c.loginLocked(user) {

--- a/internal/core/pat.go
+++ b/internal/core/pat.go
@@ -159,7 +159,7 @@ func (c *KeyorixCore) ValidatePATToken(ctx context.Context, raw string) (*models
 	// without this an admin's suspend would cut off session access yet leave the user's
 	// personal access tokens fully working. Mirror ValidateSessionToken's account-state
 	// gate so suspension is immediately effective on every credential type.
-	if AccountLoginBlocked(user.AccountState) {
+	if AccountLoginBlocked(user.ID, user.AccountState) {
 		return nil, nil, nil, 0, fmt.Errorf("account is not active")
 	}
 

--- a/internal/core/pat_expiry_enforce_test.go
+++ b/internal/core/pat_expiry_enforce_test.go
@@ -247,7 +247,7 @@ func TestValidatePATToken_ValidNonExpiredPAT_Succeeds(t *testing.T) {
 	ms.On("GetPersonalAccessTokenByHash", ctx, hash).
 		Return(&models.PersonalAccessToken{ID: 7, UserID: 2, ExpiresAt: &future}, nil)
 	ms.On("GetUser", ctx, uint(2)).
-		Return(&models.User{ID: 2, Username: "alice", IsActive: true}, nil)
+		Return(&models.User{ID: 2, Username: "alice", IsActive: true, AccountState: AccountActive}, nil)
 	ms.On("GetUserRoles", ctx, uint(2)).
 		Return([]*models.Role{{Name: "project_viewer"}}, nil)
 

--- a/internal/core/pat_test.go
+++ b/internal/core/pat_test.go
@@ -73,7 +73,7 @@ func TestValidatePATToken(t *testing.T) {
 		ms := new(MockStorage)
 		c := NewKeyorixCore(ms)
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{ID: 9, UserID: 1}, nil)
-		ms.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: acctTestUser, IsActive: true}, nil)
+		ms.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: acctTestUser, IsActive: true, AccountState: AccountActive}, nil)
 		role := "system_viewer"
 		ms.On("GetUserRoles", ctx, uint(1)).Return([]*models.Role{{Name: role}}, nil)
 
@@ -91,7 +91,7 @@ func TestValidatePATToken(t *testing.T) {
 		ms.On("GetPersonalAccessTokenByHash", ctx, hash).Return(&models.PersonalAccessToken{
 			ID: 9, UserID: 1, Scopes: `["secrets.read"]`, ProjectScope: 4,
 		}, nil)
-		ms.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: acctTestUser, IsActive: true}, nil)
+		ms.On("GetUser", ctx, uint(1)).Return(&models.User{ID: 1, Username: acctTestUser, IsActive: true, AccountState: AccountActive}, nil)
 		ms.On("GetUserRoles", ctx, uint(1)).Return([]*models.Role{{Name: "system_viewer"}}, nil)
 
 		_, _, restriction, _, err := c.ValidatePATToken(ctx, raw)

--- a/internal/core/saml_flow_test.go
+++ b/internal/core/saml_flow_test.go
@@ -88,7 +88,7 @@ func TestCompleteSAML_ExistingUser(t *testing.T) {
 	c, store := samlTestCore(stub)
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-1").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ReturnTo: "/home", ExpiresAt: time.Now().Add(time.Minute)}, nil)
-	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|123").Return(&models.User{ID: 7, IsActive: true}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|123").Return(&models.User{ID: 7, IsActive: true, AccountState: AccountActive}, nil)
 	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 7, SessionToken: "tok"}, nil)
 	store.On("UpdateLastLogin", mock.Anything, uint(7), mock.Anything).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
@@ -293,7 +293,7 @@ func TestCompleteSAML_JITProvisionDoesNotReuseUnverifiedEmailMatch(t *testing.T)
 	store.On("GetUserByUsername", mock.Anything, "victim").Return((*models.User)(nil), userNotFound())
 	var created *models.User
 	store.On("CreateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool { created = u; return true })).
-		Return(&models.User{ID: 99, IsActive: true}, nil)
+		Return(&models.User{ID: 99, IsActive: true, AccountState: AccountActive}, nil)
 	store.On("GetRoleByName", mock.Anything, "system_viewer").Return(&models.Role{ID: 3}, nil)
 	store.On("AssignRole", mock.Anything, uint(99), uint(3), mock.Anything).Return(nil)
 	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 99, SessionToken: "tok"}, nil)
@@ -324,10 +324,10 @@ func TestCompleteSAML_TrustAssertedEmailOptInLinksExistingAccount(t *testing.T) 
 	store.On("ConsumeSSOLoginState", mock.Anything, "relay-7").Return(
 		&models.SSOLoginState{Provider: "corp", Nonce: "req-1", ExpiresAt: time.Now().Add(time.Minute)}, nil)
 	store.On("GetUserByExternalID", mock.Anything, "sso:corp:corp|123").Return((*models.User)(nil), userNotFound())
-	store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, IsActive: true, ExternalID: ""}, nil)
+	store.On("GetUserByEmail", mock.Anything, "ada@x.io").Return(&models.User{ID: 9, IsActive: true, AccountState: AccountActive, ExternalID: ""}, nil)
 	store.On("UpdateUser", mock.Anything, mock.MatchedBy(func(u *models.User) bool {
 		return u.ID == 9 && u.ExternalID == "sso:corp:corp|123"
-	})).Return(&models.User{ID: 9, IsActive: true, ExternalID: "sso:corp:corp|123"}, nil)
+	})).Return(&models.User{ID: 9, IsActive: true, AccountState: AccountActive, ExternalID: "sso:corp:corp|123"}, nil)
 	store.On("CreateSession", mock.Anything, mock.Anything).Return(&models.Session{ID: 1, UserID: 9, SessionToken: "tok"}, nil)
 	store.On("UpdateLastLogin", mock.Anything, uint(9), mock.Anything).Return(nil)
 	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)

--- a/internal/core/scim_suspend_wins_test.go
+++ b/internal/core/scim_suspend_wins_test.go
@@ -39,7 +39,7 @@ func TestUpdateSCIMUser_AdminSuspensionSurvivesReactivation(t *testing.T) {
 	updated, err := c.UpdateSCIMUser(ctx, 2, 1, nil, nil, &yes) // IdP sync
 	require.NoError(t, err)
 	assert.Equal(t, AccountSuspended, updated.AccountState, "SCIM activation must not clear an admin suspension")
-	assert.True(t, AccountLoginBlocked(updated.AccountState), "the account stays login-blocked")
+	assert.True(t, AccountLoginBlocked(updated.ID, updated.AccountState), "the account stays login-blocked")
 }
 
 // The legitimate SCIM lifecycle still works: deactivation blocks login (deprovisioned),
@@ -53,13 +53,13 @@ func TestUpdateSCIMUser_DeactivateThenReactivate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, AccountDeprovisioned, off.AccountState)
 	assert.False(t, off.IsActive)
-	assert.True(t, AccountLoginBlocked(off.AccountState), "a SCIM-deactivated account is login-blocked")
+	assert.True(t, AccountLoginBlocked(off.ID, off.AccountState), "a SCIM-deactivated account is login-blocked")
 
 	on, err := c.UpdateSCIMUser(ctx, 2, 1, nil, nil, &yes)
 	require.NoError(t, err)
 	assert.Equal(t, AccountActive, on.AccountState, "reactivation clears its own deactivation")
 	assert.True(t, on.IsActive)
-	assert.False(t, AccountLoginBlocked(on.AccountState))
+	assert.False(t, AccountLoginBlocked(on.ID, on.AccountState))
 }
 
 // An admin-forced credential reset (password_reset_required) must survive a routine

--- a/internal/core/setup_consume.go
+++ b/internal/core/setup_consume.go
@@ -95,7 +95,7 @@ func (c *KeyorixCore) completePasswordSetup(ctx context.Context, tok *models.Set
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
 	}
 	// A suspended account cannot be activated via a setup link.
-	if AccountLoginBlocked(user.AccountState) {
+	if AccountLoginBlocked(user.ID, user.AccountState) {
 		return nil, fmt.Errorf("account suspended")
 	}
 	// Externally-managed identities (SSO/SCIM) must not get a local password: it would

--- a/internal/core/setup_delivery.go
+++ b/internal/core/setup_delivery.go
@@ -242,7 +242,7 @@ func (c *KeyorixCore) ResendAccountSetupLink(ctx context.Context, userID, create
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
 	}
-	if AccountLoginBlocked(user.AccountState) {
+	if AccountLoginBlocked(user.ID, user.AccountState) {
 		return nil, fmt.Errorf("account suspended")
 	}
 	return c.provisionSetupLinkThrottled(ctx, IssueSetupTokenRequest{

--- a/internal/core/sso.go
+++ b/internal/core/sso.go
@@ -213,7 +213,7 @@ func (c *KeyorixCore) CompleteSSO(ctx context.Context, providerName, code, state
 	if err != nil {
 		return nil, nil, "", err
 	}
-	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
+	if !user.IsActive || AccountLoginBlocked(user.ID, user.AccountState) {
 		return nil, nil, "", fmt.Errorf("account suspended")
 	}
 	// Enforce per-account brute-force lockout (distinct from deactivation/suspension)
@@ -354,7 +354,7 @@ func (c *KeyorixCore) CompleteSAML(ctx context.Context, name string, r *http.Req
 			return nil, nil, "", err
 		}
 	}
-	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
+	if !user.IsActive || AccountLoginBlocked(user.ID, user.AccountState) {
 		return nil, nil, "", fmt.Errorf("account suspended")
 	}
 	// Enforce per-account brute-force lockout BEFORE any IdP-driven state mutation

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -292,7 +292,7 @@ func (c *KeyorixCore) BeginWebAuthnLogin(ctx context.Context, challenge string) 
 // is blocked (suspended/deactivated) or locked out, mirroring the TOTP path in
 // VerifyMFALogin and the passwordless path below.
 func (c *KeyorixCore) checkWebAuthnAccountGates(wu *webauthnUser) error {
-	if !wu.user.IsActive || AccountLoginBlocked(wu.user.AccountState) {
+	if !wu.user.IsActive || AccountLoginBlocked(wu.user.ID, wu.user.AccountState) {
 		return fmt.Errorf("account is not active")
 	}
 	// Per-IP limiters are spoofable behind a proxy; bind assertion failures to the
@@ -496,7 +496,7 @@ func (c *KeyorixCore) FinishWebAuthnPasswordlessLogin(ctx context.Context, sessi
 func (c *KeyorixCore) checkPasswordlessAccountState(ctx context.Context, user *models.User) error {
 	// IsActive is an independent gate from AccountState — an admin deactivation
 	// (is_active=false) leaves AccountState="active", so both must be checked.
-	if !user.IsActive || AccountLoginBlocked(user.AccountState) {
+	if !user.IsActive || AccountLoginBlocked(user.ID, user.AccountState) {
 		return fmt.Errorf("account is not active")
 	}
 	// Honor an active per-account lockout even for a valid passkey (defense in depth).

--- a/server/grpc/services/audit_service.go
+++ b/server/grpc/services/audit_service.go
@@ -154,7 +154,7 @@ func (s *AuditGRPCService) reauthorizeAuditStream(ctx context.Context, actor *in
 		return nil
 	}
 	u, err := s.core.Storage().GetUser(ctx, actor.UserID)
-	if err != nil || !u.IsActive || core.AccountLoginBlocked(u.AccountState) {
+	if err != nil || !u.IsActive || core.AccountLoginBlocked(u.ID, u.AccountState) {
 		return status.Error(codes.PermissionDenied, "account is no longer active")
 	}
 	if actor.SessionID != nil {

--- a/server/http/handlers/scim.go
+++ b/server/http/handlers/scim.go
@@ -55,7 +55,7 @@ func scimError(w http.ResponseWriter, status int, detail string) {
 // toSCIMUser maps a Keyorix user to a SCIM User resource. SCIM userName echoes the
 // email (what the IdP sent); the derived Keyorix username is internal.
 func toSCIMUser(u *models.User) map[string]interface{} {
-	active := u.IsActive && !core.AccountLoginBlocked(u.AccountState)
+	active := u.IsActive && !core.AccountLoginBlocked(u.ID, u.AccountState)
 	res := map[string]interface{}{
 		"schemas":     []string{scimUserSchema},
 		"id":          strconv.FormatUint(uint64(u.ID), 10),


### PR DESCRIPTION
## Summary
**Do not merge before #1741 (G1-G3) lands.** This PR is safe to review independently (no file overlap, no compile dependency on #1741), but its safety argument formally depends on #1741's Postgres CHECK constraint and backfill being in place first — see bullet 1 below.

Closes the root cause of the confirmed account-takeover chain (#1721/#1722/#1723): a blank or unrecognized `users.account_state` used to read as "not blocked" (fail-open) in `AccountLoginBlocked`, which is how a full-row storage overwrite silently reactivated a suspended/deprovisioned account for login. `AccountLoginBlocked` now fails closed on blank, whitespace-only, and any other unrecognized value — not just blank.

The original fail-open default weighed wrongful-lockout and wrongful-access as comparable costs. At this specific authentication boundary they are not: a lockout is admin-recoverable in minutes and loudly visible; a bypass through this exact gate is what actually happened, and may never be detected. This reasoning is specific to this one call site — it does not generalize to the rest of the codebase (`AccountRestricted`'s own fail-closed default, which was already correct, is untouched).

**Four preconditions make this safe, not a new blast radius** (all recorded in the rewritten doc comment):
1. Postgres CHECK constraint (#1741) restricts `account_state` to the canonical set at the schema level.
2. `TestAccountLoginBlocked_ExhaustsStateRegistry` statically asserts every declared account-state constant is explicitly handled in this switch — adding a new state without updating it fails CI.
3. Every existing blank row was already backfilled to an explicit `active` (#1741), so this flip doesn't retroactively lock out a benign case.
4. The failure is loud, never silent: every fail-closed hit logs the value + user ID at security level and increments a Prometheus counter, so a lockout is immediately diagnosable and alertable.

**`completePasswordSetup` needed no separate change.** It already routes through this same shared `AccountLoginBlocked` gate — fixing this one function automatically and correctly closes that call site too, with the right semantics (Active/PendingFirstLogin/PasswordResetRequired all remain allowed). A plain "must be Active" allow-list — floated earlier in this investigation — would have been wrong: it would break every brand-new user's first-ever setup, since new users start `PendingFirstLogin`, not `Active`.

**Mechanical**: `AccountLoginBlocked` gained a `userID` parameter (for the log line); updated all 20 call sites across `internal/core`, `server/grpc/services`, and `server/http/handlers`.

Also fixed several test fixtures this flip correctly surfaced as incomplete: multiple tests constructed a `models.User{...}` meant to represent a normal, successful-path account but never set `AccountState`, silently defaulting to blank — tolerated by accident under the old fail-open behavior. Fixed the fixtures, not the assertions, per this repo's own standing practice for a test whose premise turns out to be untested.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean across the whole repo
- [x] `gosec -severity medium -exclude-generated` clean on all touched packages
- [x] Full `internal/core`, `server/grpc`, `server/http` suites green (verified independently twice)
- [x] Red/green verified `TestAccountLoginBlocked_ExhaustsStateRegistry` (temporarily removed a state from the switch, confirmed it fails, restored and confirmed green)
- [x] New regression tests: blank/whitespace fails closed, metric/log fires only on the anomalous path (not on routine suspended/deprovisioned/active checks)