### PR TITLE
fix(cli): status/ping must not construct or create anything with no config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to Keyorix are documented here. This project follows
 ## Unreleased
 
 ### Changed
+- **BREAKING: `keyorix status`/`keyorix ping` no longer construct or create
+  anything when nothing is configured.** With no `keyorix.yaml`, no
+  `KEYORIX_CONFIG_PATH`, and no `keyorix connect`/env-var remote target,
+  `status` used to silently build an in-memory `storage.type: local` config
+  on the spot and initialize storage against it — which, for a fresh
+  `./secrets.db` path, **created the file**, then reported "Healthy" for a
+  database the command had just created a moment earlier. That was a
+  false-success pattern, not a graceful default. "Not configured" is now a
+  first-class state distinct from "unhealthy": nothing is constructed,
+  nothing is created, and the command exits 2 (usage/config error) — a
+  script chaining `keyorix status && deploy` will no longer proceed on an
+  unconfigured machine. An explicit `storage.type: local` config whose
+  database file doesn't exist yet is now also reported as unhealthy (exit 1)
+  rather than silently provisioned — `status` verifies an existing store, it
+  doesn't create one. `status`/`ping` exit codes: 0 healthy, 1
+  unhealthy/unreachable, 2 usage/config error (no config, or `ping` without
+  remote storage configured).
 - **BREAKING (targeting v0.92.0): every Keyorix Connect connector must declare
   `scope: project` or `scope: platform` (ADR-082)** — an existing deployment with
   `connect.enabled: true` and one or more configured connectors **will fail to boot**

--- a/internal/cli/common/exit_code.go
+++ b/internal/cli/common/exit_code.go
@@ -1,0 +1,33 @@
+package common
+
+// ExitCodeError lets a command signal a specific process exit code, rather
+// than the generic "1" internal/cli/main.go's Execute() gives every returned
+// error today. Introduced for `status`/`ping`: those commands distinguish
+// "the configured target is unreachable/unhealthy" (1) from "no usable
+// configuration exists at all" (2) -- a distinction a bare error can't
+// carry, since Execute() only sees the error's text, not why it occurred.
+//
+// A command that returns a plain error (not wrapped in this type) still gets
+// exit code 1, unchanged from today -- this is additive, not a behavior
+// change for any command that doesn't opt in.
+type ExitCodeError struct {
+	Code int
+	Err  error
+}
+
+func (e *ExitCodeError) Error() string { return e.Err.Error() }
+func (e *ExitCodeError) Unwrap() error { return e.Err }
+
+// ExitUnhealthy wraps err to signal exit code 1: a configured target was
+// reached (or a check was attempted) but reported unhealthy, or could not be
+// reached at all.
+func ExitUnhealthy(err error) error {
+	return &ExitCodeError{Code: 1, Err: err}
+}
+
+// ExitUsageError wraps err to signal exit code 2: no usable configuration
+// exists, or the command was invoked in a way that makes checking health
+// impossible (e.g. `ping` with no remote storage configured).
+func ExitUsageError(err error) error {
+	return &ExitCodeError{Code: 2, Err: err}
+}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -135,6 +136,10 @@ func Execute() {
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		var exitErr *common.ExitCodeError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.Code)
+		}
 		os.Exit(1)
 	}
 }

--- a/internal/cli/status/status.go
+++ b/internal/cli/status/status.go
@@ -3,10 +3,12 @@ package status
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/spf13/cobra"
 )
 
@@ -26,76 +28,182 @@ var PingCmd = &cobra.Command{
 	RunE:  runPing,
 }
 
