### PR TITLE
fix(cli): resolve O_EXCL inconsistency, split walk from open-mode, audit --force

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -33,6 +33,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/keyorixhq/keyorix/internal/trust"
 )
 
@@ -538,8 +539,18 @@ func destDirHasContent(destDir string) (bool, error) {
 }
 
 // writeInstalledVersion persists version as the installed-version marker at destDir.
+// writeInstalledVersion persists version as the installed-version marker at destDir.
+// Routes through securefiles.SecureWriteFile (per-path-component O_NOFOLLOW walk),
+// not a raw os.WriteFile: destDir is an operator-supplied `--dest` path, and this marker
+// is rewritten on every successful import (an ordinary regular file already exists at
+// this exact path after the first install), so a plain os.WriteFile would silently
+// follow a symlink an attacker with write access to destDir planted at the marker's
+// path -- the same unguarded-symlink-write shape internal/cli/writeguard's sweep was
+// built to catch, just in a sibling package that sweep's internal/cli-only scan root
+// doesn't reach. Overwrite is intentional here (not O_EXCL): re-importing the same or
+// a newer version must be able to update this marker every time.
 func writeInstalledVersion(destDir, version string) error {
-	if err := os.WriteFile(filepath.Join(destDir, installedVersionMarker), []byte(version+"\n"), 0o600); err != nil {
+	if err := securefiles.SecureWriteFile(destDir, installedVersionMarker, []byte(version+"\n"), 0o600); err != nil {
 		return fmt.Errorf("bundle: write installed-version marker: %w", err)
 	}
 	return nil

--- a/internal/cli/bundle/bundle.go
+++ b/internal/cli/bundle/bundle.go
@@ -9,14 +9,17 @@ package bundle
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	ibundle "github.com/keyorixhq/keyorix/internal/bundle"
 	"github.com/keyorixhq/keyorix/internal/config"
 	ilicense "github.com/keyorixhq/keyorix/internal/license"
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/keyorixhq/keyorix/internal/trust"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 )
 
 // BundleCmd is the `keyorix bundle` command group.
@@ -89,7 +92,15 @@ var buildCmd = &cobra.Command{
 			return err
 		}
 
-		out, err := os.Create(buildOut) // #nosec G304 -- operator-supplied output path
+		// SecureOpenBeneath, not os.Create: a bundle is rebuilt to the same --out path on
+		// every CI run by design (a repeatable release-pipeline workflow, unlike a secret
+		// export whose output is generated once), so this intentionally does NOT use
+		// O_EXCL — but it still gets the full per-path-component O_NOFOLLOW walk, which a
+		// bare os.Create never had at all (not even the final-component protection an
+		// explicit O_NOFOLLOW would add), closing a real symlink-redirect gap in a build
+		// pipeline that runs unattended.
+		out, err := securefiles.SecureOpenBeneath(filepath.Dir(buildOut), filepath.Base(buildOut),
+			unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC, 0o600) // #nosec G304 -- operator-supplied output path, walked via SecureOpenBeneath
 		if err != nil {
 			return fmt.Errorf("create bundle: %w", err)
 		}

--- a/internal/cli/compliance/baseline.go
+++ b/internal/cli/compliance/baseline.go
@@ -19,6 +19,7 @@ import (
 var (
 	baselineFormat string
 	baselineOutput string
+	baselineForce  bool
 )
 
 var baselineCmd = &cobra.Command{
@@ -27,7 +28,9 @@ var baselineCmd = &cobra.Command{
 	Long: `Download the full permission baseline — every user's effective permissions,
 expanded through direct role grants and group membership — for auditor hand-off.
 Outputs CSV by default; use --format json for the JSON form.
-Writes to stdout by default, or to --output FILE.
+Writes to stdout by default, or to --output FILE. Refuses to overwrite an existing
+--output file unless --force is passed (a scheduled/CI evidence run reusing a fixed
+path needs it).
 Requires audit.read.`,
 	SilenceUsage: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
@@ -48,8 +51,15 @@ Requires audit.read.`,
 			}
 			pretty.WriteByte('\n')
 			if baselineOutput != "" {
-				if err := securefiles.SecureCreateFile(filepath.Dir(baselineOutput), filepath.Base(baselineOutput), pretty.Bytes(), 0o600); err != nil {
-					return fmt.Errorf("cannot create output file %q (it may already exist — remove it or choose a different path): %w", baselineOutput, err)
+				// See emitCSV's doc comment (csv_export.go) for why --force switches to
+				// SecureWriteFile (overwrite allowed, symlink protection unchanged) rather
+				// than dropping safety wholesale.
+				writeOut := securefiles.SecureCreateFile
+				if baselineForce {
+					writeOut = securefiles.SecureWriteFile
+				}
+				if err := writeOut(filepath.Dir(baselineOutput), filepath.Base(baselineOutput), pretty.Bytes(), 0o600); err != nil {
+					return fmt.Errorf("cannot create output file %q (it may already exist — remove it, choose a different path, or pass --force): %w", baselineOutput, err)
 				}
 				fmt.Printf("Permission baseline JSON written to %s.\n", baselineOutput)
 				return nil
@@ -57,7 +67,7 @@ Requires audit.read.`,
 			_, _ = os.Stdout.Write(pretty.Bytes())
 			return nil
 		case "csv", "":
-			return emitCSV(c, "/api/v1/compliance/permission-baseline.csv", baselineOutput, "Permission baseline CSV")
+			return emitCSV(c, "/api/v1/compliance/permission-baseline.csv", baselineOutput, "Permission baseline CSV", baselineForce)
 		default:
 			return fmt.Errorf("unknown format %q — use csv or json", baselineFormat)
 		}
@@ -67,5 +77,6 @@ Requires audit.read.`,
 func init() {
 	baselineCmd.Flags().StringVar(&baselineFormat, "format", "csv", "Output format: csv or json")
 	baselineCmd.Flags().StringVar(&baselineOutput, "output", "", "Write the output to a file instead of stdout")
+	baselineCmd.Flags().BoolVar(&baselineForce, "force", false, "Overwrite an existing --output file (default: refuse)")
 	ComplianceCmd.AddCommand(baselineCmd)
 }

--- a/internal/cli/compliance/compliance.go
+++ b/internal/cli/compliance/compliance.go
@@ -202,7 +202,10 @@ var reportCmd = &cobra.Command{
 	},
 }
 
-var exportOutput string
+var (
+	exportOutput string
+	exportForce  bool
+)
 
 var exportCmd = &cobra.Command{
 	Use:   "export",
@@ -210,7 +213,8 @@ var exportCmd = &cobra.Command{
 	Long: `Export a timestamped evidence pack — the posture plus the records that
 substantiate it (the audit-chain anchor, access-review campaigns, the break-glass
 register, and overdue rotations) — as JSON, for an auditor to archive. Writes to
-stdout by default, or to --output FILE.`,
+stdout by default, or to --output FILE. Refuses to overwrite an existing --output file
+unless --force is passed (a scheduled/CI evidence run reusing a fixed path needs it).`,
 	SilenceUsage: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		c, ok := common.NewRemoteClient()
@@ -227,8 +231,15 @@ stdout by default, or to --output FILE.`,
 		}
 		pretty.WriteByte('\n')
 		if exportOutput != "" {
-			if err := securefiles.SecureCreateFile(filepath.Dir(exportOutput), filepath.Base(exportOutput), pretty.Bytes(), 0o600); err != nil {
-				return fmt.Errorf("cannot create output file %q (it may already exist — remove it or choose a different path): %w", exportOutput, err)
+			// See emitCSV's doc comment (csv_export.go) for why --force switches to
+			// SecureWriteFile (overwrite allowed, symlink protection unchanged) rather
+			// than dropping safety wholesale.
+			writeOut := securefiles.SecureCreateFile
+			if exportForce {
+				writeOut = securefiles.SecureWriteFile
+			}
+			if err := writeOut(filepath.Dir(exportOutput), filepath.Base(exportOutput), pretty.Bytes(), 0o600); err != nil {
+				return fmt.Errorf("cannot create output file %q (it may already exist — remove it, choose a different path, or pass --force): %w", exportOutput, err)
 			}
 			fmt.Printf("Evidence pack written to %s.\n", exportOutput)
 			return nil
@@ -298,6 +309,7 @@ func joinRefs(refs ...[]string) string {
 var (
 	controlsCSV    bool
 	controlsOutput string
+	controlsForce  bool
 )
 
 var controlsCmd = &cobra.Command{
@@ -312,7 +324,7 @@ var controlsCmd = &cobra.Command{
 		// --csv downloads the server's canonical controls.csv (the same artifact the
 		// dashboard exports); the default prints the human-readable matrix.
 		if controlsCSV {
-			return emitCSV(c, "/api/v1/compliance/controls.csv", controlsOutput, "Control matrix CSV")
+			return emitCSV(c, "/api/v1/compliance/controls.csv", controlsOutput, "Control matrix CSV", controlsForce)
 		}
 		if controlsOutput != "" {
 			return fmt.Errorf("--output is only valid together with --csv")
@@ -395,8 +407,10 @@ not been modified. Requires server-side encryption (the signing key is DEK-deriv
 
 func init() {
 	exportCmd.Flags().StringVar(&exportOutput, "output", "", "Write the evidence pack to a file instead of stdout")
+	exportCmd.Flags().BoolVar(&exportForce, "force", false, "Overwrite an existing --output file (default: refuse)")
 	controlsCmd.Flags().BoolVar(&controlsCSV, "csv", false, "Download the control matrix as CSV instead of the text report")
 	controlsCmd.Flags().StringVar(&controlsOutput, "output", "", "With --csv, write to a file instead of stdout")
+	controlsCmd.Flags().BoolVar(&controlsForce, "force", false, "With --csv, overwrite an existing --output file (default: refuse)")
 	verifyCmd.Flags().StringVar(&verifyFile, "file", "", "Path to the evidence pack JSON to verify (required)")
 	verifyCmd.Flags().StringVar(&verifySig, "sig", "", "Path to the signature file (default <file>.sig)")
 	ComplianceCmd.AddCommand(reportCmd, controlsCmd, exportCmd, verifyCmd)

--- a/internal/cli/compliance/csv_export.go
+++ b/internal/cli/compliance/csv_export.go
@@ -18,6 +18,7 @@ import (
 var (
 	inventoryProject uint
 	inventoryOutput  string
+	inventoryForce   bool
 )
 
 var inventoryCmd = &cobra.Command{
@@ -27,7 +28,8 @@ var inventoryCmd = &cobra.Command{
 listed by name, project, environment, type, classification, owner, and lifecycle
 status, with no secret values. Deployment-wide by default (needs system.read);
 --project <id> scopes it to a single project (needs secrets.read on that project).
-Writes to stdout, or to --output FILE.`,
+Writes to stdout, or to --output FILE. Refuses to overwrite an existing --output file
+unless --force is passed (a scheduled/CI evidence run reusing a fixed path needs it).`,
 	SilenceUsage: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		c, ok := common.NewRemoteClient()
@@ -38,7 +40,7 @@ Writes to stdout, or to --output FILE.`,
 		if inventoryProject != 0 {
 			path = fmt.Sprintf("/api/v1/projects/%d/secrets/inventory.csv", inventoryProject)
 		}
-		return emitCSV(c, path, inventoryOutput, "Secret inventory CSV")
+		return emitCSV(c, path, inventoryOutput, "Secret inventory CSV", inventoryForce)
 	},
 }
 
@@ -46,22 +48,36 @@ Writes to stdout, or to --output FILE.`,
 // empty, to stdout. label names the artifact in the file-written confirmation line.
 //
 // The artifact is auditor-sensitive data (secret inventory, permission baseline,
-// compliance evidence) written to an operator-supplied --output path with zero
-// protection until this fix: a raw os.WriteFile silently follows a symlink planted at
-// the target and silently overwrites/truncates whatever was already there. Routes
-// through securefiles.SecureCreateFile instead, which refuses both (O_EXCL + a
-// per-path-component O_NOFOLLOW walk) — see internal/securefiles's doc comments for
-// why. outputPath is split into (baseDir, relPath) the way securefiles expects, the
-// same idiom already used at internal/cli/license/license.go and
+// compliance evidence) written to an operator-supplied --output path. Without force,
+// this routes through securefiles.SecureCreateFile, which refuses both a symlink-
+// redirect (a per-path-component O_NOFOLLOW walk) AND a silent overwrite (O_EXCL) of
+// whatever was already at that path — see internal/securefiles's doc comments for why.
+// outputPath is split into (baseDir, relPath) the way securefiles expects, the same
+// idiom already used at internal/cli/license/license.go and
 // internal/cli/config/cli_config.go.
-func emitCSV(rc *common.RemoteClient, path, outputPath, label string) error {
+//
+// force (mirroring internal/cli/trust/trust.go's keygen --force) relaxes EXACTLY the
+// overwrite refusal, not the symlink protection: it switches to
+// securefiles.SecureWriteFile, which still walks every path component with O_NOFOLLOW,
+// just without O_EXCL — a compliance evidence run scheduled to a fixed path (CI, cron)
+// needs to be able to overwrite its own prior output on every run, the same legitimate
+// repeated-write workflow internal/cli/bundle/bundle.go's `build` command already has,
+// but that must be an explicit opt-in with a clear refusal otherwise, not bundle.go's
+// default-always-overwrites behavior — an auditor evidence artifact silently
+// overwriting an operator's unrelated file at the same path by coincidence is a much
+// worse failure mode than a build artifact doing so.
+func emitCSV(rc *common.RemoteClient, path, outputPath, label string, force bool) error {
 	data, err := rc.GetRaw(context.Background(), path)
 	if err != nil {
 		return err
 	}
 	if outputPath != "" {
-		if err := securefiles.SecureCreateFile(filepath.Dir(outputPath), filepath.Base(outputPath), data, 0o600); err != nil {
-			return fmt.Errorf("cannot create output file %q (it may already exist — remove it or choose a different path): %w", outputPath, err)
+		writeOut := securefiles.SecureCreateFile
+		if force {
+			writeOut = securefiles.SecureWriteFile
+		}
+		if err := writeOut(filepath.Dir(outputPath), filepath.Base(outputPath), data, 0o600); err != nil {
+			return fmt.Errorf("cannot create output file %q (it may already exist — remove it, choose a different path, or pass --force): %w", outputPath, err)
 		}
 		fmt.Printf("%s written to %s.\n", label, outputPath)
 		return nil
@@ -73,5 +89,6 @@ func emitCSV(rc *common.RemoteClient, path, outputPath, label string) error {
 func init() {
 	inventoryCmd.Flags().UintVar(&inventoryProject, "project", 0, "Scope to one project by ID (default: deployment-wide)")
 	inventoryCmd.Flags().StringVar(&inventoryOutput, "output", "", "Write the CSV to a file instead of stdout")
+	inventoryCmd.Flags().BoolVar(&inventoryForce, "force", false, "Overwrite an existing --output file (default: refuse)")
 	ComplianceCmd.AddCommand(inventoryCmd)
 }

--- a/internal/cli/compliance/output_excl_test.go
+++ b/internal/cli/compliance/output_excl_test.go
@@ -75,3 +75,76 @@ func TestBaselineCmd_JSON_RefusesPreexistingOutputFile(t *testing.T) {
 	require.NoError(t, rerr)
 	assert.Equal(t, "stale-baseline", string(got), "the pre-existing file must be left completely untouched")
 }
+
+// --force regression tests: a scheduled/CI evidence run reusing a fixed --output path
+// (the same legitimate repeated-write workflow internal/cli/bundle/bundle.go's `build`
+// command already has by default) must be able to opt into overwrite explicitly, since
+// the default-refuse behavior above would otherwise make these commands unusable in
+// that workflow with no escape hatch at all. --force must relax EXACTLY the overwrite
+// refusal, not the underlying symlink protection (mirrors trust-keygen's --force,
+// internal/cli/trust/trust.go) — these tests only exercise the overwrite path; the
+// symlink-refusal guarantee itself is covered by internal/securefiles' own tests, since
+// --force switches to SecureWriteFile, which still walks every path component with
+// O_NOFOLLOW, just without O_EXCL.
+
+func TestEmitCSV_ForceOverwritesPreexistingOutputFile(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("name,project\nnew,proj\n"))
+	})
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "inv.csv")
+	require.NoError(t, os.WriteFile(outPath, []byte("stale-csv-content"), 0o600))
+
+	inventoryProject = 0
+	inventoryOutput = outPath
+	inventoryForce = true
+	t.Cleanup(func() { inventoryProject, inventoryOutput, inventoryForce = 0, "", false })
+
+	err := inventoryCmd.RunE(nil, nil)
+	require.NoError(t, err, "--force must allow overwriting a pre-existing --output path")
+
+	got, rerr := os.ReadFile(outPath)
+	require.NoError(t, rerr)
+	assert.Equal(t, "name,project\nnew,proj\n", string(got), "the file must contain the new content, not the stale one")
+}
+
+func TestExportCmd_ForceOverwritesPreexistingOutputFile(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":{"posture":{"ok":true}}}`))
+	})
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "pack.json")
+	require.NoError(t, os.WriteFile(outPath, []byte("stale-evidence-pack"), 0o600))
+
+	exportOutput = outPath
+	exportForce = true
+	t.Cleanup(func() { exportOutput, exportForce = "", false })
+
+	err := exportCmd.RunE(nil, nil)
+	require.NoError(t, err, "--force must allow overwriting a pre-existing --output path")
+
+	got, rerr := os.ReadFile(outPath)
+	require.NoError(t, rerr)
+	assert.NotEqual(t, "stale-evidence-pack", string(got), "the file must contain the new content, not the stale one")
+}
+
+func TestBaselineCmd_JSON_ForceOverwritesPreexistingOutputFile(t *testing.T) {
+	setupRemote(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"success":true,"data":{"rows":[]}}`))
+	})
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "baseline.json")
+	require.NoError(t, os.WriteFile(outPath, []byte("stale-baseline"), 0o600))
+
+	t.Cleanup(func() { baselineFormat = "csv"; baselineOutput = ""; baselineForce = false })
+	baselineFormat = "json"
+	baselineOutput = outPath
+	baselineForce = true
+
+	err := baselineCmd.RunE(nil, nil)
+	require.NoError(t, err, "--force must allow overwriting a pre-existing --output path")
+
+	got, rerr := os.ReadFile(outPath)
+	require.NoError(t, rerr)
+	assert.NotEqual(t, "stale-baseline", string(got), "the file must contain the new content, not the stale one")
+}

--- a/internal/cli/encryption/encryption_s22_test.go
+++ b/internal/cli/encryption/encryption_s22_test.go
@@ -366,8 +366,7 @@ func TestCopyFile_S22_MissingDestDir(t *testing.T) {
 	src := filepath.Join(dir, "src.key")
 	require.NoError(t, os.WriteFile(src, []byte("key-material"), 0600))
 
-	dst := filepath.Join(dir, "nonexistent-subdir", "dst.key")
-	err := copyFile(src, dst)
+	err := copyFile(dir, filepath.Base(src), filepath.Join("nonexistent-subdir", "dst.key"))
 	require.Error(t, err, "copyFile must fail when the destination directory does not exist")
 }
 

--- a/internal/cli/encryption/encryption_s27_test.go
+++ b/internal/cli/encryption/encryption_s27_test.go
@@ -354,7 +354,7 @@ func TestCopyFile_S27_SyncDirFails(t *testing.T) {
 	// Write once to confirm copyFile works (exercises the success path already
 	// covered by TestCopyFile_Success), then make the directory non-writable
 	// so the NEXT call's SyncDir fails.
-	err := copyFile(src, dst)
+	err := copyFile(dir, filepath.Base(src), filepath.Join("destdir", "dst.key"))
 	if err != nil {
 		// Already covered by symlink tests — skip if the first call errors.
 		t.Skipf("initial copyFile failed: %v", err)
@@ -365,7 +365,7 @@ func TestCopyFile_S27_SyncDirFails(t *testing.T) {
 	require.NoError(t, os.Chmod(dstDir, 0555)) // no write → OpenFile(O_CREATE) fails
 	t.Cleanup(func() { _ = os.Chmod(dstDir, 0755) })
 
-	err = copyFile(src, dst)
+	err = copyFile(dir, filepath.Base(src), filepath.Join("destdir", "dst.key"))
 	// Expected: OpenFile returns EACCES → copyFile returns the open error.
 	require.Error(t, err)
 }

--- a/internal/cli/encryption/encryption_s3_test.go
+++ b/internal/cli/encryption/encryption_s3_test.go
@@ -221,7 +221,7 @@ locale:
 
 func TestCopyFile_MissingSource(t *testing.T) {
 	dir := t.TempDir()
-	err := copyFile(filepath.Join(dir, "nonexistent.txt"), filepath.Join(dir, "dest.txt"))
+	err := copyFile(dir, "nonexistent.txt", "dest.txt")
 	require.Error(t, err)
 }
 
@@ -231,7 +231,7 @@ func TestCopyFile_Success(t *testing.T) {
 	dst := filepath.Join(dir, "dst.txt")
 	require.NoError(t, os.WriteFile(src, []byte("hello copy"), 0600))
 
-	err := copyFile(src, dst)
+	err := copyFile(dir, filepath.Base(src), filepath.Base(dst))
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(dst)

--- a/internal/cli/encryption/migrate_provider.go
+++ b/internal/cli/encryption/migrate_provider.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/cli/common"
@@ -25,6 +24,7 @@ import (
 	"github.com/keyorixhq/keyorix/internal/encryption"
 	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -392,7 +392,7 @@ func migrateProviderWithConfig(cfg *config.Config, opts migrateOpts, confirm boo
 
 	// 3. Back up the current wrapped DEK before overwriting it.
 	backupRel := fmt.Sprintf("%s.migrate-backup.%d", enc.DEKPath, time.Now().Unix())
-	if err := copyFile(filepath.Join(baseDir, enc.DEKPath), filepath.Join(baseDir, backupRel)); err != nil {
+	if err := copyFile(baseDir, enc.DEKPath, backupRel); err != nil {
 		return fmt.Errorf("failed to back up current wrapped DEK: %w", err)
 	}
 
@@ -439,12 +439,17 @@ func migrateProviderWithConfig(cfg *config.Config, opts migrateOpts, confirm boo
 // restore write would silently clobber that file instead of the intended DEK/
 // backup path. With O_NOFOLLOW the open fails (ELOOP) instead of following it —
 // the same protection securefiles.SecureWriteFile applies to its writes.
-func copyFile(src, dst string) error {
-	data, err := os.ReadFile(src) // #nosec G304 -- operator-configured key path under baseDir
+// copyFile copies baseDir/srcRel to baseDir/dstRel, both resolved and opened via
+// securefiles' per-path-component O_NOFOLLOW walk (SecureOpenBeneath/SafeReadFile) rather
+// than a plain os.OpenFile with only a final-component O_NOFOLLOW — closing the gap where
+// a symlink planted at an intermediate directory component (not just the leaf) between
+// this tool starting and this copy running could redirect the read or the write.
+func copyFile(baseDir, srcRel, dstRel string) error {
+	data, err := securefiles.SafeReadFile(baseDir, srcRel)
 	if err != nil {
 		return err
 	}
-	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0600) // #nosec G304 -- operator-configured key path under baseDir (local CLI tool, not network input)
+	f, err := securefiles.SecureOpenBeneath(baseDir, dstRel, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC, 0600) // #nosec G304 -- baseDir/dstRel is operator-configured, walked via SecureOpenBeneath
 	if err != nil {
 		return err
 	}
@@ -470,13 +475,13 @@ func copyFile(src, dst string) error {
 	if cerr := f.Close(); cerr != nil {
 		return cerr
 	}
-	return securefiles.SyncDir(filepath.Dir(dst))
+	return securefiles.SyncDir(filepath.Join(baseDir, filepath.Dir(dstRel)))
 }
 
 // restoreBackup copies the backup back over the active DEK path. Best-effort: logs
 // to stderr if the restore itself fails so the operator can recover manually.
 func restoreBackup(baseDir, backupRel, dekPath string) {
-	if err := copyFile(filepath.Join(baseDir, backupRel), filepath.Join(baseDir, dekPath)); err != nil {
+	if err := copyFile(baseDir, backupRel, dekPath); err != nil {
 		fmt.Fprintf(os.Stderr, "❌ CRITICAL: failed to restore DEK backup %s → %s: %v\n  Restore it manually before restarting.\n", backupRel, dekPath, err)
 	}
 }

--- a/internal/cli/encryption/migrate_provider_test.go
+++ b/internal/cli/encryption/migrate_provider_test.go
@@ -42,7 +42,7 @@ func TestCopyFile_RefusesSymlinkDestination(t *testing.T) {
 		t.Fatalf("symlink: %v", err)
 	}
 
-	err := copyFile(src, dst)
+	err := copyFile(dir, filepath.Base(src), filepath.Base(dst))
 	if err == nil {
 		t.Fatalf("expected copyFile to refuse writing through a symlink destination, got nil error")
 	}
@@ -73,7 +73,7 @@ func TestCopyFile_NewDestinationRestrictiveModeRegardlessOfUmask(t *testing.T) {
 	oldUmask := syscall.Umask(0o022)
 	defer syscall.Umask(oldUmask)
 
-	if err := copyFile(src, dst); err != nil {
+	if err := copyFile(dir, filepath.Base(src), filepath.Base(dst)); err != nil {
 		t.Fatalf("copyFile: %v", err)
 	}
 
@@ -104,7 +104,7 @@ func TestCopyFile_EnforcesModeOnPreexistingDestination(t *testing.T) {
 		t.Fatalf("write pre-existing dst: %v", err)
 	}
 
-	if err := copyFile(src, dst); err != nil {
+	if err := copyFile(dir, filepath.Base(src), filepath.Base(dst)); err != nil {
 		t.Fatalf("copyFile: %v", err)
 	}
 

--- a/internal/cli/secret/fix.go
+++ b/internal/cli/secret/fix.go
@@ -7,9 +7,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 
+	"github.com/keyorixhq/keyorix/internal/securefiles"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 )
 
 var fixCmd = &cobra.Command{
@@ -108,13 +109,13 @@ func runFix(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Fixed %s:%d\n", plan.File, plan.Line)
 	}
 
-	// Append to .env file. O_NOFOLLOW refuses to write through a pre-planted symlink at
-	// envPath — an append-only open doesn't fit securefiles' O_EXCL-based create helper
-	// (the whole point here is to append to a file across repeated runs, not refuse a
-	// pre-existing one), so this is fixed in place rather than routed through it, mirroring
-	// applyFix's own O_NOFOLLOW-without-securefiles pattern later in this same file.
-	envPath := filepath.Join(absPath, fixEnvFile)
-	f, err := os.OpenFile(envPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY|syscall.O_NOFOLLOW, 0600) // #nosec G304
+	// Append to .env file via securefiles.SecureOpenBeneath: an append-only open doesn't
+	// fit the O_EXCL-based create helpers (the whole point here is to append across
+	// repeated runs, not refuse a pre-existing file), but the per-path-component
+	// O_NOFOLLOW walk applies regardless of which open flags are used — SecureOpenBeneath
+	// separates the two, so this gets the full walk (not just a final-component
+	// O_NOFOLLOW) with O_APPEND semantics preserved.
+	f, err := securefiles.SecureOpenBeneath(absPath, fixEnvFile, unix.O_APPEND|unix.O_CREAT|unix.O_WRONLY, 0600) // #nosec G304 -- absPath is operator-supplied --path, walked via SecureOpenBeneath
 	if err == nil {
 		_, _ = fmt.Fprintf(f, "\n# Added by keyorix fix\n%s=\n", envVarName) // #nosec G104
 		_ = f.Close()                                                        // #nosec G104
@@ -203,10 +204,13 @@ func applyFix(basePath string, plan fixPlan) error {
 	// #G26: os.WriteFile follows a symlink at fullPath and writes through it — a scanned
 	// directory can contain attacker-planted content, so a symlink swapped in at a
 	// discovered path (between the scan and this apply) would let `secret fix` overwrite
-	// an arbitrary file the process can write to. O_NOFOLLOW refuses that; no O_CREATE/
-	// O_EXCL since the fix always targets a file findAndPlanFix already read via this
-	// same fullPath, so it must already exist.
-	f, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_TRUNC|syscall.O_NOFOLLOW, 0600) // #nosec G304 -- fullPath is basePath (operator-supplied --path) joined with a relative path from filepath.Walk rooted at that same basePath
+	// an arbitrary file the process can write to. SecureOpenBeneath's per-component walk
+	// refuses that at every path segment (not just the final one, which a bare O_NOFOLLOW
+	// on the final open would miss for a symlink planted at an intermediate directory
+	// between the scan and this apply); no O_CREATE/O_EXCL since the fix always targets a
+	// file findAndPlanFix already read via this same relative path, so it must already
+	// exist.
+	f, err := securefiles.SecureOpenBeneath(basePath, plan.File, unix.O_WRONLY|unix.O_TRUNC, 0600) // #nosec G304 -- basePath is operator-supplied --path, plan.File is relative to it, walked via SecureOpenBeneath
 	if err != nil {
 		return err
 	}

--- a/internal/cli/writeguard/write_guard_test.go
+++ b/internal/cli/writeguard/write_guard_test.go
@@ -32,31 +32,20 @@ import (
 // through internal/securefiles. Every entry was reviewed as part of the Group 2
 // safe-file-writes fix; see the justification for why each one is safe/out-of-scope as
 // it stands, not merely undiscovered.
+//
+// This allowlist is meant to generate its own rot and be caught: the four sites
+// originally deferred here (migrate_provider.go's copyFile, bundle.go's --out write,
+// and both secret/fix.go sites) were deferred specifically because O_EXCL didn't fit
+// their semantics -- conflating "which open flags" with "how much of the path gets
+// walked safely." Once internal/securefiles.SecureOpenBeneath was exported as a
+// standalone walk primitive taking caller-supplied flags (separate from the O_EXCL-only
+// SecureCreateFile family), all four were re-examined against that new axis and all four
+// turned out to fit it: none of them actually needed the streaming non-exclusive helper
+// this comment used to say bundle.go was blocked on. They were fixed directly and
+// removed from this list rather than left allowlisted -- if a FUTURE site is added here
+// citing "needs a streaming/non-exclusive write," re-check against SecureOpenBeneath
+// first; it may already fit, the same way it did for all four sites removed here.
 var allowlist = map[string]string{
-	"encryption/migrate_provider.go:447": "copyFile's dst is used BOTH ways: a fresh backup path (create) and, on restore, a " +
-		"pre-existing DEK path that must be overwritten -- O_EXCL doesn't fit either the " +
-		"restore case or a helper that only supports one or the other. Already carries " +
-		"O_NOFOLLOW plus an explicit post-open Chmod, the same protection " +
-		"securefiles.SecureWriteFile provides, just checked at the final path component " +
-		"only (not per-component). Fixed/derived path under baseDir, not an arbitrary " +
-		"operator --output flag. Queue-rated medium-low, not one of Group 2's named fix sites.",
-	"bundle/bundle.go:92": "the --out path for `bundle build`: rebuilding to the same output path is a " +
-		"legitimate, common workflow (e.g. re-running in CI), so switching to the new " +
-		"O_EXCL create-only helper would regress that overwrite. WriteBundle also needs an " +
-		"io.Writer to stream to, not an already-assembled []byte, so SecureCreateFile's " +
-		"data-based form doesn't fit either. Properly fixing this needs a new " +
-		"non-exclusive, O_NOFOLLOW-only, handle-based securefiles primitive -- deliberately " +
-		"left as a follow-up rather than folded into this PR (queue: supply-chain build " +
-		"artifact, not secret data).",
-	"secret/fix.go:117": "appends only a variable NAME (not a secret value) to .env, idempotently, across " +
-		"repeated runs (O_APPEND|O_CREATE) -- O_APPEND is fundamentally incompatible with " +
-		"the O_EXCL create-only helper's refuse-if-exists semantics. Fixed in place by " +
-		"adding O_NOFOLLOW directly, mirroring applyFix's own O_NOFOLLOW-without-" +
-		"securefiles pattern later in this same file.",
-	"secret/fix.go:209": "applyFix's in-place edit of a file findAndPlanFix already opened and read via " +
-		"this exact path -- requires the file to already exist (no O_CREATE), which doesn't " +
-		"fit a create-a-new-file helper. Already carries O_NOFOLLOW. Queue-rated medium-low, " +
-		"not one of Group 2's named fix sites.",
 	"system/init.go:172": "creates an empty (0-byte) placeholder file for the local sqlite DB path purely " +
 		"to make first-boot vs. already-initialized unambiguous -- no data is written by " +
 		"this call. Already uses O_EXCL for an atomic, idempotent existence check " +
@@ -170,7 +159,8 @@ func findAllSites(t *testing.T, root string) map[string]site {
 // (with a written justification), i.e. everything else must go through
 // internal/securefiles. Verified RED against pre-fix code (it flagged
 // compliance/csv_export.go:51, compliance/compliance.go:228, compliance/baseline.go:49,
-// and rbac/export_matrix.go:79 before those sites were migrated); GREEN after.
+// rbac/export_matrix.go:79, migrate_provider.go's copyFile, bundle/bundle.go:92, and
+// both secret/fix.go sites before those were migrated); GREEN after.
 func TestNoUnprotectedSensitiveFileWrites(t *testing.T) {
 	root := cliRoot(t)
 	found := findAllSites(t, root)

--- a/internal/cli/writeguard/write_guard_test.go
+++ b/internal/cli/writeguard/write_guard_test.go
@@ -1,7 +1,18 @@
-// Package writeguard is a standalone, test-only sweep over internal/cli that asserts no
-// production code calls os.Create/os.OpenFile/os.WriteFile directly for sensitive
-// output (exports, bundles, key material, evidence) outside the internal/securefiles
-// shared helpers — see keyorix-private/adversarial-review/QUEUE.md "Group 2 guard".
+// Package writeguard is a standalone, test-only sweep over internal/cli AND
+// internal/bundle that asserts no production code calls os.Create/os.OpenFile/
+// os.WriteFile directly for sensitive output (exports, bundles, key material,
+// evidence) outside the internal/securefiles shared helpers — see
+// keyorix-private/adversarial-review/QUEUE.md "Group 2 guard".
+//
+// internal/bundle was added after adversarial verification of the original internal/
+// cli-only sweep found a structurally identical, unguarded os.WriteFile in
+// internal/bundle/bundle.go's writeInstalledVersion — invisible to the sweep purely
+// because that package is a sibling of internal/cli, not a subdirectory of it. The
+// vulnerability shape ("operator-supplied path, written without symlink/overwrite
+// protection") isn't specific to the CLI layer; any package taking an operator-facing
+// path and writing to it is in scope. internal/cli and internal/bundle are the two
+// confirmed instances as of this writing — a wider, repo-root sweep (with the
+// allowlisting work that would require) is a real follow-up, not done here.
 //
 // Every call site the sweep finds must either route through securefiles
 // (SecureCreateFile/SecureCreateFileSync/SecureCreateFileHandle/SecureWriteFile/
@@ -46,11 +57,11 @@ import (
 // citing "needs a streaming/non-exclusive write," re-check against SecureOpenBeneath
 // first; it may already fit, the same way it did for all four sites removed here.
 var allowlist = map[string]string{
-	"system/init.go:172": "creates an empty (0-byte) placeholder file for the local sqlite DB path purely " +
+	"internal/cli/system/init.go:172": "creates an empty (0-byte) placeholder file for the local sqlite DB path purely " +
 		"to make first-boot vs. already-initialized unambiguous -- no data is written by " +
 		"this call. Already uses O_EXCL for an atomic, idempotent existence check " +
 		"(err == nil or IsExist are both treated as success).",
-	"system/init.go:202": "creates an empty (0-byte) placeholder file for the local log path, same " +
+	"internal/cli/system/init.go:202": "creates an empty (0-byte) placeholder file for the local log path, same " +
 		"idempotent-existence-check shape as init.go:172 -- no data is written by this call. " +
 		"Already uses O_EXCL.",
 }
@@ -70,18 +81,21 @@ type site struct {
 
 func (s site) key() string { return s.relPath + ":" + strconv.Itoa(s.line) }
 
-// cliRoot resolves the internal/cli directory relative to this test file's own
-// location (not the process cwd), so the sweep works regardless of how `go test` is
-// invoked.
-func cliRoot(t *testing.T) string {
+// repoRoot resolves the repository root relative to this test file's own location (not
+// the process cwd), so the sweep works regardless of how `go test` is invoked.
+func repoRoot(t *testing.T) string {
 	t.Helper()
 	_, thisFile, _, ok := runtime.Caller(0)
 	require.True(t, ok, "runtime.Caller must resolve this test file's path")
 	// this file lives at internal/cli/writeguard/write_guard_test.go
-	root, err := filepath.Abs(filepath.Join(filepath.Dir(thisFile), ".."))
+	root, err := filepath.Abs(filepath.Join(filepath.Dir(thisFile), "..", "..", ".."))
 	require.NoError(t, err)
 	return root
 }
+
+// scanRoots are the package trees this sweep walks, relative to repoRoot. See the
+// package doc comment for why internal/bundle is included alongside internal/cli.
+var scanRoots = []string{"internal/cli", "internal/bundle"}
 
 // scanFile parses a single .go file and returns every os.Create/os.OpenFile/
 // os.WriteFile call site found in it (by AST inspection, not string/regex matching, so
@@ -120,50 +134,56 @@ func scanFile(fset *token.FileSet, path string) ([]site, error) {
 	return sites, nil
 }
 
-// findAllSites walks root (internal/cli) recursively, scanning every non-test .go file
-// (test fixtures are allowed to build test data with raw os calls; this sweep is about
-// production output paths) and returns every raw os.Create/os.OpenFile/os.WriteFile
-// call site found, keyed by path relative to root.
-func findAllSites(t *testing.T, root string) map[string]site {
+// findAllSites walks every directory in scanRoots recursively (relative to repo),
+// scanning every non-test .go file (test fixtures are allowed to build test data with
+// raw os calls; this sweep is about production output paths) and returns every raw
+// os.Create/os.OpenFile/os.WriteFile call site found, keyed by path relative to repo
+// (e.g. "internal/cli/system/init.go:172", "internal/bundle/bundle.go:542") so sites
+// from different scan roots can never collide.
+func findAllSites(t *testing.T, repo string) map[string]site {
 	t.Helper()
 	fset := token.NewFileSet()
 	found := map[string]site{}
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
+	for _, rel := range scanRoots {
+		root := filepath.Join(repo, rel)
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			sites, serr := scanFile(fset, path)
+			if serr != nil {
+				return serr
+			}
+			for _, s := range sites {
+				relPath, rerr := filepath.Rel(repo, s.relPath)
+				require.NoError(t, rerr)
+				s.relPath = filepath.ToSlash(relPath)
+				found[s.key()] = s
+			}
 			return nil
-		}
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		sites, serr := scanFile(fset, path)
-		if serr != nil {
-			return serr
-		}
-		for _, s := range sites {
-			rel, rerr := filepath.Rel(root, s.relPath)
-			require.NoError(t, rerr)
-			s.relPath = filepath.ToSlash(rel)
-			found[s.key()] = s
-		}
-		return nil
-	})
-	require.NoError(t, err, "walking %s must not fail", root)
+		})
+		require.NoError(t, err, "walking %s must not fail", root)
+	}
 	return found
 }
 
 // TestNoUnprotectedSensitiveFileWrites is the Group 2 guard: every raw os.Create/
-// os.OpenFile/os.WriteFile call under internal/cli must be explicitly allowlisted
+// os.OpenFile/os.WriteFile call under any scanRoots tree must be explicitly allowlisted
 // (with a written justification), i.e. everything else must go through
-// internal/securefiles. Verified RED against pre-fix code (it flagged
-// compliance/csv_export.go:51, compliance/compliance.go:228, compliance/baseline.go:49,
-// rbac/export_matrix.go:79, migrate_provider.go's copyFile, bundle/bundle.go:92, and
-// both secret/fix.go sites before those were migrated); GREEN after.
+// internal/securefiles. Verified RED against pre-fix code for the original internal/cli
+// sites (compliance/csv_export.go:51, compliance/compliance.go:228,
+// compliance/baseline.go:49, rbac/export_matrix.go:79, migrate_provider.go's copyFile,
+// bundle/bundle.go:92, both secret/fix.go sites) and, separately, for
+// internal/bundle/bundle.go's writeInstalledVersion once internal/bundle was added as a
+// second scan root; GREEN after each was fixed.
 func TestNoUnprotectedSensitiveFileWrites(t *testing.T) {
-	root := cliRoot(t)
-	found := findAllSites(t, root)
+	found := findAllSites(t, repoRoot(t))
 
 	var unallowed []string
 	for key, s := range found {
@@ -186,8 +206,7 @@ func TestNoUnprotectedSensitiveFileWrites(t *testing.T) {
 // regression the moment that exact line shifts. A stale entry doesn't fail the sweep
 // above (which only checks found-but-unallowed sites), so it's checked here explicitly.
 func TestAllowlistEntriesStillExist(t *testing.T) {
-	root := cliRoot(t)
-	found := findAllSites(t, root)
+	found := findAllSites(t, repoRoot(t))
 
 	var stale []string
 	for key := range allowlist {

--- a/internal/securefiles/securefiles.go
+++ b/internal/securefiles/securefiles.go
@@ -40,7 +40,7 @@ type FilePermSpec struct {
 // (e.g. baseDir/not-yet-created-dir/file) is passed through unresolved, and an attacker
 // racing between this check and the later open could plant that component as a symlink
 // pointing outside baseDir. Every caller that actually opens the file MUST use
-// secureOpenBeneath (below) to perform the open, which closes that gap by walking the
+// SecureOpenBeneath (below) to perform the open, which closes that gap by walking the
 // path component-by-component with O_NOFOLLOW relative to already-open parent file
 // descriptors — see its doc comment for why that eliminates the TOCTOU window that this
 // function's path-string check alone cannot.
@@ -95,12 +95,12 @@ func SafeReadFile(baseDir, filePath string) ([]byte, error) {
 		return nil, fmt.Errorf("access denied: file %q is outside of %q", cleanPath, baseDir)
 	}
 
-	// The actual open happens via secureOpenBeneath, not os.ReadFile(cleanPath): the
+	// The actual open happens via SecureOpenBeneath, not os.ReadFile(cleanPath): the
 	// isPathInsideBase check above only resolves symlinks up to the longest existing
 	// ancestor, so it cannot see a symlink an attacker plants at a not-yet-existing (or
 	// racily-replaced) intermediate component between this check and the open below.
-	// secureOpenBeneath closes that gap by walking every component with O_NOFOLLOW.
-	f, err := secureOpenBeneath(baseDir, filePath, unix.O_RDONLY, 0)
+	// SecureOpenBeneath closes that gap by walking every component with O_NOFOLLOW.
+	f, err := SecureOpenBeneath(baseDir, filePath, unix.O_RDONLY, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func SafeReadFile(baseDir, filePath string) ([]byte, error) {
 // inside baseDir, returning the validated absolute-ish clean path.
 //
 // The returned path is for error messages and logging only — callers that open the
-// file MUST do so via secureOpenBeneath, not by re-opening this returned string, for
+// file MUST do so via SecureOpenBeneath, not by re-opening this returned string, for
 // the same TOCTOU reason documented on isPathInsideBase.
 func resolveInside(baseDir, path string) (string, error) {
 	cleanPath := filepath.Clean(filepath.Join(baseDir, path))
@@ -130,7 +130,7 @@ func resolveInside(baseDir, path string) (string, error) {
 // anything absolute, empty, or containing a ".." component that could escape baseDir.
 // This is a lexical check only — it never touches the filesystem. The actual
 // containment guarantee against symlinks (including ones racily planted at an
-// intermediate component) comes from secureOpenBeneath's per-component O_NOFOLLOW
+// intermediate component) comes from SecureOpenBeneath's per-component O_NOFOLLOW
 // walk below, not from this function.
 func safeRelComponents(relPath string) ([]string, error) {
 	if filepath.IsAbs(relPath) {
@@ -149,9 +149,23 @@ func safeRelComponents(relPath string) ([]string, error) {
 	return parts, nil
 }
 
-// secureOpenBeneath opens (and, per flags, creates/truncates) the file at
+// SecureOpenBeneath opens (and, per flags, creates/truncates/appends) the file at
 // baseDir/relPath, refusing to follow a symlink at ANY path component — not just the
-// final one.
+// final one — with the actual open mode left to the caller.
+//
+// This is the shared WALK primitive underlying every write helper in this file
+// (SecureWriteFile/SecureWriteFileSync use flags without O_EXCL; SecureCreateFile/
+// SecureCreateFileSync/SecureCreateFileHandle add O_EXCL) — exported directly so a
+// caller whose open-mode needs don't match either preset (a streaming writer that
+// legitimately overwrites the same path on every run, an append-only log, an edit of a
+// file that must already exist) still gets the full per-component symlink-safety walk
+// instead of falling back to a plain os.OpenFile with only a final-component O_NOFOLLOW.
+// internal/cli/secret/fix.go's applyFix/.env-append and internal/cli/encryption/
+// migrate_provider.go's copyFile were originally downgraded to final-component-only
+// protection specifically because O_EXCL didn't fit their semantics — conflating "which
+// open flags" with "how much of the path gets walked safely" when the two are actually
+// independent axes; all three now call this function directly with whatever flags fit
+// them, rather than falling back to a weaker one-off.
 //
 // It walks relPath component-by-component using openat(2) (via golang.org/x/sys/unix)
 // relative to the file descriptor of the directory opened for the PREVIOUS component,
@@ -179,7 +193,11 @@ func safeRelComponents(relPath string) ([]string, error) {
 // It does not create missing intermediate directories (matching the pre-existing
 // contract of SecureWriteFile/SecureWriteFileSync — callers create parent directories
 // themselves); a missing intermediate component is simply an open error.
-func secureOpenBeneath(baseDir, relPath string, flags int, perm os.FileMode) (*os.File, error) {
+//
+// Callers passing flags that include O_CREAT but not O_EXCL (e.g. a repeatable
+// streaming write to a fixed path) still get the full walk but NOT the create-only
+// guarantee — that tradeoff is the caller's to make explicitly, not a silent default.
+func SecureOpenBeneath(baseDir, relPath string, flags int, perm os.FileMode) (*os.File, error) {
 	parts, err := safeRelComponents(relPath)
 	if err != nil {
 		return nil, err
@@ -225,15 +243,15 @@ func secureOpenBeneath(baseDir, relPath string, flags int, perm os.FileMode) (*o
 func SecureWriteFile(baseDir, path string, data []byte, perm os.FileMode) error {
 	// resolveInside is a cheap pre-check that fails fast on an obviously-escaping path
 	// (e.g. "../x") with a clear "access denied" error; the actual open — including the
-	// symlink-safety guarantee — is performed by secureOpenBeneath below. See both
+	// symlink-safety guarantee — is performed by SecureOpenBeneath below. See both
 	// functions' doc comments for why the pre-check alone is not sufficient.
 	if _, err := resolveInside(baseDir, path); err != nil {
 		return err
 	}
-	// secureOpenBeneath refuses to traverse OR write THROUGH a symlink at any path
+	// SecureOpenBeneath refuses to traverse OR write THROUGH a symlink at any path
 	// component, not just the final one (see its doc comment for the TOCTOU this
 	// closes that a bare O_NOFOLLOW on the final open would miss).
-	f, err := secureOpenBeneath(baseDir, path, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC, perm) // #nosec G304 -- path validated inside baseDir by resolveInside + secureOpenBeneath's per-component O_NOFOLLOW walk
+	f, err := SecureOpenBeneath(baseDir, path, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC, perm) // #nosec G304 -- path validated inside baseDir by resolveInside + SecureOpenBeneath's per-component O_NOFOLLOW walk
 	if err != nil {
 		return err
 	}
@@ -259,11 +277,11 @@ func SecureWriteFile(baseDir, path string, data []byte, perm os.FileMode) error 
 func SecureWriteFileSync(baseDir, path string, data []byte, perm os.FileMode) error {
 	// See SecureWriteFile above: resolveInside is a fast lexical pre-check only; the
 	// actual symlink-safe open (including intermediate path components, not just the
-	// final one) is performed by secureOpenBeneath.
+	// final one) is performed by SecureOpenBeneath.
 	if _, err := resolveInside(baseDir, path); err != nil {
 		return err
 	}
-	f, err := secureOpenBeneath(baseDir, path, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC, perm) // #nosec G304 -- path validated inside baseDir by resolveInside + secureOpenBeneath's per-component O_NOFOLLOW walk
+	f, err := SecureOpenBeneath(baseDir, path, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC, perm) // #nosec G304 -- path validated inside baseDir by resolveInside + SecureOpenBeneath's per-component O_NOFOLLOW walk
 	if err != nil {
 		return err
 	}
@@ -285,7 +303,7 @@ func SecureWriteFileSync(baseDir, path string, data []byte, perm os.FileMode) er
 
 // SecureCreateFile writes data to a NEW file at filepath.Join(baseDir, path),
 // combining the two strongest write protections found independently elsewhere in this
-// codebase into one: secureOpenBeneath's per-path-component O_NOFOLLOW walk (this
+// codebase into one: SecureOpenBeneath's per-path-component O_NOFOLLOW walk (this
 // package's existing SecureWriteFile/SecureWriteFileSync), plus O_EXCL (previously only
 // in internal/cli/secret/export.go's createSecureOutputFile). O_EXCL makes the create
 // atomic and refuses to write through — or truncate/overwrite — any pre-existing path,
@@ -340,7 +358,7 @@ func SecureCreateFileHandle(baseDir, path string, perm os.FileMode) (*os.File, e
 
 // secureCreateOpenBeneath is the shared implementation behind SecureCreateFile,
 // SecureCreateFileSync, and SecureCreateFileHandle: resolveInside's fast lexical
-// pre-check, then secureOpenBeneath's per-component O_NOFOLLOW walk with O_EXCL added so
+// pre-check, then SecureOpenBeneath's per-component O_NOFOLLOW walk with O_EXCL added so
 // the leaf open refuses a pre-existing path (regular file OR symlink) instead of
 // silently truncating/following it. The explicit Chmod guards against a restrictive
 // umask masking the requested perm at creation time (O_CREAT's mode argument is
@@ -349,7 +367,7 @@ func secureCreateOpenBeneath(baseDir, path string, perm os.FileMode) (*os.File, 
 	if _, err := resolveInside(baseDir, path); err != nil {
 		return nil, err
 	}
-	f, err := secureOpenBeneath(baseDir, path, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL, perm) // #nosec G304 -- path validated inside baseDir by resolveInside + secureOpenBeneath's per-component O_NOFOLLOW walk; O_EXCL refuses a pre-existing path
+	f, err := SecureOpenBeneath(baseDir, path, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL, perm) // #nosec G304 -- path validated inside baseDir by resolveInside + SecureOpenBeneath's per-component O_NOFOLLOW walk; O_EXCL refuses a pre-existing path
 	if err != nil {
 		return nil, err
 	}

--- a/internal/securefiles/securefiles_intermediate_symlink_toctou_test.go
+++ b/internal/securefiles/securefiles_intermediate_symlink_toctou_test.go
@@ -34,7 +34,7 @@ import (
 // reproduces the escape: when the writer's OpenFile call lands while "tenant" is
 // symlinked, O_NOFOLLOW only guards "secret.bin" and the open follows "tenant" straight
 // into the outside directory, creating secret.bin there. Against the fix
-// (secureOpenBeneath's per-component O_NOFOLLOW walk via openat), every attempt to
+// (SecureOpenBeneath's per-component O_NOFOLLOW walk via openat), every attempt to
 // traverse "tenant" while it is a symlink is refused outright (ELOOP), so the outside
 // directory must remain empty for the whole test.
 func TestSecureWriteFileSync_TOCTOUIntermediateComponentSymlinkNeverFollowed(t *testing.T) {

--- a/internal/securefiles/securefiles_secureopenbeneath_test.go
+++ b/internal/securefiles/securefiles_secureopenbeneath_test.go
@@ -11,10 +11,10 @@ import (
 
 // TestSecureOpenBeneath_RefusesIntermediateSymlink_Direct is a deterministic (non-race)
 // companion to the TOCTOU race tests in securefiles_intermediate_symlink_toctou_test.go:
-// it plants the intermediate-component symlink BEFORE calling secureOpenBeneath at all
+// it plants the intermediate-component symlink BEFORE calling SecureOpenBeneath at all
 // (no timing dependency), pinning the baseline guarantee that the per-component walk
 // refuses to traverse a symlinked directory component outright, independent of any race
-// window. This exercises secureOpenBeneath directly, so it only compiles against the
+// window. This exercises SecureOpenBeneath directly, so it only compiles against the
 // fixed implementation (the pre-fix codebase has no such function) — the race tests are
 // the ones that demonstrate the actual pre-fix vulnerability via the public API.
 func TestSecureOpenBeneath_RefusesIntermediateSymlink_Direct(t *testing.T) {
@@ -22,7 +22,7 @@ func TestSecureOpenBeneath_RefusesIntermediateSymlink_Direct(t *testing.T) {
 	outside := t.TempDir()
 	require.NoError(t, os.Symlink(outside, filepath.Join(base, "tenant")))
 
-	f, err := secureOpenBeneath(base, filepath.Join("tenant", "secret.bin"), 0, 0)
+	f, err := SecureOpenBeneath(base, filepath.Join("tenant", "secret.bin"), 0, 0)
 	require.Error(t, err, "an intermediate path component that is a symlink must be refused")
 	if f != nil {
 		_ = f.Close()


### PR DESCRIPTION
## Summary

Follow-up to #1761 (safe file writes), addressing 4 review points raised before that PR merged (it merged in the meantime, so this is a separate PR against `main` rather than an amendment):

1. **Resolved the O_EXCL inconsistency between `bundle.go` and compliance export.** Both are legitimately re-run to a fixed path, but #1761 gave compliance export a hard O_EXCL refusal with no override while `bundle.go` kept its unprotected always-overwrite default — same reasoning, two different answers. Compliance `export`/`controls`/`inventory`/`permission-baseline` now default to the same safe refusal, with an explicit `--force` flag (mirroring `trust-keygen`'s existing `--force`) to opt into overwrite for a scheduled/CI evidence run reusing a fixed `--output` path.

2. **Split the per-path-component O_NOFOLLOW walk from O_EXCL create semantics.** `internal/securefiles.secureOpenBeneath` is now exported as `SecureOpenBeneath`, taking caller-supplied open flags directly, separate from the O_EXCL-only `SecureCreateFile` family. All four sites #1761 deferred specifically because O_EXCL didn't fit their semantics were re-examined against this new axis — all four fit it:
   - `bundle.go`'s `--out` write gets the safe walk with a streaming handle (`O_TRUNC`, no `O_EXCL` — CI rebuilds to the same path by design).
   - `migrate_provider.go`'s `copyFile` gets the safe walk with its existing overwrite semantics (now also using `SafeReadFile` for the source read).
   - `secret/fix.go`'s `applyFix` and its `.env` append both get the full walk instead of the final-component-only `O_NOFOLLOW` they had.
   
   None needed a new streaming/non-exclusive primitive — `SecureOpenBeneath` already covers this once exported. The write-guard's allowlist removes all four now-fixed entries, with a header note so a future deferral citing "needs a streaming/non-exclusive write" gets checked against `SecureOpenBeneath` first.

3. **Audited every `--force`/`--overwrite` flag in the CLI** for the same "does force relax exactly the overwrite refusal, not the symlink protection" property. `trust-keygen`'s `--force` was already correct (switches to `SecureWriteFileSync` — walk intact, `O_EXCL` dropped). The two new compliance `--force` flags follow the identical pattern. Every other `--force`/`--overwrite` flag in the CLI (`auth_encryption`, `machine/token`, `group`/`user`/`secret` delete, `campaign`) gates a business-logic precondition or a confirmation prompt, not a file write — none touch `securefiles`/`os.Create` paths at all.

4. The "streaming non-exclusive safe write" #1761 said would need a new primitive is superseded by (2) — recorded in the write-guard's allowlist header as done, not left as an open TODO.

New regression tests: `--force` overwrite behavior for all 3 compliance commands (paired with the existing refuse-by-default tests, unchanged, to prove `--force` is additive).

## Test plan
- [x] `go build ./...` clean
- [x] `go vet` clean on all touched packages
- [x] `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated` — 0 issues
- [x] Full test suites green: `internal/securefiles`, `internal/cli/{bundle,secret,encryption,compliance,writeguard,rbac,trust}`