### PR TITLE
fix(dynamic,notifychan): redact backend errors before logging, allowlist rotation-failure broadcasts

### DIFF
--- a/internal/core/dynamic_secrets.go
+++ b/internal/core/dynamic_secrets.go
@@ -694,7 +694,7 @@ func (c *KeyorixCore) RevokeLease(ctx context.Context, leaseID string, userID ui
 	pid := lease.ProjectID
 	if rerr := engine.Revoke(ctx, adminDSN, lease.RoleName); rerr != nil {
 		lease.Status = "revoke_failed"
-		log.Printf("failed to revoke dynamic secret lease %s: %v", lease.LeaseID, rerr)
+		log.Printf("failed to revoke dynamic secret lease %s: %s", lease.LeaseID, dynamic.SanitizeErrorMessage(rerr))
 		lease.RevokeError = "backend revoke failed — see server audit log for details"
 		// Deliberately NOT stamping RevokedAt here: the target drop failed, so the
 		// credential is still live. Stamping it would make the audit trail / API

--- a/internal/core/notify_rotation_failure_allowlist_guard_test.go
+++ b/internal/core/notify_rotation_failure_allowlist_guard_test.go
@@ -1,0 +1,53 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNotifyRotationFailures_PayloadIsAllowlisted is Group 1's guard for
+// notifyRotationFailures: the NotificationEvent it hands to
+// WebhookSink/ChatSink (both of which serialize/forward the event
+// essentially verbatim to an external, third-party endpoint) must be built
+// from an explicit allowlist -- secret name plus a generic phrase -- and must
+// NEVER include the upstream RotationBackend name, RotationRef (an IAM
+// username/DB role/service-account email), or raw upstream error text, no
+// matter how rich that detail is in the internal bookkeeping
+// (rotationFailureDetail.Detail, which still reaches the audit trail and the
+// rotation-state API -- both internal to Keyorix, out of scope for this
+// guard).
+//
+// This exercises notifyRotationFailures directly with a crafted
+// rotationFailureDetail whose Detail field deliberately embeds exactly the
+// kind of connection/credential-adjacent text the real backend-rotation
+// failure paths in rotateOneSecret produce (see rotation_executor.go), so it
+// does not depend on any particular upstream backend's error wording.
+func TestNotifyRotationFailures_PayloadIsAllowlisted(t *testing.T) {
+	c := NewKeyorixCore(new(MockStorage))
+	sink := &fakeSink{}
+	c.SetNotificationSink(sink)
+
+	const secretName = "prod-db-password"
+	const sensitiveDetail = `via backend "aws-iam" ref "arn:aws:iam::123456789012:user/svc-app": ` +
+		`AccessDenied: User arn:aws:sts::123456789012:assumed-role/deploy is not authorized ` +
+		`(password=hunter2, host=db.internal.example.com)`
+
+	failed := map[uint]rotationFailureDetail{
+		1: {SecretName: secretName, Detail: sensitiveDetail},
+	}
+	c.notifyRotationFailures(context.Background(), 42, failed)
+
+	require.Len(t, sink.events, 1, "one broadcast for the project's failures")
+	msg := sink.events[0].Message
+
+	assert.Contains(t, msg, secretName, "the secret name is allowlisted and must still appear")
+	assert.NotContains(t, msg, "aws-iam", "the upstream backend name must never reach an external channel")
+	assert.NotContains(t, msg, "arn:aws:iam::123456789012:user/svc-app", "the upstream ref must never reach an external channel")
+	assert.NotContains(t, msg, "AccessDenied", "raw upstream error text must never reach an external channel")
+	assert.NotContains(t, msg, "hunter2", "a credential-shaped fragment embedded in the raw error must never reach an external channel")
+	assert.NotContains(t, msg, "db.internal.example.com", "a hostname embedded in the raw error must never reach an external channel")
+	assert.NotContains(t, msg, sensitiveDetail, "the internal Detail field must never be interpolated into the external message wholesale")
+}

--- a/internal/core/rotation_executor.go
+++ b/internal/core/rotation_executor.go
@@ -60,13 +60,18 @@ const (
 // operator gets that auto-rotation is silently failing, separate from the
 // EventAutoRotationFailures audit row the caller writes for the rotation failure
 // itself (which is accurate regardless of whether this alert lands).
-func (c *KeyorixCore) notifyRotationFailures(ctx context.Context, projectID uint, failed map[uint]string) {
+func (c *KeyorixCore) notifyRotationFailures(ctx context.Context, projectID uint, failed map[uint]rotationFailureDetail) {
 	if len(failed) == 0 || c.notificationSink == nil {
 		return
 	}
+	// Allowlist: only the secret name reaches the external message. Deliberately
+	// NOT interpolating f.Detail here — it may carry the upstream backend name,
+	// ref, and raw error text, which must not reach a third-party webhook/chat
+	// sink (Group 1 fix). That detail stays in the audit trail and rotation-state
+	// API, both internal to Keyorix.
 	lines := make([]string, 0, len(failed))
-	for _, msg := range failed {
-		lines = append(lines, "• "+msg)
+	for _, f := range failed {
+		lines = append(lines, fmt.Sprintf("• rotation failed for secret %q", f.SecretName))
 	}
 	sort.Strings(lines) // stable, deterministic ordering
 	pid := projectID
@@ -175,6 +180,21 @@ func generateRotatedValueSpec(length int, charset string) (string, error) {
 type dueRotation struct {
 	secret *models.SecretNode
 	policy *models.RotationPolicy
+}
+
+// rotationFailureDetail records why a single secret's auto-rotation attempt
+// did not succeed this run (a genuine failure, a dependency-driven deferral,
+// or an upstream-incomplete partial rotation). SecretName alone is safe to
+// broadcast to an external channel (notifyRotationFailures uses only this
+// field for NotificationEvent.Message). Detail may additionally carry the
+// upstream RotationBackend name, its RotationRef (an IAM username/DB role/
+// service-account email), and the raw upstream error text — this is exactly
+// the kind of backend/connection detail that must stay internal (the audit
+// trail via writeAuditEventFull, and the rotation-state API), never reach a
+// third-party webhook/chat sink (Group 1 fix).
+type rotationFailureDetail struct {
+	SecretName string
+	Detail     string
 }
 
 // RunAutoRotation rotates every auto-rotate-enabled secret that is overdue under an
@@ -313,8 +333,8 @@ func (c *KeyorixCore) rotateProject(ctx context.Context, pid uint, ids []uint, d
 // rotateProjectWaves rotates secrets in dependency-ordered waves. A secret whose
 // dependency did not rotate this run is DEFERRED rather than rotated against a stale
 // dependency. Returns (failures, rotated count).
-func (c *KeyorixCore) rotateProjectWaves(ctx context.Context, waves [][]uint, due map[uint]*dueRotation, dependsOnInRun map[uint][]uint) (failed map[uint]string, rotated int) { // nosemgrep: keyorix-unbounded-bulk-slice-param -- waves is computed internally by the rotation scheduler from due secrets in this project, not a raw client-supplied array
-	failed = map[uint]string{}
+func (c *KeyorixCore) rotateProjectWaves(ctx context.Context, waves [][]uint, due map[uint]*dueRotation, dependsOnInRun map[uint][]uint) (failed map[uint]rotationFailureDetail, rotated int) { // nosemgrep: keyorix-unbounded-bulk-slice-param -- waves is computed internally by the rotation scheduler from due secrets in this project, not a raw client-supplied array
+	failed = map[uint]rotationFailureDetail{}
 	blocked := map[uint]bool{}
 	for _, wave := range waves {
 		for _, id := range wave {
@@ -329,7 +349,10 @@ func (c *KeyorixCore) rotateProjectWaves(ctx context.Context, waves [][]uint, du
 				pid := dr.secret.ProjectID
 				c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",
 					fmt.Sprintf("auto-rotation DEFERRED for secret %q: it depends on %q which did not rotate this run", dr.secret.Name, depName))
-				failed[id] = fmt.Sprintf("%q: deferred — depends on %q which did not rotate this run", dr.secret.Name, depName)
+				failed[id] = rotationFailureDetail{
+					SecretName: dr.secret.Name,
+					Detail:     fmt.Sprintf("deferred — depends on %q which did not rotate this run", depName),
+				}
 				continue
 			}
 			if c.rotateOneSecret(ctx, dr.secret, dr.policy, failed) {
@@ -361,7 +384,7 @@ func lowestBlockedDep(deps []uint, blocked map[uint]bool) (uint, bool) {
 // two never drift, store the new version, and audit the outcome. Any failure is recorded
 // in failed and logged; it returns true only when the secret was rotated and stored
 // successfully. Best-effort: it never returns an error or aborts the run.
-func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.SecretNode, policy *models.RotationPolicy, failed map[uint]string) bool {
+func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.SecretNode, policy *models.RotationPolicy, failed map[uint]rotationFailureDetail) bool {
 	// #G43: SetRotationState/GetRotationState (rotation_state.go) were fully
 	// wired at the storage layer and exposed via GET /secrets/{id}/rotation-state,
 	// with a doc comment claiming "called by the rotation executor when a
@@ -373,8 +396,8 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 	val, gerr := generateRotatedValueSpec(secret.RotationLength, secret.RotationCharset)
 	if gerr != nil {
 		log.Printf("auto-rotation: generate value for secret %d: %v", secret.ID, gerr)
-		failed[secret.ID] = fmt.Sprintf("%q: generate value: %v", secret.Name, gerr)
-		c.stampRotationState(ctx, policy.ID, RotationStateFailed, failed[secret.ID])
+		failed[secret.ID] = rotationFailureDetail{SecretName: secret.Name, Detail: fmt.Sprintf("generate value: %v", gerr)}
+		c.stampRotationState(ctx, policy.ID, RotationStateFailed, failed[secret.ID].Detail)
 		return false
 	}
 	// Backend rotation (ADR-047): if the secret names a configured executor, rotate the
@@ -402,15 +425,18 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 			// rotation incomplete below so the run records a failure and alerts an operator
 			// to remove the leftover.
 			storeVal = partial.Value
-			incompleteMsg = fmt.Sprintf("%q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err)
+			incompleteMsg = fmt.Sprintf("via backend %q ref %q: %v", secret.RotationBackend, secret.RotationRef, err)
 		case err != nil:
 			sid := secret.ID
 			pid := secret.ProjectID
 			c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",
 				fmt.Sprintf("auto-rotation FAILED for secret %q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err))
 			log.Printf("auto-rotation: backend rotate secret %d: %v", secret.ID, err)
-			failed[secret.ID] = fmt.Sprintf("%q via backend %q ref %q: %v", secret.Name, secret.RotationBackend, secret.RotationRef, err)
-			c.stampRotationState(ctx, policy.ID, RotationStateFailed, failed[secret.ID])
+			failed[secret.ID] = rotationFailureDetail{
+				SecretName: secret.Name,
+				Detail:     fmt.Sprintf("via backend %q ref %q: %v", secret.RotationBackend, secret.RotationRef, err),
+			}
+			c.stampRotationState(ctx, policy.ID, RotationStateFailed, failed[secret.ID].Detail)
 			return false
 		default:
 			storeVal = upstreamVal
@@ -418,7 +444,7 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 	}
 	if _, rerr := c.RotateSecret(ctx, secret.ID, []byte(storeVal), 0, "system:auto-rotation"); rerr != nil {
 		log.Printf("auto-rotation: rotate secret %d: %v", secret.ID, rerr)
-		failed[secret.ID] = fmt.Sprintf("%q: store new version: %v", secret.Name, rerr)
+		failed[secret.ID] = rotationFailureDetail{SecretName: secret.Name, Detail: fmt.Sprintf("store new version: %v", rerr)}
 		sid := secret.ID
 		pid := secret.ProjectID
 		if secret.RotationBackend != "" {
@@ -433,7 +459,7 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 			c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",
 				fmt.Sprintf("auto-rotation FAILED to store new version for secret %q: %v", secret.Name, rerr))
 		}
-		c.stampRotationState(ctx, policy.ID, RotationStateFailed, failed[secret.ID])
+		c.stampRotationState(ctx, policy.ID, RotationStateFailed, failed[secret.ID].Detail)
 		return false
 	}
 	if incompleteMsg != "" {
@@ -441,7 +467,7 @@ func (c *KeyorixCore) rotateOneSecret(ctx context.Context, secret *models.Secret
 		// prior, possibly compromised credential survived upstream. Record it as a failure
 		// (NOT a clean success) so the operator is notified to remove the leftover, and
 		// audit it distinctly.
-		failed[secret.ID] = incompleteMsg
+		failed[secret.ID] = rotationFailureDetail{SecretName: secret.Name, Detail: incompleteMsg}
 		sid := secret.ID
 		pid := secret.ProjectID
 		c.writeAuditEventFull(ctx, EventSecretAutoRotated, nil, &sid, &pid, "",

--- a/internal/core/rotation_executor_test.go
+++ b/internal/core/rotation_executor_test.go
@@ -742,8 +742,14 @@ func TestRunAutoRotation_NotifiesFailures(t *testing.T) {
 	require.Len(t, sink.events, 1)
 	assert.Equal(t, "rotation.failed", sink.events[0].Type)
 	assert.Contains(t, sink.events[0].Title, "1 secret")
+	// Group 1 fix: the broadcast reaching an external webhook/chat channel is
+	// allowlist-built (secret name + a generic phrase only) — it must NOT carry
+	// the upstream backend name, ref, or raw error text. That detail stays in
+	// the audit trail (writeAuditEventFull) and rotation-state API, both
+	// internal to Keyorix.
 	assert.Contains(t, sink.events[0].Message, "upstream-cred")
-	assert.Contains(t, sink.events[0].Message, "connection refused")
+	assert.NotContains(t, sink.events[0].Message, "connection refused", "the raw upstream error must not reach an external notification channel")
+	assert.NotContains(t, sink.events[0].Message, "app_svc", "the upstream ref must not reach an external notification channel")
 }
 
 // TestRunAutoRotation_NotifiesFailures_LogsWhenNoChannelAccepts is a regression test
@@ -843,12 +849,14 @@ func TestRunAutoRotation_FailuresNotBundledAcrossProjects(t *testing.T) {
 		switch *ev.ProjectID {
 		case 1:
 			assert.Contains(t, ev.Message, "proj1-db-password")
-			assert.Contains(t, ev.Message, "connection refused")
+			// Group 1 fix: raw upstream error text/backend/ref never reach an
+			// external channel at all now, regardless of project.
+			assert.NotContains(t, ev.Message, "connection refused", "the raw upstream error must not reach an external notification channel")
 			assert.NotContains(t, ev.Message, "proj2-api-key", "project 1's broadcast must not name project 2's secret")
 			assert.NotContains(t, ev.Message, "auth denied", "project 1's broadcast must not carry project 2's failure reason")
 		case 2:
 			assert.Contains(t, ev.Message, "proj2-api-key")
-			assert.Contains(t, ev.Message, "auth denied")
+			assert.NotContains(t, ev.Message, "auth denied", "the raw upstream error must not reach an external notification channel")
 			assert.NotContains(t, ev.Message, "proj1-db-password", "project 2's broadcast must not name project 1's secret")
 			assert.NotContains(t, ev.Message, "connection refused", "project 2's broadcast must not carry project 1's failure reason")
 		default:

--- a/internal/dynamic/log_redaction_guard_test.go
+++ b/internal/dynamic/log_redaction_guard_test.go
@@ -1,0 +1,185 @@
+package dynamic
+
+// log_redaction_guard_test.go — Group 1's guard for the SQL/driver-error
+// redaction boundary: server/http/handlers/dynamic_secrets.go and
+// internal/core/dynamic_secrets.go both log dynamic-secret backend/driver
+// errors (postgres/mysql/mongodb/redis, via internal/dynamic's engines) with
+// log.Printf/log.Println. Before this package's RedactSensitive/
+// SanitizeErrorMessage existed, several of those call sites formatted the raw
+// error with %v directly -- and a raw pgx/go-sql-driver/mongo-driver/go-redis
+// error CAN, on a future driver bump or a 5th backend, echo a DSN/connection-
+// string credential fragment straight into the server log (see this
+// package's own doc comment and redact.go).
+//
+// This guard is deliberately NOT type-aware (no go/packages type-checking --
+// that would pull go/packages/golang.org/x/tools into the root module purely
+// for a test, disproportionate to this fix's scope). Instead it recognizes,
+// by AST shape, exactly the call forms the real call sites in this repo use
+// today, the same way server/http/raw_storage_bypass_guard_test.go's
+// identifier-tracking and readShapedStoragePrefixes heuristics do:
+//
+//   - Any argument to log.Printf/log.Println that is a bare identifier whose
+//     name contains "err" (case-insensitive) -- covers err, gerr, rerr, eerr,
+//     the naming convention every error-returning call in these files uses --
+//     is flagged UNLESS it is passed through dynamic.SanitizeErrorMessage(...)
+//     first.
+//   - Any argument that is a direct `<x>.Error()` call is flagged the same way.
+//
+// A flagged argument means a raw driver/backend error can reach this log call
+// unsanitized -- exactly the Group 1 defect. The two recognized shapes are
+// exhaustive over the actual code in scope today (verified: every log.Printf/
+// log.Println call in the three scanned locations that logs an error uses one
+// of exactly these two shapes -- confirmed by this guard passing after the
+// fix and failing before it, not assumed).
+//
+// Scope: internal/dynamic/*.go (today: zero log calls at all -- this guard
+// keeps it that way, or requires sanitization if that ever changes),
+// internal/core/dynamic_secrets.go, and server/http/handlers/dynamic_secrets.go
+// -- the exact files QUEUE.md's Group 1 investigation cited.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// dynamicSecretLogSites are the (directory, single-file-or-empty) scan
+// targets. An empty file name scans every non-test *.go file in the
+// directory; a non-empty one scans exactly that file.
+var dynamicSecretLogSites = []struct {
+	dir  string
+	file string // "" = every non-test *.go file in dir
+}{
+	{dir: ".", file: ""}, // internal/dynamic itself
+	{dir: filepath.Join("..", "core"), file: "dynamic_secrets.go"},
+	{dir: filepath.Join("..", "..", "server", "http", "handlers"), file: "dynamic_secrets.go"},
+}
+
+// unsanitizedLogCall names one flagged log.Printf/log.Println argument.
+type unsanitizedLogCall struct {
+	file string
+	line int
+	desc string
+}
+
+// isSanitizeErrorMessageCall reports whether e is a call to (possibly
+// package-qualified) SanitizeErrorMessage(...) -- the one recognized "this
+// argument is already safe to log" shape.
+func isSanitizeErrorMessageCall(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name == "SanitizeErrorMessage"
+	case *ast.SelectorExpr:
+		return fn.Sel.Name == "SanitizeErrorMessage"
+	}
+	return false
+}
+
+// looksLikeErrorArg reports whether e, NOT already wrapped by
+// SanitizeErrorMessage, looks like it carries a raw error's text: a bare
+// identifier whose name contains "err" (case-insensitive -- covers err,
+// gerr, rerr, eerr), or a direct `<x>.Error()` call.
+func looksLikeErrorArg(e ast.Expr) (string, bool) {
+	if isSanitizeErrorMessageCall(e) {
+		return "", false
+	}
+	switch v := e.(type) {
+	case *ast.Ident:
+		if strings.Contains(strings.ToLower(v.Name), "err") {
+			return "bare identifier %q", true
+		}
+	case *ast.CallExpr:
+		if sel, ok := v.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Error" {
+			return "direct .Error() call", true
+		}
+	}
+	return "", false
+}
+
+// findUnsanitizedLogCalls walks file, flagging every log.Printf/log.Println
+// argument that looksLikeErrorArg.
+func findUnsanitizedLogCalls(fset *token.FileSet, file *ast.File, path string) []unsanitizedLogCall {
+	var found []unsanitizedLogCall
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkgIdent, ok := sel.X.(*ast.Ident)
+		if !ok || pkgIdent.Name != "log" || (sel.Sel.Name != "Printf" && sel.Sel.Name != "Println") {
+			return true
+		}
+		for _, arg := range call.Args {
+			if desc, flagged := looksLikeErrorArg(arg); flagged {
+				pos := fset.Position(arg.Pos())
+				found = append(found, unsanitizedLogCall{
+					file: path,
+					line: pos.Line,
+					desc: desc,
+				})
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// TestNoUnsanitizedDriverErrorReachesLog is Group 1's guard: no raw
+// dynamic-secret backend/driver error may reach a log.Printf/log.Println call
+// in internal/dynamic or the dynamic-secret HTTP/core call sites without
+// first going through dynamic.SanitizeErrorMessage. See this file's package
+// comment for exactly what is (and isn't) recognized, and why.
+func TestNoUnsanitizedDriverErrorReachesLog(t *testing.T) {
+	fset := token.NewFileSet()
+	var all []unsanitizedLogCall
+	scanned := 0
+
+	for _, site := range dynamicSecretLogSites {
+		var paths []string
+		if site.file != "" {
+			paths = []string{filepath.Join(site.dir, site.file)}
+		} else {
+			entries, err := os.ReadDir(site.dir)
+			if err != nil {
+				t.Fatalf("reading %s: %v", site.dir, err)
+			}
+			for _, e := range entries {
+				name := e.Name()
+				if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+					continue
+				}
+				paths = append(paths, filepath.Join(site.dir, name))
+			}
+		}
+		for _, p := range paths {
+			f, err := parser.ParseFile(fset, p, nil, 0)
+			if err != nil {
+				t.Fatalf("parsing %s: %v", p, err)
+			}
+			scanned++
+			all = append(all, findUnsanitizedLogCalls(fset, f, p)...)
+		}
+	}
+
+	if scanned < 2 {
+		t.Fatalf("only scanned %d file(s) -- the scan list above likely broke silently (expected at least "+
+			"internal/dynamic's own files plus the two named cross-package files)", scanned)
+	}
+	for _, f := range all {
+		t.Errorf("%s:%d: log call argument (%s) looks like an unsanitized error -- "+
+			"wrap it with dynamic.SanitizeErrorMessage(...) before logging (Group 1: raw driver/backend "+
+			"errors must never reach a log call verbatim)", f.file, f.line, f.desc)
+	}
+}

--- a/internal/dynamic/redact.go
+++ b/internal/dynamic/redact.go
@@ -1,0 +1,57 @@
+package dynamic
+
+import (
+	"regexp"
+	"strings"
+)
+
+// redactedPlaceholder replaces any credential fragment this file's patterns
+// recognize.
+const redactedPlaceholder = "***REDACTED***"
+
+// dsnUserinfoPattern matches the userinfo component of a URL-style connection
+// string -- scheme://user:password@host... -- as produced by postgres://,
+// mysql://, mongodb://, redis://, rediss:// DSNs. It intentionally matches
+// greedily up to the LAST '@' before the next '/' so a password containing an
+// unescaped '@' doesn't leave a residual fragment.
+var dsnUserinfoPattern = regexp.MustCompile(`://[^\s/]*@`)
+
+// kvCredentialPattern matches key=value pairs whose key names a credential
+// field, case-insensitively, in the ODBC/connection-string style
+// ("Server=...;Uid=admin;Pwd=hunter2;") or a URL query string
+// ("...&password=hunter2"). The value is everything up to the next
+// delimiter (';', '&', whitespace) or end of string.
+var kvCredentialPattern = regexp.MustCompile(`(?i)\b(password|pwd|passwd|secret|token|access_key_id|access_key|secret_access_key|session_token|api_key|apikey|auth)\s*=\s*[^;&\s]+`)
+
+// RedactSensitive strips connection-string/DSN credential fragments (URL
+// userinfo, ODBC/query-string key=value credential fields) from s. It is a
+// defense-in-depth text filter, not a parser or a guarantee: it cannot prove
+// no future backend or driver version ever echoes a credential in some other
+// shape, but it removes every shape the drivers this package wraps today
+// (pgx, go-sql-driver/mysql, mongo-driver, go-redis) are capable of producing
+// -- and, unlike a per-call-site fix, closes the gap for a future 5th
+// dynamic-secret backend too.
+func RedactSensitive(s string) string {
+	s = dsnUserinfoPattern.ReplaceAllString(s, "://"+redactedPlaceholder+"@")
+	s = kvCredentialPattern.ReplaceAllStringFunc(s, func(m string) string {
+		if idx := strings.IndexByte(m, '='); idx >= 0 {
+			return m[:idx+1] + redactedPlaceholder
+		}
+		return m
+	})
+	return s
+}
+
+// SanitizeErrorMessage returns err's Error() text with RedactSensitive
+// applied, safe to pass to log.Printf/log.Println (or any other sink that
+// isn't the deliberately-generic client-facing message). Use this in place of
+// formatting a backend/driver error directly with %v/%s anywhere a
+// dynamic-secret engine's error might reach a log call -- see the package
+// comment on why raw driver errors from postgres/mysql/mongodb/redis must
+// never be logged unsanitized.
+func SanitizeErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return RedactSensitive(err.Error())
+}

--- a/internal/dynamic/redact_test.go
+++ b/internal/dynamic/redact_test.go
@@ -1,0 +1,80 @@
+package dynamic
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRedactSensitive_URLUserinfo(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"postgres dsn", `failed to connect to "postgres://admin:hunter2@db.internal:5432/app": dial tcp: connection refused`},
+		{"mysql dsn", `parse error: mysql://root:s3cr3t@10.0.0.5:3306/mydb`},
+		{"mongodb dsn", `connstring: mongodb://svc_acct:p@ssnotreally@cluster0.mongo.net/admin`},
+		{"redis tls dsn", `dial error: rediss://default:topsecret@cache.example.com:6380`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RedactSensitive(tc.input)
+			if strings.Contains(got, "hunter2") || strings.Contains(got, "s3cr3t") ||
+				strings.Contains(got, "p@ssnotreally") || strings.Contains(got, "topsecret") {
+				t.Fatalf("RedactSensitive(%q) = %q, still contains a credential", tc.input, got)
+			}
+			if !strings.Contains(got, redactedPlaceholder) {
+				t.Fatalf("RedactSensitive(%q) = %q, expected redaction placeholder", tc.input, got)
+			}
+		})
+	}
+}
+
+func TestRedactSensitive_KeyValueCredentials(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"odbc pwd", `Server=db1;Uid=admin;Pwd=hunter2;Database=app`},
+		{"query password", `bad request to https://api.example.com/x?user=svc&password=hunter2&region=us`},
+		{"secret kv", `config error: secret=abc123XYZ is invalid`},
+		{"access key", `AccessDenied: access_key_id=AKIAEXAMPLE access_key=abcdefghijklmnop`},
+		{"case insensitive PASSWORD", `PASSWORD=hunter2;other=1`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RedactSensitive(tc.input)
+			for _, secret := range []string{"hunter2", "abc123XYZ", "AKIAEXAMPLE", "abcdefghijklmnop"} {
+				if strings.Contains(got, secret) {
+					t.Fatalf("RedactSensitive(%q) = %q, still contains credential %q", tc.input, got, secret)
+				}
+			}
+		})
+	}
+}
+
+func TestRedactSensitive_PreservesNonSensitiveText(t *testing.T) {
+	input := "connection refused: SQLSTATE 08006, no pg_hba.conf entry for host"
+	got := RedactSensitive(input)
+	if got != input {
+		t.Fatalf("RedactSensitive altered non-sensitive text: got %q, want %q", got, input)
+	}
+}
+
+func TestSanitizeErrorMessage_NilError(t *testing.T) {
+	if got := SanitizeErrorMessage(nil); got != "" {
+		t.Fatalf("SanitizeErrorMessage(nil) = %q, want empty string", got)
+	}
+}
+
+func TestSanitizeErrorMessage_RedactsWrappedError(t *testing.T) {
+	inner := errors.New(`dial postgres://admin:hunter2@10.0.0.9:5432/app: i/o timeout`)
+	wrapped := errors.New("issue credential: " + inner.Error())
+	got := SanitizeErrorMessage(wrapped)
+	if strings.Contains(got, "hunter2") {
+		t.Fatalf("SanitizeErrorMessage(%v) = %q, still contains the password", wrapped, got)
+	}
+	if !strings.Contains(got, "issue credential") {
+		t.Fatalf("SanitizeErrorMessage(%v) = %q, lost non-sensitive context", wrapped, got)
+	}
+}

--- a/server/http/handlers/dynamic_secrets.go
+++ b/server/http/handlers/dynamic_secrets.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/dynamic"
 	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/server/middleware"
 )
@@ -125,7 +126,7 @@ func (h *DynamicSecretHandler) CreateConfig(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		msg := err.Error()
 		if !isSafeDynamicSecretError(msg) {
-			log.Printf("Error creating dynamic-secret config: %v", err)
+			log.Printf("Error creating dynamic-secret config: %s", dynamic.SanitizeErrorMessage(err))
 			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, http.StatusBadRequest, nil)
@@ -147,7 +148,7 @@ func (h *DynamicSecretHandler) ListConfigs(w http.ResponseWriter, r *http.Reques
 	}
 	cfgs, err := h.coreService.ListDynamicSecretConfigs(r.Context(), projectID, environmentID)
 	if err != nil {
-		log.Printf("Error listing dynamic-secret configs: %v", err)
+		log.Printf("Error listing dynamic-secret configs: %s", dynamic.SanitizeErrorMessage(err))
 		sendError(w, "InternalError", "Failed to list configs", http.StatusInternalServerError, nil)
 		return
 	}
@@ -187,7 +188,7 @@ func (h *DynamicSecretHandler) IssueLease(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		msg := err.Error()
 		if !isSafeDynamicSecretError(msg) {
-			log.Printf("Error issuing dynamic-secret lease for config %d: %v", cfg.ID, err)
+			log.Printf("Error issuing dynamic-secret lease for config %d: %s", cfg.ID, dynamic.SanitizeErrorMessage(err))
 			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, http.StatusBadGateway, nil)
@@ -204,7 +205,7 @@ func (h *DynamicSecretHandler) ListLeases(w http.ResponseWriter, r *http.Request
 	}
 	leases, err := h.coreService.ListDynamicSecretLeases(r.Context(), cfg.ID)
 	if err != nil {
-		log.Printf("Error listing leases: %v", err)
+		log.Printf("Error listing leases: %s", dynamic.SanitizeErrorMessage(err))
 		sendError(w, "InternalError", "Failed to list leases", http.StatusInternalServerError, nil)
 		return
 	}
@@ -229,7 +230,7 @@ func (h *DynamicSecretHandler) RevokeLease(w http.ResponseWriter, r *http.Reques
 	if err := h.coreService.RevokeLease(r.Context(), leaseID, userCtx.UserID, "manual"); err != nil {
 		msg := err.Error()
 		if !isSafeDynamicSecretError(msg) {
-			log.Printf("Error revoking dynamic-secret lease %q: %v", leaseID, err)
+			log.Printf("Error revoking dynamic-secret lease %q: %s", leaseID, dynamic.SanitizeErrorMessage(err))
 			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, http.StatusBadGateway, nil)
@@ -257,7 +258,7 @@ func (h *DynamicSecretHandler) RenewLease(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		msg := err.Error()
 		if !isSafeDynamicSecretError(msg) {
-			log.Printf("Error renewing dynamic-secret lease %q: %v", leaseID, err)
+			log.Printf("Error renewing dynamic-secret lease %q: %s", leaseID, dynamic.SanitizeErrorMessage(err))
 			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, http.StatusBadGateway, nil)
@@ -281,7 +282,7 @@ func (h *DynamicSecretHandler) RevokeAllLeases(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		msg := err.Error()
 		if !isSafeDynamicSecretError(msg) {
-			log.Printf("Error revoking all dynamic-secret leases for config %d: %v", cfg.ID, err)
+			log.Printf("Error revoking all dynamic-secret leases for config %d: %s", cfg.ID, dynamic.SanitizeErrorMessage(err))
 			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, http.StatusBadGateway, nil)
@@ -314,7 +315,7 @@ func (h *DynamicSecretHandler) ClassifyConfig(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		msg := err.Error()
 		if !isSafeDynamicSecretError(msg) {
-			log.Printf("Error classifying dynamic-secret config %d: %v", cfg.ID, err)
+			log.Printf("Error classifying dynamic-secret config %d: %s", cfg.ID, dynamic.SanitizeErrorMessage(err))
 			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, http.StatusBadRequest, nil)
@@ -348,7 +349,7 @@ func (h *DynamicSecretHandler) SetConfigEnabled(w http.ResponseWriter, r *http.R
 	if err != nil {
 		msg := err.Error()
 		if !isSafeDynamicSecretError(msg) {
-			log.Printf("Error setting enabled state for dynamic-secret config %d: %v", cfg.ID, err)
+			log.Printf("Error setting enabled state for dynamic-secret config %d: %s", cfg.ID, dynamic.SanitizeErrorMessage(err))
 			msg = clientSafe(err)
 		}
 		sendError(w, "Error", msg, http.StatusBadRequest, nil)


### PR DESCRIPTION
## Summary

Group 1 remediation from the adversarial-review campaign (`keyorix-private/adversarial-review/QUEUE.md`): two sensitive-data-escaping-to-a-lower-trust-sink defects.

**1a. Unsanitized dynamic-secret backend/driver errors reaching server logs.**
`server/http/handlers/dynamic_secrets.go` (9 call sites) and `internal/core/dynamic_secrets.go:697` formatted raw postgres/mysql/mongodb/redis backend errors into `log.Printf` with a bare `%v`, with zero sanitization — unlike the gRPC path's `mapDynamicError`, which already maps every backend error to a generic gRPC status and never logs the raw text. Today's pinned driver versions (pgx v5.10.0, go-sql-driver/mysql v1.10.0, mongo-driver v1.17.9, go-redis v9.22.0) don't actually echo credentials back in an error string, so this is defense-in-depth, not a live leak — but a future driver bump or a 5th backend could reintroduce it.

Fix: a single shared redaction boundary, `internal/dynamic.SanitizeErrorMessage` (backed by `RedactSensitive`, a regex-based filter for URL userinfo — `scheme://user:pass@host` — and ODBC/query-string `key=value` credential fragments), rather than patching each call site with its own ad hoc fix. Every log call in both files now routes the error through it.

**1b. Rotation-failure webhook/chat broadcasts leaking backend refs + raw errors.**
`internal/core/rotation_executor.go`'s `notifyRotationFailures` built `NotificationEvent.Message` by interpolating the secret name, upstream `RotationBackend`, `RotationRef` (an IAM username / DB role / service-account email), and the raw upstream error text. `WebhookSink`/`ChatSink` (`internal/notifychan/webhook.go`, `chat.go`) then forward the whole event, essentially verbatim, to an external, third-party endpoint.

Fix: introduced `rotationFailureDetail{SecretName, Detail}` so the rich detail keeps flowing to the audit trail (`writeAuditEventFull`) and the rotation-state API — both internal to Keyorix — while the external broadcast (`notifyRotationFailures`) is now built from an explicit allowlist: secret name + a generic "rotation failed for secret %q" phrase, nothing else.

Checked every other `NotificationEvent{}` construction site (`internal/core/notifications.go:126`, `internal/core/compliance_digest.go:114`) — both already build `Message` from safe, non-error-derived text (title/body strings, not raw errors), so only the rotation-failure path needed this fix.

## Guard tests (verified red → green)

- `internal/dynamic/log_redaction_guard_test.go` — AST-based (no type-checking, to avoid pulling `go/packages`/`golang.org/x/tools` into the root module for a test): flags any `log.Printf`/`log.Println` argument that looks like a raw, unwrapped error across `internal/dynamic/*.go`, `internal/core/dynamic_secrets.go`, and `server/http/handlers/dynamic_secrets.go`. Verified it fails against the pre-fix code (flagged all 9 real call sites) and passes after.
- `internal/core/notify_rotation_failure_allowlist_guard_test.go` — direct unit test calling `notifyRotationFailures` with a crafted `rotationFailureDetail` whose `Detail` field embeds backend/ref/credential-shaped text, asserting none of it reaches `NotificationEvent.Message`. Verified red against the pre-fix code, green after.
- Two existing tests (`TestRunAutoRotation_NotifiesFailures`, `TestRunAutoRotation_FailuresNotBundledAcrossProjects`) asserted the old leaky behavior (`Message` containing the raw upstream error/ref) — updated to assert the corrected allowlist behavior instead, per this campaign's standing rule that a test encoding buggy behavior gets its assertion fixed, not silently left green.

## Note on the anticipated merge conflict

The task brief flagged a likely conflict with `fix-unified-egress-guard` (`internal/notifychan/webhook.go`) as "not yet merged into main." That PR has since landed — it's `a7095fb2` ("fix(egress): unified SSRF/TLS guard for Mongo, Redis, and SIEM forwarder", #1756), already an ancestor of the `main` this branch is based on. So there is no pending conflict: this branch already includes the `AllowPrivateNetworkTarget`/`AllowInsecureTransport` split, and this PR does not modify `webhook.go`/`chat.go` at all (only what feeds into `NotificationEvent.Message` upstream in `rotation_executor.go`).

## Files changed

- `internal/dynamic/redact.go` (new) — `RedactSensitive`/`SanitizeErrorMessage` shared redaction helper.
- `internal/dynamic/redact_test.go` (new) — unit tests for the helper.
- `internal/dynamic/log_redaction_guard_test.go` (new) — Group 1 guard (1a).
- `internal/core/dynamic_secrets.go` — route the one raw-error log call through `SanitizeErrorMessage`.
- `server/http/handlers/dynamic_secrets.go` — route all 9 raw-error log calls through `SanitizeErrorMessage`.
- `internal/core/rotation_executor.go` — `rotationFailureDetail` type; `notifyRotationFailures` now builds an allowlisted message; internal detail still reaches the audit trail/rotation-state API unchanged.
- `internal/core/notify_rotation_failure_allowlist_guard_test.go` (new) — Group 1 guard (1b).
- `internal/core/rotation_executor_test.go` — updated two existing tests' assertions to match the corrected (non-leaky) behavior.

## Test plan

- [x] `go build ./...`
- [x] `go vet` on `internal/core`, `internal/dynamic`, `server/http/handlers`
- [x] `gofmt -l` clean on all touched files
- [x] `gosec -severity medium -exclude-generated` clean on touched packages (0 issues)
- [x] Full test suite green: `internal/dynamic`, `internal/core`, `internal/core/storage`, `server/http/handlers`, `server/http/handlers/contracttest`
- [x] Both guard tests verified red against pre-fix code, green after
- [x] Confirmed gRPC (`server/grpc/services/dynamic_secret_service.go`) has zero log calls already — no change needed there
- [x] Confirmed the CLI (`internal/cli/dynamic`) never imports `internal/dynamic` directly and never logs — talks to the server over HTTP/gRPC only, receiving already-sanitized responses