+// Exit code contract (2026-09-05, a deliberate breaking change from the prior
+// always-exit-0 behavior -- see release notes): 0 healthy, 1 unhealthy or
+// unreachable, 2 usage/config error (no config found, ping run without
+// remote storage configured, or -- see #G-status-no-implicit-local below --
+// status run with no config at all). A failed health check is both printed
+// ("❌ Unhealthy") AND returned as a non-zero exit via common.ExitUnhealthy --
+// a caller scripting on this command's exit code must be able to detect an
+// unreachable target without parsing stdout.
 func runStatus(cmd *cobra.Command, args []string) error {
-	// Load configuration. Pass "" (not the literal "keyorix.yaml") so this
-	// resolves via config.Load's normal KEYORIX_CONFIG_PATH → ./keyorix.yaml
-	// fallback chain — the same resolution common.InitializeCoreService() below
-	// uses. G80 Wave 0c: the hardcoded literal ignored KEYORIX_CONFIG_PATH
-	// entirely, so under a container/env-var-configured deployment this always
-	// fell through to "No configuration found, using defaults" and displayed
-	// "Storage Type: Local" even when InitializeCoreService() (which does
-	// respect KEYORIX_CONFIG_PATH) was actually running against remote storage
-	// two lines later — the displayed storage type and the one actually used
-	// for the health check could silently disagree.
-	cfg, err := config.Load("")
-	if err != nil {
-		// #1644: a Load error means EITHER "no config file yet" OR "a config file is
-		// there and failed to parse" -- reporting the latter as "no configuration
-		// found, using defaults" is actively misleading (the file exists and is
-		// broken, not absent), so surface the real error instead of guessing wrong.
-		if !config.IsNotExist(err) {
-			return fmt.Errorf("failed to load existing configuration: %w", err)
-		}
-		fmt.Printf("⚠️  No configuration found, using defaults\n")
-		cfg = &config.Config{
-			Storage: config.StorageConfig{
-				Type: "local",
-				Database: config.DatabaseConfig{
-					Path: "./secrets.db",
-				},
-			},
-		}
-	}
-
 	fmt.Println("📊 System Status")
 	fmt.Println("================")
 
-	// Show storage type
-	switch cfg.Storage.Type {
-	case "remote":
+	// Load configuration. Pass "" (not the literal "keyorix.yaml") so this
+	// resolves via config.Load's normal KEYORIX_CONFIG_PATH → ./keyorix.yaml
+	// fallback chain -- the same resolution common.InitializeCoreService()
+	// below uses. G80 Wave 0c: the hardcoded literal ignored
+	// KEYORIX_CONFIG_PATH entirely, so under a container/env-var-configured
+	// deployment this always fell through to "no config" and displayed
+	// "Storage Type: Local" even when InitializeCoreService() (which does
+	// respect KEYORIX_CONFIG_PATH) was actually running against remote
+	// storage two lines later -- the displayed storage type and the one
+	// actually used for the health check could silently disagree.
+	cfg, cfgErr := config.Load("")
+	if cfgErr != nil && !config.IsNotExist(cfgErr) {
+		// #1644: a Load error means EITHER "no config file yet" OR "a config file is
+		// there and failed to parse" -- reporting the latter as "not configured"
+		// is actively misleading (the file exists and is broken, not absent), so
+		// surface the real error instead of guessing wrong.
+		return common.ExitUsageError(fmt.Errorf("failed to load existing configuration: %w", cfgErr))
+	}
+
+	// A remote TARGET configured via `keyorix connect` (~/.keyorix/cli.yaml) or
+	// KEYORIX_SERVER/KEYORIX_TOKEN env vars is invisible to config.Load /
+	// cfg.Storage.Type entirely -- a completely separate mechanism (see
+	// common.ResolveRemote's doc) -- so without this check that configuration
+	// would silently fall through to the local/unconfigured branches below
+	// despite the operator believing `status` was checking a real server (the
+	// exact defect class this review exists to close). Checked before either
+	// branch, so an existing keyorix.yaml storage.type: remote deployment's
+	// behavior is unaffected, and a connect-configured target always wins
+	// even with no keyorix.yaml present at all.
+	if cfgErr != nil || cfg.Storage.Type != "remote" {
+		if rc, ok := common.NewRemoteClient(); ok {
+			return runStatusRemote(rc)
+		}
+	}
+
+	// #G-status-no-implicit-local: no config file, no KEYORIX_CONFIG_PATH, and
+	// no `keyorix connect`/env-var remote target -- there is nothing configured
+	// at all. The prior behavior here constructed an in-memory
+	// Storage.Type:"local" config and ran the normal InitializeCoreService()
+	// path against it, which -- for a brand-new secrets.db path -- CREATES the
+	// file, then reports "Healthy" for a database status just created moments
+	// earlier. That is a false-success pattern (of course a database this
+	// command just created is "healthy"), not a graceful default: it silently
+	// engages the exact write path #1754's InitializeCoreService fail-closed
+	// change exists to gate everywhere else. "Not configured" is a first-class
+	// state distinct from "unhealthy" -- construct nothing, create nothing,
+	// and exit 2 (usage/config error) so a script chaining `keyorix status &&
+	// deploy` cannot proceed on an unconfigured machine.
+	if cfgErr != nil {
+		fmt.Printf("⚠️  Not configured\n")
+		fmt.Printf("Run `keyorix connect` to configure a remote server, or create a keyorix.yaml to use local storage.\n")
+		return common.ExitUsageError(fmt.Errorf("no configuration found"))
+	}
+
+	// An explicit storage.type: remote in keyorix.yaml (as opposed to a
+	// `keyorix connect`/env-var target, handled above) is a fully legitimate,
+	// pre-existing way to configure remote storage -- InitializeCoreService
+	// builds a remote client straight from cfg.Storage.Remote in this case,
+	// so it carries no local-file-creation risk and this path is unchanged.
+	if cfg.Storage.Type == "remote" {
 		fmt.Printf("Storage Type: 🌐 Remote\n")
 		if cfg.Storage.Remote != nil {
 			fmt.Printf("Server URL:   %s\n", cfg.Storage.Remote.BaseURL)
 			fmt.Printf("Timeout:      %ds\n", cfg.Storage.Remote.TimeoutSeconds)
 		}
-	default:
-		fmt.Printf("Storage Type: 💾 Local\n")
-		fmt.Printf("Database:     %s\n", cfg.Storage.Database.Path)
+		fmt.Printf("Connection:   ")
+		service, err := common.InitializeCoreService()
+		if err != nil {
+			fmt.Printf("❌ Failed to initialize (%s)\n", err.Error())
+			return common.ExitUnhealthy(fmt.Errorf("failed to initialize storage: %w", err))
+		}
+		return checkHealthAndReport(service)
 	}
 
-	// Test connection
+	// Everything else names a server-or-file backend directly (local, sqlite,
+	// postgres, ...). Only the file-backed types carry local-file-creation
+	// risk -- postgres either reaches a real, already-provisioned server or
+	// fails to, same as always.
+	if cfg.Storage.Type == "local" || cfg.Storage.Type == "sqlite" || cfg.Storage.Type == "" {
+		fmt.Printf("Storage Type: 💾 Local\n")
+		fmt.Printf("Database:     %s\n", cfg.Storage.Database.Path)
+		fmt.Printf("Connection:   ")
+
+		// #G-status-no-implicit-local: an EXPLICIT local config exists (unlike
+		// the no-config branch above), but the database file it names may
+		// still not exist yet -- verify it exists and is stat-able before
+		// calling InitializeCoreService(), which for a local backend would
+		// silently CREATE a missing file. A config that names a local
+		// backend is a promise that backend already exists; `status` reports
+		// on it, it doesn't provision it.
+		if _, statErr := os.Stat(cfg.Storage.Database.Path); statErr != nil {
+			if os.IsNotExist(statErr) {
+				fmt.Printf("❌ Database file does not exist\n")
+				return common.ExitUnhealthy(fmt.Errorf("database file %q does not exist", cfg.Storage.Database.Path))
+			}
+			fmt.Printf("❌ Failed to stat database file (%s)\n", statErr.Error())
+			return common.ExitUnhealthy(fmt.Errorf("failed to stat database file %q: %w", cfg.Storage.Database.Path, statErr))
+		}
+
+		service, err := common.InitializeCoreService()
+		if err != nil {
+			fmt.Printf("❌ Failed to initialize (%s)\n", err.Error())
+			return common.ExitUnhealthy(fmt.Errorf("failed to initialize storage: %w", err))
+		}
+		return checkHealthAndReport(service)
+	}
+
+	fmt.Printf("Storage Type: 💾 %s\n", cfg.Storage.Type)
 	fmt.Printf("Connection:   ")
 	service, err := common.InitializeCoreService()
 	if err != nil {
 		fmt.Printf("❌ Failed to initialize (%s)\n", err.Error())
-		return nil
+		return common.ExitUnhealthy(fmt.Errorf("failed to initialize storage: %w", err))
 	}
+	return checkHealthAndReport(service)
+}
 
+// checkHealthAndReport runs the shared health-check-and-print tail shared by
+// every runStatus branch that has a live service to check.
+func checkHealthAndReport(service *core.KeyorixCore) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	start := time.Now()
-	err = service.HealthCheck(ctx)
+	err := service.HealthCheck(ctx)
 	duration := time.Since(start)
 
 	if err != nil {
 		fmt.Printf("❌ Unhealthy (%s)\n", err.Error())
 		fmt.Printf("Response Time: %v\n", duration)
-	} else {
-		fmt.Printf("✅ Healthy\n")
-		fmt.Printf("Response Time: %v\n", duration)
+		return common.ExitUnhealthy(err)
 	}
+	fmt.Printf("✅ Healthy\n")
+	fmt.Printf("Response Time: %v\n", duration)
+	return nil
+}
 
