### PR TITLE
fix(bundle): close whole-destDir-wipe downgrade bypass; remove dead status.PingCmd

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -290,10 +290,27 @@ func Extract(r io.Reader, reg *trust.KeyRegistry, destDir, installedVersion stri
 	return process(r, reg, &extractOpts{destDir: destDir, installedVersion: installedVersion})
 }
 
+// ExtractAllowingStateReset is like Extract, but additionally accepts the operator's
+// explicit acknowledgement that destDir's install state may have been intentionally
+// reset (see ErrInstallStateReset). Without acknowledgeReset=true, a destDir that looks
+// like a fresh/first install (per readInstalledVersion) while the external install-state
+// record (see readExternalInstallState) still remembers a previously-installed version
+// is refused outright — that mismatch is exactly the signature of an actor deleting the
+// whole destDir to reset the no-downgrade gate, which a marker-only check cannot see
+// (the marker lives inside the directory being wiped). Passing acknowledgeReset=true
+// does NOT disable the no-downgrade check itself (unlike installedVersion=""+--force at
+// the CLI layer) — it only resolves which record to trust when they disagree, in favor
+// of whatever destDir/its internal marker actually shows; CheckUpgrade still runs
+// against that resolved value.
+func ExtractAllowingStateReset(r io.Reader, reg *trust.KeyRegistry, destDir, installedVersion string, acknowledgeReset bool) (*Manifest, error) {
+	return process(r, reg, &extractOpts{destDir: destDir, installedVersion: installedVersion, resetAcknowledged: acknowledgeReset})
+}
+
 // extractOpts is the staging configuration for process; nil means verify-only.
 type extractOpts struct {
-	destDir          string
-	installedVersion string
+	destDir           string
+	installedVersion  string
+	resetAcknowledged bool
 }
 
 // process is the single streaming pass shared by Verify and Extract. It reads the manifest
@@ -346,6 +363,15 @@ func process(r io.Reader, reg *trust.KeyRegistry, opts *extractOpts) (*Manifest,
 		if err := writeInstalledVersion(opts.destDir, m.Version); err != nil {
 			return nil, err
 		}
+		// Also (re)anchor the external install-state record outside destDir — see
+		// ErrInstallStateReset for why this second, independent record exists. A failed
+		// write here is surfaced rather than swallowed: components are already durably
+		// staged (same posture as a writeInstalledVersion failure just above), but letting
+		// this fail silently would leave the external record stale/absent, which the next
+		// import would then have to treat as an unexplained mismatch or missing anchor.
+		if err := writeExternalInstallState(opts.destDir, m.Version); err != nil {
+			return nil, err
+		}
 	}
 	return &m, nil
 }
