### PR TITLE
fix(ci): pass --repo to gh pr comment in family-check.yml

### DIFF
--- a/.github/workflows/family-check.yml
+++ b/.github/workflows/family-check.yml
@@ -130,6 +130,15 @@ jobs:
       # touch no tracked family at all, and a check that comments on every PR
       # regardless of relevance is exactly the noise that gets a check
       # disabled (see family-check-scope.json's own scoping rationale).
+      #
+      # --repo is required: this step's working directory is $GITHUB_WORKSPACE
+      # itself, which has no .git of its own (both checkouts above go to the
+      # head/ and base/ subdirectories) -- without an explicit --repo, gh's
+      # repo auto-detection fails outright with "fatal: not a git repository"
+      # any time the report is actually non-empty (an all-main "changes" job
+      # -only PR like the one that introduced this workflow never exercises
+      # this line at all, since its own report is empty and the early exit
+      # above skips straight past both gh calls).
       - name: Post or update PR comment
         if: always()
         env:
@@ -139,6 +148,6 @@ jobs:
             echo "family-membership check: nothing to report, skipping comment"
             exit 0
           fi
-          if ! gh pr comment "${{ github.event.pull_request.number }}" --edit-last --body-file family-check-report.md 2>/dev/null; then
-            gh pr comment "${{ github.event.pull_request.number }}" --body-file family-check-report.md
+          if ! gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --edit-last --body-file family-check-report.md 2>/dev/null; then
+            gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --body-file family-check-report.md
           fi


### PR DESCRIPTION
## Summary
Second bug found in `family-check.yml` (following #1758's base-fallback fix):
the "Post or update PR comment" step calls `gh pr comment` without `--repo`.
That step's working directory is `$GITHUB_WORKSPACE` itself, which has no
`.git` of its own -- both checkouts in this workflow go to `head/` and
`base/` subdirectories, never the root. Without an explicit `--repo`, `gh`'s
repo auto-detection fails with `fatal: not a git repository` any time the
report is actually non-empty.

`#1758`'s own PR never exercised this code path: its family-check report is
empty (a CI-workflow-only change touches no tracked family), so the script's
early exit skips both `gh pr comment` calls before hitting the bug. It
surfaced on #1755/#1756/#1757 once the base-fallback fix let `family-check`
actually run to completion and produce a real, non-empty report.

Verified `--repo` bypasses the git-directory requirement by running
`gh pr view --repo keyorixhq/keyorix` from a non-git CWD.

## Test plan
- [x] `actionlint .github/workflows/family-check.yml`
- [x] Manually verified `--repo` avoids git auto-detection from a non-git working directory
- [ ] Confirm `family-check`'s comment step succeeds on a PR with a real, non-empty report once this merges