### PR TITLE
fix(connect): add optional account_id pin to aws-secrets-manager connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,22 @@ All notable changes to Keyorix are documented here. This project follows
   crash notifications on fleet VMs. ([#1222])
 
 ### Security
+- **Optional `account_id` pin for `aws-secrets-manager` Keyorix Connect connectors**
+  — the AWS sibling of the `gcp-secret-manager` `project_id` pin above, but with a
+  narrower risk shape: a bare secret-name ref (the common case) is always resolved
+  within the ambient credential's own AWS account by the Secrets Manager API itself,
+  so it never carries a confused-deputy gap; only a full-ARN ref naming a DIFFERENT
+  account is at risk, and only if that target account's own resource policy has
+  separately granted cross-account access (a double opt-in, unlike GCP's
+  single-opt-in ambient-reach gap). Because of that, `account_id` is **optional, not
+  mandatory** — no existing deployment is broken by this change. When set,
+  `validateConnectAWSAccountID` (`internal/config/config.go`) fails boot if it is
+  not exactly 12 digits (the AWS account ID format), and
+  `AWSSecretsManagerConnector.GetSecret` independently refuses any ARN-shaped ref
+  naming a different account (defense in depth). When unset, `server/main.go` logs
+  a startup recommendation rather than failing boot. See
+  `docs/CONFIGURATION.md`'s Keyorix Connect section for the exact field and its
+  documented scope boundary (a bare-name ref is never checked, by construction).
 - **PAT scope enforcement, WebAuthn identity binding, template injection, K8s sync
   RBAC, TOTP anti-replay on proxy, operator Helm `clusterScoped`** — five
   security hardening items from the DAST/SAST backlog (PAT-SCOPE-002, WAUN-001,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1175,6 +1175,11 @@ connect:
     - name: prod-aws            # API path key (unique); GET /api/v1/connect/prod-aws/secret?ref=…
       type: aws-secrets-manager # aws-secrets-manager | gcp-secret-manager | azure-key-vault | vault
       region: eu-west-1         # AWS region (aws-secrets-manager)
+      account_id: "111111111111" # optional: pins the connector to one AWS account (12 digits);
+                                  # a full-ARN ref naming a DIFFERENT account is rejected before
+                                  # the backend call. A bare secret-name ref is unaffected either
+                                  # way — see the note below for why this field is optional, not
+                                  # required like gcp-secret-manager's project_id.
       scope: project             # project | platform (ADR-082) — required
       project: payments          # Keyorix project name (not ID) that owns this connector;
                                   # required when scope is "project", omit when "platform"
@@ -1234,6 +1239,20 @@ connect:
   that bypasses config validation). **Breaking change**: an existing deployment
   upgrading from before this requirement landed must add `project_id` to every
   `gcp-secret-manager` connector before upgrading — see CHANGELOG.md.
+- `aws-secrets-manager`'s `account_id` is the AWS sibling of `project_id` above, but
+  **optional, not required** — the risk shape is narrower. The Secrets Manager
+  `SecretId` accepts either a bare secret name (always resolved within the ambient
+  credential's own AWS account — no confused-deputy gap is possible for that shape)
+  or a full ARN (`arn:PARTITION:secretsmanager:REGION:ACCOUNT:secret:NAME`), which
+  CAN name a different account, but only succeeds if that target account's own
+  resource policy has separately granted this connector's identity cross-account
+  access (a double opt-in, unlike GCP's single-opt-in ambient-reach gap). Setting
+  `account_id` (12 digits) pins the connector: any ARN-shaped ref naming a different
+  account is rejected before the backend call, both at config-load time (a malformed,
+  non-12-digit value fails boot) and again at read time (defense in depth). Leaving
+  it unset is a legal, still-supported configuration — `server/main.go` logs a
+  startup recommendation, not a failure — and a bare-name ref is never checked
+  against the pin either way, since it never carries a competing account segment.
 - A federated read is bounded by up to **three** controls: the backend identity's IAM
   policy (the load-bearing one — scope the connector's credentials to exactly the
   intended secrets); optionally the per-connector **`allowed_refs`** prefix allowlist

--- a/docs/security-closures.tsv
+++ b/docs/security-closures.tsv
@@ -18,6 +18,7 @@ FIX-7-breakglass	./internal/storage/store	TestDeleteExpiredBreakGlassBefore_Reco
 FIX-8-csv	./internal/core	TestCSVWriters_EncodeAgainstFormulaInjection	d1b93444	structural: every CSV writer applies an encoder
 INV-1-grant-authority	./server/http	TestEveryDirectRoleGrantChecksAuthority	pre-existing	structural: every direct role grant checks authority
 GCP-CONN-PROJECTID	./internal/connect	TestGCPSM_RequiresProjectID	pending	unpinned gcp-secret-manager connector must refuse reads, not span any GCP project
+AWS-CONN-ACCOUNTID	./internal/connect	TestAWSSM_AccountPin	pending	pinned aws-secrets-manager connector must refuse an ARN naming a different AWS account
 
 # NOT LISTED, deliberately:
 #   FIX-1 actorID==0 fast-path (internal/core/authz.go:614). The eight-site reroute

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -196,6 +196,22 @@ type ConnectorConfig struct {
 	// project_id to every gcp-secret-manager connector first (see CHANGELOG.md).
 	// Unrelated to Project below — this is a GCP-side identifier, Project is Keyorix's.
 	ProjectID string `yaml:"project_id"`
+	// AccountID optionally pins an "aws-secrets-manager" connector to a single AWS
+	// account: an ARN-shaped ref naming a DIFFERENT account is rejected before the
+	// backend call. Unlike ProjectID above, this is NOT required: a bare secret-name
+	// ref (the common shape) is always resolved within the ambient credential's own
+	// AWS account by the Secrets Manager API itself, so it never carries a competing
+	// account to check, and a full-ARN ref naming another account additionally
+	// requires that target account's own resource policy to have separately granted
+	// cross-account access (a double opt-in, unlike GCP's single-opt-in
+	// ambient-reach gap — see internal/connect/awssm.go's doc comment). When set,
+	// validateConnectAWSAccountID (below) fails boot if it is not exactly 12 digits
+	// (the AWS account ID format); when unset, server/main.go logs a startup
+	// recommendation but boots — a deliberate phase-in, not a bug: making this
+	// mandatory would force every connector that only ever reads bare-name refs
+	// (which cannot cross accounts regardless) to configure a field with zero
+	// enforcement value for them.
+	AccountID string `yaml:"account_id"`
 	// TokenEnv names the environment variable holding the backend token for type
 	// "vault" (default "VAULT_TOKEN"). The token is read from the environment, never
 	// from this file.
@@ -2142,6 +2158,10 @@ func (c *Config) Validate() error { // NOSONAR -- cognitive complexity 32, suppr
 		return err
 	}
 
+	if err := validateConnectAWSAccountID(c.Connect); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -2249,6 +2269,40 @@ func validateConnectGCPProjectID(cc ConnectConfig) error {
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("connect: gcp-secret-manager connector(s) missing required \"project_id\" — an unset project_id lets a caller read secrets from ANY GCP project the ambient ADC identity can reach, regardless of this connector's Keyorix tenant scope (a confused-deputy gap; #431/ADR-082): %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// awsAccountIDPattern is the AWS account ID format: exactly 12 digits.
+var awsAccountIDPattern = regexp.MustCompile(`^[0-9]{12}$`)
+
+// validateConnectAWSAccountID checks the OPTIONAL account_id pin on
+// "aws-secrets-manager" connectors — the AWS sibling of
+// validateConnectGCPProjectID above, but deliberately NOT a mandatory-field check:
+// see ConnectorConfig.AccountID's own doc comment and internal/connect/awssm.go for
+// why AWS's confused-deputy risk shape is narrower than GCP's (a bare secret-name
+// ref, the common case, can never cross AWS accounts at all; a full-ARN ref naming
+// another account additionally requires that account's own resource policy to have
+// separately granted access — a double opt-in). Because the field is optional, this
+// only ever rejects a connector that DID set account_id but set it to something that
+// is not a well-formed AWS account ID (exactly 12 digits) — catching a typo at boot
+// rather than at first read. A missing account_id is not an error here; server/main.go
+// logs a startup recommendation for that case instead (mirroring the phase-in
+// idiom GCP's project_id itself used before it became mandatory). Aggregates every
+// offending connector into one error, mirroring validateConnectGCPProjectID's own
+// aggregation style.
+func validateConnectAWSAccountID(cc ConnectConfig) error {
+	var malformed []string
+	for _, connector := range cc.Connectors {
+		if connector.Type != "aws-secrets-manager" || connector.AccountID == "" {
+			continue
+		}
+		if !awsAccountIDPattern.MatchString(connector.AccountID) {
+			malformed = append(malformed, fmt.Sprintf("%s (account_id: %q)", connector.Name, connector.AccountID))
+		}
+	}
+	if len(malformed) > 0 {
+		return fmt.Errorf("connect: aws-secrets-manager connector(s) with malformed \"account_id\" (must be exactly 12 digits, the AWS account ID format): %s", strings.Join(malformed, ", "))
 	}
 	return nil
 }

--- a/internal/config/connect_config_test.go
+++ b/internal/config/connect_config_test.go
@@ -362,6 +362,121 @@ func TestValidate_ConnectGCPProjectIDWired(t *testing.T) {
 	assert.Contains(t, err.Error(), "project_id")
 }
 
+// TestValidateConnectAWSAccountID covers the AWS sibling of
+// TestValidateConnectGCPProjectID — but account_id is deliberately OPTIONAL, not
+// mandatory (see ConnectorConfig.AccountID's own doc comment for the risk-shape
+// reason): a missing account_id must NOT fail boot, only a malformed one (not
+// exactly 12 digits) does. Mirrors TestValidateConnectGCPProjectID's own structure
+// and aggregation-assertion style.
+func TestValidateConnectAWSAccountID(t *testing.T) {
+	tests := []struct {
+		name      string
+		cc        ConnectConfig
+		wantErr   bool
+		wantNames []string
+	}{
+		{
+			name: "missing account_id is valid -- optional, unlike GCP's project_id",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "aws1", Type: "aws-secrets-manager", Scope: "platform"},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "malformed account_id (not 12 digits), single connector, fails boot",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "aws1", Type: "aws-secrets-manager", Scope: "platform", AccountID: "12345"},
+			}},
+			wantErr:   true,
+			wantNames: []string{"aws1"},
+		},
+		{
+			name: "non-numeric account_id fails boot",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "aws1", Type: "aws-secrets-manager", Scope: "platform", AccountID: "not-an-account-id"},
+			}},
+			wantErr:   true,
+			wantNames: []string{"aws1"},
+		},
+		{
+			name: "malformed account_id, multiple connectors, aggregated in one error",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "aws1", Type: "aws-secrets-manager", Scope: "platform", AccountID: "bad"},
+				{Name: "aws2", Type: "aws-secrets-manager", Scope: "platform", AccountID: "also-bad"},
+				{Name: "aws3", Type: "aws-secrets-manager", Scope: "platform", AccountID: "123456789012"}, // valid — must not appear
+			}},
+			wantErr:   true,
+			wantNames: []string{"aws1", "aws2"},
+		},
+		{
+			name: "non-aws connector types are never checked",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "gcp", Type: "gcp-secret-manager", Scope: "platform", ProjectID: "my-proj"},
+				{Name: "azure", Type: "azure-key-vault", Scope: "platform"},
+				{Name: "vault", Type: "vault", Scope: "platform"},
+			}},
+			wantErr: false,
+		},
+		{
+			name:    "no connectors is valid",
+			cc:      ConnectConfig{},
+			wantErr: false,
+		},
+		{
+			name: "aws connector with well-formed account_id is valid",
+			cc: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "aws", Type: "aws-secrets-manager", Scope: "platform", AccountID: "123456789012"},
+			}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConnectAWSAccountID(tt.cc)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, name := range tt.wantNames {
+				assert.Contains(t, err.Error(), name, "error must name every offending connector")
+			}
+		})
+	}
+}
+
+// TestValidate_ConnectAWSAccountIDWired confirms Config.Validate() itself surfaces
+// a malformed aws-secrets-manager account_id — not just the unexported helper in
+// isolation — so the boot path (server/main.go's cfg.Validate() call) actually
+// enforces the format check. Also confirms the converse: a missing account_id
+// (the common, still-supported case) does NOT fail Validate() — account_id is
+// optional, unlike gcp-secret-manager's project_id.
+func TestValidate_ConnectAWSAccountIDWired(t *testing.T) {
+	t.Run("malformed account_id fails Validate()", func(t *testing.T) {
+		c := &Config{
+			Storage: StorageConfig{Type: "local", Database: DatabaseConfig{Path: "/tmp/keyorix-connect-aws-accountid-test.db"}},
+			Connect: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "malformed-aws", Type: "aws-secrets-manager", Scope: "platform", AccountID: "not-12-digits"},
+			}},
+		}
+		err := c.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "malformed-aws")
+		assert.Contains(t, err.Error(), "account_id")
+	})
+
+	t.Run("missing account_id does not fail Validate()", func(t *testing.T) {
+		c := &Config{
+			Storage: StorageConfig{Type: "local", Database: DatabaseConfig{Path: "/tmp/keyorix-connect-aws-accountid-test2.db"}},
+			Connect: ConnectConfig{Connectors: []ConnectorConfig{
+				{Name: "unpinned-aws", Type: "aws-secrets-manager", Scope: "platform"},
+			}},
+		}
+		require.NoError(t, c.Validate())
+	})
+}
+
 // TestValidate_ConnectTypesRunsBeforeScopes confirms validateConnectTypes runs
 // before validateConnectScopes in Config.Validate() (see that function's own
 // comment for why: an unrecognized type is more fundamental than a scope-shape