@@ -385,7 +411,7 @@ func validateAndPrepareExtract(opts *extractOpts, m *Manifest) error {
 func resolveIdempotentInstall(opts *extractOpts, m *Manifest) (installed string, idempotent bool, err error) {
 	installed = strings.TrimSpace(opts.installedVersion)
 	fromMarker := false
-	if marker, ok, merr := readInstalledVersion(opts.destDir); merr != nil {
+	if marker, ok, merr := reconcileInstallState(opts.destDir, opts.resetAcknowledged); merr != nil {
 		return "", false, merr
 	} else if ok {
 		installed, fromMarker = marker, true
@@ -477,18 +503,29 @@ func checkAllComponentsSeen(pinned map[string]Component, seen map[string]bool) e
 const installedVersionMarker = ".keyorix-installed-version"
 
 // PersistedInstalledVersion returns the version recorded by a previous successful `import`
-// at destDir (see readInstalledVersion): ok is true and version is set when a marker from a
-// prior import anchors the no-downgrade / anti-skip gate for this destination; ok is false
-// when destDir is empty/nonexistent (a genuine first import, with nothing yet to anchor
-// against). A present-but-unreadable marker, or an otherwise non-empty destDir with no
-// marker, is returned as an error (fail closed — see readInstalledVersion).
+// at destDir, reconciling the internal marker (see readInstalledVersion) against the
+// external install-state record (see readExternalInstallState, ErrInstallStateReset): ok is
+// true and version is set when either record anchors the no-downgrade / anti-skip gate for
+// this destination; ok is false when destDir is empty/nonexistent AND no external record
+// exists (a genuine first import, with nothing yet to anchor against). A present-but-
+// unreadable marker, an otherwise non-empty destDir with no marker, or a destDir that looks
+// like a first install while the external record still remembers a prior one, is returned
+// as an error (fail closed).
 //
 // CLI callers use this to decide whether an operator-supplied --installed-version flag can
 // safely be treated as optional for a given import (a marker already anchors the gate) or
 // must be required (no anchor exists yet, so an omitted flag would silently disable
 // downgrade protection for that import — cli-project-001).
 func PersistedInstalledVersion(destDir string) (version string, ok bool, err error) {
-	return readInstalledVersion(destDir)
+	return reconcileInstallState(destDir, false)
+}
+
+// PersistedInstalledVersionAllowingReset is like PersistedInstalledVersion, but takes the
+// operator's explicit acknowledgement (acknowledgeReset) that destDir's install state may
+// have been intentionally reset — see ExtractAllowingStateReset / ErrInstallStateReset for
+// what that means and what it does (and does not) bypass.
+func PersistedInstalledVersionAllowingReset(destDir string, acknowledgeReset bool) (version string, ok bool, err error) {
+	return reconcileInstallState(destDir, acknowledgeReset)
 }
 
 // readInstalledVersion returns the persisted installed version at destDir. ok is false

--- a/internal/bundle/install_state.go
+++ b/internal/bundle/install_state.go
@@ -1,0 +1,265 @@
+package bundle
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/keyorixhq/keyorix/internal/securefiles"
+)
+
+// ErrInstallStateReset means the external install-state record (see
+// readExternalInstallState below) remembers a previously-installed version for this
+// destDir, but destDir itself shows no trace of one — the same signature
+// readInstalledVersion's own #111 fix already catches for a marker-only deletion, except
+// here the ENTIRE destDir (marker included) was removed.
+//
+// readInstalledVersion's #111 fix closes one path to resetting the no-downgrade gate:
+// deleting only the marker file while other staged component files remain is detected
+// (destDirHasContent still sees the leftover files) and refused. It does not close the
+// other, equally trivial path: deleting the WHOLE destDir. destDirHasContent returns
+// false for both a directory that never existed and one that existed and was wiped —
+// there is no way to tell them apart by looking only inside destDir, because the marker
+// that would normally say "something was here" lives in the very directory being wiped.
+// A first-install check that only ever looks inside destDir cannot, even in principle,
+// distinguish "nothing has ever been staged here" from "something was staged here and
+// then removed" — the evidence for the second case has to live somewhere else.
+//
+// This external record is that somewhere else: a second copy of the installed version,
+// written to a fixed location outside destDir (see externalStateBaseDir) every time
+// Extract/ExtractAllowingStateReset succeeds. An actor who can rm -rf destDir cannot, by
+// that action alone, also erase this external record — deleting destDir no longer resets
+// the gate to "first install" with zero signal; it now produces a detectable mismatch
+// that has to be explicitly resolved (see ExtractAllowingStateReset).
+var ErrInstallStateReset = errors.New("bundle: external install-state record exists for this destination, but destDir shows no trace of a prior install")
+
+// installStateDirEnvOverride lets an operator (or a test) pin the external install-state
+// directory explicitly, taking priority over the XDG/home-directory defaults below. This
+// matters when no $HOME is available at all (e.g. a minimal service-account container
+// running scheduled imports) and when an operator wants the record kept somewhere more
+// deliberately separated from --dest than their own home directory.
+const installStateDirEnvOverride = "KEYORIX_BUNDLE_STATE_DIR"
+
+// installStateDisabledValue is a distinguished installStateDirEnvOverride value that
+// explicitly opts out of external install-state tracking, degrading to the internal-marker-
+// only protection that existed before this record (documented, not silent). This is
+// distinct from simply leaving the variable unset, which instead falls through to the
+// XDG_CONFIG_HOME / $HOME/.keyorix defaults below — an unset override must not be
+// mistakable for "disabled" given those defaults usually do resolve to somewhere real.
+const installStateDisabledValue = "-"
+
+// externalStateBaseDir resolves the directory external install-state records are kept
+// in, mirroring the precedent already established for the CLI's own config file
+// (internal/cli/config.getDefaultCLIConfigPath): an explicit override, then
+// XDG_CONFIG_HOME, then $HOME/.keyorix, then "" (unresolvable). It deliberately never
+// falls back to a shared/world-writable temp directory: the entire point is a location
+// that is NOT simply "one more thing inside (or trivially alongside) the operator-
+// supplied, potentially more widely writable --dest staging directory."
+//
+// An unresolvable result ("") is not itself an error — see readExternalInstallState /
+// writeExternalInstallState — it degrades to the internal-marker-only protection that
+// existed before this record, which is documented, not silent.
+func externalStateBaseDir() string {
+	if v := strings.TrimSpace(os.Getenv(installStateDirEnvOverride)); v != "" {
+		if v == installStateDisabledValue {
+			return ""
+		}
+		return filepath.Join(v, "bundle-installs")
+	}
+	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+		return filepath.Join(xdg, "keyorix", "bundle-installs")
+	}
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		return filepath.Join(home, ".keyorix", "bundle-installs")
+	}
+	return ""
+}
+
+// externalStateRecord is the on-disk shape of one external install-state record.
+type externalStateRecord struct {
+	DestDir string `json:"dest_dir"`
+	Version string `json:"version"`
+}
+
+// externalStatePath returns the path the external install-state record for destDir would
+// live at, or "" if no external base directory is resolvable (see externalStateBaseDir).
+// It is keyed by the SHA-256 of destDir's absolute, cleaned form so distinct destinations
+// never collide and the record's filename never embeds a raw filesystem path.
+func externalStatePath(destDir string) (string, error) {
+	base := externalStateBaseDir()
+	if base == "" {
+		return "", nil
+	}
+	abs, err := filepath.Abs(destDir)
+	if err != nil {
+		return "", fmt.Errorf("bundle: resolve destination for install-state key: %w", err)
+	}
+	sum := sha256.Sum256([]byte(filepath.Clean(abs)))
+	return filepath.Join(base, hex.EncodeToString(sum[:])+".json"), nil
+}
+
+// readExternalInstallState reads the external install-state record for destDir. ok is
+// false when no external directory is resolvable, or none exists yet for this destDir —
+// both are unremarkable (external tracking is new, or this destination has simply never
+// been recorded before). A present-but-corrupt/unreadable record fails closed, the same
+// posture readInstalledVersion already takes for the internal marker.
+func readExternalInstallState(destDir string) (version string, ok bool, err error) {
+	path, err := externalStatePath(destDir)
+	if err != nil {
+		return "", false, err
+	}
+	if path == "" {
+		return "", false, nil
+	}
+	base, name := filepath.Dir(path), filepath.Base(path)
+	// If the external state directory itself doesn't exist yet, there is certainly no
+	// record in it — return the ordinary "nothing recorded" result without ever calling
+	// securefiles.SafeReadFile. This sidesteps a real quirk beyond just avoiding a
+	// pointless syscall: SafeReadFile's containment check (isPathInsideBase) resolves
+	// symlinks on baseDir only when baseDir itself already exists; when it doesn't, the
+	// check falls back to resolving the target's longest EXISTING ancestor instead (e.g.
+	// this base dir's own parent, which does exist) — on a platform where that ancestor
+	// sits behind a symlink (macOS: /var -> /private/var), the two resolve to different
+	// prefixes and SafeReadFile spuriously reports "outside of" the very base directory it
+	// was just joined from. Guaranteeing base exists before ever calling SafeReadFile
+	// (both here and in writeExternalInstallState's mkdirAllNoSymlink call) avoids the
+	// mismatch entirely instead of working around it after the fact.
+	if fi, statErr := os.Stat(base); statErr != nil {
+		if errors.Is(statErr, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("bundle: check external install-state directory: %w", statErr)
+	} else if !fi.IsDir() {
+		return "", false, fmt.Errorf("bundle: external install-state path %q exists and is not a directory", base)
+	}
+	b, err := securefiles.SafeReadFile(base, name)
+	if err != nil {
+		// securefiles.SafeReadFile's underlying open walks through several layers of
+		// fmt.Errorf("...: %w", ...) wrapping (secureOpenBeneath's own "open base
+		// directory" / per-component errors) before reaching the raw ENOENT — plain
+		// os.IsNotExist does not unwrap arbitrary %w chains (it only recognizes
+		// *PathError/*LinkError/*SyscallError directly), so it would misreport "no
+		// record yet" as a hard read error here. errors.Is walks the full chain and
+		// syscall.Errno implements Is(fs.ErrNotExist), so this correctly recognizes
+		// "the bundle-installs directory, or the record file in it, doesn't exist yet"
+		// as the ordinary, unremarkable case it is.
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("bundle: read external install-state record: %w", err)
+	}
+	var rec externalStateRecord
+	if err := json.Unmarshal(b, &rec); err != nil {
+		return "", false, fmt.Errorf("bundle: parse external install-state record %q: %w", path, err)
+	}
+	if strings.TrimSpace(rec.Version) == "" {
+		return "", false, fmt.Errorf("bundle: external install-state record %q has no version", path)
+	}
+	return strings.TrimSpace(rec.Version), true, nil
+}
+
+// writeExternalInstallState persists version as the external install-state record for
+// destDir. A non-resolvable external directory (externalStateBaseDir returning "") is not
+// an error — the write is silently skipped, and protection degrades to the internal
+// marker alone, exactly as it existed before this record was introduced.
+func writeExternalInstallState(destDir, version string) error {
+	path, err := externalStatePath(destDir)
+	if err != nil {
+		return err
+	}
+	if path == "" {
+		return nil
+	}
+	base, name := filepath.Dir(path), filepath.Base(path)
+	if err := mkdirAllNoSymlink(base, base); err != nil {
+		return fmt.Errorf("bundle: create external install-state directory: %w", err)
+	}
+	abs, err := filepath.Abs(destDir)
+	if err != nil {
+		return fmt.Errorf("bundle: resolve destination for install-state record: %w", err)
+	}
+	rec := externalStateRecord{DestDir: filepath.Clean(abs), Version: version}
+	b, err := json.Marshal(&rec)
+	if err != nil {
+		return err
+	}
+	if err := securefiles.SecureWriteFileSync(base, name, b, 0o600); err != nil {
+		return fmt.Errorf("bundle: write external install-state record: %w", err)
+	}
+	return nil
+}
+
+// reconcileInstallState is the single point where the internal marker (readInstalledVersion,
+// living inside destDir) and the external install-state record (readExternalInstallState,
+// living outside it) are compared. It is the function both Extract's own no-downgrade gate
+// (resolveIdempotentInstall) and the CLI's pre-flight check (PersistedInstalledVersion)
+// call, so the same rule applies everywhere destDir's install state is consulted, not just
+// at one of the two call sites.
+//
+//   - Internal error (an unreadable marker, or "content but no marker" — #111): returned
+//     verbatim. The external record only ever ADDS a check on top of this one; it never
+//     loosens it.
+//   - Both present and agreeing: return that version, anchored (the ordinary case for
+//     every import after the first).
+//   - Internal present, external absent: accepted as-is (a marker predating this feature,
+//     or a destination whose external directory only just became resolvable) — not
+//     suspicious. writeExternalInstallState backfills the external record on the next
+//     successful import.
+//   - Internal present, external present, but DISAGREEING: destDir's own marker was
+//     edited in place to claim an older installed version (a variant #111's "content but
+//     no marker" check cannot see, since the marker is still present — just wrong).
+//     Refused unless acknowledgeReset is true, in which case the internal value is
+//     trusted (it reflects what destDir actually, physically holds) and CheckUpgrade
+//     still runs against it — acknowledging a reset does not disable the downgrade check.
+//   - Internal absent, external present: destDir looks like a fresh/first install, but the
+//     external record remembers otherwise — the wiped-destDir attack this whole mechanism
+//     exists to catch. Refused (ErrInstallStateReset) unless acknowledgeReset is true, in
+//     which case this is treated as a genuine first install (no anchor).
+//   - Neither present: an ordinary, unremarkable first install.
+func reconcileInstallState(destDir string, acknowledgeReset bool) (version string, ok bool, err error) {
+	intVersion, intOk, err := readInstalledVersion(destDir)
+	if err != nil {
+		return "", false, err
+	}
+	extVersion, extOk, err := readExternalInstallState(destDir)
+	if err != nil {
+		return "", false, err
+	}
+
+	switch {
+	case intOk && extOk:
+		if intVersion == extVersion {
+			return intVersion, true, nil
+		}
+		if acknowledgeReset {
+			return intVersion, true, nil
+		}
+		return "", false, fmt.Errorf(
+			"%w: destination marker at %q records %q but the external install-state record says %q — "+
+				"one of the two disagrees with the other (possible tampering, or a partially-applied "+
+				"manual fix); if this destination's install state was intentionally reset, re-run with "+
+				"the reset explicitly acknowledged",
+			ErrInstallStateReset, destDir, intVersion, extVersion)
+	case intOk && !extOk:
+		return intVersion, true, nil
+	case !intOk && extOk:
+		if acknowledgeReset {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf(
+			"%w: external install-state record says %q was previously imported into %q, but the "+
+				"destination itself shows no trace of it — this is exactly what deleting the whole "+
+				"destination (instead of just its marker file) would produce; if this destination's "+
+				"install state was intentionally reset (e.g. deliberately cleared for a fresh start), "+
+				"re-run with the reset explicitly acknowledged, otherwise treat this as a possible "+
+				"downgrade attempt and investigate before proceeding",
+			ErrInstallStateReset, extVersion, destDir)
+	default:
+		return "", false, nil
+	}
+}

--- a/internal/bundle/install_state_test.go
+++ b/internal/bundle/install_state_test.go
@@ -1,0 +1,224 @@
+package bundle
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/trust"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMain sandboxes every test in this package against a throwaway
+// KEYORIX_BUNDLE_STATE_DIR, so running `go test ./internal/bundle/...` never reads or
+// writes the real developer/CI-runner home directory's ~/.keyorix/bundle-installs — the
+// production default (externalStateBaseDir) deliberately resolves there when no override
+// is set, which is correct in production but not something a test run should touch.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "keyorix-bundle-state-test-*")
+	if err != nil {
+		os.Exit(1)
+	}
+	if err := os.Setenv(installStateDirEnvOverride, dir); err != nil {
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// resignForRegistry builds + signs a NEW bundle for keyID, registering a freshly generated
+// key under that keyID in the EXISTING reg (overwriting whatever key was previously
+// registered there — trust.KeyRegistry.Add allows re-registering a keyID with a different
+// key under the same purpose; only cross-purpose reuse is refused). This lets a test build
+// a second, differently-versioned bundle that still verifies against the same registry
+// object passed to an earlier Extract call, without needing to keep the original signing
+// key around (signedBundle doesn't return one reusable across calls with a shared registry).
+func resignForRegistry(t *testing.T, reg *trust.KeyRegistry, files map[string]string, version, keyID, minFrom string) []byte {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	dir := srcDirWith(t, files)
+	m, err := BuildManifest(dir, version, keyID, minFrom, time.Unix(1_700_000_000, 0))
+	require.NoError(t, err)
+	sig, err := Sign(m, priv)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, WriteBundle(&buf, dir, m, sig))
+	require.NoError(t, reg.Add(trust.PurposeUpdate, keyID, pub))
+	return buf.Bytes()
+}
+
+// TestExtract_WholeDestDirWipe_ResetsGateWithoutExternalState is the RED case: with the
+// external install-state record disabled (nothing to compare against, i.e. the world
+// before this fix), deleting the ENTIRE destDir after a successful import is treated as an
+// unremarkable first install, and a subsequent downgrade sails through with no error. This
+// pins the pre-fix gap for the specific code path that no longer has it once
+// KEYORIX_BUNDLE_STATE_DIR resolves to somewhere real (see the GREEN test below).
+func TestExtract_WholeDestDirWipe_ResetsGateWithoutExternalState(t *testing.T) {
+	t.Setenv(installStateDirEnvOverride, installStateDisabledValue) // disable the external record for this test only
+	dest := t.TempDir()
+
+	raw1, reg, _ := signedBundle(t, map[string]string{"a.bin": "x"}, "v2.0.0", "k-wipe", "")
+	_, err := Extract(bytes.NewReader(raw1), reg, dest, "")
+	require.NoError(t, err)
+
+	// Simulate an import-capable adversary (or a confused operator) wiping the whole
+	// destination, not just the marker file.
+	require.NoError(t, os.RemoveAll(dest))
+	require.NoError(t, os.MkdirAll(dest, 0o750))
+
+	raw0 := resignForRegistry(t, reg, map[string]string{"a.bin": "x"}, "v1.0.0", "k-wipe", "")
+	_, err = Extract(bytes.NewReader(raw0), reg, dest, "")
+	assert.NoError(t, err, "documents the pre-fix gap: with no external record, a wiped destDir "+
+		"looks like a genuine first install and the downgrade to v1.0.0 is silently allowed")
+}
+
+// TestExtract_WholeDestDirWipe_RefusedByExternalState is the GREEN case: with the external
+// install-state record resolvable (the default posture once KEYORIX_BUNDLE_STATE_DIR — or
+// $HOME/.keyorix in production — is set, as TestMain arranges for this whole package),
+// wiping the entire destDir no longer resets the gate silently: Extract refuses with
+// ErrInstallStateReset instead of treating the wipe as a first install.
+func TestExtract_WholeDestDirWipe_RefusedByExternalState(t *testing.T) {
+	dest := t.TempDir()
+
+	raw1, reg, _ := signedBundle(t, map[string]string{"a.bin": "x"}, "v2.0.0", "k-wipe2", "")
+	_, err := Extract(bytes.NewReader(raw1), reg, dest, "")
+	require.NoError(t, err)
+
+	require.NoError(t, os.RemoveAll(dest))
+	require.NoError(t, os.MkdirAll(dest, 0o750))
+
+	raw0 := resignForRegistry(t, reg, map[string]string{"a.bin": "x"}, "v1.0.0", "k-wipe2", "")
+	_, err = Extract(bytes.NewReader(raw0), reg, dest, "")
+	require.Error(t, err, "a wiped destDir must not be silently treated as a first install when an "+
+		"external install-state record still remembers v2.0.0 was installed here")
+	assert.True(t, errors.Is(err, ErrInstallStateReset), "got: %v", err)
+
+	// A refused import must not write anything to dest (fail closed before any component
+	// write, exactly like every other Extract refusal) — dest was wiped by the test setup
+	// above and must stay that way, not partially re-populated by the refused attempt.
+	_, statErr := os.Stat(filepath.Join(dest, "a.bin"))
+	assert.True(t, os.IsNotExist(statErr), "a refused import must not stage any component; got stat err: %v", statErr)
+}
+
+// TestExtract_WholeDestDirWipe_AcknowledgedResetStillEnforcesDowngrade verifies that
+// acknowledging the reset does NOT disable the no-downgrade check itself — it only resolves
+// which record to trust. Since the internal marker was wiped along with the rest of
+// destDir, the reconciled state is "no anchor" (a genuine first install), so an
+// operator-supplied --installed-version (or its absence) governs exactly as it would for
+// any other first install, and the check resumes enforcing on the very next import.
+func TestExtract_WholeDestDirWipe_AcknowledgedResetStillEnforcesDowngrade(t *testing.T) {
+	dest := t.TempDir()
+
+	raw1, reg, _ := signedBundle(t, map[string]string{"a.bin": "x"}, "v2.0.0", "k-wipe3", "")
+	_, err := Extract(bytes.NewReader(raw1), reg, dest, "")
+	require.NoError(t, err)
+
+	require.NoError(t, os.RemoveAll(dest))
+	require.NoError(t, os.MkdirAll(dest, 0o750))
+
+	raw0 := resignForRegistry(t, reg, map[string]string{"a.bin": "x"}, "v1.0.0", "k-wipe3", "")
+
+	// Acknowledging the reset without an --installed-version to anchor against still lets
+	// the (older, but now-unanchored) bundle stage — matching first-install semantics
+	// exactly (this is why the CLI layer additionally requires --installed-version or
+	// --force on a true first install; the library call alone does not).
+	m, err := ExtractAllowingStateReset(bytes.NewReader(raw0), reg, dest, "", true)
+	require.NoError(t, err)
+	assert.Equal(t, "v1.0.0", m.Version)
+
+	// A second, later import of an even older version, now anchored by the record
+	// ExtractAllowingStateReset just wrote, must still be caught as a downgrade.
+	rawOlder := resignForRegistry(t, reg, map[string]string{"a.bin": "x"}, "v0.9.0", "k-wipe3", "")
+	_, err = Extract(bytes.NewReader(rawOlder), reg, dest, "")
+	require.Error(t, err, "the no-downgrade check must resume enforcing normally after an acknowledged reset")
+	assert.True(t, errors.Is(err, ErrNotUpgrade), "got: %v", err)
+}
+
+// TestExtract_MarkerEditedInPlace_RefusedByExternalState covers the OTHER gap the external
+// record closes, beyond outright destDir deletion: editing the marker file's CONTENT to
+// claim an older installed version (the marker still exists, so #111's "content but no
+// marker" check never fires) is also caught, because the internal and external records now
+// disagree.
+func TestExtract_MarkerEditedInPlace_RefusedByExternalState(t *testing.T) {
+	dest := t.TempDir()
+
+	raw2, reg, _ := signedBundle(t, map[string]string{"a.bin": "x"}, "v2.0.0", "k-edit", "")
+	_, err := Extract(bytes.NewReader(raw2), reg, dest, "")
+	require.NoError(t, err)
+
+	// Edit the marker in place to claim an older installed version, without touching
+	// anything else (no deletion at all — the #111 "content but no marker" check cannot
+	// see this, because the marker is still present).
+	require.NoError(t, os.WriteFile(filepath.Join(dest, installedVersionMarker), []byte("v1.0.0\n"), 0o600))
+
+	rawRepeat := resignForRegistry(t, reg, map[string]string{"a.bin": "x"}, "v1.5.0", "k-edit", "")
+	_, err = Extract(bytes.NewReader(rawRepeat), reg, dest, "")
+	require.Error(t, err, "an in-place-edited marker claiming v1.0.0 must not let v1.5.0 verify as an upgrade")
+	assert.True(t, errors.Is(err, ErrInstallStateReset), "got: %v", err)
+}
+
+// TestPersistedInstalledVersionAllowingReset_Cov exercises the CLI-facing entry point
+// directly (mirroring the existing PersistedInstalledVersion coverage in
+// bundle_coverage_test.go), across the reset/no-reset combinations.
+func TestPersistedInstalledVersionAllowingReset_Cov(t *testing.T) {
+	dest := t.TempDir()
+	raw, reg, _ := signedBundle(t, map[string]string{"a.bin": "x"}, "v3.0.0", "k-parv", "")
+	_, err := Extract(bytes.NewReader(raw), reg, dest, "")
+	require.NoError(t, err)
+
+	version, ok, err := PersistedInstalledVersionAllowingReset(dest, false)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "v3.0.0", version)
+
+	require.NoError(t, os.RemoveAll(dest))
+	require.NoError(t, os.MkdirAll(dest, 0o750))
+
+	_, ok, err = PersistedInstalledVersionAllowingReset(dest, false)
+	assert.False(t, ok)
+	assert.True(t, errors.Is(err, ErrInstallStateReset), "got: %v", err)
+
+	_, ok, err = PersistedInstalledVersionAllowingReset(dest, true)
+	assert.False(t, ok)
+	assert.NoError(t, err, "acknowledging the reset must clear the refusal and read back as a first install")
+}
+
+// TestReconcileInstallState_BackfillsExistingInternalMarker verifies the "internal present,
+// external absent" case is NOT suspicious: an install performed before external tracking
+// existed (or targeting a destDir whose external directory only just became resolvable)
+// must not be refused, and a following import backfills the external record.
+func TestReconcileInstallState_BackfillsExistingInternalMarker(t *testing.T) {
+	dest := t.TempDir()
+
+	// Write the internal marker directly, bypassing Extract entirely, to simulate a
+	// pre-existing install that predates this feature (no external record was ever
+	// written for it).
+	require.NoError(t, os.WriteFile(filepath.Join(dest, installedVersionMarker), []byte("v4.0.0\n"), 0o600))
+
+	version, ok, err := PersistedInstalledVersion(dest)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "v4.0.0", version)
+
+	// A subsequent import must both succeed and backfill the external record — verified by
+	// checking that a wipe-then-reimport-older-version is now caught (which would not
+	// happen if the external record was never written).
+	raw, reg, _ := signedBundle(t, map[string]string{"a.bin": "x"}, "v4.1.0", "k-backfill", "")
+	_, err = Extract(bytes.NewReader(raw), reg, dest, "v4.0.0")
+	require.NoError(t, err)
+
+	require.NoError(t, os.RemoveAll(dest))
+	require.NoError(t, os.MkdirAll(dest, 0o750))
+
+	rawOld := resignForRegistry(t, reg, map[string]string{"a.bin": "x"}, "v1.0.0", "k-backfill", "")
+	_, err = Extract(bytes.NewReader(rawOld), reg, dest, "")
+	require.Error(t, err, "the backfilled external record must now catch a post-wipe downgrade")
+	assert.True(t, errors.Is(err, ErrInstallStateReset), "got: %v", err)
+}

--- a/internal/cli/bundle/bundle.go
+++ b/internal/cli/bundle/bundle.go
@@ -7,6 +7,7 @@
 package bundle
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -32,19 +33,20 @@ at build time — trust follows a pinned chain, never a key shipped inside the b
 }
 
 var (
-	buildSrc        string
-	buildOut        string
-	buildVersion    string
-	buildKeyID      string
-	buildSignKey    string
-	buildMinFrom    string
-	buildReleased   string
-	verifyInstalled string
-	verifyForce     bool
-	importDest      string
-	importInstalled string
-	importForce     bool
-	importLicense   string
+	buildSrc         string
+	buildOut         string
+	buildVersion     string
+	buildKeyID       string
+	buildSignKey     string
+	buildMinFrom     string
+	buildReleased    string
+	verifyInstalled  string
+	verifyForce      bool
+	importDest       string
+	importInstalled  string
+	importForce      bool
+	importLicense    string
+	importResetState bool
 )
 
 // defaultRegistryFn is the function used to load the trusted key registry for