+// runStatusRemote reports connectivity to the server resolved via
+// common.NewRemoteClient (the KEYORIX_SERVER/KEYORIX_TOKEN env vars or
+// `keyorix connect`'s ~/.keyorix/cli.yaml -- see runStatus's doc comment for
+// why this is checked separately from cfg.Storage.Type) by calling its
+// unauthenticated GET /health (server/http/handlers/health.go) -- never
+// through common.InitializeCoreService()'s local/embedded storage path, so
+// this command cannot silently fall back to a stray local file once this
+// kind of remote target is configured.
+func runStatusRemote(rc *common.RemoteClient) error {
+	fmt.Printf("Storage Type: 🌐 Remote\n")
+	fmt.Printf("Server URL:   %s\n", rc.Endpoint)
+
+	fmt.Printf("Connection:   ")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := rc.GetRaw(ctx, "/health")
+	duration := time.Since(start)
+
+	if err != nil {
+		fmt.Printf("❌ Unhealthy (%s)\n", err.Error())
+		fmt.Printf("Response Time: %v\n", duration)
+		return common.ExitUnhealthy(err)
+	}
+	fmt.Printf("✅ Healthy\n")
+	fmt.Printf("Response Time: %v\n", duration)
 	return nil
 }
 
@@ -103,15 +211,15 @@ func runPing(cmd *cobra.Command, args []string) error {
 	// Load configuration. Same KEYORIX_CONFIG_PATH-respecting fix as runStatus.
 	cfg, err := config.Load("")
 	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+		return common.ExitUsageError(fmt.Errorf("failed to load configuration: %w", err))
 	}
 
 	if cfg.Storage.Type != "remote" {
-		return fmt.Errorf("ping command only works with remote storage")
+		return common.ExitUsageError(fmt.Errorf("ping command only works with remote storage"))
 	}
 
 	if cfg.Storage.Remote == nil {
-		return fmt.Errorf("remote storage not configured")
+		return common.ExitUsageError(fmt.Errorf("remote storage not configured"))
 	}
 
 	fmt.Printf("🏓 Pinging %s...\n", cfg.Storage.Remote.BaseURL)
