### PR TITLE
fix(cli): route sensitive CLI output through an O_EXCL-safe securefiles helper

### DIFF
--- a/internal/cli/compliance/baseline.go
+++ b/internal/cli/compliance/baseline.go
@@ -9,8 +9,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/spf13/cobra"
 )
 
@@ -46,8 +48,8 @@ Requires audit.read.`,
 			}
 			pretty.WriteByte('\n')
 			if baselineOutput != "" {
-				if err := os.WriteFile(baselineOutput, pretty.Bytes(), 0o600); err != nil {
-					return fmt.Errorf("failed to write %s: %w", baselineOutput, err)
+				if err := securefiles.SecureCreateFile(filepath.Dir(baselineOutput), filepath.Base(baselineOutput), pretty.Bytes(), 0o600); err != nil {
+					return fmt.Errorf("cannot create output file %q (it may already exist — remove it or choose a different path): %w", baselineOutput, err)
 				}
 				fmt.Printf("Permission baseline JSON written to %s.\n", baselineOutput)
 				return nil

--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -12,9 +12,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/spf13/cobra"
 )
 
@@ -225,8 +227,8 @@ stdout by default, or to --output FILE.`,
 		}
 		pretty.WriteByte('\n')
 		if exportOutput != "" {
-			if err := os.WriteFile(exportOutput, pretty.Bytes(), 0o600); err != nil {
-				return fmt.Errorf("failed to write %s: %w", exportOutput, err)
+			if err := securefiles.SecureCreateFile(filepath.Dir(exportOutput), filepath.Base(exportOutput), pretty.Bytes(), 0o600); err != nil {
+				return fmt.Errorf("cannot create output file %q (it may already exist — remove it or choose a different path): %w", exportOutput, err)
 			}
 			fmt.Printf("Evidence pack written to %s.\n", exportOutput)
 			return nil

--- a/internal/cli/compliance/compliance_s24_test.go
+++ b/internal/cli/compliance/compliance_s24_test.go
@@ -256,14 +256,14 @@ func TestInventory_ToFile(t *testing.T) {
 	assert.Contains(t, string(got), "secret,proj")
 }
 
-// TestEmitCSV_WriteError covers the os.WriteFile error branch in emitCSV when
-// the output path is not writable.
+// TestEmitCSV_WriteError covers the securefiles.SecureCreateFile error branch in
+// emitCSV when the output path is not writable.
 func TestEmitCSV_WriteError(t *testing.T) {
 	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("col\nval\n"))
 	})
 	dir := t.TempDir()
-	// Make the directory read-only so WriteFile fails.
+	// Make the directory read-only so the create fails.
 	require.NoError(t, os.Chmod(dir, 0o555))
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
 
@@ -273,5 +273,8 @@ func TestEmitCSV_WriteError(t *testing.T) {
 
 	err := inventoryCmd.RunE(nil, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to write")
+	// The wrapper message ("cannot create output file...") is shared with the O_EXCL
+	// already-exists case, so assert on the actual OS-level denial reason instead of
+	// the wrapper text, which is what actually distinguishes this failure mode.
+	assert.Contains(t, err.Error(), "permission denied")
 }

--- a/internal/cli/compliance/csv_export.go
+++ b/internal/cli/compliance/csv_export.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/spf13/cobra"
 )
 
@@ -42,14 +44,24 @@ Writes to stdout, or to --output FILE.`,
 
 // emitCSV downloads the CSV artifact at path and writes it to outputPath (0600) or, if
 // empty, to stdout. label names the artifact in the file-written confirmation line.
+//
+// The artifact is auditor-sensitive data (secret inventory, permission baseline,
+// compliance evidence) written to an operator-supplied --output path with zero
+// protection until this fix: a raw os.WriteFile silently follows a symlink planted at
+// the target and silently overwrites/truncates whatever was already there. Routes
+// through securefiles.SecureCreateFile instead, which refuses both (O_EXCL + a
+// per-path-component O_NOFOLLOW walk) — see internal/securefiles's doc comments for
+// why. outputPath is split into (baseDir, relPath) the way securefiles expects, the
+// same idiom already used at internal/cli/license/license.go and
+// internal/cli/config/cli_config.go.
 func emitCSV(rc *common.RemoteClient, path, outputPath, label string) error {
 	data, err := rc.GetRaw(context.Background(), path)
 	if err != nil {
 		return err
 	}
 	if outputPath != "" {
-		if err := os.WriteFile(outputPath, data, 0o600); err != nil {
-			return fmt.Errorf("failed to write %s: %w", outputPath, err)
+		if err := securefiles.SecureCreateFile(filepath.Dir(outputPath), filepath.Base(outputPath), data, 0o600); err != nil {
+			return fmt.Errorf("cannot create output file %q (it may already exist — remove it or choose a different path): %w", outputPath, err)
 		}
 		fmt.Printf("%s written to %s.\n", label, outputPath)
 		return nil

--- a/internal/cli/compliance/g80_error_paths_test.go
+++ b/internal/cli/compliance/g80_error_paths_test.go
@@ -40,8 +40,8 @@ func TestExport_ServerError(t *testing.T) {
 	assert.Contains(t, err.Error(), "500")
 }
 
-// TestExport_WriteError covers the os.WriteFile error branch in exportCmd
-// when --output points at a non-writable directory.
+// TestExport_WriteError covers the securefiles.SecureCreateFile error branch in
+// exportCmd when --output points at a non-writable directory.
 func TestExport_WriteError(t *testing.T) {
 	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"posture":{"ok":true}}}`))
