### PR TITLE
fix(storage): reject blank storage.type instead of silently defaulting to local

### DIFF
--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -161,26 +161,28 @@ func InitializeCoreService() (*core.KeyorixCore, error) {
 	// Load configuration
 	cfg, err := config.Load("")
 	if err != nil {
-		// #1644: a Load error means EITHER "no config file yet" (safe to fall back to
+		// #1644: a Load error means EITHER "no config file yet" (used to fall back to
 		// local storage) OR "a config file is there and failed to parse" (must NOT
 		// silently proceed as if unconfigured -- that would run against the wrong
 		// storage backend with no indication anything was wrong). Only the first case
-		// may fall back to a default.
+		// used to fall back to a default.
 		if !config.IsNotExist(err) {
 			return nil, fmt.Errorf("failed to load existing configuration: %w", err)
 		}
-		cfg = &config.Config{
-			Locale: config.LocaleConfig{
-				Language:         "en",
-				FallbackLanguage: "en",
-			},
-			Storage: config.StorageConfig{
-				Type: "local",
-				Database: config.DatabaseConfig{
-					Path: "./secrets.db",
-				},
-			},
-		}
+		// #G-blank-storage-default: this used to construct a cfg with
+		// Storage.Type/Database.Path hardwired to "local"/"./secrets.db" -- the
+		// CLI silently creating a real, on-disk local database file for a
+		// command run with zero usable configuration (no keyorix.yaml, no
+		// KEYORIX_CONFIG_PATH), completely bypassing whatever storage backend
+		// (e.g. a `keyorix connect`-configured remote server) the operator
+		// actually intended. The CLI must never apply this default (see the
+		// matching comment in internal/storage/factory.go's CreateStorage) --
+		// only the server's own boot path (server/main.go) may. Leaving
+		// Storage unset here means factory.CreateStorage below now returns a
+		// clear "storage.type is not set" error instead of silently writing to
+		// ./secrets.db. Locale still defaults sensibly: i18n.Initialize below
+		// already falls back to "en" for a blank Language/FallbackLanguage.
+		cfg = &config.Config{}
 	}
 
 	// Initialize i18n system

--- a/internal/cli/common/common_s4_test.go
+++ b/internal/cli/common/common_s4_test.go
@@ -297,9 +297,19 @@ func TestRemoteClient_GetRaw_ReadBodyError(t *testing.T) {
 
 // ── InitializeCoreService: default-config fallback path ─────────────────────
 
-// TestInitializeCoreService_NoConfigFile exercises the "config.Load fails →
-// use default local storage" branch (lines 50-64) by pointing
-// KEYORIX_CONFIG_PATH at a non-existent file so config.Load returns an error.
+// TestInitializeCoreService_NoConfigFile exercises the "config.Load fails
+// with IsNotExist" branch by pointing KEYORIX_CONFIG_PATH at a non-existent
+// file so config.Load returns an error.
+//
+// #G-blank-storage-default: this used to assert InitializeCoreService silently
+// falls back to a local SQLite config (Storage.Type="local",
+// Database.Path="./secrets.db") and succeeds — a CLI command run with zero
+// usable configuration (no keyorix.yaml, no KEYORIX_CONFIG_PATH) silently
+// created a real, on-disk local database file, completely bypassing whatever
+// backend (e.g. a `keyorix connect`-configured remote server) the operator
+// actually intended. The CLI must never apply that default (see the matching
+// comment in internal/storage/factory.go's CreateStorage) — it must now fail
+// loudly instead of silently creating ./secrets.db.
 func TestInitializeCoreService_NoConfigFile(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
@@ -310,9 +320,9 @@ func TestInitializeCoreService_NoConfigFile(t *testing.T) {
 	t.Setenv("KEYORIX_CONFIG_PATH", filepath.Join(dir, "does-not-exist.yaml"))
 
 	svc, err := InitializeCoreService()
-	// The function falls back to a local SQLite config — it should succeed.
-	require.NoError(t, err)
-	assert.NotNil(t, svc)
+	require.Error(t, err)
+	assert.Nil(t, svc)
+	assert.Contains(t, err.Error(), "storage.type is not set")
 }
 
 // ── InitializeCoreService: wireSecretEncryption error propagated ─────────────

--- a/internal/cli/invite/invite_s2_test.go
+++ b/internal/cli/invite/invite_s2_test.go
@@ -7,6 +7,7 @@ package invite
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
@@ -23,6 +24,14 @@ import (
 func seedInviteDB(t *testing.T) (projectID uint, invitationID uint) {
 	t.Helper()
 	ctx := context.Background()
+
+	// #G-blank-storage-default: InitializeCoreService no longer silently
+	// defaults storage.type to "local" when no config file is present (a CLI
+	// command run with zero usable config now fails loudly instead of
+	// creating a stray ./secrets.db) -- write an explicit minimal config so
+	// this fixture keeps exercising a real file-backed SQLite DB, matching
+	// what it did implicitly before.
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte("storage:\n  type: local\n  database:\n    path: ./secrets.db\n"), 0o600))
 
 	// First call creates ./secrets.db and runs the full storage migration.
 	svc, err := common.InitializeCoreService()
@@ -88,6 +97,11 @@ func TestRunList_NoProjectSet(t *testing.T) {
 	t.Setenv("KEYORIX_TOKEN", "")
 	t.Setenv("KEYORIX_PROJECT", "")
 	t.Setenv("XDG_CONFIG_HOME", dir) // isolate cli.yaml lookup
+	// #G-blank-storage-default: runList's InitializeCoreService call now hard-errors
+	// on a blank storage.type instead of silently defaulting to local storage — write
+	// an explicit config so the test still reaches the "no project specified" branch
+	// this test is targeting, rather than failing earlier on storage init.
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte("storage:\n  type: local\n  database:\n    path: ./secrets.db\n"), 0o600))
 
 	orig := listProject
 	defer func() { listProject = orig }()
@@ -242,6 +256,8 @@ func TestRunSend_NoProject(t *testing.T) {
 	t.Setenv("KEYORIX_TOKEN", "")
 	t.Setenv("KEYORIX_PROJECT", "")
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	// #G-blank-storage-default: see TestRunList_NoProjectSet above.
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte("storage:\n  type: local\n  database:\n    path: ./secrets.db\n"), 0o600))
 
 	origEmail, origRole, origBy, origProject := sendEmail, sendRole, sendBy, sendProject
 	defer func() {

--- a/internal/cli/rbac/rbac_s2_test.go
+++ b/internal/cli/rbac/rbac_s2_test.go
@@ -167,13 +167,12 @@ func TestCheckPermission_EmbeddedMode_ValidFormat(t *testing.T) {
 // ──────────────────────────── runAuditLogsEmbedded ───────────────────────────
 
 // TestAuditLogs_EmbeddedMode_Empty tests runAuditLogsEmbedded with an empty DB.
-// runAuditLogsEmbedded uses InitializeCoreService (has fallback config), so even
-// without keyorix.yaml it will create a SQLite at ./secrets.db and return no logs.
+// #G-blank-storage-default: runAuditLogsEmbedded uses InitializeCoreService,
+// which no longer silently falls back to local storage with no config file
+// present — write an explicit minimal keyorix.yaml via setupEmbeddedMode so
+// this still exercises a real SQLite-backed run, exactly as before.
 func TestAuditLogs_EmbeddedMode_Empty(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-	t.Setenv("KEYORIX_SERVER", "")
-	t.Setenv("KEYORIX_TOKEN", "")
+	setupEmbeddedMode(t)
 
 	origL, origO := auditLimit, auditOffset
 	defer func() { auditLimit = origL; auditOffset = origO }()
@@ -188,10 +187,7 @@ func TestAuditLogs_EmbeddedMode_Empty(t *testing.T) {
 
 // TestAuditLogs_EmbeddedMode_ZeroLimit verifies the auditLimit < 1 → 50 branch.
 func TestAuditLogs_EmbeddedMode_ZeroLimit(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-	t.Setenv("KEYORIX_SERVER", "")
-	t.Setenv("KEYORIX_TOKEN", "")
+	setupEmbeddedMode(t)
 
 	origL, origO := auditLimit, auditOffset
 	defer func() { auditLimit = origL; auditOffset = origO }()
@@ -204,10 +200,7 @@ func TestAuditLogs_EmbeddedMode_ZeroLimit(t *testing.T) {
 
 // TestAuditLogsEmbedded_NonZeroOffset verifies pagination calculation (page > 1).
 func TestAuditLogsEmbedded_NonZeroOffset(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir)
-	t.Setenv("KEYORIX_SERVER", "")
-	t.Setenv("KEYORIX_TOKEN", "")
+	setupEmbeddedMode(t)
 
 	origL, origO := auditLimit, auditOffset
 	defer func() { auditLimit = origL; auditOffset = origO }()

--- a/internal/cli/request/bulk_s1_test.go
+++ b/internal/cli/request/bulk_s1_test.go
@@ -23,6 +23,7 @@ import (
 // returns the request ID along with the approver's user ID.
 func seedBulkApproveDB(t *testing.T) (reqID, approverID uint, svc *core.KeyorixCore) {
 	t.Helper()
+	writeLocalStorageConfig(t) // see request_s3_test.go — #G-blank-storage-default
 	var err error
 	svc, err = common.InitializeCoreService()
 	require.NoError(t, err)

--- a/internal/cli/request/request_coverage_gaps_test.go
+++ b/internal/cli/request/request_coverage_gaps_test.go
@@ -150,6 +150,11 @@ func TestRunList_ResolveProjectError(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
 	t.Setenv("KEYORIX_PROJECT", "")
+	// #G-blank-storage-default: runList's InitializeCoreService call now hard-errors
+	// on a blank storage.type instead of silently defaulting to local storage — write
+	// an explicit config so the test still reaches the "no project specified" branch
+	// this test is targeting, rather than failing earlier on storage init.
+	writeLocalStorageConfig(t)
 
 	origProject := listProject
 	defer func() { listProject = origProject }()

--- a/internal/cli/request/request_s3_test.go
+++ b/internal/cli/request/request_s3_test.go
@@ -13,6 +13,7 @@ package request
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
@@ -21,10 +22,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// writeLocalStorageConfig writes a minimal keyorix.yaml (storage.type: local)
+// into the current working directory (must already be a temp dir via
+// t.Chdir). #G-blank-storage-default: common.InitializeCoreService no longer
+// silently defaults storage.type to "local" when no config file is present
+// (a CLI command run with zero usable config now fails loudly instead of
+// creating a stray ./secrets.db) — every embedded-mode test in this package
+// that used to rely on that implicit fallback must now write this explicit
+// config first, to keep exercising a real file-backed SQLite DB exactly as
+// before.
+func writeLocalStorageConfig(t *testing.T) {
+	t.Helper()
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte("storage:\n  type: local\n  database:\n    path: ./secrets.db\n"), 0o600))
+}
+
 // seedRequestDB seeds the minimal graph the request commands need.
 // It returns the admin's user ID and the project ID.
 func seedRequestDB(t *testing.T) (adminID, projectID uint, svc *core.KeyorixCore) {
 	t.Helper()
+	writeLocalStorageConfig(t)
 	var err error
 	svc, err = common.InitializeCoreService()
 	require.NoError(t, err)

--- a/internal/cli/secret/bulk_delete_test.go
+++ b/internal/cli/secret/bulk_delete_test.go
@@ -348,12 +348,18 @@ func TestRunBulkDeleteEmbedded_PreviewMode(t *testing.T) {
 		bulkDeleteIDs = origIDs
 		bulkDeleteNames = origNames
 		bulkDeleteConfirm = origConfirm
-		_ = os.Remove("secrets.db")
 	})
 	bulkDeleteProject = 1
 	bulkDeleteIDs = []uint{42}
 	bulkDeleteNames = nil
 	bulkDeleteConfirm = false
+
+	// #G-blank-storage-default: InitializeCoreService no longer silently
+	// defaults storage.type to "local" with no config file present — write an
+	// explicit minimal config in an isolated temp dir so this still exercises
+	// the real ./secrets.db-backed path exactly as before.
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte("storage:\n  type: local\n  database:\n    path: ./secrets.db\n"), 0o600))
 
 	// InitializeCoreService creates ./secrets.db and initialises i18n with English.
 	err := runBulkDeleteEmbedded(context.Background())
@@ -370,12 +376,15 @@ func TestRunBulkDeleteEmbedded_DeleteNotFound(t *testing.T) {
 		bulkDeleteIDs = origIDs
 		bulkDeleteNames = origNames
 		bulkDeleteConfirm = origConfirm
-		_ = os.Remove("secrets.db")
 	})
 	bulkDeleteProject = 1
 	bulkDeleteIDs = []uint{9999}
 	bulkDeleteNames = nil
 	bulkDeleteConfirm = true
+
+	// #G-blank-storage-default: see TestRunBulkDeleteEmbedded_PreviewMode above.
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte("storage:\n  type: local\n  database:\n    path: ./secrets.db\n"), 0o600))
 
 	// BulkDeleteSecrets returns (result, nil) with 9999 in Failed (record not found).
 	err := runBulkDeleteEmbedded(context.Background())
@@ -535,12 +544,15 @@ func TestRunBulkDeleteEmbedded_NamesNotFound(t *testing.T) {
 		bulkDeleteIDs = origIDs
 		bulkDeleteNames = origNames
 		bulkDeleteConfirm = origConfirm
-		_ = os.Remove("secrets.db")
 	})
 	bulkDeleteProject = 1
 	bulkDeleteIDs = nil
 	bulkDeleteNames = []string{"does-not-exist"}
 	bulkDeleteConfirm = true
+
+	// #G-blank-storage-default: see TestRunBulkDeleteEmbedded_PreviewMode above.
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte("storage:\n  type: local\n  database:\n    path: ./secrets.db\n"), 0o600))
 
 	err := runBulkDeleteEmbedded(context.Background())
 	require.Error(t, err)
