### PR TITLE
fix(connect): require project_id on gcp-secret-manager connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,25 @@ All notable changes to Keyorix are documented here. This project follows
   as of this same change: a caller must be a member of the connector's owning
   project (or hold a matching `ConnectRefGrant`) to read through it — see
   `docs/adr-082-connect-connector-tenant-scoping.md`.
+- **BREAKING (targeting v0.92.0): every `gcp-secret-manager` Keyorix Connect
+  connector must set `project_id` (#431)** — an existing deployment with
+  `connect.enabled: true` and one or more `gcp-secret-manager` connectors **will
+  fail to boot** after upgrading unless every such connector gains an explicit
+  `project_id`. Previously, an unset `project_id` only logged a startup warning and
+  let the connector boot unpinned — since a GCP Secret Manager ref embeds its own
+  project ID (unlike Vault's `address` or Azure Key Vault's `address` vault URL,
+  which each already pin the connector to one backend), an unpinned connector could
+  read a secret from **any** GCP project the ambient ADC identity can reach,
+  regardless of which Keyorix project/scope (ADR-082) the connector itself is bound
+  to — a confused-deputy gap. **There is no escape hatch**: add `project_id: <your
+  GCP project>` to every `gcp-secret-manager` connector before upgrading (see
+  `docs/CONFIGURATION.md`'s Keyorix Connect section for the exact field). The
+  project-pin is now enforced twice — once at config-load time
+  (`validateConnectGCPProjectID`) and again at read time inside
+  `GCPSecretManagerConnector.GetSecret` (defense in depth; a ref naming a different
+  project, or a connector somehow left unpinned despite the boot check, is refused
+  before ever reaching the backend) — see `docs/adr-082-connect-connector-tenant-scoping.md`'s
+  "Out of scope" section for how this closes a gap that ADR explicitly deferred.
 - **BREAKING (targeting v0.92.0): a Keyorix Connect connector with an unrecognized
   `type` now fails boot instead of booting with that connector silently skipped
   (#1476)** — previously, `server/main.go`'s Connect-wiring loop logged a warning

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1182,7 +1182,7 @@ connect:
         - keyorix/              # (defense-in-depth on top of the backend's IAM scope)
     - name: prod-gcp
       type: gcp-secret-manager  # ref is the version resource name (creds from ADC)
-      project_id: my-proj       # recommended: pins the connector to one GCP project (#431);
+      project_id: my-proj       # REQUIRED: pins the connector to one GCP project (#431);
                                  # a ref naming a different project is rejected before the backend call
                                  # (a GCP project ID — unrelated to Keyorix's own project: below)
       scope: project
@@ -1223,13 +1223,17 @@ connect:
   instance-profile / IRSA; GCP: ADC; Azure: `DefaultAzureCredential`; Vault:
   `token_env`), never from this config. A backend failure surfaces as `502 Bad Gateway`.
 - Unlike Vault (pinned to one `address`) and Azure Key Vault (pinned to one `address`
-  vault URL), a GCP Secret Manager ref carries **its own project ID**, so a
-  `gcp-secret-manager` connector with no **`project_id`** can address secrets in
-  **any** GCP project the ambient ADC identity can reach — `allowed_refs` is then the
-  only guardrail. Setting `project_id` (#431) pins the connector to one project: any
-  ref naming a different project is rejected before the backend call. It is optional
-  (existing configs keep today's cross-project behavior for compatibility) but
-  strongly recommended; an unset `project_id` logs a startup warning.
+  vault URL), a GCP Secret Manager ref carries **its own project ID**. `project_id`
+  is therefore **required** for every `gcp-secret-manager` connector — a missing
+  `project_id` **fails server boot** (there is no escape hatch): without it, a
+  connector could address secrets in **any** GCP project the ambient ADC identity
+  can reach, regardless of which Keyorix tenant it is scoped to (a confused-deputy
+  gap). `project_id` pins the connector to one project: any ref naming a different
+  project is rejected before the backend call, both at config-load time and again at
+  read time (defense in depth, in case a connector is ever constructed through a path
+  that bypasses config validation). **Breaking change**: an existing deployment
+  upgrading from before this requirement landed must add `project_id` to every
+  `gcp-secret-manager` connector before upgrading — see CHANGELOG.md.
 - A federated read is bounded by up to **three** controls: the backend identity's IAM
   policy (the load-bearing one — scope the connector's credentials to exactly the
   intended secrets); optionally the per-connector **`allowed_refs`** prefix allowlist

--- a/docs/adr-082-connect-connector-tenant-scoping.md
+++ b/docs/adr-082-connect-connector-tenant-scoping.md
@@ -141,11 +141,12 @@ runtime CRUD, no numeric ID.
 `gcp-secret-manager` connector config type already has a `ProjectID` field
 (`server/main.go:570-574`) — but that is a **GCP** project ID (an
 ambient-cloud-identity scope string, #431), unrelated to Keyorix's own
-`Project` entity. An unset GCP `project_id` today produces only a
-boot-time `log.Printf` warning, not enforcement. **These two `ProjectID`
-concepts are unrelated and must not share a config field name.** Fixing the
-GCP one's boot-warning-only enforcement gap is out of scope for this ADR
-(see "Out of scope").
+`Project` entity. An unset GCP `project_id` at the time this ADR was
+written produced only a boot-time `log.Printf` warning, not enforcement.
+**These two `ProjectID` concepts are unrelated and must not share a config
+field name.** Fixing the GCP one's boot-warning-only enforcement gap was
+out of scope for this ADR (see "Out of scope") and was closed in a later
+change — see that section for the resolution.
 
 ## Decision
 
@@ -829,9 +830,14 @@ design, with (D) added.)
 
 - Enforcement semantics for `environment:` (G) — its own follow-up ADR.
 - The GCP `gcp-secret-manager` connector's own `project_id` field and its
-  current boot-warning-only (not enforced) behavior (#431) — a real,
+  then-boot-warning-only (not enforced) behavior (#431) — a real,
   separate gap at the ambient-cloud-identity layer, unrelated to Keyorix's
-  `Project` entity; not fixed by this ADR.
+  `Project` entity; not fixed by this ADR. **Closed in a later change**:
+  `project_id` is now a required field (`validateConnectGCPProjectID`,
+  `internal/config/config.go`) — a missing value fails boot, aggregated
+  across every offending connector like this ADR's own scope checks — and
+  `GCPSecretManagerConnector.GetSecret` independently refuses every read
+  when `projectID` is empty (defense in depth, not just a boot-time check).
 - The exact `connect.platform.use` permission description string and the
   exact delegation-audit decision-reason marker text — implementation
   detail, not a design axis.

--- a/docs/security-closures.tsv
+++ b/docs/security-closures.tsv
@@ -17,6 +17,7 @@ FIX-6-sod-oracle	./internal/core	TestDeleteSoDPolicy_NonAdmin_NonExistentAndNonO
 FIX-7-breakglass	./internal/storage/store	TestDeleteExpiredBreakGlassBefore_ReconciledRowStillRevocable	d1b93444	purge must not hard-delete a row mid-reconciliation
 FIX-8-csv	./internal/core	TestCSVWriters_EncodeAgainstFormulaInjection	d1b93444	structural: every CSV writer applies an encoder
 INV-1-grant-authority	./server/http	TestEveryDirectRoleGrantChecksAuthority	pre-existing	structural: every direct role grant checks authority
+GCP-CONN-PROJECTID	./internal/connect	TestGCPSM_RequiresProjectID	pending	unpinned gcp-secret-manager connector must refuse reads, not span any GCP project
 
 # NOT LISTED, deliberately:
 #   FIX-1 actorID==0 fast-path (internal/core/authz.go:614). The eight-site reroute

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,10 +186,14 @@ type ConnectorConfig struct {
 	// every ref must embed this exact project ID
 	// (projects/PROJECT/secrets/NAME/versions/VERSION), or the read is rejected before
 	// reaching the backend. Unlike Address for "vault"/"azure-key-vault", a GCP ref
-	// carries its own project ID, so leaving this unset lets a single connector (and
-	// the ambient ADC identity it runs under) address secrets in ANY project that
-	// identity can reach, relying solely on AllowedRefs to scope reach. Strongly
-	// recommended; left empty only for backward compatibility with an existing config.
+	// carries its own project ID, so leaving this unset would let a single connector
+	// (and the ambient ADC identity it runs under) address secrets in ANY project
+	// that identity can reach, regardless of this connector's Keyorix-side tenant
+	// scope (a confused-deputy gap). Required, unconditionally, for every
+	// "gcp-secret-manager" connector — validateConnectGCPProjectID (below) fails
+	// boot on an unset value, with no deployment-wide escape hatch, mirroring how
+	// Scope has none. An existing deployment upgrading past this change must add
+	// project_id to every gcp-secret-manager connector first (see CHANGELOG.md).
 	// Unrelated to Project below — this is a GCP-side identifier, Project is Keyorix's.
 	ProjectID string `yaml:"project_id"`
 	// TokenEnv names the environment variable holding the backend token for type
@@ -2080,6 +2084,10 @@ func (c *Config) Validate() error { // NOSONAR -- cognitive complexity 32, suppr
 		return err
 	}
 
+	if err := validateConnectGCPProjectID(c.Connect); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -2157,6 +2165,36 @@ func validateConnectScopes(cc ConnectConfig) error {
 	}
 	if len(platformRejectsProject) > 0 {
 		return fmt.Errorf("connect: connector(s) with scope \"platform\" must not set \"project\" (a platform connector is not owned by any single project): %s", strings.Join(platformRejectsProject, ", "))
+	}
+	return nil
+}
+
+// validateConnectGCPProjectID closes a confused-deputy gap in the
+// "gcp-secret-manager" connector: unlike the Vault/Azure Address (the backend's own
+// base URL — the connector IS the tenant boundary), a GCP Secret Manager ref carries
+// its own project ID embedded in the resource name
+// (projects/PROJECT/secrets/NAME/versions/VERSION). validateConnectScopes above
+// already binds a connector to a Keyorix-side tenant (project/platform scope), but
+// that says nothing about which GCP project the ambient ADC identity actually
+// reaches — a connector scoped to Keyorix project X with no project_id set would
+// let any connect.read-holding caller in project X's scope read a secret from GCP
+// project Y (or any other project the ADC identity can reach), as long as the
+// backend IAM happens to allow it. project_id (#431) is the only thing that pins
+// the GCP-side project to match the Keyorix-side scope, so — like Scope above — it
+// is required unconditionally, with no deployment-wide escape hatch: a missing
+// project_id fails boot for every "gcp-secret-manager" connector, aggregated into
+// one error naming every offending connector by name (mirrors validateConnectScopes's
+// own aggregation style). Only connectors of type "gcp-secret-manager" are checked;
+// other types have their own binding field (Address) which is enforced separately.
+func validateConnectGCPProjectID(cc ConnectConfig) error {
+	var missing []string
+	for _, connector := range cc.Connectors {
+		if connector.Type == "gcp-secret-manager" && connector.ProjectID == "" {
+			missing = append(missing, connector.Name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("connect: gcp-secret-manager connector(s) missing required \"project_id\" — an unset project_id lets a caller read secrets from ANY GCP project the ambient ADC identity can reach, regardless of this connector's Keyorix tenant scope (a confused-deputy gap; #431/ADR-082): %s", strings.Join(missing, ", "))
 	}
 	return nil
 }

--- a/internal/config/connect_config_test.go
+++ b/internal/config/connect_config_test.go
@@ -273,6 +273,95 @@ func TestValidate_ConnectTypesWired(t *testing.T) {
 	assert.Contains(t, err.Error(), "mistyped-connector")
 }
 
+// TestValidateConnectGCPProjectID covers the confused-deputy gap closed by
+// requiring project_id on every "gcp-secret-manager" connector: unlike Vault/Azure's
+// Address (the connector's own tenant boundary), a GCP ref carries its own project
+// ID, so an unset project_id would let a caller reach any GCP project the ambient
+// ADC identity can access, regardless of the connector's Keyorix-side scope. Mirrors
+// TestValidateConnectScopes/TestValidateConnectTypes's own structure and
+// aggregation-assertion style. This test is RED against the pre-fix behavior (an
+// unset project_id only logged a startup warning in server/main.go and booted
+// fine) and GREEN once validateConnectGCPProjectID is wired into Config.Validate().
+func TestValidateConnectGCPProjectID(t *testing.T) {
+	tests := []struct {
+		name      string
+		cc        ConnectConfig
+		wantErr   bool
+		wantNames []string
+	}{
+		{
+			name: "missing project_id, single gcp connector, fails boot",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "gcp1", Type: "gcp-secret-manager", Scope: "platform"},
+			}},
+			wantErr:   true,
+			wantNames: []string{"gcp1"},
+		},
+		{
+			name: "missing project_id, multiple gcp connectors, aggregated in one error",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "gcp1", Type: "gcp-secret-manager", Scope: "platform"},
+				{Name: "gcp2", Type: "gcp-secret-manager", Scope: "platform"},
+				{Name: "gcp3", Type: "gcp-secret-manager", Scope: "platform", ProjectID: "my-proj"}, // valid — must not appear
+			}},
+			wantErr:   true,
+			wantNames: []string{"gcp1", "gcp2"},
+		},
+		{
+			name: "non-gcp connector types are never checked",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "aws", Type: "aws-secrets-manager", Scope: "platform"},
+				{Name: "azure", Type: "azure-key-vault", Scope: "platform"},
+				{Name: "vault", Type: "vault", Scope: "platform"},
+			}},
+			wantErr: false,
+		},
+		{
+			name:    "no connectors is valid",
+			cc:      ConnectConfig{},
+			wantErr: false,
+		},
+		{
+			name: "gcp connector with project_id set is valid",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "gcp", Type: "gcp-secret-manager", Scope: "platform", ProjectID: "my-proj"},
+			}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConnectGCPProjectID(tt.cc)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, name := range tt.wantNames {
+				assert.Contains(t, err.Error(), name, "error must name every offending connector")
+			}
+		})
+	}
+}
+
+// TestValidate_ConnectGCPProjectIDWired confirms Config.Validate() itself surfaces
+// a missing gcp-secret-manager project_id — not just the unexported helper in
+// isolation — so the boot path (server/main.go's cfg.Validate() call) actually
+// enforces the requirement.
+func TestValidate_ConnectGCPProjectIDWired(t *testing.T) {
+	c := &Config{
+		Storage: StorageConfig{Type: "local", Database: DatabaseConfig{Path: "/tmp/keyorix-connect-gcp-projectid-test.db"}},
+		Connect: ConnectConfig{Connectors: []ConnectorConfig{
+			{Name: "unbound-gcp", Type: "gcp-secret-manager", Scope: "platform"},
+		}},
+	}
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unbound-gcp")
+	assert.Contains(t, err.Error(), "project_id")
+}
+
 // TestValidate_ConnectTypesRunsBeforeScopes confirms validateConnectTypes runs
 // before validateConnectScopes in Config.Validate() (see that function's own
 // comment for why: an unrecognized type is more fundamental than a scope-shape