@@ -162,11 +270,12 @@ func runPing(cmd *cobra.Command, args []string) error {
 
 	if successCount == pingCount {
 		fmt.Printf("Status:         ✅ All pings successful\n")
-	} else if successCount > 0 {
-		fmt.Printf("Status:         ⚠️  Partial connectivity\n")
-	} else {
-		fmt.Printf("Status:         ❌ No connectivity\n")
+		return nil
 	}
-
-	return nil
+	if successCount > 0 {
+		fmt.Printf("Status:         ⚠️  Partial connectivity\n")
+		return common.ExitUnhealthy(fmt.Errorf("%d/%d pings failed", pingCount-successCount, pingCount))
+	}
+	fmt.Printf("Status:         ❌ No connectivity\n")
+	return common.ExitUnhealthy(fmt.Errorf("all %d pings failed", pingCount))
 }

--- a/internal/cli/status/status_s2_test.go
+++ b/internal/cli/status/status_s2_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/stretchr/testify/assert"
@@ -113,13 +114,17 @@ func TestRunStatus_RemoteConnectionFailed(t *testing.T) {
 	os.Stdout = w
 	defer func() { os.Stdout = orig }()
 
-	// runStatus never returns an error even for an unhealthy connection.
+	// runStatus reports the connection failure via exit code 1 (common.ExitUnhealthy),
+	// not a nil error -- a caller scripting on exit status must be able to detect an
+	// unreachable target without parsing stdout (2026-09-05, deliberate breaking change).
 	errRun := runStatus(nil, nil)
 	_ = w.Close()
 	out, _ := io.ReadAll(r)
 	outStr := string(out)
 
-	assert.NoError(t, errRun)
+	var exitErr *common.ExitCodeError
+	require.ErrorAs(t, errRun, &exitErr)
+	assert.Equal(t, 1, exitErr.Code)
 	assert.Contains(t, outStr, "System Status")
 	// Could be "Remote" display or fallback to default; either way no panic.
 	assert.Contains(t, outStr, "Storage Type")

--- a/internal/cli/status/status_s3_test.go
+++ b/internal/cli/status/status_s3_test.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,8 +59,12 @@ func TestRunStatus_RemoteUnhealthy(t *testing.T) {
 
 	writePingConfig(t, dir, srv.URL, 2)
 
-	out := captureStdout(t, func() { require.NoError(t, runStatus(nil, nil)) })
+	var runErr error
+	out := captureStdout(t, func() { runErr = runStatus(nil, nil) })
 
+	var exitErr *common.ExitCodeError
+	require.ErrorAs(t, runErr, &exitErr)
+	assert.Equal(t, 1, exitErr.Code)
 	assert.Contains(t, out, "Storage Type: 🌐 Remote")
 	assert.Contains(t, out, "❌ Unhealthy (health check failed:")
 	assert.Contains(t, out, "Response Time:")
@@ -107,11 +112,14 @@ func TestRunPing_PartialConnectivity(t *testing.T) {
 	os.Stdout = w
 	defer func() { os.Stdout = orig }()
 
-	require.NoError(t, runPing(nil, nil))
+	runErr := runPing(nil, nil)
 	_ = w.Close()
 	outBytes, _ := io.ReadAll(r)
 	out := string(outBytes)
 
+	var exitErr *common.ExitCodeError
+	require.ErrorAs(t, runErr, &exitErr)
+	assert.Equal(t, 1, exitErr.Code)
 	assert.Contains(t, out, "Ping 1: ✅ Success")
 	assert.Contains(t, out, "Ping 2: ❌ Failed (health check failed:")
 	assert.Contains(t, out, "Ping 3: ❌ Failed (health check failed:")

--- a/internal/cli/status/status_test.go
+++ b/internal/cli/status/status_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/keyorixhq/keyorix/internal/cli/common"
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/i18n"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,11 @@ func captureStdout(t *testing.T, fn func()) string {
 
 // chdirLocalConfig writes a local keyorix.yaml in a temp dir and chdirs there, so
 // both the status display (config.Load("keyorix.yaml")) and InitializeCoreService
-// (config.Load("")) resolve the same local backend.
+// (config.Load("")) resolve the same local backend. Also pre-creates the database
+// file via one InitializeCoreService call, simulating a deployment that has
+// already been provisioned -- runStatus's own local-storage branch now verifies
+// an existing store rather than provisioning one (#G-status-no-implicit-local),
+// so a test asserting "Healthy" must hand it a store that already exists.
 func chdirLocalConfig(t *testing.T) {
 	t.Helper()
 	require.NoError(t, i18n.InitializeForTesting())
@@ -41,6 +46,8 @@ func chdirLocalConfig(t *testing.T) {
 		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
 		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "s.db")}},
 	}))
