### PR TITLE
docs: redirect stale keyorix-ping references to status, document trust-keygen gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,15 @@ All notable changes to Keyorix are documented here. This project follows
   tag when nothing enforced that. See ADR-070 for the full rationale and the
   CI/CD consolidation decisions (CodeQL, Sonar, SBOM, dependency review).
 
+### Removed
+- **`keyorix ping`** — removed as dead code: it was never registered as a
+  runnable subcommand (only `keyorix status` was wired into the root command),
+  so invoking `keyorix ping` has always produced "unknown command," regardless
+  of this change. `keyorix status` already covers the same connectivity/
+  response-time check, with a real exit-code contract (`0` healthy, `1`
+  unhealthy/unreachable, `2` not configured) `ping` never had. Documentation
+  that referenced `keyorix ping` has been updated to point to `status`.
+
 ### Added
 - **FinOps billing report** — `GET /api/v1/admin/billing/report?from=&to=[&project_id=]`
   and `keyorix billing report --from --to [--project-id] [--format table|json]`.

--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -50,11 +50,9 @@ This will prompt for your API key and store it securely.
 keyorix status
 ```
 
-Or test connectivity:
-
-```bash
-keyorix ping
-```
+`status` exits `0` when healthy, `1` when the configured target is unreachable
+or unhealthy, and `2` if nothing is configured — safe to script against
+(`keyorix status && deploy`) without parsing its printed output.
 
 ## Configuration Options
 
@@ -149,8 +147,8 @@ storage:
 
 ### Status Commands
 
-- `keyorix status` - Check system health and connection
-- `keyorix ping` - Test remote server connectivity
+- `keyorix status` - Check system health and connection (exits non-zero on
+  unhealthy/unreachable/unconfigured, so it's safe to script against)
 
 ### Audit Commands
 
@@ -431,7 +429,7 @@ keyorix auth login
 
 1. **Check network connectivity:**
    ```bash
-   keyorix ping
+   keyorix status
    ```
 
 2. **Verify server URL:**

--- a/docs/REMOTE_CLI_TROUBLESHOOTING.md
+++ b/docs/REMOTE_CLI_TROUBLESHOOTING.md
@@ -7,11 +7,9 @@ This guide helps you diagnose and resolve common issues when using the Keyorix C
 Run these commands to quickly diagnose issues:
 
 ```bash
-# Check overall system status
+# Check overall system status (also tests remote connectivity; exits non-zero
+# on unhealthy/unreachable/unconfigured, so it's safe to script against)
 keyorix status
-
-# Test remote connectivity
-keyorix ping
 
 # Check configuration
 keyorix config status
@@ -106,10 +104,10 @@ keyorix auth status
        timeout_seconds: 60  # Increase from default 30
    ```
 
-2. **Test with ping:**
+2. **Check response time:**
    ```bash
-   keyorix ping
-   # Check response times
+   keyorix status
+   # Prints "Response Time: <duration>" for the last health check
    ```
 
 3. **Check server performance:**
@@ -242,9 +240,9 @@ keyorix auth status
 
 **Diagnostics:**
 
-1. **Measure response times:**
+1. **Measure response time:**
    ```bash
-   keyorix ping
+   keyorix status
    ```
 
 2. **Check network latency:**
@@ -404,7 +402,7 @@ keyorix --version
 keyorix config status
 
 # Connection test
-keyorix ping
+keyorix status
 
 # Error messages (run failing command with debug)
 KEYORIX_DEBUG=true keyorix your-failing-command

--- a/internal/keyfiles/registry.go
+++ b/internal/keyfiles/registry.go
@@ -119,6 +119,20 @@ func resolve(baseDir, path string) string {
 //     and already self-protected at write time (copyFile always chmods to
 //     0600 even when reusing an existing destination, internal/cli/
 //     encryption/migrate_provider.go).
+//   - `trust-keygen`'s ed25519 signing keypair (internal/cli/trust/trust.go,
+//     ADR-062) -- the offline key that signs update bundles and licenses.
+//     Not config-driven: no *config.EncryptionConfig field names its path
+//     (it's a CLI `--dir`/`--key-id` argument, often on a separate, offline
+//     signing workstation this registry's baseDir has no reach into anyway),
+//     so there is no mechanical way for a config-shape-driven enumeration to
+//     include it. It IS written at 0600 via SecureWriteFileSync at creation
+//     time -- but unlike the "file" provider above, there is no ongoing
+//     self-check anywhere in this codebase: if its permissions drift later
+//     (a backup tool, a manual copy, an operator `chmod`), nothing would ever
+//     catch it. This is a real, currently-untracked residual gap, not one
+//     this registry's design can close -- worth a dedicated follow-up (a
+//     permission self-check callable at signing time, or in `trust-keygen`
+//     itself), not silently accepted as equivalent to the exclusions above.
 func Registry(enc *config.EncryptionConfig, baseDir string) ([]securefiles.FilePermSpec, error) {
 	if enc == nil {
 		return nil, nil


### PR DESCRIPTION
## Summary

Two small, non-security consistency fixes, no code behavior changed.

**1. Stale `keyorix ping` docs.** `keyorix ping` was removed as dead code by #1764 — it was never registered as a runnable subcommand (only `status` was wired into the root command), so invoking it has always produced "unknown command," independent of that PR's merge. `docs/REMOTE_CLI_SETUP.md` and `docs/REMOTE_CLI_TROUBLESHOOTING.md` still instructed operators to run it, in the troubleshooting doc's case precisely when something is already wrong.

- Swept the whole repo for `keyorix ping` (docs, README, scripts, Go source) rather than just the two files, per the enumerate-by-shape convention — no other occurrences found outside historical CHANGELOG entries describing *past* status/ping behavior changes, left as-is (append-only record, not living documentation).
- Confirmed `keyorix status` already covers `ping`'s use case (connectivity check + response-time reporting) with a real exit-code contract `ping` never had (`0` healthy, `1` unhealthy/unreachable, `2` not configured) — every instruction is redirected to `status`, not deleted outright.
- Added a `### Removed` CHANGELOG entry for the dead-code removal itself.

**2. `internal/keyfiles/registry.go` doc gap.** #1762's commit message claimed the reasoning for excluding `trust-keygen`'s signing keypair from the key-permission registry "lives in registry.go's doc comment" — it didn't. Added it, including the honest residual gap: unlike the `file` provider (which self-checks at read time), there is no ongoing permission check on `trust-keygen`'s output anywhere in the codebase, so a later permission drift would go uncaught. Recorded as a real follow-up, not glossed over as equivalent to the other, already-closed exclusions in that list.

## Test plan
- [x] `go build`, `go test ./internal/keyfiles/...` clean
- [x] `gofmt -l` clean
- [x] Docs-only + doc-comment-only changes — no code paths touched, no new tests needed