@@ -185,7 +187,15 @@ var importCmd = &cobra.Command{
 
 		// Extract verifies the signature and the no-downgrade gate BEFORE writing anything,
 		// then stages each verified component atomically. It fails closed.
-		m, err := ibundle.Extract(f, reg, importDest, importInstalled)
+		//
+		// ExtractAllowingStateReset also reconciles importDest's internal marker against
+		// the external install-state record kept outside importDest (see
+		// ibundle.ErrInstallStateReset): a destination that looks like a fresh/first
+		// install while the external record still remembers a previously-installed
+		// version is refused unless --reset-install-state explicitly acknowledges it —
+		// closing the gap where deleting the WHOLE --dest (not just its marker file)
+		// would otherwise reset the no-downgrade gate with zero signal.
+		m, err := ibundle.ExtractAllowingStateReset(f, reg, importDest, importInstalled, importResetState)
 		if err != nil {
 			return fmt.Errorf("import failed (fail-closed, nothing staged on a verify failure): %w", err)
 		}
@@ -281,13 +291,26 @@ func requireVerifyInstalledVersion() error {
 // bundle import --dest /stage <bundle>` invocation from the command's own help text staged a
 // substituted, older-but-validly-signed bundle with zero downgrade protection. This makes
 // that gap an explicit, auditable operator choice (--force) instead of a silent default.
+//
+// The marker-at---dest mechanism has its own gap, closed separately: it lives inside --dest,
+// so deleting the whole directory (not just the marker file) resets it to "first install"
+// with no signal. ibundle.PersistedInstalledVersionAllowingReset also checks an external
+// install-state record kept outside --dest; a mismatch there surfaces as
+// ibundle.ErrInstallStateReset, requiring --reset-install-state to proceed instead of being
+// silently treated as an ordinary first install.
 func requireImportInstalledVersion() error {
 	importInstalled = strings.TrimSpace(importInstalled)
 	if importInstalled != "" {
 		return nil
 	}
-	_, hasMarker, err := ibundle.PersistedInstalledVersion(importDest)
+	_, hasMarker, err := ibundle.PersistedInstalledVersionAllowingReset(importDest, importResetState)
 	if err != nil {
+		if errors.Is(err, ibundle.ErrInstallStateReset) {
+			return fmt.Errorf("import failed (fail-closed): %w. If --dest's install state was "+
+				"intentionally reset (e.g. you deliberately cleared it for a fresh start), re-run with "+
+				"--reset-install-state to proceed; otherwise treat this as a possible downgrade attempt "+
+				"and investigate before proceeding", err)
+		}
 		return fmt.Errorf("import failed (fail-closed, nothing staged on a verify failure): %w", err)
 	}
 	if hasMarker {
@@ -335,6 +358,11 @@ func init() {
 	importCmd.Flags().BoolVar(&importForce, "force", false,
 		"proceed without --installed-version on a first import into --dest (dangerous — skips the no-downgrade / anti-skip check)")
 	importCmd.Flags().StringVar(&importLicense, "license", "", "path to the installed license token (bundle import is a commercial feature)")
+	importCmd.Flags().BoolVar(&importResetState, "reset-install-state", false,
+		"acknowledge that --dest's install state was intentionally reset (e.g. --dest was deliberately "+
+			"cleared or recreated): required when the external install-state record disagrees with --dest "+
+			"itself, otherwise refused as a possible downgrade-reset attempt. Does not disable the "+
+			"no-downgrade check itself — combine with --installed-version or --force as usual")
 	_ = importCmd.MarkFlagRequired("dest")
 
 	BundleCmd.AddCommand(buildCmd)

--- a/internal/cli/bundle/bundle_state_sandbox_test.go
+++ b/internal/cli/bundle/bundle_state_sandbox_test.go
@@ -1,0 +1,26 @@
+package bundle
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain sandboxes every test in this package against a throwaway
+// KEYORIX_BUNDLE_STATE_DIR, so running `go test ./internal/cli/bundle/...` never reads or
+// writes the real developer/CI-runner home directory's ~/.keyorix/bundle-installs (see
+// internal/bundle/install_state.go's externalStateBaseDir). This package's import/verify
+// tests exercise ibundle.Extract for real, which — with no override in place — would
+// otherwise write genuine external install-state records into $HOME/.keyorix/bundle-installs
+// on whatever machine runs `go test`, one file per distinct --dest used across the suite.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "keyorix-cli-bundle-state-test-*")
+	if err != nil {
+		os.Exit(1)
+	}
+	if err := os.Setenv("KEYORIX_BUNDLE_STATE_DIR", dir); err != nil {
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -18,14 +18,6 @@ var StatusCmd = &cobra.Command{
 	RunE:  runStatus,
 }
 
-// PingCmd represents the ping command
-var PingCmd = &cobra.Command{
-	Use:   "ping",
-	Short: "Test connectivity to remote server",
-	Long:  "Test network connectivity and response time to remote server",
-	RunE:  runPing,
-}
-
 func runStatus(cmd *cobra.Command, args []string) error {
 	// Load configuration. Pass "" (not the literal "keyorix.yaml") so this
 	// resolves via config.Load's normal KEYORIX_CONFIG_PATH → ./keyorix.yaml
@@ -94,78 +86,6 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Printf("✅ Healthy\n")
 		fmt.Printf("Response Time: %v\n", duration)
-	}
-
-	return nil
-}
-
-func runPing(cmd *cobra.Command, args []string) error {
-	// Load configuration. Same KEYORIX_CONFIG_PATH-respecting fix as runStatus.
-	cfg, err := config.Load("")
-	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
-	}
-
-	if cfg.Storage.Type != "remote" {
-		return fmt.Errorf("ping command only works with remote storage")
-	}
-
-	if cfg.Storage.Remote == nil {
-		return fmt.Errorf("remote storage not configured")
-	}
-
-	fmt.Printf("🏓 Pinging %s...\n", cfg.Storage.Remote.BaseURL)
-
-	// Perform multiple pings
-	const pingCount = 3
-	var totalDuration time.Duration
-	successCount := 0
-
-	for i := 0; i < pingCount; i++ {
-		service, err := common.InitializeCoreService()
-		if err != nil {
-			fmt.Printf("Ping %d: ❌ Failed to initialize (%s)\n", i+1, err.Error())
-			continue
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		start := time.Now()
-		err = service.HealthCheck(ctx)
-		duration := time.Since(start)
-		cancel()
-
-		if err != nil {
-			fmt.Printf("Ping %d: ❌ Failed (%s) - %v\n", i+1, err.Error(), duration)
-		} else {
-			fmt.Printf("Ping %d: ✅ Success - %v\n", i+1, duration)
-			totalDuration += duration
-			successCount++
-		}
-
-		// Wait between pings (except for the last one)
-		if i < pingCount-1 {
-			time.Sleep(1 * time.Second)
-		}
-	}
-
-	// Show summary
-	fmt.Println("\n📈 Summary")
-	fmt.Println("==========")
-	fmt.Printf("Pings sent:     %d\n", pingCount)
-	fmt.Printf("Successful:     %d\n", successCount)
-	fmt.Printf("Failed:         %d\n", pingCount-successCount)
-
-	if successCount > 0 {
-		avgDuration := totalDuration / time.Duration(successCount)
-		fmt.Printf("Average time:   %v\n", avgDuration)
-	}
-
-	if successCount == pingCount {
-		fmt.Printf("Status:         ✅ All pings successful\n")
-	} else if successCount > 0 {
-		fmt.Printf("Status:         ⚠️  Partial connectivity\n")
-	} else {
-		fmt.Printf("Status:         ❌ No connectivity\n")
 	}
 
 	return nil

--- a/internal/cli/status/status_remote_test.go
+++ b/internal/cli/status/status_remote_test.go
@@ -1,15 +1,12 @@
 // status_remote_test.go — additional coverage for the status package.
-// The existing status_test.go already covers runStatus (local) and the ping
-// error-guards.  This file covers remaining uncovered paths in runStatus
-// (remote display) and the successful runPing path via an in-process httptest
-// stub that lets the command reach the core service init.
+// The existing status_test.go already covers runStatus (local). This file
+// covers remaining uncovered paths in runStatus (remote display).
 package status
 
 import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -61,61 +58,8 @@ func TestRunStatus_RemoteTypeDisplayed(t *testing.T) {
 	assert.Contains(t, string(out), "Storage Type: 🌐 Remote")
 }
 
-// ──────────────────────────── runPing ──────────────────────────────────────
-
-// TestRunPing_RemoteNoConnectivity verifies that runPing with a configured
-// remote endpoint (nothing listening) runs all three ping iterations and
-// prints the summary without panicking, even though all pings fail.
-// This exercises the ping loop, the successCount=0 summary branch, and
-// the "No connectivity" status line.
-//
-// Note: this test takes ~3 s wall-clock because runPing sleep(1s) between pings.
-// We mitigate this by pointing at 127.0.0.1:1 (connection refused, fast failure).
-func TestRunPing_RemoteNoConnectivity(t *testing.T) {
-	require.NoError(t, i18n.InitializeForTesting())
-	dir := t.TempDir()
-	t.Chdir(dir)
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	t.Setenv("KEYORIX_SERVER", "")
-	t.Setenv("KEYORIX_TOKEN", "")
-
-	cfgPath := filepath.Join(dir, "keyorix.yaml")
-	require.NoError(t, config.Save(cfgPath, &config.Config{
-		Locale: config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
-		Storage: config.StorageConfig{
-			Type: "remote",
-			Remote: &config.RemoteConfig{
-				BaseURL:        "http://127.0.0.1:1", // port 1 = IANA reserved; connection refused
-				TimeoutSeconds: 1,
-			},
-		},
-	}))
-
-	orig := os.Stdout
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stdout = w
-	defer func() { os.Stdout = orig }()
-
-	// runPing never returns an error (the loop handles each failure inline).
-	_ = runPing(nil, nil)
-	_ = w.Close()
-	out, _ := io.ReadAll(r)
-	outStr := string(out)
-
-	assert.Contains(t, outStr, "Pinging")
-	assert.Contains(t, outStr, "Summary")
-	assert.Contains(t, outStr, "Pings sent:")
-	// With a connection-refused backend the summary is either "No connectivity"
-	// or "Partial connectivity"; either is acceptable depending on the OS.
-	assert.True(t,
-		strings.Contains(outStr, "No connectivity") || strings.Contains(outStr, "Partial connectivity"),
-		"expected a connectivity status line, got:\n%s", outStr)
-}
-
-// TestStatusCmdRegistered verifies StatusCmd and PingCmd are exported and
-// have the correct Use strings.
+// TestStatusCmdRegistered verifies StatusCmd is exported and has the correct
+// Use string.
 func TestStatusCmdRegistered(t *testing.T) {
 	assert.Equal(t, "status", StatusCmd.Use)
-	assert.Equal(t, "ping", PingCmd.Use)
 }

--- a/internal/cli/status/status_s2_test.go
+++ b/internal/cli/status/status_s2_test.go
@@ -1,16 +1,11 @@
 // status_s2_test.go — sprint-2 coverage additions for the status package.
-// Targets: runPing success path (successCount == pingCount), partial connectivity
-// path, and the runStatus connection failure branch.
+// Targets: the runStatus connection failure branch.
 package status
 
 import (
-	"fmt"
 	"io"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/config"
@@ -33,54 +28,6 @@ func writePingConfig(t *testing.T, dir, baseURL string, timeoutSecs int) {
 			},
 		},
 	}))
-}
-
-// TestRunPing_AllPingsSucceed exercises the "all pings successful" branch in
-// runPing. We point at a real httptest server that answers health-check requests
-// so common.InitializeCoreService succeeds and all three pings return healthy.
-//
-// Note: runPing sleeps 1s between iterations so this test takes ~2 s.
-func TestRunPing_AllPingsSucceed(t *testing.T) {
-	require.NoError(t, i18n.InitializeForTesting())
-
-	// Health-check endpoint — the core remote storage client calls /health; the
-	// remote client expects {"success":true} in the response body.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintln(w, `{"success":true}`)
-	}))
-	defer srv.Close()
-
-	dir := t.TempDir()
-	t.Chdir(dir)
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	t.Setenv("KEYORIX_SERVER", "")
-	t.Setenv("KEYORIX_TOKEN", "")
-	t.Setenv("KEYORIX_REMOTE_API_KEY", "test-api-key")
-
-	writePingConfig(t, dir, srv.URL, 2)
-
-	orig := os.Stdout
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stdout = w
-	defer func() { os.Stdout = orig }()
-
-	_ = runPing(nil, nil)
-	_ = w.Close()
-	out, _ := io.ReadAll(r)
-	outStr := string(out)
-
-	assert.Contains(t, outStr, "Pinging")
-	assert.Contains(t, outStr, "Summary")
-	assert.Contains(t, outStr, "Pings sent:")
-	// Either all succeed or there's partial connectivity (depends on whether
-	// HealthCheck wires up properly against the remote backend).
-	assert.True(t,
-		strings.Contains(outStr, "All pings successful") ||
-			strings.Contains(outStr, "Partial connectivity") ||
-			strings.Contains(outStr, "No connectivity"),
-		"expected connectivity status line, got:\n%s", outStr)
 }
 
 // TestRunStatus_RemoteConnectionFailed checks that runStatus still prints the
