### PR TITLE
ci(security): add per-PR family-membership check

### DIFF
--- a/.github/family-check-scope.json
+++ b/.github/family-check-scope.json
@@ -1,7 +1,11 @@
-[
-  "github.com/keyorixhq/keyorix/internal/connect.Connector",
-  "github.com/keyorixhq/keyorix/internal/crypto.KMSClient",
-  "github.com/keyorixhq/keyorix/internal/dynamic.CredentialEngine",
-  "github.com/keyorixhq/keyorix/internal/rotation.Executor",
-  "github.com/keyorixhq/keyorix/internal/rotation.GeneratingExecutor"
-]
+{
+  "last_reconciled": "2026-09-05",
+  "note": "Refreshed by the quarterly implementation-asymmetry scan (see keyorix-private/adversarial-review/IMPLEMENTATION-ASYMMETRY-SCAN-*.md for the method, QUEUE.md for the current follow-up queue and the Mode A dismissal log). Mode B only gates a NEW MEMBER of a family already listed here -- a brand-new family this list doesn't know about is covered by nothing until the next scan adds it. familycheck logs a non-blocking warning once this goes stale; treat that as the forcing function to re-run the scan, not just a formality.",
+  "families": [
+    "github.com/keyorixhq/keyorix/internal/connect.Connector",
+    "github.com/keyorixhq/keyorix/internal/crypto.KMSClient",
+    "github.com/keyorixhq/keyorix/internal/dynamic.CredentialEngine",
+    "github.com/keyorixhq/keyorix/internal/rotation.Executor",
+    "github.com/keyorixhq/keyorix/internal/rotation.GeneratingExecutor"
+  ]
+}

--- a/.github/family-check-scope.json
+++ b/.github/family-check-scope.json
@@ -1,0 +1,7 @@
+[
+  "github.com/keyorixhq/keyorix/internal/connect.Connector",
+  "github.com/keyorixhq/keyorix/internal/crypto.KMSClient",
+  "github.com/keyorixhq/keyorix/internal/dynamic.CredentialEngine",
+  "github.com/keyorixhq/keyorix/internal/rotation.Executor",
+  "github.com/keyorixhq/keyorix/internal/rotation.GeneratingExecutor"
+]

--- a/.github/workflows/family-check.yml
+++ b/.github/workflows/family-check.yml
@@ -1,0 +1,113 @@
+# Preventive half of the implementation-asymmetry scan (docs at
+# keyorix-private/adversarial-review/IMPLEMENTATION-ASYMMETRY-SCAN-2026-09-05.md).
+# The scan itself is detective -- this catches the same shape (a PR touches
+# some but not all members of an interface-unified family, or adds a new
+# member) before it lands, not a quarter later by accident. See
+# devtools/familycheck/README.md for the two modes and the replay evidence
+# (PR #1449, PR #740) that this would have caught both historical misses.
+name: Family Membership Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    # See ci.yml's own comment: also covers stacked-PR review chains.
+    branches: [main, 'adr082/**', 'feat/**', 'fix/**']
+    paths: ['**.go']
+
+permissions: {}
+
+concurrency:
+  group: family-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  family-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+          fetch-depth: 0
+
+      - name: Checkout PR base
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26.6'
+
+      # Both devtools/ tools are standalone modules (not in go.work, like
+      # operator/) so golang.org/x/tools never becomes a dependency of the
+      # shipped keyorix binary. Built from the HEAD checkout: a PR that
+      # modifies the tools themselves is checked with its own version of them.
+      - name: Build analyzer and checker
+        run: |
+          GOWORK=off go build -o /tmp/asymanalyzer ./head/devtools/asymanalyzer
+          GOWORK=off go build -o /tmp/familycheck ./head/devtools/familycheck
+
+      - name: Compute family lists (base and head)
+        run: |
+          GOWORK=off /tmp/asymanalyzer -json -root "$PWD/base" base base/operator > base-families.json
+          GOWORK=off /tmp/asymanalyzer -json -root "$PWD/head" head head/operator > head-families.json
+
+      # Matches ci.yml's own `changes` job convention: the GitHub API's PR
+      # file list, not a local `git diff`, since it correctly reflects
+      # GitHub's own PR-diff computation across force-pushes/rebases rather
+      # than depending on this checkout's local history lining up.
+      - name: Compute changed files
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[].filename' > changed-files.txt
+
+      - name: Write PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: printf '%s' "$PR_BODY" > pr-body.txt
+
+      # Mode A (partial family edit) never fails this step. Mode B (new
+      # member, unconfirmed) exits 1 -- that's the intentional hard gate,
+      # narrowly scoped per family-check-scope.json plus the security-keyword
+      # heuristic in familycheck itself (see its README for why the keyword
+      # scan reads every family member's content, not just the touched ones).
+      - name: Run family check
+        run: |
+          /tmp/familycheck \
+            -base-families base-families.json \
+            -head-families head-families.json \
+            -changed-files changed-files.txt \
+            -pr-body pr-body.txt \
+            -scope head/.github/family-check-scope.json \
+            -repo-root head \
+            > family-check-report.md
+
+      # Runs even when the check above failed (Mode B), so the author sees
+      # the sibling checklist on the PR itself, not just in CI logs. An empty
+      # report (nothing in scope was touched) posts nothing -- most Go PRs
+      # touch no tracked family at all, and a check that comments on every PR
+      # regardless of relevance is exactly the noise that gets a check
+      # disabled (see family-check-scope.json's own scoping rationale).
+      - name: Post or update PR comment
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ ! -s family-check-report.md ]; then
+            echo "family-membership check: nothing to report, skipping comment"
+            exit 0
+          fi
+          if ! gh pr comment "${{ github.event.pull_request.number }}" --edit-last --body-file family-check-report.md 2>/dev/null; then
+            gh pr comment "${{ github.event.pull_request.number }}" --body-file family-check-report.md
+          fi

