### PR TITLE
fix(encryption,connect,notifychan): close first-boot key race, fix Vault KV misdetection, drain HTTP bodies

### DIFF
--- a/internal/cli/common/remote_client.go
+++ b/internal/cli/common/remote_client.go
@@ -237,6 +237,21 @@ func refuseRemoteClientRedirect(req *http.Request, _ []*http.Request) error {
 	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
 }
 
+// drainAndClose discards any unread response body before closing it. Go's
+// net/http Transport only returns a connection to its keep-alive pool once the
+// body has been read to EOF (or closed after being fully drained) — a branch
+// that returns early without reading the body (every non-2xx/4xx error branch
+// below used to do exactly this) forces the underlying TCP connection to be
+// torn down instead of reused, on every single such response. Every method
+// below defers this instead of a bare resp.Body.Close(). The discard is capped
+// at maxRemoteResponseBytes, matching the read cap already used for a
+// successful decode, so draining a hostile/misbehaving oversized body can't
+// itself become an unbounded read.
+func drainAndClose(resp *http.Response) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxRemoteResponseBytes))
+	_ = resp.Body.Close()
+}
+
 // defaultConnectTimeout bounds only the TCP handshake (DNS + dial). A few
 // seconds is enough for any genuinely reachable server on a real network; an
 // unreachable or misconfigured KEYORIX_SERVER fails within this window
