### PR TITLE
fix(rotation): move g05 concurrency lock from AWS-only to the shared orchestrator

### DIFF
--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -16,6 +16,7 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/rotation"
@@ -471,12 +472,40 @@ func (c *KeyorixCore) stampRotationState(ctx context.Context, policyID uint, sta
 	}
 }
 
+// rotationLockKey identifies the (backend, ref) pair rotationBackendLocks serializes
+// on. A struct key (rather than a delimited string concatenation) avoids any ambiguity
+// between e.g. backend="a", ref="b:c" and backend="a:b", ref="c".
+type rotationLockKey struct{ backend, ref string }
+
+// rotationBackendLock returns the mutex serializing applyBackendRotation calls for the
+// given (backend, ref) pair, creating one on first use. See rotationBackendLocks' doc
+// comment (service.go) for why this is keyed per-pair rather than a single global lock,
+// and for the scope/limits of what it does and does not close. The mutex is never
+// removed — fine, since backend names and refs are operator-configured (bounded
+// cardinality), mirroring the reasoning the now-removed internal/rotation/awsiam.go
+// refLocks documented for the same tradeoff.
+func (c *KeyorixCore) rotationBackendLock(backend, ref string) *sync.Mutex {
+	v, _ := c.rotationBackendLocks.LoadOrStore(rotationLockKey{backend, ref}, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
 // applyBackendRotation resolves the secret's named rotation executor and rotates the
 // upstream credential (ADR-047). It returns the VALUE to store in Keyorix: for a
 // generate-upstream backend (rotation.GeneratingExecutor, e.g. a cloud key API) that is
 // the value the upstream minted; for a password-set backend it is the candidate passed
 // in (which the executor applied). Returns an error (so the caller does NOT store
 // anything) when no manager is configured, the backend is unknown, or the apply fails.
+//
+// Serializes against any other in-flight applyBackendRotation call for this SAME
+// (backend, ref) pair, across BOTH callers of this function — the auto-rotation
+// scheduler (rotateOneSecret) and on-demand rotation (RotateSecretOnDemand) — for the
+// ENTIRE upstream call (GenerateUpstream's list/evict/create/delete sequence, or
+// Rotate's apply), released only once it returns. This is a single, generic choke
+// point: it locks BEFORE inspecting whether exec is a GeneratingExecutor, so every
+// backend registered in c.rotationManager is covered uniformly regardless of its
+// concrete type — see rotationBackendLocks' doc comment (service.go) for the full
+// rationale and its scope/limits (in-process only; does not close the orphan-on-crash
+// window, which is unrelated and out of scope here).
 func (c *KeyorixCore) applyBackendRotation(ctx context.Context, secret *models.SecretNode, candidate string) (string, error) {
 	if c.rotationManager == nil {
 		return "", fmt.Errorf("no rotation backends configured")
@@ -488,6 +517,11 @@ func (c *KeyorixCore) applyBackendRotation(ctx context.Context, secret *models.S
 	if secret.RotationRef == "" {
 		return "", fmt.Errorf("rotation_ref is required for backend rotation")
 	}
+
+	mu := c.rotationBackendLock(secret.RotationBackend, secret.RotationRef)
+	mu.Lock()
+	defer mu.Unlock()
+
 	if gen, ok := exec.(rotation.GeneratingExecutor); ok {
 		return gen.GenerateUpstream(ctx, secret.RotationRef)
 	}

--- a/internal/core/rotation_executor_registry_exhaustiveness_test.go
+++ b/internal/core/rotation_executor_registry_exhaustiveness_test.go
@@ -1,0 +1,167 @@
+// rotation_executor_registry_exhaustiveness_test.go — a structural guard, in the same
+// family as account_state_exhaustiveness_guard_test.go, statically proving that every
+// rotation-backend executor constructor declared in internal/rotation is known to and
+// covered by this package's orchestrator-level rotation lock (rotationBackendLock /
+// applyBackendRotation, see rotation_orchestrator_lock_test.go).
+//
+// The lock itself is keyed purely by (backend, ref) and never inspects the concrete
+// rotation.Executor type (TestRotationBackendLock_KeyedByBackendAndRefOnly proves
+// this), so in principle every executor is ALREADY covered structurally, by
+// construction, the moment it's registered through a *rotation.Manager. What this file
+// guards against is a hand-maintained list quietly going stale: if a future 4th (5th,
+// ...) backend constructor is added to internal/rotation and nobody re-derives that
+// this claim still holds for it, that omission must fail loudly here -- not pass
+// silently because nobody thought to update a list. This mirrors the campaign's
+// established pattern (enumerate by call shape via source, not by a maintained list --
+// see server/http/raw_storage_bypass_guard_test.go and
+// internal/core/csv_writer_completeness_test.go for the same idiom applied elsewhere).
+package core
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/rotation"
+)
+
+// knownRotationExecutorConstructors is every internal/rotation constructor this file
+// has verified is instantiable and registers correctly through a *rotation.Manager
+// (TestRotationExecutorRegistry_AllKnownConstructorsRegisterAndResolve). Each entry's
+// factory builds a minimal, harmless instance (a bogus DSN/region, one allowed_refs
+// entry) purely to prove construction + registration + Manager.Get resolution work
+// identically regardless of type -- it deliberately never calls Rotate/
+// GenerateUpstream on these real instances (that would attempt a real network/DB call).
+// The actual concurrency proof uses a generic fake executor instead (see
+// rotation_orchestrator_lock_test.go) precisely because the lock does not care about
+// concrete type -- this map exists ONLY to be checked for completeness against the
+// real source below, not to re-prove the locking mechanism per backend.
+var knownRotationExecutorConstructors = map[string]func(name string) rotation.Executor{
+	"NewAWSIAMExecutor": func(name string) rotation.Executor {
+		return rotation.NewAWSIAMExecutor(name, "us-east-1", []string{"svc-"})
+	},
+	"NewAzureAppSecretExecutor": func(name string) rotation.Executor {
+		return rotation.NewAzureAppSecretExecutor(name, []string{"svc-"})
+	},
+	"NewGCPServiceAccountKeyExecutor": func(name string) rotation.Executor {
+		return rotation.NewGCPServiceAccountKeyExecutor(name, []string{"svc-"})
+	},
+	"NewPostgresExecutor": func(name string) rotation.Executor {
+		return rotation.NewPostgresExecutor(name, "postgres://unused/unused", []string{"svc-"})
+	},
+	"NewMySQLExecutor": func(name string) rotation.Executor {
+		return rotation.NewMySQLExecutor(name, "unused:unused@tcp(unused)/unused", []string{"svc-"})
+	},
+	"NewMongoExecutor": func(name string) rotation.Executor {
+		return rotation.NewMongoExecutor(name, "mongodb://unused/unused", []string{"svc-"})
+	},
+	"NewRedisExecutor": func(name string) rotation.Executor {
+		return rotation.NewRedisExecutor(name, "redis://unused/0", []string{"svc-"})
+	},
+}
+
+// TestRotationExecutorRegistry_NoUncoveredConstructor parses internal/rotation's
+// actual source (not a filename list) and fails if it declares an exported
+// `New*Executor` top-level constructor that knownRotationExecutorConstructors above
+// does not know about -- the guard against a silently-missed future backend.
+func TestRotationExecutorRegistry_NoUncoveredConstructor(t *testing.T) {
+	discovered := discoverRotationExecutorConstructors(t)
+	if len(discovered) == 0 {
+		t.Fatal("found zero New*Executor constructors in internal/rotation -- the discovery logic itself is broken")
+	}
+
+	var uncovered []string
+	for _, name := range discovered {
+		if _, ok := knownRotationExecutorConstructors[name]; !ok {
+			uncovered = append(uncovered, name)
+		}
+	}
+	sort.Strings(uncovered)
+	if len(uncovered) > 0 {
+		t.Errorf("internal/rotation declares constructor(s) %v not present in knownRotationExecutorConstructors "+
+			"(rotation_executor_registry_exhaustiveness_test.go) -- add each one there (and re-run "+
+			"TestRotationExecutorRegistry_AllKnownConstructorsRegisterAndResolve) before landing; a new rotation "+
+			"backend must never silently ship without confirming it goes through applyBackendRotation's central "+
+			"(backend, ref) lock like every other backend", uncovered)
+	}
+}
+
+// TestRotationExecutorRegistry_AllKnownConstructorsRegisterAndResolve builds every
+// known constructor's executor, registers them all in ONE *rotation.Manager (the exact
+// registry applyBackendRotation calls Get on), and confirms every one resolves back by
+// name -- proving the registry/Get mechanism applyBackendRotation depends on is
+// type-agnostic across every currently known backend, not just the three
+// generate-upstream ones (AWS/Azure/GCP) this fix's finding named explicitly.
+func TestRotationExecutorRegistry_AllKnownConstructorsRegisterAndResolve(t *testing.T) {
+	var execs []rotation.Executor
+	for name, factory := range knownRotationExecutorConstructors {
+		execs = append(execs, factory(name))
+	}
+	mgr := rotation.NewManager(execs)
+
+	names := mgr.Names()
+	if len(names) != len(knownRotationExecutorConstructors) {
+		t.Fatalf("expected %d distinct registered backends, got %d (%v) -- a name collision or construction failure silently dropped one",
+			len(knownRotationExecutorConstructors), len(names), names)
+	}
+	for name := range knownRotationExecutorConstructors {
+		exec, ok := mgr.Get(name)
+		if !ok {
+			t.Errorf("Manager.Get(%q) returned not-found after registration", name)
+			continue
+		}
+		if exec.Name() != name {
+			t.Errorf("Manager.Get(%q) returned an executor whose own Name() is %q", name, exec.Name())
+		}
+	}
+}
+
+// discoverRotationExecutorConstructors parses every non-test .go file in
+// internal/rotation and returns the name of each exported top-level function matching
+// `New*Executor` (e.g. NewAWSIAMExecutor) -- the actual, current set of rotation
+// backend constructors, derived from source rather than hand-maintained, so this
+// enumeration can't silently go stale as backends are added or renamed.
+//
+// Reads the directory and parses each file individually (rather than go/parser's
+// ParseDir, deprecated since Go 1.25) so this stays simple dependency-free source
+// inspection, matching account_state_exhaustiveness_guard_test.go's per-file idiom.
+func discoverRotationExecutorConstructors(t *testing.T) []string {
+	t.Helper()
+	const dir = "../rotation"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+
+	fset := token.NewFileSet()
+	var names []string
+	for _, entry := range entries {
+		n := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(n, ".go") || strings.HasSuffix(n, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, dir+"/"+n, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s/%s: %v", dir, n, err)
+		}
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Recv != nil { // skip methods; only top-level funcs are constructors
+				continue
+			}
+			if !fd.Name.IsExported() {
+				continue
+			}
+			name := fd.Name.Name
+			if strings.HasPrefix(name, "New") && strings.HasSuffix(name, "Executor") {
+				names = append(names, name)
+			}
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/core/rotation_orchestrator_lock_test.go
+++ b/internal/core/rotation_orchestrator_lock_test.go
@@ -1,0 +1,228 @@
+// rotation_orchestrator_lock_test.go — proves the g05 concurrency fix: protection
+// against two concurrent backend-rotation calls for the SAME (backend, ref) pair now
+// lives centrally in applyBackendRotation (rotationBackendLock), not inside any one
+// executor. Before this change, that protection existed ONLY inside
+// internal/rotation/awsiam.go's own private refLocks -- Azure's and GCP's
+// GenerateUpstream implementations (internal/rotation/azure.go,
+// internal/rotation/gcpsa.go) perform the exact same kind of unsynchronized
+// list-then-mint-then-delete sequence against their respective cloud APIs, with
+// nothing serializing two concurrent calls for the same ref. Confirmed by direct
+// reading of both files: neither declares a sync.Mutex, sync.Map, nor calls Lock()
+// anywhere -- same for postgres.go/mysql.go/redis.go/mongodb.go's Rotate path. That is
+// the RED state this file's first sub-test reproduces directly (bypassing the fix, by
+// calling the fake executor's GenerateUpstream on its own) before proving the fix
+// (calling it THROUGH applyBackendRotation) closes it.
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/rotation"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// raceGeneratingExecutor is a rotation.GeneratingExecutor test double whose
+// GenerateUpstream is instrumented to detect overlapping calls: the FIRST call to
+// enter (call "A") signals aEntered and then blocks on releaseA until the test lets
+// it proceed -- exactly the orchestration internal/rotation/awsiam_test.go's
+// (now-removed) raceFakeIAM used, generalized away from AWS-specific semantics so it
+// can stand in for ANY backend. inFlight/peak record how many calls were ever
+// concurrently inside the body, the direct signal of whether serialization held.
+type raceGeneratingExecutor struct {
+	name string
+
+	mu       sync.Mutex
+	inFlight int
+	peak     int
+	calls    int
+
+	aEntered chan struct{}
+	releaseA chan struct{}
+}
+
+func newRaceGeneratingExecutor(name string) *raceGeneratingExecutor {
+	return &raceGeneratingExecutor{name: name, aEntered: make(chan struct{}), releaseA: make(chan struct{})}
+}
+
+func (r *raceGeneratingExecutor) Name() string { return r.name }
+func (r *raceGeneratingExecutor) Type() string { return "race-fake" }
+func (r *raceGeneratingExecutor) Rotate(_ context.Context, _, _ string) error {
+	return fmt.Errorf("race-fake: use GenerateUpstream")
+}
+
+func (r *raceGeneratingExecutor) GenerateUpstream(_ context.Context, ref string) (string, error) {
+	r.mu.Lock()
+	r.inFlight++
+	if r.inFlight > r.peak {
+		r.peak = r.inFlight
+	}
+	seq := r.calls
+	r.calls++
+	r.mu.Unlock()
+
+	if seq == 0 {
+		close(r.aEntered)
+		<-r.releaseA
+	}
+
+	r.mu.Lock()
+	r.inFlight--
+	r.mu.Unlock()
+	return fmt.Sprintf("val-%d-%s", seq, ref), nil
+}
+
+func (r *raceGeneratingExecutor) peakInFlight() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.peak
+}
+
+// TestRaceGeneratingExecutor_UnserializedCallsOverlap is the RED half: calling the
+// fake executor's GenerateUpstream directly from two goroutines for the same ref --
+// with NOTHING serializing them, exactly how Azure's/GCP's/every other backend's
+// GenerateUpstream/Rotate behaves today with no lock of its own -- lets the second
+// call enter and complete while the first is still in flight. This is the baseline
+// this package's orchestrator-level lock (tested below) must close.
+func TestRaceGeneratingExecutor_UnserializedCallsOverlap(t *testing.T) {
+	fake := newRaceGeneratingExecutor("unlocked")
+
+	bDone := make(chan struct{})
+	go func() {
+		_, _ = fake.GenerateUpstream(context.Background(), "svc-app")
+	}()
+	<-fake.aEntered // call A is inside the body, blocked on releaseA
+
+	go func() {
+		_, _ = fake.GenerateUpstream(context.Background(), "svc-app")
+		close(bDone)
+	}()
+
+	select {
+	case <-bDone:
+		// Expected pre-fix behaviour: B raced ahead and finished while A was still
+		// blocked -- proving there is genuinely nothing serializing these calls at
+		// the executor level.
+	case <-time.After(2 * time.Second):
+		t.Fatal("call B did not complete concurrently with A -- this fake no longer reproduces the unsynchronized baseline the orchestrator lock is supposed to fix")
+	}
+	assert.Equal(t, 2, fake.peakInFlight(), "both calls were concurrently in-flight with no lock in place -- confirms the RED baseline")
+
+	close(fake.releaseA)
+}
+
+// TestApplyBackendRotation_ConcurrentSameBackendRef_Serializes is the GREEN half:
+// the SAME fake executor, called the SAME way, but THROUGH applyBackendRotation (the
+// shared entry point rotateOneSecret and RotateSecretOnDemand both use) -- must now
+// serialize. Call B must not even enter GenerateUpstream until call A's entire
+// applyBackendRotation call (which holds the per-(backend,ref) lock for its whole
+// duration) has returned.
+func TestApplyBackendRotation_ConcurrentSameBackendRef_Serializes(t *testing.T) {
+	fake := newRaceGeneratingExecutor("locked")
+	c := &KeyorixCore{}
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+
+	secretA := &models.SecretNode{RotationBackend: fake.Name(), RotationRef: "svc-app"}
+	secretB := &models.SecretNode{RotationBackend: fake.Name(), RotationRef: "svc-app"} // SAME (backend, ref)
+
+	type outcome struct {
+		val string
+		err error
+	}
+	aCh := make(chan outcome, 1)
+	bCh := make(chan outcome, 1)
+
+	go func() {
+		v, err := c.applyBackendRotation(context.Background(), secretA, "cand")
+		aCh <- outcome{v, err}
+	}()
+	<-fake.aEntered // A is inside GenerateUpstream, holding the orchestrator lock
+
+	go func() {
+		v, err := c.applyBackendRotation(context.Background(), secretB, "cand")
+		bCh <- outcome{v, err}
+	}()
+
+	// B must be blocked acquiring the lock A already holds -- it cannot even reach
+	// GenerateUpstream, let alone finish, until A's applyBackendRotation returns.
+	select {
+	case <-bCh:
+		t.Fatal("call B completed while call A was still inside applyBackendRotation for the SAME (backend, ref) -- the orchestrator lock did not serialize them")
+	case <-time.After(2 * time.Second):
+		// Expected once serialized: B is correctly still waiting for A's lock.
+	}
+	assert.Equal(t, 1, fake.peakInFlight(), "at most one call may be inside GenerateUpstream at a time for the same (backend, ref)")
+
+	close(fake.releaseA) // let A's held GenerateUpstream return; A can now finish
+	a := <-aCh
+	b := <-bCh
+
+	require.NoError(t, a.err)
+	require.NoError(t, b.err)
+	assert.Equal(t, "val-0-svc-app", a.val)
+	assert.Equal(t, "val-1-svc-app", b.val)
+	assert.Equal(t, 1, fake.peakInFlight(), "peak concurrency inside GenerateUpstream must never exceed 1 for the same (backend, ref), even after both calls complete")
+}
+
+// TestApplyBackendRotation_DifferentRefs_RunConcurrently confirms the lock is keyed
+// per (backend, ref), NOT a single global lock: two DIFFERENT refs under the SAME
+// backend must be able to run concurrently, exactly like awsiam.go's removed
+// refLocks documented ("Keyed per ref ... so rotations for DIFFERENT IAM users still
+// run concurrently"). A global lock here would be a correctness-preserving but
+// needlessly serializing regression (every rotation across every ref queued behind
+// one mutex), so this is asserted explicitly, not just assumed.
+func TestApplyBackendRotation_DifferentRefs_RunConcurrently(t *testing.T) {
+	fake := newRaceGeneratingExecutor("locked-multi-ref")
+	c := &KeyorixCore{}
+	c.SetRotationManager(rotation.NewManager([]rotation.Executor{fake}))
+
+	secretA := &models.SecretNode{RotationBackend: fake.Name(), RotationRef: "svc-a"}
+	secretB := &models.SecretNode{RotationBackend: fake.Name(), RotationRef: "svc-b"} // DIFFERENT ref
+
+	bDone := make(chan struct{})
+	go func() {
+		_, _ = c.applyBackendRotation(context.Background(), secretA, "cand")
+	}()
+	<-fake.aEntered // A (ref svc-a) is inside GenerateUpstream, holding ITS lock
+
+	go func() {
+		_, _ = c.applyBackendRotation(context.Background(), secretB, "cand")
+		close(bDone)
+	}()
+
+	select {
+	case <-bDone:
+		// Expected: a different ref's lock is independent, so B is not blocked by A.
+	case <-time.After(2 * time.Second):
+		t.Fatal("call B (a DIFFERENT ref than A) was blocked -- the lock must be keyed per (backend, ref), not a single global lock")
+	}
+
+	close(fake.releaseA)
+}
+
+// TestRotationBackendLock_KeyedByBackendAndRefOnly proves the lock's identity is a
+// pure function of (backend, ref) -- it never inspects, dispatches on, or otherwise
+// depends on the concrete rotation.Executor type registered under that backend name.
+// This is what makes coverage automatic for every CURRENT and FUTURE executor type:
+// applyBackendRotation acquires this same lock unconditionally, before it ever checks
+// whether exec is a rotation.GeneratingExecutor -- see TestRotationExecutorRegistry_*
+// in rotation_executor_registry_exhaustiveness_test.go for the companion guard that
+// keeps the set of known executor constructors from silently drifting stale.
+func TestRotationBackendLock_KeyedByBackendAndRefOnly(t *testing.T) {
+	c := &KeyorixCore{}
+
+	same1 := c.rotationBackendLock("aws-prod", "svc-app")
+	same2 := c.rotationBackendLock("aws-prod", "svc-app")
+	assert.Same(t, same1, same2, "the same (backend, ref) pair must always resolve to the same mutex")
+
+	diffRef := c.rotationBackendLock("aws-prod", "svc-other")
+	assert.NotSame(t, same1, diffRef, "a different ref under the same backend must get its own mutex")
+
+	diffBackend := c.rotationBackendLock("gcp-prod", "svc-app")
+	assert.NotSame(t, same1, diffBackend, "the same ref under a different backend must get its own mutex")
+}

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -231,6 +231,43 @@ type KeyorixCore struct {
 	// rotationManager holds the backend rotation executors (ADR-047) that apply a new
 	// credential to an upstream system during rotation. nil = no backends configured.
 	rotationManager *rotation.Manager
+	// rotationBackendLocks serializes applyBackendRotation calls against the SAME
+	// (backend, ref) pair — the single shared entry point BOTH the auto-rotation
+	// scheduler (rotateOneSecret) and on-demand rotation (RotateSecretOnDemand) go
+	// through (rotation_executor.go). Previously this protection existed only inside
+	// AWSIAMExecutor's own private refLocks (internal/rotation/awsiam.go, g05), so
+	// Azure and GCP's generate-upstream executors — whose GenerateUpstream is the same
+	// kind of unsynchronized list→evict→create→delete read-modify-write against their
+	// respective cloud APIs — had ZERO concurrency protection: two concurrent calls for
+	// the same ref (e.g. the single-replica-gated auto-rotation scheduler tick racing a
+	// manually-triggered on-demand rotation, both goroutines in the SAME process) could
+	// interleave and, in the worst case, one call's cleanup could delete the credential
+	// the other call just minted and is about to report back to its own caller as "the"
+	// live value. Moving the lock here, keyed generically by (backend, ref) rather than
+	// inside one executor's private state, gives every registered backend — present and
+	// future, regardless of concrete type — this protection for free; see
+	// rotationBackendLock and applyBackendRotation.
+	//
+	// Keyed per (backend, ref) — not one global lock — so rotations for different
+	// backends/refs still run concurrently. A plain sync.Map (rather than the fixed-shard
+	// loginFailureMu array) is fine here: backend names and refs are operator-configured
+	// (allowed_refs is itself an admin-set allowlist), not attacker-controlled cardinality
+	// — the same reasoning awsiam.go's now-removed refLocks documented.
+	//
+	// Scope: this closes the race WITHIN one Keyorix process only — the primary
+	// reachable case, since the scheduler ticker and the HTTP/gRPC on-demand handlers
+	// all run in the server's own process. It does NOT close the same race across two HA
+	// replicas (ADR-039), and it does NOT close the separate, larger orphaned-credential
+	// crash window: applyBackendRotation's lock is released the instant it returns —
+	// BEFORE the caller (rotateOneSecret/RotateSecretOnDemand) persists the new value via
+	// RotateSecret. A process crash between "upstream committed a new credential" and
+	// "Keyorix stored it" still leaves a live, valid credential with NO Keyorix record at
+	// all (an orphan), for every backend, exactly as it did before this change for AWS.
+	// Closing THAT window needs a write-intent-first / two-phase-commit-style redesign
+	// (persist "attempting to rotate (backend, ref)" durably before calling upstream,
+	// plus a reconciliation pass) — out of scope here; EventSecretRotateBackendStarted is
+	// the existing (pre-this-change) breadcrumb for manual reconciliation, not a fix.
+	rotationBackendLocks sync.Map // map[rotationLockKey]*sync.Mutex
 	// evidenceForwarder ships the scheduled compliance-evidence pack to an off-box
 	// target (webhook). nil = local-file only. Set via SetEvidenceForwarder.
 	evidenceForwarder EvidenceForwarder

--- a/internal/rotation/awsiam.go
+++ b/internal/rotation/awsiam.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -34,44 +33,6 @@ type AWSIAMExecutor struct {
 	allowedRefs []string
 	// newClient builds an IAM client; nil uses the real client (ambient chain). Tests inject.
 	newClient func(ctx context.Context) (iamAPI, error)
-	// refLocks serializes GenerateUpstream calls against the SAME IAM user (g05):
-	// the list→evict→create→delete sequence below is an unsynchronized read-modify-
-	// write against AWS IAM, so two concurrent calls for one ref (e.g. the
-	// single-replica-gated auto-rotation scheduler tick — server/main.go,
-	// schedLockAutoRotate — racing a manually-triggered on-demand rotation, both of
-	// which run as goroutines in the SAME process and share this executor instance)
-	// can interleave: both may see the user below the two-key cap and both create a
-	// key (one CreateAccessKey then fails outright at AWS's hard limit), or one
-	// call's cleanup can delete a key the other call just minted and is about to
-	// hand back to its own caller as "the" live credential.
-	//
-	// Keyed per ref (not one global lock) so rotations for DIFFERENT IAM users still
-	// run concurrently. A plain sync.Map (rather than core.KeyorixCore's fixed-shard
-	// loginFailureMu array) is fine here: refs are drawn from allowedRefs, an
-	// operator-configured allowlist, not attacker-controlled cardinality.
-	//
-	// This closes the race WITHIN one Keyorix process — the primary reachable case,
-	// since the scheduler ticker and the HTTP/gRPC on-demand handlers all run in the
-	// server's own process. It does NOT close the same race across two HA replicas
-	// (ADR-039): e.g. two on-demand rotations for the same secret landing on
-	// different replicas at once, or an on-demand rotation on replica A racing the
-	// auto-rotation scheduler tick running on replica B. The scheduler tick itself
-	// is already single-replica-gated (schedLockAutoRotate via
-	// storage.WithSchedulerLock), so that residual window is narrower than the case
-	// fixed here; fully closing it needs a keyed *distributed* lock — the closest
-	// existing precedent is storage.WithAuditCheckpointLock (ADR-029), which blocks
-	// rather than skips, but is a single global lock, not keyed per identity.
-	// Extending it here would be a Storage-interface change spanning Local/Remote
-	// backends, out of scope for this fix.
-	refLocks sync.Map // map[string]*sync.Mutex
-}
-
-// lockRef returns the mutex serializing GenerateUpstream calls for ref, creating one
-// on first use. The mutex is never removed — see refLocks' doc comment for why that's
-// fine (bounded, operator-configured ref cardinality).
-func (e *AWSIAMExecutor) lockRef(ref string) *sync.Mutex {
-	v, _ := e.refLocks.LoadOrStore(ref, &sync.Mutex{})
-	return v.(*sync.Mutex)
 }
 
 // NewAWSIAMExecutor builds an AWS IAM rotation executor. region configures the client
@@ -120,14 +81,16 @@ func (e *AWSIAMExecutor) GenerateUpstream(ctx context.Context, ref string) (stri
 	if !prefixAllowed(e.allowedRefs, ref) {
 		return "", fmt.Errorf("aws-iam: user %q is not permitted by this backend's allowed_refs", ref)
 	}
-	// Serialize against any other in-flight GenerateUpstream for this SAME ref (g05)
-	// — see refLocks' doc comment. Held for the entire list/evict/create/delete
-	// sequence below, not just individual calls, so a second caller for this ref
-	// never observes (or acts on) an intermediate state left by the first.
-	mu := e.lockRef(ref)
-	mu.Lock()
-	defer mu.Unlock()
-
+	// Concurrency note (g05): this list→evict→create→delete sequence is an
+	// unsynchronized read-modify-write against AWS IAM — two concurrent calls for the
+	// SAME ref could otherwise interleave (e.g. one call's cleanup deleting a key the
+	// other just minted and is about to report as "the" live credential). This used to
+	// be guarded by a private per-ref mutex here; that protection now lives centrally
+	// in internal/core/rotation_executor.go's applyBackendRotation (rotationBackendLock),
+	// the single entry point both the auto-rotation scheduler and on-demand rotation go
+	// through — which also extends the same protection to every OTHER registered
+	// backend (Azure, GCP, …), not just AWS. See that function's doc comment for the
+	// full rationale and scope/limits.
 	cl, err := e.client(ctx)
 	if err != nil {
 		return "", err

--- a/internal/rotation/awsiam_test.go
+++ b/internal/rotation/awsiam_test.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
@@ -186,213 +183,16 @@ func TestAWSIAM_GenerateUpstream_Errors(t *testing.T) {
 	})
 }
 
-// raceFakeIAM is a concurrency-safe, orchestratable fake of a real IAM user's access
-// key state — used only by TestAWSIAM_GenerateUpstream_ConcurrentSameRef below to
-// deterministically reproduce the g05 unsynchronized-race finding. Unlike fakeIAM
-// (whose fields are only ever mutated by one goroutine at a time in every other
-// test), this fake must itself be safe under concurrent calls, and provides hooks to
-// force a specific interleaving between two concurrent GenerateUpstream calls for
-// the SAME ref.
-type raceFakeIAM struct {
-	mu      sync.Mutex
-	keys    []string             // current live access key ids, mutation-guarded by mu
-	created map[string]time.Time // id -> CreateDate, so evictableAccessKey picks realistically
-	seq     int
-
-	listCalls int
-	// aListed is closed the instant the FIRST ListAccessKeys call (call "A") returns
-	// its snapshot — the test uses this to know it is now safe to start the second
-	// concurrent caller ("B") without risking B racing ahead to be the first Lister.
-	aListed chan struct{}
-	// createLanded is closed the instant the first CreateAccessKey call's new key is
-	// appended to `keys` (i.e. visible to a subsequent List) — letting B's List (the
-	// second List call) proceed only once A's new key genuinely exists upstream,
-	// exactly the moment a live race would let B observe it.
-	createLanded chan struct{}
-	// releaseCreate is closed by the test to let the FIRST CreateAccessKey call
-	// return control to its caller (A), after B has been allowed to run its entire
-	// GenerateUpstream call to completion first. This is what manufactures the
-	// dangerous interleaving: A believes it is still mid-rotation while B has
-	// already listed, evicted, created, and cleaned up against the same ref.
-	releaseCreate chan struct{}
-}
-
-func newRaceFakeIAM(seedKeyID string, seedAge time.Duration) *raceFakeIAM {
-	return &raceFakeIAM{
-		keys:          []string{seedKeyID},
-		created:       map[string]time.Time{seedKeyID: time.Now().Add(-seedAge)},
-		aListed:       make(chan struct{}),
-		createLanded:  make(chan struct{}),
-		releaseCreate: make(chan struct{}),
-	}
-}
-
-func (f *raceFakeIAM) ListAccessKeys(_ context.Context, in *iam.ListAccessKeysInput, _ ...func(*iam.Options)) (*iam.ListAccessKeysOutput, error) {
-	f.mu.Lock()
-	n := f.listCalls
-	f.listCalls++
-	f.mu.Unlock()
-
-	if n == 0 {
-		defer close(f.aListed)
-	} else {
-		// The second concurrent List (B's) only proceeds once A's create has landed
-		// — i.e. once there is something new upstream for B to (wrongly) sweep up.
-		<-f.createLanded
-	}
-
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	md := make([]iamtypes.AccessKeyMetadata, 0, len(f.keys))
-	for _, id := range f.keys {
-		id := id
-		ct := f.created[id]
-		md = append(md, iamtypes.AccessKeyMetadata{AccessKeyId: &id, CreateDate: &ct, UserName: in.UserName})
-	}
-	return &iam.ListAccessKeysOutput{AccessKeyMetadata: md}, nil
-}
-
-func (f *raceFakeIAM) CreateAccessKey(_ context.Context, in *iam.CreateAccessKeyInput, _ ...func(*iam.Options)) (*iam.CreateAccessKeyOutput, error) {
-	f.mu.Lock()
-	// Mirror AWS's real hard two-key-per-user cap: a properly serialized rotation
-	// never calls Create while already at 2 keys (it evicts first); an interleaved
-	// one can, and here it fails exactly like AWS would.
-	if len(f.keys) >= 2 {
-		f.mu.Unlock()
-		return nil, fmt.Errorf("LimitExceeded: cannot create more than 2 access keys")
-	}
-	f.seq++
-	id := fmt.Sprintf("KNEW%d", f.seq)
-	f.keys = append(f.keys, id)
-	f.created[id] = time.Now()
-	first := f.seq == 1
-	f.mu.Unlock()
-
-	if first {
-		close(f.createLanded)
-		// Hold A here — after AWS-side creation has already landed — until the test
-		// lets B run its entire concurrent rotation to completion first.
-		<-f.releaseCreate
-	}
-	return &iam.CreateAccessKeyOutput{AccessKey: &iamtypes.AccessKey{
-		AccessKeyId: aws.String(id), SecretAccessKey: aws.String("secret-" + id), UserName: in.UserName,
-	}}, nil
-}
-
-func (f *raceFakeIAM) DeleteAccessKey(_ context.Context, in *iam.DeleteAccessKeyInput, _ ...func(*iam.Options)) (*iam.DeleteAccessKeyOutput, error) {
-	id := aws.ToString(in.AccessKeyId)
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	out := f.keys[:0]
-	found := false
-	for _, k := range f.keys {
-		if k == id {
-			found = true
-			continue
-		}
-		out = append(out, k)
-	}
-	f.keys = out
-	if !found {
-		// Real AWS DeleteAccessKey on an already-gone key id returns NoSuchEntity —
-		// which is exactly what happens when a concurrent rotation already deleted
-		// this same key out from under the caller.
-		return nil, fmt.Errorf("NoSuchEntity: access key %s not found", id)
-	}
-	return &iam.DeleteAccessKeyOutput{}, nil
-}
-
-func (f *raceFakeIAM) liveKeys() []string {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return append([]string(nil), f.keys...)
-}
-
-// TestAWSIAM_GenerateUpstream_ConcurrentSameRef reproduces the g05 finding:
-// GenerateUpstream performs an unsynchronized list→evict→create→delete sequence
-// against AWS IAM, so two concurrent calls for the SAME ref (e.g. the auto-rotation
-// scheduler tick racing a manually-triggered on-demand rotation — both reachable in
-// the same process) can interleave.
-//
-// Orchestration: the IAM user starts with one key (K0, seeded old). Call "A" lists
-// (sees only K0, below the 2-key cap, so no eviction) and creates a new key — which
-// is deliberately held from returning to A's Go code until call "B" has been allowed
-// to run its ENTIRE GenerateUpstream to completion. Pre-fix, nothing stops B from
-// doing exactly that: B lists (now sees [K0, A's new key] — AT the cap), evicts the
-// genuinely-oldest K0, creates its own new key, and then — in its final "delete every
-// prior" cleanup — deletes A's brand-new key, the one A is about to report back to
-// ITS OWN caller as the current live credential. Post-fix, B cannot even begin its
-// List until A's mutex-held rotation fully completes, so this interleaving is
-// structurally impossible; the test detects that as B still being blocked after a
-// generous timeout, then lets A finish and confirms both rotations independently
-// leave a fully consistent, sequential result.
-func TestAWSIAM_GenerateUpstream_ConcurrentSameRef(t *testing.T) {
-	fake := newRaceFakeIAM("K0", time.Hour)
-	exec := NewAWSIAMExecutor("aws", "us-east-1", []string{"svc-"})
-	exec.newClient = func(context.Context) (iamAPI, error) { return fake, nil }
-
-	type outcome struct {
-		val string
-		err error
-	}
-	aCh := make(chan outcome, 1)
-	bCh := make(chan outcome, 1)
-
-	go func() {
-		v, err := exec.GenerateUpstream(context.Background(), "svc-app")
-		aCh <- outcome{v, err}
-	}()
-	<-fake.aListed // A has listed (and is on its way to Create); safe to start B now
-
-	go func() {
-		v, err := exec.GenerateUpstream(context.Background(), "svc-app")
-		bCh <- outcome{v, err}
-	}()
-
-	// Pre-fix: nothing blocks B, so it races ahead and finishes almost immediately.
-	// Post-fix: B is blocked acquiring the per-ref mutex A already holds, and will
-	// NOT complete until A does — which A cannot do until we release it below. This
-	// wait is not a flaky timing race: whichever branch fires is fully determined by
-	// whether the fix's mutex exists, not by scheduling luck.
-	var b outcome
-	bDone := false
-	select {
-	case b = <-bCh:
-		bDone = true
-	case <-time.After(2 * time.Second):
-		// Expected once serialized: B is correctly still waiting for A's lock.
-	}
-
-	// The core g05 assertion, taken RIGHT HERE — before A is released to resume —
-	// because this is the only point that is not itself racing B's independent
-	// execution: if B already fully completed while A was still parked mid-flight,
-	// A's own brand-new key (deterministically "KNEW1": the aListed gate above
-	// guarantees A is always the first Create call) must still exist upstream. A is
-	// about to report that exact id back to its own caller as the current live
-	// credential — if it's already gone, that's a caller being handed a credential
-	// invalidated before it was ever returned, the danger this fix closes. (Once B
-	// is legitimately allowed to run a SEPARATE, later rotation of the same secret
-	// after A has actually returned, it deleting A's now-superseded key is normal,
-	// not a bug — which is why this check must happen now, not after both finish.)
-	if bDone {
-		assert.Contains(t, fake.liveKeys(), "KNEW1",
-			"call B's concurrent rotation for the same ref already deleted call A's brand-new access key %q before A had even reported it as the current credential — the exact g05 race", "KNEW1")
-	}
-
-	close(fake.releaseCreate) // let A's held Create return; A can now finish
-	a := <-aCh
-	if !bDone {
-		b = <-bCh // now that A released the lock, B must finish too
-	}
-
-	// Once properly serialized, neither call should ever need the partial-failure
-	// path — every delete a call attempts is always of a key it alone is entitled to
-	// remove, so it always succeeds. (Pre-fix, A's own final cleanup attempts to
-	// delete a key B already removed, surfacing exactly as this kind of error.)
-	require.NoError(t, a.err, "call A should not need PartialRotationError when properly serialized")
-	require.NoError(t, b.err, "call B should not need PartialRotationError when properly serialized")
-
-	// Exactly one access key should remain live after two full rotations of the same
-	// ref have completed, run one after the other rather than interleaved.
-	assert.Len(t, fake.liveKeys(), 1, "exactly one access key should remain live after two serialized rotations")
-}
+// NOTE on the g05 concurrency finding: this file used to carry
+// TestAWSIAM_GenerateUpstream_ConcurrentSameRef, which reproduced two concurrent
+// GenerateUpstream calls for the SAME ref interleaving unsafely, via a private
+// per-ref mutex (refLocks) AWSIAMExecutor held internally. That protection has moved:
+// it now lives centrally in internal/core/rotation_executor.go's applyBackendRotation
+// (rotationBackendLock), the single entry point both the auto-rotation scheduler and
+// on-demand rotation go through for EVERY registered backend, not just AWS. Exercising
+// AWSIAMExecutor.GenerateUpstream in isolation (as this package's tests do, correctly,
+// for everything else) can no longer demonstrate that protection — it was never this
+// executor's job to serialize itself once the orchestrator does it centrally. The
+// equivalent (and now broader) concurrency proof lives in
+// internal/core/rotation_orchestrator_lock_test.go, which exercises the real shared
+// entry point instead.


### PR DESCRIPTION
## Summary

`internal/rotation/awsiam.go`'s `refLocks` serialized concurrent `GenerateUpstream` calls for the same ref (the scheduler tick racing an on-demand trigger, both in-process) — but only for AWS. Azure and GCP rotation executors had zero concurrency protection of any kind (confirmed via repo-wide grep).

- Moved the lock out of the individual executor and into the shared orchestrator path both the auto-rotation scheduler and on-demand rotation go through (`internal/core/rotation_executor.go`'s `applyBackendRotation`), keyed per (backend, ref). AWS keeps the same protection it had; Azure and GCP now get it too, for free, without each needing their own copy of lock-management code.
- Removed the now-redundant `refLocks`/`lockRef` from `awsiam.go`.
- Added a registry-exhaustiveness test (`internal/core/rotation_executor_registry_exhaustiveness_test.go`) that AST-parses every `New*Executor` constructor in `internal/rotation` and fails if one isn't covered — so a future 4th+ backend can't silently ship unlocked. Verified both directions (removed a constructor from the coverage map, confirmed it fails; restored, confirmed it passes).
- Verified red-then-green for the core concurrency fix too: temporarily disabled the new lock, confirmed the new test failed as expected.

## Explicit scope boundary — read before assuming this is "done"

This PR closes the **in-process concurrency race** only. It does **not** close the **orphaned-credential crash window**: a process crash between the upstream backend committing a new credential and `RotateSecret` persisting it into Keyorix's own storage leaves a live, valid, untracked credential. This gap existed for AWS even before this change (the old lock released before `RotateSecret` was ever called) and remains open for all three backends after this fix — `EventSecretRotateBackendStarted`'s audit-trail breadcrumb is the only mitigation, not a fix. Closing it needs a write-intent-first/two-phase-commit-style redesign, deliberately out of scope here.

## Test plan
- [x] `go build ./...`, `go vet ./...` (whole repo) clean
- [x] `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated` on `internal/core`, `internal/rotation` — 0 issues
- [x] `golangci-lint run` on both packages — 0 issues (fixed one pre-existing deprecated-API finding along the way)
- [x] Full test suites green under `-race`, including existing AWS rotation tests unchanged in behavior
- [x] Concurrency test and exhaustiveness guard both verified red-then-green independently