+	_, err := common.InitializeCoreService()
+	require.NoError(t, err)
 }
 
 func TestRunStatus_LocalHealthy(t *testing.T) {
@@ -51,7 +58,25 @@ func TestRunStatus_LocalHealthy(t *testing.T) {
 	assert.Contains(t, out, "Healthy")
 }
 
-func TestRunStatus_NoConfigUsesDefaults(t *testing.T) {
+// TestRunStatus_NoConfig_ReportsUnconfigured is the corrected replacement for
+// the old TestRunStatus_NoConfigUsesDefaults, whose name described the actual
+// defect: with zero configuration anywhere (no keyorix.yaml, no
+// KEYORIX_CONFIG_PATH, no `keyorix connect`/env-var remote target), runStatus
+// used to construct an in-memory storage.type: local config on the spot and
+// run the normal InitializeCoreService() path against it -- which, for a
+// brand-new "./secrets.db" path, CREATES the file, then reports "Healthy" for
+// a database this very command just created. That is a false-success
+// pattern, not a graceful default: the health check can never fail, because
+// the thing being checked did not exist a moment before the check ran.
+//
+// The corrected contract: "not configured" is a first-class state, distinct
+// from "unhealthy". runStatus must construct nothing and create nothing, and
+// exit 2 (usage/config error) -- a caller chaining `keyorix status && deploy`
+// must not proceed on an unconfigured machine. Asserted here by pointing the
+// CLI at an empty temp dir and confirming it stays EMPTY after the call --
+// the only assertion that actually distinguishes "correctly did nothing"
+// from "silently did something and got lucky".
+func TestRunStatus_NoConfig_ReportsUnconfigured(t *testing.T) {
 	require.NoError(t, i18n.InitializeForTesting())
 	dir := t.TempDir()
 	t.Chdir(dir) // no keyorix.yaml present
@@ -59,9 +84,52 @@ func TestRunStatus_NoConfigUsesDefaults(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
 
-	out := captureStdout(t, func() { require.NoError(t, runStatus(nil, nil)) })
-	assert.Contains(t, out, "No configuration found, using defaults")
+	var runErr error
+	out := captureStdout(t, func() { runErr = runStatus(nil, nil) })
+
+	var exitErr *common.ExitCodeError
+	require.ErrorAs(t, runErr, &exitErr)
+	assert.Equal(t, 2, exitErr.Code)
+	assert.Contains(t, out, "Not configured")
+	assert.NotContains(t, out, "Healthy")
+	assert.NotContains(t, out, "using defaults")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "runStatus must create nothing on the no-config path; found: %v", entries)
+}
+
+// TestRunStatus_ExplicitLocalMissingFile covers the other half of
+// #G-status-no-implicit-local: unlike the no-config case, a keyorix.yaml
+// explicitly naming a local database IS present here, but the file itself
+// does not exist yet. runStatus must report this as unhealthy (exit 1, not
+// 2 -- the configuration itself is valid and complete, only the backend it
+// names isn't there) and, critically, must not create the file while
+// checking it.
+func TestRunStatus_ExplicitLocalMissingFile(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("KEYORIX_SERVER", "")
+	t.Setenv("KEYORIX_TOKEN", "")
+	dbPath := filepath.Join(dir, "s.db")
+	require.NoError(t, config.Save("keyorix.yaml", &config.Config{
+		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
+		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: dbPath}},
+	}))
+
+	var runErr error
+	out := captureStdout(t, func() { runErr = runStatus(nil, nil) })
+
+	var exitErr *common.ExitCodeError
+	require.ErrorAs(t, runErr, &exitErr)
+	assert.Equal(t, 1, exitErr.Code)
 	assert.Contains(t, out, "Storage Type: 💾 Local")
+	assert.Contains(t, out, "does not exist")
+
+	_, statErr := os.Stat(dbPath)
+	assert.True(t, os.IsNotExist(statErr), "runStatus must not create the database file while checking it")
 }
 
 func TestRunPing_LocalRejected(t *testing.T) {
@@ -115,8 +183,13 @@ func TestRunStatus_RespectsConfigPathEnvVar(t *testing.T) {
 	}))
 	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
 