@@ -123,25 +70,4 @@ func TestRunStatus_RemoteConnectionFailed(t *testing.T) {
 	assert.Contains(t, outStr, "System Status")
 	// Could be "Remote" display or fallback to default; either way no panic.
 	assert.Contains(t, outStr, "Storage Type")
-}
-
-// TestRunPing_RemoteNilConfig tests the "remote storage not configured" error path.
-func TestRunPing_RemoteNilConfig(t *testing.T) {
-	require.NoError(t, i18n.InitializeForTesting())
-	dir := t.TempDir()
-	t.Chdir(dir)
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	t.Setenv("KEYORIX_SERVER", "")
-	t.Setenv("KEYORIX_TOKEN", "")
-
-	// Write a config with storage.type=remote but no remote block.
-	cfgPath := filepath.Join(dir, "keyorix.yaml")
-	require.NoError(t, config.Save(cfgPath, &config.Config{
-		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
-		Storage: config.StorageConfig{Type: "remote"},
-	}))
-
-	err := runPing(nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "remote storage not configured")
 }

--- a/internal/cli/status/status_s3_test.go
+++ b/internal/cli/status/status_s3_test.go
@@ -1,16 +1,11 @@
 // status_s3_test.go — sprint-3 coverage additions for the status package.
 // Targets: runStatus's "Unhealthy" branch (service initializes but HealthCheck
