### PR TITLE
fix(security): unify key-permission checkers on a shared registry (G81)

### DIFF
--- a/cmd/system/fixfileperm.go
+++ b/cmd/system/fixfileperm.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/keyfiles"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/keyorixhq/keyorix/internal/startup"
 	"github.com/spf13/cobra"
@@ -52,21 +53,20 @@ func runFixFilePermNoExit() bool {
 	// the same containment check validateFilePermissions applies before
 	// FixFilePerms, so a config-driven '..' can't chmod an unintended file.
 	var files []securefiles.FilePermSpec
-	for _, spec := range []struct{ label, path string }{
-		{"KEK salt", cfg.Storage.Encryption.SaltPath},
-		{"DEK", cfg.Storage.Encryption.DEKPath},
-		{"config file", resolvedPath},
-	} {
-		if spec.path == "" {
-			continue
-		}
-		clean, cerr := startup.SafeFilePermPath(spec.label, spec.path)
+	if resolvedPath != "" {
+		clean, cerr := startup.SafeFilePermPath("config file", resolvedPath)
 		if cerr != nil {
 			fmt.Println("Failed to fix file permissions:", cerr)
 			return true
 		}
 		files = append(files, securefiles.FilePermSpec{Path: clean, Mode: 0600})
 	}
+	specs, err := keyfiles.Registry(&cfg.Storage.Encryption, ".")
+	if err != nil {
+		fmt.Println("Failed to fix file permissions:", err)
+		return true
+	}
+	files = append(files, specs...)
 
 	// fix permissions: autofix = true
 	if err := securefiles.FixFilePerms(files, true); err != nil {

--- a/docs/security-closures.tsv
+++ b/docs/security-closures.tsv
@@ -18,6 +18,7 @@ FIX-7-breakglass	./internal/storage/store	TestDeleteExpiredBreakGlassBefore_Reco
 FIX-8-csv	./internal/core	TestCSVWriters_EncodeAgainstFormulaInjection	d1b93444	structural: every CSV writer applies an encoder
 INV-1-grant-authority	./server/http	TestEveryDirectRoleGrantChecksAuthority	pre-existing	structural: every direct role grant checks authority
 GCP-CONN-PROJECTID	./internal/connect	TestGCPSM_RequiresProjectID	pending	unpinned gcp-secret-manager connector must refuse reads, not span any GCP project
+G81-KEYPERM-REGISTRY	./internal/keyfiles	TestRegistry_IncludesWrappedKeyPathForEveryWriteCapableType	pending	TPM/cloud-KMS wrapped-KEK blob must be covered by the shared key-permission checker registry, not just DEK/salt
 
 # NOT LISTED, deliberately:
 #   FIX-1 actorID==0 fast-path (internal/core/authz.go:614). The eight-site reroute

--- a/internal/cli/system/audit.go
+++ b/internal/cli/system/audit.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/keyfiles"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
-	"github.com/keyorixhq/keyorix/internal/startup"
 	"github.com/spf13/cobra"
 )
 
@@ -54,25 +54,17 @@ func runAuditNoExit() bool {
 		return true
 	}
 
-	// #G59 (sibling gap): SaltPath/DEKPath are config-driven and about to be
-	// Lstat'd/opened — sanitized the same way validateFilePermissions and
+	// #G59 (sibling gap): every key-material path below is config-driven and about
+	// to be Lstat'd/opened — sanitized the same way validateFilePermissions and
 	// fixfileperm.go's autofix path do, so a config-driven '..' can't probe an
 	// unintended file's permissions even in audit-only mode.
 	files := []securefiles.FilePermSpec{{Path: configPath, Mode: 0600}}
-	for _, spec := range []struct{ label, path string }{
-		{"KEK salt", cfg.Storage.Encryption.SaltPath},
-		{"DEK", cfg.Storage.Encryption.DEKPath},
-	} {
-		if spec.path == "" {
-			continue
-		}
-		clean, cerr := startup.SafeFilePermPath(spec.label, spec.path)
-		if cerr != nil {
-			fmt.Println("Failed to fix file permissions:", cerr)
-			return true
-		}
-		files = append(files, securefiles.FilePermSpec{Path: clean, Mode: 0600})
+	specs, err := keyfiles.Registry(&cfg.Storage.Encryption, ".")
+	if err != nil {
+		fmt.Println("Failed to fix file permissions:", err)
+		return true
 	}
+	files = append(files, specs...)
 
 	if err := securefiles.FixFilePerms(files, false); err != nil { // false = audit only
 		fmt.Println("\nAudit finished with warnings/errors. Please fix the issues.")

--- a/internal/encryption/encryption_s2_test.go
+++ b/internal/encryption/encryption_s2_test.go
@@ -224,7 +224,7 @@ func TestAuthEncryption_GetAuthEncryptionStatus_Disabled(t *testing.T) {
 
 // --- KeyManager.ValidateKeyFiles and FixKeyFilePermissions ---
 
-func newInitializedKeyManager(t *testing.T) *KeyManager {
+func newInitializedKeyManager(t *testing.T) (*KeyManager, *config.EncryptionConfig) {
 	t.Helper()
 	dir := t.TempDir()
 	// Build a KeyManager via Service initialization so files are written.
@@ -235,28 +235,36 @@ func newInitializedKeyManager(t *testing.T) *KeyManager {
 	}
 	svc := NewService(cfg, dir)
 	require.NoError(t, svc.Initialize("test-passphrase-s2"))
-	return svc.keyManager
+	return svc.keyManager, cfg
 }
 
 // TestKeyManager_Initialized_Suite shares one newInitializedKeyManager call across
 // subtests to avoid redundant PBKDF2 derivations.
 func TestKeyManager_Initialized_Suite(t *testing.T) {
-	km := newInitializedKeyManager(t)
+	km, cfg := newInitializedKeyManager(t)
 
 	t.Run("ValidateKeyFiles", func(t *testing.T) {
 		// After successful init the files exist with 0600; validate must succeed.
-		require.NoError(t, km.ValidateKeyFiles())
+		require.NoError(t, km.ValidateKeyFiles(cfg))
 	})
 
 	t.Run("FixKeyFilePermissions", func(t *testing.T) {
 		// Loosen permissions so FixKeyFilePermissions has something to fix.
 		require.NoError(t, os.Chmod(filepath.Join(km.baseDir, km.dekPath), 0644))
 		require.NoError(t, os.Chmod(filepath.Join(km.baseDir, km.saltPath), 0644))
-		require.NoError(t, km.FixKeyFilePermissions())
+		require.NoError(t, km.FixKeyFilePermissions(cfg))
 		info, err := os.Stat(filepath.Join(km.baseDir, km.dekPath))
 		require.NoError(t, err)
 		assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
 	})
+}
+
+// TestKeyManager_ValidateKeyFiles_NilConfig exercises the enc==nil path (a
+// KeyManager used without ever registering an encryption config, e.g. a
+// standalone unit test) directly, alongside the missing-files case above.
+func TestKeyManager_ValidateKeyFiles_NilConfig(t *testing.T) {
+	km, _ := newInitializedKeyManager(t)
+	require.NoError(t, km.ValidateKeyFiles(nil))
 }
 
 func TestKeyManager_ValidateKeyFiles_MissingFiles(t *testing.T) {
@@ -266,7 +274,7 @@ func TestKeyManager_ValidateKeyFiles_MissingFiles(t *testing.T) {
 		dekPath:  "missing.dek",
 		saltPath: "missing.salt",
 	}
-	err := km.ValidateKeyFiles()
+	err := km.ValidateKeyFiles(nil)
 	require.Error(t, err)
 }
 

--- a/internal/encryption/keymanager_io.go
+++ b/internal/encryption/keymanager_io.go
@@ -7,6 +7,8 @@ package encryption
 import (
 	"path/filepath"
 
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/keyfiles"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
 )
 
@@ -55,22 +57,64 @@ func (km *KeyManager) GetAuditCheckpointKey() (key []byte, keyID string, ok bool
 	return key, km.auditCheckpointKeyID, true
 }
 
-// ValidateKeyFiles checks that key files exist and have correct permissions (0600).
-func (km *KeyManager) ValidateKeyFiles() error {
-	files := []securefiles.FilePermSpec{
-		{Path: filepath.Join(km.baseDir, km.dekPath), Mode: 0600},
-		{Path: filepath.Join(km.baseDir, km.saltPath), Mode: 0600},
+// ValidateKeyFiles checks that key files exist and have correct permissions
+// (0600). enc is the full encryption config (used to also cover any
+// KeyProviderConfig-driven key material -- TPM/cloud-KMS wrapped-KEK blobs,
+// Shamir share files -- via internal/keyfiles.Registry, not just the DEK and
+// salt km itself was constructed with); nil checks DEK+salt only, for a
+// KeyManager built without one (e.g. directly in a test).
+func (km *KeyManager) ValidateKeyFiles(enc *config.EncryptionConfig) error {
+	files, err := km.keyFileSpecs(enc)
+	if err != nil {
+		return err
 	}
 	return securefiles.FixFilePerms(files, false)
 }
 
-// FixKeyFilePermissions corrects key file permissions to 0600.
-func (km *KeyManager) FixKeyFilePermissions() error {
-	files := []securefiles.FilePermSpec{
-		{Path: filepath.Join(km.baseDir, km.dekPath), Mode: 0600},
-		{Path: filepath.Join(km.baseDir, km.saltPath), Mode: 0600},
+// FixKeyFilePermissions corrects key file permissions to 0600. See
+// ValidateKeyFiles for what enc adds.
+func (km *KeyManager) FixKeyFilePermissions(enc *config.EncryptionConfig) error {
+	files, err := km.keyFileSpecs(enc)
+	if err != nil {
+		return err
 	}
 	return securefiles.FixFilePerms(files, true)
+}
+
+// keyFileSpecs builds the FilePermSpec list shared by ValidateKeyFiles and
+// FixKeyFilePermissions: km's own DEK/salt paths, plus (when enc is provided)
+// every other key-material path internal/keyfiles.Registry derives from the
+// full encryption config. km.dekPath/km.saltPath are used directly (rather
+// than enc.DEKPath/enc.SaltPath) so this still works for a KeyManager built
+// without a config at all.
+func (km *KeyManager) keyFileSpecs(enc *config.EncryptionConfig) ([]securefiles.FilePermSpec, error) {
+	dekFull := filepath.Join(km.baseDir, km.dekPath)
+	saltFull := filepath.Join(km.baseDir, km.saltPath)
+	files := []securefiles.FilePermSpec{
+		{Path: dekFull, Mode: 0600},
+		{Path: saltFull, Mode: 0600},
+	}
+	if enc == nil {
+		return files, nil
+	}
+	specs, err := keyfiles.Registry(enc, km.baseDir)
+	if err != nil {
+		return nil, err
+	}
+	// enc's own SaltPath/DEKPath normally resolve to the same files as
+	// km.dekPath/km.saltPath (both are set from the same config at
+	// construction, see NewService) -- deduped here rather than trusted to
+	// match, so a caller that ever passes a mismatched enc still gets km's
+	// real DEK/salt checked exactly once, not silently dropped or doubled.
+	seen := map[string]bool{dekFull: true, saltFull: true}
+	for _, s := range specs {
+		if seen[s.Path] {
+			continue
+		}
+		seen[s.Path] = true
+		files = append(files, s)
+	}
+	return files, nil
 }
 
 // Wipe securely removes the DEK, the evidence-signing key, and the

--- a/internal/encryption/service_rotation.go
+++ b/internal/encryption/service_rotation.go
@@ -264,14 +264,18 @@ func (s *Service) RewrapDEKWithProvider(newProvider crypto.KeyProvider) error {
 	return s.keyManager.RewrapDEK(newProvider)
 }
 
-// ValidateKeyFiles validates encryption key files exist with correct permissions.
+// ValidateKeyFiles validates encryption key files exist with correct
+// permissions -- the DEK/salt (ADR-004) plus any KeyProviderConfig-driven key
+// material (TPM/cloud-KMS wrapped-KEK blob, Shamir share files) s.config
+// declares; see internal/keyfiles.Registry.
 func (s *Service) ValidateKeyFiles() error {
-	return s.keyManager.ValidateKeyFiles()
+	return s.keyManager.ValidateKeyFiles(s.config)
 }
 
-// FixKeyFilePermissions fixes key file permissions to 0600.
+// FixKeyFilePermissions fixes key file permissions to 0600, for the same set
+// ValidateKeyFiles checks.
 func (s *Service) FixKeyFilePermissions() error {
-	return s.keyManager.FixKeyFilePermissions()
+	return s.keyManager.FixKeyFilePermissions(s.config)
 }
 
 // GetKeyVersion returns the current key version string.

--- a/internal/keyfiles/registry.go
+++ b/internal/keyfiles/registry.go
@@ -1,0 +1,191 @@
+// Package keyfiles is the single, shared enumeration of every on-disk
+// encryption key-material file a key-permission checker must inspect.
+//
+// Before this package existed, four independent call sites each hand-built
+// their own []securefiles.FilePermSpec list for the same underlying key
+// material: internal/cli/system/audit.go (`keyorix system audit`),
+// cmd/system/fixfileperm.go (`keyorix system fixfileperm`),
+// internal/startup/validation.go (every server boot), and
+// internal/encryption/keymanager_io.go (KeyManager.ValidateKeyFiles /
+// FixKeyFilePermissions). All four only ever listed the KEK salt and the
+// wrapped DEK (ADR-004) -- true for the original password-only provider, but
+// no longer complete once ADR-038 (TPM) and ADR-041 (cloud KMS) added a
+// SEPARATE wrapped-KEK blob (KeyProviderConfig.WrappedKeyPath) that none of
+// the four lists ever grew to include.
+//
+// Registry replaces all four hand-copied lists with one enumeration driven by
+// *config.EncryptionConfig itself: a future 5th KeyProviderConfig provider
+// type that writes new key material to disk needs to be added HERE once (see
+// the guard test in registry_exhaustiveness_test.go) to be picked up by every
+// caller, instead of requiring four separate, easy-to-miss edits -- which is
+// exactly how WrappedKeyPath got missed in the first place.
+package keyfiles
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/securefiles"
+)
+
+// keyMaterialMode is the permission mode required for every file this
+// registry enumerates: private key material, readable/writable only by the
+// process owner.
+const keyMaterialMode = 0600
+
+// writeCapableProviderTypes are the KeyProviderConfig.Type values whose
+// provider constructor (internal/encryption/service.go's buildSingleProvider)
+// persists key material to WrappedKeyPath -- see
+// registry_exhaustiveness_test.go, which re-derives this list from the actual
+// source rather than trusting it blindly. "shamir" is handled separately
+// below: crypto.ShamirKeyProvider itself never writes, but its share files
+// are written by a different tool (`keyorix encryption shamir-split`) and are
+// config-driven the same way, so they belong in this registry too.
+var writeCapableProviderTypes = map[string]bool{
+	"tpm":       true,
+	"aws-kms":   true,
+	"gcp-kms":   true,
+	"azure-kms": true,
+}
+
+// SafePath cleans path and rejects it if the cleaned form still contains a
+// ".." segment. Every path this package adds to a Registry() result passes
+// through this first: these paths come from several independently-authored
+// config fields (salt, DEK, per-provider wrapped-key/shamir-share paths,
+// recursively through Fallbacks) that securefiles.FixFilePerms will
+// Lstat/Chmod/Chown, so a config-driven path-traversal can't steer it at an
+// unintended file.
+func SafePath(label, path string) (string, error) {
+	clean := filepath.Clean(path)
+	if strings.Contains(clean, "..") {
+		return "", fmt.Errorf("%s path is unsafe (contains '..'): %s", label, path)
+	}
+	return clean, nil
+}
+
+// resolve maps a configured key-material path to its on-disk location: an
+// absolute path is used as-is, a relative one is resolved under baseDir.
+// Mirrors internal/startup's resolveKeyPath. A naive filepath.Join(baseDir,
+// path) is NOT equivalent when path is absolute -- Join silently discards the
+// leading slash (filepath.Join(".", "/etc/x") == "etc/x", not "/etc/x"), which
+// would turn a configured absolute key path into the wrong relative one.
+func resolve(baseDir, path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(baseDir, path))
+}
+
+// Registry enumerates every on-disk key-material file governed by enc, rooted
+// at baseDir, as the FilePermSpec list a key-permission checker should pass to
+// securefiles.FixFilePerms.
+//
+// Included:
+//   - The KEK salt and wrapped DEK (enc.SaltPath / enc.DEKPath, ADR-004) --
+//     required: FixFilePerms itself fails closed if either is missing,
+//     matching this repo's existing behavior (an operator provisions these
+//     via `keyorix system init --encryption` before the server's first real
+//     boot; see internal/startup/validation.go's identical pre-existing
+//     requirement for these same two paths).
+//   - Their ".pending" rotation-staging siblings
+//     (internal/encryption/keymanager_{rotation,rewrap,kek_rotation}.go) --
+//     OPTIONAL: only added when the file currently exists. These exist only
+//     during an in-flight key rotation; requiring them unconditionally would
+//     fail every ordinary boot.
+//   - Every KeyProviderConfig-driven path this repo's own provider code
+//     writes to disk, for the primary provider (enc.KeyProvider) AND every
+//     entry in its Fallbacks (one level -- Fallbacks' own nested Fallbacks
+//     field is never read by buildSingleProvider either, so it is not a live
+//     configuration shape): the TPM/cloud-KMS wrapped-KEK blob
+//     (WrappedKeyPath, required) and Shamir KEK share files
+//     (ShamirShareFiles, required -- they must already exist for the shamir
+//     provider to reconstruct the KEK at all).
+//
+// Deliberately excluded (see the PR description for the full reasoning):
+//   - The "file" provider's FilePath. It is externally managed (e.g. a
+//     Kubernetes/CSI secret mount, a sealed/SOPS-decrypted file) and already
+//     self-checked at read time by crypto.FileKeyProvider.KEK() with looser,
+//     mount-appropriate semantics (rejects group/world read-or-write, but
+//     does not require exact 0600 or same-UID ownership). This registry's
+//     stricter requirement would misfire on a legitimately-safe-but-
+//     differently-owned mount (e.g. a K8s Secret volume, commonly root-owned
+//     0440 via fsGroup).
+//   - "env" / "exec" providers: no file at all.
+//   - `migrate-provider`'s timestamped `<dekPath>.migrate-backup.*` files:
+//     glob-named, not a fixed path this registry's list shape can express,
+//     and already self-protected at write time (copyFile always chmods to
+//     0600 even when reusing an existing destination, internal/cli/
+//     encryption/migrate_provider.go).
+func Registry(enc *config.EncryptionConfig, baseDir string) ([]securefiles.FilePermSpec, error) {
+	if enc == nil {
+		return nil, nil
+	}
+
+	var files []securefiles.FilePermSpec
+	seen := make(map[string]bool)
+
+	add := func(label, path string, requireExists bool) error {
+		if path == "" {
+			return nil
+		}
+		clean, err := SafePath(label, path)
+		if err != nil {
+			return err
+		}
+		full := resolve(baseDir, clean)
+		if seen[full] {
+			return nil
+		}
+		if !requireExists {
+			if _, statErr := os.Stat(full); statErr != nil {
+				return nil // optional/transient file not currently present -- skip
+			}
+		}
+		seen[full] = true
+		files = append(files, securefiles.FilePermSpec{Path: full, Mode: keyMaterialMode})
+		return nil
+	}
+
+	if err := add("KEK salt", enc.SaltPath, true); err != nil {
+		return nil, err
+	}
+	if err := add("DEK", enc.DEKPath, true); err != nil {
+		return nil, err
+	}
+	if enc.SaltPath != "" {
+		if err := add("KEK salt rotation-staging", enc.SaltPath+".pending", false); err != nil {
+			return nil, err
+		}
+	}
+	if enc.DEKPath != "" {
+		if err := add("DEK rotation-staging", enc.DEKPath+".pending", false); err != nil {
+			return nil, err
+		}
+	}
+
+	providers := make([]config.KeyProviderConfig, 0, 1+len(enc.KeyProvider.Fallbacks))
+	providers = append(providers, enc.KeyProvider)
+	providers = append(providers, enc.KeyProvider.Fallbacks...)
+
+	for i := range providers {
+		kp := &providers[i]
+		if writeCapableProviderTypes[kp.Type] {
+			if err := add(kp.Type+" wrapped KEK", kp.WrappedKeyPath, true); err != nil {
+				return nil, err
+			}
+		}
+		if kp.Type == "shamir" {
+			for j, share := range kp.ShamirShareFiles {
+				label := fmt.Sprintf("shamir share file [%d]", j)
+				if err := add(label, share, true); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	return files, nil
+}

--- a/internal/keyfiles/registry_exhaustiveness_test.go
+++ b/internal/keyfiles/registry_exhaustiveness_test.go
@@ -1,0 +1,228 @@
+// registry_exhaustiveness_test.go -- Group 3 guard: a future KeyProviderConfig
+// provider type that writes new key material to disk must fail this test the
+// moment it's added without also being wired into Registry, rather than
+// silently shipping with no checker coverage (exactly how WrappedKeyPath was
+// missed across all four hand-copied FilePermSpec lists this package
+// replaces).
+//
+// TestSourceScan_WriteCapableProviderTypesMatchRegistry re-derives, from the
+// actual source tree at test time, which KeyProviderConfig.Type values
+// dispatch (in internal/encryption/service.go's buildSingleProvider) to a
+// provider constructor whose file (in internal/crypto) calls
+// SecureWriteFileSync/SecureWriteFile -- then asserts that set is exactly
+// writeCapableProviderTypes. This is a genuine cross-check against the
+// source, not a mirror of the constant: it goes red if a new crypto provider
+// file starts writing without a matching registry.go entry, AND if
+// writeCapableProviderTypes grows a stale entry that no longer corresponds to
+// a real writer.
+package keyfiles
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+)
+
+// repoRoot locates the repository root from this test file's own path, so the
+// source scan below works regardless of the working directory a test runner
+// uses.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed to resolve this test file's path")
+	}
+	// this file lives at <root>/internal/keyfiles/registry_exhaustiveness_test.go
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+var constructorFuncRe = regexp.MustCompile(`(?m)^func (New\w+)\(`)
+
+// writerConstructors scans every non-test .go file directly under
+// internal/crypto for a call to SecureWriteFileSync/SecureWriteFile, and
+// returns the set of "New*" constructor function names DEFINED IN THAT SAME
+// FILE (internal/crypto's one-constructor-per-provider-file layout makes this
+// a reliable proxy for "this provider's constructor returns a value that
+// writes key material").
+func writerConstructors(t *testing.T) map[string]bool {
+	t.Helper()
+	dir := filepath.Join(repoRoot(t), "internal", "crypto")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+
+	result := make(map[string]bool)
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, name)) // #nosec G304 -- fixed repo-relative test-only path
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		src := string(data)
+		if !strings.Contains(src, "SecureWriteFileSync(") && !strings.Contains(src, "SecureWriteFile(") {
+			continue
+		}
+		for _, m := range constructorFuncRe.FindAllStringSubmatch(src, -1) {
+			result[m[1]] = true
+		}
+	}
+	return result
+}
+
+// buildSingleProviderCaseDispatch parses internal/encryption/service.go's
+// buildSingleProvider switch and returns, for every `case "type", "type2":`
+// (or `case "":`) clause, the set of constructor function names
+// (crypto.New\w+) called anywhere in that case's body.
+func buildSingleProviderCaseDispatch(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+	path := filepath.Join(repoRoot(t), "internal", "encryption", "service.go")
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed repo-relative test-only path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	src := string(data)
+
+	start := strings.Index(src, "func buildSingleProvider(")
+	if start < 0 {
+		t.Fatal("buildSingleProvider not found in internal/encryption/service.go -- has it been renamed/moved? update this test's assumptions")
+	}
+	// The function body runs from its opening brace to the matching closing
+	// brace at column 0 (the next top-level "}\n" -- buildSingleProvider is
+	// the last case in this switch-only function, followed by the next
+	// top-level func).
+	rest := src[start:]
+	nextFunc := regexp.MustCompile(`(?m)^func `).FindStringIndex(rest[1:])
+	body := rest
+	if nextFunc != nil {
+		body = rest[:nextFunc[0]+1]
+	}
+
+	caseRe := regexp.MustCompile(`(?m)^\tcase ([^:]+):`)
+	caseIdx := caseRe.FindAllStringSubmatchIndex(body, -1)
+	if len(caseIdx) == 0 {
+		t.Fatal("no `case` clauses found while parsing buildSingleProvider -- source shape changed, update this test")
+	}
+	constructorRe := regexp.MustCompile(`crypto\.(New\w+)\(`)
+
+	result := make(map[string]map[string]bool)
+	for i, idx := range caseIdx {
+		caseLabels := body[idx[2]:idx[3]]
+		bodyStart := idx[1]
+		bodyEnd := len(body)
+		if i+1 < len(caseIdx) {
+			bodyEnd = caseIdx[i+1][0]
+		}
+		caseBody := body[bodyStart:bodyEnd]
+
+		constructors := make(map[string]bool)
+		for _, m := range constructorRe.FindAllStringSubmatch(caseBody, -1) {
+			constructors[m[1]] = true
+		}
+
+		for _, label := range strings.Split(caseLabels, ",") {
+			label = strings.TrimSpace(label)
+			label = strings.Trim(label, `"`)
+			result[label] = constructors
+		}
+	}
+	return result
+}
+
+func TestSourceScan_WriteCapableProviderTypesMatchRegistry(t *testing.T) {
+	writers := writerConstructors(t)
+	if len(writers) == 0 {
+		t.Fatal("source scan found zero writer constructors in internal/crypto -- the scan itself is broken (password/tpm/kms providers are known writers), not that none exist")
+	}
+
+	dispatch := buildSingleProviderCaseDispatch(t)
+	if len(dispatch) == 0 {
+		t.Fatal("source scan found zero case clauses in buildSingleProvider -- the parser is broken")
+	}
+
+	derived := make(map[string]bool)
+	for typeName, constructors := range dispatch {
+		for c := range constructors {
+			if writers[c] {
+				derived[typeName] = true
+			}
+		}
+	}
+
+	// "" and "password" both dispatch to NewPasswordKeyProvider, which writes
+	// EncryptionConfig.SaltPath directly -- not a KeyProviderConfig field, so
+	// it's handled unconditionally in Registry rather than through
+	// writeCapableProviderTypes. Exclude both from the derived set before
+	// comparing: they are confirmed writers, but of a path this package
+	// already covers by a different, unconditional code path.
+	delete(derived, "")
+	delete(derived, "password")
+
+	var derivedList, wantList []string
+	for typeName := range derived {
+		derivedList = append(derivedList, typeName)
+	}
+	for typeName := range writeCapableProviderTypes {
+		wantList = append(wantList, typeName)
+	}
+	sort.Strings(derivedList)
+	sort.Strings(wantList)
+
+	if fmt.Sprint(derivedList) != fmt.Sprint(wantList) {
+		t.Fatalf("writeCapableProviderTypes (registry.go) = %v, but the source scan derived %v from internal/crypto + buildSingleProvider's dispatch -- a provider type's write-capability changed without registry.go being updated to match", wantList, derivedList)
+	}
+}
+
+// TestRegistry_IncludesWrappedKeyPathForEveryWriteCapableType is the positive
+// half of the guard: for every type this package believes is write-capable,
+// Registry must actually surface its configured WrappedKeyPath. Deleting a
+// case from Registry's switch (without touching
+// writeCapableProviderTypes) makes THIS test catch it, even though the
+// source-scan test above only catches writeCapableProviderTypes itself
+// drifting from the true writer set.
+func TestRegistry_IncludesWrappedKeyPathForEveryWriteCapableType(t *testing.T) {
+	for providerType := range writeCapableProviderTypes {
+		t.Run(providerType, func(t *testing.T) {
+			dir := t.TempDir()
+			enc := &config.EncryptionConfig{
+				Enabled: true,
+				KeyProvider: config.KeyProviderConfig{
+					Type:           providerType,
+					WrappedKeyPath: "wrapped.key",
+				},
+			}
+			// A required entry doesn't need to exist on disk for Registry to
+			// list it (existence is enforced downstream by FixFilePerms) --
+			// but SaltPath/DEKPath are unset here (KeyProvider.Type isn't
+			// "password"), so isolate to just the KeyProvider-driven path by
+			// leaving them empty; Registry must skip empty paths, not error.
+			specs, err := Registry(enc, dir)
+			if err != nil {
+				t.Fatalf("Registry: %v", err)
+			}
+			want := filepath.Join(dir, "wrapped.key")
+			found := false
+			for _, s := range specs {
+				if s.Path == want {
+					found = true
+					if s.Mode != 0600 {
+						t.Errorf("wrapped-key spec mode = %o, want 0600", s.Mode)
+					}
+				}
+			}
+			if !found {
+				t.Fatalf("Registry(%q) did not include the wrapped-key path %s; got %+v", providerType, want, specs)
+			}
+		})
+	}
+}

--- a/internal/keyfiles/registry_test.go
+++ b/internal/keyfiles/registry_test.go
@@ -1,0 +1,319 @@
+package keyfiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+)
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), 0600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestRegistry_NilConfig(t *testing.T) {
+	specs, err := Registry(nil, "")
+	if err != nil {
+		t.Fatalf("Registry(nil): %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("Registry(nil) = %+v, want empty", specs)
+	}
+}
+
+func TestRegistry_SaltAndDEK(t *testing.T) {
+	dir := t.TempDir()
+	enc := &config.EncryptionConfig{SaltPath: "salt.key", DEKPath: "dek.key"}
+	specs, err := Registry(enc, dir)
+	if err != nil {
+		t.Fatalf("Registry: %v", err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("Registry = %+v, want exactly salt+DEK", specs)
+	}
+	wantSalt := filepath.Join(dir, "salt.key")
+	wantDEK := filepath.Join(dir, "dek.key")
+	var gotSalt, gotDEK bool
+	for _, s := range specs {
+		if s.Path == wantSalt {
+			gotSalt = true
+		}
+		if s.Path == wantDEK {
+			gotDEK = true
+		}
+		if s.Mode != 0600 {
+			t.Errorf("spec %+v mode != 0600", s)
+		}
+	}
+	if !gotSalt || !gotDEK {
+		t.Fatalf("Registry = %+v, missing salt or DEK", specs)
+	}
+}
+
+func TestRegistry_EmptyPathsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	specs, err := Registry(&config.EncryptionConfig{}, dir)
+	if err != nil {
+		t.Fatalf("Registry: %v", err)
+	}
+	if len(specs) != 0 {
+		t.Fatalf("Registry with no configured paths = %+v, want empty", specs)
+	}
+}
+
+func TestRegistry_AbsolutePathPreserved(t *testing.T) {
+	dir := t.TempDir()
+	absSalt := filepath.Join(dir, "abs-salt.key")
+	enc := &config.EncryptionConfig{SaltPath: absSalt}
+	specs, err := Registry(enc, "/some/unrelated/base")
+	if err != nil {
+		t.Fatalf("Registry: %v", err)
+	}
+	if len(specs) != 1 || specs[0].Path != absSalt {
+		t.Fatalf("Registry = %+v, want the absolute salt path preserved as-is (%s)", specs, absSalt)
+	}
+}
+
+func TestRegistry_PendingFiles_OnlyIncludedWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	enc := &config.EncryptionConfig{SaltPath: "salt.key", DEKPath: "dek.key"}
+
+	// No .pending files yet: must not appear (and must not be required either
+	// -- Registry itself never stats the required salt/DEK paths, only the
+	// optional .pending ones).
+	specs, err := Registry(enc, dir)
+	if err != nil {
+		t.Fatalf("Registry: %v", err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("Registry with no .pending files = %+v, want just salt+DEK", specs)
+	}
+
+	// Create the DEK's .pending rotation-staging file: it must now appear.
+	writeFile(t, filepath.Join(dir, "dek.key.pending"))
+	specs, err = Registry(enc, dir)
+	if err != nil {
+		t.Fatalf("Registry: %v", err)
+	}
+	wantPending := filepath.Join(dir, "dek.key.pending")
+	var found bool
+	for _, s := range specs {
+		if s.Path == wantPending {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Registry after creating dek.key.pending = %+v, want it included", specs)
+	}
+	if len(specs) != 3 {
+		t.Fatalf("Registry = %+v, want exactly salt+DEK+dek.pending", specs)
+	}
+}
+
+func TestRegistry_TPMWrappedKeyPath(t *testing.T) {
+	dir := t.TempDir()
+	enc := &config.EncryptionConfig{
+		KeyProvider: config.KeyProviderConfig{Type: "tpm", WrappedKeyPath: "tpm-wrapped.key"},
+	}
+	specs, err := Registry(enc, dir)
+	if err != nil {
+		t.Fatalf("Registry: %v", err)
+	}
+	want := filepath.Join(dir, "tpm-wrapped.key")
+	var found bool
+	for _, s := range specs {
+		if s.Path == want && s.Mode == 0600 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Registry (tpm) = %+v, want wrapped-key path %s at 0600", specs, want)
+	}
+}
+
+func TestRegistry_KMSWrappedKeyPath_AllThreeCloudTypes(t *testing.T) {
+	for _, providerType := range []string{"aws-kms", "gcp-kms", "azure-kms"} {
+		t.Run(providerType, func(t *testing.T) {
+			dir := t.TempDir()
+			enc := &config.EncryptionConfig{
+				KeyProvider: config.KeyProviderConfig{Type: providerType, WrappedKeyPath: "kms-wrapped.key"},
+			}
+			specs, err := Registry(enc, dir)
+			if err != nil {
+				t.Fatalf("Registry: %v", err)
+			}
+			want := filepath.Join(dir, "kms-wrapped.key")
+			var found bool
+			for _, s := range specs {
+				if s.Path == want {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("Registry (%s) = %+v, want wrapped-key path %s", providerType, specs, want)
+			}
+		})
+	}
+}
+
+func TestRegistry_PasswordAndFileAndEnvAndExec_NoExtraPaths(t *testing.T) {
+	for _, providerType := range []string{"", "password", "file", "env", "exec"} {
+		t.Run(providerType, func(t *testing.T) {
+			dir := t.TempDir()
+			enc := &config.EncryptionConfig{
+				KeyProvider: config.KeyProviderConfig{
+					Type:        providerType,
+					FilePath:    "/etc/keyorix/kek.key", // must NOT be added -- externally managed, self-checked elsewhere
+					EnvVar:      "KEYORIX_KEK",
+					ExecCommand: []string{"op", "read", "op://vault/kek"},
+				},
+			}
+			specs, err := Registry(enc, dir)
+			if err != nil {
+				t.Fatalf("Registry: %v", err)
+			}
+			if len(specs) != 0 {
+				t.Fatalf("Registry (%q) = %+v, want no entries (no salt/DEK/wrapped-key configured, and FilePath/EnvVar/ExecCommand are deliberately not registered)", providerType, specs)
+			}
+		})
+	}
+}
+
+func TestRegistry_ShamirShareFiles(t *testing.T) {
+	dir := t.TempDir()
+	enc := &config.EncryptionConfig{
+		KeyProvider: config.KeyProviderConfig{
+			Type:             "shamir",
+			ShamirShareFiles: []string{"share1.hex", "", "share3.hex"},
+		},
+	}
+	specs, err := Registry(enc, dir)
+	if err != nil {
+		t.Fatalf("Registry: %v", err)
+	}
+	want1 := filepath.Join(dir, "share1.hex")
+	want3 := filepath.Join(dir, "share3.hex")
+	var got1, got3 bool
+	for _, s := range specs {
+		if s.Path == want1 {
+			got1 = true
+		}
+		if s.Path == want3 {
+			got3 = true
+		}
+	}
+	if !got1 || !got3 {
+		t.Fatalf("Registry (shamir) = %+v, want both non-empty share files included", specs)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("Registry (shamir) = %+v, want exactly 2 entries (the empty share entry must be skipped)", specs)
+	}
+}
+
+func TestRegistry_Fallbacks_OneLevel(t *testing.T) {
+	dir := t.TempDir()
+	enc := &config.EncryptionConfig{
+		KeyProvider: config.KeyProviderConfig{
+			Type:           "tpm",
+			WrappedKeyPath: "primary-wrapped.key",
+			Fallbacks: []config.KeyProviderConfig{
+				{Type: "aws-kms", WrappedKeyPath: "fallback-wrapped.key"},
+			},
+		},
+	}
+	specs, err := Registry(enc, dir)
+	if err != nil {
+		t.Fatalf("Registry: %v", err)
+	}
+	wantPrimary := filepath.Join(dir, "primary-wrapped.key")
+	wantFallback := filepath.Join(dir, "fallback-wrapped.key")
+	var gotPrimary, gotFallback bool
+	for _, s := range specs {
+		if s.Path == wantPrimary {
+			gotPrimary = true
+		}
+		if s.Path == wantFallback {
+			gotFallback = true
+		}
+	}
+	if !gotPrimary || !gotFallback {
+		t.Fatalf("Registry (with fallback) = %+v, want both primary and fallback wrapped-key paths", specs)
+	}
+}
+
+func TestRegistry_RejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	const traversal = "sub/../../outside/salt.key"
+
+	t.Run("salt", func(t *testing.T) {
+		enc := &config.EncryptionConfig{SaltPath: traversal, DEKPath: filepath.Join(dir, "dek.key")}
+		if _, err := Registry(enc, dir); err == nil {
+			t.Fatal("expected error for a salt path containing '..'")
+		}
+	})
+	t.Run("dek", func(t *testing.T) {
+		enc := &config.EncryptionConfig{SaltPath: filepath.Join(dir, "salt.key"), DEKPath: traversal}
+		if _, err := Registry(enc, dir); err == nil {
+			t.Fatal("expected error for a DEK path containing '..'")
+		}
+	})
+	t.Run("wrapped key path", func(t *testing.T) {
+		enc := &config.EncryptionConfig{
+			KeyProvider: config.KeyProviderConfig{Type: "tpm", WrappedKeyPath: traversal},
+		}
+		if _, err := Registry(enc, dir); err == nil {
+			t.Fatal("expected error for a wrapped-key path containing '..'")
+		}
+	})
+	t.Run("shamir share file", func(t *testing.T) {
+		enc := &config.EncryptionConfig{
+			KeyProvider: config.KeyProviderConfig{Type: "shamir", ShamirShareFiles: []string{traversal}},
+		}
+		if _, err := Registry(enc, dir); err == nil {
+			t.Fatal("expected error for a shamir share path containing '..'")
+		}
+	})
+}
+
+func TestRegistry_DedupesRepeatedPaths(t *testing.T) {
+	dir := t.TempDir()
+	// A misconfiguration where the fallback's wrapped-key path happens to
+	// equal the primary's -- must not produce two FixFilePerms entries for
+	// the same file.
+	enc := &config.EncryptionConfig{
+		KeyProvider: config.KeyProviderConfig{
+			Type:           "tpm",
+			WrappedKeyPath: "same.key",
+			Fallbacks: []config.KeyProviderConfig{
+				{Type: "aws-kms", WrappedKeyPath: "same.key"},
+			},
+		},
+	}
+	specs, err := Registry(enc, dir)
+	if err != nil {
+		t.Fatalf("Registry: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("Registry = %+v, want the duplicate path deduped to a single entry", specs)
+	}
+}
+
+func TestSafePath_RejectsTraversal(t *testing.T) {
+	if _, err := SafePath("test", "sub/../../outside"); err == nil {
+		t.Fatal("expected error for a traversal path")
+	}
+}
+
+func TestSafePath_AcceptsCleanRelative(t *testing.T) {
+	clean, err := SafePath("test", "sub/file.key")
+	if err != nil {
+		t.Fatalf("SafePath: %v", err)
+	}
+	if clean != filepath.Clean("sub/file.key") {
+		t.Fatalf("SafePath = %q, want %q", clean, filepath.Clean("sub/file.key"))
+	}
+}

--- a/internal/startup/validation.go
+++ b/internal/startup/validation.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/keyfiles"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
 )
 
@@ -116,20 +117,18 @@ func validateFilePermissions(cfg *config.Config, configPath string, forceAutoFix
 	}
 
 	if cfg.Storage.Encryption.Enabled {
-		// The KEK is passphrase-derived and never on disk (ADR-004); the salt and
-		// the wrapped DEK are the only key files to lock down.
-		saltPath, err := SafeFilePermPath("KEK salt", cfg.Storage.Encryption.SaltPath)
+		// The KEK salt and wrapped DEK (ADR-004) are always present; a TPM/cloud-KMS
+		// key_provider (ADR-038/ADR-041) adds a separate wrapped-KEK blob, and a
+		// shamir key_provider's share files are also key material -- see
+		// internal/keyfiles.Registry, the single enumeration every key-permission
+		// checker in this repo shares (this function used to hand-build a
+		// salt+DEK-only list here, which is exactly how the wrapped-KEK blob went
+		// unchecked for every TPM/KMS deployment).
+		specs, err := keyfiles.Registry(&cfg.Storage.Encryption, ".")
 		if err != nil {
 			return err
 		}
-		dekPath, err := SafeFilePermPath("DEK", cfg.Storage.Encryption.DEKPath)
-		if err != nil {
-			return err
-		}
-		files = append(files,
-			securefiles.FilePermSpec{Path: saltPath, Mode: 0600},
-			securefiles.FilePermSpec{Path: dekPath, Mode: 0600},
-		)
+		files = append(files, specs...)
 	}
 
 	// Mirror Config.Validate()'s switch on Storage.Type: only "local"/"" storage has a


### PR DESCRIPTION
## Summary

Four independent call sites each hand-built their own `[]securefiles.FilePermSpec`
list for the encryption key-material a "key-permission checker" is supposed to
lock down, and all four only ever listed the KEK salt and wrapped DEK (ADR-004):

- `internal/cli/system/audit.go` (`keyorix system audit`, audit-only)
- `cmd/system/fixfileperm.go` (`keyorix system fixfileperm`, autofix)
- `internal/startup/validation.go`'s `validateFilePermissions` (runs on every
  server boot)
- `internal/encryption/keymanager_io.go`'s `KeyManager.ValidateKeyFiles` /
  `FixKeyFilePermissions`

None of the four covered `cfg.Storage.Encryption.KeyProvider.WrappedKeyPath` --
the KMS-wrapped KEK blob (`internal/crypto/kms_provider.go`) or the TPM-sealed
KEK blob (`internal/crypto/tpm_provider.go`) -- so any deployment using `tpm`,
`aws-kms`, `gcp-kms`, or `azure-kms` as its `key_provider` had that key material
silently unchecked by every one of the four tools meant to catch exactly that.
`validation.go`'s own comment ("the salt and wrapped DEK are the only key files
to lock down") was stale since ADR-038 (TPM) and ADR-041 (cloud KMS) added
`WrappedKeyPath`.

## What changed

Added `internal/keyfiles`, a new package exporting `Registry(enc
*config.EncryptionConfig, baseDir string) ([]securefiles.FilePermSpec, error)` --
the single enumeration of every on-disk key-material file, covering:

- KEK salt and wrapped DEK (required, unconditional -- matches existing
  behavior: `FixFilePerms` already fails closed if either is missing, and an
  operator provisions both via `system init --encryption` before a server's
  first real boot).
- Their `.pending` rotation-staging siblings
  (`keymanager_{rotation,rewrap,kek_rotation}.go`) -- **optional**, only added
  when the file currently exists, since they're present only mid-rotation
  (requiring them unconditionally would fail every ordinary boot).
- `WrappedKeyPath` for `tpm` / `aws-kms` / `gcp-kms` / `azure-kms`, and Shamir
  KEK share files for `shamir` -- walked through both the primary
  `key_provider` and every entry in its `fallbacks` (one level, matching what
  `buildSingleProvider` actually dispatches).
- Every path is sanitized the same way `internal/startup.SafeFilePermPath`
  already did (rejects a cleaned path that still contains `..`), since these
  paths are config-driven and about to be `Lstat`/`Chmod`/`Chown`'d.

All four checkers now call `keyfiles.Registry` instead of hand-building their
own list, so a future 5th `key_provider` type only needs to be added in one
place to be picked up everywhere.

### Guard test (registry-exhaustiveness)

`internal/keyfiles/registry_exhaustiveness_test.go` re-derives, from the actual
source tree at test time, which `KeyProviderConfig.Type` values are
write-capable: it scans `internal/crypto`'s non-test files for
`SecureWriteFileSync`/`SecureWriteFile` calls, then parses
`internal/encryption/service.go`'s `buildSingleProvider` switch to see which
`Type` strings dispatch to one of those writer files' constructors, and asserts
the derived set equals the registry's own `writeCapableProviderTypes`. This
goes red both ways: a new writer not yet wired into the registry, or a stale
registry entry that no longer corresponds to a real writer. Confirmed genuinely
red by temporarily dropping `"tpm"` from the registry (both this test and the
positive-inclusion test failed) before restoring it.

### Deliberately excluded (see `registry.go`'s doc comment for the full reasoning)

- **`file` provider's `FilePath`** -- externally managed (e.g. a Kubernetes/CSI
  secret mount, a sealed/SOPS-decrypted file) and already self-checked at read
  time by `crypto.FileKeyProvider.KEK()` with looser, mount-appropriate
  semantics (rejects group/world read-or-write, but not this registry's
  stricter exact-0600 + same-UID requirement, which would misfire on a
  legitimately-safe-but-differently-owned mount, e.g. a K8s Secret volume
  commonly root-owned 0440 via `fsGroup`).
- **`env` / `exec` providers** -- no file at all.
- **`trust-keygen`'s output** -- not config-driven (output path is a CLI
  `--dir` flag, not a config field), and typically lives on a separate
  offline/air-gapped signing workstation rather than the host any of these
  four checkers run on. Needs its own registration mechanism (e.g. a
  `--check` mode, or a config field recording where the operator put it) --
  flagged, not built here.
- **`migrate-provider`'s `<dekPath>.migrate-backup.*` files** -- glob-named
  (not a fixed path this registry's list shape expresses), and already
  self-protected at write time (`copyFile` always chmods to 0600, even when
  reusing an existing destination).

### Not fixed here (flagged as follow-up)

- **Containing-directory permissions/ownership are never checked** by any of
  the four checkers (leaf-file-only). Checking a directory is a different
  mechanism than `FixFilePerms`' current file-only design (no directory-mode
  concept in `FilePermSpec` today) -- scoping this out rather than bolting it
  on as a special case.
- **GID is never checked, only UID** -- same reasoning; `FixFilePerms` itself
  would need a mode/GID-aware rewrite, which is a larger, separate change from
  "enumerate the right file list."

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean on every touched package
- [x] `gosec -severity medium -exclude-generated` clean on every touched
      package
- [x] Full test suite green for `internal/keyfiles`, `internal/startup`,
      `internal/cli/system`, `cmd/system`, `internal/encryption`,
      `internal/cli/encryption` (all 4 existing checkers' own tests
      unmodified in behavior, only their internal plumbing changed)
- [x] `scripts/check-closures.sh` passes, including a new ledger row
      (`G81-KEYPERM-REGISTRY`) proving the wrapped-KEK-blob coverage
- [x] Guard test confirmed RED (dropped `tpm` from the registry) then GREEN
      (restored) before landing