### PR TITLE
chore(deps): pin fast-uri override, add root npm to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,3 +73,20 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  # The repo root also has its own package.json/package-lock.json
+  # (keyorix-ci-tools: cdxgen + spectral-cli, pinned for Scorecard
+  # supply-chain compliance). Dependabot's security updates already cover
+  # it regardless of this file (PR #1687 bumped fast-uri here without any
+  # entry below) -- this entry is only for routine patch/minor version
+  # updates, which this directory had none of until now.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      npm-patch-minor:
+        update-types:
+          - "minor"
+          - "patch"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "overrides": {
     "brace-expansion": "5.0.9",
     "tar": "7.5.22",
-    "undici": "7.29.0"
+    "undici": "7.29.0",
+    "fast-uri": "3.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- fast-uri already resolves to 3.1.7 on `main` (PR #1687), which patches GHSA-5jgf-p345-68v8, -f65p-4m7j-42xc, -fph4-wmhf-6fwf, -jqff-g426-hqxp (all fixed at 3.1.6+) — but only implicitly via ajv's `^3.0.1` range. Add an explicit override alongside the existing brace-expansion/tar/undici pins so a future lockfile regen can't silently drop below 3.1.6.
- Add an `npm` entry for the repo root to `dependabot.yml`. Only `/web` had one, so the root `package.json`/`package-lock.json` (keyorix-ci-tools: cdxgen + spectral-cli) got no routine patch/minor update PRs. Security-driven updates already cover it independently of this file (that's how PR #1687 landed without one), so this only adds routine-freshness coverage.
- Dependabot alerts #11-#14 (the fast-uri High findings) were dismissed directly via the API as already-fixed — the fix landed 2026-09-03 and predates the most recent commit Dependabot's own dependency-file check scanned, but the alerts hadn't auto-closed.

## Test plan
- [x] `npm audit` shows 0 fast-uri findings after the override
- [x] Confirmed `fast-uri@3.1.7` in the regenerated lockfile
- [x] Confirmed via `git merge-base --is-ancestor` that PR #1687's fix commit is an ancestor of the commit Dependabot's alert page cites as last-scanned