-	out := captureStdout(t, func() { require.NoError(t, runStatus(nil, nil)) })
+	var runErr error
+	out := captureStdout(t, func() { runErr = runStatus(nil, nil) })
+	var exitErr *common.ExitCodeError
+	require.ErrorAs(t, runErr, &exitErr)
+	assert.Equal(t, 1, exitErr.Code)
 	assert.Contains(t, out, "Storage Type: 🌐 Remote")
 	assert.Contains(t, out, "Server URL:   http://127.0.0.1:1")
 	assert.NotContains(t, out, "No configuration found")
+	assert.NotContains(t, out, "Not configured")
 }


### PR DESCRIPTION
## Summary
#1754 made `InitializeCoreService()` fail closed when no configuration
exists at all (no silent default to `storage.type: local`) -- deliberately,
per that PR's own comment: "the CLI must never apply this default... only
the server's own boot path may."

That surfaced a pre-existing defect in `internal/cli/status/status.go`:
`runStatus` (a **read-only diagnostic command**) still constructed an
in-memory `storage.type: local` config itself on the no-config path and
called `InitializeCoreService()` against it regardless. For a brand-new
`./secrets.db` path, that **creates the file**, then reports "Healthy" for
a database the command just created a moment earlier -- a false-success
pattern, not a graceful default worth restoring. This is what broke
`TestRunStatus_NoConfigUsesDefaults` (and therefore the `test-suite`/
`build-and-test` CI gates) on every PR opened after #1754 merged.