--- a/.github/workflows/family-check.yml
+++ b/.github/workflows/family-check.yml
@@ -51,10 +51,15 @@ jobs:
       # operator/) so golang.org/x/tools never becomes a dependency of the
       # shipped keyorix binary. Built from the HEAD checkout: a PR that
       # modifies the tools themselves is checked with its own version of them.
+      # `cd` into each tool's own directory before building: with GOWORK=off,
+      # `go build` resolves the main module from the CURRENT directory, not
+      # the target package path, so building `./head/devtools/x` from the
+      # workspace root (which has no go.mod of its own) fails with "go.mod
+      # file not found in current directory or any parent directory".
       - name: Build analyzer and checker
         run: |
-          GOWORK=off go build -o /tmp/asymanalyzer ./head/devtools/asymanalyzer
-          GOWORK=off go build -o /tmp/familycheck ./head/devtools/familycheck
+          (cd head/devtools/asymanalyzer && GOWORK=off go build -o /tmp/asymanalyzer .)
+          (cd head/devtools/familycheck && GOWORK=off go build -o /tmp/familycheck .)
 
       - name: Compute family lists (base and head)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,8 @@ certs/
 # Claude Code internal state and local tooling
 /.claire/
 /tools
+
+# devtools/*/'s own `go build ./...` output -- each is a main package that
+# builds a same-named binary directly into its source directory by default.
+/devtools/asymanalyzer/asymanalyzer
+/devtools/familycheck/familycheck

--- a/devtools/asymanalyzer/README.md
+++ b/devtools/asymanalyzer/README.md
@@ -1,0 +1,31 @@
+# asymanalyzer
+
+Finds every repo-defined Go interface with 2+ concrete implementers, via
+`golang.org/x/tools/go/packages` + `go/types.Implements` — not grep. Backs the
+`family-membership-check` CI job (`.github/workflows/family-check.yml`) and the
+implementation-asymmetry scan method (see
+`keyorix-private/adversarial-review/IMPLEMENTATION-ASYMMETRY-SCAN-2026-09-05.md`
+for the finding history that motivated this becoming a CI check rather than a
+one-off report).
+
+A standalone Go module (like `operator/`) so `golang.org/x/tools` never becomes
+a dependency of the shipped `keyorix` binary — build/run with `GOWORK=off`.
+
+## Usage
+
+```
+GOWORK=off go build -o asymanalyzer .
+GOWORK=off ./asymanalyzer [-json] [-root <repo-root>] <dir> [<dir> ...]
+```
+
+`-root` makes reported file paths relative to a common base (default: the
+first `<dir>`), so paths from a separately-scanned module like `operator/`
+still read as `operator/internal/foo/bar.go` — matching `git diff --name-only`
+output from the outer checkout, which is what the CI job diffs against.
+
+Only finds interface-unified families — it cannot find sibling packages doing
+the same job without a shared interface (the SIEM-forwarder case from the
+2026-09-05 report) or parallel function-naming families
+(`rotateAWS`/`rotateAzure`/...). Those need a human/agent pass, not this tool;
+`family-check.yml`'s scope list (`.github/family-check-scope.json`) is where
+those non-interface families get added by hand when found.

--- a/devtools/asymanalyzer/go.mod
+++ b/devtools/asymanalyzer/go.mod
@@ -1,0 +1,9 @@
+module asymanalyzer
+
+go 1.26.6
+
+require (
+	golang.org/x/mod v0.38.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/tools v0.48.0 // indirect
+)

--- a/devtools/asymanalyzer/go.sum
+++ b/devtools/asymanalyzer/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
+golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.48.0 h1:3+hClM1aLL5mjMKm5ovokw9epgRXPuu2tILgismM6RE=
+golang.org/x/tools v0.48.0/go.mod h1:08xX0orndb/F7jJxGDicx061tyd5pcMto75YMAXr6lk=