--- a/internal/connect/connect_s22_test.go
+++ b/internal/connect/connect_s22_test.go
@@ -160,7 +160,7 @@ func TestAzureKV_GetSecret_ClientError_S22(t *testing.T) {
 // GCPSecretManagerConnector.GetSecret where the client factory returns an
 // error (e.g., ADC credential failure).
 func TestGCPSM_GetSecret_ClientError_S22(t *testing.T) {
-	c := NewGCPSecretManagerConnector("gcp", "", nil)
+	c := NewGCPSecretManagerConnector("gcp", "p", nil)
 	c.newClient = func(_ context.Context) (gcpSMAccessAPI, error) {
 		return nil, errors.New("ADC: no credentials")
 	}

--- a/internal/connect/coverage_test.go
+++ b/internal/connect/coverage_test.go
@@ -181,7 +181,7 @@ func TestGCPSM_ClientRealPath(t *testing.T) {
 // an error, checking GetSecret propagation.
 func TestGCPSM_ClientInjectedError(t *testing.T) {
 	injectedErr := errors.New("injected gcp client error")
-	c := NewGCPSecretManagerConnector("gcp-inject-err", "", nil)
+	c := NewGCPSecretManagerConnector("gcp-inject-err", "p", nil)
 	c.newClient = func(_ context.Context) (gcpSMAccessAPI, error) {
 		return nil, injectedErr
 	}

--- a/internal/connect/gcpsm.go
+++ b/internal/connect/gcpsm.go
@@ -7,9 +7,16 @@
 //
 // Unlike the Vault connector (pinned to one address) and the Azure connector (pinned
 // to one vaultURL), the GCP project ID lives entirely inside the caller-supplied ref
-// — so an unpinned connector can address secrets in any project the ambient identity
-// can reach. Setting projectID (#431) pins the connector to a single project and
-// rejects any ref embedding a different one.
+// — so a connector with no project_id could address secrets in any project the
+// ambient identity can reach, regardless of which Keyorix tenant it is scoped to
+// (a confused-deputy gap: ADR-082 scopes the connector to a Keyorix project, but
+// nothing tied that to which GCP project the ADC identity actually reaches). Setting
+// projectID (#431) pins the connector to a single project and rejects any ref
+// embedding a different one. projectID is now a REQUIRED binding, not an optional
+// pin: internal/config.validateConnectGCPProjectID refuses to boot a
+// "gcp-secret-manager" connector with an unset project_id, and GetSecret itself
+// independently refuses every read on an empty projectID (defense in depth — it does
+// not merely trust that boot validation ran).
 package connect
 
 import (
@@ -39,18 +46,21 @@ type GCPSecretManagerConnector struct {
 	newClient func(ctx context.Context) (gcpSMAccessAPI, error)
 }
 
-// NewGCPSecretManagerConnector builds a GCP Secret Manager connector. projectID,
-// when non-empty, pins the connector to a single GCP project — mirroring how the
-// Vault connector pins an address and the Azure connector pins a vaultURL: every ref
-// passed to GetSecret must embed this exact project ID (`projects/PROJECT/...`), or
-// the read is rejected before ever reaching the backend. Unlike Vault/Azure, a GCP
-// ref carries its own project ID, so without this pin a single configured connector
+// NewGCPSecretManagerConnector builds a GCP Secret Manager connector. projectID
+// pins the connector to a single GCP project — mirroring how the Vault connector
+// pins an address and the Azure connector pins a vaultURL: every ref passed to
+// GetSecret must embed this exact project ID (`projects/PROJECT/...`), or the read
+// is rejected before ever reaching the backend. Unlike Vault/Azure, a GCP ref
+// carries its own project ID, so without this pin a single configured connector
 // (and the ambient ADC identity it runs under) can address secrets in ANY project
-// that identity can reach, with only allowedRefs standing in the way — leave
-// projectID empty only for backward compatibility with an existing config that
-// intentionally spans multiple projects. allowedRefs, when non-empty, restricts
-// readable references to those with one of the given prefixes (a guardrail on top of
-// the workload identity's IAM scope).
+// that identity can reach. projectID is a required binding: the config-validation
+// layer (internal/config.validateConnectGCPProjectID) refuses to boot a
+// "gcp-secret-manager" connector with an unset project_id, and GetSecret itself
+// refuses every read when projectID is empty (defense in depth, in case a
+// connector is ever constructed via a path that bypasses that validation).
+// allowedRefs, when non-empty, additionally restricts readable references to
+// those with one of the given prefixes (a guardrail on top of the workload
+// identity's IAM scope).
 func NewGCPSecretManagerConnector(name, projectID string, allowedRefs []string) *GCPSecretManagerConnector {
 	return &GCPSecretManagerConnector{name: name, projectID: projectID, allowedRefs: allowedRefs}
 }
@@ -92,14 +102,20 @@ func (c *GCPSecretManagerConnector) GetSecret(ctx context.Context, ref string) (
 	if !prefixAllowed(c.allowedRefs, ref) {
 		return "", fmt.Errorf("gcp-secret-manager: ref %q is not permitted by this connector's allowed_refs", ref)
 	}
-	if c.projectID != "" {
-		refProject, ok := gcpRefProjectID(ref)
-		if !ok {
-			return "", fmt.Errorf("gcp-secret-manager: ref %q does not start with projects/PROJECT/... so it cannot be checked against the connector's pinned project %q", ref, c.projectID)
-		}
-		if refProject != c.projectID {
-			return "", fmt.Errorf("gcp-secret-manager: ref %q targets project %q, but this connector is pinned to project %q", ref, refProject, c.projectID)
-		}
+	// project_id is a required binding (validateConnectGCPProjectID enforces this at
+	// boot) — but this check does not merely trust that boot validation ran: an empty
+	// projectID here is refused outright rather than falling back to the pre-#431
+	// unrestricted-cross-project behavior, so a bug or bypass in config validation
+	// cannot silently reopen the confused-deputy gap this connector used to have.
+	if c.projectID == "" {
+		return "", fmt.Errorf("gcp-secret-manager: connector %q has no project_id configured — refusing to read (project_id is a required binding, not optional)", c.name)
+	}
+	refProject, ok := gcpRefProjectID(ref)
+	if !ok {
+		return "", fmt.Errorf("gcp-secret-manager: ref %q does not start with projects/PROJECT/... so it cannot be checked against the connector's pinned project %q", ref, c.projectID)
+	}
+	if refProject != c.projectID {
+		return "", fmt.Errorf("gcp-secret-manager: ref %q targets project %q, but this connector is pinned to project %q", ref, refProject, c.projectID)
 	}
 	cl, err := c.client(ctx)
 	if err != nil {

--- a/internal/connect/gcpsm_test.go
+++ b/internal/connect/gcpsm_test.go
@@ -25,8 +25,14 @@ func (f *fakeGCPSM) AccessSecretVersion(_ context.Context, req *secretmanagerpb.
 }
 func (f *fakeGCPSM) Close() error { f.closed = true; return nil }
 
+// gcpConnectorWith builds a pinned connector for tests that exercise GetSecret
+// behavior unrelated to project pinning (backend errors, empty payloads, allowed_refs,
+// client lifecycle, etc.) — every ref used with connectors built by this helper
+// embeds project "p", so the (now mandatory, see TestGCPSM_RequiresProjectID)
+// project pin check passes transparently and does not interfere with what each test
+// actually means to exercise.
 func gcpConnectorWith(name string, fake *fakeGCPSM, allowed ...string) *GCPSecretManagerConnector {
-	c := NewGCPSecretManagerConnector(name, "", allowed)
+	c := NewGCPSecretManagerConnector(name, "p", allowed)
 	c.newClient = func(_ context.Context) (gcpSMAccessAPI, error) { return fake, nil }
 	return c
 }
@@ -80,10 +86,13 @@ func TestGCPSM_GetSecret_Errors(t *testing.T) {
 	})
 }
 
-// TestGCPSM_ProjectPin covers #431: an unpinned connector (projectID == "", the
-// pre-existing default) may address any project the ADC identity can reach — no
-// regression — while a pinned connector rejects a ref naming a different project and
-// still works normally for its own project's refs.
+// TestGCPSM_ProjectPin covers #431: a pinned connector rejects a ref naming a
+// different project and still works normally for its own project's refs. project_id
+// is now a required binding (validateConnectGCPProjectID enforces this at boot,
+// server/main.go's gcp-secret-manager case constructs every connector with a
+// non-empty ProjectID) — an unpinned (projectID == "") connector is no longer a
+// legacy-compatible "allow all projects" configuration, it is refused outright at
+// use-time; see TestGCPSM_RequiresProjectID.
 func TestGCPSM_ProjectPin(t *testing.T) {
 	t.Run("pinned connector rejects a ref targeting a different project", func(t *testing.T) {
 		fake := &fakeGCPSM{out: &secretmanagerpb.AccessSecretVersionResponse{Payload: &secretmanagerpb.SecretPayload{Data: []byte("x")}}}
@@ -114,14 +123,29 @@ func TestGCPSM_ProjectPin(t *testing.T) {
 		assert.Empty(t, fake.got)
 	})
 
-	t.Run("unpinned connector (legacy/default config) still reads across projects", func(t *testing.T) {
-		fake := &fakeGCPSM{out: &secretmanagerpb.AccessSecretVersionResponse{Payload: &secretmanagerpb.SecretPayload{Data: []byte("g0ph3r")}}}
-		c := gcpConnectorWith("gcp", fake) // projectID == "" — the pre-existing default
-		ref := "projects/some-other-proj/secrets/db/versions/latest"
-		val, err := c.GetSecret(context.Background(), ref)
-		require.NoError(t, err, "no regression: an unpinned connector keeps today's cross-project behavior")
-		assert.Equal(t, "g0ph3r", val)
-	})
+}
+
+// TestGCPSM_RequiresProjectID is the use-time guard test for the confused-deputy gap
+// this connector used to have: a connector with no project_id configured must
+// refuse EVERY read (fail closed), not fall back to the old "reach any project the
+// ADC identity can access" behavior. This is defense in depth on top of
+// internal/config.validateConnectGCPProjectID's boot-time requirement — it must
+// hold even if a connector somehow got constructed with an empty projectID despite
+// that boot check (a bug in wiring, a bypass, a future caller of
+// NewGCPSecretManagerConnector that skips cfg.Validate()). Before this change, this
+// exact scenario (empty projectID, a ref naming an arbitrary project) returned the
+// secret value with no error — this test is RED against that old behavior and GREEN
+// against the fail-closed fix.
+func TestGCPSM_RequiresProjectID(t *testing.T) {
+	fake := &fakeGCPSM{out: &secretmanagerpb.AccessSecretVersionResponse{Payload: &secretmanagerpb.SecretPayload{Data: []byte("g0ph3r")}}}
+	c := NewGCPSecretManagerConnector("gcp", "", nil) // projectID == "" — must never reach the backend
+	c.newClient = func(_ context.Context) (gcpSMAccessAPI, error) { return fake, nil }
+
+	ref := "projects/some-other-proj/secrets/db/versions/latest"
+	_, err := c.GetSecret(context.Background(), ref)
+	require.Error(t, err, "a connector with no project_id must refuse every read, not fall back to unrestricted cross-project access")
+	assert.Contains(t, err.Error(), "project_id")
+	assert.Empty(t, fake.got, "the backend must never be reached when project_id is unset")
 }
 
 func TestGCPRefProjectID(t *testing.T) {

--- a/internal/connect/types.go
+++ b/internal/connect/types.go
@@ -9,8 +9,9 @@ package connect
 // missing/invalid connector scope. server/main.go's initializeCoreService
 // still dispatches on a literal switch (each type needs a different
 // constructor call, some with type-specific side effects — e.g. the
-// gcp-secret-manager case's project_id Fatal/warn, the vault case's token TTL
-// check — that don't reduce to a uniform map[string]func lookup), but
+// gcp-secret-manager case's defensive project_id Fatal (config validation already
+// requires it), the vault case's token TTL check — that don't reduce to a uniform
+// map[string]func lookup), but
 // server/connector_type_registry_test.go asserts that switch's case set is
 // always exactly this list, so the two cannot silently drift apart.
 var KnownTypes = []string{

--- a/server/main.go
+++ b/server/main.go
@@ -644,10 +644,18 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			case "aws-secrets-manager":
 				connectors = append(connectors, connect.NewAWSSecretsManagerConnector(cn.Name, cn.Region, cn.AllowedRefs))
 			case "gcp-secret-manager":
-				if cn.ProjectID == "" && len(cn.AllowedRefs) == 0 {
-					log.Fatalf("Keyorix Connect: gcp-secret-manager connector %q has neither project_id nor allowed_refs — this grants unrestricted cross-project read access to the ambient identity; set project_id or allowed_refs before starting", cn.Name)
-				} else if cn.ProjectID == "" {
-					log.Printf("Keyorix Connect: gcp-secret-manager connector %q has no project_id configured — reads can reach any GCP project the ambient identity can access; allowed_refs is the only scope restriction; set project_id to pin the connector to one project (#431)", cn.Name)
+				// project_id is now a required field: unreachable via a config that
+				// passed cfg.Validate() — validateConnectGCPProjectID
+				// (internal/config/config.go) already refused to boot a
+				// gcp-secret-manager connector with an unset project_id, before this
+				// function is ever reached (see the cfg.Validate() call at the top of
+				// initializeCoreService). Fail loud rather than silently construct an
+				// unpinned connector if this is somehow reached anyway (e.g. a future
+				// caller of this loop that bypasses Validate()) — the old behavior let an
+				// unpinned connector boot with only a log warning, which is exactly the
+				// confused-deputy gap this field now closes.
+				if cn.ProjectID == "" {
+					log.Fatalf("Keyorix Connect: gcp-secret-manager connector %q has no project_id — this should have been caught by cfg.Validate()", cn.Name)
 				}
 				connectors = append(connectors, connect.NewGCPSecretManagerConnector(cn.Name, cn.ProjectID, cn.AllowedRefs))
 			case "azure-key-vault":

--- a/server/server_s4_test.go
+++ b/server/server_s4_test.go
@@ -435,6 +435,13 @@ func TestInitializeCoreService_Connect_KnownTypes(t *testing.T) {
 
 // ── initializeCoreService — Connect (gcp, no project_id) ────────────────────
 
+// project_id is now a required field for gcp-secret-manager connectors — an unset
+// project_id used to only log a startup warning (an unpinned connector could reach
+// any GCP project the ambient ADC identity can access, regardless of this
+// connector's Keyorix tenant scope: a confused-deputy gap). This test's own name
+// and assertion, until this change, encoded exactly that now-obsolete "boots fine"
+// behavior. It now fails cfg.Validate() (called inside initializeCoreService)
+// before boot ever reaches the Connect-wiring loop.
 func TestInitializeCoreService_Connect_GCP_NoProjectID(t *testing.T) {
 	initI18n(t)
 	cfg := newMinimalCfg(t)
@@ -446,8 +453,11 @@ func TestInitializeCoreService_Connect_GCP_NoProjectID(t *testing.T) {
 	}
 
 	_, _, err := initializeCoreService(cfg)
-	if err != nil {
-		t.Fatalf("initializeCoreService with GCP no project_id: %v", err)
+	if err == nil {
+		t.Fatal("expected initializeCoreService to refuse to boot a gcp-secret-manager connector with no project_id")
+	}
+	if got := err.Error(); !contains(got, "gcp-noproj") || !contains(got, "project_id") {
+		t.Fatalf("expected error to name the connector and project_id, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`internal/connect/gcpsm.go`'s GCP Secret Manager connector had both `project_id` and `AllowedRefs` optional. A GCP secret ref carries its own embedded project ID, so a connector with no configured `project_id` reads whatever GCP project the ambient Application Default Credentials identity happens to have access to, regardless of which Keyorix tenant/project the connector is scoped to — a confused-deputy gap. Boot-time validation (`validateConnectScopes`) enforced Keyorix-side tenant scope but never required `project_id` itself.

- `project_id` is now mandatory, enforced twice: at config-load time (`validateConnectGCPProjectID`, fails boot listing every offending connector) and at use-time inside `GetSecret` (defense in depth against a bug/bypass in the boot-time wiring).
- **Sibling sweep (AWS/Azure)**: neither has the same confused-deputy shape. AWS's bare secret-name refs resolve within the ambient credential's own account by API design (a cross-account ARN additionally requires an explicit resource-policy grant on the target side — a different, double-opt-in risk shape). Azure's `address` (vault URL) already exclusively determines which vault every read reaches, with no competing ref-embedded tenant ID — its only gap is fail-closed-but-late (boots fine with no address, errors on first read), a minor UX issue, not confidentiality. **Note**: AWS Secrets Manager account-pinning is a real, separate, still-open gap with the *same* shape as this one — it is intentionally NOT touched by this PR and is being tracked separately (see `keyorix-private/adversarial-review/QUEUE.md`, Group 5) rather than assumed closed here.
- **Migration ordering**: zero shipped example configs (`configs/*.yaml`, docs) have any connector configured at all, so blast radius on real/example configs is 0. Added a `BREAKING (targeting v0.92.0)` CHANGELOG entry.
- Guard tests verified genuinely red (temporarily reverted the fix, confirmed failure) then green.

## Test plan
- [x] `go build ./...`, `go vet` on `internal/connect`, `internal/config`, `server` clean
- [x] `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated` — 0 issues (209 files)
- [x] `go test ./internal/connect/... ./internal/config/... ./server/...` — full tree green (`server/http` needed `-timeout 30m`, 475 real-server tests, confirmed unrelated to this change)
- [x] `scripts/check-closures.sh` — 12/12 claims verified