### PR TITLE
fix(dynamic): close redaction bypasses for slash-bearing and scheme-less DSNs

### DIFF
--- a/internal/dynamic/redact.go
+++ b/internal/dynamic/redact.go
@@ -11,10 +11,30 @@ const redactedPlaceholder = "***REDACTED***"
 
 // dsnUserinfoPattern matches the userinfo component of a URL-style connection
 // string -- scheme://user:password@host... -- as produced by postgres://,
-// mysql://, mongodb://, redis://, rediss:// DSNs. It intentionally matches
-// greedily up to the LAST '@' before the next '/' so a password containing an
-// unescaped '@' doesn't leave a residual fragment.
-var dsnUserinfoPattern = regexp.MustCompile(`://[^\s/]*@`)
+// mysql://, mongodb://, redis://, rediss:// DSNs. It matches greedily up to
+// the LAST '@' before the next whitespace so a password containing an
+// unescaped '@' -- or, critically, an unescaped '/' -- doesn't leave a
+// residual fragment or bypass the match entirely. An earlier version excluded
+// '/' from the userinfo character class, which meant ANY password containing
+// a literal '/' (plausible for a base64-shaped generated credential) was left
+// completely unredacted rather than partially redacted -- found and fixed
+// after adversarial verification reproduced it against a real
+// postgres://user:base64pass/w+xyz==@host DSN.
+var dsnUserinfoPattern = regexp.MustCompile(`://[^\s]*@`)
+
+// bareUserinfoPattern matches a "user:password@" credential fragment with NO
+// scheme prefix -- go-sql-driver/mysql's native DSN format
+// ("user:pass@tcp(host:3306)/db", from mysql.Config.FormatDSN/ParseDSN) never
+// has a "://" scheme at all, so dsnUserinfoPattern alone never matches it; the
+// same bare shape also appears in generic dial/DNS error text
+// ("dial tcp: lookup admin:hunter2@db.internal"). Runs after
+// dsnUserinfoPattern, which has already consumed and replaced every
+// scheme-prefixed occurrence (leaving redactedPlaceholder behind, which
+// contains no ':' and so cannot be re-matched here). The username half
+// excludes ':', '@', and '/' (real DSN usernames don't contain these); the
+// password half only excludes '@' and whitespace, so it -- like
+// dsnUserinfoPattern's userinfo -- can contain '/' and still match correctly.
+var bareUserinfoPattern = regexp.MustCompile(`[^\s:@/]+:[^\s@]+@`)
 
 // kvCredentialPattern matches key=value pairs whose key names a credential
 // field, case-insensitively, in the ODBC/connection-string style