@@ -55,7 +55,10 @@ func TestExport_WriteError(t *testing.T) {
 
 	err := exportCmd.RunE(nil, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to write")
+	// The wrapper message ("cannot create output file...") is shared with the O_EXCL
+	// already-exists case, so assert on the actual OS-level denial reason instead of
+	// the wrapper text, which is what actually distinguishes this failure mode.
+	assert.Contains(t, err.Error(), "permission denied")
 }
 
 func TestControls_ServerError(t *testing.T) {
@@ -150,8 +153,8 @@ func TestBaselineCmd_JSON_ServerError(t *testing.T) {
 	assert.Contains(t, err.Error(), "500")
 }
 
-// TestBaselineCmd_JSONWriteError covers the os.WriteFile error branch of the
-// json-format path in baselineCmd, when --output points at a non-writable
+// TestBaselineCmd_JSONWriteError covers the securefiles.SecureCreateFile error branch
+// of the json-format path in baselineCmd, when --output points at a non-writable
 // directory.
 func TestBaselineCmd_JSONWriteError(t *testing.T) {
 	dir := t.TempDir()
@@ -168,5 +171,8 @@ func TestBaselineCmd_JSONWriteError(t *testing.T) {
 
 	err := baselineCmd.RunE(nil, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to write")
+	// The wrapper message ("cannot create output file...") is shared with the O_EXCL
+	// already-exists case, so assert on the actual OS-level denial reason instead of
+	// the wrapper text, which is what actually distinguishes this failure mode.
+	assert.Contains(t, err.Error(), "permission denied")
 }

--- a/internal/cli/compliance/output_excl_test.go
+++ b/internal/cli/compliance/output_excl_test.go
@@ -1,0 +1,77 @@
+package compliance
+
+// Regression tests for Group 2 (safe file writes): the compliance package's --output
+// paths (inventory/controls CSV via emitCSV, evidence export JSON, permission-baseline
+// JSON) used to write via raw os.WriteFile — no O_NOFOLLOW, no O_EXCL, silently
+// overwriting/truncating whatever was already at --output. They now route through
+// securefiles.SecureCreateFile, which refuses to create through OR overwrite a
+// pre-existing path. See keyorix-private/adversarial-review/QUEUE.md "Group 2".
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmitCSV_RefusesPreexistingOutputFile(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("name,project\nnew,proj\n"))
+	})
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "inv.csv")
+	require.NoError(t, os.WriteFile(outPath, []byte("stale-csv-content"), 0o600))
+
+	inventoryProject = 0
+	inventoryOutput = outPath
+	t.Cleanup(func() { inventoryProject, inventoryOutput = 0, "" })
+
+	err := inventoryCmd.RunE(nil, nil)
+	require.Error(t, err, "a pre-existing --output path must now be refused, not silently overwritten")
+
+	got, rerr := os.ReadFile(outPath)
+	require.NoError(t, rerr)
+	assert.Equal(t, "stale-csv-content", string(got), "the pre-existing file must be left completely untouched")
+}
+
+func TestExportCmd_RefusesPreexistingOutputFile(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":{"posture":{"ok":true}}}`))
+	})
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "pack.json")
+	require.NoError(t, os.WriteFile(outPath, []byte("stale-evidence-pack"), 0o600))
+
+	exportOutput = outPath
+	t.Cleanup(func() { exportOutput = "" })
+
+	err := exportCmd.RunE(nil, nil)
+	require.Error(t, err, "a pre-existing --output path must now be refused, not silently overwritten")
+
+	got, rerr := os.ReadFile(outPath)
+	require.NoError(t, rerr)
+	assert.Equal(t, "stale-evidence-pack", string(got), "the pre-existing file must be left completely untouched")
+}
+
+func TestBaselineCmd_JSON_RefusesPreexistingOutputFile(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":{"rows":[]}}`))
+	})
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "baseline.json")
+	require.NoError(t, os.WriteFile(outPath, []byte("stale-baseline"), 0o600))
+
+	t.Cleanup(func() { baselineFormat = "csv"; baselineOutput = "" })
+	baselineFormat = "json"
+	baselineOutput = outPath
+
+	err := baselineCmd.RunE(nil, nil)
+	require.Error(t, err, "a pre-existing --output path must now be refused, not silently overwritten")
+
+	got, rerr := os.ReadFile(outPath)
+	require.NoError(t, rerr)
+	assert.Equal(t, "stale-baseline", string(got), "the pre-existing file must be left completely untouched")
+}

--- a/internal/cli/rbac/export_matrix.go
+++ b/internal/cli/rbac/export_matrix.go
@@ -8,12 +8,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"syscall"
 	"text/tabwriter"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/spf13/cobra"
 )
 
@@ -65,26 +65,21 @@ type remoteMatrixRow struct {
 	ExpiresAt       *time.Time `json:"expires_at"`
 }
 