@@ -615,7 +627,6 @@ func TestRunBulkDeleteEmbedded_BulkDeleteError(t *testing.T) {
 		bulkDeleteIDs = origIDs
 		bulkDeleteNames = origNames
 		bulkDeleteConfirm = origConfirm
-		_ = os.Remove("secrets.db")
 	})
 	// Set confirm=true and empty IDs so the call reaches BulkDeleteSecrets with
 	// an empty slice, which returns an error ("at least one secret ID is required").
@@ -623,6 +634,10 @@ func TestRunBulkDeleteEmbedded_BulkDeleteError(t *testing.T) {
 	bulkDeleteIDs = nil
 	bulkDeleteNames = nil
 	bulkDeleteConfirm = true
+
+	// #G-blank-storage-default: see TestRunBulkDeleteEmbedded_PreviewMode above.
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte("storage:\n  type: local\n  database:\n    path: ./secrets.db\n"), 0o600))
 
 	err := runBulkDeleteEmbedded(context.Background())
 	require.Error(t, err)
@@ -644,12 +659,15 @@ func TestRunBulkDelete_EmbeddedPath(t *testing.T) {
 		bulkDeleteIDs = origIDs
 		bulkDeleteNames = origNames
 		bulkDeleteConfirm = origConfirm
-		_ = os.Remove("secrets.db")
 	})
 
 	// Unset the server env so NewRemoteClient returns !ok.
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
+
+	// #G-blank-storage-default: see TestRunBulkDeleteEmbedded_PreviewMode above.
+	t.Chdir(t.TempDir())
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte("storage:\n  type: local\n  database:\n    path: ./secrets.db\n"), 0o600))
 
 	bulkDeleteProject = 1
 	bulkDeleteIDs = []uint{42}

