### PR TITLE
fix(egress): unified SSRF/TLS guard for Mongo, Redis, and SIEM forwarder

### DIFF
--- a/internal/audit/siem/egress_guard_test.go
+++ b/internal/audit/siem/egress_guard_test.go
@@ -1,0 +1,96 @@
+// egress_guard_test.go — direct behavioral coverage for the SIEM forwarder's
+// egress guard (2b/2d): before this fix, newForwarder built a bare
+// http.Transport with NO SSRF or TLS enforcement of any kind -- an
+// operator-configured Endpoint pointing at a private/internal host, or using
+// plain http://, went through completely unchecked. These tests exercise
+// newForwarder's own validation directly (network-free: the checks run
+// before any request is ever sent), plus the dial-time IP re-validation via
+// a fake resolver (mirroring internal/dynamic's dialResolve test pattern),
+// never a real DNS query.
+package siem
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewForwarder_RefusesPrivateNetworkTargetByDefault(t *testing.T) {
+	origResolve := dialResolve
+	defer func() { dialResolve = origResolve }()
+	dialResolve = func(_ context.Context, host string) ([]net.IPAddr, error) {
+		require.Equal(t, "internal-siem.example.net", host)
+		return []net.IPAddr{{IP: net.ParseIP("10.0.0.5")}}, nil
+	}
+
+	f, err := newForwarder(Config{
+		Enabled:  true,
+		Provider: ProviderWebhook,
+		Endpoint: "https://internal-siem.example.net/collect",
+	}, defaultBaseBackoff)
+	require.NoError(t, err, "construction succeeds -- the SSRF guard is dial-time, not construction-time")
+	t.Cleanup(f.Close)
+
+	_, sendErr := f.send(context.Background(), sampleEvent())
+	require.Error(t, sendErr, "a private-network resolved target must be refused at dial time")
+	assert.Contains(t, sendErr.Error(), "disallowed address")
+}
+
+func TestNewForwarder_AllowPrivateNetworkTargetOptsOut(t *testing.T) {
+	origResolve := dialResolve
+	defer func() { dialResolve = origResolve }()
+	dialResolve = func(_ context.Context, _ string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("10.0.0.5")}}, nil
+	}
+
+	f, err := newForwarder(Config{
+		Enabled: true, Provider: ProviderWebhook,
+		// Port 1 (nothing listening) so send() still fails -- the point is
+		// that it must NOT fail via the private-network guard.
+		Endpoint:                  "https://internal-siem.example.net:1/collect",
+		AllowPrivateNetworkTarget: true,
+	}, defaultBaseBackoff)
+	require.NoError(t, err)
+	t.Cleanup(f.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, sendErr := f.send(ctx, sampleEvent())
+	require.Error(t, sendErr, "still fails -- nothing is listening -- but NOT via the private-network guard")
+	assert.NotContains(t, sendErr.Error(), "disallowed address")
+}
+
+func TestNewForwarder_LoopbackTargetPermittedWithoutOptOut(t *testing.T) {
+	f, err := newForwarder(Config{
+		Enabled:  true,
+		Provider: ProviderWebhook,
+		Endpoint: "http://127.0.0.1:1/collect",
+	}, defaultBaseBackoff)
+	require.NoError(t, err, "http on loopback must be permitted without any opt-out (matches evidencesink/notifychan convention)")
+	t.Cleanup(f.Close)
+}
+
+func TestNewForwarder_RefusesPlaintextNonLoopbackByDefault(t *testing.T) {
+	_, err := newForwarder(Config{
+		Enabled:  true,
+		Provider: ProviderWebhook,
+		Endpoint: "http://siem.example.net/collect",
+	}, defaultBaseBackoff)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must use TLS")
+}
+
+func TestNewForwarder_AllowInsecureTransportOptsOut(t *testing.T) {
+	f, err := newForwarder(Config{
+		Enabled:                true,
+		Provider:               ProviderWebhook,
+		Endpoint:               "http://siem.example.net/collect",
+		AllowInsecureTransport: true,
+	}, defaultBaseBackoff)
+	require.NoError(t, err, "the explicit opt-out must permit a plaintext non-loopback endpoint")
+	t.Cleanup(f.Close)
+}

--- a/internal/audit/siem/forwarder.go
+++ b/internal/audit/siem/forwarder.go
@@ -22,13 +22,52 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/netutil"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
+
+// dialResolve resolves an Endpoint hostname to its IP addresses for the
+// dial-time SSRF re-check (see newForwarder) -- a var (like internal/dynamic's
+// identically-shaped dialResolve, and evidencesink/notifychan's lookupIPAddr)
+// so tests can substitute a fake resolver to simulate a DNS-rebinding target
+// without a real DNS query.
+var dialResolve netutil.Resolver = netutil.DefaultResolver
+
+// isLoopbackHost reports whether host names the local machine -- "localhost"
+// or a literal loopback IP. Mirrors evidencesink/notifychan's identically-
+// named helper: a SIEM collector, like a webhook/evidence receiver, is an
+// operator-configured EXTERNAL endpoint (not a backend-infrastructure admin
+// DSN like the dynamic-secrets Postgres/MySQL/Mongo/Redis connections, where
+// even loopback is refused) -- a local receiver is a legitimate dev/test
+// target for this class of destination.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// isDisallowedIP reports whether ip is a private or link-local address,
+// mirroring evidencesink/notifychan's identically-named helper (loopback
+// permitted, unlike netutil.IsPrivateOrLinkLocal's stricter backend-DSN
+// policy -- see isLoopbackHost above for why the two destination classes
+// warrant different defaults).
+func isDisallowedIP(ip net.IP) bool {
+	if ip.IsLoopback() {
+		return false
+	}
+	return ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+}
 
 // refuseRedirect blocks a redirect to a different host or an https->http downgrade.
 // The SIEM auth rides in custom headers (DD-API-KEY, Splunk token) that Go does NOT
@@ -70,6 +109,15 @@ type Config struct {
 	// replayed until the SIEM accepts it, so a sustained outage no longer silently
 	// loses the off-box copy. Empty = best-effort only (the prior behaviour).
 	SpoolDir string
+	// AllowPrivateNetworkTarget opts Endpoint out of the SSRF guard -- a
+	// SEPARATE decision from InsecureSkipVerify (#130). False by default:
+	// Endpoint's resolved host must not be private/link-local/IMDS (loopback
+	// exempt -- see isLoopbackHost/isDisallowedIP).
+	AllowPrivateNetworkTarget bool
+	// AllowInsecureTransport permits a plaintext (http://) Endpoint. False by
+	// default: Endpoint must be https unless it targets loopback. Every use of
+	// this opt-out is logged (2d) -- see netutil.Guard.RequireTLS.
+	AllowInsecureTransport bool
 }
 
 // queueSize bounds in-flight events; httpTimeout bounds a single delivery.
@@ -128,7 +176,31 @@ func newForwarder(cfg Config, baseBackoff time.Duration) (*Forwarder, error) {
 		return nil, fmt.Errorf("siem: unknown provider %q (want splunk|datadog|webhook)", cfg.Provider)
 	}
 
+	// 2b/2d: route every outbound SIEM connection through the shared egress
+	// guard instead of a bare http.Transport -- before this, the SIEM
+	// forwarder had NO SSRF or TLS enforcement of any kind (unlike the
+	// dynamic-secrets Postgres/MySQL admin DSNs, or notifychan/evidencesink's
+	// webhook targets), so an operator-configured Endpoint pointing at a
+	// private/internal host, or using plain http://, went through completely
+	// unchecked. A malformed Endpoint (e.g. one url.Parse itself rejects,
+	// like an embedded control character) is intentionally NOT treated as a
+	// construction-time error here: buildRequest/send already surface that
+	// failure via http.NewRequestWithContext at send time, and duplicating
+	// the check here would only change WHEN the (unavoidable) error appears,
+	// not whether the SIEM forwarder is safe.
+	guard := netutil.Guard{AllowInsecureTransport: cfg.AllowInsecureTransport}
+	if u, perr := url.Parse(cfg.Endpoint); perr == nil {
+		tlsSatisfied := u.Scheme == "https" || isLoopbackHost(u.Hostname())
+		if err := guard.RequireTLS(tlsSatisfied, "siem endpoint", cfg.Endpoint); err != nil {
+			return nil, err
+		}
+	}
+
 	transport := &http.Transport{}