-// openSecureOutputFile opens path for the --output file. The permission
-// matrix is deployment-wide access-control data (usernames, emails, every
-// user/role/permission/scope tuple) — sensitive enough that it must never
-// land on disk world/group-readable, regardless of the process umask (G68).
-// O_TRUNC alone keeps a pre-existing file's mode untouched, so the perm
-// argument to OpenFile only takes effect when the file is freshly created;
-// the explicit Chmod below enforces 0600 even when --output points at an
-// already-existing (possibly world-readable) path. O_NOFOLLOW refuses to
-// write through a final-component symlink. Mirrors
-// securefiles.SecureWriteFile/SecureWriteFileSync.
+// openSecureOutputFile opens path for the --output file. The permission matrix is
+// deployment-wide access-control data (usernames, emails, every user/role/permission/
+// scope tuple) — sensitive enough that it must never land on disk world/group-readable,
+// regardless of the process umask (G68), and must never be silently written through a
+// planted symlink. Delegates to securefiles.SecureCreateFileHandle: per-path-component
+// O_NOFOLLOW (not just the final component, which this function used to check alone)
+// plus O_EXCL, which refuses to open through OR overwrite an already-existing path —
+// closing this out onto the same shared, strongest-in-repo pattern
+// internal/cli/secret/export.go's createSecureOutputFile uses, rather than keeping a
+// second, weaker, independently hand-rolled copy. This is a behavior change from the
+// previous O_TRUNC-based version: re-running export-matrix against an --output path
+// that already exists now fails instead of silently overwriting it — remove the old
+// file, or choose a fresh path, same as `secret export --output` already requires.
 func openSecureOutputFile(path string) (*os.File, error) {
-	f, err := os.OpenFile(filepath.Clean(path), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0o600) // #nosec G304 -- operator-supplied CLI output path, not attacker input
-	if err != nil {
-		return nil, err
-	}
-	if cerr := f.Chmod(0o600); cerr != nil {
-		_ = f.Close()
-		return nil, cerr
-	}
-	return f, nil
+	return securefiles.SecureCreateFileHandle(filepath.Dir(path), filepath.Base(path), 0o600)
 }
 
 func runExportMatrix(cmd *cobra.Command, args []string) error {
@@ -94,7 +89,7 @@ func runExportMatrix(cmd *cobra.Command, args []string) error {
 	if exportMatrixOutput != "" {
 		f, err := openSecureOutputFile(exportMatrixOutput)
 		if err != nil {
-			return fmt.Errorf("failed to open output file: %w", err)
+			return fmt.Errorf("cannot create output file %q (it may already exist — remove it or choose a different path): %w", exportMatrixOutput, err)
 		}
 		defer func() { _ = f.Close() }()
 		out = f

--- a/internal/cli/rbac/export_matrix_test.go
+++ b/internal/cli/rbac/export_matrix_test.go
@@ -673,7 +673,7 @@ func TestExportMatrix_EmbeddedOutputFileCreateError(t *testing.T) {
 
 	err := runExportMatrix(exportMatrixCmd, nil)
 	require.Error(t, err, "invalid output path must cause an error")
-	assert.Contains(t, err.Error(), "failed to open output file")
+	assert.Contains(t, err.Error(), "cannot create output file")
 }
 
 // TestExportMatrix_EmbeddedProjectNotFound — project filter with a missing project
@@ -771,19 +771,23 @@ func TestExportMatrix_OutputFileRestrictiveModeRegardlessOfUmask(t *testing.T) {
 // must tighten its mode to 0600 rather than leaving it as-is: O_TRUNC alone keeps a
 // pre-existing file's mode untouched, so the 0600 passed to OpenFile only takes
 // effect at creation time.
-func TestOpenSecureOutputFile_EnforcesModeOnPreexistingDestination(t *testing.T) {
+// TestOpenSecureOutputFile_RefusesPreexistingDestination pins the O_EXCL migration:
+// openSecureOutputFile used to silently overwrite (and tighten the mode of) a
+// pre-existing --output destination via O_TRUNC; it now delegates to
+// securefiles.SecureCreateFileHandle, which refuses to open through an already-existing
+// path at all (closing the TOCTOU an O_TRUNC-based check-then-write leaves open) —
+// leaving the original file, and its original content, untouched.
+func TestOpenSecureOutputFile_RefusesPreexistingDestination(t *testing.T) {
 	dir := t.TempDir()
 	path := dir + "/existing.json"
 	require.NoError(t, os.WriteFile(path, []byte("stale"), 0o644))
 
-	f, err := openSecureOutputFile(path)
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
+	_, err := openSecureOutputFile(path)
+	require.Error(t, err, "a pre-existing --output destination must now be refused, not silently overwritten")
 
-	info, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
-		"pre-existing destination mode must be tightened to 0600")
+	got, rerr := os.ReadFile(path)
+	require.NoError(t, rerr)
+	assert.Equal(t, "stale", string(got), "the pre-existing file must be left completely untouched")
 }
 
 // TestExportMatrix_EmbeddedProjectFound — project filter resolves successfully when

--- a/internal/cli/secret/export.go
+++ b/internal/cli/secret/export.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -27,17 +28,19 @@ var (
 )
 
 // createSecureOutputFile opens path for a fresh output file (export, render
-// --output, scan --report). O_EXCL refuses to write through a pre-existing
-// path — including a symlink an attacker (with write access to a shared
-// directory, e.g. /tmp) planted at the target ahead of time, which
-// os.Create's/os.WriteFile's default O_TRUNC would silently follow, writing
-// plaintext secrets to wherever the symlink points. O_NOFOLLOW is a second
-// layer against a dangling symlink placed in the instant between the check
-// and the open. 0600 keeps the output from being world/group-readable on
-// disk (#114). #G26: this pattern was originally export-only; every
-// --output/--report-style file write in this package now goes through it.
+// --output, scan --report). Delegates to securefiles.SecureCreateFileHandle, which
+// combines O_EXCL (refuses to write through OR overwrite a pre-existing path —
+// including a symlink an attacker with write access to a shared directory, e.g. /tmp,
+// planted at the target ahead of time) with a per-path-component O_NOFOLLOW walk
+// (stronger than a final-component-only check: it also refuses a symlink planted at an
+// intermediate directory component). 0600 keeps the output from being world/group-
+// readable on disk (#114). #G26: this pattern was originally export-only; every
+// --output/--report-style file write in this package now goes through it. path may be
+// an arbitrary operator-supplied absolute or relative path, so it's split into
+// (baseDir, relPath) the way securefiles expects — the same idiom already used at
+// internal/cli/license/license.go and internal/cli/config/cli_config.go.
 func createSecureOutputFile(path string) (*os.File, error) {
-	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL|syscall.O_NOFOLLOW, 0o600) // #nosec G304 -- operator-supplied CLI output path, not attacker input
+	return securefiles.SecureCreateFileHandle(filepath.Dir(path), filepath.Base(path), 0o600)
 }
 
 var exportCmd = &cobra.Command{

--- a/internal/cli/secret/fix.go
+++ b/internal/cli/secret/fix.go
@@ -108,9 +108,13 @@ func runFix(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Fixed %s:%d\n", plan.File, plan.Line)
 	}
 
-	// Append to .env file
+	// Append to .env file. O_NOFOLLOW refuses to write through a pre-planted symlink at
+	// envPath — an append-only open doesn't fit securefiles' O_EXCL-based create helper
+	// (the whole point here is to append to a file across repeated runs, not refuse a
+	// pre-existing one), so this is fixed in place rather than routed through it, mirroring
+	// applyFix's own O_NOFOLLOW-without-securefiles pattern later in this same file.
 	envPath := filepath.Join(absPath, fixEnvFile)
-	f, err := os.OpenFile(envPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600) // #nosec G304
+	f, err := os.OpenFile(envPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY|syscall.O_NOFOLLOW, 0600) // #nosec G304
 	if err == nil {
 		_, _ = fmt.Fprintf(f, "\n# Added by keyorix fix\n%s=\n", envVarName) // #nosec G104
 		_ = f.Close()                                                        // #nosec G104

--- a/internal/cli/trust/trust.go
+++ b/internal/cli/trust/trust.go
@@ -86,16 +86,29 @@ var keygenCmd = &cobra.Command{
 		pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
 
 		// Both at 0600 — the private key is a signing secret; the public key need not be
-		// world-readable here (it is published separately). SecureWriteFileSync (#265)
-		// refuses to write through a pre-planted symlink (O_NOFOLLOW) and enforces the
-		// mode even if a file already existed with a looser one — a plain os.WriteFile
-		// silently follows a symlink and never chmods an existing file, so the ROOT
-		// signing key could land world-readable or redirected to an attacker-controlled
-		// path with no error. Sync'd since this is unrecoverable key material.
-		if err := securefiles.SecureWriteFileSync(keygenDir, keyID+".private.pem", privPEM, 0o600); err != nil {
+		// world-readable here (it is published separately). SecureWriteFileSync/
+		// SecureCreateFileSync (#265) refuse to write through a pre-planted symlink
+		// (O_NOFOLLOW) and enforce the mode even if a file already existed with a looser
+		// one — a plain os.WriteFile silently follows a symlink and never chmods an
+		// existing file, so the ROOT signing key could land world-readable or redirected
+		// to an attacker-controlled path with no error. Sync'd since this is
+		// unrecoverable key material.
+		//
+		// Without --force, use SecureCreateFileSync: O_EXCL makes the create atomic and
+		// closes the TOCTOU window the os.Stat check above cannot — an attacker who drops
+		// in a replacement file in the gap between that check and this write no longer
+		// gets it silently truncated/replaced, they get the write refused (the check above
+		// remains for a fast, clear error message in the non-race case; O_EXCL is now the
+		// actual enforcement, not the check). --force intentionally allows overwrite, so it
+		// keeps using the non-exclusive SecureWriteFileSync (O_TRUNC).
+		writeKey := securefiles.SecureCreateFileSync
+		if keygenForce {
+			writeKey = securefiles.SecureWriteFileSync
+		}
+		if err := writeKey(keygenDir, keyID+".private.pem", privPEM, 0o600); err != nil {
 			return fmt.Errorf("write private key: %w", err)
 		}
-		if err := securefiles.SecureWriteFileSync(keygenDir, keyID+".public.pem", pubPEM, 0o600); err != nil {
+		if err := writeKey(keygenDir, keyID+".public.pem", pubPEM, 0o600); err != nil {
 			return fmt.Errorf("write public key: %w", err)
 		}
 

--- a/internal/cli/writeguard/write_guard_test.go
+++ b/internal/cli/writeguard/write_guard_test.go
@@ -1,0 +1,255 @@
+// Package writeguard is a standalone, test-only sweep over internal/cli that asserts no
+// production code calls os.Create/os.OpenFile/os.WriteFile directly for sensitive
+// output (exports, bundles, key material, evidence) outside the internal/securefiles
+// shared helpers — see keyorix-private/adversarial-review/QUEUE.md "Group 2 guard".
+//
+// Every call site the sweep finds must either route through securefiles
+// (SecureCreateFile/SecureCreateFileSync/SecureCreateFileHandle/SecureWriteFile/
+// SecureWriteFileSync) or appear in the allowlist below with a written justification —
+// an empty justification, or a call site the sweep can no longer find, fails the test
+// (see TestAllowlistJustificationsAreNonEmpty and TestAllowlistEntriesStillExist): this
+// keeps the allowlist honest rather than a place stale exemptions accumulate silently.
+package writeguard
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// allowlist maps "relative/path/from/internal/cli.go:LINE" to a written justification
+// for a raw os.Create/os.OpenFile/os.WriteFile call that intentionally does NOT route
+// through internal/securefiles. Every entry was reviewed as part of the Group 2
+// safe-file-writes fix; see the justification for why each one is safe/out-of-scope as
+// it stands, not merely undiscovered.
+var allowlist = map[string]string{
+	"encryption/migrate_provider.go:447": "copyFile's dst is used BOTH ways: a fresh backup path (create) and, on restore, a " +
+		"pre-existing DEK path that must be overwritten -- O_EXCL doesn't fit either the " +
+		"restore case or a helper that only supports one or the other. Already carries " +
+		"O_NOFOLLOW plus an explicit post-open Chmod, the same protection " +
+		"securefiles.SecureWriteFile provides, just checked at the final path component " +
+		"only (not per-component). Fixed/derived path under baseDir, not an arbitrary " +
+		"operator --output flag. Queue-rated medium-low, not one of Group 2's named fix sites.",
+	"bundle/bundle.go:92": "the --out path for `bundle build`: rebuilding to the same output path is a " +
+		"legitimate, common workflow (e.g. re-running in CI), so switching to the new " +
+		"O_EXCL create-only helper would regress that overwrite. WriteBundle also needs an " +
+		"io.Writer to stream to, not an already-assembled []byte, so SecureCreateFile's " +
+		"data-based form doesn't fit either. Properly fixing this needs a new " +
+		"non-exclusive, O_NOFOLLOW-only, handle-based securefiles primitive -- deliberately " +
+		"left as a follow-up rather than folded into this PR (queue: supply-chain build " +
+		"artifact, not secret data).",
+	"secret/fix.go:117": "appends only a variable NAME (not a secret value) to .env, idempotently, across " +
+		"repeated runs (O_APPEND|O_CREATE) -- O_APPEND is fundamentally incompatible with " +
+		"the O_EXCL create-only helper's refuse-if-exists semantics. Fixed in place by " +
+		"adding O_NOFOLLOW directly, mirroring applyFix's own O_NOFOLLOW-without-" +
+		"securefiles pattern later in this same file.",
+	"secret/fix.go:209": "applyFix's in-place edit of a file findAndPlanFix already opened and read via " +
+		"this exact path -- requires the file to already exist (no O_CREATE), which doesn't " +
+		"fit a create-a-new-file helper. Already carries O_NOFOLLOW. Queue-rated medium-low, " +
+		"not one of Group 2's named fix sites.",
+	"system/init.go:172": "creates an empty (0-byte) placeholder file for the local sqlite DB path purely " +
+		"to make first-boot vs. already-initialized unambiguous -- no data is written by " +
+		"this call. Already uses O_EXCL for an atomic, idempotent existence check " +
+		"(err == nil or IsExist are both treated as success).",
+	"system/init.go:202": "creates an empty (0-byte) placeholder file for the local log path, same " +
+		"idempotent-existence-check shape as init.go:172 -- no data is written by this call. " +
+		"Already uses O_EXCL.",
+}
+
+// sensitiveFn is the set of os.* functions this sweep flags.
+var sensitiveFn = map[string]bool{
+	"Create":    true,
+	"OpenFile":  true,
+	"WriteFile": true,
+}
+
+type site struct {
+	relPath string
+	line    int
+	fn      string
+}
+
+func (s site) key() string { return s.relPath + ":" + strconv.Itoa(s.line) }
+
+// cliRoot resolves the internal/cli directory relative to this test file's own
+// location (not the process cwd), so the sweep works regardless of how `go test` is
+// invoked.
+func cliRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller must resolve this test file's path")
+	// this file lives at internal/cli/writeguard/write_guard_test.go
+	root, err := filepath.Abs(filepath.Join(filepath.Dir(thisFile), ".."))
+	require.NoError(t, err)
+	return root
+}
+
+// scanFile parses a single .go file and returns every os.Create/os.OpenFile/
+// os.WriteFile call site found in it (by AST inspection, not string/regex matching, so
+// it isn't fooled by the call appearing in a comment or string literal, and isn't
+// blind to unusual formatting).
+func scanFile(fset *token.FileSet, path string) ([]site, error) {
+	src, err := os.ReadFile(path) // #nosec G304 -- fixed repo-internal path built from filepath.Walk below, not external input
+	if err != nil {
+		return nil, err
+	}
+	f, err := parser.ParseFile(fset, path, src, 0)
+	if err != nil {
+		return nil, err
+	}
+	var sites []site
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkgIdent, ok := sel.X.(*ast.Ident)
+		if !ok || pkgIdent.Name != "os" {
+			return true
+		}
+		if !sensitiveFn[sel.Sel.Name] {
+			return true
+		}
+		pos := fset.Position(call.Pos())
+		sites = append(sites, site{relPath: path, line: pos.Line, fn: sel.Sel.Name})
+		return true
+	})
+	return sites, nil
+}
+
+// findAllSites walks root (internal/cli) recursively, scanning every non-test .go file
+// (test fixtures are allowed to build test data with raw os calls; this sweep is about
+// production output paths) and returns every raw os.Create/os.OpenFile/os.WriteFile
+// call site found, keyed by path relative to root.
+func findAllSites(t *testing.T, root string) map[string]site {
+	t.Helper()
+	fset := token.NewFileSet()
+	found := map[string]site{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		sites, serr := scanFile(fset, path)
+		if serr != nil {
+			return serr
+		}
+		for _, s := range sites {
+			rel, rerr := filepath.Rel(root, s.relPath)
+			require.NoError(t, rerr)
+			s.relPath = filepath.ToSlash(rel)
+			found[s.key()] = s
+		}
+		return nil
+	})
+	require.NoError(t, err, "walking %s must not fail", root)
+	return found
+}
+
+// TestNoUnprotectedSensitiveFileWrites is the Group 2 guard: every raw os.Create/
+// os.OpenFile/os.WriteFile call under internal/cli must be explicitly allowlisted
+// (with a written justification), i.e. everything else must go through
+// internal/securefiles. Verified RED against pre-fix code (it flagged
+// compliance/csv_export.go:51, compliance/compliance.go:228, compliance/baseline.go:49,
+// and rbac/export_matrix.go:79 before those sites were migrated); GREEN after.
+func TestNoUnprotectedSensitiveFileWrites(t *testing.T) {
+	root := cliRoot(t)
+	found := findAllSites(t, root)
+
+	var unallowed []string
+	for key, s := range found {
+		if _, ok := allowlist[key]; !ok {
+			unallowed = append(unallowed, key+" (os."+s.fn+")")
+		}
+	}
+	sort.Strings(unallowed)
+	assert.Empty(t, unallowed,
+		"raw os.Create/os.OpenFile/os.WriteFile call(s) for sensitive CLI output found with "+
+			"no securefiles routing and no allowlist entry -- route through "+
+			"securefiles.SecureCreateFile(Sync|Handle) (or SecureWriteFile(Sync) for an "+
+			"intentional-overwrite case), or add a reviewed allowlist entry with a written "+
+			"justification: %v", unallowed)
+}
+
+// TestAllowlistEntriesStillExist is the flip side of the guard above: an allowlist
+// entry for a call site that no longer exists (renamed, deleted, or — worse — silently
+// migrated onto securefiles without removing its exemption) would hide a
+// regression the moment that exact line shifts. A stale entry doesn't fail the sweep
+// above (which only checks found-but-unallowed sites), so it's checked here explicitly.
+func TestAllowlistEntriesStillExist(t *testing.T) {
+	root := cliRoot(t)
+	found := findAllSites(t, root)
+
+	var stale []string
+	for key := range allowlist {
+		if _, ok := found[key]; !ok {
+			stale = append(stale, key)
+		}
+	}
+	sort.Strings(stale)
+	assert.Empty(t, stale,
+		"allowlist entry no longer matches any real os.Create/os.OpenFile/os.WriteFile "+
+			"call site (the code moved, or was fixed, without updating this list): %v", stale)
+}
+
+// TestAllowlistJustificationsAreNonEmpty guards against an allowlist entry added with
+// an empty/placeholder reason, per this campaign's standing rule that an exemption
+// needs a written justification, not just a line number.
+func TestAllowlistJustificationsAreNonEmpty(t *testing.T) {
+	for key, reason := range allowlist {
+		assert.NotEmpty(t, strings.TrimSpace(reason), "allowlist entry %q has no justification", key)
+	}
+}
+
+// TestScannerDetectsRawWriteCalls is a self-check on the AST sweep itself: a guard
+// that has never been observed to fail on a genuinely bad input is not a guard (a test
+// asserting emptiness of a possibly-always-empty scan would pass even if the AST
+// matching logic were broken, e.g. matching the wrong selector or the wrong package
+// name). This proves the scanner actually detects each of the three flagged os.*
+// functions when they're present, independent of internal/cli's current contents.
+func TestScannerDetectsRawWriteCalls(t *testing.T) {
+	dir := t.TempDir()
+	src := `package fixture
+
+import "os"
+
+func bad1() { os.Create("x") }
+func bad2() { f, _ := os.OpenFile("x", os.O_CREATE, 0600); _ = f }
+func bad3() { _ = os.WriteFile("x", nil, 0600) }
+func fine() { _, _ = os.ReadFile("x") }
+`
+	path := filepath.Join(dir, "fixture.go")
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+
+	fset := token.NewFileSet()
+	sites, err := scanFile(fset, path)
+	require.NoError(t, err)
+
+	got := map[string]bool{}
+	for _, s := range sites {
+		got[s.fn] = true
+	}
+	assert.True(t, got["Create"], "scanner must detect os.Create")
+	assert.True(t, got["OpenFile"], "scanner must detect os.OpenFile")
+	assert.True(t, got["WriteFile"], "scanner must detect os.WriteFile")
+	assert.Len(t, sites, 3, "scanner must not also flag os.ReadFile or find phantom sites")
+}

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -283,6 +283,83 @@ func SecureWriteFileSync(baseDir, path string, data []byte, perm os.FileMode) er
 	return f.Close()
 }
 
+// SecureCreateFile writes data to a NEW file at filepath.Join(baseDir, path),
+// combining the two strongest write protections found independently elsewhere in this
+// codebase into one: secureOpenBeneath's per-path-component O_NOFOLLOW walk (this
+// package's existing SecureWriteFile/SecureWriteFileSync), plus O_EXCL (previously only
+// in internal/cli/secret/export.go's createSecureOutputFile). O_EXCL makes the create
+// atomic and refuses to write through — or truncate/overwrite — any pre-existing path,
+// including one planted in the window between an earlier existence check and this call
+// (the TOCTOU that a bare os.Stat-then-write leaves open). Unlike SecureWriteFile, this
+// intentionally does NOT silently overwrite: it returns an error (wrapping O_EXCL's
+// EEXIST) if path already exists. Callers that need overwrite-on-purpose (an explicit
+// --force) should use SecureWriteFile/SecureWriteFileSync instead. The perm argument is
+// Chmod'd explicitly after creation (in addition to being passed to the underlying
+// open) so the intended mode is enforced even under a restrictive process umask.
+func SecureCreateFile(baseDir, path string, data []byte, perm os.FileMode) error {
+	f, err := secureCreateOpenBeneath(baseDir, path, perm)
+	if err != nil {
+		return err
+	}
+	if _, werr := f.Write(data); werr != nil {
+		_ = f.Close()
+		return werr
+	}
+	return f.Close()
+}
+
+// SecureCreateFileSync writes like SecureCreateFile but fsyncs before returning, for
+// durability-critical material created for the first time (e.g. a freshly generated
+// signing key) — mirroring SecureWriteFileSync's relationship to SecureWriteFile.
+func SecureCreateFileSync(baseDir, path string, data []byte, perm os.FileMode) error {
+	f, err := secureCreateOpenBeneath(baseDir, path, perm)
+	if err != nil {
+		return err
+	}
+	if _, werr := f.Write(data); werr != nil {
+		_ = f.Close()
+		return werr
+	}
+	if serr := f.Sync(); serr != nil {
+		_ = f.Close()
+		return serr
+	}
+	return f.Close()
+}
+
+// SecureCreateFileHandle opens a NEW file at baseDir/path for writing and returns the
+// open *os.File, for callers that need to stream output (e.g. a CSV/JSON encoder or a
+// tar writer) rather than write a single already-assembled []byte — see SecureCreateFile
+// for the data-based variant this mirrors. The caller owns the returned file and must
+// close it. Same O_EXCL + per-component-O_NOFOLLOW guarantee as SecureCreateFile: it
+// refuses to create through a symlink at any path component and refuses to write
+// through (or replace) a pre-existing path.
+func SecureCreateFileHandle(baseDir, path string, perm os.FileMode) (*os.File, error) {
+	return secureCreateOpenBeneath(baseDir, path, perm)
+}
+
+// secureCreateOpenBeneath is the shared implementation behind SecureCreateFile,
+// SecureCreateFileSync, and SecureCreateFileHandle: resolveInside's fast lexical
+// pre-check, then secureOpenBeneath's per-component O_NOFOLLOW walk with O_EXCL added so
+// the leaf open refuses a pre-existing path (regular file OR symlink) instead of
+// silently truncating/following it. The explicit Chmod guards against a restrictive
+// umask masking the requested perm at creation time (O_CREAT's mode argument is
+// masked by umask, same reasoning SecureWriteFile documents for its own Chmod call).
+func secureCreateOpenBeneath(baseDir, path string, perm os.FileMode) (*os.File, error) {
+	if _, err := resolveInside(baseDir, path); err != nil {
+		return nil, err
+	}
+	f, err := secureOpenBeneath(baseDir, path, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL, perm) // #nosec G304 -- path validated inside baseDir by resolveInside + secureOpenBeneath's per-component O_NOFOLLOW walk; O_EXCL refuses a pre-existing path
+	if err != nil {
+		return nil, err
+	}
+	if cerr := f.Chmod(perm); cerr != nil {
+		_ = f.Close()
+		return nil, cerr
+	}
+	return f, nil
+}
+
 // SyncDir fsyncs the directory dirPath so a preceding file create or rename
 // within it is durable (the directory entry is flushed). On platforms where
 // opening a directory for sync is unsupported the error is returned to the

--- a/internal/securefiles/securefiles_create_test.go
+++ b/internal/securefiles/securefiles_create_test.go
@@ -1,0 +1,141 @@
+package securefiles
+
+// Regression tests for SecureCreateFile/SecureCreateFileSync/SecureCreateFileHandle —
+// see keyorix-private/adversarial-review/QUEUE.md "Group 2 — Safe file writes". These
+// combine SecureWriteFile's per-path-component O_NOFOLLOW walk with O_EXCL (previously
+// only in internal/cli/secret/export.go's createSecureOutputFile), into one shared
+// create-only helper used across internal/cli/{secret,rbac,compliance,trust}.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecureCreateFile_CreatesFreshFileWithPerm(t *testing.T) {
+	base := t.TempDir()
+	want := []byte("fresh-bytes")
+	require.NoError(t, SecureCreateFile(base, "out.txt", want, 0600))
+
+	info, err := os.Stat(filepath.Join(base, "out.txt"))
+	require.NoError(t, err)
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	}
+	got, err := SafeReadFile(base, "out.txt")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestSecureCreateFile_RefusesPreexistingRegularFile(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "already-there.txt")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0o600))
+
+	err := SecureCreateFile(base, "already-there.txt", []byte("new"), 0600)
+	require.Error(t, err, "O_EXCL must refuse to overwrite a pre-existing file")
+
+	got, rerr := os.ReadFile(target) //nolint:gosec // test-controlled fixed path
+	require.NoError(t, rerr)
+	assert.Equal(t, "old", string(got), "the pre-existing file's content must be left untouched")
+}
+
+func TestSecureCreateFile_RefusesPrePlantedSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	base := t.TempDir()
+	outside := filepath.Join(filepath.Dir(base), "attacker-owned.txt")
+	link := filepath.Join(base, "planted-link.txt")
+	require.NoError(t, os.Symlink(outside, link))
+
+	err := SecureCreateFile(base, "planted-link.txt", []byte("secret"), 0600)
+	require.Error(t, err, "a symlinked target must be refused, not followed")
+	_, statErr := os.Stat(outside)
+	assert.True(t, os.IsNotExist(statErr), "the symlink target must never have been created/written")
+}
+
+func TestSecureCreateFile_RejectsTraversal(t *testing.T) {
+	base := t.TempDir()
+	err := SecureCreateFile(base, "../escape.txt", []byte("x"), 0600)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access denied")
+	_, statErr := os.Stat(filepath.Join(filepath.Dir(base), "escape.txt"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestSecureCreateFileSync_CreatesFreshFileDurably(t *testing.T) {
+	base := t.TempDir()
+	want := []byte("durable-fresh-bytes")
+	require.NoError(t, SecureCreateFileSync(base, "sync.txt", want, 0600))
+
+	got, err := SafeReadFile(base, "sync.txt")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestSecureCreateFileSync_RefusesPreexistingFile(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "existing.key")
+	require.NoError(t, os.WriteFile(target, []byte("old-key"), 0o600))
+
+	err := SecureCreateFileSync(base, "existing.key", []byte("new-key"), 0600)
+	require.Error(t, err)
+
+	got, rerr := os.ReadFile(target) //nolint:gosec // test-controlled fixed path
+	require.NoError(t, rerr)
+	assert.Equal(t, "old-key", string(got))
+}
+
+func TestSecureCreateFileHandle_StreamingWriteAndClose(t *testing.T) {
+	base := t.TempDir()
+	f, err := SecureCreateFileHandle(base, "stream.csv", 0600)
+	require.NoError(t, err)
+	_, werr := f.WriteString("a,b,c\n1,2,3\n")
+	require.NoError(t, werr)
+	require.NoError(t, f.Close())
+
+	info, err := os.Stat(filepath.Join(base, "stream.csv"))
+	require.NoError(t, err)
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	}
+	got, err := SafeReadFile(base, "stream.csv")
+	require.NoError(t, err)
+	assert.Equal(t, "a,b,c\n1,2,3\n", string(got))
+}
+
+func TestSecureCreateFileHandle_RefusesPreexistingFile(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "matrix.json")
+	require.NoError(t, os.WriteFile(target, []byte("{}"), 0o644))
+
+	_, err := SecureCreateFileHandle(base, "matrix.json", 0600)
+	require.Error(t, err, "a pre-existing destination must be refused, not silently truncated/overwritten")
+
+	got, rerr := os.ReadFile(target) //nolint:gosec // test-controlled fixed path
+	require.NoError(t, rerr)
+	assert.Equal(t, "{}", string(got), "the pre-existing file must be left completely untouched")
+}
+
+func TestSecureCreateFileHandle_RefusesIntermediateSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	base := t.TempDir()
+	outsideDir := t.TempDir()
+	// Plant a symlink AT an intermediate directory component pointing outside base --
+	// the property SecureCreateFile has that a bare final-component-O_NOFOLLOW open
+	// (like the pre-fix openSecureOutputFile) does not.
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(base, "subdir")))
+
+	_, err := SecureCreateFileHandle(base, "subdir/out.txt", 0600)
+	require.Error(t, err, "a symlink at an intermediate path component must be refused")
+
+	_, statErr := os.Stat(filepath.Join(outsideDir, "out.txt"))
+	assert.True(t, os.IsNotExist(statErr), "nothing must have been created through the planted intermediate symlink")
+}


