### PR TITLE
test(core,http): close low-coverage gaps found in a corrected coverage audit

### DIFF
--- a/internal/core/auth_login_remote_test.go
+++ b/internal/core/auth_login_remote_test.go
@@ -1,0 +1,102 @@
+// auth_login_remote_test.go covers Login's RemoteLoginVerifier branch
+// (auth.go), entirely untested before this file: every existing Login test
+// exercises the direct LocalStorage (bcrypt) path, never a storage backend
+// that implements RemoteLoginVerifier (storage.type: remote, #508). The four
+// branches below mirror the four the LocalStorage path already has coverage
+// for (verify error, MFA-required, defensive nil-session fail-closed, and
+// success) so both dispatch paths carry the same invariant coverage.
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// remoteLoginVerifierStorage wraps MockStorage to additionally implement
+// RemoteLoginVerifier, so Login's `c.storage.(RemoteLoginVerifier)` type
+// assertion succeeds -- MockStorage alone does not implement this interface.
+type remoteLoginVerifierStorage struct {
+	*MockStorage
+	verify func(ctx context.Context, username, password, userAgent, ipAddress string) (*models.User, *models.Session, error)
+}
+
+func (m *remoteLoginVerifierStorage) VerifyLoginCredentials(ctx context.Context, username, password, userAgent, ipAddress string) (*models.User, *models.Session, error) {
+	return m.verify(ctx, username, password, userAgent, ipAddress)
+}
+
+func TestLogin_Remote_VerifyError(t *testing.T) {
+	storage := &remoteLoginVerifierStorage{
+		MockStorage: new(MockStorage),
+		verify: func(ctx context.Context, username, password, userAgent, ipAddress string) (*models.User, *models.Session, error) {
+			return nil, nil, errors.New("invalid credentials")
+		},
+	}
+	c := NewKeyorixCore(storage)
+	session, user, err := c.Login(context.Background(), &LoginRequest{Username: "alice", Password: "pw"})
+	require.Error(t, err)
+	assert.Nil(t, session)
+	assert.Nil(t, user)
+}
+
+func TestLogin_Remote_MFARequired(t *testing.T) {
+	storage := &remoteLoginVerifierStorage{
+		MockStorage: new(MockStorage),
+		verify: func(ctx context.Context, username, password, userAgent, ipAddress string) (*models.User, *models.Session, error) {
+			return &models.User{ID: 1, Username: "alice", MFAEnabled: true}, nil, nil
+		},
+	}
+	c := NewKeyorixCore(storage)
+	session, user, err := c.Login(context.Background(), &LoginRequest{Username: "alice", Password: "pw"})
+	require.ErrorIs(t, err, ErrMFARequired)
+	assert.Nil(t, session)
+	require.NotNil(t, user)
+	assert.Equal(t, uint(1), user.ID)
+}
+
+// TestLogin_Remote_NilSessionWithoutMFA_FailsClosed pins the defensive branch:
+// an upstream that reports no MFA/WebAuthn gate but still withholds a session
+// (a contract violation on the upstream's part) must not let Login proceed
+// with a nil session -- it fails closed with an explicit error instead.
+func TestLogin_Remote_NilSessionWithoutMFA_FailsClosed(t *testing.T) {
+	storage := &remoteLoginVerifierStorage{
+		MockStorage: new(MockStorage),
+		verify: func(ctx context.Context, username, password, userAgent, ipAddress string) (*models.User, *models.Session, error) {
+			return &models.User{ID: 2, Username: "bob"}, nil, nil
+		},
+	}
+	c := NewKeyorixCore(storage)
+	session, user, err := c.Login(context.Background(), &LoginRequest{Username: "bob", Password: "pw"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not return one")
+	assert.Nil(t, session)
+	assert.Nil(t, user)
+}
+
+func TestLogin_Remote_Success(t *testing.T) {
+	wantUser := &models.User{ID: 3, Username: "carol"}
+	wantSession := &models.Session{ID: 99, UserID: 3, SessionToken: "tok-abc"}
+	storage := &remoteLoginVerifierStorage{
+		MockStorage: new(MockStorage),
+		verify: func(ctx context.Context, username, password, userAgent, ipAddress string) (*models.User, *models.Session, error) {
+			assert.Equal(t, "carol", username)
+			assert.Equal(t, "correct-horse", password)
+			assert.Equal(t, "test-agent", userAgent)
+			assert.Equal(t, "10.0.0.1", ipAddress)
+			return wantUser, wantSession, nil
+		},
+	}
+	c := NewKeyorixCore(storage)
+	session, user, err := c.Login(context.Background(), &LoginRequest{
+		Username: "carol", Password: "correct-horse", UserAgent: "test-agent", IPAddress: "10.0.0.1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.Equal(t, wantSession.SessionToken, session.SessionToken)
+	require.NotNil(t, user)
+	assert.Equal(t, uint(3), user.ID)
+}

--- a/internal/core/connect_delegation_test.go
+++ b/internal/core/connect_delegation_test.go
@@ -1,0 +1,83 @@
+// connect_delegation_test.go covers connectorHasAnyDelegationForActor
+// (connect.go) -- used by ConnectReadableConnectorNames to decide whether a
+// connector shows up in a listing. Previously untested: the storage-error
+// branch, the no-grants-at-all short-circuit, actorRoleIDs' own error, an
+// active grant matching the actor's roles, and an active grant NOT matching
+// (wrong role) plus an expired grant that WOULD match by role alone.
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectorHasAnyDelegationForActor_ListGrantsError(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("ListConnectRefGrantsByConnector", mock.Anything, "db-prod").Return(nil, errors.New("db error"))
+	c := NewKeyorixCore(ms)
+	ok, err := c.connectorHasAnyDelegationForActor(context.Background(), ActorTypeMachine, 1, "db-prod")
+	require.Error(t, err)
+	assert.False(t, ok)
+}
+
+func TestConnectorHasAnyDelegationForActor_NoGrants(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("ListConnectRefGrantsByConnector", mock.Anything, "db-prod").Return([]*models.ConnectRefGrant{}, nil)
+	c := NewKeyorixCore(ms)
+	ok, err := c.connectorHasAnyDelegationForActor(context.Background(), ActorTypeMachine, 1, "db-prod")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	ms.AssertNotCalled(t, "GetMachineRoles", mock.Anything, mock.Anything)
+}
+
+func TestConnectorHasAnyDelegationForActor_ActorRoleIDsError(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("ListConnectRefGrantsByConnector", mock.Anything, "db-prod").Return(
+		[]*models.ConnectRefGrant{{ID: 1, RoleID: 5, Connector: "db-prod"}}, nil)
+	ms.On("GetMachineRoles", mock.Anything, uint(1)).Return(nil, errors.New("db error"))
+	c := NewKeyorixCore(ms)
+	ok, err := c.connectorHasAnyDelegationForActor(context.Background(), ActorTypeMachine, 1, "db-prod")
+	require.Error(t, err)
+	assert.False(t, ok)
+}
+
+func TestConnectorHasAnyDelegationForActor_MatchingActiveGrant_True(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("ListConnectRefGrantsByConnector", mock.Anything, "db-prod").Return(
+		[]*models.ConnectRefGrant{{ID: 1, RoleID: 5, Connector: "db-prod", RefPrefix: ""}}, nil)
+	ms.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{{ID: 5, Name: "db-reader"}}, nil)
+	c := NewKeyorixCore(ms)
+	ok, err := c.connectorHasAnyDelegationForActor(context.Background(), ActorTypeMachine, 1, "db-prod")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestConnectorHasAnyDelegationForActor_RoleMismatch_False(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("ListConnectRefGrantsByConnector", mock.Anything, "db-prod").Return(
+		[]*models.ConnectRefGrant{{ID: 1, RoleID: 5, Connector: "db-prod", RefPrefix: ""}}, nil)
+	ms.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{{ID: 6, Name: "unrelated"}}, nil)
+	c := NewKeyorixCore(ms)
+	ok, err := c.connectorHasAnyDelegationForActor(context.Background(), ActorTypeMachine, 1, "db-prod")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestConnectorHasAnyDelegationForActor_ExpiredGrant_False(t *testing.T) {
+	ms := new(MockStorage)
+	past := time.Now().Add(-time.Hour)
+	ms.On("ListConnectRefGrantsByConnector", mock.Anything, "db-prod").Return(
+		[]*models.ConnectRefGrant{{ID: 1, RoleID: 5, Connector: "db-prod", RefPrefix: "", ExpiresAt: &past}}, nil)
+	ms.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{{ID: 5, Name: "db-reader"}}, nil)
+	c := NewKeyorixCore(ms)
+	ok, err := c.connectorHasAnyDelegationForActor(context.Background(), ActorTypeMachine, 1, "db-prod")
+	require.NoError(t, err)
+	assert.False(t, ok, "an expired grant must not authorize even though the role matches")
+}

--- a/internal/core/machine_token_replace_credential_test.go
+++ b/internal/core/machine_token_replace_credential_test.go
@@ -1,0 +1,108 @@
+// machine_token_replace_credential_test.go covers validateReplacementCredential
+// and the PAT-006 replace-credential-atomically-with-issuance flow in
+// IssueMachineToken (machine_token.go) -- previously exercised by NO test at
+// all: every existing IssueMachineToken test leaves ReplaceCredentialID unset,
+// so only the replaceID==0 short-circuit branch of validateReplacementCredential
+// had ever run.
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateReplacementCredential_ZeroID_NoOp(t *testing.T) {
+	ms := new(MockStorage)
+	c := NewKeyorixCore(ms)
+	hash, err := c.validateReplacementCredential(context.Background(), 1, 0)
+	require.NoError(t, err)
+	assert.Empty(t, hash)
+	ms.AssertNotCalled(t, "GetMachineIdentityCredentialByID", mock.Anything, mock.Anything)
+}
+
+func TestValidateReplacementCredential_NotFound(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetMachineIdentityCredentialByID", mock.Anything, uint(50)).Return(nil, errors.New("not found"))
+	c := NewKeyorixCore(ms)
+	_, err := c.validateReplacementCredential(context.Background(), 1, 50)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found on this machine")
+}
+
+// TestValidateReplacementCredential_WrongMachine_Rejected pins the ownership
+// check: a credential ID that resolves to a REAL row belonging to a DIFFERENT
+// machine must be rejected exactly like a not-found ID -- never revealed as
+// "found but not yours".
+func TestValidateReplacementCredential_WrongMachine_Rejected(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetMachineIdentityCredentialByID", mock.Anything, uint(50)).
+		Return(&models.MachineIdentityCredential{ID: 50, MachineIdentityID: 999, TokenHash: "victim-hash"}, nil)
+	c := NewKeyorixCore(ms)
+	hash, err := c.validateReplacementCredential(context.Background(), 1, 50)
+	require.Error(t, err)
+	assert.Empty(t, hash)
+}
+
+func TestValidateReplacementCredential_Success(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetMachineIdentityCredentialByID", mock.Anything, uint(50)).
+		Return(&models.MachineIdentityCredential{ID: 50, MachineIdentityID: 1, TokenHash: "old-hash"}, nil)
+	c := NewKeyorixCore(ms)
+	hash, err := c.validateReplacementCredential(context.Background(), 1, 50)
+	require.NoError(t, err)
+	assert.Equal(t, "old-hash", hash)
+}
+
+// TestIssueMachineToken_ReplaceCredential_EndToEnd exercises PAT-006's whole
+// point: rotating a credential mints the new one FIRST, then revokes the old
+// one, and returns the old token's hash for the caller to evict from any auth
+// cache -- never tested end-to-end before this.
+func TestIssueMachineToken_ReplaceCredential_EndToEnd(t *testing.T) {
+	store := new(MockStorage)
+	fixed := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
+	store.On("GetMachineIdentityCredentialByID", mock.Anything, uint(50)).
+		Return(&models.MachineIdentityCredential{ID: 50, MachineIdentityID: 1, TokenHash: "old-hash"}, nil)
+	store.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
+	stubAuthorizedPrincipal(store, 7, Scope{ProjectID: 2}, permRolesAssign)
+	store.On("CreateMachineIdentityCredential", mock.Anything, mock.AnythingOfType("*models.MachineIdentityCredential")).
+		Return(&models.MachineIdentityCredential{ID: 51}, nil)
+	store.On("RevokeMachineIdentityCredential", mock.Anything, uint(2), uint(50)).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	c := NewKeyorixCore(store)
+	c.now = func() time.Time { return fixed }
+	res, err := c.IssueMachineToken(context.Background(), 2, 1, 7, IssueMachineTokenParams{
+		Name: "rotated-ci", ReplaceCredentialID: 50,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "old-hash", res.ReplacedTokenHash, "the old credential's hash must be returned for cache eviction")
+	store.AssertCalled(t, "RevokeMachineIdentityCredential", mock.Anything, uint(2), uint(50))
+}
+
+// TestIssueMachineToken_ReplaceCredential_BadID_FailsFast pins the ordering
+// guarantee the code comment states: an invalid ReplaceCredentialID must be
+// caught BEFORE the new credential is created, so a bad rotation request never
+// leaves an orphaned extra credential behind.
+func TestIssueMachineToken_ReplaceCredential_BadID_FailsFast(t *testing.T) {
+	store := new(MockStorage)
+	store.On("GetMachineIdentity", mock.Anything, uint(1)).Return(&models.MachineIdentity{ID: 1, ProjectID: 2, State: MachineActive}, nil)
+	store.On("GetMachineIdentityCredentialByID", mock.Anything, uint(999)).Return(nil, errors.New("not found"))
+	store.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{}, nil)
+	stubAuthorizedPrincipal(store, 7, Scope{ProjectID: 2}, permRolesAssign)
+
+	c := NewKeyorixCore(store)
+	_, err := c.IssueMachineToken(context.Background(), 2, 1, 7, IssueMachineTokenParams{
+		Name: "rotated-ci", ReplaceCredentialID: 999,
+	})
+	require.Error(t, err)
+	store.AssertNotCalled(t, "CreateMachineIdentityCredential", mock.Anything, mock.Anything)
+}

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1765,7 +1765,16 @@ func (m *MockStorage) RemovePermissionFromRole(_ context.Context, _, _ uint) err
 
 // Keyorix Connect per-reference grants (ADR-045) — core enforcement is tested against
 // real SQLite, so these mock stubs just satisfy the interface.
-func (m *MockStorage) ListConnectRefGrantsByConnector(_ context.Context, _ string) ([]*models.ConnectRefGrant, error) {
+func (m *MockStorage) ListConnectRefGrantsByConnector(ctx context.Context, connector string) ([]*models.ConnectRefGrant, error) {
+	for _, c := range m.ExpectedCalls {
+		if c.Method == "ListConnectRefGrantsByConnector" {
+			args := m.Called(ctx, connector)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).([]*models.ConnectRefGrant), args.Error(1)
+		}
+	}
 	return nil, nil
 }
 func (m *MockStorage) ListConnectRefGrants(_ context.Context) ([]*models.ConnectRefGrant, error) {

--- a/internal/core/setup_token_expire_by_id_error_test.go
+++ b/internal/core/setup_token_expire_by_id_error_test.go
@@ -1,0 +1,34 @@
+// setup_token_expire_by_id_error_test.go covers ExpireSetupTokenByID's two
+// error-shaped branches (setup_token.go) -- setup_token_expire_audit_test.go
+// (#1622) only exercises the found-and-expired success path. Untested before
+// this file: an unknown ID (a no-op, matching the raw storage primitive's own
+// long-standing idempotent semantics) and a genuine storage failure (which
+// must surface as a wrapped error, not be swallowed like the not-found case).
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpireSetupTokenByID_UnknownID_NoOp(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetSetupTokenByID", mock.Anything, uint(404)).Return(nil, errors.New("setup token not found"))
+	c := NewKeyorixCore(ms)
+	err := c.ExpireSetupTokenByID(context.Background(), 404)
+	require.NoError(t, err)
+	ms.AssertNotCalled(t, "MarkSetupTokenExpired", mock.Anything, mock.Anything)
+}
+
+func TestExpireSetupTokenByID_GenuineStorageError_Surfaces(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetSetupTokenByID", mock.Anything, uint(5)).Return(nil, errors.New("connection reset"))
+	c := NewKeyorixCore(ms)
+	err := c.ExpireSetupTokenByID(context.Background(), 5)
+	require.Error(t, err)
+	ms.AssertNotCalled(t, "MarkSetupTokenExpired", mock.Anything, mock.Anything)
+}

--- a/internal/core/sod_machine_grant_violation_test.go
+++ b/internal/core/sod_machine_grant_violation_test.go
@@ -1,0 +1,102 @@
+// sod_machine_grant_violation_test.go extends requireMachineGrantNoSoDViolation's
+// coverage (sod.go) past its early-return branches (already covered by
+// core_s30_test.go: list-policies error, no policies, GetRole error, admin-role
+// bypass). Untested before this file: the role's OWN permission-lookup error,
+// the machine's-other-roles lookup error, the held-permissions accumulation
+// loop's own per-role error, the actual violation-detected rejection, and the
+// no-violation success path -- i.e. the entire reason this check exists.
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireMachineGrantNoSoDViolation_AddingRolePermissionsError(t *testing.T) {
+	ms := new(MockStorage)
+	policy := &models.SoDPolicy{ID: 1, Name: "split-duty", PermissionA: "secrets.write", PermissionB: "secrets.delete"}
+	ms.On("ListSoDPolicies", mock.Anything).Return([]*models.SoDPolicy{policy}, nil)
+	ms.On("GetRole", mock.Anything, uint(10)).Return(&models.Role{ID: 10, Name: "custom_writer"}, nil)
+	ms.On("GetRolePermissions", mock.Anything, uint(10)).Return(nil, errors.New("db error"))
+	c := NewKeyorixCore(ms)
+	err := c.requireMachineGrantNoSoDViolation(context.Background(), 1, 10)
+	require.Error(t, err)
+}
+
+func TestRequireMachineGrantNoSoDViolation_NoAddedPermissions_NoOp(t *testing.T) {
+	ms := new(MockStorage)
+	policy := &models.SoDPolicy{ID: 1, Name: "split-duty", PermissionA: "secrets.write", PermissionB: "secrets.delete"}
+	ms.On("ListSoDPolicies", mock.Anything).Return([]*models.SoDPolicy{policy}, nil)
+	ms.On("GetRole", mock.Anything, uint(11)).Return(&models.Role{ID: 11, Name: "empty_role"}, nil)
+	ms.On("GetRolePermissions", mock.Anything, uint(11)).Return([]*models.Permission{}, nil)
+	c := NewKeyorixCore(ms)
+	err := c.requireMachineGrantNoSoDViolation(context.Background(), 1, 11)
+	require.NoError(t, err)
+	ms.AssertNotCalled(t, "GetMachineRoles", mock.Anything, mock.Anything)
+}
+
+func TestRequireMachineGrantNoSoDViolation_MachineRolesError(t *testing.T) {
+	ms := new(MockStorage)
+	policy := &models.SoDPolicy{ID: 1, Name: "split-duty", PermissionA: "secrets.write", PermissionB: "secrets.delete"}
+	ms.On("ListSoDPolicies", mock.Anything).Return([]*models.SoDPolicy{policy}, nil)
+	ms.On("GetRole", mock.Anything, uint(12)).Return(&models.Role{ID: 12, Name: "custom_writer"}, nil)
+	ms.On("GetRolePermissions", mock.Anything, uint(12)).Return([]*models.Permission{{ID: 1, Name: "secrets.write"}}, nil)
+	ms.On("GetMachineRoles", mock.Anything, uint(1)).Return(nil, errors.New("db error"))
+	c := NewKeyorixCore(ms)
+	err := c.requireMachineGrantNoSoDViolation(context.Background(), 1, 12)
+	require.Error(t, err)
+}
+
+func TestRequireMachineGrantNoSoDViolation_HeldRolePermissionsError(t *testing.T) {
+	ms := new(MockStorage)
+	policy := &models.SoDPolicy{ID: 1, Name: "split-duty", PermissionA: "secrets.write", PermissionB: "secrets.delete"}
+	ms.On("ListSoDPolicies", mock.Anything).Return([]*models.SoDPolicy{policy}, nil)
+	ms.On("GetRole", mock.Anything, uint(13)).Return(&models.Role{ID: 13, Name: "custom_writer"}, nil)
+	ms.On("GetRolePermissions", mock.Anything, uint(13)).Return([]*models.Permission{{ID: 1, Name: "secrets.write"}}, nil)
+	ms.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{{ID: 20, Name: "other_role"}}, nil)
+	ms.On("GetRolePermissions", mock.Anything, uint(20)).Return(nil, errors.New("db error"))
+	c := NewKeyorixCore(ms)
+	err := c.requireMachineGrantNoSoDViolation(context.Background(), 1, 13)
+	require.Error(t, err)
+}
+
+// TestRequireMachineGrantNoSoDViolation_ViolationDetected_Blocked is the
+// invariant this whole check exists for: a machine that already holds
+// secrets.delete (via an unrelated existing role) must be rejected when
+// granted a role that adds secrets.write, since the pair completes the SoD
+// policy.
+func TestRequireMachineGrantNoSoDViolation_ViolationDetected_Blocked(t *testing.T) {
+	ms := new(MockStorage)
+	policy := &models.SoDPolicy{ID: 1, Name: "split-duty", PermissionA: "secrets.write", PermissionB: "secrets.delete"}
+	ms.On("ListSoDPolicies", mock.Anything).Return([]*models.SoDPolicy{policy}, nil)
+	ms.On("GetRole", mock.Anything, uint(14)).Return(&models.Role{ID: 14, Name: "writer_role"}, nil)
+	ms.On("GetRolePermissions", mock.Anything, uint(14)).Return([]*models.Permission{{ID: 1, Name: "secrets.write"}}, nil)
+	ms.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{{ID: 21, Name: "deleter_role"}}, nil)
+	ms.On("GetRolePermissions", mock.Anything, uint(21)).Return([]*models.Permission{{ID: 2, Name: "secrets.delete"}}, nil)
+	c := NewKeyorixCore(ms)
+	err := c.requireMachineGrantNoSoDViolation(context.Background(), 1, 14)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "split-duty")
+}
+
+// TestRequireMachineGrantNoSoDViolation_NoViolation_Allowed is the success
+// path: granting a role that adds a permission with no SoD-conflicting
+// counterpart already held must succeed.
+func TestRequireMachineGrantNoSoDViolation_NoViolation_Allowed(t *testing.T) {
+	ms := new(MockStorage)
+	policy := &models.SoDPolicy{ID: 1, Name: "split-duty", PermissionA: "secrets.write", PermissionB: "secrets.delete"}
+	ms.On("ListSoDPolicies", mock.Anything).Return([]*models.SoDPolicy{policy}, nil)
+	ms.On("GetRole", mock.Anything, uint(15)).Return(&models.Role{ID: 15, Name: "reader_role"}, nil)
+	ms.On("GetRolePermissions", mock.Anything, uint(15)).Return([]*models.Permission{{ID: 3, Name: "secrets.read"}}, nil)
+	ms.On("GetMachineRoles", mock.Anything, uint(1)).Return([]*models.Role{{ID: 22, Name: "another_role"}}, nil)
+	ms.On("GetRolePermissions", mock.Anything, uint(22)).Return([]*models.Permission{{ID: 4, Name: "projects.read"}}, nil)
+	c := NewKeyorixCore(ms)
+	err := c.requireMachineGrantNoSoDViolation(context.Background(), 1, 15)
+	require.NoError(t, err)
+}

--- a/internal/core/sso_complete_success_test.go
+++ b/internal/core/sso_complete_success_test.go
@@ -1,0 +1,112 @@
+// sso_complete_success_test.go covers CompleteSSO's success tail (sso.go) --
+// every existing CompleteSSO test in sso_test.go exercises a REJECTION path
+// (SAML-typed provider, password-expiry-gate error, locked account). None
+// reaches mintSession: the group/role sync, password-expiry no-op, session
+// creation, RecordLogin, and audit-write branches were entirely untested.
+package core
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompleteSSO_Success_MintsSessionAndAudits(t *testing.T) {
+	c, store, key, p := ssoTestCore(t)
+	// GroupSync/GroupRoleMap enabled with no groups claim on the token: exercises
+	// CompleteSSO's own two call sites into syncSSOGroups/syncSSORoles (an absent
+	// claim makes both a fast no-op internally, already covered by
+	// TestSyncSSOGroups/TestSyncSSORoles's own dedicated tests elsewhere).
+	p.GroupSync = true
+	p.GroupRoleMap = map[string]string{"keyorix-admins": "system_admin"}
+
+	activeUser := &models.User{ID: 77, IsActive: true, AccountState: "active"}
+
+	const testNonce = "nonce-success"
+	idToken := signToken(t, key, "kid-1", jwt.MapClaims{
+		"iss":            "https://idp.test",
+		"aud":            "client-1",
+		"sub":            "okta|77",
+		"email":          "success@x.io",
+		"email_verified": true,
+		"nonce":          testNonce,
+		"exp":            time.Now().Add(time.Hour).Unix(),
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body := fmt.Sprintf(`{"access_token":"at","token_type":"Bearer","id_token":%q}`, idToken)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer ts.Close()
+	p.OAuth.Endpoint.TokenURL = ts.URL
+
+	store.On("ConsumeSSOLoginState", mock.Anything, "state-ok").Return(
+		&models.SSOLoginState{Provider: "okta", Nonce: testNonce, ReturnTo: "/dashboard", ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|77").Return(activeUser, nil)
+	store.On("CreateSession", mock.Anything, mock.AnythingOfType("*models.Session")).
+		Return(&models.Session{ID: 1, UserID: 77, SessionToken: "sess-tok"}, nil)
+	store.On("UpdateLastLogin", mock.Anything, uint(77), mock.Anything).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	session, user, returnTo, err := c.CompleteSSO(context.Background(), "okta", "auth-code", "state-ok", "ua", "1.2.3.4")
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.Equal(t, "sess-tok", session.SessionToken)
+	require.NotNil(t, user)
+	assert.Equal(t, uint(77), user.ID)
+	assert.Equal(t, "/dashboard", returnTo)
+	store.AssertCalled(t, "UpdateLastLogin", mock.Anything, uint(77), mock.Anything)
+
+	var auditEvent *models.AuditEvent
+	for _, call := range store.Calls {
+		if call.Method == "LogAuditEvent" {
+			auditEvent = call.Arguments.Get(1).(*models.AuditEvent)
+		}
+	}
+	require.NotNil(t, auditEvent, "a successful SSO login must write an audit event")
+	assert.Equal(t, EventSSOLogin, auditEvent.EventType)
+}
+
+// TestCompleteSSO_MintSessionError_Propagates covers the one remaining error
+// branch in CompleteSSO's tail: a session-creation failure must surface as an
+// error, and RecordLogin/the audit write must never run for a login that
+// didn't actually complete.
+func TestCompleteSSO_MintSessionError_Propagates(t *testing.T) {
+	c, store, key, p := ssoTestCore(t)
+
+	activeUser := &models.User{ID: 78, IsActive: true, AccountState: "active"}
+	const testNonce = "nonce-mint-error"
+	idToken := signToken(t, key, "kid-1", jwt.MapClaims{
+		"iss": "https://idp.test", "aud": "client-1", "sub": "okta|78",
+		"email": "minterr@x.io", "email_verified": true, "nonce": testNonce,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body := fmt.Sprintf(`{"access_token":"at","token_type":"Bearer","id_token":%q}`, idToken)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer ts.Close()
+	p.OAuth.Endpoint.TokenURL = ts.URL
+
+	store.On("ConsumeSSOLoginState", mock.Anything, "state-mint-err").Return(
+		&models.SSOLoginState{Provider: "okta", Nonce: testNonce, ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|78").Return(activeUser, nil)
+	store.On("CreateSession", mock.Anything, mock.AnythingOfType("*models.Session")).
+		Return(nil, assert.AnError)
+
+	session, _, _, err := c.CompleteSSO(context.Background(), "okta", "auth-code", "state-mint-err", "ua", "1.2.3.4")
+	require.Error(t, err)
+	assert.Nil(t, session)
+	store.AssertNotCalled(t, "UpdateLastLogin", mock.Anything, mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+}

--- a/internal/core/sso_ensure_user_test.go
+++ b/internal/core/sso_ensure_user_test.go
@@ -1,0 +1,74 @@
+// sso_ensure_user_test.go covers ensureSSOUser's three branches (sso.go) --
+// every existing CompleteSSO test resolves an EXISTING user via
+// GetUserByExternalID, so only the "existing != nil" branch had ever run.
+// Untested before this file: auto-provisioning disabled (a clean rejection,
+// not a silent account creation) and auto-provisioning enabled (the full JIT
+// account-creation path, provisionSSOUser).
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureSSOUser_ExistingReturnedDirectly(t *testing.T) {
+	c, _, _, p := ssoTestCore(t)
+	existing := &models.User{ID: 7, Email: "ada@x.io"}
+	got, err := c.ensureSSOUser(context.Background(), p, existing, "okta|7", "ada@x.io", true, "Ada")
+	require.NoError(t, err)
+	assert.Same(t, existing, got)
+}
+
+func TestEnsureSSOUser_NoAutoProvision_Rejected(t *testing.T) {
+	c, _, _, p := ssoTestCore(t)
+	p.AutoProvision = false
+	_, err := c.ensureSSOUser(context.Background(), p, nil, "okta|new", "new@x.io", true, "New Person")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no Keyorix account matches")
+}
+
+// TestEnsureSSOUser_AutoProvision_CreatesUser exercises the full JIT
+// provisioning path (provisionSSOUser): no existing user by external ID or
+// email, a fresh username derived, the account created active with the
+// provider's default role assigned.
+func TestEnsureSSOUser_AutoProvision_CreatesUser(t *testing.T) {
+	c, store, _, p := ssoTestCore(t)
+	p.AutoProvision = true
+	p.DefaultRole = "system_viewer"
+
+	store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|new").
+		Return(nil, storage.ErrUserNotFound).Once() // provisionSSOUser's own race-guard call to resolveSSOUser
+	store.On("GetUserByEmail", mock.Anything, "new@x.io").
+		Return(nil, storage.ErrUserNotFound).Once()
+	store.On("GetUserByUsername", mock.Anything, "new").
+		Return(nil, storage.ErrUserNotFound)
+	store.On("CreateUser", mock.Anything, mock.AnythingOfType("*models.User")).
+		Return(&models.User{ID: 42, Username: "new", Email: "new@x.io", ExternalID: "sso:okta:okta|new"}, nil)
+	store.On("GetRoleByName", mock.Anything, "system_viewer").
+		Return(&models.Role{ID: 3, Name: "system_viewer"}, nil)
+	store.On("AssignRole", mock.Anything, uint(42), uint(3), storage.Scope{}).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
+
+	got, err := c.ensureSSOUser(context.Background(), p, nil, "okta|new", "new@x.io", true, "New Person")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, uint(42), got.ID)
+	store.AssertCalled(t, "AssignRole", mock.Anything, uint(42), uint(3), storage.Scope{})
+}
+
+// TestEnsureSSOUser_AutoProvision_NoEmail_Rejected pins provisionSSOUser's own
+// precondition: an IdP assertion with no email can never be auto-provisioned,
+// regardless of AutoProvision being enabled.
+func TestEnsureSSOUser_AutoProvision_NoEmail_Rejected(t *testing.T) {
+	c, _, _, p := ssoTestCore(t)
+	p.AutoProvision = true
+	_, err := c.ensureSSOUser(context.Background(), p, nil, "okta|new", "", true, "New Person")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no email")
+}

--- a/internal/core/sso_suspended_account_test.go
+++ b/internal/core/sso_suspended_account_test.go
@@ -1,0 +1,74 @@
+// sso_suspended_account_test.go covers CompleteSSO's account-suspended/
+// deactivated rejection (sso.go) -- untested before this file: a suspended or
+// deactivated account must be refused an SSO session even though the IdP
+// itself authenticated the identity successfully.
+package core
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompleteSSO_DeactivatedAccount_Rejected(t *testing.T) {
+	c, store, key, p := ssoTestCore(t)
+	deactivated := &models.User{ID: 88, IsActive: false, AccountState: "active"}
+
+	const testNonce = "nonce-deactivated"
+	idToken := signToken(t, key, "kid-1", jwt.MapClaims{
+		"iss": "https://idp.test", "aud": "client-1", "sub": "okta|88",
+		"email": "deactivated@x.io", "email_verified": true, "nonce": testNonce,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"access_token":"at","token_type":"Bearer","id_token":%q}`, idToken)))
+	}))
+	defer ts.Close()
+	p.OAuth.Endpoint.TokenURL = ts.URL
+
+	store.On("ConsumeSSOLoginState", mock.Anything, "state-deact").Return(
+		&models.SSOLoginState{Provider: "okta", Nonce: testNonce, ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|88").Return(deactivated, nil)
+
+	session, _, _, err := c.CompleteSSO(context.Background(), "okta", "auth-code", "state-deact", "ua", "1.2.3.4")
+	require.Error(t, err)
+	assert.Nil(t, session)
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}
+
+func TestCompleteSSO_SuspendedAccount_Rejected(t *testing.T) {
+	c, store, key, p := ssoTestCore(t)
+	suspended := &models.User{ID: 89, IsActive: true, AccountState: AccountSuspended}
+
+	const testNonce = "nonce-suspended"
+	idToken := signToken(t, key, "kid-1", jwt.MapClaims{
+		"iss": "https://idp.test", "aud": "client-1", "sub": "okta|89",
+		"email": "suspended@x.io", "email_verified": true, "nonce": testNonce,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"access_token":"at","token_type":"Bearer","id_token":%q}`, idToken)))
+	}))
+	defer ts.Close()
+	p.OAuth.Endpoint.TokenURL = ts.URL
+
+	store.On("ConsumeSSOLoginState", mock.Anything, "state-susp").Return(
+		&models.SSOLoginState{Provider: "okta", Nonce: testNonce, ExpiresAt: time.Now().Add(time.Minute)}, nil)
+	store.On("GetUserByExternalID", mock.Anything, "sso:okta:okta|89").Return(suspended, nil)
+
+	session, _, _, err := c.CompleteSSO(context.Background(), "okta", "auth-code", "state-susp", "ua", "1.2.3.4")
+	require.Error(t, err)
+	assert.Nil(t, session)
+	store.AssertNotCalled(t, "CreateSession", mock.Anything, mock.Anything)
+}

--- a/internal/core/sso_suspended_account_test.go
+++ b/internal/core/sso_suspended_account_test.go
@@ -31,7 +31,7 @@ func TestCompleteSSO_DeactivatedAccount_Rejected(t *testing.T) {
 	})
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"access_token":"at","token_type":"Bearer","id_token":%q}`, idToken)))
+		_, _ = fmt.Fprintf(w, `{"access_token":"at","token_type":"Bearer","id_token":%q}`, idToken)
 	}))
 	defer ts.Close()
 	p.OAuth.Endpoint.TokenURL = ts.URL
@@ -58,7 +58,7 @@ func TestCompleteSSO_SuspendedAccount_Rejected(t *testing.T) {
 	})
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"access_token":"at","token_type":"Bearer","id_token":%q}`, idToken)))
+		_, _ = fmt.Fprintf(w, `{"access_token":"at","token_type":"Bearer","id_token":%q}`, idToken)
 	}))
 	defer ts.Close()
 	p.OAuth.Endpoint.TokenURL = ts.URL