@@ -357,7 +372,7 @@ func (c *RemoteClient) Get(ctx context.Context, path string, out interface{}) er
 	if err != nil {
 		return c.classifyTransportError(err, "request failed")
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
@@ -380,7 +395,7 @@ func (c *RemoteClient) GetRaw(ctx context.Context, path string) ([]byte, error) 
 	if err != nil {
 		return nil, c.classifyTransportError(err, "request failed")
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
@@ -413,7 +428,7 @@ func (c *RemoteClient) Post(ctx context.Context, path string, body interface{}, 
 	if err != nil {
 		return c.classifyTransportError(err, "request failed")
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
@@ -456,7 +471,7 @@ func (c *RemoteClient) Put(ctx context.Context, path string, body interface{}, o
 	if err != nil {
 		return c.classifyTransportError(err, "request failed")
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
@@ -486,7 +501,7 @@ func (c *RemoteClient) Patch(ctx context.Context, path string, body interface{},
 	if err != nil {
 		return c.classifyTransportError(err, "request failed")
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
@@ -516,7 +531,7 @@ func (c *RemoteClient) DeleteWithBody(ctx context.Context, path string, body int
 	if err != nil {
 		return c.classifyTransportError(err, "request failed")
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)
@@ -536,7 +551,7 @@ func (c *RemoteClient) Delete(ctx context.Context, path string) error {
 	if err != nil {
 		return c.classifyTransportError(err, "request failed")
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("server returned HTTP %d for %s", resp.StatusCode, path)

--- a/internal/connect/connect_s22_test.go
+++ b/internal/connect/connect_s22_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
@@ -38,11 +39,18 @@ func TestVault_GetSecret_EmptyAddress_S22(t *testing.T) {
 
 // TestVault_GetSecret_InvalidJSON_S22 covers the json.Unmarshal failure branch
 // in GetSecret: a 200 response whose body is not valid JSON returns an error
-// containing "has no data".
+// containing "has no data". The mount-info lookup (resolveKVMountVersion) is
+// stubbed with a valid response so the test still exercises the SECRET
+// response's own unmarshal failure, not the mount-info lookup's.
 func TestVault_GetSecret_InvalidJSON_S22(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("X-Vault-Token") != "tok" {
 			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/v1/sys/internal/ui/mounts/") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(vaultMountInfoV1()))
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -76,28 +84,33 @@ func TestVault_GetSecret_MissingDataKey_S22(t *testing.T) {
 	assert.Contains(t, err.Error(), "has no data")
 }
 
-// TestVault_GetSecret_KVv2DataWithoutMetadata_S22 covers the KV v2 detection
-// fallback: when the inner object has a "data" sub-key but no "metadata"
-// sub-key (len(kv2.Metadata) == 0), the code falls back to the KV v1 path
-// and returns the outer data map as-is.
-func TestVault_GetSecret_KVv2DataWithoutMetadata_S22(t *testing.T) {
-	// Inner object has "data" but no "metadata" — not recognised as KV v2.
+// TestVault_GetSecret_KVv1_LiteralDataFieldNotMisdetectedAsV2_S22 pins the fix
+// for one of the two concrete KV-version misdetection bugs: a genuine KV v1
+// secret whose OWN stored fields happen to be literally named "data" (a
+// plausible field name an operator might choose) must not be misdetected as
+// KV v2 just because the response happens to have that shape. The mount is
+// explicitly v1 here (via the mount-info stub), so the whole outer data map is
+// returned as-is regardless of what its field names happen to be.
+func TestVault_GetSecret_KVv1_LiteralDataFieldNotMisdetectedAsV2_S22(t *testing.T) {
 	srv := fakeVault(t, "tok", map[string]string{
-		"/v1/secret/legacy": `{"data":{"data":{"apikey":"abc"}}}`,
+		"/v1/sys/internal/ui/mounts/secret/legacy": vaultMountInfoV1(),
+		"/v1/secret/legacy":                        `{"data":{"data":{"apikey":"abc"}}}`,
 	})
 	c := NewVaultConnector("v", srv.URL, "tok", nil)
 	val, err := c.GetSecret(context.Background(), "secret/legacy")
 	require.NoError(t, err)
-	// Falls back to KV v1: the outer data map (which happens to contain a
-	// nested "data" key) is returned as raw JSON.
+	// Mount is explicitly v1: the outer data map (which happens to contain a
+	// field literally named "data") is returned as-is, not unwrapped.
 	assert.JSONEq(t, `{"data":{"apikey":"abc"}}`, val)
 }
 
-// TestVault_GetSecret_KVv2MetadataWithoutData_S22 is a symmetric case: the
-// inner object has "metadata" but no "data" — still not KV v2, falls to KV v1.
-func TestVault_GetSecret_KVv2MetadataWithoutData_S22(t *testing.T) {
+// TestVault_GetSecret_KVv1_LiteralMetadataFieldNotMisdetectedAsV2_S22 is the
+// symmetric case: a genuine v1 secret whose own field is literally named
+// "metadata". Same fix, same reasoning.
+func TestVault_GetSecret_KVv1_LiteralMetadataFieldNotMisdetectedAsV2_S22(t *testing.T) {
 	srv := fakeVault(t, "tok", map[string]string{
-		"/v1/secret/legacy": `{"data":{"metadata":{"version":1}}}`,
+		"/v1/sys/internal/ui/mounts/secret/legacy": vaultMountInfoV1(),
+		"/v1/secret/legacy":                        `{"data":{"metadata":{"version":1}}}`,
 	})
 	c := NewVaultConnector("v", srv.URL, "tok", nil)
 	val, err := c.GetSecret(context.Background(), "secret/legacy")

--- a/internal/connect/connect_s23_test.go
+++ b/internal/connect/connect_s23_test.go
@@ -236,7 +236,8 @@ func TestVault_S23_GetSecret_NetworkError(t *testing.T) {
 // just the inner data object, not the outer envelope.
 func TestVault_S23_GetSecret_KVv2BothDataAndMetadata(t *testing.T) {
 	srv := fakeVault(t, "tok", map[string]string{
-		"/v1/secret/data/svc": `{"data":{"data":{"key":"val"},"metadata":{"version":7,"created_time":"2024-01-01T00:00:00Z"}}}`,
+		"/v1/sys/internal/ui/mounts/secret/data/svc": vaultMountInfoV2(),
+		"/v1/secret/data/svc":                        `{"data":{"data":{"key":"val"},"metadata":{"version":7,"created_time":"2024-01-01T00:00:00Z"}}}`,
 	})
 	c := NewVaultConnector("v", srv.URL, "tok", nil)
 	val, err := c.GetSecret(context.Background(), "secret/data/svc")

--- a/internal/connect/vault.go
+++ b/internal/connect/vault.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -29,6 +30,14 @@ type VaultConnector struct {
 	token       string
 	allowedRefs []string
 	client      *http.Client
+
+	// mountVersionsMu guards mountVersions: a per-connector cache of KV mount
+	// version (1 or 2), keyed by the mount's own path as Vault reports it (e.g.
+	// "secret/"). Populated by resolveKVMountVersion so a connector serving many
+	// reads under the same mount(s) queries sys/internal/ui/mounts at most once
+	// per distinct mount, not once per GetSecret call.
+	mountVersionsMu sync.Mutex
+	mountVersions   map[string]int
 }
 
 // NewVaultConnector builds a Vault connector. address is the Vault base URL; token
@@ -136,6 +145,87 @@ func validateConnectorURL(address string) error {
 	return nil
 }
 
+// resolveKVMountVersion determines whether the KV mount serving safeRef is v1 or
+// v2 by querying Vault's sys/internal/ui/mounts/<path> API directly (the
+// endpoint Vault's own CLI/UI use for this exact purpose), instead of
+// inferring it from the shape of a secret-read response. Response-shape
+// sniffing has two concrete failure modes it replaces: (1) a genuine KV v1
+// secret whose own stored fields happen to be literally named "data" and
+// "metadata" is misdetected as v2, silently discarding every other field; (2)
+// a soft-deleted KV v2 secret (`{"data": null, "metadata": {...}}`) fails a
+// naive non-empty check on "data" and falls through to returning Vault's
+// entire internal envelope as if it were the plaintext secret. Querying the
+// mount directly has neither failure mode: the version is a property of the
+// MOUNT, never the stored data.
+//
+// Results are cached per mount path (as Vault itself reports it, e.g.
+// "secret/") for this connector's lifetime — the KV version of a live mount
+// essentially never changes, and a connector is typically used repeatedly
+// across many reads under the same mount(s), so this keeps the common case to
+// one extra round-trip per distinct mount rather than one per read.
+func (c *VaultConnector) resolveKVMountVersion(ctx context.Context, safeRef string) (int, error) {
+	c.mountVersionsMu.Lock()
+	for mountPath, version := range c.mountVersions {
+		if strings.HasPrefix(safeRef, mountPath) {
+			c.mountVersionsMu.Unlock()
+			return version, nil
+		}
+	}
+	c.mountVersionsMu.Unlock()
+
+	reqURL := c.address + "/v1/sys/internal/ui/mounts/" + safeRef
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("vault: new mount-info request: %w", err)
+	}
+	req.Header.Set("X-Vault-Token", c.token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("vault: mount-info lookup failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, vaultMaxResponseBytes))
+		return 0, fmt.Errorf("vault: mount-info lookup for %q returned HTTP %d", safeRef, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, vaultMaxResponseBytes))
+	if err != nil {
+		return 0, fmt.Errorf("vault: read response: %w", err)
+	}
+
+	var mountResp struct {
+		Data struct {
+			Path    string `json:"path"`
+			Options struct {
+				Version string `json:"version"`
+			} `json:"options"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &mountResp); err != nil {
+		return 0, fmt.Errorf("vault: parse mount-info response: %w", err)
+	}
+
+	version := 1
+	if mountResp.Data.Options.Version == "2" {
+		version = 2
+	}
+	mountPath := mountResp.Data.Path
+	if mountPath == "" {
+		// Should not normally happen for a real Vault response, but fall back to
+		// caching under the exact ref rather than caching nothing, so a repeat
+		// lookup of the identical ref is still free.
+		mountPath = safeRef
+	}
+	c.mountVersionsMu.Lock()
+	if c.mountVersions == nil {
+		c.mountVersions = make(map[string]int)
+	}
+	c.mountVersions[mountPath] = version
+	c.mountVersionsMu.Unlock()
+	return version, nil
+}
+
 func (c *VaultConnector) GetSecret(ctx context.Context, ref string) (string, error) {
 	if ref == "" {
 		return "", fmt.Errorf("vault: secret reference (path) is required, e.g. secret/data/myapp")
@@ -164,6 +254,15 @@ func (c *VaultConnector) GetSecret(ctx context.Context, ref string) (string, err
 	if err != nil {
 		return "", err
 	}
+
+	// Determine KV v1 vs v2 explicitly, via Vault's own mount-info API, before
+	// ever looking at the secret response's shape (see resolveKVMountVersion's
+	// doc comment for the two concrete bugs this replaces).
+	kvVersion, err := c.resolveKVMountVersion(ctx, safeRef)
+	if err != nil {
+		return "", fmt.Errorf("vault: could not determine KV mount version for %q: %w", ref, err)
+	}
+
 	reqURL := c.address + "/v1/" + safeRef
 	// The query traces this sink's taint back to server/http/handlers/connect.go's
 	// r.URL.Query().Get("ref") (an incoming-request field that happens to match
@@ -191,6 +290,7 @@ func (c *VaultConnector) GetSecret(ctx context.Context, ref string) (string, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, vaultMaxResponseBytes))
 		return "", fmt.Errorf("vault: %s returned HTTP %d for %q", c.address, resp.StatusCode, ref)
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, vaultMaxResponseBytes))
@@ -200,18 +300,34 @@ func (c *VaultConnector) GetSecret(ctx context.Context, ref string) (string, err
 
 	// Vault wraps the secret under "data". KV v2 nests it again under data.data
 	// (alongside data.metadata); KV v1 puts the secret map directly under data.
+	// Which shape to expect is now decided by kvVersion (resolved above via
+	// Vault's own mount-info API), never by sniffing which fields happen to be
+	// present in the response — see resolveKVMountVersion's doc comment for why
+	// shape-sniffing is unsafe.
 	var env struct {
 		Data json.RawMessage `json:"data"`
 	}
 	if err := json.Unmarshal(body, &env); err != nil || len(env.Data) == 0 {
 		return "", fmt.Errorf("vault: secret %q has no data", ref)
 	}
+	if kvVersion == 1 {
+		return string(env.Data), nil // KV v1: the data map itself, whatever fields it contains
+	}
+
+	// KV v2: unwrap data.data. A soft-deleted (but not yet destroyed) version
+	// reads back as `{"data": null, "metadata": {...}}` — a 200 OK, not a 404 —
+	// so it must be handled explicitly here as "not found," not returned as if
+	// the null were the plaintext secret value or, worse, the whole envelope
+	// (including Vault's internal version/deletion-time metadata) mistaken for
+	// the secret.
 	var kv2 struct {
-		Data     json.RawMessage `json:"data"`
-		Metadata json.RawMessage `json:"metadata"`
+		Data json.RawMessage `json:"data"`
 	}
-	if err := json.Unmarshal(env.Data, &kv2); err == nil && len(kv2.Data) > 0 && len(kv2.Metadata) > 0 {
-		return string(kv2.Data), nil // KV v2: return the inner data map
+	if err := json.Unmarshal(env.Data, &kv2); err != nil {
+		return "", fmt.Errorf("vault: parse KV v2 envelope for %q: %w", ref, err)
 	}
-	return string(env.Data), nil // KV v1: the data map itself
+	if len(kv2.Data) == 0 || string(kv2.Data) == "null" {
+		return "", fmt.Errorf("vault: secret %q not found (KV v2 version has no data — likely deleted or destroyed)", ref)
+	}
+	return string(kv2.Data), nil
 }

--- a/internal/connect/vault_test.go
+++ b/internal/connect/vault_test.go
@@ -36,10 +36,22 @@ func TestVault_TypeAndName(t *testing.T) {
 	assert.Equal(t, "vault", c.Type())
 }
 
+// vaultMountInfoV2/vaultMountInfoV1 are canned sys/internal/ui/mounts/<path>
+// responses for the two KV versions, used to stub resolveKVMountVersion's
+// lookup in fakeVault-backed tests below.
+func vaultMountInfoV2() string {
+	return `{"data":{"path":"secret/","type":"kv","options":{"version":"2"}}}`
+}
+func vaultMountInfoV1() string {
+	return `{"data":{"path":"secret/","type":"kv","options":{"version":"1"}}}`
+}
+
 func TestVault_GetSecret_KVv2(t *testing.T) {
-	// KV v2 nests the secret under data.data, with a sibling data.metadata.
+	// KV v2 nests the secret under data.data, with a sibling data.metadata. The
+	// version comes from the mount-info lookup, not from sniffing this shape.
 	srv := fakeVault(t, "tok", map[string]string{
-		"/v1/secret/data/myapp": `{"data":{"data":{"password":"p@ss","user":"svc"},"metadata":{"version":3}}}`,
+		"/v1/sys/internal/ui/mounts/secret/data/myapp": vaultMountInfoV2(),
+		"/v1/secret/data/myapp":                        `{"data":{"data":{"password":"p@ss","user":"svc"},"metadata":{"version":3}}}`,
 	})
 	c := NewVaultConnector("v", srv.URL, "tok", nil)
 	val, err := c.GetSecret(context.Background(), "secret/data/myapp")
@@ -49,12 +61,61 @@ func TestVault_GetSecret_KVv2(t *testing.T) {
 
 func TestVault_GetSecret_KVv1(t *testing.T) {
 	srv := fakeVault(t, "tok", map[string]string{
-		"/v1/secret/legacy": `{"data":{"apikey":"abc123"}}`,
+		"/v1/sys/internal/ui/mounts/secret/legacy": vaultMountInfoV1(),
+		"/v1/secret/legacy":                        `{"data":{"apikey":"abc123"}}`,
 	})
 	c := NewVaultConnector("v", srv.URL, "tok", nil)
 	val, err := c.GetSecret(context.Background(), "secret/legacy")
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"apikey":"abc123"}`, val, "KV v1 data map is returned as-is")
+}
+
+// TestVault_GetSecret_KVv1_LiteralDataAndMetadataFieldsBothPresent pins the
+// fix for concrete bug (1) of the KV-version misdetection finding: a genuine
+// KV v1 secret can legitimately have its OWN fields literally named "data" and
+// "metadata" (plausible field names an operator might pick). The old
+// response-shape-sniffing code misdetected this exact shape as KV v2 —
+// confirmed empirically against the old code's exact branch logic before this
+// fix (a standalone harness reproducing vault.go's old GetSecret tail
+// byte-for-byte returned val="api-key-value", silently discarding the
+// "metadata"/"other_field" values) — because json.RawMessage captures the raw
+// bytes of ANY present JSON value, including a plain string, so
+// `len(kv2.Data) > 0 && len(kv2.Metadata) > 0` was satisfied by ordinary field
+// values, not just KV v2's nested-object envelope. With version now resolved
+// explicitly from the mount (v1 here), the full outer object — every field —
+// is returned as-is regardless of what its field names happen to be.
+func TestVault_GetSecret_KVv1_LiteralDataAndMetadataFieldsBothPresent(t *testing.T) {
+	srv := fakeVault(t, "tok", map[string]string{
+		"/v1/sys/internal/ui/mounts/secret/legacy": vaultMountInfoV1(),
+		"/v1/secret/legacy":                        `{"data":{"data":"api-key-value","metadata":"some-metadata-value","other_field":"other-value"}}`,
+	})
+	c := NewVaultConnector("v", srv.URL, "tok", nil)
+	val, err := c.GetSecret(context.Background(), "secret/legacy")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"data":"api-key-value","metadata":"some-metadata-value","other_field":"other-value"}`, val,
+		"every field of the genuine v1 secret must survive, not just the literal \"data\" field's value")
+}
+
+// TestVault_GetSecret_KVv2_SoftDeletedReturnsNotFoundError pins the fix for
+// concrete bug (2): Vault's real soft-deleted KV v2 response shape
+// (`{"data": null, "metadata": {...}}`, taken verbatim from Vault's own docs)
+// must surface as a clear "not found/deleted" error, never as a successful
+// read. Confirmed empirically against the old code's exact branch logic
+// before this fix: json.RawMessage captures the literal 4 bytes "null" for a
+// JSON null value (len=4, NOT 0), so the old `len(kv2.Data) > 0 &&
+// len(kv2.Metadata) > 0` check was satisfied and returned the bare string
+// "null" as if it were the plaintext secret — with a nil error, i.e. silent
+// success on a deleted secret.
+func TestVault_GetSecret_KVv2_SoftDeletedReturnsNotFoundError(t *testing.T) {
+	srv := fakeVault(t, "tok", map[string]string{
+		"/v1/sys/internal/ui/mounts/secret/data/deleted-secret": vaultMountInfoV2(),
+		"/v1/secret/data/deleted-secret":                        `{"data":{"data":null,"metadata":{"created_time":"2018-03-22T02:24:06.945319214Z","deletion_time":"2018-03-23T02:24:06.945319214Z","destroyed":false,"version":1}}}`,
+	})
+	c := NewVaultConnector("v", srv.URL, "tok", nil)
+	val, err := c.GetSecret(context.Background(), "secret/data/deleted-secret")
+	require.Error(t, err, "a soft-deleted KV v2 version must be reported as an error, never as a successful read")
+	assert.Empty(t, val)
+	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestVault_GetSecret_Errors(t *testing.T) {
@@ -166,7 +227,8 @@ func TestVault_GetSecret_CrossTenantTraversalIsRejected(t *testing.T) {
 // a legitimately scoped caller read their own secret.
 func TestVault_GetSecret_LegitimateScopedRefStillWorks(t *testing.T) {
 	srv := fakeVault(t, "tok", map[string]string{
-		"/v1/secret/data/myapp/config": `{"data":{"data":{"password":"p@ss"},"metadata":{}}}`,
+		"/v1/sys/internal/ui/mounts/secret/data/myapp/config": vaultMountInfoV2(),
+		"/v1/secret/data/myapp/config":                        `{"data":{"data":{"password":"p@ss"},"metadata":{}}}`,
 	})
 	c := NewVaultConnector("v", srv.URL, "tok", []string{"secret/data/myapp/"})
 
@@ -219,6 +281,9 @@ func TestVault_GetSecret_RefusesSameHostRedirect(t *testing.T) {
 	var mux http.ServeMux
 	srv := httptest.NewServer(&mux)
 	t.Cleanup(srv.Close)
+	mux.HandleFunc("/v1/sys/internal/ui/mounts/secret/data/myapp", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(vaultMountInfoV2()))
+	})
 	mux.HandleFunc("/v1/secret/data/myapp", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, srv.URL+"/v1/secret/data/other", http.StatusMovedPermanently)
 	})

--- a/internal/dynamic/kubernetes.go
+++ b/internal/dynamic/kubernetes.go
@@ -353,6 +353,17 @@ func refuseRedirect(req *http.Request, _ []*http.Request) error {
 	return fmt.Errorf("kubernetes: refusing to follow redirect to %q", req.URL)
 }
 
+// drainAndClose discards any unread response body before closing it, so the
+// underlying connection can be returned to net/http's keep-alive pool instead
+// of being torn down. Every realK8sMinter method below used to defer a bare
+// resp.Body.Close() and then return without reading the body on several
+// branches (the 401/403/>=400 error branches, and deleteBoundSecret's success
+// branch) — this closes the gap for all of them in one place.
+func drainAndClose(resp *http.Response) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxK8sAPIResponseBytes))
+	_ = resp.Body.Close()
+}
+
 func (m *realK8sMinter) mintToken(ctx context.Context, namespace, serviceAccount string, audiences []string, expiration time.Duration, bound *boundObjectRef) (string, time.Time, error) {
 	expSeconds := int64(expiration.Seconds())
 	spec := map[string]interface{}{
@@ -396,7 +407,7 @@ func (m *realK8sMinter) mintToken(ctx context.Context, namespace, serviceAccount
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return "", time.Time{}, fmt.Errorf("not authorized (HTTP %d) — the caller needs create on serviceaccounts/token for %s/%s", resp.StatusCode, namespace, serviceAccount)
 	}
@@ -457,7 +468,7 @@ func (m *realK8sMinter) createBoundSecret(ctx context.Context, namespace, name s
 	if err != nil {
 		return "", fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return "", fmt.Errorf("not authorized (HTTP %d) — the caller needs create on secrets in %s (required when revocable is true)", resp.StatusCode, namespace)
 	}
@@ -495,7 +506,7 @@ func (m *realK8sMinter) deleteBoundSecret(ctx context.Context, namespace, name s
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 	if resp.StatusCode == http.StatusNotFound {
 		return nil // already gone — revoke is idempotent
 	}

--- a/internal/encryption/encryption_s24_test.go
+++ b/internal/encryption/encryption_s24_test.go
@@ -849,15 +849,21 @@ func TestAuthEncryption_Disabled_EncryptClientSecret_Plaintext(t *testing.T) {
 	assert.Equal(t, "secret", got)
 }
 
-// ─── Service.AcquireExclusiveKeyLock: not initialized ────────────────────────
+// ─── Service.AcquireExclusiveKeyLock: works before Initialize ────────────────
 
-func TestService_AcquireExclusiveKeyLock_NotInitialized_Error(t *testing.T) {
+// TestService_AcquireExclusiveKeyLock_SucceedsBeforeInitialize_Error is the
+// s24 sibling of TestService_AcquireExclusiveKeyLock_BeforeInitialize_Succeeds
+// in encryption_s2_test.go — duplicated across coverage-wave test files, same
+// as the pre-fix "not initialized" assertion it replaces was. AcquireExclusiveKeyLock
+// no longer requires the Service to be initialized (see service_rotation.go):
+// the first-boot key-bootstrap race fix requires the exclusive lock to be
+// acquirable BEFORE Initialize runs.
+func TestService_AcquireExclusiveKeyLock_SucceedsBeforeInitialize_Error(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
 	svc := NewService(cfg, dir)
-	err := svc.AcquireExclusiveKeyLock()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not initialized")
+	t.Cleanup(svc.Shutdown)
+	require.NoError(t, svc.AcquireExclusiveKeyLock())
 }
 
 // ─── Service.AcquireSharedKeyLock: not initialized ───────────────────────────

--- a/internal/encryption/encryption_s2_test.go
+++ b/internal/encryption/encryption_s2_test.go
@@ -645,8 +645,17 @@ func TestService_AcquireExclusiveKeyLock(t *testing.T) {
 	require.NoError(t, err2)
 }
 
-// TestService_AcquireExclusiveKeyLock_NotInitialized covers the "not initialized" error branch.
-func TestService_AcquireExclusiveKeyLock_NotInitialized(t *testing.T) {
+// TestService_AcquireExclusiveKeyLock_BeforeInitialize_Succeeds pins the
+// first-boot-race fix: AcquireExclusiveKeyLock must succeed on a freshly
+// constructed, NOT-yet-initialized Service, since the flock only needs
+// keyManager.baseDir (fixed at construction) — never Initialize's KEK/DEK
+// material. server/main.go's initializeEncryption relies on exactly this:
+// it acquires the exclusive lock BEFORE calling Initialize, so first-boot key
+// generation (ensureSaltExists/ensureWrappedDEKExists) is itself
+// race-protected, not just steady-state DEK access. This used to be
+// impossible — the lock required s.initialized, so this exact call order
+// failed with "not initialized" (see git history / PR description).
+func TestService_AcquireExclusiveKeyLock_BeforeInitialize_Succeeds(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.EncryptionConfig{
 		Enabled:  true,
@@ -654,9 +663,11 @@ func TestService_AcquireExclusiveKeyLock_NotInitialized(t *testing.T) {
 		SaltPath: "salt.key",
 	}
 	svc := NewService(cfg, dir)
-	err := svc.AcquireExclusiveKeyLock()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not initialized")
+	t.Cleanup(svc.Shutdown)
+
+	require.NoError(t, svc.AcquireExclusiveKeyLock())
+	// Initialize must still work normally after the lock is already held.
+	require.NoError(t, svc.Initialize("test-passphrase"))
 }
 
 // TestService_AcquireSharedKeyLock exercises the shared lock path.

--- a/internal/encryption/firstboot_lock_order_test.go
+++ b/internal/encryption/firstboot_lock_order_test.go
@@ -1,0 +1,97 @@
+package encryption
+
+// firstboot_lock_order_test.go — regression test for the first-boot
+// key-bootstrap race: two processes (simulated here as independent Service
+// instances sharing the same fresh key directory) must never both pass the
+// unlocked check-then-write in ensureSaltExists/ensureWrappedDEKExists
+// (keymanager_lifecycle.go). AcquireExclusiveKeyLock must be acquired BEFORE
+// Initialize, not after, so the loser is refused immediately at the lock step
+// — before it ever touches salt/dek files — rather than racing key-material
+// generation and only surfacing as a corrupted/mismatched key pair on a LATER
+// restart ("wrong passphrase or corrupted key file").
+//
+// TestFirstBootKeyBootstrap_LockBeforeInitialize_ExactlyOneWinner exercises the
+// CORRECTED call order directly (AcquireExclusiveKeyLock() then Initialize()).
+// Before the fix, AcquireExclusiveKeyLock required the Service to already be
+// initialized, which made this order impossible to use at all — every racer
+// failed at the lock step with "not initialized", not a lock-contention error,
+// and none of the ordering's protection was exercised. That is confirmed
+// separately by TestService_AcquireExclusiveKeyLock_BeforeInitialize_Succeeds
+// in encryption_s2_test.go.
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+)
+
+func TestFirstBootKeyBootstrap_LockBeforeInitialize_ExactlyOneWinner(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.EncryptionConfig{Enabled: true, DEKPath: "dek.key", SaltPath: "kek.salt"}
+	const passphrase = "shared-first-boot-passphrase"
+
+	const racers = 8
+	var wg sync.WaitGroup
+	wg.Add(racers)
+	lockErrs := make([]error, racers)
+	initErrs := make([]error, racers)
+	svcs := make([]*Service, racers)
+	for i := 0; i < racers; i++ {
+		svcs[i] = NewService(cfg, dir)
+	}
+
+	for i := 0; i < racers; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			// The fix under test: acquire the exclusive lock BEFORE Initialize,
+			// mirroring the corrected order in server/main.go's
+			// initializeEncryption.
+			if err := svcs[i].AcquireExclusiveKeyLock(); err != nil {
+				lockErrs[i] = err
+				return
+			}
+			initErrs[i] = svcs[i].Initialize(passphrase)
+		}()
+	}
+	wg.Wait()
+	for i := 0; i < racers; i++ {
+		defer svcs[i].Shutdown()
+	}
+
+	winners := 0
+	for i := 0; i < racers; i++ {
+		if lockErrs[i] == nil {
+			winners++
+			if initErrs[i] != nil {
+				t.Errorf("racer %d won the lock but Initialize failed: %v", i, initErrs[i])
+			}
+			continue
+		}
+		// A loser must be refused at the LOCK step with a clear
+		// lock-contention error, and must never have gone on to run
+		// Initialize (so it never touched the salt/dek files at all).
+		if !strings.Contains(lockErrs[i].Error(), "DEK lock") {
+			t.Errorf("racer %d: expected a DEK-lock contention error, got: %v", i, lockErrs[i])
+		}
+		if initErrs[i] != nil {
+			t.Errorf("racer %d: Initialize must never run after a failed lock acquisition, got: %v", i, initErrs[i])
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("expected exactly 1 racer to win the exclusive lock and complete first-boot Initialize, got %d", winners)
+	}
+
+	// Simulate a LATER restart: a brand-new Service, independent of any racer,
+	// must unwrap the on-disk key material cleanly. This is the concrete
+	// failure mode the race produces when unprotected — a delayed, confusing
+	// "wrong passphrase or corrupted key file" on a later restart, rather than
+	// an immediate, clear error at the moment of the actual race.
+	restarted := NewService(cfg, dir)
+	if err := restarted.Initialize(passphrase); err != nil {
+		t.Fatalf("a later restart must unwrap the on-disk key material cleanly, got: %v", err)
+	}
+	restarted.Shutdown()
+}

--- a/internal/encryption/service_rotation.go
+++ b/internal/encryption/service_rotation.go
@@ -293,16 +293,22 @@ func (s *Service) CleanPendingDEK() {
 // AcquireExclusiveKeyLock takes an exclusive, non-blocking OS advisory lock on
 // the key directory, so no OTHER process using the same DEK — another server
 // instance, or a concurrent rotation — can hold it at the same time (#92). The
-// server calls this once at startup (held for its whole lifetime); rotation
-// calls it at the start of RotateDEKWithSweep (held only for the sweep). Either
-// way it is released by Shutdown. Idempotent: a second call while already held
-// by this Service is a no-op.
+// server calls this BEFORE Initialize (not after — see server/main.go's
+// initializeEncryption), so first-boot key generation itself
+// (ensureSaltExists/ensureWrappedDEKExists in keymanager_lifecycle.go, an
+// unlocked check-then-write) is race-protected too, not just steady-state DEK
+// access; the lock is then held for the server's whole lifetime. Rotation
+// calls it at the start of RotateDEKWithSweep, after its own Initialize has
+// already run (held only for the sweep). Either way it is released by
+// Shutdown. Deliberately does NOT require the Service to be initialized: the
+// lock only needs keyManager.baseDir, which is fixed at construction
+// (NewService/NewKeyManager), so it can be taken before any key material
+// exists on disk — unlike AcquireSharedKeyLock, which is only ever used after
+// Initialize by read-only CLI commands. Idempotent: a second call while
+// already held by this Service is a no-op.
 func (s *Service) AcquireExclusiveKeyLock() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if !s.initialized {
-		return fmt.Errorf("encryption service not initialized")
-	}
 	if s.serverLock != nil {
 		return nil
 	}

--- a/internal/k8ssync/keyorix_fetcher.go
+++ b/internal/k8ssync/keyorix_fetcher.go
@@ -275,7 +275,7 @@ func (f *KeyorixFetcher) getJSON(ctx context.Context, path string, out interface
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return fmt.Errorf("not authorized (HTTP %d) — check the agent's token and its permissions: %w", resp.StatusCode, ErrUpstreamGone)

--- a/internal/k8ssync/rest_sink.go
+++ b/internal/k8ssync/rest_sink.go
@@ -40,6 +40,19 @@ const (
 // maxResponseBodyBytes (keyorix_fetcher.go) caps how much of a single Kubernetes
 // API response this sink will buffer during json.Decode.
 
+// drainAndClose discards any unread response body before closing it, so the
+// underlying connection can be returned to net/http's keep-alive pool instead
+// of being torn down. Every RESTSink method below (and KeyorixFetcher.getJSON
+// in keyorix_fetcher.go, same package) used to defer a bare
+// resp.Body.Close() and return without reading the body on several
+// branches (every >=400/404/409 error branch, and createSecret/
+// applyOwnedSecret/Delete's success branches, which never decode a body at
+// all).
+func drainAndClose(resp *http.Response) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxResponseBodyBytes))
+	_ = resp.Body.Close()
+}
+
 // NewInClusterSink builds a RESTSink from the standard in-cluster environment: the
 // API host/port from KUBERNETES_SERVICE_HOST/PORT and the projected service-account
 // token + CA bundle. Returns an error when not running inside a cluster.
@@ -86,7 +99,7 @@ func (s *RESTSink) Get(ctx context.Context, namespace, name string) (map[string]
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, nil
@@ -206,7 +219,7 @@ func (s *RESTSink) createSecret(ctx context.Context, namespace, name string, pay
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("create secret %s/%s: HTTP %d", namespace, name, resp.StatusCode)
 	}
@@ -237,7 +250,7 @@ func (s *RESTSink) applyOwnedSecret(ctx context.Context, namespace, name string,
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("apply secret %s/%s: HTTP %d", namespace, name, resp.StatusCode)
 	}
@@ -259,7 +272,7 @@ func (s *RESTSink) List(ctx context.Context, namespace string) ([]string, error)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("list secrets in %s: HTTP %d", namespace, resp.StatusCode)
 	}
@@ -311,7 +324,7 @@ func (s *RESTSink) Delete(ctx context.Context, namespace, name string) error {
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 	switch {
 	case resp.StatusCode == http.StatusNotFound, resp.StatusCode == http.StatusConflict:
 		// 404: already gone. 409: the object changed since our owner-check (precondition
@@ -336,7 +349,7 @@ func (s *RESTSink) getOwnedMeta(ctx context.Context, namespace, name string) (ui
 	if err != nil {
 		return "", "", false, false, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 	if resp.StatusCode == http.StatusNotFound {
 		return "", "", false, false, nil
 	}

--- a/internal/notifychan/chat.go
+++ b/internal/notifychan/chat.go
@@ -118,7 +118,7 @@ func (s *ChatSink) send(ctx context.Context, ev core.NotificationEvent) (retryab
 	if err != nil {
 		return true, err // transport / timeout — transient
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer drainAndClose(resp)
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return false, nil
 	}

--- a/internal/notifychan/webhook.go
+++ b/internal/notifychan/webhook.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -32,7 +33,25 @@ import (
 const (
 	webhookTimeout   = 10 * time.Second
 	webhookQueueSize = 256
+	// notifyDrainMaxBytes caps how much of a notification-receiver's response
+	// body drainAndClose will discard. These sinks never care about the
+	// response body's content (only the status code), so any small body is
+	// just read-and-thrown-away to let the connection be reused — this cap
+	// guards that against a hostile/misbehaving receiver returning an
+	// effectively unbounded body.
+	notifyDrainMaxBytes = 1 << 20 // 1 MiB
 )
+
+// drainAndClose discards any unread response body before closing it, so the
+// underlying connection can be returned to net/http's keep-alive pool instead
+// of torn down. Shared by WebhookSink.send and ChatSink.send (chat.go) — both
+// used to defer a bare resp.Body.Close() and never read the body on EITHER
+// the success or the error path, since neither cares about the response
+// content, only the status code.
+func drainAndClose(resp *http.Response) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, notifyDrainMaxBytes))
+	_ = resp.Body.Close()
+}
 
 // WebhookConfig configures the webhook notification channel.
 type WebhookConfig struct {
@@ -154,7 +173,7 @@ func (s *WebhookSink) send(ctx context.Context, ev core.NotificationEvent) (retr
 	if err != nil {
 		return true, err // transport / timeout — transient
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer drainAndClose(resp)
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return false, nil
 	}

--- a/operator/internal/keyorix/client.go
+++ b/operator/internal/keyorix/client.go
@@ -84,6 +84,18 @@ func refuseRedirect(req *http.Request, _ []*http.Request) error {
 	return fmt.Errorf("keyorix: refusing to follow redirect to %q", req.URL)
 }
 
+// drainAndClose discards any unread response body before closing it, so the
+// underlying connection can be returned to net/http's keep-alive pool instead
+// of being torn down. FetchValue used to defer a bare resp.Body.Close() and
+// return without reading the body on every one of its five error branches
+// (404/403/401/400/>=400) — this operator is a single cluster-wide singleton
+// reconciler (see the maxResponseBodyBytes doc comment above), so an
+// unnecessarily torn-down connection on every error response is not free.
+func drainAndClose(resp *http.Response) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxResponseBodyBytes))
+	_ = resp.Body.Close()
+}
+
 // validateClientBaseURL checks that the client's base URL is a well-formed https
 // destination — matching validateServer's own https requirement in the controller
 // package, which this client's baseURL is sourced from (see FetchValue). http is
@@ -144,7 +156,7 @@ func (c *Client) FetchValue(ctx context.Context, ref string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close() //nolint:errcheck
+	defer drainAndClose(resp)
 
 	switch {
 	case resp.StatusCode == http.StatusNotFound:

--- a/server/main.go
+++ b/server/main.go
@@ -323,17 +323,29 @@ func initializeEncryption(cfg *config.Config, auditSink encryption.AuditSink) (*
 	if auditSink != nil {
 		svc.SetAuditSink(auditSink)
 	}
+	// Acquire the exclusive DEK lock BEFORE Initialize, not after. Initialize
+	// performs first-boot key generation (ensureSaltExists/ensureWrappedDEKExists
+	// in keymanager_lifecycle.go), which is an unlocked check-then-write: two
+	// processes racing a shared, fresh key directory (e.g. two HA replicas'
+	// simultaneous first boot) could each pass the not-exists check before
+	// either wrote, silently clobbering or interleaving each other's salt/DEK
+	// files. That failure is not even immediate — it surfaces as a delayed,
+	// confusing "wrong passphrase or corrupted key file" on a LATER restart,
+	// not a clear error at the moment of the actual race. Holding the exclusive
+	// DEK lock — the same lock this server keeps for its whole lifetime anyway,
+	// so DEK rotation (a separate CLI process) can never promote a new DEK
+	// while this server still has the old one cached in memory (#92) — across
+	// the ENTIRE first-boot sequence closes the race at its root: whichever
+	// process wins the flock proceeds, the other is refused immediately with a
+	// clear lock-contention error, before it ever touches a key file. Refuses
+	// to start if another live holder (another server instance, or an
+	// in-progress rotation) already has it.
+	if err := svc.AcquireExclusiveKeyLock(); err != nil {
+		return nil, fmt.Errorf("failed to acquire the encryption key lock: %w", err)
+	}
 	svc.CleanPendingDEK() // remove leftover .pending file from any interrupted prior rotation
 	if err := svc.Initialize(passphrase); err != nil {
 		return nil, fmt.Errorf("failed to initialize encryption (KEK derivation): %w", err)
-	}
-	// Hold the exclusive DEK lock for the server's whole lifetime (released by
-	// Shutdown on graceful stop) so DEK rotation — a separate CLI process — can
-	// never promote a new DEK while this server still has the old one cached in
-	// memory (#92). Refuses to start if another live holder (another server
-	// instance, or an in-progress rotation) already has it.
-	if err := svc.AcquireExclusiveKeyLock(); err != nil {
-		return nil, fmt.Errorf("failed to acquire the encryption key lock: %w", err)
 	}
 
 	kekSource := providerType


### PR DESCRIPTION
## Summary

Group 7 hygiene batch (per adversarial-review/QUEUE.md) — three independent fixes:

**1. First-boot key-bootstrap race (`server/main.go`, `internal/encryption`)**

`initializeEncryption` called `svc.Initialize(passphrase)` before `svc.AcquireExclusiveKeyLock()`, so the only cross-process lock was acquired AFTER first-boot key material (salt, wrapped DEK) was already generated by `ensureSaltExists`/`ensureWrappedDEKExists` (`keymanager_lifecycle.go`) — an unlocked check-then-write with a non-atomic write. Two processes racing a shared, fresh key directory (e.g. two HA replicas' simultaneous first boot) could both pass the not-exists check before either wrote, clobbering/interleaving each other's key files. This didn't fail closed: it surfaced later as a confusing "wrong passphrase or corrupted key file" on a subsequent restart rather than an immediate error.

Fix: reorder so `AcquireExclusiveKeyLock()` runs before `Initialize()`. This required removing `Service.AcquireExclusiveKeyLock`'s `!s.initialized` guard — the flock only needs `keyManager.baseDir`, which is fixed at construction, not at `Initialize` time — since that guard is what made the naive reorder impossible in the first place (confirmed: a new regression test run against the pre-fix code showed every racer failing with "not initialized" rather than a lock-contention error). Every existing caller of `AcquireExclusiveKeyLock` already calls it *after* its own `Initialize`, so removing the guard doesn't change behavior for rotation or any other caller — only the server-startup path, which now benefits from the reorder.

Added `TestFirstBootKeyBootstrap_LockBeforeInitialize_ExactlyOneWinner`, which races 8 Service instances against a shared fresh key directory using the corrected lock-then-initialize order, and confirms exactly one wins while the rest are refused immediately at the lock step (never touching key files), with the winner's on-disk state cleanly readable by a simulated later restart.

**2. Vault KV-version misdetection (`internal/connect/vault.go`)**

`GetSecret` inferred KV v1 vs v2 by sniffing whether the response had non-empty `data`/`metadata` fields. Two concrete bugs: (a) a genuine KV v1 secret whose own stored fields happen to be literally named `data`/`metadata` was misdetected as v2, silently discarding every other field; (b) a soft-deleted KV v2 secret (`{"data": null, "metadata": {...}}`) was not reported as "not found" — empirically confirmed the old code returned the bare string `"null"` as if it were the plaintext value, with a nil error.

Fix: query Vault's own `sys/internal/ui/mounts/<path>` API once per distinct mount (cached for the connector's lifetime, prefix-matched against the ref) to determine the KV version explicitly, instead of inferring it from response shape. The soft-deleted case is now handled explicitly and returns a clear "not found (likely deleted or destroyed)" error.

**3. HTTP response bodies not drained (shared clients only)**

Fixed at each shared client's single choke point (not per call site): `internal/cli/common/remote_client.go` (Get/GetRaw/Post/Put/Patch/DeleteWithBody/Delete), `internal/connect/vault.go`'s `GetSecret` (plus the new mount-info lookup), `internal/dynamic/kubernetes.go`'s `realK8sMinter` (mintToken/createBoundSecret/deleteBoundSecret), `internal/notifychan/webhook.go` + `chat.go` (previously never drained on either the success or error path), `internal/k8ssync/rest_sink.go` (all 6 methods) + `keyorix_fetcher.go`, and `operator/internal/keyorix/client.go`. Every one of these had at least one branch — almost always the non-2xx error branch — that returned without reading the response body, forcing the underlying connection to be torn down instead of reused for keep-alive. Left the explicitly-scoped one-off call sites untouched, per QUEUE.md.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean (main module + operator module with `GOWORK=off`)
- [x] `gofmt -l` clean on every touched file
- [x] `gosec -severity medium -exclude-generated` clean on every touched package (main + operator)
- [x] Full test suite green for every touched package: `internal/encryption`, `internal/connect`, `internal/cli/common`, `internal/dynamic`, `internal/notifychan`, `internal/k8ssync`, `operator/...`
- [x] RED-before-GREEN verified for both Task 1 (new race test failed against pre-fix code with "not initialized" instead of a lock error) and Task 2 (empirically reproduced both misdetection bugs against the exact pre-fix branch logic in a standalone harness before fixing)
- Note: an unrelated, pre-existing local-only slowdown/timeout in `server/http`'s full test suite was observed while running the whole repo's tests (not a package this PR touches, and structurally unreachable from any of these changes — `server/main.go` is package `main` and isn't imported by anything, and the `internal/encryption` change only widens a previously-erroring path to succeed). Matches a documented pre-existing local-only characteristic of that package.