### PR DESCRIPTION
## Summary

- Compliance export (`csv_export.go`'s `emitCSV`, `compliance.go`'s evidence-pack export, `baseline.go`'s JSON permission-baseline) wrote auditor-sensitive data via raw `os.WriteFile` to an operator-supplied `--output` path with zero protection: no `O_NOFOLLOW`, no `O_EXCL`, silently following a planted symlink or overwriting whatever was already there.
- `trust-keygen` had a real TOCTOU: an `os.Stat` "does this key already exist" check followed later by the actual write, with a window in between where an attacker could drop in a replacement file and bypass the `--force` requirement silently (the write itself already refused symlinks, so this was bounded to an overwrite-bypass, not arbitrary-file-write).
- `rbac/export_matrix.go` had an independently hand-rolled, weaker copy of the same pattern (final-component-only `O_NOFOLLOW`, no `O_EXCL`).

## Fix

Added `SecureCreateFile`/`SecureCreateFileSync`/`SecureCreateFileHandle` to `internal/securefiles`, combining the package's existing per-path-component `O_NOFOLLOW` walk with `O_EXCL` (previously only in `secret/export.go`'s `createSecureOutputFile`, the strongest pattern in the repo). Routed onto the new shared helper:

- `internal/cli/compliance/csv_export.go` (`emitCSV`), `compliance.go` (`export`), `baseline.go` (`permission-baseline --format json`)
- `internal/cli/rbac/export_matrix.go`'s `openSecureOutputFile` (behavior change: re-running to an existing `--output` path now fails instead of silently overwriting, matching `secret export`'s existing convention)
- `internal/cli/secret/export.go`'s own `createSecureOutputFile` (upgrades `render`/`scan --report` too, for free — closes the intermediate-symlink gap even the "best" existing pattern had)
- `internal/cli/trust/trust.go`'s non-`--force` write path (the `os.Stat` pre-check stays for a fast, clear error message; `O_EXCL` is now the actual enforcement, closing the race). `--force` keeps the existing overwrite-capable `SecureWriteFileSync`.