--- a/devtools/asymanalyzer/main.go
+++ b/devtools/asymanalyzer/main.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/types"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// Finds every repo-defined interface with 2+ distinct concrete implementer
+// types, across a set of module directories passed on argv.
+//
+// Usage: asymanalyzer [-json] [-root <repo-root>] <dir> [<dir> ...]
+//
+// -root sets the base all reported file paths are made relative to (so they
+// match `git diff --name-only` output from the outer checkout, even when a
+// separately-scanned module like operator/ lives in a subdirectory). Defaults
+// to the first <dir> argument.
+
+type implEntry struct {
+	typeName string
+	pkgPath  string
+	file     string
+	line     int
+	col      int
+	isPtr    bool
+}
+
+type ifaceInfo struct {
+	name     string
+	pkgPath  string
+	file     string
+	line     int
+	col      int
+	numMeths int
+	impls    map[string]implEntry // key: pkgPath+"."+typeName (dedup ptr/value)
+}
+
+// JSON output schema. `id` is pkgPath+"."+name -- stable across runs as long
+// as the interface keeps its package and name, which is exactly the identity
+// a per-PR check needs (rename/move is itself worth flagging separately, not
+// silently re-IDed).
+type jsonMember struct {
+	Type          string `json:"type"`
+	Package       string `json:"package"`
+	File          string `json:"file"`
+	Line          int    `json:"line"`
+	IsPtrReceiver bool   `json:"is_ptr_receiver"`
+}
+
+type jsonFamily struct {
+	ID         string       `json:"id"`
+	Interface  string       `json:"interface"`
+	Package    string       `json:"package"`
+	File       string       `json:"file"`
+	Line       int          `json:"line"`
+	NumMethods int          `json:"num_methods"`
+	Members    []jsonMember `json:"members"`
+}
+
+func main() {
+	jsonOut := flag.Bool("json", false, "emit structured JSON instead of text")
+	root := flag.String("root", "", "repo root to make file paths relative to (default: first scan dir)")
+	flag.Parse()
+	dirs := flag.Args()
+	if len(dirs) < 1 {
+		fmt.Fprintln(os.Stderr, "usage: asymanalyzer [-json] [-root <repo-root>] <dir> [<dir> ...]")
+		os.Exit(1)
+	}
+	relBase := *root
+	if relBase == "" {
+		relBase = dirs[0]
+	}
+	absRelBase, err := filepath.Abs(relBase)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "resolve -root %q: %v\n", relBase, err)
+		os.Exit(1)
+	}
+
+	var allFamilies []jsonFamily
+
+	for _, dir := range dirs {
+		cfg := &packages.Config{
+			Dir:  dir,
+			Mode: packages.NeedName | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax | packages.NeedImports | packages.NeedDeps | packages.NeedFiles,
+			Env:  os.Environ(),
+		}
+		pkgs, err := packages.Load(cfg, "./...")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "load error for %s: %v\n", dir, err)
+			os.Exit(1)
+		}
+		if n := packages.PrintErrors(pkgs); n > 0 {
+			fmt.Fprintf(os.Stderr, "WARNING: %d package load errors for %s (see above), continuing with what loaded\n", n, dir)
+		}
+
+		seenPkg := map[string]bool{}
+		var allPkgs []*packages.Package
+		packages.Visit(pkgs, func(p *packages.Package) bool {
+			if seenPkg[p.PkgPath] {
+				return true
+			}
+			seenPkg[p.PkgPath] = true
+			if isRepoPkg(p.PkgPath) {
+				allPkgs = append(allPkgs, p)
+			}
+			return true
+		}, nil)
+
+		type ifaceWithType struct {
+			info  *ifaceInfo
+			iface *types.Interface
+		}
+		var withType []ifaceWithType
+		type concreteType struct {
+			name    string
+			pkgPath string
+			file    string
+			line    int
+			col     int
+			named   *types.Named
+		}
+		var concreteTypes []concreteType
+
+		for _, p := range allPkgs {
+			if p.Types == nil {
+				continue
+			}
+			scope := p.Types.Scope()
+			for _, name := range scope.Names() {
+				obj := scope.Lookup(name)
+				tn, ok := obj.(*types.TypeName)
+				if !ok {
+					continue
+				}
+				named, ok := tn.Type().(*types.Named)
+				if !ok {
+					continue
+				}
+				pos := p.Fset.Position(obj.Pos())
+				if iface, ok := named.Underlying().(*types.Interface); ok {
+					if iface.NumMethods() == 0 {
+						continue // skip empty interfaces (any, marker interfaces)
+					}
+					info := &ifaceInfo{
+						name:     name,
+						pkgPath:  p.PkgPath,
+						file:     pos.Filename,
+						line:     pos.Line,
+						col:      pos.Column,
+						numMeths: iface.NumMethods(),
+						impls:    map[string]implEntry{},
+					}
+					withType = append(withType, ifaceWithType{info, iface})
+				} else {
+					concreteTypes = append(concreteTypes, concreteType{
+						name:    name,
+						pkgPath: p.PkgPath,
+						file:    pos.Filename,
+						line:    pos.Line,
+						col:     pos.Column,
+						named:   named,
+					})
+				}
+			}
+		}
+
+		for _, iw := range withType {
+			for _, ct := range concreteTypes {
+				if ct.pkgPath+"."+ct.name == iw.info.pkgPath+"."+iw.info.name {
+					continue
+				}
+				ptrType := types.NewPointer(ct.named)
+				implementsVal := types.Implements(ct.named, iw.iface)
+				implementsPtr := types.Implements(ptrType, iw.iface)
+				if !implementsVal && !implementsPtr {
+					continue
+				}
+				implKey := ct.pkgPath + "." + ct.name
+				iw.info.impls[implKey] = implEntry{
+					typeName: ct.name,
+					pkgPath:  ct.pkgPath,
+					file:     ct.file,
+					line:     ct.line,
+					col:      ct.col,
+					isPtr:    !implementsVal && implementsPtr,
+				}
+			}
+		}
+
+		var keys []string
+		infoByKey := map[string]*ifaceInfo{}
+		for _, iw := range withType {
+			k := iw.info.pkgPath + "." + iw.info.name
+			infoByKey[k] = iw.info
+			if len(iw.info.impls) >= 2 {
+				keys = append(keys, k)
+			}
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			info := infoByKey[k]
+			var implKeys []string
+			for ik := range info.impls {
+				implKeys = append(implKeys, ik)
+			}
+			sort.Strings(implKeys)
+
+			fam := jsonFamily{
+				ID:         k,
+				Interface:  info.name,
+				Package:    info.pkgPath,
+				File:       relPath(absRelBase, info.file),
+				Line:       info.line,
+				NumMethods: info.numMeths,
+			}
+			for _, ik := range implKeys {
+				e := info.impls[ik]
+				fam.Members = append(fam.Members, jsonMember{
+					Type:          e.typeName,
+					Package:       e.pkgPath,
+					File:          relPath(absRelBase, e.file),
+					Line:          e.line,
+					IsPtrReceiver: e.isPtr,
+				})
+			}
+			allFamilies = append(allFamilies, fam)
+		}
+	}
+
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(allFamilies); err != nil {
+			fmt.Fprintf(os.Stderr, "encode json: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	for _, fam := range allFamilies {
+		fmt.Printf("### INTERFACE %s (%s:%d) methods=%d impls=%d\n", fam.Interface, fam.File, fam.Line, fam.NumMethods, len(fam.Members))
+		for _, m := range fam.Members {
+			ptrNote := ""
+			if m.IsPtrReceiver {
+				ptrNote = " (ptr-receiver)"
+			}
+			fmt.Printf("  - %s.%s%s at %s:%d\n", m.Package, m.Type, ptrNote, m.File, m.Line)
+		}
+	}
+}
+
+// relPath makes file relative to base; falls back to the absolute path if it
+// isn't under base (e.g. a type defined in a dependency, which shouldn't
+// happen given isRepoPkg but fail soft rather than erroring the whole run).
+func relPath(base, file string) string {
+	rel, err := filepath.Rel(base, file)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return file
+	}
+	return rel
+}
+
+func isRepoPkg(pkgPath string) bool {
+	return strings.HasPrefix(pkgPath, "github.com/keyorixhq/keyorix")
+}

