### PR TITLE
fix(delivery,notifychan): dedupe the insecure-SMTP env-var gate

### DIFF
--- a/internal/delivery/delivery.go
+++ b/internal/delivery/delivery.go
@@ -14,8 +14,8 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
-	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/envflag"
 )
 
 // EnvAllowInsecureLogDelivery gates credential_delivery.mode=log (ADR-028). Writing a
@@ -26,18 +26,6 @@ import (
 // opt-in rather than defaulting on — mode=log refuses to activate unless this env var is
 // set to a truthy value.
 const EnvAllowInsecureLogDelivery = "KEYORIX_ALLOW_INSECURE_LOG_DELIVERY"
-
-// envFlagEnabled reports whether the named environment variable is set to a truthy
-// value (accepts anything strconv.ParseBool accepts: "1", "t", "true", etc., case
-// sensitive per ParseBool). Unset or unparsable = false (fail closed).
-func envFlagEnabled(name string) bool {
-	v, ok := os.LookupEnv(name)
-	if !ok {
-		return false
-	}
-	b, err := strconv.ParseBool(v)
-	return err == nil && b
-}
 
 // Delivery modes (credential_delivery.mode).
 const (
@@ -129,7 +117,7 @@ func New(cfg Config) (CredentialDelivery, error) {
 	case ModeOutOfBand:
 		return &OutOfBandDelivery{}, nil
 	case ModeLog:
-		if !envFlagEnabled(EnvAllowInsecureLogDelivery) {
+		if !envflag.Enabled(EnvAllowInsecureLogDelivery) {
 			return nil, fmt.Errorf("delivery: credential_delivery.mode=log writes a live, usable setup link to the log; refusing unless the operator explicitly opts in by setting %s=true", EnvAllowInsecureLogDelivery)
 		}
 		log.Printf("delivery: WARNING credential_delivery.mode=log is ACTIVE — setup links (live, usable credentials) will be written to the application log; dev/test only, never use in production")

--- a/internal/delivery/delivery_s17_test.go
+++ b/internal/delivery/delivery_s17_test.go
@@ -8,35 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// envFlagEnabled — unparsable value path (set but not a valid bool)
-// ---------------------------------------------------------------------------
-
-// TestEnvFlagEnabled_UnparsableValue confirms that a set-but-invalid value
-// (e.g. "yes" or "maybe") returns false (fail closed).
-func TestEnvFlagEnabled_UnparsableValue(t *testing.T) {
-	t.Setenv("TEST_FLAG_ENABLED_S17", "yes") // not accepted by strconv.ParseBool
-	assert.False(t, envFlagEnabled("TEST_FLAG_ENABLED_S17"))
-}
-
-func TestEnvFlagEnabled_FalseValue(t *testing.T) {
-	t.Setenv("TEST_FLAG_ENABLED_S17", "false")
-	assert.False(t, envFlagEnabled("TEST_FLAG_ENABLED_S17"))
-}
-
-func TestEnvFlagEnabled_TrueValue(t *testing.T) {
-	t.Setenv("TEST_FLAG_ENABLED_S17", "1")
-	assert.True(t, envFlagEnabled("TEST_FLAG_ENABLED_S17"))
-}
-
-func TestEnvFlagEnabled_Unset(t *testing.T) {
-	// Make sure the variable is not set.
-	t.Setenv("TEST_FLAG_UNSET_S17", "")
-	// LookupEnv returns ok=true for empty string — only "not set" returns false.
-	// For "not set", we need to ensure we're testing the !ok branch.
-	// Use a key that definitely isn't set.
-	assert.False(t, envFlagEnabled("KEYORIX_FLAG_DEFINITELY_NOT_SET_S17_UNIQUE_XYZ"))
-}
+// envFlagEnabled's generic behavior (unset/empty/false/true/unparsable) is now
+// tested once at its source of truth, internal/envflag/envflag_test.go — this
+// package's own coverage is the integration-level checks below (does SMTP's
+// tls=none actually refuse/allow per that shared helper).
 
 // ---------------------------------------------------------------------------
 // LogDelivery — Name() and empty link error path

--- a/internal/delivery/smtp.go
+++ b/internal/delivery/smtp.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	mail "github.com/wneessen/go-mail"
+
+	"github.com/keyorixhq/keyorix/internal/envflag"
 )
 
 // smtpDialTimeout bounds a single send so a wedged relay cannot stall the request.
@@ -37,12 +39,10 @@ const (
 	smtpTLSNone     = "none"
 )
 
-// EnvAllowInsecureSMTP gates credential_delivery.smtp.tls=none. Cleartext SMTP sends
-// the setup-link email (and, if the relay requires auth, the relay credentials) over
-// the wire unencrypted — mirroring the explicit-opt-in convention used for other
-// insecure toggles in this codebase (e.g. insecure_skip_verify), tls=none refuses to
-// activate unless this env var is set to a truthy value.
-const EnvAllowInsecureSMTP = "KEYORIX_ALLOW_INSECURE_SMTP"
+// EnvAllowInsecureSMTP gates credential_delivery.smtp.tls=none. Shared with the
+// notification-email channel (internal/notifychan) via internal/envflag — see
+// AllowInsecureSMTP's doc comment there for why the two must stay one definition.
+const EnvAllowInsecureSMTP = envflag.AllowInsecureSMTP
 
 // SMTPDelivery sends setup links via the operator's configured SMTP relay.
 type SMTPDelivery struct {
@@ -61,7 +61,7 @@ func newSMTPDelivery(cfg SMTPSettings) (*SMTPDelivery, error) {
 	switch strings.ToLower(cfg.TLS) {
 	case "", smtpTLSStartTLS, smtpTLSImplicit:
 	case smtpTLSNone:
-		if !envFlagEnabled(EnvAllowInsecureSMTP) {
+		if !envflag.Enabled(EnvAllowInsecureSMTP) {
 			return nil, fmt.Errorf("delivery: smtp.tls=none sends mail (and any relay credentials) in cleartext; refusing unless the operator explicitly opts in by setting %s=true", EnvAllowInsecureSMTP)
 		}
 		log.Printf("delivery: WARNING smtp.tls=none is ACTIVE — setup-link email will be sent over CLEARTEXT SMTP; dev/test only, never use in production")

--- a/internal/envflag/envflag.go
+++ b/internal/envflag/envflag.go
@@ -1,0 +1,35 @@
+// Package envflag provides the shared helper for environment-variable-gated
+// insecure-mode opt-ins used throughout this codebase (e.g. insecure_skip_verify):
+// unset or unparsable means disabled (fail closed).
+//
+// Extracted from two independent copies (internal/delivery, internal/notifychan)
+// that had each grown their own identical envFlagEnabled implementation — see
+// keyorix-private/adversarial-review/IMPLEMENTATION-ASYMMETRY-SCAN-2026-09-05.md,
+// finding F6: the duplicated copies also duplicated AllowInsecureSMTP itself
+// under two different names, which is exactly the kind of duplication that
+// silently diverges when one copy's gate is tightened and the other isn't.
+package envflag
+
+import (
+	"os"
+	"strconv"
+)
+
+// AllowInsecureSMTP gates tls=none for every SMTP-sending channel in this
+// codebase (credential-delivery setup-link mail, ADR-028; the notification
+// email channel). Cleartext SMTP sends the message — and, if the relay
+// requires auth, the relay credentials — over the wire unencrypted, so
+// tls=none refuses to activate unless this is set to a truthy value.
+const AllowInsecureSMTP = "KEYORIX_ALLOW_INSECURE_SMTP"
+
+// Enabled reports whether the named environment variable is set to a truthy
+// value (accepts anything strconv.ParseBool accepts: "1", "t", "true", etc.,
+// case sensitive per ParseBool). Unset or unparsable = false (fail closed).
+func Enabled(name string) bool {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return false
+	}
+	b, err := strconv.ParseBool(v)
+	return err == nil && b
+}

--- a/internal/envflag/envflag_test.go
+++ b/internal/envflag/envflag_test.go
@@ -1,0 +1,37 @@
+package envflag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEnabled_UnparsableValue confirms that a set-but-invalid value (e.g.
+// "yes" or "maybe") returns false (fail closed).
+func TestEnabled_UnparsableValue(t *testing.T) {
+	t.Setenv("TEST_FLAG_ENABLED_ENVFLAG", "yes") // not accepted by strconv.ParseBool
+	assert.False(t, Enabled("TEST_FLAG_ENABLED_ENVFLAG"))
+}
+
+func TestEnabled_FalseValue(t *testing.T) {
+	t.Setenv("TEST_FLAG_ENABLED_ENVFLAG", "false")
+	assert.False(t, Enabled("TEST_FLAG_ENABLED_ENVFLAG"))
+}
+
+func TestEnabled_TrueValue(t *testing.T) {
+	t.Setenv("TEST_FLAG_ENABLED_ENVFLAG", "1")
+	assert.True(t, Enabled("TEST_FLAG_ENABLED_ENVFLAG"))
+}
+
+// TestEnabled_NotSetAtAll covers the !ok branch (the environment variable is
+// entirely absent from the environment, not merely set-and-empty).
+func TestEnabled_NotSetAtAll(t *testing.T) {
+	assert.False(t, Enabled("KEYORIX_FLAG_DEFINITELY_NOT_SET_ENVFLAG_UNIQUE_XYZ"))
+}
+
+// TestEnabled_SetButEmpty covers the "set but empty" branch: LookupEnv
+// returns ok=true for an empty string, and ParseBool("") fails.
+func TestEnabled_SetButEmpty(t *testing.T) {
+	t.Setenv("TEST_FLAG_EMPTY_ENVFLAG", "")
+	assert.False(t, Enabled("TEST_FLAG_EMPTY_ENVFLAG"))
+}

--- a/internal/notifychan/email.go
+++ b/internal/notifychan/email.go
@@ -18,37 +18,19 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
 	mail "github.com/wneessen/go-mail"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/envflag"
 )
 
 const (
 	emailTimeout   = 10 * time.Second
 	emailQueueSize = 256
 )
-
-// envAllowInsecureSMTP gates tls=none for the notification-email channel, mirroring
-// the same opt-in required for credential-delivery SMTP (internal/delivery) and the
-// explicit-opt-in convention used for other insecure toggles in this codebase (e.g.
-// insecure_skip_verify): cleartext SMTP is never enabled by default.
-const envAllowInsecureSMTP = "KEYORIX_ALLOW_INSECURE_SMTP"
-
-// envFlagEnabled reports whether the named environment variable is set to a truthy
-// value. Unset or unparsable = false (fail closed).
-func envFlagEnabled(name string) bool {
-	v, ok := os.LookupEnv(name)
-	if !ok {
-		return false
-	}
-	b, err := strconv.ParseBool(v)
-	return err == nil && b
-}
 
 // EmailConfig configures the SMTP notification channel.
 type EmailConfig struct {
@@ -91,8 +73,8 @@ func newEmail(cfg EmailConfig, baseBackoff time.Duration) (*EmailSink, error) {
 	switch strings.ToLower(cfg.TLS) {
 	case "", "starttls", "implicit":
 	case "none":
-		if !envFlagEnabled(envAllowInsecureSMTP) {
-			return nil, fmt.Errorf("notifychan: email smtp tls=none sends mail (and any relay credentials) in cleartext; refusing unless the operator explicitly opts in by setting %s=true", envAllowInsecureSMTP)
+		if !envflag.Enabled(envflag.AllowInsecureSMTP) {
+			return nil, fmt.Errorf("notifychan: email smtp tls=none sends mail (and any relay credentials) in cleartext; refusing unless the operator explicitly opts in by setting %s=true", envflag.AllowInsecureSMTP)
 		}
 		log.Printf("notifychan: WARNING email smtp tls=none is ACTIVE — notification email will be sent over CLEARTEXT SMTP; dev/test only, never use in production")
 	default:

--- a/internal/notifychan/email_test.go
+++ b/internal/notifychan/email_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/envflag"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,11 +57,11 @@ func TestNewEmail_Validation(t *testing.T) {
 }
 
 func TestNewEmail_TLSNoneRequiresExplicitOptIn(t *testing.T) {
-	t.Setenv(envAllowInsecureSMTP, "")
+	t.Setenv(envflag.AllowInsecureSMTP, "")
 	_, err := NewEmail(EmailConfig{Host: "smtp.x.io", From: "ops@x.io", TLS: "none"})
 	require.Error(t, err, "cleartext SMTP must fail closed by default")
 
-	t.Setenv(envAllowInsecureSMTP, "true")
+	t.Setenv(envflag.AllowInsecureSMTP, "true")
 	s, err := NewEmail(EmailConfig{Host: "smtp.x.io", From: "ops@x.io", TLS: "none"})
 	require.NoError(t, err, "tls=none must succeed once the operator opts in")
 	s.Close()
@@ -75,7 +76,7 @@ func TestNewEmail_TLSNoneRequiresExplicitOptIn(t *testing.T) {
 // NOT attempted, and it produces a "dropped" delivery outcome an operator can alert
 // on, instead of leaving zero trace anywhere.
 func TestEmailSink_BroadcastWithNoDestinationConfiguredIsDroppedAndCounted(t *testing.T) {
-	t.Setenv(envAllowInsecureSMTP, "true")
+	t.Setenv(envflag.AllowInsecureSMTP, "true")
 	before := emailOutcomeTotal(t)
 	sink, err := NewEmail(EmailConfig{Host: "smtp.invalid", From: "ops@x.io", TLS: "none"})
 	require.NoError(t, err)
@@ -242,7 +243,7 @@ func fakeSMTPServer(t *testing.T) (host string, port int) {
 // test in this file leaves uncovered because they all point send() at a
 // refusing/closed port to exercise the failure path.
 func TestEmailSink_Send_DeliversAgainstFakeSMTPServer(t *testing.T) {
-	t.Setenv(envAllowInsecureSMTP, "true")
+	t.Setenv(envflag.AllowInsecureSMTP, "true")
 	host, port := fakeSMTPServer(t)
 
 	delivBefore := testutil.ToFloat64(notifyDeliveries.WithLabelValues("email", outcomeDelivered))
@@ -258,7 +259,7 @@ func TestEmailSink_Send_DeliversAgainstFakeSMTPServer(t *testing.T) {
 }
 
 func TestEmailSink_BroadcastRoutesToConfiguredDestination(t *testing.T) {
-	t.Setenv(envAllowInsecureSMTP, "true")
+	t.Setenv(envflag.AllowInsecureSMTP, "true")
 	before := emailOutcomeTotal(t)
 	sink, err := NewEmail(EmailConfig{Host: "127.0.0.1", Port: 1, From: "ops@x.io", TLS: "none", BroadcastTo: "admin@x.io"})
 	require.NoError(t, err)

--- a/internal/notifychan/notifychan_s17_test.go
+++ b/internal/notifychan/notifychan_s17_test.go
@@ -16,7 +16,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -363,40 +362,10 @@ func TestNewEmail_DefaultTLS(t *testing.T) {
 	s.Close()
 }
 
-// TestEnvFlagEnabled_NotSetAtAllReturnsFalse covers the !ok branch
-// (the environment variable is entirely absent from the environment).
-func TestEnvFlagEnabled_NotSetAtAllReturnsFalse(t *testing.T) {
-	// Use a name that is guaranteed not to be in the environment.
-	const notExist = "KEYORIX_TEST_ENV_FLAG_NOT_EXIST_S17"
-	// Make sure this var is absent (not just empty).
-	os.Unsetenv(notExist) //nolint:errcheck
-	assert.False(t, envFlagEnabled(notExist))
-}
-
-// TestEnvFlagEnabled_UnsetReturnsFalse covers the "set but empty" branch.
-func TestEnvFlagEnabled_UnsetReturnsFalse(t *testing.T) {
-	t.Setenv(envAllowInsecureSMTP, "")
-	// An empty value is set but empty string; ParseBool("") fails → false.
-	assert.False(t, envFlagEnabled(envAllowInsecureSMTP))
-}
-
-// TestEnvFlagEnabled_FalseValueReturnsFalse covers the ParseBool=false branch.
-func TestEnvFlagEnabled_FalseValueReturnsFalse(t *testing.T) {
-	t.Setenv(envAllowInsecureSMTP, "false")
-	assert.False(t, envFlagEnabled(envAllowInsecureSMTP))
-}
-
-// TestEnvFlagEnabled_TrueValueReturnsTrue covers the ParseBool=true branch.
-func TestEnvFlagEnabled_TrueValueReturnsTrue(t *testing.T) {
-	t.Setenv(envAllowInsecureSMTP, "true")
-	assert.True(t, envFlagEnabled(envAllowInsecureSMTP))
-}
-
-// TestEnvFlagEnabled_InvalidValueReturnsFalse covers the ParseBool error branch.
-func TestEnvFlagEnabled_InvalidValueReturnsFalse(t *testing.T) {
-	t.Setenv(envAllowInsecureSMTP, "not-a-bool")
-	assert.False(t, envFlagEnabled(envAllowInsecureSMTP))
-}
+// envFlagEnabled's generic behavior (unset/empty/false/true/unparsable) is now
+// tested once at its source of truth, internal/envflag/envflag_test.go — this
+// package's own coverage is TestNewEmail_TLSNoneRequiresExplicitOptIn below
+// (does email's tls=none actually refuse/allow per that shared helper).
 
 // ── chat.go ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `internal/delivery` and `internal/notifychan` each grew their own identical copy of the `KEYORIX_ALLOW_INSECURE_SMTP` constant and its truthy-env-var check (`EnvAllowInsecureSMTP`/`envFlagEnabled` vs `envAllowInsecureSMTP`/`envFlagEnabled`) instead of sharing one. Currently symmetric — no live defect — but a duplicated security-gate constant is exactly what drifts unnoticed if one copy's check is ever tightened and the other isn't. Flagged as finding F6 in `keyorix-private/adversarial-review/IMPLEMENTATION-ASYMMETRY-SCAN-2026-09-05.md`.
- Extracted both into a new `internal/envflag` package: `AllowInsecureSMTP` (the constant) and `Enabled` (the generic truthy-env-var helper — also now used by `delivery`'s separate `EnvAllowInsecureLogDelivery` toggle, which had its own copy of the same generic logic).
- `delivery.EnvAllowInsecureSMTP` stays as an exported alias (`= envflag.AllowInsecureSMTP`) so its own call sites/tests are untouched.
- Generic `envFlagEnabled` behavior (unset/empty/false/true/unparsable) is now tested once at its source of truth instead of twice; each package's own tests cover only their own integration behavior.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/envflag/... ./internal/delivery/... ./internal/notifychan/...` green
- [x] `gofmt -l`, `go vet`, `gosec -severity medium -exclude-generated`, `golangci-lint run` all clean on the touched packages
- [x] Verified the moved tests actually catch a regression: broke `envflag.Enabled`'s false-value branch, confirmed `internal/envflag`'s own test goes red while `delivery`/`notifychan`'s integration tests correctly stay green (they test their own behavior, not re-litigating the generic helper) — reverted before committing