Also fixed `internal/cli/secret/fix.go`'s `.env` append (added `O_NOFOLLOW` directly — `O_APPEND` doesn't fit the O_EXCL create-only helper's semantics).

**Deferred, with reasons** (allowlisted in the new guard test rather than silently dropped):
- `internal/cli/bundle/bundle.go:92` — rebuilding to the same `--out` path is a legitimate workflow (e.g. CI), so `O_EXCL` would regress that; also needs an `io.Writer` to stream to, which the data-based helper doesn't provide. Needs a new non-exclusive, handle-based primitive — real follow-up work, not folded into this PR.
- `internal/cli/encryption/migrate_provider.go:447` — `copyFile`'s `dst` is used both as a fresh backup path and (on restore) a pre-existing path that must be overwritten, so `O_EXCL` doesn't fit either case cleanly; already carries `O_NOFOLLOW` + explicit `Chmod`, same protection `SecureWriteFile` gives, just final-component only. Queue-rated medium-low.
- `internal/cli/secret/fix.go:209` (`applyFix`) — edits a file already opened/read via the same path, requires no `O_CREATE`. Already carries `O_NOFOLLOW`. Queue-rated medium-low.
- `internal/cli/system/init.go:172,202` — create empty (0-byte) placeholder files for idempotent first-boot detection; already use `O_EXCL`, no data written.

## Guard test

Added `internal/cli/writeguard` — an AST-based sweep asserting no raw `os.Create`/`os.OpenFile`/`os.WriteFile` call exists for sensitive CLI output outside `securefiles`, with an allowlist requiring a written justification per entry, plus a self-check proving the scanner actually detects each flagged function shape. Verified red against the pre-fix code (flagged all the sites above); green after.

## Test plan

- [x] `go build ./...`
- [x] `go vet` on every touched package
- [x] `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated` clean on touched packages
- [x] Full test suite green for every touched package (`internal/securefiles`, `internal/cli/{secret,rbac,compliance,trust,writeguard}`), including updated fixtures for the two intentional behavior changes (export-matrix and trust-keygen no longer silently overwrite)
- [x] New regression tests: `securefiles_create_test.go` (O_EXCL + per-component symlink refusal), `compliance/output_excl_test.go`, `rbac/export_matrix_test.go`'s rewritten overwrite test
- [x] Guard test verified RED pre-fix, GREEN post-fix