+	if !cfg.AllowPrivateNetworkTarget {
+		guard.Dial = netutil.Dialer{Disallow: isDisallowedIP, Resolve: dialResolve}
+		transport.DialContext = guard.Dial.DialContext
+	}
 	if cfg.InsecureSkipVerify {
 		log.Printf("WARNING: SIEM forwarder %q has TLS verification disabled (insecure_skip_verify); do not use in production", cfg.Endpoint)
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 -- NOSONAR go:S4830 go:S5527: InsecureSkipVerify is an explicit operator opt-in, guarded by config flag and WARNING log

--- a/internal/audit/siem/siem_g80_test.go
+++ b/internal/audit/siem/siem_g80_test.go
@@ -26,7 +26,7 @@ import (
 // possible) must fail loudly here rather than shipping truncated/invalid JSON to
 // the SIEM.
 func TestBuildRequest_MarshalErrorOnInvalidDiff(t *testing.T) {
-	f, err := New(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: "http://example.invalid"})
+	f, err := New(Config{Enabled: true, Provider: ProviderWebhook, Endpoint: "http://example.invalid", AllowInsecureTransport: true})
 	require.NoError(t, err)
 	t.Cleanup(f.Close)
 
@@ -45,7 +45,7 @@ func TestBuildRequest_MarshalErrorOnInvalidDiff(t *testing.T) {
 func TestBuildRequest_MarshalErrorOnInvalidDiff_AllProviders(t *testing.T) {
 	for _, p := range []Provider{ProviderSplunk, ProviderDatadog, ProviderWebhook} {
 		t.Run(string(p), func(t *testing.T) {
-			f, err := New(Config{Enabled: true, Provider: p, Endpoint: "http://example.invalid", Token: "tok"})
+			f, err := New(Config{Enabled: true, Provider: p, Endpoint: "http://example.invalid", Token: "tok", AllowInsecureTransport: true})
 			require.NoError(t, err)
 			t.Cleanup(f.Close)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -895,6 +895,18 @@ type SIEMConfig struct {
 	// accepts them, so a sustained outage doesn't silently lose the off-box copy.
 	// Empty = best-effort only.
 	SpoolDir string `yaml:"spool_dir"`
+	// AllowPrivateNetworkTarget opts Endpoint out of the SSRF guard -- a
+	// SEPARATE decision from InsecureSkipVerify (#130): an operator forwarding
+	// audit events to a self-signed on-prem SIEM collector should not also
+	// have to disable the private-network/SSRF check, and vice versa. False
+	// by default: Endpoint's resolved host must not be private/link-local/
+	// IMDS (loopback is exempt -- see notifychan/evidencesink's identical
+	// convention for this class of operator-configured external receiver).
+	AllowPrivateNetworkTarget bool `yaml:"allow_private_network_target"`
+	// AllowInsecureTransport permits a plaintext (http://) Endpoint. False by
+	// default: Endpoint must be https unless it targets loopback. Every use
+	// of this opt-out is logged (2d) -- see internal/netutil.Guard.RequireTLS.
+	AllowInsecureTransport bool `yaml:"allow_insecure_transport"`
 }
 
 // GetToken returns the resolved SIEM token, preferring the environment variable.
@@ -1118,6 +1130,15 @@ type EvidenceWebhookConfig struct {
 	// AllowPrivateNetworkTarget opts the endpoint out of the SSRF guard — a
 	// SEPARATE decision from InsecureSkipVerify; see evidencesink.WebhookConfig.
 	AllowPrivateNetworkTarget bool `yaml:"allow_private_network_target"`
+	// AllowInsecureTransport permits a plaintext (http://) endpoint to a
+	// non-loopback host. False by default: Endpoint must be https unless it
+	// targets loopback. A SEPARATE decision from AllowPrivateNetworkTarget
+	// (previously conflated: enabling AllowPrivateNetworkTarget alone used to
+	// ALSO silently unlock cleartext HTTP to any public host, not just a
+	// private one — an operator opting in to reach a legitimate internal
+	// receiver got a second, unrelated, broader exception for free). Every
+	// use of this opt-out is logged; see evidencesink.WebhookConfig.
+	AllowInsecureTransport bool `yaml:"allow_insecure_transport"`
 }
 
 // GetToken returns the resolved webhook token, preferring the environment variable.
@@ -1254,6 +1275,14 @@ type NotificationWebhookConfig struct {
 	// AllowPrivateNetworkTarget opts the endpoint out of the SSRF guard — a
 	// SEPARATE decision from InsecureSkipVerify; see notifychan.WebhookConfig.
 	AllowPrivateNetworkTarget bool `yaml:"allow_private_network_target"`
+	// AllowInsecureTransport permits a plaintext (http://) endpoint to a
+	// non-loopback host. False by default: Endpoint must be https unless it
+	// targets loopback. A SEPARATE decision from AllowPrivateNetworkTarget
+	// (previously conflated: enabling AllowPrivateNetworkTarget alone used to
+	// ALSO silently unlock cleartext HTTP to any public host, not just a
+	// private one). Every use of this opt-out is logged; see
+	// notifychan.WebhookConfig.
+	AllowInsecureTransport bool `yaml:"allow_insecure_transport"`
 	// SigningSecret HMAC-signs each payload (X-Keyorix-Signature) so the receiver can
 	// verify authenticity. Use KEYORIX_NOTIFY_WEBHOOK_SIGNING_SECRET instead of the file.
 	SigningSecret string `yaml:"signing_secret"`
@@ -1748,6 +1777,15 @@ type DynamicSecretsConfig struct {
 	// 169.254.169.254). Set this only when the dynamic-secret backend legitimately
 	// lives on a private network segment that Keyorix must reach.
 	AllowPrivateNetworkTargets bool `yaml:"allow_private_network_targets"`
+	// AllowInsecureTransport, when true, disables the TLS-required-by-default
+	// guard on the mongodb/redis backends (the two backends here whose wire
+	// protocol has no bolted-on-elsewhere TLS enforcement of its own -- see
+	// internal/netutil.Guard.RequireTLS). False by default: a mongodb:// (no
+	// tls=true) or redis:// (non-rediss://) admin_dsn is rejected. Every
+	// connection actually made under this opt-out is logged (2d) -- set this
+	// only when the backend legitimately cannot use TLS (e.g. a legacy/
+	// internal deployment).
+	AllowInsecureTransport bool `yaml:"allow_insecure_transport"`
 }
 
 // GetSweepInterval returns the auto-revoke sweep cadence, parsing SweepInterval

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -74,6 +74,10 @@ type KeyorixCore struct {
 	// config's own MaxTTLSeconds, which has no ceiling of its own. Zero = the
 	// package default (90 days) applies. Set via SetDynamicMaxLeaseTTL.
 	dynamicMaxLeaseTTL time.Duration
+	// dynamicAllowInsecureTransport mirrors config
+	// dynamic_secrets.allow_insecure_transport (see
+	// SetDynamicAllowInsecureTransport).
+	dynamicAllowInsecureTransport bool
 	// dynamicAllowPrivateTargets mirrors config
 	// dynamic_secrets.allow_private_network_targets. When false (the default), the
 	// SSRF guard in CreateDynamicSecretConfig rejects admin DSNs whose host resolves
@@ -758,6 +762,16 @@ func (c *KeyorixCore) SetDynamicAllowPrivateTargets(allow bool) {
 	c.dynamicAllowPrivateTargets = allow
 }
 
+// SetDynamicAllowInsecureTransport controls whether the mongodb/redis
+// backends' TLS-required-by-default guard is bypassed. When false (the
+// default), connecting to either backend without TLS is refused. Set to true
+// only when the dynamic-secret backend legitimately cannot use TLS (e.g. a
+// legacy/internal deployment) — every connection made under this opt-out is
+// logged (2d).
+func (c *KeyorixCore) SetDynamicAllowInsecureTransport(allow bool) {
+	c.dynamicAllowInsecureTransport = allow
+}
+
 // SetDynamicMaxLeaseTTL sets the install-wide dynamic-secret lease TTL ceiling
 // (config dynamic_secrets.max_lease_ttl, #97). A non-positive value is ignored — the
 // package default (90 days) applies instead of disabling the ceiling.
@@ -777,7 +791,7 @@ func (c *KeyorixCore) dynamicEngine(backendType string) (dynamic.CredentialEngin
 	if c.dynamicEngineFactory != nil {
 		return c.dynamicEngineFactory(backendType)
 	}
-	return dynamic.New(backendType, c.dynamicAllowPrivateTargets)
+	return dynamic.New(backendType, c.dynamicAllowPrivateTargets, c.dynamicAllowInsecureTransport)
 }
 
 // SetTrustRegistryFunc overrides how the update/license signing-key trust registry

--- a/internal/dynamic/dynamic_s23_test.go
+++ b/internal/dynamic/dynamic_s23_test.go
@@ -631,7 +631,10 @@ func TestParseMongoRoles_Empty(t *testing.T) {
 func TestConnectMongo_InvalidURI(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	_, err := connectMongo(ctx, "not-a-valid-mongodb-uri")
+	// allowInsecureTransport: true so this reaches ApplyURI/mongo.Connect (the
+	// branch this test targets) instead of being refused earlier by the TLS
+	// guard — "not-a-valid-mongodb-uri" has no scheme for that check to see.
+	_, err := connectMongo(ctx, "not-a-valid-mongodb-uri", false, true)
 	require.Error(t, err)
 	// mongo.Connect returns an "invalid URI" error when ApplyURI fails.
 	// The exact message varies by driver version but always contains "URI".

--- a/internal/dynamic/dynamic_s25_test.go
+++ b/internal/dynamic/dynamic_s25_test.go
@@ -657,7 +657,11 @@ func startFakeMongoServer(t *testing.T) string {
 
 func TestMongoEngine_Issue_Success(t *testing.T) {
 	uri := startFakeMongoServer(t)
-	e := &MongoEngine{}
+	// G48/2b: dials a fake MongoDB server on 127.0.0.1 (an explicit,
+	// intentional loopback target) speaking plain (non-TLS) wire protocol —
+	// mirrors PostgresEngine's own fake-server tests (e.g.
+	// TestPostgresEngine_Issue_CreateRoleFails).
+	e := &MongoEngine{allowPrivateNetwork: true, allowInsecureTransport: true}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	cred, role, err := e.Issue(ctx, uri, `{"roles": ["readWrite"]}`, time.Minute)
@@ -669,7 +673,7 @@ func TestMongoEngine_Issue_Success(t *testing.T) {
 
 func TestMongoEngine_Issue_EmptyTemplate_Success(t *testing.T) {
 	uri := startFakeMongoServer(t)
-	e := &MongoEngine{}
+	e := &MongoEngine{allowPrivateNetwork: true, allowInsecureTransport: true}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	// Empty template → empty roles slice, no roles.
@@ -683,7 +687,7 @@ func TestMongoEngine_Issue_EmptyTemplate_Success(t *testing.T) {
 
 func TestMongoEngine_Revoke_Success(t *testing.T) {
 	uri := startFakeMongoServer(t)
-	e := &MongoEngine{}
+	e := &MongoEngine{allowPrivateNetwork: true, allowInsecureTransport: true}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	err := e.Revoke(ctx, uri, "kx_dyn_validname123")
@@ -769,6 +773,10 @@ func TestAWSSTSEngine_Issue_NoExpiration_NoExpirationField(t *testing.T) {
 func TestMongoEngine_connectMongo_InvalidURIScheme(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	_, err := connectMongo(ctx, "http://admin:pass@localhost:27017/admin")
+	// allowInsecureTransport: true so this reaches ApplyURI (the branch this
+	// test targets) instead of being refused earlier by the TLS guard --
+	// "http" is a non-TLS scheme, and the point of this test is the invalid
+	// *mongodb* scheme, not the TLS check.
+	_, err := connectMongo(ctx, "http://admin:pass@localhost:27017/admin", false, true)
 	require.Error(t, err)
 }

--- a/internal/dynamic/dynamic_s26_test.go
+++ b/internal/dynamic/dynamic_s26_test.go
@@ -283,7 +283,9 @@ func startFakeMongoServerCmdErr(t *testing.T, cmdKey string, code int32, codeNam
 
 func TestMongoEngine_Issue_CreateUserFails(t *testing.T) {
 	uri := startFakeMongoServerCmdErr(t, "createUser", 13, "Unauthorized", "not authorized on admin")
-	e := &MongoEngine{}
+	// G48/2b: dials a fake MongoDB server on 127.0.0.1 -- an explicit,
+	// intentional loopback target speaking plain (non-TLS) wire protocol.
+	e := &MongoEngine{allowPrivateNetwork: true, allowInsecureTransport: true}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	_, _, err := e.Issue(ctx, uri, `{"roles": ["readWrite"]}`, time.Minute)
@@ -293,7 +295,7 @@ func TestMongoEngine_Issue_CreateUserFails(t *testing.T) {
 
 func TestMongoEngine_Revoke_DropUserFails_NotIdempotent(t *testing.T) {
 	uri := startFakeMongoServerCmdErr(t, "dropUser", 13, "Unauthorized", "not authorized on admin")
-	e := &MongoEngine{}
+	e := &MongoEngine{allowPrivateNetwork: true, allowInsecureTransport: true}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	err := e.Revoke(ctx, uri, "kx_dyn_validname123")
@@ -303,7 +305,7 @@ func TestMongoEngine_Revoke_DropUserFails_NotIdempotent(t *testing.T) {
 
 func TestMongoEngine_Revoke_DropUserNotFound_IsIdempotent(t *testing.T) {
 	uri := startFakeMongoServerCmdErr(t, "dropUser", 11, "UserNotFound", "user not found")
-	e := &MongoEngine{}
+	e := &MongoEngine{allowPrivateNetwork: true, allowInsecureTransport: true}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	err := e.Revoke(ctx, uri, "kx_dyn_validname123")

--- a/internal/dynamic/dynamic_s2_test.go
+++ b/internal/dynamic/dynamic_s2_test.go
@@ -245,13 +245,13 @@ func TestParseMongoRoles_WhitespaceOnly(t *testing.T) {
 // ──────────────────────────── connectRedis error path ─────────────────────
 
 func TestConnectRedis_InvalidURI(t *testing.T) {
-	_, err := connectRedis(context.Background(), "not-a-redis-uri://whatever")
+	_, err := connectRedis(context.Background(), "not-a-redis-uri://whatever", false, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "redis admin URI")
 }
 
 func TestConnectRedis_UnreachableHost(t *testing.T) {
-	_, err := connectRedis(context.Background(), "redis://:pass@localhost:19999/0")
+	_, err := connectRedis(context.Background(), "redis://:pass@localhost:19999/0", false, false)
 	require.Error(t, err)
 }
 
@@ -260,7 +260,7 @@ func TestConnectRedis_UnreachableHost(t *testing.T) {
 func TestConnectMongo_UnreachableHost(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	_, err := connectMongo(ctx, "mongodb://admin:pass@localhost:27099/")
+	_, err := connectMongo(ctx, "mongodb://admin:pass@localhost:27099/", false, false)
 	require.Error(t, err)
 }
 

--- a/internal/dynamic/dynamic_s3_test.go
+++ b/internal/dynamic/dynamic_s3_test.go
@@ -633,7 +633,9 @@ func handleRESP(conn net.Conn) {
 
 func TestRedisEngine_Issue_Success(t *testing.T) {
 	addr := startRESPServer(t)
-	e := &RedisEngine{}
+	// G48/2b: dials a fake Redis server on 127.0.0.1 -- an explicit,
+	// intentional loopback target speaking plain (non-TLS) RESP.
+	e := &RedisEngine{allowPrivateNetwork: true, allowInsecureTransport: true}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	cred, role, err := e.Issue(ctx, "redis://"+addr+"/0", "~app:* +@read", time.Minute)
@@ -645,7 +647,7 @@ func TestRedisEngine_Issue_Success(t *testing.T) {
 
 func TestRedisEngine_Revoke_Success(t *testing.T) {
 	addr := startRESPServer(t)
-	e := &RedisEngine{}
+	e := &RedisEngine{allowPrivateNetwork: true, allowInsecureTransport: true}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	err := e.Revoke(ctx, "redis://"+addr+"/0", "kx_dyn_abc123")
@@ -732,7 +734,7 @@ func handleRESPWithACLError(conn net.Conn) {
 
 func TestRedisEngine_Issue_ACLError(t *testing.T) {
 	addr := startRESPServerWithACLError(t)
-	e := &RedisEngine{}
+	e := &RedisEngine{allowPrivateNetwork: true, allowInsecureTransport: true}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	_, _, err := e.Issue(ctx, "redis://"+addr+"/0", "~app:* +@read", time.Minute)
@@ -742,7 +744,7 @@ func TestRedisEngine_Issue_ACLError(t *testing.T) {
 
 func TestRedisEngine_Revoke_ACLError(t *testing.T) {
 	addr := startRESPServerWithACLError(t)
-	e := &RedisEngine{}
+	e := &RedisEngine{allowPrivateNetwork: true, allowInsecureTransport: true}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	err := e.Revoke(ctx, "redis://"+addr+"/0", "kx_dyn_abc123")

--- a/internal/dynamic/egress_guard_test.go
+++ b/internal/dynamic/egress_guard_test.go
@@ -1,0 +1,309 @@
+// egress_guard_test.go — the structural guard for the unified egress-guard
+// fix (2e): no code path in the MongoDB/Redis dynamic-secret backends
+// (internal/dynamic/mongodb.go, internal/dynamic/redis.go) or the SIEM/audit
+// forwarder (internal/audit/siem/forwarder.go) may open a raw, unguarded
+// outbound connection that bypasses the shared netutil.Dialer/netutil.Guard
+// egress guard.
+//
+// Two independent checks, an AST walk over each scanned file (go/parser, not
+// a regex/string scan — the same style as server/http's
+// raw_storage_bypass_guard_test.go):
+//
+//   - forbiddenRawDialUses: net.Dial/net.DialTimeout/a literal net.Dialer{}
+//     value, found ANYWHERE in the scanned files. There is no legitimate
+//     reason for internal/dynamic or internal/audit/siem to construct one of
+//     these directly — the shared guard (netutil.Dialer/netutil.Guard) is the
+//     only sanctioned way to open an outbound connection from these packages;
+//     netutil's own internal fallback (a plain net.Dialer{} default, used
+//     only when a Dialer's own Dial field is unset) lives inside
+//     internal/netutil itself, a different, unscanned package.
+//   - unguardedDriverConstruction: a driver/http-client construction call
+//     (mongo.Connect, redis.NewClient/NewUniversalClient/NewFailoverClient/
+//     NewClusterClient, a `http.Client{}`/`&http.Client{}` composite literal)
+//     found OUTSIDE the one file per backend that legitimately makes it
+//     (mongodb.go/redis.go/forwarder.go), OR found INSIDE that file but in a
+//     function whose body never references netutil.Dialer/netutil.Guard —
+//     i.e. the construction exists, but nothing wires the guard to it. This
+//     is the check that actually caught the pre-fix gap: before 2b,
+//     connectMongo/connectRedis called mongo.Connect/redis.NewClient with
+//     ZERO reference to netutil anywhere in the function, and the SIEM
+//     forwarder built a bare &http.Transport{} with no DialContext at all —
+//     confirmed RED against that code (see this file's own test,
+//     TestNoUnguardedEgress, and the campaign notes on verifying red-before-
+//     green). A future backend that adds a second, forgotten driver-connect
+//     call site (the sibling-miss shape this campaign repeatedly finds) trips
+//     this the same way.
+package dynamic
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// egressGuardScanDir is one directory this guard scans, plus the single file
+// within it (if any) allowed to construct a driver client / http.Client
+// directly — the legitimate implementation site for that backend's guarded
+// connect helper.
+type egressGuardScanDir struct {
+	dir         string
+	allowedFile string
+}
+
+var egressGuardScanDirs = []egressGuardScanDir{
+	{dir: ".", allowedFile: "mongodb.go"},                                    // MongoDB dynamic-secret backend
+	{dir: ".", allowedFile: "redis.go"},                                      // Redis dynamic-secret backend
+	{dir: filepath.Join("..", "audit", "siem"), allowedFile: "forwarder.go"}, // SIEM/audit forwarder
+}
+
+// knownOutOfScopeEgressFiles are files this walk finds a raw http.Client
+// construction in that are DELIBERATELY not covered by this fix -- named
+// explicitly so the exclusion is visible and auditable rather than a case
+// this guard silently never looked at.
+//
+// internal/dynamic/kubernetes.go's realK8sMinter builds a raw *http.Client
+// with no DialContext (found during this fix's repo-wide enumeration -- the
+// same unguarded-egress shape as Mongo/Redis/SIEM before this change).
+// NOT fixed here: unlike Mongo/Redis/SIEM (all external, off-box network
+// targets where refusing a private/link-local resolved address is
+// unconditionally the right default), a Kubernetes api_server is routinely,
+// LEGITIMATELY a private RFC-1918 address (kubernetes.go's own doc comment
+// example: "api_server":"https://10.0.0.1:443") -- wiring the same
+// IsPrivateOrLinkLocal policy here by default would break the common,
+// intended case, not just an attacker's. Closing this gap correctly needs
+// its own threat-model decision (what, if anything, should be disallowed for
+// an api_server target) that this change's scope (2b-2e, explicitly Mongo/
+// Redis/SIEM) does not make for it. Tracked as a known, reasoned exclusion,
+// not silently missed.
+var knownOutOfScopeEgressFiles = map[string]map[string]bool{
+	".": {"kubernetes.go": true},
+}
+
+// scanEgressGuardDir returns every non-test .go file in dir, parsed.
+func scanEgressGuardDir(t *testing.T, dir string) map[string]*ast.File {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+	fset := token.NewFileSet()
+	files := map[string]*ast.File{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		files[name] = f
+	}
+	return files
+}
+
+// identSel reports the (X, Sel) of a SelectorExpr whose X is a bare
+// identifier — e.g. net.Dial → ("net", "Dial").
+func egressIdentSel(e ast.Expr) (pkg, sel string, ok bool) {
+	se, isSel := e.(*ast.SelectorExpr)
+	if !isSel {
+		return "", "", false
+	}
+	id, isIdent := se.X.(*ast.Ident)
+	if !isIdent {
+		return "", "", false
+	}
+	return id.Name, se.Sel.Name, true
+}
+
+var forbiddenRawDialSelectors = map[string]bool{
+	"Dial":        true, // net.Dial
+	"DialTimeout": true, // net.DialTimeout
+}
+
+var driverConstructionSelectors = map[string]bool{
+	"Connect":            true, // mongo.Connect
+	"NewClient":          true, // redis.NewClient
+	"NewUniversalClient": true, // redis.NewUniversalClient
+	"NewFailoverClient":  true, // redis.NewFailoverClient
+	"NewClusterClient":   true, // redis.NewClusterClient
+}
+
+// findForbiddenRawDial returns a description of every net.Dial/net.DialTimeout
+// call, and every literal net.Dialer{} composite literal, in file.
+func findForbiddenRawDial(file *ast.File) []string {
+	var found []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch e := n.(type) {
+		case *ast.CallExpr:
+			if pkg, sel, ok := egressIdentSel(e.Fun); ok && pkg == "net" && forbiddenRawDialSelectors[sel] {
+				found = append(found, "net."+sel+"(...) called directly")
+			}
+		case *ast.CompositeLit:
+			if sel, ok := e.Type.(*ast.SelectorExpr); ok {
+				if id, ok := sel.X.(*ast.Ident); ok && id.Name == "net" && sel.Sel.Name == "Dialer" {
+					found = append(found, "net.Dialer{...} constructed directly")
+				}
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// funcBodyReferencesNetutilGuard reports whether fd's body references
+// netutil.Dialer or netutil.Guard anywhere — the structural signal that SOME
+// guard wiring happens in the same function that opens the connection.
+func funcBodyReferencesNetutilGuard(fd *ast.FuncDecl) bool {
+	if fd.Body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if id, ok := sel.X.(*ast.Ident); ok && id.Name == "netutil" && (sel.Sel.Name == "Dialer" || sel.Sel.Name == "Guard") {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// driverConstructionIssue describes one flagged driver/http-client
+// construction call site.
+type driverConstructionIssue struct {
+	call   string
+	reason string
+}
+
+// findUnguardedDriverConstruction walks every top-level function in file and
+// returns an issue for each mongo.Connect / redis.New*Client /
+// http.Client{}/&http.Client{} construction whose enclosing function body
+// does not also reference netutil.Dialer/netutil.Guard.
+func findUnguardedDriverConstruction(file *ast.File) []driverConstructionIssue {
+	var issues []driverConstructionIssue
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Body == nil {
+			continue
+		}
+		guarded := funcBodyReferencesNetutilGuard(fd)
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			var call string
+			switch e := n.(type) {
+			case *ast.CallExpr:
+				if pkg, sel, ok := egressIdentSel(e.Fun); ok && driverConstructionSelectors[sel] &&
+					(pkg == "mongo" || pkg == "redis") {
+					call = pkg + "." + sel + "(...)"
+				}
+			case *ast.CompositeLit:
+				if sel, ok := e.Type.(*ast.SelectorExpr); ok {
+					if id, ok := sel.X.(*ast.Ident); ok && id.Name == "http" && sel.Sel.Name == "Client" {
+						call = "http.Client{...}"
+					}
+				}
+			}
+			if call == "" {
+				return true
+			}
+			if !guarded {
+				issues = append(issues, driverConstructionIssue{
+					call:   call,
+					reason: "in function " + fd.Name.Name + "() with no netutil.Dialer/netutil.Guard reference anywhere in its body",
+				})
+			}
+			return true
+		})
+	}
+	return issues
+}
+
+// TestNoUnguardedEgress is the guard: every driver/http-client construction
+// in the scanned backends must be wired through the shared egress guard.
+// Verified RED against the pre-2b code (mongodb.go/redis.go had zero
+// netutil reference in connectMongo/connectRedis; forwarder.go built a bare
+// &http.Transport{} with no DialContext) and GREEN after.
+func TestNoUnguardedEgress(t *testing.T) {
+	seenDirs := map[string]map[string]*ast.File{}
+	allowedFiles := map[string]map[string]bool{}
+	for _, sd := range egressGuardScanDirs {
+		if _, ok := seenDirs[sd.dir]; !ok {
+			seenDirs[sd.dir] = scanEgressGuardDir(t, sd.dir)
+			allowedFiles[sd.dir] = map[string]bool{}
+		}
+		allowedFiles[sd.dir][sd.allowedFile] = true
+	}
+
+	for dir, files := range seenDirs {
+		if len(files) == 0 {
+			t.Fatalf("scanned directory %q yielded zero .go files -- the walk likely broke silently", dir)
+		}
+		for name, file := range files {
+			for _, msg := range findForbiddenRawDial(file) {
+				t.Errorf("%s/%s: forbidden raw dial: %s -- outbound connections from this package must go "+
+					"through netutil.Dialer/netutil.Guard, never construct a raw net.Dial/net.Dialer{} directly",
+					dir, name, msg)
+			}
+			if !allowedFiles[dir][name] {
+				issues := findUnguardedDriverConstructionAnyFunc(file)
+				if knownOutOfScopeEgressFiles[dir][name] {
+					if len(issues) == 0 {
+						t.Errorf("%s/%s is listed in knownOutOfScopeEgressFiles but no longer constructs a "+
+							"raw driver/http.Client at all -- remove it from the exclusion list (fixed and forgotten)",
+							dir, name)
+					}
+					continue
+				}
+				// Not the designated implementation file for any backend --
+				// it must not construct a driver client / http.Client at all.
+				for _, issue := range issues {
+					t.Errorf("%s/%s: %s found outside its backend's designated guarded-connect file -- "+
+						"every driver/http-client construction site must live in the one file that wires "+
+						"the shared egress guard, not be duplicated elsewhere", dir, name, issue)
+				}
+				continue
+			}
+			for _, issue := range findUnguardedDriverConstruction(file) {
+				t.Errorf("%s/%s: %s %s -- every driver/http-client construction site in this file must be "+
+					"wired through netutil.Dialer/netutil.Guard in the SAME function, or a future call site "+
+					"can silently reintroduce the unguarded-egress gap this test exists to catch",
+					dir, name, issue.call, issue.reason)
+			}
+		}
+	}
+}
+
+// findUnguardedDriverConstructionAnyFunc is findUnguardedDriverConstruction's
+// sibling for a file that isn't any backend's designated implementation file
+// at all: ANY driver/http.Client construction there is itself the problem,
+// regardless of whether netutil is referenced nearby.
+func findUnguardedDriverConstructionAnyFunc(file *ast.File) []string {
+	var found []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch e := n.(type) {
+		case *ast.CallExpr:
+			if pkg, sel, ok := egressIdentSel(e.Fun); ok && driverConstructionSelectors[sel] &&
+				(pkg == "mongo" || pkg == "redis") {
+				found = append(found, pkg+"."+sel+"(...)")
+			}
+		case *ast.CompositeLit:
+			if sel, ok := e.Type.(*ast.SelectorExpr); ok {
+				if id, ok := sel.X.(*ast.Ident); ok && id.Name == "http" && sel.Sel.Name == "Client" {
+					found = append(found, "http.Client{...}")
+				}
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/internal/dynamic/egress_tls_srv_test.go
+++ b/internal/dynamic/egress_tls_srv_test.go
@@ -1,0 +1,139 @@
+// egress_tls_srv_test.go — direct coverage for the two backend-specific
+// gaps 2c/2d ask this fix to close explicitly: Mongo's TLS-default
+// computation (mongodb+srv:// implies TLS; a plain mongodb:// URI does not
+// unless tls=true/ssl=true) and the unix:// scheme refusal for Redis. Tests
+// here are deliberately network-free wherever the assertion allows it (the
+// TLS/scheme checks in both connectMongo/connectRedis run BEFORE any dial is
+// attempted, so a bad input never needs a real connection to observe the
+// refusal) — netutil/egress_test.go already covers Guard.ValidateSRVTargets'
+// own logic thoroughly with a fake SRV resolver; this file only proves
+// connectMongo actually WIRES that check in for a mongodb+srv:// URI.
+package dynamic
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ──────────────────────────── mongoTLSEnabled (pure, no I/O) ───────────────
+
+func TestMongoTLSEnabled_PlainMongoDBDefaultsToFalse(t *testing.T) {
+	u, err := url.Parse("mongodb://admin:pass@db.example.net:27017/app")
+	require.NoError(t, err)
+	assert.False(t, mongoTLSEnabled(u), "a plain mongodb:// URI with no tls/ssl param must default to no TLS")
+}
+
+func TestMongoTLSEnabled_SRVSchemeDefaultsToTrue(t *testing.T) {
+	u, err := url.Parse("mongodb+srv://admin:pass@cluster0.example.net/app")
+	require.NoError(t, err)
+	assert.True(t, mongoTLSEnabled(u), "mongodb+srv:// must default to TLS, matching the driver's own documented behaviour")
+}
+
+func TestMongoTLSEnabled_ExplicitTLSTrueOverridesPlainScheme(t *testing.T) {
+	u, err := url.Parse("mongodb://admin:pass@db.example.net:27017/app?tls=true")
+	require.NoError(t, err)
+	assert.True(t, mongoTLSEnabled(u))
+}
+
+func TestMongoTLSEnabled_ExplicitTLSFalseOverridesSRVDefault(t *testing.T) {
+	u, err := url.Parse("mongodb+srv://admin:pass@cluster0.example.net/app?tls=false")
+	require.NoError(t, err)
+	assert.False(t, mongoTLSEnabled(u), "an explicit tls=false must win over the mongodb+srv:// implicit default")
+}
+
+func TestMongoTLSEnabled_SSLParamAlias(t *testing.T) {
+	u, err := url.Parse("mongodb://admin:pass@db.example.net:27017/app?ssl=true")
+	require.NoError(t, err)
+	assert.True(t, mongoTLSEnabled(u), "ssl=true is the legacy alias for tls=true")
+}
+
+// ──────────────────────────── connectMongo TLS enforcement ─────────────────
+//
+// These are network-free: guard.RequireTLS runs before connectMongo ever
+// calls options.Client().ApplyURI/mongo.Connect, so a plaintext mongodb://
+// URI is refused without attempting any connection at all.
+
+func TestConnectMongo_RefusesPlaintextByDefault(t *testing.T) {
+	_, err := connectMongo(context.Background(), "mongodb://admin:pass@db.example.net:27017/app", true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must use TLS")
+}
+
+func TestConnectMongo_AllowInsecureTransportOptsOut(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// allowPrivateNetwork: true and a literal, non-routable TEST-NET-3 address
+	// (RFC 5737) keep this bounded and DNS-free -- the connection itself will
+	// still fail (nothing is listening), but NOT via the TLS guard.
+	_, err := connectMongo(ctx, "mongodb://admin:pass@203.0.113.1:1/app", true, true)
+	require.Error(t, err, "still fails -- nothing is listening -- but NOT via the TLS guard")
+	assert.NotContains(t, err.Error(), "must use TLS")
+}
+
+// TestConnectMongo_SRVSchemeValidatesTargetsBeforeConnecting proves
+// connectMongo actually wires Guard.ValidateSRVTargets in for a
+// mongodb+srv:// URI when allowPrivateNetwork is false (the default) --
+// the one piece netutil's own fake-resolver tests can't reach, since they
+// exercise Guard directly rather than connectMongo's wiring of it. An empty
+// host name resolves via ONE real (but fast: ~20ms measured, and guaranteed
+// negative, RFC-1035-invalid) SRV query rather than a fabricated hostname,
+// to avoid depending on a specific external domain's behaviour; bounded by a
+// short context regardless.
+func TestConnectMongo_SRVSchemeValidatesTargetsBeforeConnecting(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := connectMongo(ctx, "mongodb+srv:///app", false, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SRV")
+}
+
+// TestConnectMongo_SRVValidationSkippedWhenAllowPrivateNetwork proves the
+// explicit opt-out disables the SRV pre-check too, not just the per-dial
+// guard -- mirrors TestPostgresEngine_Issue_AllowPrivateNetworkOptsOut.
+func TestConnectMongo_SRVValidationSkippedWhenAllowPrivateNetwork(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := connectMongo(ctx, "mongodb+srv://cluster0.invalid-test-domain-xyz.example/app", true, true)
+	require.Error(t, err, "still fails -- mongo.Connect itself will reject or fail to reach this -- but NOT via the SRV guard")
+	assert.NotContains(t, err.Error(), "SRV target")
+}
+
+// ──────────────────────────── connectRedis scheme/TLS enforcement ─────────
+//
+// Also network-free: redis.ParseURL + the scheme/TLS checks are pure/local,
+// run before connectRedis ever calls redis.NewClient/client.Ping.
+
+func TestConnectRedis_RefusesUnixScheme(t *testing.T) {
+	_, err := connectRedis(context.Background(), "unix:///var/run/redis/redis.sock?db=0", false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unix")
+}
+
+func TestConnectRedis_RefusesPlaintextByDefault(t *testing.T) {
+	_, err := connectRedis(context.Background(), "redis://admin:pass@db.example.net:6379/0", true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must use TLS")
+}
+
+func TestConnectRedis_RedissSchemeSatisfiesTLSRequirement(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// rediss:// satisfies RequireTLS, so the failure (nothing listening on
+	// this literal, non-routable address) must NOT be the TLS guard.
+	_, err := connectRedis(ctx, "rediss://admin:pass@203.0.113.1:1/0", true, false)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "must use TLS")
+}
+
+func TestConnectRedis_AllowInsecureTransportOptsOut(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := connectRedis(ctx, "redis://admin:pass@203.0.113.1:1/0", true, true)
+	require.Error(t, err, "still fails -- nothing is listening -- but NOT via the TLS guard")
+	assert.NotContains(t, err.Error(), "must use TLS")
+}

--- a/internal/dynamic/engine.go
+++ b/internal/dynamic/engine.go
@@ -74,21 +74,28 @@ type CredentialEngine interface {
 // New returns the engine for a backend type. allowPrivateNetwork mirrors
 // KeyorixCore.dynamicAllowPrivateTargets (dynamic_secrets.allow_private_network_targets):
 // when false (the default), an engine that dials the admin DSN itself
-// (postgres, mysql) re-validates the resolved target address on every
-// connection and refuses a private/link-local one — closing the DNS-rebinding
-// gap a validate-once-at-config-time guard alone leaves open (G48). The other
-// backends (cloud-IAM engines, Kubernetes' in-cluster/explicit api_server)
-// don't dial an admin_dsn host the same way and ignore this parameter.
-func New(backendType string, allowPrivateNetwork bool) (CredentialEngine, error) {
+// (postgres, mysql, mongodb, redis) re-validates the resolved target address
+// on every connection and refuses a private/link-local one — closing the
+// DNS-rebinding gap a validate-once-at-config-time guard alone leaves open
+// (G48). allowInsecureTransport mirrors
+// KeyorixCore.dynamicAllowInsecureTransport
+// (dynamic_secrets.allow_insecure_transport): when false (the default),
+// mongodb/redis (the two backends here whose wire protocol has no
+// bolted-on-elsewhere TLS enforcement of its own — Postgres/MySQL are
+// pre-existing, verified-correct call sites out of this change's scope)
+// refuse a connection that isn't using TLS. The cloud-IAM engines and
+// Kubernetes (in-cluster/explicit api_server) don't dial an admin_dsn host
+// the same way and ignore both parameters.
+func New(backendType string, allowPrivateNetwork, allowInsecureTransport bool) (CredentialEngine, error) {
 	switch backendType {
 	case "postgres":
 		return &PostgresEngine{allowPrivateNetwork: allowPrivateNetwork}, nil
 	case "mysql":
 		return &MySQLEngine{allowPrivateNetwork: allowPrivateNetwork}, nil
 	case "mongodb":
-		return &MongoEngine{}, nil
+		return &MongoEngine{allowPrivateNetwork: allowPrivateNetwork, allowInsecureTransport: allowInsecureTransport}, nil
 	case "redis":
-		return &RedisEngine{}, nil
+		return &RedisEngine{allowPrivateNetwork: allowPrivateNetwork, allowInsecureTransport: allowInsecureTransport}, nil
 	case "aws-sts":
 		return &AWSSTSEngine{}, nil
 	case "gcp":

--- a/internal/dynamic/engine_extra_test.go
+++ b/internal/dynamic/engine_extra_test.go
@@ -109,7 +109,7 @@ func TestFakeEngine_IssueFields(t *testing.T) {
 
 // TestNew_UnsupportedBackend validates that an unsupported backend type is rejected.
 func TestNew_UnsupportedBackend(t *testing.T) {
-	_, err := New("cassandra", false)
+	_, err := New("cassandra", false, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported")
 	assert.Contains(t, err.Error(), "cassandra")
@@ -131,7 +131,7 @@ func TestNew_AllBackendTypes(t *testing.T) {
 		{"kubernetes", true},
 	}
 	for _, b := range backends {
-		eng, err := New(b.name, false)
+		eng, err := New(b.name, false, false)
 		require.NoErrorf(t, err, "backend %q must be constructable", b.name)
 		assert.Equal(t, b.name, eng.BackendType())
 		if b.ephemeral {

--- a/internal/dynamic/engine_test.go
+++ b/internal/dynamic/engine_test.go
@@ -10,31 +10,31 @@ import (
 )
 
 func TestNew_Backends(t *testing.T) {
-	pg, err := New("postgres", false)
+	pg, err := New("postgres", false, false)
 	require.NoError(t, err)
 	assert.Equal(t, "postgres", pg.BackendType())
 
-	my, err := New("mysql", false)
+	my, err := New("mysql", false, false)
 	require.NoError(t, err)
 	assert.Equal(t, "mysql", my.BackendType())
 
-	mg, err := New("mongodb", false)
+	mg, err := New("mongodb", false, false)
 	require.NoError(t, err)
 	assert.Equal(t, "mongodb", mg.BackendType())
 
-	rd, err := New("redis", false)
+	rd, err := New("redis", false, false)
 	require.NoError(t, err)
 	assert.Equal(t, "redis", rd.BackendType())
 
 	for _, bt := range []string{"aws-sts", "gcp", "azure", "kubernetes"} {
-		eng, err := New(bt, false)
+		eng, err := New(bt, false, false)
 		require.NoError(t, err)
 		assert.Equal(t, bt, eng.BackendType())
 		assert.True(t, eng.IsEphemeralBackend(), "%s mints self-expiring credentials", bt)
 		assert.True(t, eng.SupportsNativeExpiry(), "%s expiry enforced by the provider", bt)
 	}
 
-	_, err = New("cassandra", false)
+	_, err = New("cassandra", false, false)
 	require.Error(t, err, "an unsupported backend is rejected")
 }
 

--- a/internal/dynamic/mongodb.go
+++ b/internal/dynamic/mongodb.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/keyorixhq/keyorix/internal/netutil"
 )
 
 // MongoEngine mints short-lived MongoDB users on the target's `admin` database and
@@ -30,7 +33,18 @@ import (
 // is structurally impossible; the role spec is the operator-authored trust boundary.
 // Users are created in the `admin` auth database; their roles may target any
 // database.
-type MongoEngine struct{}
+type MongoEngine struct {
+	// allowPrivateNetwork mirrors dynamic_secrets.allow_private_network_targets
+	// (see New). When false, every connection re-validates the resolved
+	// target address (including every mongodb+srv:// SRV-discovered target)
+	// and refuses a private/link-local one (G48).
+	allowPrivateNetwork bool
+	// allowInsecureTransport mirrors dynamic_secrets.allow_insecure_transport
+	// (see New). When false, connectMongo refuses a connection that isn't
+	// using TLS, logging the exception when the operator has explicitly set
+	// this true.
+	allowInsecureTransport bool
+}
 
 func (e *MongoEngine) BackendType() string      { return "mongodb" }
 func (e *MongoEngine) IsEphemeralBackend() bool { return false }
@@ -55,7 +69,7 @@ func (e *MongoEngine) Issue(ctx context.Context, adminDSN, creationTemplate stri
 	if err != nil {
 		return Credential{}, "", err
 	}
-	client, err := connectMongo(ctx, adminDSN)
+	client, err := connectMongo(ctx, adminDSN, e.allowPrivateNetwork, e.allowInsecureTransport)
 	if err != nil {
 		return Credential{}, "", err
 	}
@@ -92,7 +106,7 @@ func (e *MongoEngine) Revoke(ctx context.Context, adminDSN, roleName string) err
 	if err := assertSafeUsername(roleName); err != nil {
 		return err
 	}
-	client, err := connectMongo(ctx, adminDSN)
+	client, err := connectMongo(ctx, adminDSN, e.allowPrivateNetwork, e.allowInsecureTransport)
 	if err != nil {
 		return err
 	}
@@ -166,11 +180,53 @@ func parseMongoRoles(template string) ([]interface{}, error) {
 	return doc.Roles, nil
 }
 
-// connectMongo opens and verifies a connection to the target using the admin URI.
-func connectMongo(ctx context.Context, adminDSN string) (*mongo.Client, error) {
+// connectMongo opens and verifies a connection to the target using the admin
+// URI, pinning the dial to a re-validated target address unless
+// allowPrivateNetwork opts out, and requiring TLS unless allowInsecureTransport
+// opts out. Replaces a bare mongo.Connect(ctx, options.Client().ApplyURI(...)):
+// that path offers no hook to control the underlying TCP dial, and — critically
+// — the actual connection it makes would otherwise re-resolve adminDSN's host
+// independently of whatever check ran when the config was created or the DSN
+// last decrypted, letting a DNS-rebinding attacker swap in a private/link-local
+// address between the two resolutions (the same G48 gap Postgres/MySQL already
+// close).
+//
+// mongodb+srv:// is a second, separate gap a plain dial-hook wrap does not
+// cover: the driver resolves the SRV record internally, before any
+// caller-supplied Dialer is ever invoked (see Guard.ValidateSRVTargets' doc
+// comment for the verified driver-internals trail), so a caller has no
+// visibility into which hostnames that step discovers. Guard.ValidateSRVTargets
+// pre-resolves and validates them here, before the URI is ever handed to the
+// driver — defense-in-depth on top of options.SetDialer below, which still
+// re-validates the actual per-server dial regardless of discovery mode.
+func connectMongo(ctx context.Context, adminDSN string, allowPrivateNetwork, allowInsecureTransport bool) (*mongo.Client, error) {
 	connectCtx, cancel := context.WithTimeout(ctx, mongoConnectTimeout)
 	defer cancel()
-	client, err := mongo.Connect(connectCtx, options.Client().ApplyURI(adminDSN))
+
+	u, err := url.Parse(adminDSN)
+	if err != nil {
+		return nil, fmt.Errorf("invalid mongodb admin URI: %w", err)
+	}
+
+	guard := netutil.Guard{AllowInsecureTransport: allowInsecureTransport}
+	if !allowPrivateNetwork {
+		guard.Dial = netutil.Dialer{Disallow: netutil.IsPrivateOrLinkLocal, Resolve: dialResolve}
+		if u.Scheme == "mongodb+srv" {
+			if err := guard.ValidateSRVTargets(connectCtx, "mongodb", "tcp", u.Hostname()); err != nil {
+				return nil, fmt.Errorf("invalid mongodb admin URI: %w", err)
+			}
+		}
+	}
+
+	if err := guard.RequireTLS(mongoTLSEnabled(u), "mongodb admin_dsn", u.Hostname()); err != nil {
+		return nil, err
+	}
+
+	opts := options.Client().ApplyURI(adminDSN)
+	if !allowPrivateNetwork {
+		opts = opts.SetDialer(guard.Dial)
+	}
+	client, err := mongo.Connect(connectCtx, opts)
 	if err != nil {
 		return nil, fmt.Errorf("invalid mongodb admin URI: %w", err)
 	}
@@ -179,6 +235,25 @@ func connectMongo(ctx context.Context, adminDSN string) (*mongo.Client, error) {
 		return nil, fmt.Errorf("connect to target: %w", err)
 	}
 	return client, nil
+}
+
+// mongoTLSEnabled reports whether adminURI's connection will use TLS:
+// mongodb+srv:// implies TLS by default (the MongoDB driver's own documented
+// behaviour); a plain mongodb:// URI does not unless tls=true/ssl=true is
+// present in the query string. An explicit tls=false/ssl=false always wins
+// over the mongodb+srv:// default, matching the driver's own precedence. A
+// pure function of the parsed URI (no I/O), so it's testable without a real
+// connection attempt or DNS lookup.
+func mongoTLSEnabled(u *url.URL) bool {
+	tlsEnabled := u.Scheme == "mongodb+srv"
+	q := u.Query()
+	if v := q.Get("tls"); v != "" {
+		return v == "true"
+	}
+	if v := q.Get("ssl"); v != "" {
+		return v == "true"
+	}
+	return tlsEnabled
 }
 
 // isMongoUserNotFound reports whether err is MongoDB's UserNotFound (code 11),

--- a/internal/dynamic/redis.go
+++ b/internal/dynamic/redis.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+
+	"github.com/keyorixhq/keyorix/internal/netutil"
 )
 
 // RedisEngine mints short-lived Redis ACL users on the target and drops them on
@@ -28,7 +30,17 @@ import (
 // credential can never be parsed as an ACL token — injection is structurally
 // impossible. The ACL rule tokens are the operator-authored trust boundary (the
 // analogue of the SQL creation_template / Mongo role spec).
-type RedisEngine struct{}
+type RedisEngine struct {
+	// allowPrivateNetwork mirrors dynamic_secrets.allow_private_network_targets
+	// (see New). When false, every connection re-validates the resolved
+	// target address and refuses a private/link-local one (G48).
+	allowPrivateNetwork bool
+	// allowInsecureTransport mirrors dynamic_secrets.allow_insecure_transport
+	// (see New). When false, connectRedis refuses a connection that isn't
+	// using TLS (rediss://), logging the exception when the operator has
+	// explicitly set this true.
+	allowInsecureTransport bool
+}
 
 func (e *RedisEngine) BackendType() string      { return "redis" }
 func (e *RedisEngine) IsEphemeralBackend() bool { return false }
@@ -47,7 +59,7 @@ const redisOpTimeout = 10 * time.Second
 func (e *RedisEngine) Issue(ctx context.Context, adminDSN, creationTemplate string, _ time.Duration) (Credential, string, error) {
 	rules := parseRedisACLRules(creationTemplate)
 
-	client, err := connectRedis(ctx, adminDSN)
+	client, err := connectRedis(ctx, adminDSN, e.allowPrivateNetwork, e.allowInsecureTransport)
 	if err != nil {
 		return Credential{}, "", err
 	}
@@ -88,7 +100,7 @@ func (e *RedisEngine) Revoke(ctx context.Context, adminDSN, roleName string) err
 	if err := assertSafeUsername(roleName); err != nil {
 		return err
 	}
-	client, err := connectRedis(ctx, adminDSN)
+	client, err := connectRedis(ctx, adminDSN, e.allowPrivateNetwork, e.allowInsecureTransport)
 	if err != nil {
 		return err
 	}
@@ -118,12 +130,49 @@ func parseRedisACLRules(template string) []string {
 	return strings.Fields(template)
 }
 
-// connectRedis opens and verifies a connection to the target using the admin URI.
-func connectRedis(ctx context.Context, adminDSN string) (*redis.Client, error) {
+// connectRedis opens and verifies a connection to the target using the admin
+// URI, pinning the dial to a re-validated target address unless
+// allowPrivateNetwork opts out, and requiring TLS (rediss://) unless
+// allowInsecureTransport opts out. Replaces bare redis.NewClient(opts): that
+// path offers no hook to control the underlying TCP dial, and — critically —
+// the actual connection it makes would otherwise re-resolve adminDSN's host
+// independently of whatever check ran when the config was created or the DSN
+// last decrypted, letting a DNS-rebinding attacker swap in a private/link-local
+// address between the two resolutions (the same G48 gap Postgres/MySQL already
+// close).
+//
+// A "unix://" admin DSN is refused outright: it names a local domain-socket
+// path, not a network address, so there is no IP for the dial-time guard to
+// validate at all — a different threat model (local filesystem access) this
+// connector doesn't attempt to police. No dynamic-secret Redis config in this
+// codebase (docs, tests, or shipped examples) uses unix://; grepped repo-wide
+// before making this call.
+func connectRedis(ctx context.Context, adminDSN string, allowPrivateNetwork, allowInsecureTransport bool) (*redis.Client, error) {
 	opts, err := redis.ParseURL(adminDSN)
 	if err != nil {
 		return nil, fmt.Errorf("invalid redis admin URI: %w", err)
 	}
+	if err := netutil.RefuseScheme(opts.Network, "unix", "redis admin_dsn"); err != nil {
+		return nil, err
+	}
+
+	guard := netutil.Guard{AllowInsecureTransport: allowInsecureTransport}
+	if !allowPrivateNetwork {
+		guard.Dial = netutil.Dialer{Disallow: netutil.IsPrivateOrLinkLocal, Resolve: dialResolve}
+	}
+	if err := guard.RequireTLS(opts.TLSConfig != nil, "redis admin_dsn", opts.Addr); err != nil {
+		return nil, err
+	}
+	if !allowPrivateNetwork {
+		// go-redis's own default dialer (used when Options.Dialer is left
+		// unset) layers TLS itself atop the raw dial; overriding Dialer here
+		// (required to get the dial-time IP re-validation) takes over that
+		// responsibility entirely, so RedisDialer replicates the same TLS
+		// layering on top of the guarded dial rather than silently dropping
+		// it for every rediss:// admin DSN. See RedisDialer's doc comment.
+		opts.Dialer = guard.RedisDialer(opts.TLSConfig)
+	}
+
 	client := redis.NewClient(opts)
 	pingCtx, cancel := context.WithTimeout(ctx, redisOpTimeout)
 	defer cancel()

--- a/internal/evidencesink/evidencesink_extra_test.go
+++ b/internal/evidencesink/evidencesink_extra_test.go
@@ -87,16 +87,16 @@ func TestIsLoopbackHost(t *testing.T) {
 // TestValidateEndpoint_HTTPLoopback verifies that http:// to a loopback address
 // is accepted without AllowPrivateNetworkTarget.
 func TestValidateEndpoint_HTTPLoopback(t *testing.T) {
-	err := validateEndpoint("http://localhost/evidence", false)
+	err := validateEndpoint("http://localhost/evidence", false, false)
 	assert.NoError(t, err, "http to loopback must be allowed without AllowPrivateNetworkTarget")
 
-	err = validateEndpoint("http://127.0.0.1/evidence", false)
+	err = validateEndpoint("http://127.0.0.1/evidence", false, false)
 	assert.NoError(t, err, "http to 127.0.0.1 must be allowed without AllowPrivateNetworkTarget")
 }
 
 // TestValidateEndpoint_UnknownScheme covers the default (non-https/http) branch.
 func TestValidateEndpoint_UnknownScheme(t *testing.T) {
-	err := validateEndpoint("ftp://example.com/evidence", false)
+	err := validateEndpoint("ftp://example.com/evidence", false, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must use https")
 }
@@ -275,7 +275,7 @@ func TestMulti_AllFailing(t *testing.T) {
 // validateEndpoint (previously unreached — every existing test used a
 // syntactically valid URL, so only the well-formed path was exercised).
 func TestValidateEndpoint_MalformedURL(t *testing.T) {
-	err := validateEndpoint("http://[::1", false)
+	err := validateEndpoint("http://[::1", false, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid endpoint")
 }

--- a/internal/evidencesink/evidencesink_s25_test.go
+++ b/internal/evidencesink/evidencesink_s25_test.go
@@ -115,23 +115,34 @@ func TestNewWebhook_InsecureSkipVerify(t *testing.T) {
 // validateEndpoint — http + AllowPrivateNetworkTarget with non-loopback host.
 // ---------------------------------------------------------------------------
 
-// TestValidateEndpoint_HTTPAllowPrivateNetworkNonLoopback covers the branch where
-// scheme=="http", allowPrivateNetwork==true but host is not loopback — previously
-// the AllowPrivateNetworkTarget test only used a non-loopback domain with http.
-// Here we verify the SSRF check is truly bypassed (no refuseDisallowedHost call).
-func TestValidateEndpoint_HTTPAllowPrivateNetworkNonLoopback(t *testing.T) {
-	// A private RFC-1918 address; without AllowPrivateNetworkTarget this would be
-	// refused — with it the check is skipped.
-	err := validateEndpoint("http://10.0.0.50/evidence", true)
-	assert.NoError(t, err, "http to private IP must be allowed when AllowPrivateNetworkTarget is true")
+// TestValidateEndpoint_HTTPAllowPrivateNetworkAloneStillRejectsHTTP is the
+// flag-conflation regression test: allowPrivateNetwork alone (allowInsecureTransport
+// false) must NOT also permit cleartext http to a non-loopback host — that
+// single-bool coupling was a real bug (previously named
+// TestValidateEndpoint_HTTPAllowPrivateNetworkNonLoopback, whose original
+// assertion of NoError encoded the bug rather than testing for it).
+func TestValidateEndpoint_HTTPAllowPrivateNetworkAloneStillRejectsHTTP(t *testing.T) {
+	err := validateEndpoint("http://10.0.0.50/evidence", true, false)
+	assert.Error(t, err, "allowPrivateNetwork alone must not also permit cleartext http")
+	assert.Contains(t, err.Error(), "https")
+}
+
+// TestValidateEndpoint_HTTPAllowPrivateNetworkAndInsecureTransportTogether
+// proves the corrected, split behaviour: reaching a private IP over cleartext
+// http now requires BOTH independent opt-ins.
+func TestValidateEndpoint_HTTPAllowPrivateNetworkAndInsecureTransportTogether(t *testing.T) {
+	err := validateEndpoint("http://10.0.0.50/evidence", true, true)
+	assert.NoError(t, err, "http to a private IP must be allowed when BOTH allowPrivateNetwork and allowInsecureTransport are true")
 }
 
 // TestValidateEndpoint_HTTPSAllowPrivateNetworkSkipsHostCheck verifies that
-// AllowPrivateNetworkTarget also skips the refuseDisallowedHost call for https.
+// AllowPrivateNetworkTarget also skips the refuseDisallowedHost call for https
+// (allowInsecureTransport is irrelevant here -- https already satisfies the
+// scheme check on its own).
 func TestValidateEndpoint_HTTPSAllowPrivateNetworkSkipsHostCheck(t *testing.T) {
 	// 169.254.169.254 is the AWS metadata link-local address that is normally
 	// refused by refuseDisallowedHost even for https.
-	err := validateEndpoint("https://169.254.169.254/latest/meta-data", true)
+	err := validateEndpoint("https://169.254.169.254/latest/meta-data", true, false)
 	assert.NoError(t, err, "AllowPrivateNetworkTarget must bypass the host check even for https")
 }
 

--- a/internal/evidencesink/webhook.go
+++ b/internal/evidencesink/webhook.go
@@ -36,6 +36,12 @@ type WebhookConfig struct {
 	// SEPARATE decision from InsecureSkipVerify (#130); see notifychan's
 	// WebhookConfig.AllowPrivateNetworkTarget for the rationale.
 	AllowPrivateNetworkTarget bool
+	// AllowInsecureTransport permits a plaintext (http://) endpoint to a
+	// non-loopback host — a SEPARATE decision from AllowPrivateNetworkTarget
+	// (see validateEndpoint's doc comment below for the conflation this used
+	// to be and why it's split now). False by default: Endpoint must be
+	// https unless it targets loopback.
+	AllowInsecureTransport bool
 }
 
 // Webhook POSTs the evidence pack JSON to an HTTP endpoint. Delivery is synchronous
@@ -62,7 +68,7 @@ func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*Webhook, error) 
 	// webhook, this path previously sent the bearer token + the FULL compliance evidence
 	// pack to whatever URL was configured — an http:// endpoint shipped both in cleartext
 	// on every POST, and refuseRedirect only guards bounces, not the initial request.
-	if err := validateEndpoint(cfg.Endpoint, cfg.AllowPrivateNetworkTarget); err != nil {
+	if err := validateEndpoint(cfg.Endpoint, cfg.AllowPrivateNetworkTarget, cfg.AllowInsecureTransport); err != nil {
 		return nil, err
 	}
 	transport := &http.Transport{}
@@ -95,14 +101,19 @@ func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*Webhook, error) 
 
 // validateEndpoint rejects a non-https evidence endpoint (which would send the bearer
 // token and the full compliance pack in cleartext), allowing http only for a loopback
-// target or the explicit allowPrivateNetwork opt-in. It also refuses a destination
+// target or the explicit allowInsecureTransport opt-in. It also refuses a destination
 // whose hostname RESOLVES to a private/link-local IP unless allowPrivateNetwork is
 // set (SSRF/exfil hardening: an evidence pack must not be POSTed to cloud metadata or
 // an internal host).
 //
-// allowPrivateNetwork is INTENTIONALLY separate from TLS-certificate verification
-// (#130) — see notifychan's identically-named parameter for the rationale.
-func validateEndpoint(raw string, allowPrivateNetwork bool) error {
+// allowPrivateNetwork and allowInsecureTransport are TWO INDEPENDENT knobs (#130,
+// plus a later fix closing a real conflation this file had until then) — see
+// notifychan's identically-named parameters for the full rationale. Before the
+// split, a single allowPrivateNetwork bool gated BOTH the private/link-local-host
+// check AND the https-required check, so opting in to reach a legitimate on-prem
+// receiver at a private address also silently unlocked cleartext HTTP to any
+// PUBLIC host. allowInsecureTransport defaults to false (deny).
+func validateEndpoint(raw string, allowPrivateNetwork, allowInsecureTransport bool) error {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("evidencesink: invalid endpoint %q: %w", raw, err)
@@ -111,8 +122,8 @@ func validateEndpoint(raw string, allowPrivateNetwork bool) error {
 	case "https":
 		// scheme OK; fall through to the destination-IP check
 	case "http":
-		if !allowPrivateNetwork && !isLoopbackHost(u.Hostname()) {
-			return fmt.Errorf("evidencesink: endpoint %q must use https (set allow_private_network_target only for a trusted internal or loopback target)", raw)
+		if !allowInsecureTransport && !isLoopbackHost(u.Hostname()) {
+			return fmt.Errorf("evidencesink: endpoint %q must use https (set allow_insecure_transport only for a trusted internal or loopback target)", raw)
 		}
 	default:
 		return fmt.Errorf("evidencesink: endpoint %q must use https", raw)

--- a/internal/evidencesink/webhook_test.go
+++ b/internal/evidencesink/webhook_test.go
@@ -39,11 +39,14 @@ func TestWebhook_RejectsInsecureEndpoints(t *testing.T) {
 
 	// #130: InsecureSkipVerify (a TLS-certificate-trust decision) must NOT also
 	// bypass the https/SSRF guard — that coupling was the bug. Only the dedicated
-	// AllowPrivateNetworkTarget opt-in does.
+	// AllowInsecureTransport opt-in does (AllowPrivateNetworkTarget governs a
+	// SEPARATE decision and, since a later fix, no longer also implies this one).
 	_, err = NewWebhook(WebhookConfig{Endpoint: "http://collector.example.com/evidence", InsecureSkipVerify: true})
 	require.Error(t, err, "InsecureSkipVerify alone must not bypass the https requirement")
 	_, err = NewWebhook(WebhookConfig{Endpoint: "http://collector.example.com/evidence", AllowPrivateNetworkTarget: true})
-	require.NoError(t, err, "AllowPrivateNetworkTarget is the dedicated opt-in for a non-https/internal target")
+	require.Error(t, err, "AllowPrivateNetworkTarget alone must NOT also bypass the https requirement -- that conflation was a real bug, fixed by splitting the two decisions")
+	_, err = NewWebhook(WebhookConfig{Endpoint: "http://collector.example.com/evidence", AllowInsecureTransport: true})
+	require.NoError(t, err, "AllowInsecureTransport is the dedicated opt-in for a non-https target")
 }
 
 func TestWebhook_PostsEvidenceWithAuth(t *testing.T) {

--- a/internal/netutil/dialer.go
+++ b/internal/netutil/dialer.go
@@ -87,11 +87,43 @@ func (d Dialer) DialContext(ctx context.Context, network, addr string) (net.Conn
 		dial = (&net.Dialer{}).DialContext
 	}
 
+	chosen, err := d.resolveValidated(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	// Dial the validated IP literal explicitly, not the hostname: this is the
+	// step that actually closes the DNS-rebinding gap, since net.Dial on a
+	// literal IP performs no further name resolution.
+	pinnedAddr := net.JoinHostPort(chosen.String(), port)
+	return dial(ctx, network, pinnedAddr)
+}
+
+// ValidateHost resolves (or, for a literal IP, parses) host and confirms
+// every candidate address passes Disallow — the same check DialContext
+// performs before dialing — WITHOUT dialing anything. For a caller that must
+// pre-validate a hostname discovered through a channel other than
+// DialContext itself: e.g. a mongodb+srv:// URI's SRV-resolved target hosts,
+// which the MongoDB Go driver resolves internally, before any caller-supplied
+// dial hook is ever invoked (see internal/netutil/egress.go's
+// Guard.ValidateSRVTargets, which uses this method).
+func (d Dialer) ValidateHost(ctx context.Context, host string) error {
+	_, err := d.resolveValidated(ctx, host)
+	return err
+}
+
+// resolveValidated implements the shared resolve-then-validate logic behind
+// both DialContext and ValidateHost: a literal IP is validated directly;
+// otherwise host is resolved and EVERY candidate address is validated before
+// any is returned — a hostname that resolves to a mix of public and private
+// addresses must not be allowed through just because one answer happened to
+// be checked first. Returns the first validated address.
+func (d Dialer) resolveValidated(ctx context.Context, host string) (net.IP, error) {
 	if ip := net.ParseIP(host); ip != nil {
 		if d.disallow(ip) {
 			return nil, fmt.Errorf("netutil: refusing to dial disallowed address %s", ip)
 		}
-		return dial(ctx, network, addr)
+		return ip, nil
 	}
 
 	resolve := d.Resolve
@@ -106,9 +138,6 @@ func (d Dialer) DialContext(ctx context.Context, network, addr string) (net.Conn
 		return nil, fmt.Errorf("netutil: host %q did not resolve to any address", host)
 	}
 
-	// Validate every resolved address before dialing any of them — a hostname
-	// that resolves to a mix of public and private addresses must not be
-	// allowed through just because one answer happened to be checked first.
 	var chosen net.IP
 	for _, a := range addrs {
 		if d.disallow(a.IP) {
@@ -118,12 +147,7 @@ func (d Dialer) DialContext(ctx context.Context, network, addr string) (net.Conn
 			chosen = a.IP
 		}
 	}
-
-	// Dial the validated IP literal explicitly, not the hostname: this is the
-	// step that actually closes the DNS-rebinding gap, since net.Dial on a
-	// literal IP performs no further name resolution.
-	pinnedAddr := net.JoinHostPort(chosen.String(), port)
-	return dial(ctx, network, pinnedAddr)
+	return chosen, nil
 }
 
 // DialContextTCP adapts DialContext to the func(ctx, addr) (net.Conn, error)

--- a/internal/netutil/dialer_test.go
+++ b/internal/netutil/dialer_test.go
@@ -230,6 +230,48 @@ func TestDefaultResolver_ResolvesLoopback(t *testing.T) {
 	assert.True(t, found, "localhost must resolve to a loopback address, got %v", addrs)
 }
 
+func TestDialer_ValidateHost_LiteralIPAllowed(t *testing.T) {
+	d := Dialer{Disallow: IsPrivateOrLinkLocal}
+	require.NoError(t, d.ValidateHost(context.Background(), "93.184.216.34"))
+}
+
+func TestDialer_ValidateHost_LiteralIPRefused(t *testing.T) {
+	d := Dialer{Disallow: IsPrivateOrLinkLocal}
+	err := d.ValidateHost(context.Background(), "169.254.169.254")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disallowed address")
+}
+
+func TestDialer_ValidateHost_ResolvesAndValidatesEveryAddress(t *testing.T) {
+	d := Dialer{
+		Disallow: IsPrivateOrLinkLocal,
+		Resolve: func(_ context.Context, host string) ([]net.IPAddr, error) {
+			require.Equal(t, "srv-target.example.net", host)
+			return []net.IPAddr{
+				{IP: net.ParseIP("203.0.113.10")},
+				{IP: net.ParseIP("10.0.0.5")},
+			}, nil
+		},
+	}
+	err := d.ValidateHost(context.Background(), "srv-target.example.net")
+	require.Error(t, err, "a mix of public and private addresses must refuse the whole host")
+	assert.Contains(t, err.Error(), "disallowed address")
+}
+
+func TestDialer_ValidateHost_DoesNotDial(t *testing.T) {
+	d := Dialer{
+		Disallow: IsPrivateOrLinkLocal,
+		Resolve: func(_ context.Context, _ string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("203.0.113.10")}}, nil
+		},
+		Dial: func(_ context.Context, _, addr string) (net.Conn, error) {
+			t.Fatalf("ValidateHost must never dial, got addr %q", addr)
+			return nil, nil
+		},
+	}
+	require.NoError(t, d.ValidateHost(context.Background(), "safe.example"))
+}
+
 func TestIsPrivateOrLinkLocal(t *testing.T) {
 	disallowed := []string{
 		"10.1.2.3", "172.16.0.1", "192.168.1.1", "127.0.0.1",

--- a/internal/netutil/egress.go
+++ b/internal/netutil/egress.go
@@ -1,0 +1,179 @@
+package netutil
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Guard is the single outbound-egress control point every backend that opens
+// a connection to an operator-configured or secret-ref-derived address is
+// expected to route through, rather than hand-rolling its own dial/http-
+// client construction. Before this existed, that exact recipe (dial-time IP
+// re-validation + TLS-by-default-with-a-logged-exception) was independently
+// duplicated at every such call site (internal/dynamic/postgres.go,
+// internal/dynamic/mysql.go, internal/notifychan's secure_transport.go,
+// internal/evidencesink's webhook.go), while MongoDB, Redis, and the SIEM/
+// audit forwarder had NO such guard at all. Guard wraps Dialer (the dial-
+// time IP re-validation primitive, unchanged) with the transport- and
+// scheme-level policy nearly every such backend also needs.
+type Guard struct {
+	// Dial is applied to every outbound connection this Guard makes. Its own
+	// Disallow/Resolve fields carry the actual SSRF policy; the zero value
+	// (nil Disallow) permits every address — the explicit "allow private
+	// network target" opt-out, mirrored by leaving Dial unset entirely at
+	// call sites that follow the existing postgres.go/mysql.go convention of
+	// only wiring a Dialer when the opt-out is NOT set.
+	Dial Dialer
+	// AllowInsecureTransport permits a plaintext (non-TLS) connection when
+	// true. False (the default) refuses one outright via RequireTLS. Every
+	// construction site that sets this true logs the exception (2d) — see
+	// RequireTLS.
+	AllowInsecureTransport bool
+}
+
+// RequireTLS enforces this Guard's TLS policy: tlsSatisfied must be true
+// unless AllowInsecureTransport is set, in which case the plaintext
+// connection is permitted but logged — an explicit, audited exception, never
+// a silent fallback. context/target identify what connected without TLS
+// (e.g. "mongodb admin_dsn", "cluster0.example.net"), so an operator can find
+// and reconsider every insecure connection actually made, not just learn one
+// exists somewhere.
+func (g Guard) RequireTLS(tlsSatisfied bool, context, target string) error {
+	if tlsSatisfied {
+		return nil
+	}
+	if !g.AllowInsecureTransport {
+		return fmt.Errorf("netutil: %s %q must use TLS (set allow_insecure_transport to permit a plaintext connection)", context, target)
+	}
+	log.Printf("WARNING: %s %q is using a plaintext (non-TLS) connection; allow_insecure_transport is explicitly enabled", context, target)
+	return nil
+}
+
+// RefuseScheme rejects addr's scheme when it equals disallowed — e.g. a
+// Redis "unix" scheme pointing at a local domain-socket path, which carries
+// no IP address for Dial to validate at all: a local-filesystem access
+// vector, a different threat model than the network-egress SSRF guard this
+// Guard exists to enforce, not something Dial (or any IP-based check) can
+// meaningfully evaluate.
+func RefuseScheme(scheme, disallowed, context string) error {
+	if scheme == disallowed {
+		return fmt.Errorf("netutil: %s scheme %q is refused: it names a local resource with no network "+
+			"address for the egress guard to validate — a different threat model (local filesystem access) "+
+			"than the network-SSRF guard this connector enforces", context, scheme)
+	}
+	return nil
+}
+
+// HTTPClient builds an *http.Client whose Transport dials exclusively
+// through g.Dial, so every request this client makes — including a
+// same-host redirect target checkRedirect allows through — gets the
+// identical dial-time IP re-validation. Suitable for the SIEM/audit
+// forwarder and any future outbound webhook-style client built on Guard.
+func (g Guard) HTTPClient(timeout time.Duration, tlsConfig *tls.Config, checkRedirect func(*http.Request, []*http.Request) error) *http.Client {
+	return &http.Client{
+		Timeout:       timeout,
+		CheckRedirect: checkRedirect,
+		Transport: &http.Transport{
+			DialContext:     g.Dial.DialContext,
+			TLSClientConfig: tlsConfig,
+		},
+	}
+}
+
+// RedisDialer adapts g.Dial to go-redis's Options.Dialer shape
+// (func(ctx, network, addr) (net.Conn, error)). go-redis's own default
+// dialer (NewDialer, in redis/go-redis's options.go) layers TLS itself atop
+// the raw dial, but ONLY when Options.Dialer is left unset — setting a
+// custom Dialer (required here to get the dial-time IP re-validation every
+// other Guard-wired backend gets) takes over that responsibility entirely:
+// without replicating the TLS layering here, every rediss:// admin DSN would
+// silently downgrade to plaintext underneath a caller that configured TLS
+// and has no way to notice it was dropped (confirmed by reading redis.go:
+// the client calls nothing but c.opt.Dialer(ctx, network, addr) — there is
+// no second, independent TLS step elsewhere in the library to fall back on).
+//
+// ServerName is derived from the ORIGINAL dial hostname (the addr this func
+// receives), never the pinned IP g.Dial actually connects to underneath, so
+// certificate verification still checks the real target name — the same
+// hostname-for-TLS/IP-for-TCP split pgx and go-sql-driver/mysql already rely
+// on for Postgres/MySQL (their own DialFunc only ever controls the raw TCP
+// dial; each driver's TLS layer verifies against the original hostname
+// independently).
+func (g Guard) RedisDialer(tlsConfig *tls.Config) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := g.Dial.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		if tlsConfig == nil {
+			return conn, nil
+		}
+		cfg := tlsConfig
+		if cfg.ServerName == "" {
+			if host, _, splitErr := net.SplitHostPort(addr); splitErr == nil && net.ParseIP(host) == nil {
+				cloned := cfg.Clone()
+				cloned.ServerName = host
+				cfg = cloned
+			}
+		}
+		tlsConn := tls.Client(conn, cfg)
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("netutil: TLS handshake with %q: %w", addr, err)
+		}
+		return tlsConn, nil
+	}
+}
+
+// srvLookup is net.DefaultResolver.LookupSRV's shape — a package-level var
+// (not a Guard field) so it's overridable independently of any one Guard
+// value, mirroring how internal/dynamic's dialResolve var lets tests
+// substitute a fake DNS answer without a real query.
+var srvLookup = net.DefaultResolver.LookupSRV
+
+// ValidateSRVTargets pre-resolves the SRV record for name (service/proto,
+// e.g. "mongodb"/"tcp") and validates every discovered target hostname
+// against g.Dial's own resolve-and-validate policy (Dialer.ValidateHost) —
+// closing a gap a bare TCP dial hook cannot see on its own.
+//
+// The MongoDB Go driver performs this exact SRV lookup internally, for a
+// mongodb+srv:// URI, deep inside options.Client().ApplyURI — before any
+// caller-supplied Dialer is ever invoked. Confirmed by reading the driver
+// source (go.mongodb.org/mongo-driver@v1.17.9): connstring.Parse's parser
+// hardcodes dnsResolver to dns.DefaultResolver (x/mongo/driver/connstring/
+// connstring.go:100), with no exported hook to override it, so a caller has
+// no visibility into, or control over, which hostnames that internal step
+// discovers. The actual per-server TCP dial for every server the driver ever
+// connects to — SRV-discovered or not — DOES still funnel through whatever
+// Dialer IS configured (x/mongo/driver/topology/connection.go:
+// c.config.dialer.DialContext(dialCtx, c.addr.Network(), c.addr.String()),
+// wired unconditionally from ClientOptions.Dialer regardless of discovery
+// mode per x/mongo/driver/topology/topology_options.go), so g.Dial's own
+// dial-time re-validation remains the authoritative, DNS-rebinding-safe
+// check either way. This pre-check is defense-in-depth that turns a
+// deep, less legible dial-time rejection (surfacing from inside the
+// driver's connection pool, on whichever server it happens to try first)
+// into one clear, fail-fast error before the URI is ever handed to the
+// driver at all.
+func (g Guard) ValidateSRVTargets(ctx context.Context, service, proto, name string) error {
+	_, srvs, err := srvLookup(ctx, service, proto, name)
+	if err != nil {
+		return fmt.Errorf("netutil: resolve SRV record for %q: %w", name, err)
+	}
+	if len(srvs) == 0 {
+		return fmt.Errorf("netutil: SRV record for %q returned no targets", name)
+	}
+	for _, srv := range srvs {
+		target := strings.TrimSuffix(srv.Target, ".")
+		if err := g.Dial.ValidateHost(ctx, target); err != nil {
+			return fmt.Errorf("netutil: SRV target %q for %q: %w", target, name, err)
+		}
+	}
+	return nil
+}

--- a/internal/netutil/egress_test.go
+++ b/internal/netutil/egress_test.go
@@ -1,0 +1,292 @@
+package netutil
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ──────────────────────────── Guard.RequireTLS ─────────────────────────────
+
+func TestGuard_RequireTLS_SatisfiedNoop(t *testing.T) {
+	g := Guard{}
+	require.NoError(t, g.RequireTLS(true, "test target", "example.net"))
+}
+
+func TestGuard_RequireTLS_UnsatisfiedRefusedByDefault(t *testing.T) {
+	g := Guard{}
+	err := g.RequireTLS(false, "test target", "example.net")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must use TLS")
+	assert.Contains(t, err.Error(), "example.net")
+}
+
+func TestGuard_RequireTLS_UnsatisfiedAllowedWithOptOut(t *testing.T) {
+	g := Guard{AllowInsecureTransport: true}
+	require.NoError(t, g.RequireTLS(false, "test target", "example.net"), "the explicit opt-out must permit the plaintext connection")
+}
+
+// ──────────────────────────── RefuseScheme ─────────────────────────────────
+
+func TestRefuseScheme_MatchingSchemeRefused(t *testing.T) {
+	err := RefuseScheme("unix", "unix", "redis admin_dsn")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unix")
+}
+
+func TestRefuseScheme_DifferentSchemeAllowed(t *testing.T) {
+	require.NoError(t, RefuseScheme("tcp", "unix", "redis admin_dsn"))
+}
+
+// ──────────────────────────── Guard.HTTPClient ─────────────────────────────
+
+func TestGuard_HTTPClient_WiresDialContext(t *testing.T) {
+	var dialed string
+	g := Guard{
+		Dial: Dialer{
+			Dial: func(_ context.Context, _, addr string) (net.Conn, error) {
+				dialed = addr
+				return &fakeConn{}, nil
+			},
+		},
+	}
+	client := g.HTTPClient(5*time.Second, nil, nil)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.DialContext)
+	_, err := transport.DialContext(context.Background(), "tcp", "203.0.113.10:443")
+	require.NoError(t, err)
+	assert.Equal(t, "203.0.113.10:443", dialed)
+}
+
+// ──────────────────────────── Guard.RedisDialer ────────────────────────────
+
+func TestGuard_RedisDialer_NoTLS_ReturnsRawConn(t *testing.T) {
+	g := Guard{
+		Dial: Dialer{
+			Dial: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return &fakeConn{}, nil
+			},
+		},
+	}
+	dialer := g.RedisDialer(nil)
+	conn, err := dialer(context.Background(), "tcp", "203.0.113.10:6379")
+	require.NoError(t, err)
+	_, isTLS := conn.(*tls.Conn)
+	assert.False(t, isTLS, "no tlsConfig means the raw conn must be returned unwrapped")
+}
+
+func TestGuard_RedisDialer_DialErrorPropagates(t *testing.T) {
+	wantErr := errors.New("dial refused")
+	g := Guard{
+		Dial: Dialer{
+			Dial: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return nil, wantErr
+			},
+		},
+	}
+	dialer := g.RedisDialer(&tls.Config{})
+	_, err := dialer(context.Background(), "tcp", "203.0.113.10:6379")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestGuard_RedisDialer_TLSHandshakeFailurePropagates(t *testing.T) {
+	// A real (non-TLS-speaking) local listener stands in for a server whose
+	// TLS handshake fails immediately (it never sends a ServerHello), so
+	// HandshakeContext returns an error rather than hanging.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	go func() {
+		conn, aerr := ln.Accept()
+		if aerr == nil {
+			// Close immediately without speaking TLS -- the client's
+			// handshake will fail with an EOF/reset rather than hang.
+			_ = conn.Close()
+		}
+	}()
+
+	g := Guard{Dial: Dialer{}}
+	dialer := g.RedisDialer(&tls.Config{})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err = dialer(ctx, "tcp", ln.Addr().String())
+	require.Error(t, err, "a failed TLS handshake over a real (non-TLS) conn must surface as an error, not hang or silently downgrade")
+	assert.Contains(t, err.Error(), "TLS handshake")
+}
+
+// TestGuard_RedisDialer_ServerNameDefaultsToOriginalHostname proves
+// RedisDialer's ServerName-derivation logic against a REAL TLS handshake
+// (not just that no panic occurs): the server's GetConfigForClient callback
+// observes the SNI the client actually sent, then deliberately aborts the
+// handshake (returning an error) so the test needs no real/self-signed
+// certificate at all. The underlying (fake) Dial simulates what Dialer's own
+// pinning does in production — it connects somewhere that is NOT the
+// original hostname — so this proves RedisDialer derives ServerName from the
+// addr IT was called with (the original hostname:port), never from whatever
+// the inner Dial actually connected to.
+func TestGuard_RedisDialer_ServerNameDefaultsToOriginalHostname(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	var gotServerName string
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		defer conn.Close()
+		tlsConn := tls.Server(conn, &tls.Config{
+			GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+				gotServerName = hello.ServerName
+				return nil, errors.New("deliberately abort handshake after capturing SNI")
+			},
+		})
+		_ = tlsConn.Handshake() // expected to fail — that's fine, we only need the SNI
+	}()
+
+	g := Guard{Dial: Dialer{
+		// A fake Resolve avoids a REAL (and, for a non-resolving name like
+		// "db.example.net", potentially very slow or hanging) DNS lookup —
+		// this test only cares what ServerName RedisDialer derives from
+		// addr's hostname, not about actually resolving it.
+		Resolve: func(_ context.Context, _ string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, nil
+		},
+		Dial: func(_ context.Context, network, _ string) (net.Conn, error) {
+			// Simulate Dialer's own pinned-IP dial: connect to the real
+			// listener regardless of what addr RedisDialer was told to dial.
+			return net.Dial(network, ln.Addr().String())
+		},
+	}}
+	dialer := g.RedisDialer(&tls.Config{InsecureSkipVerify: true})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, _ = dialer(ctx, "tcp", "db.example.net:6380") // expected to fail post-handshake-abort
+	<-serverDone
+	assert.Equal(t, "db.example.net", gotServerName, "ServerName must be the ORIGINAL hostname, not a pinned IP")
+}
+
+// TestGuard_RedisDialer_ServerNameNotOverriddenWhenAlreadySet proves the
+// caller's own explicit ServerName wins over the derived-from-addr default.
+func TestGuard_RedisDialer_ServerNameNotOverriddenWhenAlreadySet(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	var gotServerName string
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		defer conn.Close()
+		tlsConn := tls.Server(conn, &tls.Config{
+			GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+				gotServerName = hello.ServerName
+				return nil, errors.New("deliberately abort handshake after capturing SNI")
+			},
+		})
+		_ = tlsConn.Handshake()
+	}()
+
+	g := Guard{Dial: Dialer{
+		// See TestGuard_RedisDialer_ServerNameDefaultsToOriginalHostname for
+		// why Resolve is faked rather than left to hit real DNS.
+		Resolve: func(_ context.Context, _ string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("127.0.0.1")}}, nil
+		},
+		Dial: func(_ context.Context, network, _ string) (net.Conn, error) {
+			return net.Dial(network, ln.Addr().String())
+		},
+	}}
+	dialer := g.RedisDialer(&tls.Config{ServerName: "explicit.example.net", InsecureSkipVerify: true})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, _ = dialer(ctx, "tcp", "db.example.net:6380")
+	<-serverDone
+	assert.Equal(t, "explicit.example.net", gotServerName)
+}
+
+// ──────────────────────────── Guard.ValidateSRVTargets ─────────────────────
+
+func TestGuard_ValidateSRVTargets_AllTargetsValid(t *testing.T) {
+	origLookup := srvLookup
+	defer func() { srvLookup = origLookup }()
+	srvLookup = func(_ context.Context, service, proto, name string) (string, []*net.SRV, error) {
+		assert.Equal(t, "mongodb", service)
+		assert.Equal(t, "tcp", proto)
+		assert.Equal(t, "cluster0.example.net", name)
+		return "", []*net.SRV{
+			{Target: "shard00-00.cluster0.example.net.", Port: 27017},
+			{Target: "shard00-01.cluster0.example.net.", Port: 27017},
+		}, nil
+	}
+	g := Guard{Dial: Dialer{
+		Disallow: IsPrivateOrLinkLocal,
+		Resolve: func(_ context.Context, host string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("203.0.113.10")}}, nil
+		},
+	}}
+	require.NoError(t, g.ValidateSRVTargets(context.Background(), "mongodb", "tcp", "cluster0.example.net"))
+}
+
+func TestGuard_ValidateSRVTargets_OneDisallowedTargetRefusesAll(t *testing.T) {
+	origLookup := srvLookup
+	defer func() { srvLookup = origLookup }()
+	srvLookup = func(_ context.Context, _, _, _ string) (string, []*net.SRV, error) {
+		return "", []*net.SRV{
+			{Target: "shard00-00.cluster0.example.net.", Port: 27017},
+			{Target: "shard00-01.cluster0.example.net.", Port: 27017},
+		}, nil
+	}
+	g := Guard{Dial: Dialer{
+		Disallow: IsPrivateOrLinkLocal,
+		Resolve: func(_ context.Context, host string) ([]net.IPAddr, error) {
+			if host == "shard00-01.cluster0.example.net" {
+				return []net.IPAddr{{IP: net.ParseIP("169.254.169.254")}}, nil
+			}
+			return []net.IPAddr{{IP: net.ParseIP("203.0.113.10")}}, nil
+		},
+	}}
+	err := g.ValidateSRVTargets(context.Background(), "mongodb", "tcp", "cluster0.example.net")
+	require.Error(t, err, "a DNS-rebinding-safe SRV pre-check must refuse the whole lookup if ANY target is disallowed")
+	assert.Contains(t, err.Error(), "shard00-01.cluster0.example.net")
+}
+
+func TestGuard_ValidateSRVTargets_LookupErrorPropagates(t *testing.T) {
+	origLookup := srvLookup
+	defer func() { srvLookup = origLookup }()
+	srvLookup = func(_ context.Context, _, _, _ string) (string, []*net.SRV, error) {
+		return "", nil, errors.New("no such SRV record")
+	}
+	g := Guard{Dial: Dialer{Disallow: IsPrivateOrLinkLocal}}
+	err := g.ValidateSRVTargets(context.Background(), "mongodb", "tcp", "cluster0.example.net")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no such SRV record")
+}
+
+func TestGuard_ValidateSRVTargets_EmptyResultRefused(t *testing.T) {
+	origLookup := srvLookup
+	defer func() { srvLookup = origLookup }()
+	srvLookup = func(_ context.Context, _, _, _ string) (string, []*net.SRV, error) {
+		return "", nil, nil
+	}
+	g := Guard{Dial: Dialer{Disallow: IsPrivateOrLinkLocal}}
+	err := g.ValidateSRVTargets(context.Background(), "mongodb", "tcp", "cluster0.example.net")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no targets")
+}

--- a/internal/netutil/egress_test.go
+++ b/internal/netutil/egress_test.go
@@ -104,7 +104,7 @@ func TestGuard_RedisDialer_TLSHandshakeFailurePropagates(t *testing.T) {
 	// HandshakeContext returns an error rather than hanging.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 	go func() {
 		conn, aerr := ln.Accept()
 		if aerr == nil {
@@ -136,7 +136,7 @@ func TestGuard_RedisDialer_TLSHandshakeFailurePropagates(t *testing.T) {
 func TestGuard_RedisDialer_ServerNameDefaultsToOriginalHostname(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	var gotServerName string
 	serverDone := make(chan struct{})
@@ -146,7 +146,7 @@ func TestGuard_RedisDialer_ServerNameDefaultsToOriginalHostname(t *testing.T) {
 		if aerr != nil {
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		tlsConn := tls.Server(conn, &tls.Config{
 			GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
 				gotServerName = hello.ServerName
@@ -183,7 +183,7 @@ func TestGuard_RedisDialer_ServerNameDefaultsToOriginalHostname(t *testing.T) {
 func TestGuard_RedisDialer_ServerNameNotOverriddenWhenAlreadySet(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	var gotServerName string
 	serverDone := make(chan struct{})
@@ -193,7 +193,7 @@ func TestGuard_RedisDialer_ServerNameNotOverriddenWhenAlreadySet(t *testing.T) {
 		if aerr != nil {
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		tlsConn := tls.Server(conn, &tls.Config{
 			GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
 				gotServerName = hello.ServerName

--- a/internal/notifychan/chat.go
+++ b/internal/notifychan/chat.go
@@ -62,7 +62,7 @@ func newChat(cfg ChatConfig, baseBackoff time.Duration) (*ChatSink, error) {
 	if cfg.WebhookURL == "" {
 		return nil, fmt.Errorf("notifychan: chat webhook_url is required")
 	}
-	if err := validateEndpoint(cfg.WebhookURL, false); err != nil {
+	if err := validateEndpoint(cfg.WebhookURL, false, false); err != nil {
 		return nil, err
 	}
 	// G48: validateEndpoint above validates the webhook URL's host ONCE, at

--- a/internal/notifychan/notifychan_s17_test.go
+++ b/internal/notifychan/notifychan_s17_test.go
@@ -31,34 +31,50 @@ import (
 // ── secure_transport.go ───────────────────────────────────────────────────────
 
 func TestValidateEndpoint_RejectsNonHTTPSNonLoopback(t *testing.T) {
-	err := validateEndpoint("http://external.example.com/hook", false)
+	err := validateEndpoint("http://external.example.com/hook", false, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "https")
 }
 
 func TestValidateEndpoint_AllowsHTTPLoopback(t *testing.T) {
-	err := validateEndpoint("http://127.0.0.1:9000/hook", false)
+	err := validateEndpoint("http://127.0.0.1:9000/hook", false, false)
 	require.NoError(t, err)
 }
 
 func TestValidateEndpoint_AllowsHTTPLocalhostLoopback(t *testing.T) {
-	err := validateEndpoint("http://localhost:9000/hook", false)
+	err := validateEndpoint("http://localhost:9000/hook", false, false)
 	require.NoError(t, err)
 }
 
-func TestValidateEndpoint_AllowsHTTPWhenPrivateNetworkEnabled(t *testing.T) {
-	err := validateEndpoint("http://192.168.1.5/hook", true)
+// TestValidateEndpoint_PrivateNetworkAloneDoesNotAllowHTTP is the regression
+// test for the flag-conflation fix: allowPrivateNetwork alone must NOT also
+// unlock cleartext HTTP to a public (well, private, but not loopback) host —
+// that used to be true when a single bool gated both checks. Renamed from
+// TestValidateEndpoint_AllowsHTTPWhenPrivateNetworkEnabled, whose original
+// assertion (require.NoError) encoded exactly the bug this test now proves
+// fixed.
+func TestValidateEndpoint_PrivateNetworkAloneDoesNotAllowHTTP(t *testing.T) {
+	err := validateEndpoint("http://192.168.1.5/hook", true, false)
+	require.Error(t, err, "allowPrivateNetwork must not, by itself, also permit cleartext HTTP")
+	assert.Contains(t, err.Error(), "https")
+}
+
+// TestValidateEndpoint_AllowsHTTPWhenInsecureTransportEnabled is the
+// corrected replacement: reaching a private, cleartext-HTTP target now
+// requires BOTH independent opt-outs, not one bool doing double duty.
+func TestValidateEndpoint_AllowsHTTPWhenInsecureTransportEnabled(t *testing.T) {
+	err := validateEndpoint("http://192.168.1.5/hook", true, true)
 	require.NoError(t, err)
 }
 
 func TestValidateEndpoint_RejectsUnknownScheme(t *testing.T) {
-	err := validateEndpoint("ftp://example.com/hook", false)
+	err := validateEndpoint("ftp://example.com/hook", false, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "https")
 }
 
 func TestValidateEndpoint_RejectsInvalidURL(t *testing.T) {
-	err := validateEndpoint(":not-a-url", false)
+	err := validateEndpoint(":not-a-url", false, false)
 	require.Error(t, err)
 }
 
@@ -69,7 +85,7 @@ func TestValidateEndpoint_AllowsHTTPS(t *testing.T) {
 	lookupIPAddr = func(host string) ([]net.IPAddr, error) {
 		return []net.IPAddr{{IP: net.ParseIP("203.0.113.1")}}, nil // TEST-NET-3 (public)
 	}
-	err := validateEndpoint("https://external.example.com/hook", false)
+	err := validateEndpoint("https://external.example.com/hook", false, false)
 	require.NoError(t, err)
 }
 
@@ -79,7 +95,7 @@ func TestValidateEndpoint_RejectsHostnameResolvingToPrivateIP(t *testing.T) {
 	lookupIPAddr = func(host string) ([]net.IPAddr, error) {
 		return []net.IPAddr{{IP: net.ParseIP("10.0.0.1")}}, nil
 	}
-	err := validateEndpoint("https://internal.corp.example/hook", false)
+	err := validateEndpoint("https://internal.corp.example/hook", false, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "private/link-local")
 }

--- a/internal/notifychan/secure_transport.go
+++ b/internal/notifychan/secure_transport.go
@@ -10,18 +10,23 @@ import (
 
 // validateEndpoint rejects a non-https notification endpoint — which would send the
 // bearer token and payload in cleartext — allowing http only for a loopback target
-// (local testing) or the explicit allowPrivateNetwork opt-in. It also refuses a
+// (local testing) or the explicit allowInsecureTransport opt-in. It also refuses a
 // destination whose hostname RESOLVES to a private/link-local IP (e.g. cloud metadata
 // 169.254.169.254 or an internal host) unless allowPrivateNetwork is set —
 // SSRF/exfil hardening.
 //
-// allowPrivateNetwork is INTENTIONALLY a separate knob from TLS-certificate
-// verification (#130): "I trust this endpoint's self-signed cert" and "this
-// endpoint is allowed to live on an internal network" are different trust
-// decisions — an operator with a self-signed public webhook receiver should not
-// have to also disable the SSRF guard, and vice versa for a legitimate on-prem
-// receiver with a real cert.
-func validateEndpoint(raw string, allowPrivateNetwork bool) error {
+// allowPrivateNetwork and allowInsecureTransport are TWO INDEPENDENT knobs, not
+// one (#130, plus a later fix closing a real conflation this file had until then):
+// "I trust this endpoint's self-signed cert" (InsecureSkipVerify), "this endpoint
+// is allowed to live on an internal network" (allowPrivateNetwork), and "this
+// endpoint may be reached over plain, unencrypted HTTP" (allowInsecureTransport)
+// are three different trust decisions. Before the split, a single
+// allowPrivateNetwork bool gated BOTH the private/link-local-host check AND the
+// https-required check — an operator opting in only to reach a legitimate
+// on-prem receiver at a private address ALSO silently unlocked cleartext HTTP to
+// any PUBLIC host, an unrelated and much broader exception nobody asked for.
+// allowInsecureTransport defaults to false (deny), same as allowPrivateNetwork.
+func validateEndpoint(raw string, allowPrivateNetwork, allowInsecureTransport bool) error {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("notifychan: invalid endpoint %q: %w", raw, err)
@@ -30,8 +35,8 @@ func validateEndpoint(raw string, allowPrivateNetwork bool) error {
 	case "https":
 		// scheme OK; fall through to the destination-IP check
 	case "http":
-		if !allowPrivateNetwork && !isLoopbackHost(u.Hostname()) {
-			return fmt.Errorf("notifychan: endpoint %q must use https (set allow_private_network_target only for a trusted internal or loopback target)", raw)
+		if !allowInsecureTransport && !isLoopbackHost(u.Hostname()) {
+			return fmt.Errorf("notifychan: endpoint %q must use https (set allow_insecure_transport only for a trusted internal or loopback target)", raw)
 		}
 	default:
 		return fmt.Errorf("notifychan: endpoint %q must use https", raw)

--- a/internal/notifychan/webhook.go
+++ b/internal/notifychan/webhook.go
@@ -46,6 +46,12 @@ type WebhookConfig struct {
 	// and a legitimate on-prem receiver with a real cert still needs this to reach
 	// its private address.
 	AllowPrivateNetworkTarget bool
+	// AllowInsecureTransport permits a plaintext (http://) endpoint to a
+	// non-loopback host — a SEPARATE decision from AllowPrivateNetworkTarget
+	// (see validateEndpoint's doc comment for the conflation this used to be
+	// and why it's split now). False by default: Endpoint must be https
+	// unless it targets loopback.
+	AllowInsecureTransport bool
 	// SigningSecret, when set, signs each payload with HMAC-SHA256 so the receiver can
 	// verify it came from Keyorix: header X-Keyorix-Signature: sha256=<hex(hmac(body))>.
 	SigningSecret string
@@ -70,7 +76,7 @@ func newWebhook(cfg WebhookConfig, baseBackoff time.Duration) (*WebhookSink, err
 	if cfg.Endpoint == "" {
 		return nil, fmt.Errorf("notifychan: webhook endpoint is required")
 	}
-	if err := validateEndpoint(cfg.Endpoint, cfg.AllowPrivateNetworkTarget); err != nil {
+	if err := validateEndpoint(cfg.Endpoint, cfg.AllowPrivateNetworkTarget, cfg.AllowInsecureTransport); err != nil {
 		return nil, err
 	}
 	transport := &http.Transport{}

--- a/internal/notifychan/webhook_test.go
+++ b/internal/notifychan/webhook_test.go
@@ -224,11 +224,25 @@ func TestNewWebhook_RejectsNonHTTPSEndpoint(t *testing.T) {
 
 	// #130: InsecureSkipVerify (a TLS-certificate-trust decision) must NOT also
 	// bypass the https/SSRF guard — that coupling was the bug. Only the dedicated
-	// AllowPrivateNetworkTarget opt-in does.
+	// AllowInsecureTransport opt-in does (AllowPrivateNetworkTarget governs a
+	// SEPARATE decision — whether a private/link-local resolved host is
+	// permitted — and, since a later fix, no longer also implies this one).
 	_, err = NewWebhook(WebhookConfig{Endpoint: "http://siem.example.com/hook", InsecureSkipVerify: true})
 	require.Error(t, err, "InsecureSkipVerify alone must not bypass the https requirement")
 	_, err = NewWebhook(WebhookConfig{Endpoint: "http://siem.example.com/hook", AllowPrivateNetworkTarget: true})
-	require.NoError(t, err, "AllowPrivateNetworkTarget is the dedicated opt-in for a non-https/internal target")
+	require.Error(t, err, "AllowPrivateNetworkTarget alone must NOT also bypass the https requirement -- that conflation was a real bug, fixed by splitting the two decisions")
+
+	// AllowInsecureTransport satisfies the scheme check, but the (separate,
+	// still-active) private-network host check now runs for real -- mock the
+	// resolver to a public IP so this test isolates the TLS/scheme axis alone,
+	// rather than depending on siem.example.com's real DNS resolvability.
+	origResolve := lookupIPAddr
+	defer func() { lookupIPAddr = origResolve }()
+	lookupIPAddr = func(_ string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("203.0.113.5")}}, nil // public TEST-NET-3
+	}
+	_, err = NewWebhook(WebhookConfig{Endpoint: "http://siem.example.com/hook", AllowInsecureTransport: true})
+	require.NoError(t, err, "AllowInsecureTransport is the dedicated opt-in for a non-https target")
 }
 
 // TestNewWebhook_InsecureSkipVerifyWarningRedactsEndpoint is #G30: the endpoint

--- a/server/main.go
+++ b/server/main.go
@@ -534,12 +534,14 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	// when disabled, so SetAuditForwarder(nil) keeps forwarding off.
 	if sc := cfg.Audit.SIEM; sc.Enabled {
 		forwarder, ferr := siem.New(siem.Config{
-			Enabled:            sc.Enabled,
-			Provider:           siem.Provider(sc.Provider),
-			Endpoint:           sc.Endpoint,
-			Token:              sc.GetToken(),
-			InsecureSkipVerify: sc.InsecureSkipVerify,
-			SpoolDir:           sc.SpoolDir,
+			Enabled:                   sc.Enabled,
+			Provider:                  siem.Provider(sc.Provider),
+			Endpoint:                  sc.Endpoint,
+			Token:                     sc.GetToken(),
+			InsecureSkipVerify:        sc.InsecureSkipVerify,
+			SpoolDir:                  sc.SpoolDir,
+			AllowPrivateNetworkTarget: sc.AllowPrivateNetworkTarget,
+			AllowInsecureTransport:    sc.AllowInsecureTransport,
 		})
 		if ferr != nil {
 			return nil, nil, fmt.Errorf("failed to init SIEM audit forwarder: %w", ferr)
@@ -571,6 +573,7 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			Token:                     wc.GetToken(),
 			InsecureSkipVerify:        wc.InsecureSkipVerify,
 			AllowPrivateNetworkTarget: wc.AllowPrivateNetworkTarget,
+			AllowInsecureTransport:    wc.AllowInsecureTransport,
 			SigningSecret:             wc.GetSigningSecret(),
 		})
 		if werr != nil {
@@ -824,6 +827,7 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 			Token:                     ew.GetToken(),
 			InsecureSkipVerify:        ew.InsecureSkipVerify,
 			AllowPrivateNetworkTarget: ew.AllowPrivateNetworkTarget,
+			AllowInsecureTransport:    ew.AllowInsecureTransport,
 		})
 		if ferr != nil {
 			return nil, nil, fmt.Errorf("failed to init evidence webhook target: %w", ferr)
@@ -881,6 +885,10 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 	// SSRF guard for admin DSNs: disabled (private targets allowed) only when the
 	// operator explicitly opts in via dynamic_secrets.allow_private_network_targets.
 	coreService.SetDynamicAllowPrivateTargets(cfg.DynamicSecrets.AllowPrivateNetworkTargets)
+	// TLS-required-by-default guard for the mongodb/redis backends: disabled
+	// (plaintext allowed) only when the operator explicitly opts in via
+	// dynamic_secrets.allow_insecure_transport.
+	coreService.SetDynamicAllowInsecureTransport(cfg.DynamicSecrets.AllowInsecureTransport)
 	// Install-wide hard ceiling on any dynamic-secret lease's TTL (#97); enforced on
 	// top of each config's own optional (default-unbounded) MaxTTLSeconds.
 	coreService.SetDynamicMaxLeaseTTL(cfg.DynamicSecrets.GetMaxLeaseTTL())


### PR DESCRIPTION
## Summary

Hardening was applied per-implementation instead of on a shared path: Postgres/MySQL dynamic-secret backends already used `internal/netutil.Dialer` (verified correct — resolves every candidate IP, validates each against a private/link-local denylist, then dials the literal validated IP, never re-resolving the hostname, closing DNS-rebinding TOCTOU). MongoDB, Redis, and the SIEM/audit forwarder had no equivalent protection at all.

- Extracted a shared `netutil.Guard` and wired MongoDB, Redis, and the SIEM forwarder through it.
- **`mongodb+srv://` SRV lookup**: the driver hardcodes its own DNS resolver with no override hook, so a caller-supplied dialer never sees SRV-discovered hosts. Closed via `Guard.ValidateSRVTargets`, which pre-resolves and validates SRV targets before `ApplyURI` runs; the per-connection dialer remains the authoritative DNS-rebinding-safe check regardless of discovery mode.
- **`redis://` vs `unix://`**: `unix://` produces a filesystem-path target with no IP to validate — refused outright via `Guard.RefuseScheme`. No dynamic-secret Redis config in the repo uses it.
- **TLS-drop bug found and fixed while wiring this**: go-redis's default dialer layers TLS atop the raw dial, but only when `Options.Dialer` is unset — overriding it (required for IP re-validation) would have silently downgraded every `rediss://` DSN to plaintext. `Guard.RedisDialer` replicates the TLS layering explicitly, verified against a real TLS handshake in tests.
- **Flag conflation, found and fixed in the same pass**: `internal/notifychan/webhook.go` and `internal/evidencesink/webhook.go` each had one `AllowPrivateNetworkTarget` boolean silently gating both "allow private/link-local targets" and "allow cleartext HTTP to public hosts" — despite both sites' own comments claiming these were separate decisions. Split into independent `AllowPrivateNetworkTarget`/`AllowInsecureTransport` flags in both packages.
- Guard test (`internal/dynamic/egress_guard_test.go`) AST-scans for any driver/`http.Client` construction with no `netutil.Dialer`/`Guard` reference in the same function — verified red (reverted the three wired files, confirmed all three flagged) then green. `internal/dynamic/kubernetes.go` is a documented, reasoned exclusion (its `api_server` is routinely and legitimately a private address).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean repo-wide
- [x] `gosec -severity medium -exclude-generated` — 0 issues on every touched package
- [x] Full test suite green for every touched package (`netutil`, `dynamic`, `audit/siem`, `notifychan`, `evidencesink`, `core`, `config`, `server`)
- [x] Guard test verified red (bypass present) then green