-// fails) and runPing's per-iteration "Failed" branch + "Partial connectivity"
-// summary branch (some pings succeed, some fail against the same backend).
+// fails).
 package status
 
 import (
-	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"sync/atomic"
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -63,60 +58,4 @@ func TestRunStatus_RemoteUnhealthy(t *testing.T) {
 	assert.Contains(t, out, "Storage Type: 🌐 Remote")
 	assert.Contains(t, out, "❌ Unhealthy (health check failed:")
 	assert.Contains(t, out, "Response Time:")
-}
-
-// TestRunPing_PartialConnectivity exercises runPing's per-iteration "Failed"
-// branch (HealthCheck errors after a successful InitializeCoreService) and the
-// "Partial connectivity" summary branch (0 < successCount < pingCount) by
-// pointing at a real server that succeeds on the first health check and fails
-// on the rest.
-//
-// G80 Wave 0c: rewritten to fail via HTTP 404 instead of a fabricated
-// {"success":false,...} 200 body — see TestRunStatus_RemoteUnhealthy's comment;
-// the real /health endpoint cannot produce the latter, and 404 (not 5xx) keeps
-// this test's "N pings → N handler calls" assumption true without needing to
-// fight isRetryableError's 5xx retry behavior.
-//
-// Note: runPing sleeps 1s between iterations so this test takes ~2s.
-func TestRunPing_PartialConnectivity(t *testing.T) {
-	require.NoError(t, i18n.InitializeForTesting())
-
-	var calls atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if calls.Add(1) == 1 {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = fmt.Fprintln(w, `{"status":"healthy"}`)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-
-	dir := t.TempDir()
-	t.Chdir(dir)
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	t.Setenv("KEYORIX_SERVER", "")
-	t.Setenv("KEYORIX_TOKEN", "")
-	t.Setenv("KEYORIX_REMOTE_API_KEY", "test-api-key")
-
-	writePingConfig(t, dir, srv.URL, 2)
-
-	orig := os.Stdout
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stdout = w
-	defer func() { os.Stdout = orig }()
-
-	require.NoError(t, runPing(nil, nil))
-	_ = w.Close()
-	outBytes, _ := io.ReadAll(r)
-	out := string(outBytes)
-
-	assert.Contains(t, out, "Ping 1: ✅ Success")
-	assert.Contains(t, out, "Ping 2: ❌ Failed (health check failed:")
-	assert.Contains(t, out, "Ping 3: ❌ Failed (health check failed:")
-	assert.Contains(t, out, "Successful:     1")
-	assert.Contains(t, out, "Failed:         2")
-	assert.Contains(t, out, "Status:         ⚠️  Partial connectivity")
-	assert.Equal(t, int32(3), calls.Load())
 }

--- a/internal/cli/status/status_test.go
+++ b/internal/cli/status/status_test.go
@@ -64,21 +64,6 @@ func TestRunStatus_NoConfigUsesDefaults(t *testing.T) {
 	assert.Contains(t, out, "Storage Type: 💾 Local")
 }
 
-func TestRunPing_LocalRejected(t *testing.T) {
-	chdirLocalConfig(t)
-	err := runPing(nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ping command only works with remote storage")
-}
-
-func TestRunPing_NoConfig(t *testing.T) {
-	dir := t.TempDir()
-	t.Chdir(dir) // no keyorix.yaml
-	err := runPing(nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to load configuration")
-}
-
 // TestRunStatus_RespectsConfigPathEnvVar is G80 Wave 0c's regression test for
 // the runStatus config-load bug: it used to call config.Load("keyorix.yaml")
 // with a hardcoded literal, so it never looked at KEYORIX_CONFIG_PATH — the


### PR DESCRIPTION
## Summary

**1. Bundle downgrade-marker reset via directory deletion (MEDIUM, adversarial-review Re-rate 2)**

`internal/bundle/bundle.go`'s `readInstalledVersion` already refuses to treat a destination
as a first install when the marker file (`.keyorix-installed-version`) alone is deleted but
other staged content remains (#111). It did not catch the equally trivial alternative:
deleting the ENTIRE `--dest` directory. `destDirHasContent` returns `false` for both a
directory that never existed and one that existed and was wiped, so the no-downgrade gate
silently reset to "first install" with zero signal.

The marker lives *inside* the directory it's meant to protect, so any check confined to
`destDir` can be defeated by wiping that directory outright — the fix has to break that
circularity, not add another internal-only check.

**Design chosen**: a second, independent install-state record kept *outside* `--dest`
(`internal/bundle/install_state.go`), written on every successful import and keyed by
`destDir`'s absolute path. Location resolution mirrors the CLI's own existing config-path
convention (`internal/cli/config.getDefaultCLIConfigPath`): `KEYORIX_BUNDLE_STATE_DIR`
override → `XDG_CONFIG_HOME` → `$HOME/.keyorix/bundle-installs` → unresolvable (degrades to
internal-marker-only protection, documented not silent). `reconcileInstallState` is the
single place both `Extract`'s own gate and the CLI's pre-flight check consult:

- both records agree → proceed as before (the ordinary case after the first import)
- internal present, external absent → backfill (an install predating this feature); not
  suspicious
- internal absent, external present → `ErrInstallStateReset` — the wiped-`destDir`
  signature — refused unless the operator passes `--reset-install-state`
- both present but disagree → also refused; this additionally catches editing the marker
  **in place** to claim an older version, a variant #111's own check can't see since the
  marker is still present, just wrong

Acknowledging a reset does **not** disable the no-downgrade check — it only resolves which
record to trust (the internal one, closest to what `destDir` physically holds), and
`CheckUpgrade` still runs against that resolved value. `Extract` / `PersistedInstalledVersion`
keep their existing signatures (28+ existing call sites untouched); the new behavior is
reached via additive `ExtractAllowingStateReset` / `PersistedInstalledVersionAllowingReset`
and the CLI's new `--reset-install-state` flag.

Verified RED before GREEN: a test with external tracking disabled reproduces today's silent
downgrade-after-wipe; the same scenario with tracking enabled is refused with
`ErrInstallStateReset`.

**2. Dead code: `internal/cli/status.PingCmd`/`runPing`**

Re-verified independently (not just trusting the queue doc): grepped every reference to
`PingCmd`/`runPing` repo-wide — only `internal/cli/status/status.go`'s own definition and 4
of that package's own test files (which call `runPing` directly, bypassing cobra). `cli/main.go`
wires only `status.StatusCmd`; `PingCmd` is never `.AddCommand()`'d anywhere. No build tag, no
hidden flag/env dispatch, no reflection-based dispatch. Deleted both, along with the
`runPing`-only tests; tests covering shared/`runStatus` logic (including a test helper shared
across sprint-2/3 test files) were kept.

## Test plan
- [x] `go build ./...` (full repo)
- [x] `go vet ./...` (full repo)
- [x] `gofmt -l` clean on touched packages
- [x] `gosec -severity medium -exclude-generated` clean on touched packages (0 issues)
- [x] Full test suites green: `internal/bundle`, `internal/cli/bundle`, `internal/cli/status`,
      and a broader `internal/cli/...` sanity sweep
- [x] New RED→GREEN regression tests for the whole-`destDir`-wipe bypass, the in-place marker
      edit, the acknowledged-reset path (still enforces downgrade on the next import), and the
      pre-existing-install backfill path
- [x] Test-only `TestMain` sandboxing added to both `internal/bundle` and `internal/cli/bundle`
      so the new external-state writes never touch a real developer/CI-runner `$HOME`