### PR TITLE
fix(security): suppress 3 Semgrep false positives (#813, #814, #815)

### DIFF
--- a/internal/k8ssync/health.go
+++ b/internal/k8ssync/health.go
@@ -109,6 +109,10 @@ func (s *Status) HandlerWithToken(token string) http.Handler {
 	})
 	var metricsHandler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		// nosemgrep: go.lang.security.audit.xss.no-direct-write-to-responsewriter.no-direct-write-to-responsewriter
+		// s.metrics() is a hand-built Prometheus text-exposition body assembled from this
+		// process's own internal counters -- no request- or user-derived data reaches it, and
+		// the response is served as text/plain, not HTML, so there is no XSS sink here.
 		_, _ = w.Write([]byte(s.metrics()))
 	})
 	if token != "" {

--- a/internal/storage/account_state_backfill.go
+++ b/internal/storage/account_state_backfill.go
@@ -173,6 +173,11 @@ func guardAccountStateValid(db *gorm.DB) error {
 	}
 	inList := strings.Join(quoted, ",")
 	checkExpr := "account_state IN (" + inList + ")"
+	// nosemgrep: go.lang.security.audit.database.string-formatted-query.string-formatted-query
+	// constraintName is a package-level Go constant and checkExpr is built solely from the
+	// hardcoded ValidAccountStateSQLValues literals above -- neither carries any request- or
+	// row-derived data. This is also DDL (ALTER TABLE ... ADD CONSTRAINT), which Postgres
+	// cannot accept via parameterized placeholders regardless.
 	if err := db.Exec("ALTER TABLE users ADD CONSTRAINT " + constraintName +
 		" CHECK (" + checkExpr + ")").Error; err != nil {
 		// This constraint is stricter than the blank-only guard it replaces --

--- a/internal/storage/store/local_audit_chain.go
+++ b/internal/storage/store/local_audit_chain.go
@@ -16,6 +16,9 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
+	// Used only for retry-backoff jitter (see the #nosec G404 at its call site below), never
+	// for a security-sensitive value such as a token, key, or ID.
 	mathrand "math/rand"
 	"strconv"
 	"strings"


### PR DESCRIPTION
## Summary
Addresses GitHub code scanning alerts #813, #814, #815 (Semgrep OSS), all false positives:

- **#815** `internal/storage/account_state_backfill.go:176` — `string-formatted-query`. The DDL (`ALTER TABLE ... ADD CONSTRAINT`) is built entirely from hardcoded Go constants/literals, never request- or row-derived data. Postgres also has no way to parameterize DDL identifiers/clauses.
- **#814** `internal/storage/store/local_audit_chain.go:19` — `math-random-used`. `math/rand` is used only for retry-backoff jitter on SQLite-busy errors, already marked `#nosec G404` at the call site; not a security-sensitive value.
- **#813** `internal/k8ssync/health.go:112` — `no-direct-write-to-responsewriter`. The body is a hand-built Prometheus text-exposition string from internal counters, served as `text/plain`, with no user/request input — not an XSS sink.

Each site gets a `// nosemgrep: <rule-id>` comment with a one-line justification, verified against the actual data flow before suppressing.

## Test plan
- [x] `go build` / `go vet` on the touched packages
- [ ] Confirm CI (lint/CodeQL/Semgrep) is green
- [ ] Dismiss alerts #813/#814/#815 in GitHub code scanning once merged, referencing this PR