--- a/internal/connect/awssm.go
+++ b/internal/connect/awssm.go
@@ -3,12 +3,34 @@
 // credentials/region come from the standard chain (env / instance-profile / IRSA),
 // exactly like the STS dynamic backend and the KMS/S3 integrations — never from
 // Keyorix config.
+//
+// Confused-deputy scope (mirrors the gcp-secret-manager connector's project_id pin,
+// #431/ADR-082, but with a materially different risk shape): the AWS Secrets Manager
+// SecretId parameter accepts either a bare secret name or a full ARN
+// (arn:PARTITION:secretsmanager:REGION:ACCOUNT:secret:NAME). A bare name is ALWAYS
+// resolved within the account of the ambient credential itself — the AWS API gives
+// no way to cross accounts with a bare name, so that shape has no confused-deputy gap
+// at all. A full ARN naming a DIFFERENT account can still succeed if that target
+// account's own resource-based (Secrets Manager resource) policy has separately
+// granted this connector's ambient identity cross-account access — unlike GCP, where
+// ANY ref reaches ANY project the ADC identity can access with no additional
+// opt-in on the target's side, AWS's gap requires the target account to have
+// independently granted access too (a double opt-in, not a single one). Because of
+// that narrower shape, accountID is an OPTIONAL pin, not a mandatory one like GCP's
+// projectID: an operator whose connector only ever reads
+// bare-name refs gets zero benefit from being forced to set it. When set, GetSecret
+// independently refuses any ARN-shaped ref naming a different account (defense in
+// depth on top of internal/config.validateConnectAWSAccountID's boot-time format
+// check) — but this enforcement only bites ARN-shaped refs; a bare-name ref carries
+// no account segment to check, by construction, regardless of whether accountID is
+// configured.
 package connect
 
 import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -25,17 +47,40 @@ type smSecretGetter interface {
 type AWSSecretsManagerConnector struct {
 	name        string
 	region      string
+	accountID   string
 	allowedRefs []string
 	// newClient builds an SM client for the region; nil uses the real AWS client
 	// (the standard credential chain). Tests inject a fake.
 	newClient func(ctx context.Context, region string) (smSecretGetter, error)
 }
 
-// NewAWSSecretsManagerConnector builds an AWS Secrets Manager connector. allowedRefs,
+// NewAWSSecretsManagerConnector builds an AWS Secrets Manager connector. accountID,
+// when set, pins the connector to a single AWS account: any ARN-shaped ref naming a
+// DIFFERENT account is rejected before the backend call (see this file's own doc
+// comment for the full confused-deputy rationale and why, unlike GCP's projectID,
+// this pin is optional rather than mandatory, and only bites ARN-shaped refs — a
+// bare secret name never carries a competing account to check against). allowedRefs,
 // when non-empty, restricts readable references to those with one of the given
 // prefixes (a guardrail on top of the AWS IAM scope of the ambient identity).
-func NewAWSSecretsManagerConnector(name, region string, allowedRefs []string) *AWSSecretsManagerConnector {
-	return &AWSSecretsManagerConnector{name: name, region: region, allowedRefs: allowedRefs}
+func NewAWSSecretsManagerConnector(name, region, accountID string, allowedRefs []string) *AWSSecretsManagerConnector {
+	return &AWSSecretsManagerConnector{name: name, region: region, accountID: accountID, allowedRefs: allowedRefs}
+}
+
+// awsRefAccountID extracts the account ID segment from a Secrets Manager ARN
+// (arn:PARTITION:secretsmanager:REGION:ACCOUNT:secret:NAME-SUFFIX — PARTITION is
+// "aws", "aws-cn", or "aws-us-gov"). It returns ok = false for anything that isn't
+// shaped like a Secrets Manager ARN, including a bare secret name — which is the
+// common ref shape and, per this connector's own doc comment, never carries an
+// account segment to check in the first place.
+func awsRefAccountID(ref string) (account string, ok bool) {
+	parts := strings.SplitN(ref, ":", 6)
+	if len(parts) != 6 || parts[0] != "arn" || parts[2] != "secretsmanager" {
+		return "", false
+	}
+	if parts[4] == "" {
+		return "", false
+	}
+	return parts[4], true
 }
 
 func (c *AWSSecretsManagerConnector) Name() string { return c.name }
@@ -62,6 +107,15 @@ func (c *AWSSecretsManagerConnector) GetSecret(ctx context.Context, ref string) 
 	}
 	if !prefixAllowed(c.allowedRefs, ref) {
 		return "", fmt.Errorf("aws-secrets-manager: ref %q is not permitted by this connector's allowed_refs", ref)
+	}
+	// account_id is an optional pin (unlike gcp-secret-manager's mandatory
+	// project_id — see this file's doc comment for why the risk shape differs).
+	// It only has anything to check when ref is a full ARN; a bare secret name
+	// carries no account segment and is unaffected either way.
+	if c.accountID != "" {
+		if refAccount, ok := awsRefAccountID(ref); ok && refAccount != c.accountID {
+			return "", fmt.Errorf("aws-secrets-manager: ref %q targets account %q, but this connector is pinned to account %q", ref, refAccount, c.accountID)
+		}
 	}
 	cl, err := c.client(ctx)
 	if err != nil {

--- a/internal/connect/awssm_test.go
+++ b/internal/connect/awssm_test.go
@@ -24,20 +24,20 @@ func (f *fakeSM) GetSecretValue(_ context.Context, in *secretsmanager.GetSecretV
 }
 
 func connectorWith(name string, fake *fakeSM) *AWSSecretsManagerConnector {
-	c := NewAWSSecretsManagerConnector(name, "eu-west-1", nil)
+	c := NewAWSSecretsManagerConnector(name, "eu-west-1", "", nil)
 	c.newClient = func(_ context.Context, _ string) (smSecretGetter, error) { return fake, nil }
 	return c
 }
 
 func TestAWSSM_TypeAndName(t *testing.T) {
-	c := NewAWSSecretsManagerConnector("prod-aws", "us-east-1", nil)
+	c := NewAWSSecretsManagerConnector("prod-aws", "us-east-1", "", nil)
 	assert.Equal(t, "prod-aws", c.Name())
 	assert.Equal(t, "aws-secrets-manager", c.Type())
 }
 
 func TestAWSSM_AllowedRefsGuardrail(t *testing.T) {
 	fake := &fakeSM{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String("ok")}}
-	c := NewAWSSecretsManagerConnector("aws", "eu-west-1", []string{"keyorix/", "shared/"})
+	c := NewAWSSecretsManagerConnector("aws", "eu-west-1", "", []string{"keyorix/", "shared/"})
 	c.newClient = func(_ context.Context, _ string) (smSecretGetter, error) { return fake, nil }
 
 	// A ref matching an allowed prefix passes.
@@ -85,6 +85,86 @@ func TestAWSSM_GetSecret_Errors(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no value")
 	})
+}
+
+// TestAWSSM_AccountPin covers the account_id confused-deputy guard: a pinned
+// connector rejects an ARN-shaped ref naming a different AWS account, still works
+// normally for its own account's ARNs, and — the scope boundary this connector's
+// doc comment calls out explicitly — a bare secret-name ref is never checked
+// against the pin at all, because it never carries a competing account to begin
+// with (the AWS API itself always resolves it within the caller's own account).
+func TestAWSSM_AccountPin(t *testing.T) {
+	t.Run("pinned connector rejects an ARN targeting a different account", func(t *testing.T) {
+		fake := &fakeSM{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String("x")}}
+		c := NewAWSSecretsManagerConnector("aws", "eu-west-1", "111111111111", nil)
+		c.newClient = func(_ context.Context, _ string) (smSecretGetter, error) { return fake, nil }
+
+		ref := "arn:aws:secretsmanager:eu-west-1:222222222222:secret:db-AbCdEf"
+		_, err := c.GetSecret(context.Background(), ref)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "222222222222")
+		assert.Contains(t, err.Error(), "111111111111")
+		assert.Empty(t, fake.got, "a cross-account ref must not reach the backend")
+	})
+
+	t.Run("pinned connector allows an ARN targeting its own account", func(t *testing.T) {
+		fake := &fakeSM{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String("s3cr3t")}}
+		c := NewAWSSecretsManagerConnector("aws", "eu-west-1", "111111111111", nil)
+		c.newClient = func(_ context.Context, _ string) (smSecretGetter, error) { return fake, nil }
+
+		ref := "arn:aws:secretsmanager:eu-west-1:111111111111:secret:db-AbCdEf"
+		val, err := c.GetSecret(context.Background(), ref)
+		require.NoError(t, err)
+		assert.Equal(t, "s3cr3t", val)
+	})
+
+	t.Run("pinned connector does not check a bare secret name -- it never carries an account segment", func(t *testing.T) {
+		fake := &fakeSM{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String("s3cr3t")}}
+		c := NewAWSSecretsManagerConnector("aws", "eu-west-1", "111111111111", nil)
+		c.newClient = func(_ context.Context, _ string) (smSecretGetter, error) { return fake, nil }
+
+		val, err := c.GetSecret(context.Background(), "prod/db")
+		require.NoError(t, err, "a bare-name ref cannot cross accounts, so the pin has nothing to check")
+		assert.Equal(t, "s3cr3t", val)
+	})
+
+	t.Run("unpinned connector (account_id unset, the still-supported default) allows a cross-account ARN", func(t *testing.T) {
+		// Documents the deliberate scope boundary: account_id is optional (unlike
+		// GCP's project_id), so leaving it unset keeps today's behavior for ARN
+		// refs -- no regression, and consistent with server/main.go's boot-time
+		// warning (not a hard failure) for this case.
+		fake := &fakeSM{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String("g0ph3r")}}
+		c := NewAWSSecretsManagerConnector("aws", "eu-west-1", "", nil) // accountID == "" -- the default
+		c.newClient = func(_ context.Context, _ string) (smSecretGetter, error) { return fake, nil }
+
+		ref := "arn:aws:secretsmanager:eu-west-1:222222222222:secret:db-AbCdEf"
+		val, err := c.GetSecret(context.Background(), ref)
+		require.NoError(t, err)
+		assert.Equal(t, "g0ph3r", val)
+	})
+}
+
+func TestAWSRefAccountID(t *testing.T) {
+	tests := []struct {
+		name        string
+		ref         string
+		wantAccount string
+		wantOK      bool
+	}{
+		{"full ARN", "arn:aws:secretsmanager:eu-west-1:123456789012:secret:db-AbCdEf", "123456789012", true},
+		{"govcloud partition ARN", "arn:aws-us-gov:secretsmanager:us-gov-west-1:123456789012:secret:db-AbCdEf", "123456789012", true},
+		{"bare secret name", "prod/db", "", false},
+		{"empty ref", "", "", false},
+		{"non-secretsmanager ARN", "arn:aws:iam:eu-west-1:123456789012:role:db-AbCdEf", "", false},
+		{"malformed ARN, too few segments", "arn:aws:secretsmanager:eu-west-1:123456789012", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account, ok := awsRefAccountID(tt.ref)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantAccount, account)
+		})
+	}
 }
 
 func TestManager_GetAndNames(t *testing.T) {

--- a/internal/connect/connect_s22_test.go
+++ b/internal/connect/connect_s22_test.go
@@ -130,7 +130,7 @@ func TestSanitizeVaultRef_SpaceIsEncoded_S22(t *testing.T) {
 // AWSSecretsManagerConnector.GetSecret where the client factory itself returns
 // an error (e.g., AWS config load failure).
 func TestAWSSM_GetSecret_ClientError_S22(t *testing.T) {
-	c := NewAWSSecretsManagerConnector("aws", "us-east-1", nil)
+	c := NewAWSSecretsManagerConnector("aws", "us-east-1", "", nil)
 	c.newClient = func(_ context.Context, _ string) (smSecretGetter, error) {
 		return nil, errors.New("no AWS credentials configured")
 	}

--- a/internal/connect/connect_s23_test.go
+++ b/internal/connect/connect_s23_test.go
@@ -251,7 +251,7 @@ func TestVault_S23_GetSecret_KVv2BothDataAndMetadata(t *testing.T) {
 // allowed_refs is rejected before the backend client is built.
 func TestAWSSM_S23_GetSecret_TraversalRefBlockedByAllowedRefs(t *testing.T) {
 	var buildCount int
-	c := NewAWSSecretsManagerConnector("aws", "eu-west-1", []string{"keyorix/"})
+	c := NewAWSSecretsManagerConnector("aws", "eu-west-1", "", []string{"keyorix/"})
 	c.newClient = func(_ context.Context, _ string) (smSecretGetter, error) {
 		buildCount++
 		return &fakeSM{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String("x")}}, nil
@@ -287,7 +287,7 @@ func TestAWSSM_S23_GetSecret_BothStringAndBinaryNil(t *testing.T) {
 // empty region string still builds a client (region is optional in the AWS
 // credential chain) and returns the secret value.
 func TestAWSSM_S23_GetSecret_NoRegion(t *testing.T) {
-	c := NewAWSSecretsManagerConnector("aws", "", nil) // region == ""
+	c := NewAWSSecretsManagerConnector("aws", "", "", nil) // region == ""
 	c.newClient = func(_ context.Context, region string) (smSecretGetter, error) {
 		assert.Equal(t, "", region, "empty region must be forwarded as-is")
 		return &fakeSM{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String("val")}}, nil
@@ -300,7 +300,7 @@ func TestAWSSM_S23_GetSecret_NoRegion(t *testing.T) {
 // TestAWSSM_S23_TypeAndName is a sanity guard that Name() and Type() are
 // forwarded from the struct fields unchanged.
 func TestAWSSM_S23_TypeAndName(t *testing.T) {
-	c := NewAWSSecretsManagerConnector("my-connector", "us-east-1", nil)
+	c := NewAWSSecretsManagerConnector("my-connector", "us-east-1", "", nil)
 	assert.Equal(t, "my-connector", c.Name())
 	assert.Equal(t, "aws-secrets-manager", c.Type())
 }

--- a/internal/connect/connect_s24_test.go
+++ b/internal/connect/connect_s24_test.go
@@ -114,7 +114,7 @@ func TestVault_S24_NewConnector_TrailingSlashTrimmed(t *testing.T) {
 // credential files exist (it simply loads an empty configuration), this test
 // confirms the path returns a non-nil client without error.
 func TestAWSSM_S24_ClientWithNoRegion(t *testing.T) {
-	c := NewAWSSecretsManagerConnector("aws", "", nil) // region == "", newClient == nil
+	c := NewAWSSecretsManagerConnector("aws", "", "", nil) // region == "", newClient == nil
 	cl, err := c.client(context.Background())
 	// LoadDefaultConfig may read credential files; if the SDK encounters a
 	// permission error on the credential file we skip — the important thing is
@@ -130,7 +130,7 @@ func TestAWSSM_S24_ClientWithNoRegion(t *testing.T) {
 // TestAWSSM_S24_ClientWithRegion exercises the branch inside client() where
 // region != "" — the opts = append(opts, awsconfig.WithRegion(region)) line.
 func TestAWSSM_S24_ClientWithRegion(t *testing.T) {
-	c := NewAWSSecretsManagerConnector("aws", "eu-west-1", nil) // region set, newClient == nil
+	c := NewAWSSecretsManagerConnector("aws", "eu-west-1", "", nil) // region set, newClient == nil
 	cl, err := c.client(context.Background())
 	if err != nil {
 		t.Logf("client() returned error (acceptable in sandbox): %v", err)

--- a/internal/connect/coverage_test.go
+++ b/internal/connect/coverage_test.go
@@ -44,7 +44,7 @@ import (
 // newClient is nil and a region is set. awsconfig.LoadDefaultConfig almost
 // never returns an error, so we expect a non-nil client back.
 func TestAWSSM_ClientRealPath_WithRegion(t *testing.T) {
-	c := NewAWSSecretsManagerConnector("aws-real", "us-east-1", nil)
+	c := NewAWSSecretsManagerConnector("aws-real", "us-east-1", "", nil)
 	// newClient is nil — the real awsconfig.LoadDefaultConfig path runs.
 	cl, err := c.client(context.Background())
 	// LoadDefaultConfig succeeds even without credentials; we expect a valid client.
@@ -56,7 +56,7 @@ func TestAWSSM_ClientRealPath_WithRegion(t *testing.T) {
 // awssm.client(): when region is "", the opts slice stays empty and
 // awsconfig.LoadDefaultConfig is called without a region option.
 func TestAWSSM_ClientRealPath_NoRegion(t *testing.T) {
-	c := NewAWSSecretsManagerConnector("aws-real-noregion", "", nil)
+	c := NewAWSSecretsManagerConnector("aws-real-noregion", "", "", nil)
 	// newClient is nil; region is "".
 	cl, err := c.client(context.Background())
 	require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestAWSSM_ClientRealPath_NoRegion(t *testing.T) {
 // TestAWSSM_ClientInjectedError covers the newClient != nil path returning an
 // error, exercising the error-propagation in GetSecret when client() fails.
 func TestAWSSM_ClientInjectedError(t *testing.T) {
-	c := NewAWSSecretsManagerConnector("aws-err", "eu-west-1", nil)
+	c := NewAWSSecretsManagerConnector("aws-err", "eu-west-1", "", nil)
 	injectedErr := errors.New("injected client error")
 	c.newClient = func(_ context.Context, _ string) (smSecretGetter, error) {
 		return nil, injectedErr

--- a/server/main.go
+++ b/server/main.go
@@ -671,7 +671,19 @@ func initializeCoreService(cfg *config.Config) (*core.KeyorixCore, *encryption.S
 		for _, cn := range cc.Connectors {
 			switch cn.Type {
 			case "aws-secrets-manager":
-				connectors = append(connectors, connect.NewAWSSecretsManagerConnector(cn.Name, cn.Region, cn.AllowedRefs))
+				// account_id is optional (unlike gcp-secret-manager's mandatory
+				// project_id — see internal/connect/awssm.go's doc comment for why the
+				// risk shape differs: a bare secret name never crosses AWS accounts, so
+				// the confused-deputy gap only exists for ARN-shaped refs, and even then
+				// requires the target account's own resource policy to separately grant
+				// access). cfg.Validate()'s validateConnectAWSAccountID already rejected a
+				// malformed (non-12-digit) account_id before this function is ever
+				// reached; an empty account_id is a legal, if less-hardened,
+				// configuration and boots fine, with a warning recommending it be set.
+				if cn.AccountID == "" {
+					log.Printf("Keyorix Connect: aws-secrets-manager connector %q has no account_id configured — a ref supplied as a full ARN naming a DIFFERENT AWS account will still succeed if that account's own resource policy grants cross-account access; set account_id to pin the connector to one account (a bare secret-name ref is unaffected either way -- Secrets Manager always resolves those within the caller's own account)", cn.Name)
+				}
+				connectors = append(connectors, connect.NewAWSSecretsManagerConnector(cn.Name, cn.Region, cn.AccountID, cn.AllowedRefs))
 			case "gcp-secret-manager":
 				// project_id is now a required field: unreachable via a config that
 				// passed cfg.Validate() — validateConnectGCPProjectID

--- a/server/server_s4_test.go
+++ b/server/server_s4_test.go
@@ -500,6 +500,50 @@ func TestInitializeCoreService_Connect_GCP_NoProjectID(t *testing.T) {
 	}
 }
 
+// ── initializeCoreService — aws (account_id is optional, unlike GCP's project_id) ──
+
+// account_id is deliberately OPTIONAL for aws-secrets-manager connectors — see
+// ConnectorConfig.AccountID's own doc comment and internal/connect/awssm.go for the
+// risk-shape reason a mandatory pin isn't warranted here the way it is for GCP. A
+// missing account_id must still boot fine (server/main.go only logs a
+// recommendation), while a MALFORMED one (set, but not 12 digits) must fail boot —
+// validateConnectAWSAccountID's format check, run from cfg.Validate() before the
+// Connect-wiring loop is ever reached.
+func TestInitializeCoreService_Connect_AWS_NoAccountID(t *testing.T) {
+	initI18n(t)
+	cfg := newMinimalCfg(t)
+	cfg.Connect = config.ConnectConfig{
+		Enabled: true,
+		Connectors: []config.ConnectorConfig{
+			{Name: "aws-noaccount", Type: "aws-secrets-manager", AccountID: "", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
+		},
+	}
+
+	_, _, err := initializeCoreService(cfg)
+	if err != nil {
+		t.Fatalf("initializeCoreService with aws-secrets-manager, no account_id (optional, must still boot): %v", err)
+	}
+}
+
+func TestInitializeCoreService_Connect_AWS_MalformedAccountID(t *testing.T) {
+	initI18n(t)
+	cfg := newMinimalCfg(t)
+	cfg.Connect = config.ConnectConfig{
+		Enabled: true,
+		Connectors: []config.ConnectorConfig{
+			{Name: "aws-badaccount", Type: "aws-secrets-manager", AccountID: "not-12-digits", AllowedRefs: []string{"prod/*"}, Scope: "platform"},
+		},
+	}
+
+	_, _, err := initializeCoreService(cfg)
+	if err == nil {
+		t.Fatal("expected initializeCoreService to refuse to boot an aws-secrets-manager connector with a malformed account_id")
+	}
+	if got := err.Error(); !contains(got, "aws-badaccount") || !contains(got, "account_id") {
+		t.Fatalf("expected error to name the connector and account_id, got: %v", err)
+	}
+}
+
 // ── initializeCoreService — azure connector ───────────────────────────────────
 
 func TestInitializeCoreService_Connect_AzureKeyVault(t *testing.T) {


### PR DESCRIPTION
## Summary

`internal/connect/awssm.go`'s `AWSSecretsManagerConnector` had fields `name`,
`region`, `allowedRefs` -- no account-binding field at all. `GetSecret` passed
`ref` straight through as `SecretId` with no check against an expected AWS
account. A `ref` supplied as a full ARN
(`arn:PARTITION:secretsmanager:REGION:ACCOUNT:secret:NAME`) naming a
**different** AWS account succeeds if the ambient IAM identity has
cross-account access via the target secret's own resource-based policy --
structurally the same confused-deputy shape `e49778a5` ("fix(connect): require
project_id on gcp-secret-manager connectors", #1755) just closed for GCP, just
with a narrower risk surface.

**Not a duplicate of #1755.** That PR's own sibling-sweep explicitly
concluded AWS's risk shape differs and did not implement AWS pinning; this PR
is the tracked follow-up for that gap (see `docs/adr-082-connect-connector-tenant-scoping.md`'s
neighboring GCP section and the QUEUE for the reopened-item context). Cross-referencing
here for a reviewer's benefit.

## Design decision: optional, not mandatory

Unlike GCP's `project_id` (made a **mandatory** boot-time requirement in
#1755), `account_id` here is **optional**. The risk shape genuinely differs:

- A **bare secret-name ref** (the common shape) is *always* resolved within
  the ambient credential's own AWS account by the Secrets Manager API itself
  -- there is no confused-deputy gap for that shape at all, unlike GCP where
  every ref carries a project ID the ambient ADC identity can reach regardless.
- A **full-ARN ref** naming another account additionally requires that target
  account's own resource policy to have *separately* granted cross-account
  access -- a double opt-in, not GCP's single-opt-in ambient-reach gap.

Making `account_id` mandatory would force every connector that only ever
reads bare-name refs (the majority, and structurally safe regardless) to
configure a field with zero enforcement value for them. So: optional field,
format-validated when set, enforced at read time only against ARN-shaped
refs -- and `server/main.go` logs a startup recommendation (not a boot
failure) when it's unset, mirroring the exact phase-in idiom GCP's own
`project_id` used *before* #1755 made it mandatory.

## Changes

- **`internal/config/config.go`**: new `ConnectorConfig.AccountID` field
  (`yaml:"account_id"`); new `validateConnectAWSAccountID` -- fails boot only
  if a *set* `account_id` is not exactly 12 digits (the AWS account ID
  format), wired into `Config.Validate()`.
- **`internal/connect/awssm.go`**: new `accountID` field +
  `NewAWSSecretsManagerConnector` parameter; new `awsRefAccountID` ARN parser
  (handles `aws`/`aws-cn`/`aws-us-gov` partitions); `GetSecret` refuses an
  ARN-shaped ref naming a different account when `accountID` is configured.
  Doc comment explains the full risk-shape rationale.
- **`server/main.go`**: wires `cn.AccountID` through; logs a startup
  recommendation (not `log.Fatalf`) when unset.
- **`docs/CONFIGURATION.md`**: documents the new field and its scope boundary.
- **`CHANGELOG.md`**: non-breaking `### Security` entry (no existing
  deployment is broken -- verified zero shipped `configs/*.yaml`/doc examples
  set an AWS connector's account_id, matching #1755's own finding of zero AWS
  examples).
- **`docs/security-closures.tsv`**: new `AWS-CONN-ACCOUNTID` row.
- Every existing `NewAWSSecretsManagerConnector` call site updated for the
  new constructor parameter (`internal/connect/{connect_s22,connect_s23,
  connect_s24,coverage}_test.go`, `awssm_test.go`).

## Test plan

- [x] `TestAWSSM_AccountPin` -- rejects cross-account ARN, allows same-account
      ARN, allows bare name regardless of pin, unpinned connector keeps
      today's behavior for ARN refs (no regression).
- [x] `TestAWSRefAccountID` -- ARN parsing incl. partition variants and
      malformed/non-ARN inputs.
- [x] `TestValidateConnectAWSAccountID` / `TestValidate_ConnectAWSAccountIDWired`
      -- boot-time format check + confirms a *missing* account_id does NOT
      fail `Config.Validate()` (optional, unlike GCP).
- [x] `TestInitializeCoreService_Connect_AWS_{NoAccountID,MalformedAccountID}`
      -- server-wiring level.
- [x] All new tests verified **RED** against the pre-fix code (enforcement
      temporarily disabled) and **GREEN** after, per repo convention.
- [x] `go build ./...`, `go vet ./...` clean repo-wide.
- [x] `gofmt -l` clean on every touched file.
- [x] `gosec -severity medium -exclude-generated` clean on
      `internal/connect`, `internal/config`, `server`.
- [x] `go test ./internal/config/... ./internal/connect/...` -- full package
      suites green.
- [x] `go test ./server -run 'TestInitializeCoreService|TestConnect'` -- green
      (covers every test in `server/server_s4_test.go`, the only `server`
      package file touched).
- [x] `scripts/check-closures.sh` -- passes, including the new
      `AWS-CONN-ACCOUNTID` row.
- Note: a full `go test ./server/...` run separately timed out in
  `server/http` (10m, hundreds of hung `database/sql` goroutines) -- a
  package this PR does not touch at all. Documented project memory
  (`local-only-test-failures.md`) records pre-existing local-only flakiness
  in that exact package. Not a regression from this change.