--- a/internal/cli/secret/secret_s7_test.go
+++ b/internal/cli/secret/secret_s7_test.go
@@ -64,6 +64,12 @@ func newS7EmbeddedDir(t *testing.T) string {
 	t.Chdir(dir)
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
+	// #G-blank-storage-default: InitializeCoreService/InitializeStorage no
+	// longer silently default storage.type to "local" with no config file
+	// present -- write an explicit minimal config so embedded-mode tests keep
+	// exercising a real file-backed SQLite DB, matching what they did
+	// implicitly before.
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte("storage:\n  type: local\n  database:\n    path: ./secrets.db\n"), 0o600))
 	return dir
 }
 

--- a/internal/cli/secret/secret_s8_test.go
+++ b/internal/cli/secret/secret_s8_test.go
@@ -53,6 +53,8 @@ func newS8EmbeddedDir(t *testing.T) {
 	t.Chdir(t.TempDir())
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
+	// #G-blank-storage-default: see newS7EmbeddedDir in secret_s7_test.go.
+	require.NoError(t, os.WriteFile("keyorix.yaml", []byte("storage:\n  type: local\n  database:\n    path: ./secrets.db\n"), 0o600))
 }
 
 func newS8Client(t *testing.T, srv *httptest.Server) *common.RemoteClient {

--- a/internal/cli/share/share_s3_test.go
+++ b/internal/cli/share/share_s3_test.go
@@ -41,6 +41,7 @@ func writeShareTestConfig(t *testing.T, dir string) {
   language: en
   fallback_language: en
 storage:
+  type: local
   database:
     path: %q
   encryption:

--- a/internal/cli/user/create_remote_test.go
+++ b/internal/cli/user/create_remote_test.go
@@ -287,8 +287,11 @@ func TestRunCreate_SetupLink_WithBaseURL(t *testing.T) {
 	t.Setenv("KEYORIX_TOKEN", "")
 
 	// Write a minimal config with base_url so setup link minting does not fail
-	// with ErrSetupBaseURLRequired.
-	configYAML := "credential_delivery:\n  base_url: \"https://test.example.com\"\n  mode: out_of_band\n"
+	// with ErrSetupBaseURLRequired. #G-blank-storage-default: storage.type must
+	// be explicit here too -- see seedUserDB's own doc comment in
+	// user_s2_test.go for why it no longer overwrites a pre-existing
+	// keyorix.yaml.
+	configYAML := "storage:\n  type: local\n  database:\n    path: ./secrets.db\ncredential_delivery:\n  base_url: \"https://test.example.com\"\n  mode: out_of_band\n"
 	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(configYAML), 0o600))
 
 	// Seed the DB via InitializeCoreService (will create secrets.db in dir).

--- a/internal/cli/user/user_s27_test.go
+++ b/internal/cli/user/user_s27_test.go
@@ -410,7 +410,10 @@ func TestResendSetupLinkCmd_RunE_Success_WithBaseURL(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
 
-	configYAML := "credential_delivery:\n  base_url: \"https://test.example.com\"\n  mode: out_of_band\n"
+	// #G-blank-storage-default: storage.type must be explicit here too -- see
+	// seedUserDB's own doc comment in user_s2_test.go for why it no longer
+	// overwrites a pre-existing keyorix.yaml.
+	configYAML := "storage:\n  type: local\n  database:\n    path: ./secrets.db\ncredential_delivery:\n  base_url: \"https://test.example.com\"\n  mode: out_of_band\n"
 	require.NoError(t, os.WriteFile("keyorix.yaml", []byte(configYAML), 0o600))
 
 	_, targetID := seedUserDB(t)

--- a/internal/cli/user/user_s2_test.go
+++ b/internal/cli/user/user_s2_test.go
@@ -432,6 +432,19 @@ func seedUserDB(t *testing.T) (adminID uint, targetID uint) {
 	t.Helper()
 	ctx := context.Background()
 
+	// #G-blank-storage-default: InitializeCoreService no longer silently
+	// defaults storage.type to "local" when no config file is present -- write
+	// an explicit minimal config so this fixture keeps exercising a real
+	// file-backed SQLite DB, matching what it did implicitly before. Skipped
+	// if a keyorix.yaml already exists (some callers, e.g.
+	// TestResendSetupLinkCmd_RunE_Success_WithBaseURL, write their own first
+	// with additional settings like credential_delivery.base_url) -- only
+	// appending storage.type there would be more surprising than requiring
+	// callers with their own config to include storage.type themselves.
+	if _, statErr := os.Stat("keyorix.yaml"); os.IsNotExist(statErr) {
+		require.NoError(t, os.WriteFile("keyorix.yaml", []byte("storage:\n  type: local\n  database:\n    path: ./secrets.db\n"), 0o600))
+	}
+
 	svc, err := common.InitializeCoreService()
 	require.NoError(t, err)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2029,10 +2029,26 @@ func (c *Config) Validate() error { // NOSONAR -- cognitive complexity 32, suppr
 		}
 	// #1640: "sqlite" is an accepted alias for "local" -- see the matching
 	// comment in internal/storage/factory.go's CreateStorage switch.
-	case "local", "sqlite", "":
+	case "local", "sqlite":
 		if c.Storage.Database.Path == "" {
 			return fmt.Errorf("database path is not specified")
 		}
+	case "":
+		// #G-blank-storage-default: a blank storage.type used to be bucketed
+		// with "local"/"sqlite" here, so a config file with no storage: block
+		// (or one that set database.path without type) passed validation
+		// silently and then hit the storage factory's identical blank-type
+		// tolerance -- two independent layers both treating "unset" as
+		// "local", with no operator-visible signal either way. See
+		// internal/storage/factory.go's CreateStorage (#G-blank-storage-default)
+		// for the full rationale; this is that same fix's validation-layer
+		// half. The ONE legitimate "no storage: block = local SQLite" shape
+		// (an existing on-prem single-node server) is preserved by
+		// server/main.go explicitly setting cfg.Storage.Type = "local" in the
+		// server's own boot sequence BEFORE this Validate() call ever runs --
+		// not here, since this function is shared by the CLI, which must NOT
+		// get that default applied on its behalf.
+		return fmt.Errorf("storage.type is not set: no storage configuration found -- specify \"local\", \"postgres\", \"postgresql\", or \"remote\" explicitly")
 	default:
 		// #463: an unrecognized storage.type (e.g. a typo like "postgress" or
 		// "remot") used to fall through silently to the SQLite default in both

--- a/internal/config/config_extra_test.go
+++ b/internal/config/config_extra_test.go
@@ -417,6 +417,7 @@ func TestValidate_LocalStorageRequiresPath(t *testing.T) {
 // rejected.
 func TestValidate_UnsupportedLanguage(t *testing.T) {
 	c := &Config{}
+	c.Storage.Type = "local"
 	c.Storage.Database.Path = "/tmp/db"
 	c.Locale.Language = "zh"
 	err := c.Validate()
@@ -428,6 +429,7 @@ func TestValidate_UnsupportedLanguage(t *testing.T) {
 // locale.fallback_language is rejected.
 func TestValidate_UnsupportedFallbackLanguage(t *testing.T) {
 	c := &Config{}
+	c.Storage.Type = "local"
 	c.Storage.Database.Path = "/tmp/db"
 	c.Locale.Language = "en"
 	c.Locale.FallbackLanguage = "zh"
@@ -440,6 +442,7 @@ func TestValidate_UnsupportedFallbackLanguage(t *testing.T) {
 // defaults to "en" and passes validation.
 func TestValidate_DefaultLocaleIsEn(t *testing.T) {
 	c := &Config{}
+	c.Storage.Type = "local"
 	c.Storage.Database.Path = "/tmp/db"
 	// Language and FallbackLanguage left empty → should default to "en".
 	require.NoError(t, c.Validate())

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -145,6 +145,7 @@ func TestValidate_RejectsMalformedAllowedOrigin(t *testing.T) {
 // A well-formed explicit allowlist (the common case) must still validate cleanly.
 func TestValidate_AcceptsExplicitAllowedOrigins(t *testing.T) {
 	c := &Config{}
+	c.Storage.Type = "local"
 	c.Storage.Database.Path = "/tmp/keyorix.db"
 	c.Server.HTTP.AllowedOrigins = []string{"https://app.example.com", "http://localhost:3000"}
 	require.NoError(t, c.Validate())
@@ -249,6 +250,24 @@ func TestValidate_RejectsUnknownStorageType(t *testing.T) {
 	require.Contains(t, err.Error(), "postgres_typo")
 }
 
+// TestValidate_RejectsBlankStorageType is #G-blank-storage-default: a blank
+// storage.type used to be bucketed with "local"/"sqlite" (accepted, as long as
+// database.path was set) — silently identical to an operator who explicitly
+// chose local storage. It must now be a hard error from this shared validator,
+// the same as an unrecognized type, since Config.Validate is used by both the
+// server and (indirectly, via fixtures) tests that must not get a free local
+// default. The one legitimate "no storage: block = local SQLite" deployment
+// shape is preserved by server/main.go explicitly setting Storage.Type =
+// "local" BEFORE ever calling Validate() — not by this function.
+func TestValidate_RejectsBlankStorageType(t *testing.T) {
+	c := &Config{}
+	c.Storage.Type = ""
+	c.Storage.Database.Path = "/tmp/keyorix.db"
+	err := c.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "storage.type is not set")
+}
+
 // Companion to TestValidate_RejectsUnknownStorageType: every genuinely-supported
 // storage.type value must still validate cleanly — a validation change that's
 // too aggressive is as dangerous as one that's too permissive.
@@ -259,13 +278,16 @@ func TestValidate_AcceptsValidStorageTypes(t *testing.T) {
 	// TestValidate_RejectsRemoteStorageWithNoServerEnabled's comment) and now rejects
 	// "remote" unconditionally, since it's the one storage type this validator's own
 	// caller (server/main.go) can never legitimately back a server process with.
-	for _, storageType := range []string{"", "local", "sqlite", "postgres", "postgresql"} {
+	//
+	// "" is also deliberately excluded: see TestValidate_RejectsBlankStorageType
+	// (#G-blank-storage-default) -- a blank storage.type is now a hard error here.
+	for _, storageType := range []string{"local", "sqlite", "postgres", "postgresql"} {
 		c := &Config{}
 		c.Storage.Type = storageType
 		switch storageType {
 		case "postgres", "postgresql":
 			c.Storage.Database.DSN = "postgres://user:pass@localhost/db"
-		case "local", "sqlite", "":
+		case "local", "sqlite":
 			c.Storage.Database.Path = "/tmp/keyorix.db"
 		}
 		err := c.Validate()

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -193,8 +193,32 @@ func (f *DefaultStorageFactory) CreateStorage(cfg *config.Config) (storage.Stora
 	// matching the "postgres"/"postgresql" dual-spelling precedent above --
 	// operators write the storage engine's name, not this codebase's
 	// internal term for it).
-	case "local", "sqlite", "":
+	case "local", "sqlite":
 		return f.createLocalStorage(cfg)
+	case "":
+		// #G-blank-storage-default: a blank storage.type must never silently
+		// fall through to local SQLite storage -- this is the same "blank/
+		// zero-value treated as an implicit permissive default" defect shape
+		// as the AccountState ""->Active auth-bypass bug (#1741/#1742). Before
+		// this fix, "local", "sqlite", "" were one case, so a config file with
+		// no storage: block at all (or a hand-built *config.Config{} zero
+		// value) silently created a real, on-disk local database file with no
+		// operator-visible signal -- indistinguishable from an operator who
+		// explicitly chose local storage.
+		//
+		// The ONE legitimate "no storage: block in the config = local SQLite"
+		// deployment shape (an existing on-prem single-node server) is
+		// preserved, but NOT here: server/main.go's initializeCoreService (and
+		// main() itself, before its own first cfg.Validate() call) explicitly
+		// sets cfg.Storage.Type = "local" in the server's own boot sequence,
+		// before this factory or Config.Validate() ever sees the config. That
+		// keeps the default scoped to the one caller allowed to apply it. Every
+		// OTHER caller -- CLI commands (internal/cli/common.InitializeStorage/
+		// InitializeCoreService deliberately do NOT set this default), test
+		// fixtures that build a config.Config{} zero value, and any future
+		// caller -- must now see a loud, explicit error instead of a silent
+		// local database.
+		return nil, fmt.Errorf("storage.type is not set: no storage configuration found -- specify \"local\", \"postgres\", \"postgresql\", or \"remote\" explicitly")
 	default:
 		// #463: defense in depth. Config.Validate() rejects an unrecognized
 		// storage.type at boot, but this factory can also be invoked directly

--- a/internal/storage/factory_routing_test.go
+++ b/internal/storage/factory_routing_test.go
@@ -46,9 +46,16 @@ func TestCreateStorage_LocalStorage(t *testing.T) {
 	assert.NotNil(t, st)
 }
 
-// TestCreateStorage_EmptyTypeIsLocal validates that an empty storage.type is
-// treated as "local" (backward-compat).
-func TestCreateStorage_EmptyTypeIsLocal(t *testing.T) {
+// TestCreateStorage_EmptyTypeIsRejected validates that an empty storage.type is
+// now a hard error (#G-blank-storage-default), not a silent fallback to local
+// SQLite. Before this fix, "local", "sqlite", "" were one case, so this same
+// config (blank type, an explicit database path) silently created a real,
+// on-disk local database file — see the removed TestCreateStorage_EmptyTypeIsLocal,
+// which asserted exactly that as "backward-compat". The one legitimate
+// "no storage: block = local SQLite" deployment shape is now preserved solely by
+// server/main.go's own boot sequence explicitly setting Storage.Type = "local"
+// before ever reaching this factory — not by the factory itself.
+func TestCreateStorage_EmptyTypeIsRejected(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 	defer i18n.ResetForTesting()
 
@@ -58,8 +65,9 @@ func TestCreateStorage_EmptyTypeIsLocal(t *testing.T) {
 	cfg.Storage.Database.Path = filepath.Join(dir, "empty-type.db")
 
 	st, err := NewStorageFactory().CreateStorage(cfg)
-	require.NoError(t, err)
-	assert.NotNil(t, st)
+	require.Error(t, err)
+	assert.Nil(t, st)
+	assert.Contains(t, err.Error(), "storage.type is not set")
 }
 
 // TestCreateStorage_SqliteAliasIsLocal validates that "sqlite" -- the value
@@ -133,6 +141,24 @@ func TestOpenGormDB_InvalidTypeRejected(t *testing.T) {
 	_, err := OpenGormDB(cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "badtype")
+}
+
+// TestOpenGormDB_EmptyTypeIsRejected validates that OpenGormDB, like the
+// factory's CreateStorage, now hard-errors on a blank storage.type instead of
+// silently opening local SQLite (#G-blank-storage-default). These CLI admin
+// commands (DEK rotation, auth-encryption stats) load config directly with no
+// CLI-applied default, so a blank type reaching here means the operator's own
+// config genuinely never set storage.type.
+func TestOpenGormDB_EmptyTypeIsRejected(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Storage.Type = "" // explicitly empty
+	cfg.Storage.Database.Path = filepath.Join(dir, "empty-type-gormdb.db")
+
+	db, err := OpenGormDB(cfg)
+	require.Error(t, err)
+	assert.Nil(t, db)
+	assert.Contains(t, err.Error(), "storage.type is not set")
 }
 
 // TestOpenGormDB_LocalSQLite validates that OpenGormDB can open a local SQLite

--- a/internal/storage/gormdb.go
+++ b/internal/storage/gormdb.go
@@ -12,8 +12,9 @@ import (
 
 // OpenGormDB opens a raw *gorm.DB for the configured local backend, switching on
 // cfg.Storage.Type with the same mapping the factory uses (postgres/postgresql →
-// Postgres, local/"" → SQLite, anything else rejected — #463) and applying the
-// same connection-pool settings via applyPoolSettings.
+// Postgres, local/sqlite → SQLite, a blank type or anything else rejected — #463,
+// #G-blank-storage-default) and applying the same connection-pool settings via
+// applyPoolSettings.
 //
 // Unlike the factory's CreateStorage, it deliberately does NOT run migrations: it
 // exists for the handful of CLI admin commands that need a raw *gorm.DB the
@@ -48,7 +49,7 @@ func OpenGormDB(cfg *config.Config) (*gorm.DB, error) {
 	// function's own doc comment already notes these CLI admin commands run
 	// without Config.Validate() first, so it must accept the alias
 	// independently, not rely on Validate() to have normalized it upstream.
-	case "local", "sqlite", "":
+	case "local", "sqlite":
 		dbPath := cfg.Storage.Database.Path
 		if dbPath == "" {
 			dbPath = "./secrets.db"
@@ -74,6 +75,16 @@ func OpenGormDB(cfg *config.Config) (*gorm.DB, error) {
 			return nil, err
 		}
 		return db, nil
+	case "":
+		// #G-blank-storage-default: mirrors internal/storage/factory.go's
+		// CreateStorage -- a blank storage.type must never silently open local
+		// SQLite here either. These CLI admin commands (DEK rotation,
+		// auth-encryption stats) load their config directly via config.Load("")
+		// with no CLI-applied default (internal/cli/common.InitializeStorage/
+		// InitializeCoreService deliberately don't set one), so a blank type
+		// reaching this function means the operator's config genuinely has no
+		// storage.type set -- fail loudly instead of guessing local.
+		return nil, fmt.Errorf("storage.type is not set: no storage configuration found -- specify \"local\", \"postgres\", \"postgresql\", or \"remote\" explicitly")
 	default:
 		// #463: defense in depth, mirroring the factory's own hardening — these
 		// CLI admin commands run without going through Config.Validate() first,

--- a/internal/storage/storage_s24_test.go
+++ b/internal/storage/storage_s24_test.go
@@ -99,17 +99,20 @@ func TestOpenGormDB_S24_LocalDefaultPath(t *testing.T) {
 	assert.NotNil(t, db)
 }
 
-// TestOpenGormDB_S24_EmptyTypeDefaultsToLocal verifies that an empty storage
-// type (not set) is treated as "local", opening a SQLite database.
-func TestOpenGormDB_S24_EmptyTypeDefaultsToLocal(t *testing.T) {
+// TestOpenGormDB_S24_EmptyTypeIsRejected verifies that an empty storage type
+// (not set) is now a hard error (#G-blank-storage-default), not a silent
+// fallback to local SQLite — see the matching change in
+// internal/storage/factory.go's CreateStorage.
+func TestOpenGormDB_S24_EmptyTypeIsRejected(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{}
 	cfg.Storage.Type = ""
 	cfg.Storage.Database.Path = filepath.Join(dir, "empty-type.db")
 
 	db, err := OpenGormDB(cfg)
-	require.NoError(t, err)
-	assert.NotNil(t, db)
+	require.Error(t, err)
+	assert.Nil(t, db)
+	assert.Contains(t, err.Error(), "storage.type is not set")
 }
 
 // TestOpenGormDB_S24_PostgresNoDSN verifies that OpenGormDB returns a "requires

--- a/internal/storage/storage_s2_test.go
+++ b/internal/storage/storage_s2_test.go
@@ -120,17 +120,20 @@ func TestOpenGormDB_InvalidType_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid storage.type")
 }
 
-// TestOpenGormDB_EmptyType_SQLite verifies that an empty storage type falls through to
-// the SQLite path in OpenGormDB (same as "local").
-func TestOpenGormDB_EmptyType_SQLite(t *testing.T) {
+// TestOpenGormDB_EmptyType_Rejected verifies that an empty storage type is now
+// a hard error (#G-blank-storage-default), not a silent fallback to the
+// SQLite path in OpenGormDB — see the matching change in
+// internal/storage/factory.go's CreateStorage.
+func TestOpenGormDB_EmptyType_Rejected(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{}
 	cfg.Storage.Type = ""
 	cfg.Storage.Database.Path = filepath.Join(dir, "opengormdb_empty.db")
 
 	db, err := OpenGormDB(cfg)
-	require.NoError(t, err)
-	assert.NotNil(t, db)
+	require.Error(t, err)
+	assert.Nil(t, db)
+	assert.Contains(t, err.Error(), "storage.type is not set")
 }
 
 // TestOpenGormDB_Postgres_FailsFast exercises the postgres branch in OpenGormDB.

--- a/server/main.go
+++ b/server/main.go
@@ -100,6 +100,20 @@ func main() { // NOSONAR -- cognitive complexity 22, suppress go:S3776
 		log.Fatalf("Failed to load configuration: %v", err)
 	}
 
+	// #G-blank-storage-default: the server's own boot path is the ONE caller
+	// allowed to treat a blank storage.type as "local" -- see the matching
+	// comment in internal/storage/factory.go's CreateStorage, which (along with
+	// Config.Validate() below) now hard-errors on a blank type for every OTHER
+	// caller (CLI commands run with no usable config, test fixtures building a
+	// zero-value config.Config{}). This preserves an operator's existing
+	// "no storage: block in the config file = local SQLite" deployment shape
+	// without moving that default into the shared config.Load()/Validate()
+	// functions the CLI also uses. Must run BEFORE the Validate() call
+	// immediately below, since Validate() itself now rejects a blank type.
+	if cfg.Storage.Type == "" {
+		cfg.Storage.Type = "local"
+	}
+
 	// Schema/sanity validation (ports, TLS cert/key presence, storage DSN/path) — always
 	// enforced, independent of any security flag: a malformed config should never boot.
 	if err := cfg.Validate(); err != nil {
@@ -345,6 +359,18 @@ func loadCertPool(path string) (*x509.CertPool, error) {
 }
 
 func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.Service, error) { // NOSONAR -- cognitive complexity 159, suppress go:S3776
+	// #G-blank-storage-default: mirrors main()'s own default-application above —
+	// a test or any other caller that builds a *config.Config by hand and skips
+	// straight to this function bypassed that default too. This is the server's
+	// own boot path (the one caller allowed to treat a blank storage.type as
+	// "local"; see internal/storage/factory.go's CreateStorage), so apply the
+	// same default here, before the Validate() call immediately below rejects a
+	// blank type. This does NOT set a default for the CLI: this function lives
+	// in server/main.go's package main and is never called from CLI code.
+	if cfg.Storage.Type == "" {
+		cfg.Storage.Type = "local"
+	}
+
 	// #1475: mirrors main()'s own cfg.Validate() call above — a test or any other
 	// caller that builds a *config.Config by hand and skips straight to this
 	// function bypassed schema/sanity validation entirely, letting fixtures encode

--- a/server/server_s4_test.go
+++ b/server/server_s4_test.go
@@ -69,6 +69,45 @@ func TestInitializeCoreService_Baseline(t *testing.T) {
 	}
 }
 
+// TestInitializeCoreService_BlankStorageTypeDefaultsToLocal is
+// #G-blank-storage-default's core regression guard: a config with NO
+// storage.type set at all (the "no storage: block in keyorix.yaml" shape, or
+// a bare zero-value config.Config{} reached with no config file present)
+// must still boot into local SQLite storage exactly as it did before
+// internal/storage/factory.go's CreateStorage started hard-erroring on a
+// blank storage.type for every OTHER caller. The server's own boot path
+// (initializeCoreService, mirroring main()'s identical default-application)
+// is the one place allowed to supply that default -- this test constructs
+// the config the way an operator's minimal deployment would (only
+// database.path set, storage.type entirely omitted) and asserts
+// initializeCoreService still succeeds, proving the default is actually
+// wired up rather than merely intended.
+func TestInitializeCoreService_BlankStorageTypeDefaultsToLocal(t *testing.T) {
+	initI18n(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	cfg := &config.Config{
+		Storage: config.StorageConfig{
+			// Type deliberately left blank -- see doc comment above.
+			Database: config.DatabaseConfig{Path: "test.db"},
+		},
+	}
+
+	svc, enc, err := initializeCoreService(cfg)
+	if err != nil {
+		t.Fatalf("initializeCoreService with blank storage.type: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("expected non-nil core service")
+	}
+	if enc != nil {
+		t.Fatal("expected nil encSvc when encryption is disabled")
+	}
+	if cfg.Storage.Type != "local" {
+		t.Errorf("expected initializeCoreService to default cfg.Storage.Type to %q, got %q", "local", cfg.Storage.Type)
+	}
+}
+
 // ── initializeCoreService — password policy ───────────────────────────────────
 
 func TestInitializeCoreService_PasswordPolicy(t *testing.T) {


### PR DESCRIPTION
## Summary

`DefaultStorageFactory.CreateStorage` (and two sibling call sites) treated a blank `storage.type` as an implicit alias for local SQLite, with zero warning — the same defect shape as the `AccountState ""→Active` auth-bypass fixed in #1742. Any CLI command reaching these with no usable configuration present would silently create a real, on-disk local database file rather than failing loudly.

- `internal/storage/factory.go`'s `CreateStorage`: blank `storage.type` is now a hard error, not bucketed with `"local"`/`"sqlite"`.
- Extended to two sibling call sites with the identical bug, found by a parallel sweep for the same pattern: `internal/storage/gormdb.go`'s `OpenGormDB` (used by CLI DEK-rotation/auth-encryption-stats commands) and `internal/config/config.go`'s `Config.Validate()` (the boot-time gate itself still had the same silent bucketing for blank specifically, despite its own comment claiming this class of bug was already closed).
- The one legitimate default ("no `storage:` block in config = local SQLite" for a simple single-node server deployment) now lives explicitly in `server/main.go`'s boot sequence, applied *before* `Validate()` runs — not in the shared config loader, and not in the CLI's `InitializeCoreService()`/`InitializeStorage()`, which no longer apply any default at all.
- Verified every other caller of `CreateStorage`/`OpenGormDB` repo-wide (including `operator/`, `cmd/`, migrations, scripts) — none needed a similar default, all either already set an explicit type or are test-only (test fixtures relying on the old silent default were fixed, not weakened).

## Regression watched for specifically

A single-node Keyorix server with **no config file at all** (or one with no `storage:` block) must still boot into local-SQLite mode exactly as before. Verified via a new test, `TestInitializeCoreService_BlankStorageTypeDefaultsToLocal` (`server/server_s4_test.go`).

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `gofmt -l` clean on all 23 touched files
- [x] `gosec -severity medium -exclude-generated` — 0 issues (526 files, 101k lines)
- [x] Full test suites green: `internal/storage/...`, `internal/config/...`, `internal/cli/...` (all 37 subpackages), `server/...`
- [x] Verified RED before the fix (existing test asserted the silent-default behavior)