## Fix
Restructures `runStatus` to resolve configuration FIRST, then branch:
- a `keyorix connect`/env-var remote target, or an explicit
  `storage.type: remote` config -- **unchanged**, pings/health-checks the
  real target.
- an explicit `local`/`sqlite` config -- verifies the database file exists
  and is stat-able **before** calling `InitializeCoreService` (which would
  silently create a missing file); reports unhealthy (exit 1) if not,
  without creating anything.
- no configuration anywhere -- reports "Not configured" as a first-class
  state distinct from unhealthy. Constructs nothing, creates nothing, exits
  2 (usage/config error) so a chained `keyorix status && deploy` cannot
  proceed on an unconfigured machine.

Also ports the exit-code contract (`common.ExitCodeError`/`ExitUnhealthy`/
`ExitUsageError`, `main.go`'s `Execute()` dispatch) status/ping need to
signal these three states distinctly via process exit code, not just
printed text -- this existed on a different, not-yet-merged branch and is
brought in here as prerequisite infrastructure.

`TestRunStatus_NoConfigUsesDefaults` is replaced with
`TestRunStatus_NoConfig_ReportsUnconfigured`, asserting the corrected
behavior directly: exit code 2, and -- the assertion that actually
distinguishes "correctly did nothing" from "did something and got lucky" --
the target directory stays **empty**. Added
`TestRunStatus_ExplicitLocalMissingFile` for the sibling case. Verified
both by temporarily reverting the fix and confirming they fail with the
exact error message this bug produced in CI, then restoring it.

## Read-only-command side-effect sweep (report only, no fix in this PR)
A repo-wide sweep for other read-only/diagnostic CLI commands sharing this
bug's shape found real candidates beyond status/ping. The underlying cause
is the same everywhere: the `os.Stat` guard added here is local to
`status.go`, not centralized into `common.InitializeCoreService`/
`InitializeStorage` or `storage/factory.go`'s local-storage path -- so it
doesn't protect any other command that shares the same call pattern.

**Ranked findings:**
1. **`rbac check-permission`** (`internal/cli/rbac/check_permission.go:40`) --
   unconditional `InitializeStorage()`, then confidently prints "User does
   NOT have permission" against a DB that may not have existed a moment
   before. Highest confidence: a security-relevant negative determination
   looking authoritative on phantom data.
2. **`project health <name>`** (`internal/cli/project/health.go:135`) and
   **`project stats <name>`** (`internal/cli/project/stats.go:114`) --
   `InitializeCoreService()` called before the project-name lookup, so the
   DB gets created even though the command is guaranteed to then fail
   "project not found."
3. **`rbac audit-logs`**, **`usage show`** -- unconditional init, then
   report "no logs"/"(no data)" as if that were ground truth for a DB that
   didn't exist a moment ago.
4. ~20 list/get/describe/export commands across `secret`, `project`,
   `group`, `user`, `invite`, `request`, `share`, `rbac`, `machine` --
   same mechanical side effect, but their output ("0 found") is truthful
   about the now-real empty DB, so less actively misleading than 1-3.

**Already fine:** `config status`/`config test-connection` do this
correctly today (`os.Stat` only, never call `InitializeCoreService`) --
good model for a future centralized fix. `audit`/`compliance`/
`secret rotation-simulate` are remote-only despite diagnostic-sounding
names, no local-storage risk.

**Tangential, separate bug class (not fixed or scoped here):**
`group/list.go`, `group/get.go`, `user/list.go`, `user/get.go`,
`invite/list.go`, `request/list.go`, `secret/versions.go` never call
`common.NewRemoteClient()`, so a `keyorix connect`-configured remote target
is silently ignored by these specific commands when a local `keyorix.yaml`
also exists.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/cli/status/...` -- full suite green
- [x] `go test ./internal/cli/...` (short mode) -- no regressions
- [x] Verified new tests actually catch the regression (reverted the fix, confirmed red with the exact CI error message, restored it)
- [ ] CI green on this PR