--- a/devtools/familycheck/README.md
+++ b/devtools/familycheck/README.md
@@ -1,0 +1,50 @@
+# familycheck
+
+The preventive half of the implementation-asymmetry scan (see
+`keyorix-private/adversarial-review/IMPLEMENTATION-ASYMMETRY-SCAN-2026-09-05.md`).
+The scan itself is detective — it finds asymmetries that already exist. This
+is the per-PR control that's supposed to stop the next one from landing
+un-noticed: PR #1449 added a rotation-lock mutex to AWS's `GenerateUpstream`
+alone (a 7-member family), and PR #740 pinned GCP's secrets connector to a
+project ID alone (a 4-member family) — both are exactly the "touched 1 of N
+siblings" shape this tool flags.
+
+Given two `asymanalyzer -json` outputs (one at the PR's base commit, one at
+its head) plus the PR's changed-files list and body text, it flags two modes:
+
+- **Mode A (nudge, non-blocking)**: the PR touches some but not all existing
+  members of an in-scope family. Always exits 0. Dismiss with a PR-body line:
+  `family-check: intentional — <Interface>: <reason>`
+- **Mode B (gate, blocking)**: the PR ADDS a brand-new member to an existing
+  family. Exits 1 until confirmed with a PR-body line:
+  `family-check: new-member-verified — <Interface>: <what you checked>`
+
+"In scope" is deliberately narrow (see the 2026-09-05 report's own instruction
+not to let this become noise): a family is in scope if its ID is in
+`.github/family-check-scope.json`, OR if ANY of its members' current file
+content matches a broad security-category keyword set (dial/DNS/TLS, locking,
+audit logging, validation, authz/tenant checks, context deadlines, credential
+handling). The keyword scan reads every member's file, not just the touched
+ones — a brand-new member missing a control is, by definition, likely to NOT
+contain that control's keyword, so scoping Mode B by the new file's own
+content would systematically miss exactly the cases it exists to catch.
+
+## Usage
+
+```
+go build -o familycheck .
+./familycheck \
+  -base-families base.json -head-families head.json \
+  -changed-files changed.txt -pr-body body.txt \
+  -scope ../../.github/family-check-scope.json -repo-root <head checkout root>
+```
+
+Prints a Markdown report to stdout (post as a PR comment) and exits 1 iff an
+unconfirmed Mode B finding exists — Mode A never fails the build.
+
+## Replay-tested
+
+Run against PR #1449's and PR #740's actual base/head commits before this
+check went live — both fire as Mode A nudges naming exactly the untouched
+siblings that turned out to matter. See the PR that added this file for the
+replay transcript.

--- a/devtools/familycheck/README.md
+++ b/devtools/familycheck/README.md
@@ -21,13 +21,23 @@ its head) plus the PR's changed-files list and body text, it flags two modes:
 
 "In scope" is deliberately narrow (see the 2026-09-05 report's own instruction
 not to let this become noise): a family is in scope if its ID is in
-`.github/family-check-scope.json`, OR if ANY of its members' current file
-content matches a broad security-category keyword set (dial/DNS/TLS, locking,
-audit logging, validation, authz/tenant checks, context deadlines, credential
-handling). The keyword scan reads every member's file, not just the touched
-ones — a brand-new member missing a control is, by definition, likely to NOT
-contain that control's keyword, so scoping Mode B by the new file's own
-content would systematically miss exactly the cases it exists to catch.
+`.github/family-check-scope.json`'s `families` list, OR if ANY of its
+members' current file content matches a broad security-category keyword set
+(dial/DNS/TLS, locking, audit logging, validation, authz/tenant checks,
+context deadlines, credential handling). The keyword scan reads every
+member's file, not just the touched ones — a brand-new member missing a
+control is, by definition, likely to NOT contain that control's keyword, so
+scoping Mode B by the new file's own content would systematically miss
+exactly the cases it exists to catch.
+
+The scope file also carries a `last_reconciled` date (`YYYY-MM-DD`) — the last
+time a human (the quarterly asymmetry scan) confirmed the `families` list is
+current. Mode B only gates a new member of a family ALREADY in that list; a
+brand-new family the list doesn't know about is covered by nothing until the
+next scan adds it. `familycheck` logs a non-blocking warning to stderr (never
+fails the build) once `last_reconciled` is more than ~100 days old, missing,
+or unparsable — see `warnIfScopeStale` in `main.go`. That warning is the
+forcing function to re-run the scan, not a formality to silence.
 
 ## Usage
 