--- a/server/http/handlers/sso_complete_success_test.go
+++ b/server/http/handlers/sso_complete_success_test.go
@@ -91,7 +91,7 @@ func TestCompleteSSO_Success_S1727(t *testing.T) {
 	})
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"access_token":"at","token_type":"Bearer","id_token":%q}`, idToken)))
+		_, _ = fmt.Fprintf(w, `{"access_token":"at","token_type":"Bearer","id_token":%q}`, idToken)
 	}))
 	defer ts.Close()
 	p.OAuth.Endpoint.TokenURL = ts.URL

--- a/server/http/handlers/sso_complete_success_test.go
+++ b/server/http/handlers/sso_complete_success_test.go
@@ -1,0 +1,135 @@
+// sso_complete_success_test.go covers CompleteSSO's success tail (sso.go) at
+// the HTTP-handler level -- every existing handler-level CompleteSSO test
+// (auth_sso_s13_test.go and siblings) exercises a REJECTION path (unknown
+// provider, IdP error param, missing code/state, core error). None reaches
+// the success branch: setSessionCookies, the expires_at/absolute_expires_at/
+// return_to fragment fields, and the #r125-H3 invariant that a successful
+// login's session token never appears in the redirect fragment either.
+//
+// Drives the real HTTP flow: a real SQLite-backed core (BeginSSO persists a
+// real SSOLoginState row and returns the IdP authorize URL carrying the real
+// state+nonce), a real RSA-signed id_token verified against a static JWKS
+// resolver, and an httptest OAuth token endpoint -- the same shape
+// internal/core/sso_test.go's ssoTestCore uses, reimplemented here since that
+// helper (and its unexported staticResolver type) lives in package core.
+package handlers
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// staticJWKSResolver is a minimal core.JWKSResolver returning one fixed key
+// regardless of (issuer, kid) -- sufficient for a test with a single signer.
+type staticJWKSResolver struct{ key *rsa.PublicKey }
+
+func (s staticJWKSResolver) Key(_ context.Context, _, _ string) (interface{}, error) {
+	return s.key, nil
+}
+
+func signSSOToken(t *testing.T, key *rsa.PrivateKey, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = "kid-1"
+	signed, err := tok.SignedString(key)
+	require.NoError(t, err)
+	return signed
+}
+
+func TestCompleteSSO_Success_S1727(t *testing.T) {
+	cs := freshCoreS12(t)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	const providerName = "testoidc_success_1727"
+	const completeURL = "https://app.example.com/sso/complete"
+	p := &core.SSOProvider{
+		Name: providerName, Issuer: "https://idp.test.example", ClientID: "test-client-id",
+		CompleteURL: completeURL,
+		OAuth: &oauth2.Config{
+			ClientID:    "test-client-id",
+			Endpoint:    oauth2.Endpoint{AuthURL: "https://idp.test.example/authorize", TokenURL: "https://idp.test.example/token"},
+			RedirectURL: fmt.Sprintf("https://app.example.com/auth/sso/%s/callback", providerName),
+			Scopes:      []string{"openid", "email"},
+		},
+	}
+	cs.SetSSOProviders(map[string]*core.SSOProvider{providerName: p}, staticJWKSResolver{key: &key.PublicKey})
+	h := NewAuthHandler(cs, false)
+
+	// Step 1: BeginSSO persists a real SSOLoginState row and returns the
+	// authorize URL carrying the real state+nonce.
+	beginReq := withChiParam(httptest.NewRequest(http.MethodGet, "/auth/sso/"+providerName+"/login", nil), "provider", providerName)
+	beginW := httptest.NewRecorder()
+	h.BeginSSO(beginW, beginReq)
+	require.Equal(t, http.StatusFound, beginW.Code)
+	authURL, err := url.Parse(beginW.Header().Get("Location"))
+	require.NoError(t, err)
+	state := authURL.Query().Get("state")
+	nonce := authURL.Query().Get("nonce")
+	require.NotEmpty(t, state)
+	require.NotEmpty(t, nonce)
+
+	// Step 2: a real OAuth token endpoint returning a real, correctly-signed
+	// id_token for the state's nonce.
+	idToken := signSSOToken(t, key, jwt.MapClaims{
+		"iss": p.Issuer, "aud": "test-client-id", "sub": "idp-subject-1727",
+		"email": "handler-success@x.io", "email_verified": true, "nonce": nonce,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fmt.Sprintf(`{"access_token":"at","token_type":"Bearer","id_token":%q}`, idToken)))
+	}))
+	defer ts.Close()
+	p.OAuth.Endpoint.TokenURL = ts.URL
+
+	// The IdP-federated user must already exist for this to succeed without
+	// also exercising JIT provisioning (covered separately at the core level).
+	// resolveSSOUser matches it by verified email (ExternalID starts empty and
+	// self-heals to this SSO identity on this very login).
+	_, err = cs.CreateUser(context.Background(), &core.CreateUserRequest{
+		Username: "handlersuccess", Email: "handler-success@x.io",
+		DisplayName: "Handler Success", Password: "pw-Aa1!aaaa-longenough",
+	})
+	require.NoError(t, err)
+
+	reqURL := fmt.Sprintf("/auth/sso/%s/callback?code=authcode&state=%s", providerName, url.QueryEscape(state))
+	req := withChiParam(httptest.NewRequest(http.MethodGet, reqURL, nil), "provider", providerName)
+	w := httptest.NewRecorder()
+	h.CompleteSSO(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code)
+	loc := w.Header().Get("Location")
+	assert.Contains(t, loc, completeURL)
+
+	fragURL, err := url.Parse(loc)
+	require.NoError(t, err)
+	frag, err := url.ParseQuery(fragURL.Fragment)
+	require.NoError(t, err)
+	assert.NotEmpty(t, frag.Get("expires_at"))
+	assert.NotContains(t, loc, "error=", "a successful login must not carry an error fragment")
+
+	// #r125-H3: the session token is delivered via cookie, never the fragment.
+	cookies := w.Result().Cookies()
+	var sessionCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "session_token" || c.Name == "kx_session" {
+			sessionCookie = c
+		}
+	}
+	require.NotNil(t, sessionCookie, "a successful login must set a session cookie")
+	assert.NotContains(t, loc, sessionCookie.Value, "the session token must never appear in the redirect fragment")
+}


### PR DESCRIPTION
## Summary
A coverage sweep initially flagged several functions as near-0% covered (`WithSchedulerLock`, `requireMachineGrantNoSoDViolation`, `guardAccountStateNotBlank`, etc.) — turned out to be a measurement artifact of running without `KEYORIX_TEST_PG_DSN` set, which silently skips every Postgres-gated contention test in the repo. Re-running with a real Postgres instance showed those functions were already thoroughly tested (CI sets the DSN); the genuinely untested functions were a different, smaller set, all in `internal/core` and its HTTP layer:

- **`Login`** (`auth.go`): the entire `RemoteLoginVerifier` branch (`storage.type: remote`, #508) had zero coverage — every existing test only exercises the direct LocalStorage/bcrypt path.
- **`requireMachineGrantNoSoDViolation`** (`sod.go`): only the early-return branches were covered; the actual violation-detection and no-violation-success paths — the entire reason this check exists — were not.
- **`connectorHasAnyDelegationForActor`** (`connect.go`): the role-match/expiry evaluation loop backing Connect connector-listing visibility.
- **`validateReplacementCredential`** + `IssueMachineToken`'s PAT-006 replace-credential-atomically-with-issuance flow (`machine_token.go`): had **zero** test coverage of the actual rotation behavior.
- **`ExpireSetupTokenByID`** (`setup_token.go`): the not-found/storage-error branches.
- **`ensureSSOUser`** (`sso.go`): the auto-provisioning-disabled rejection and the full JIT account-creation path (`provisionSSOUser`) via `ensureSSOUser`.
- **`CompleteSSO`** (`sso.go`, core and `server/http/handlers` layers): every existing test exercises a rejection path; none reached `mintSession`. Added the success tail (session creation, group/role sync call sites, `RecordLogin`, audit write) at the core level, plus a full real-HTTP-flow success test at the handler level (`BeginSSO` → real signed `id_token` → `CompleteSSO`), including suspended/deactivated-account rejection.

**Bonus find**: a silently broken `MockStorage` stub — `ListConnectRefGrantsByConnector` was hardcoded to `return nil, nil`, never wired through testify's `m.Called(...)`, so any `.On/.Return` configured against it was silently ignored. Fixed to match the established pattern used by every other method on that mock.

## Coverage impact
Per-function, on the functions actually touched:

| Function | Before | After |
|---|---|---|
| `Login` | 59.1% | 95.5% |
| `requireMachineGrantNoSoDViolation` | 46.4% | 96.4% |
| `connectorHasAnyDelegationForActor` | 30.8% | 100% |
| `validateReplacementCredential` | 33.3% | 100% |
| `ExpireSetupTokenByID` | 50.0% | 100% |
| `ensureSSOUser` | 40.0% | 100% |
| `CompleteSSO` (core) | 59.0% | 79.5% |

Whole-repo aggregate coverage moves only marginally (88.0% → 88.1%) since these are individually small functions against a 166k-line codebase — the value is closing specific, previously **completely untested** security-relevant logic (SoD enforcement, credential rotation, SSO login), not the aggregate number. Chasing 99% overall isn't realistic or worthwhile here: `server/proto/pb` alone (generated protobuf, thousands of getters) sits at 0.7% and dominates the denominator; the remaining gaps in the Postgres lock primitives (`WithSchedulerLock` ~71%, etc.) are defensive error branches for near-impossible-to-trigger conditions (connection-pool exhaustion, mid-transaction exec failure) that would need artificial fault injection to hit — not a good trade for test signal quality.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/core/...` — 0 failures
- [x] `go test ./server/http/handlers/...` — 0 failures
- [x] `gosec -severity medium -exclude-generated ./internal/core/... ./server/http/handlers/...` — 0 issues
- [x] `gofmt -l` clean on all new/changed files
- [x] Full `go test ./...` (with `KEYORIX_TEST_PG_DSN` set against a real Postgres 16 instance) — 0 failures