@@ -33,6 +53,7 @@ var kvCredentialPattern = regexp.MustCompile(`(?i)\b(password|pwd|passwd|secret|
 // dynamic-secret backend too.
 func RedactSensitive(s string) string {
 	s = dsnUserinfoPattern.ReplaceAllString(s, "://"+redactedPlaceholder+"@")
+	s = bareUserinfoPattern.ReplaceAllString(s, redactedPlaceholder+"@")
 	s = kvCredentialPattern.ReplaceAllStringFunc(s, func(m string) string {
 		if idx := strings.IndexByte(m, '='); idx >= 0 {
 			return m[:idx+1] + redactedPlaceholder

--- a/internal/dynamic/redact_test.go
+++ b/internal/dynamic/redact_test.go
@@ -53,6 +53,59 @@ func TestRedactSensitive_KeyValueCredentials(t *testing.T) {
 	}
 }
 
+// TestRedactSensitive_ClosesAdversarialVerificationGaps regression-tests the three
+// concrete bypasses found during adversarial verification of this file's initial
+// version: a password containing an unescaped '/' left the ENTIRE userinfo segment
+// unredacted (not partially redacted -- the pattern didn't match at all), the native
+// go-sql-driver/mysql DSN shape (no "://" scheme) was never matched at all, and a bare
+// "user:pass@host" fragment in generic dial/DNS error text was likewise unmatched.
+func TestRedactSensitive_ClosesAdversarialVerificationGaps(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		secrets []string
+	}{
+		{
+			name:    "password containing a slash",
+			input:   `dial postgres://user:ab/cd@host:5432/db: connection refused`,
+			secrets: []string{"ab/cd"},
+		},
+		{
+			name:    "password containing base64-shaped slash",
+			input:   `failed: postgres://admin:base64pass/w+xyz==@10.0.0.9:5432/app`,
+			secrets: []string{"base64pass/w+xyz=="},
+		},
+		{
+			name:    "native go-sql-driver/mysql DSN, no scheme",
+			input:   `dial error: user:pass@tcp(host:3306)/db: i/o timeout`,
+			secrets: []string{"user:pass"},
+		},
+		{
+			name:    "bare user:pass@host with no scheme at all",
+			input:   `dial tcp: lookup admin:hunter2@db.internal: no such host`,
+			secrets: []string{"admin:hunter2", "hunter2"},
+		},
+		{
+			name:    "bare redis-style credential, no scheme",
+			input:   `connect failed: default:topsecret@cache.example.com:6380 refused`,
+			secrets: []string{"topsecret"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RedactSensitive(tc.input)
+			for _, secret := range tc.secrets {
+				if strings.Contains(got, secret) {
+					t.Fatalf("RedactSensitive(%q) = %q, still contains credential fragment %q", tc.input, got, secret)
+				}
+			}
+			if !strings.Contains(got, redactedPlaceholder) {
+				t.Fatalf("RedactSensitive(%q) = %q, expected redaction placeholder", tc.input, got)
+			}
+		})
+	}
+}
+
 func TestRedactSensitive_PreservesNonSensitiveText(t *testing.T) {
 	input := "connection refused: SQLSTATE 08006, no pg_hba.conf entry for host"
 	got := RedactSensitive(input)


### PR DESCRIPTION
## Summary

Adversarial verification of #1766 (already merged) found the `RedactSensitive` regex used for sanitizing dynamic-secret backend errors before logging had real, exploitable bypasses — not just theoretical edge cases:

1. **Password containing `/` → zero redaction.** `dsnUserinfoPattern` excluded `/` from the userinfo character class (`://[^\s/]*@`), so a password containing a literal `/` broke the match entirely — the whole credential passed through **completely unredacted**, not partially masked. Reproduced against `postgres://admin:base64pass/w+xyz==@host` — a realistic shape, since this codebase's own generated dynamic-secret credentials can be base64-derived and commonly contain `/`. Fixed by dropping the `/` exclusion, which restores the doc comment's own already-stated design intent (match greedily up to the *last* `@` before whitespace).

2. **Scheme-less DSN shapes were never matched at all.** The pattern hard-required a `://` prefix, so go-sql-driver/mysql's **native DSN format** (`user:pass@tcp(host:3306)/db`, produced by `mysql.Config.FormatDSN`/`ParseDSN` — the actual driver #1766's own commit message names as covered) passed through completely unredacted, as did a bare `user:pass@host` fragment in generic dial/DNS error text. Added `bareUserinfoPattern`, a second, scheme-optional pass run after the scheme-prefixed one (safe to chain: the redaction placeholder contains no `:`, so it can't be re-matched as a fresh "username").

Both gaps were confirmed genuinely red against the pre-fix regex (temporarily restored the pre-fix file via `git checkout origin/main -- internal/dynamic/redact.go`, watched the new tests fail) before being fixed, then green after restoring the fix.

## Test plan
- [x] `go build`, `go test ./internal/dynamic/...` clean
- [x] `gofmt -l` clean
- [x] `gosec -severity medium -exclude-generated` — 0 issues
- [x] Existing log-redaction and rotation-failure-allowlist guard tests still pass (no regression)
- [x] New regression tests cover all confirmed bypass shapes, verified red→green