--- a/devtools/familycheck/go.mod
+++ b/devtools/familycheck/go.mod
@@ -1,0 +1,3 @@
+module familycheck
+
+go 1.26.6

--- a/devtools/familycheck/main.go
+++ b/devtools/familycheck/main.go
@@ -20,7 +20,14 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 )
+
+// scopeStaleAfter is how long a scope file can go without reconciliation
+// before familycheck starts warning on every run. A quarter (the scan's own
+// stated cadence) plus a grace window, not the quarter itself -- this should
+// fire as a "you're now overdue," not on the day the next scan is merely due.
+const scopeStaleAfter = 100 * 24 * time.Hour
 
 type member struct {
 	Type          string `json:"type"`
@@ -42,6 +49,17 @@ type family struct {
 	Members    []member `json:"members"`
 }
 
+// scopeFile is .github/family-check-scope.json's shape. LastReconciled records
+// when a human (the quarterly implementation-asymmetry scan) last confirmed
+// this list is current -- Mode B only gates a new member of a family ALREADY
+// listed here, so a brand-new family is covered by nothing until a scan adds
+// it; this field makes that dependency checkable instead of assumed.
+type scopeFile struct {
+	LastReconciled string   `json:"last_reconciled"`
+	Note           string   `json:"note"`
+	Families       []string `json:"families"`
+}
+
 // securityCategoryPatterns are deliberately broad -- a false-positive here
 // only costs an extra non-blocking Mode A nudge (see -json's scope rule
 // below), so recall matters more than precision.
@@ -61,7 +79,7 @@ func main() {
 	headFamiliesPath := flag.String("head-families", "", "JSON family list at the PR's head commit")
 	changedFilesPath := flag.String("changed-files", "", "newline-separated repo-relative changed file paths")
 	prBodyPath := flag.String("pr-body", "", "PR body text, for dismissal/confirmation markers")
-	scopePath := flag.String("scope", "", "JSON array of allowlisted in-scope family IDs")
+	scopePath := flag.String("scope", "", "path to family-check-scope.json (last_reconciled + families)")
 	repoRoot := flag.String("repo-root", ".", "repo root, for reading head-checkout file contents for the keyword scope test")
 	flag.Parse()
 
@@ -84,11 +102,12 @@ func main() {
 	}
 	scope := map[string]bool{}
 	if *scopePath != "" {
-		var ids []string
-		mustLoadJSON(*scopePath, &ids)
-		for _, id := range ids {
+		var sf scopeFile
+		mustLoadJSON(*scopePath, &sf)
+		for _, id := range sf.Families {
 			scope[id] = true
 		}
+		warnIfScopeStale(*scopePath, sf.LastReconciled)
 	}
 
 	changedSet := map[string]bool{}
@@ -346,6 +365,28 @@ func wasWere(n int) string {
 		return "was"
 	}
 	return "were"
+}
+
+// warnIfScopeStale logs (never fails the build -- this is a nudge, like Mode
+// A) when the scope file's last_reconciled date is missing, unparsable, or
+// older than scopeStaleAfter. The scope file only covers families a human
+// scan has already seen; a stale one silently stops covering new families
+// added since, which is a coverage gap worth surfacing on every run, not
+// just at the next quarterly pass.
+func warnIfScopeStale(scopePath, lastReconciled string) {
+	if lastReconciled == "" {
+		fmt.Fprintf(os.Stderr, "family-check: WARNING %s has no last_reconciled date -- coverage freshness cannot be checked\n", scopePath)
+		return
+	}
+	t, err := time.Parse("2006-01-02", lastReconciled)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "family-check: WARNING %s last_reconciled %q is not a YYYY-MM-DD date\n", scopePath, lastReconciled)
+		return
+	}
+	if age := time.Since(t); age > scopeStaleAfter {
+		fmt.Fprintf(os.Stderr, "family-check: WARNING %s was last reconciled %s ago (on %s) -- overdue for the quarterly implementation-asymmetry scan; families added since then have no coverage\n",
+			scopePath, age.Round(24*time.Hour), lastReconciled)
+	}
 }
 
 func mustLoadFamilies(path string) []family {

--- a/devtools/familycheck/main.go
+++ b/devtools/familycheck/main.go
@@ -1,0 +1,388 @@
+// Command familycheck implements the implementation-asymmetry scan's preventive
+// control: given a family list computed at a PR's base and head commits, plus
+// the PR's changed files and body text, it flags PRs that touch some-but-not-all
+// members of a family (Mode A, non-blocking nudge) or add a brand-new member to
+// an existing family (Mode B, blocking gate).
+//
+// See keyorix-private/adversarial-review/IMPLEMENTATION-ASYMMETRY-SCAN-2026-09-05.md
+// for the method and finding history this is built to prevent from recurring
+// (PR #1449 added a rotation-lock mutex to AWS's GenerateUpstream alone; PR #431
+// pinned GCP's connector to a project ID alone -- both are 1-of-N family edits
+// that should have prompted "did the siblings need this too?").
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type member struct {
+	Type          string `json:"type"`
+	Package       string `json:"package"`
+	File          string `json:"file"`
+	Line          int    `json:"line"`
+	IsPtrReceiver bool   `json:"is_ptr_receiver"`
+}
+
+func (m member) key() string { return m.Package + "." + m.Type }
+
+type family struct {
+	ID         string   `json:"id"`
+	Interface  string   `json:"interface"`
+	Package    string   `json:"package"`
+	File       string   `json:"file"`
+	Line       int      `json:"line"`
+	NumMethods int      `json:"num_methods"`
+	Members    []member `json:"members"`
+}
+
+// securityCategoryPatterns are deliberately broad -- a false-positive here
+// only costs an extra non-blocking Mode A nudge (see -json's scope rule
+// below), so recall matters more than precision.
+var securityCategoryPatterns = regexp.MustCompile(strings.Join([]string{
+	`\bnet\.Dial`, `DialContext\b`, `\burl\.Parse\b`, `Hostname\(\)`, `\bResolve\w*Addr\b`, // dial/DNS/URL
+	`\btls\.Config\b`, `InsecureSkipVerify`, `\btls\.Dial`, `MinVersion`, // TLS
+	`sync\.Mutex`, `sync\.RWMutex`, `sync\.Map`, `\.Lock\(\)`, `\.Unlock\(\)`, `[Ll]ockRef`, `[Aa]dvisoryLock`, // locking
+	`[Aa]udit`,                                  // audit/security logging
+	`[Vv]alidate`, `[Ss]anitiz`, `[Nn]ormalize`, // input validation
+	`[Aa]uthoriz`, `\bauthz\b`, `[Tt]enant`, `allowedRefs`, `projectID`, `vaultURL`, // authz/tenant/scope
+	`context\.WithTimeout`, `context\.WithDeadline`, `\.Deadline\(\)`, // context deadlines
+	`[Cc]redential`, `[Ss]ecret`, `\bZero\(`, `[Ww]ipe`, `encContext`, `allowFallback`, // credential handling
+}, "|"))
+
+func main() {
+	baseFamiliesPath := flag.String("base-families", "", "JSON family list at the PR's base commit")
+	headFamiliesPath := flag.String("head-families", "", "JSON family list at the PR's head commit")
+	changedFilesPath := flag.String("changed-files", "", "newline-separated repo-relative changed file paths")
+	prBodyPath := flag.String("pr-body", "", "PR body text, for dismissal/confirmation markers")
+	scopePath := flag.String("scope", "", "JSON array of allowlisted in-scope family IDs")
+	repoRoot := flag.String("repo-root", ".", "repo root, for reading head-checkout file contents for the keyword scope test")
+	flag.Parse()
+
+	if *baseFamiliesPath == "" || *headFamiliesPath == "" || *changedFilesPath == "" {
+		fmt.Fprintln(os.Stderr, "usage: familycheck -base-families f.json -head-families f.json -changed-files f.txt [-pr-body f.txt] [-scope f.json] [-repo-root .]")
+		os.Exit(2)
+	}
+
+	baseFamilies := mustLoadFamilies(*baseFamiliesPath)
+	headFamilies := mustLoadFamilies(*headFamiliesPath)
+	changed := mustLoadLines(*changedFilesPath)
+	prBody := ""
+	if *prBodyPath != "" {
+		// #nosec G304 -- path is always this CLI's own -pr-body flag, supplied
+		// by the CI workflow that invokes this tool.
+		b, err := os.ReadFile(*prBodyPath)
+		if err == nil {
+			prBody = string(b)
+		}
+	}
+	scope := map[string]bool{}
+	if *scopePath != "" {
+		var ids []string
+		mustLoadJSON(*scopePath, &ids)
+		for _, id := range ids {
+			scope[id] = true
+		}
+	}
+
+	changedSet := map[string]bool{}
+	for _, f := range changed {
+		changedSet[f] = true
+	}
+
+	baseByID := map[string]family{}
+	for _, f := range baseFamilies {
+		baseByID[f.ID] = f
+	}
+
+	var modeAFindings []modeAFinding
+	var modeBFindings []modeBFinding
+
+	for _, fam := range headFamilies {
+		var touched []member
+		for _, m := range fam.Members {
+			if changedSet[m.File] {
+				touched = append(touched, m)
+			}
+		}
+		if len(touched) == 0 {
+			continue // this family wasn't touched by this PR at all
+		}
+
+		// Scope on the WHOLE family's current content, not just the touched
+		// files: a brand-new member that's missing a control its siblings
+		// have is, by definition, likely to NOT contain that control's
+		// keyword -- scoping Mode B by the new file's own content would
+		// systematically miss exactly the cases it exists to catch.
+		inScope := scope[fam.ID] || anyFileMatchesSecurityCategory(*repoRoot, fam.Members)
+		if !inScope {
+			continue
+		}
+
+		baseFam, existedBefore := baseByID[fam.ID]
+		baseMembers := map[string]bool{}
+		if existedBefore {
+			for _, m := range baseFam.Members {
+				baseMembers[m.key()] = true
+			}
+		}
+
+		var newMembers []member
+		for _, m := range touched {
+			if !baseMembers[m.key()] {
+				newMembers = append(newMembers, m)
+			}
+		}
+
+		if len(newMembers) > 0 {
+			confirmed := hasMarker(prBody, "family-check: new-member-verified", fam.ID, fam.Interface)
+			modeBFindings = append(modeBFindings, modeBFinding{fam: fam, newMembers: newMembers, confirmed: confirmed})
+			continue // a family that fired Mode B doesn't also need Mode A noise
+		}
+
+		if len(touched) < len(fam.Members) {
+			dismissed, reason := dismissalReason(prBody, "family-check: intentional", fam.ID, fam.Interface)
+			modeAFindings = append(modeAFindings, modeAFinding{fam: fam, touched: touched, dismissed: dismissed, reason: reason})
+		}
+	}
+
+	exitCode := render(modeAFindings, modeBFindings)
+	os.Exit(exitCode)
+}
+
+type modeAFinding struct {
+	fam       family
+	touched   []member
+	dismissed bool
+	reason    string
+}
+
+type modeBFinding struct {
+	fam        family
+	newMembers []member
+	confirmed  bool
+}
+
+// anyFileMatchesSecurityCategory reads each touched member's file at repoRoot
+// (the head checkout) and checks for the security-category keyword patterns.
+// Read errors are silent (fail open on the SCOPE test only -- a file that
+// can't be read for the heuristic scope check still gets caught if it's in
+// the explicit allowlist; this heuristic is a widener, not the sole gate).
+func anyFileMatchesSecurityCategory(repoRoot string, touched []member) bool {
+	seen := map[string]bool{}
+	for _, m := range touched {
+		if seen[m.File] {
+			continue
+		}
+		seen[m.File] = true
+		// #nosec G304 -- repoRoot is a CLI flag (the CI job's own checkout path)
+		// and m.File comes from asymanalyzer's JSON, itself derived from real
+		// on-disk positions go/packages resolved within that same checkout, not
+		// from untrusted network input.
+		b, err := os.ReadFile(filepath.Join(repoRoot, m.File))
+		if err != nil {
+			continue
+		}
+		if securityCategoryPatterns.Match(b) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasMarker reports whether body contains a case-insensitive line starting
+// with marker that also mentions id or name (so a marker for a DIFFERENT
+// family doesn't accidentally suppress this one).
+func hasMarker(body, marker, id, name string) bool {
+	ok, _ := dismissalReason(body, marker, id, name)
+	return ok
+}
+
+func dismissalReason(body, marker, id, name string) (bool, string) {
+	lower := strings.ToLower(body)
+	markerLower := strings.ToLower(marker)
+	idx := strings.Index(lower, markerLower)
+	if idx < 0 {
+		return false, ""
+	}
+	// Take the rest of that line as the reason/scope; require it also names
+	// this family (by id or interface name) so one marker can't blanket-
+	// dismiss every family in a PR that touches several.
+	lineEnd := strings.IndexByte(body[idx:], '\n')
+	line := body[idx:]
+	if lineEnd >= 0 {
+		line = body[idx : idx+lineEnd]
+	}
+	lowerLine := strings.ToLower(line)
+	if !strings.Contains(lowerLine, strings.ToLower(id)) && !strings.Contains(lowerLine, strings.ToLower(name)) {
+		return false, ""
+	}
+	reason := strings.TrimSpace(strings.TrimPrefix(line, marker))
+	reason = strings.TrimPrefix(strings.TrimSpace(reason), "—")
+	reason = strings.TrimPrefix(strings.TrimSpace(reason), "-")
+	return true, strings.TrimSpace(reason)
+}
+
+// render prints the Markdown report to stdout (for the CI job to post as a
+// PR comment) and returns the process exit code: 0 unless an unconfirmed
+// Mode B finding exists.
+func render(modeA []modeAFinding, modeB []modeBFinding) int {
+	exitCode := 0
+	var sb strings.Builder
+
+	var blockingB []modeBFinding
+	for _, f := range modeB {
+		if !f.confirmed {
+			blockingB = append(blockingB, f)
+		}
+	}
+	if len(blockingB) > 0 {
+		exitCode = 1
+		sb.WriteString("## 🔒 Family-membership check: new member added, confirmation required\n\n")
+		for _, f := range blockingB {
+			fmt.Fprintf(&sb, "**%s** (`%s`, %d existing member%s) gained a new member:\n\n",
+				f.fam.Interface, f.fam.ID, len(f.fam.Members)-len(f.newMembers), plural(len(f.fam.Members)-len(f.newMembers)))
+			for _, m := range f.newMembers {
+				fmt.Fprintf(&sb, "- **new**: `%s` (%s)\n", m.Type, m.File)
+			}
+			sb.WriteString("\nExisting siblings — confirm the new member carries every security-relevant control each of these has (dial/DNS/TLS, locking, audit logging, input validation, authz/tenant checks, context deadlines, credential handling):\n\n")
+			for _, m := range f.fam.Members {
+				if memberIsNew(m, f.newMembers) {
+					continue
+				}
+				fmt.Fprintf(&sb, "- `%s` (%s)\n", m.Type, m.File)
+			}
+			fmt.Fprintf(&sb, "\nTo unblock: add a line to the PR body naming this family, e.g.\n`family-check: new-member-verified — %s: <what you checked>`\n\n", f.fam.Interface)
+		}
+	}
+
+	var activeA []modeAFinding
+	for _, f := range modeA {
+		if !f.dismissed {
+			activeA = append(activeA, f)
+		}
+	}
+	if len(activeA) > 0 {
+		sb.WriteString("## ℹ️ Family-membership check: partial family edit\n\n")
+		sb.WriteString("_Non-blocking — most single-member changes are legitimate. If this one is, dismiss it with a PR-body line (see below) so the dismissal leaves a trail instead of silence._\n\n")
+		for _, f := range activeA {
+			touchedFiles := memberFiles(f.touched)
+			var untouched []member
+			for _, m := range f.fam.Members {
+				if !containsFile(f.touched, m.File) {
+					untouched = append(untouched, m)
+				}
+			}
+			fmt.Fprintf(&sb, "This PR modifies %s, %d of %d member%s of the **%s** family; %s %s not modified.\n",
+				strings.Join(touchedFiles, ", "), len(f.touched), len(f.fam.Members), plural(len(f.fam.Members)), f.fam.Interface,
+				strings.Join(memberFiles(untouched), ", "), wasWere(len(untouched)))
+			fmt.Fprintf(&sb, "\nIf intentional: `family-check: intentional — %s: <reason>`\n\n", f.fam.Interface)
+		}
+	}
+
+	for _, f := range modeA {
+		if f.dismissed {
+			fmt.Fprintf(&sb, "(dismissed: %s — %q)\n", f.fam.Interface, f.reason)
+		}
+	}
+	for _, f := range modeB {
+		if f.confirmed {
+			fmt.Fprintf(&sb, "(new member confirmed: %s)\n", f.fam.Interface)
+		}
+	}
+
+	if sb.Len() == 0 {
+		// Nothing to say: leave stdout (the PR-comment body) empty so the
+		// caller can skip posting, but still log status for the CI run.
+		fmt.Fprintln(os.Stderr, "family-membership check: no in-scope family asymmetries on this PR")
+		return 0
+	}
+	fmt.Print(sb.String())
+	return exitCode
+}
+
+func memberIsNew(m member, newMembers []member) bool {
+	for _, nm := range newMembers {
+		if nm.key() == m.key() {
+			return true
+		}
+	}
+	return false
+}
+
+func memberFiles(ms []member) []string {
+	var out []string
+	for _, m := range ms {
+		out = append(out, m.File)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func containsFile(ms []member, file string) bool {
+	for _, m := range ms {
+		if m.File == file {
+			return true
+		}
+	}
+	return false
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func wasWere(n int) string {
+	if n == 1 {
+		return "was"
+	}
+	return "were"
+}
+
+func mustLoadFamilies(path string) []family {
+	var fams []family
+	mustLoadJSON(path, &fams)
+	return fams
+}
+
+func mustLoadJSON(path string, v any) {
+	// #nosec G304 -- path is always one of this CLI's own -base-families/
+	// -head-families/-scope flags, supplied by the CI workflow that invokes
+	// this tool, not by untrusted input.
+	b, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read %s: %v\n", path, err)
+		os.Exit(2)
+	}
+	if err := json.Unmarshal(b, v); err != nil {
+		fmt.Fprintf(os.Stderr, "parse %s: %v\n", path, err)
+		os.Exit(2)
+	}
+}
+
+func mustLoadLines(path string) []string {
+	// #nosec G304 -- path is always this CLI's own -changed-files flag,
+	// supplied by the CI workflow that invokes this tool.
+	b, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read %s: %v\n", path, err)
+		os.Exit(2)
+	}
+	var out []string
+	for line := range strings.SplitSeq(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- Preventive half of the implementation-asymmetry scan (`keyorix-private/adversarial-review/IMPLEMENTATION-ASYMMETRY-SCAN-2026-09-05.md`). PR #1449 added a rotation-lock mutex to AWS's `GenerateUpstream` alone (3-member `GeneratingExecutor` family); PR #740 pinned GCP's secrets connector to a project ID alone (4-member `Connector` family). Both are the "touched 1 of N siblings" shape this check exists to catch at review time.
- `devtools/asymanalyzer`: standalone module (like `operator/`) using `go/packages` + `go/types.Implements` to find every repo-defined interface with 2+ implementers, now with a `-json` output mode for CI consumption.
- `devtools/familycheck`: given family lists at a PR's base and head commits plus its changed-files/body, flags **Mode A** (nudge, non-blocking — touches some but not all family members) and **Mode B** (gate, blocking — adds a brand-new member to an existing family). Dismiss/confirm via a PR-body marker line so either leaves an audit trail instead of silence.
- Scoped narrow on purpose: `.github/family-check-scope.json` allowlists the 5 families with a confirmed asymmetry finding; anything else only triggers via a broad security-category keyword scan across ALL of a family's members (not just the touched ones — a new member missing a control is, by definition, unlikely to contain that control's own keyword, so scoping on the new file's content alone would miss exactly the cases this exists to catch).

## Timing (1a)
~7.5s warm-cache for a full scan of both the root and operator modules combined (5.18s + 2.36s). This repo's CI already caches Go module/build state per job via `actions/setup-go` + `actions/cache`, so per-PR is clearly fast enough — no need for a committed-artifact-plus-drift-job fallback.

## Replay test (1e)
Ran the finished check against both historical PRs' actual base/head commits before wiring it into CI:
- **PR #1449** (`b277bad7` → `3410c44c`): fires as Mode A, naming `internal/rotation/azure.go`/`gcpsa.go` as untouched `GeneratingExecutor` siblings — exactly the gap later found by the asymmetry scan.
- **PR #740** (`fdf067d5` → `b1de9f4c`, the actual fix commit behind the `#431` issue reference in `gcpsm.go`'s comment): fires as Mode A, naming `awssm.go`/`azurekv.go`/`vault.go` as untouched `Connector` siblings.

Both fire via the curated allowlist AND independently via the keyword heuristic alone — confirmed by running with `-scope` omitted too.

## Test plan
- [x] `gofmt -l` clean on both new modules
- [x] `gosec -severity medium -exclude-generated` clean on both (3 legitimate G304 findings on `familycheck`, justified with `#nosec` comments — all paths are this CLI's own flags or analyzer-derived, not untrusted input)
- [x] `actionlint` clean on the new workflow
- [x] Smoke-tested all 4 logic paths (Mode A fire, Mode A dismissal, Mode B fire, Mode B confirmation) plus a genuinely out-of-scope family staying silent
- [x] Replayed against PR #1449 and PR #740 (see above)