### PR TITLE
fix(security): gate sharing read paths on live project membership (RBAC-001)

### DIFF
--- a/internal/core/core_s24_test.go
+++ b/internal/core/core_s24_test.go
@@ -642,12 +642,35 @@ func TestListSecretSharesWithPermissionCheck_NotOwner(t *testing.T) {
 
 func TestListSecretSharesWithPermissionCheck_OwnerSuccess(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("GetSecret", mock.Anything, uint(1)).Return(&models.SecretNode{ID: 1, OwnerID: 7}, nil)
+	ms.On("GetSecret", mock.Anything, uint(1)).Return(&models.SecretNode{ID: 1, OwnerID: 7, ProjectID: 5}, nil)
+	ms.On("IsProjectMember", mock.Anything, uint(7), uint(5)).Return(true, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{{ID: 3, SecretID: 1}}, nil)
 	c := NewKeyorixCore(ms)
 	got, err := c.ListSecretSharesWithPermissionCheck(context.Background(), 1, 7)
 	require.NoError(t, err)
 	assert.Len(t, got, 1)
+}
+
+// TestListSecretSharesWithPermissionCheck_DepartedOwnerDenied is the RBAC-001
+// regression test: a departed owner (removed from the secret's project, but the
+// secret row's OwnerID tag is untouched until ClearProjectSecretOwnership runs)
+// must not be able to enumerate the secret's share/recipient list, matching
+// ShareSecret/UpdateSharePermission/RevokeShare (sharing_test.go) and
+// ShareSecretWithGroup (group_sharing_test.go). Pre-fix, the bare secretOwnedBy
+// check let a departed owner through since OwnerID still matched — this test
+// fails against that old code (confirmed red before the requireLiveOwnerAuthority
+// swap) and passes now that IsProjectMember is consulted.
+func TestListSecretSharesWithPermissionCheck_DepartedOwnerDenied(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetSecret", mock.Anything, uint(1)).Return(&models.SecretNode{ID: 1, OwnerID: 7, ProjectID: 5}, nil)
+	// The owner still carries OwnerID 7 on the secret row, but no longer holds a
+	// live role grant in the secret's project.
+	ms.On("IsProjectMember", mock.Anything, uint(7), uint(5)).Return(false, nil)
+	c := NewKeyorixCore(ms)
+	_, err := c.ListSecretSharesWithPermissionCheck(context.Background(), 1, 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not authorized")
+	ms.AssertNotCalled(t, "ListSharesBySecret", mock.Anything, mock.Anything)
 }
 
 // ── sharing_query.go — CheckSharePermission ───────────────────────────────────

--- a/internal/core/core_s25_test.go
+++ b/internal/core/core_s25_test.go
@@ -733,13 +733,36 @@ func TestGetSecretSharingStatusWithIndicators_SharesError(t *testing.T) {
 
 func TestGetSecretSharingStatusWithIndicators_OwnerNoShares(t *testing.T) {
 	ms := new(MockStorage)
-	ms.On("GetSecret", mock.Anything, uint(1)).Return(&models.SecretNode{ID: 1, OwnerID: 7}, nil)
+	ms.On("GetSecret", mock.Anything, uint(1)).Return(&models.SecretNode{ID: 1, OwnerID: 7, ProjectID: 5}, nil)
 	ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
+	ms.On("IsProjectMember", mock.Anything, uint(7), uint(5)).Return(true, nil)
 	c := NewKeyorixCore(ms)
 	status, err := c.GetSecretSharingStatusWithIndicators(context.Background(), 1, 7)
 	require.NoError(t, err)
 	assert.True(t, status.IsOwner)
 	assert.False(t, status.IsShared)
+}
+
+// TestGetSecretSharingStatusWithIndicators_DepartedOwnerDenied is the RBAC-001
+// regression test: a departed owner (removed from the secret's project, but the
+// secret row's OwnerID tag is untouched until ClearProjectSecretOwnership runs)
+// must not see owner-only sharing indicators or the recipient list, matching
+// ListSecretSharesWithPermissionCheck (core_s24_test.go) and the sharing.go/
+// group_sharing.go mutation paths. Pre-fix, the bare secretOwnedBy check let a
+// departed owner through since OwnerID still matched, and — with no active
+// share for that user either — GetSecretSharingStatusWithIndicators would have
+// returned isOwner=true instead of the "no permission" error asserted here.
+func TestGetSecretSharingStatusWithIndicators_DepartedOwnerDenied(t *testing.T) {
+	ms := new(MockStorage)
+	ms.On("GetSecret", mock.Anything, uint(1)).Return(&models.SecretNode{ID: 1, OwnerID: 7, ProjectID: 5}, nil)
+	ms.On("ListSharesBySecret", mock.Anything, uint(1)).Return([]*models.ShareRecord{}, nil)
+	// The owner still carries OwnerID 7 on the secret row, but no longer holds a
+	// live role grant in the secret's project.
+	ms.On("IsProjectMember", mock.Anything, uint(7), uint(5)).Return(false, nil)
+	c := NewKeyorixCore(ms)
+	_, err := c.GetSecretSharingStatusWithIndicators(context.Background(), 1, 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission")
 }
 
 func TestGetSecretSharingStatusWithIndicators_NonOwnerWithShare(t *testing.T) {

--- a/internal/core/secret_listing_sharing.go
+++ b/internal/core/secret_listing_sharing.go
@@ -85,7 +85,22 @@ func (c *KeyorixCore) GetSecretSharingStatusWithIndicators(ctx context.Context, 
 	// status must not count or display them — keep it consistent with enforcement.
 	shares = activeShares(shares, c.shareEffectiveNow())
 
-	isOwner := secretOwnedBy(secret.OwnerID, userID)
+	// Owner authority requires live project membership (requireLiveOwnerAuthority),
+	// matching this file's GetUserSecretPermission and sharing_query.go's
+	// ListSecretSharesWithPermissionCheck (RBAC-001): a departed owner keeps their
+	// OwnerID tag until ClearProjectSecretOwnership runs, so a bare secretOwnedBy
+	// check alone would report them as still holding owner-only sharing indicators
+	// (and the full recipient list below) forever.
+	// Owner authority requires live project membership (requireLiveOwnerAuthority),
+	// matching this file's GetUserSecretPermission and sharing_query.go's
+	// ListSecretSharesWithPermissionCheck (RBAC-001): a departed owner keeps their
+	// OwnerID tag until ClearProjectSecretOwnership runs, so a bare secretOwnedBy
+	// check alone would report them as still holding owner-only sharing indicators
+	// (and the full recipient list below) forever.
+	isOwner, err := c.requireLiveOwnerAuthority(ctx, secret, userID)
+	if err != nil {
+		return nil, err
+	}
 	userPermission := ""
 	if !isOwner {
 		for _, share := range shares {
@@ -145,7 +160,21 @@ func (c *KeyorixCore) GetUserSecretPermission(ctx context.Context, secretID, use
 		return nil, err
 	}
 
-	if secretOwnedBy(secret.OwnerID, userID) {
+	// Owner authority requires live project membership (requireLiveOwnerAuthority),
+	// matching this file's GetSecretSharingStatusWithIndicators and
+	// sharing_query.go's ListSecretSharesWithPermissionCheck (RBAC-001): a departed
+	// owner keeps their OwnerID tag until ClearProjectSecretOwnership runs, so a bare
+	// secretOwnedBy check alone would report them as still holding "owner" permission.
+	// Owner authority requires live project membership (requireLiveOwnerAuthority),
+	// matching this file's GetSecretSharingStatusWithIndicators and
+	// sharing_query.go's ListSecretSharesWithPermissionCheck (RBAC-001): a departed
+	// owner keeps their OwnerID tag until ClearProjectSecretOwnership runs, so a bare
+	// secretOwnedBy check alone would report them as still holding "owner" permission.
+	isLiveOwner, err := c.requireLiveOwnerAuthority(ctx, secret, userID)
+	if err != nil {
+		return nil, err
+	}
+	if isLiveOwner {
 		return &models.UserSecretPermission{
 			SecretID:   secretID,
 			UserID:     userID,

--- a/internal/core/secret_listing_test.go
+++ b/internal/core/secret_listing_test.go
@@ -308,8 +308,9 @@ func TestKeyorixCore_GetUserSecretPermission(t *testing.T) {
 			secretID: 1,
 			userID:   1,
 			secret: &models.SecretNode{
-				ID:      1,
-				OwnerID: 1,
+				ID:        1,
+				OwnerID:   1,
+				ProjectID: 5,
 			},
 			expectedPerm:   "owner",
 			expectedSource: "owner",
@@ -356,7 +357,11 @@ func TestKeyorixCore_GetUserSecretPermission(t *testing.T) {
 
 			// Mock expectations
 			mockStorage.On("GetSecret", ctx, tt.secretID).Return(tt.secret, nil)
-			if tt.secret.OwnerID != tt.userID {
+			if tt.secret.OwnerID != 0 && tt.secret.OwnerID == tt.userID {
+				// requireLiveOwnerAuthority additionally checks live project
+				// membership (RBAC-001) before granting owner permission.
+				mockStorage.On("IsProjectMember", ctx, tt.userID, tt.secret.ProjectID).Return(true, nil)
+			} else {
 				mockStorage.On("ListSharesBySecret", ctx, tt.secretID).Return(tt.shares, nil)
 			}
 
@@ -379,4 +384,31 @@ func TestKeyorixCore_GetUserSecretPermission(t *testing.T) {
 			mockStorage.AssertExpectations(t)
 		})
 	}
+}
+
+// TestKeyorixCore_GetUserSecretPermission_DepartedOwnerDenied is the RBAC-001
+// regression test: a departed owner (removed from the secret's project, but the
+// secret row's OwnerID tag is untouched until ClearProjectSecretOwnership runs)
+// must not be reported as still holding "owner" permission, matching
+// ListSecretSharesWithPermissionCheck and GetSecretSharingStatusWithIndicators.
+// Pre-fix, the bare secretOwnedBy check let a departed owner through since
+// OwnerID still matched — confirmed to fail against that old code (would return
+// Permission "owner" with no error instead of the "no permission" error asserted
+// here) before the requireLiveOwnerAuthority swap.
+func TestKeyorixCore_GetUserSecretPermission_DepartedOwnerDenied(t *testing.T) {
+	mockStorage := new(MockStorage)
+	core := &KeyorixCore{storage: mockStorage, now: time.Now}
+	ctx := context.Background()
+	secret := &models.SecretNode{ID: 1, OwnerID: 1, ProjectID: 5}
+
+	mockStorage.On("GetSecret", ctx, uint(1)).Return(secret, nil)
+	// The owner still carries OwnerID 1 on the secret row, but no longer holds a
+	// live role grant in the secret's project.
+	mockStorage.On("IsProjectMember", ctx, uint(1), uint(5)).Return(false, nil)
+	mockStorage.On("ListSharesBySecret", ctx, uint(1)).Return([]*models.ShareRecord{}, nil)
+
+	perm, err := core.GetUserSecretPermission(ctx, 1, 1)
+	require.Error(t, err)
+	assert.Nil(t, perm)
+	mockStorage.AssertExpectations(t)
 }

--- a/internal/core/sharing_query.go
+++ b/internal/core/sharing_query.go
@@ -51,6 +51,12 @@ func (c *KeyorixCore) ListSecretShares(ctx context.Context, secretID uint) ([]*m
 // UpdateSharePermission/RevokeShare. Without this, any caller with secrets.read
 // could enumerate who has access to any secret. Authenticated request surfaces
 // (HTTP/gRPC) use this; the local CLI uses ListSecretShares directly.
+//
+// Owner authority is gated on live project membership (requireLiveOwnerAuthority),
+// matching the sharing.go/group_sharing.go mutation paths (RBAC-001): a user removed
+// from the secret's project keeps their OwnerID tag until ClearProjectSecretOwnership
+// runs, so a bare ownership check alone would let a departed owner keep reading the
+// secret's recipient list forever.
 func (c *KeyorixCore) ListSecretSharesWithPermissionCheck(ctx context.Context, secretID, userID uint) ([]*models.ShareRecord, error) {
 	if secretID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret ID is required")
@@ -59,7 +65,9 @@ func (c *KeyorixCore) ListSecretSharesWithPermissionCheck(ctx context.Context, s
 	if err != nil {
 		return nil, err
 	}
-	if !secretOwnedBy(secret.OwnerID, userID) {
+	if isLiveOwner, err := c.requireLiveOwnerAuthority(ctx, secret, userID); err != nil {
+		return nil, err
+	} else if !isLiveOwner {
 		return nil, fmt.Errorf("not authorized to view shares for this secret")
 	}
 	shares, err := c.storage.ListSharesBySecret(ctx, secretID)

--- a/server/http/handlers/handlers_s26_test.go
+++ b/server/http/handlers/handlers_s26_test.go
@@ -2139,6 +2139,14 @@ func TestListSecretShares_HappyPath_S26(t *testing.T) {
 	}
 	require.NoError(t, db.Create(secret).Error)
 
+	// Owner authority requires live project membership (RBAC-001,
+	// requireLiveOwnerAuthority) — the fixture's admin role grant is global
+	// (ProjectID 0), which IsProjectMember deliberately does not count as
+	// project membership, so seed a project-scoped role too.
+	var adminRole models.Role
+	require.NoError(t, db.Where("name = ?", "system_admin").First(&adminRole).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID, ProjectID: proj.ID}).Error)
+
 	req := withUserCtx(withChiParam_S25(
 		httptest.NewRequest(http.MethodGet,
 			fmt.Sprintf("/api/v1/secrets/%d/shares", secret.ID), nil),
@@ -2197,6 +2205,14 @@ func TestGetSharingStatusWithIndicators_HappyPath_S26(t *testing.T) {
 		OwnerID:   1, // matches withUserCtx UserID
 	}
 	require.NoError(t, db.Create(secret).Error)
+
+	// Owner authority requires live project membership (RBAC-001,
+	// requireLiveOwnerAuthority) — the fixture's admin role grant is global
+	// (ProjectID 0), which IsProjectMember deliberately does not count as
+	// project membership, so seed a project-scoped role too.
+	var adminRole models.Role
+	require.NoError(t, db.Where("name = ?", "system_admin").First(&adminRole).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: adminRole.ID, ProjectID: proj.ID}).Error)
 
 	req := withUserCtx(withChiParam_S25(
 		httptest.NewRequest(http.MethodGet,


### PR DESCRIPTION
## Summary

- `ListSecretSharesWithPermissionCheck` (reachable via HTTP `GET /api/v1/secrets/{id}/shares` and gRPC `ShareService.ListSecretShares`) authorized with a bare `secretOwnedBy` check. Commit 676be17e (RBAC-001) replaced this exact pattern with `requireLiveOwnerAuthority` in `ShareSecret`/`UpdateSharePermission`/`RevokeShare`/`ShareSecretWithGroup`, explicitly scoped to those four mutation paths — this read path was never touched, letting a departed project owner (whose `OwnerID` tag survives until `ClearProjectSecretOwnership`'s best-effort cleanup runs) indefinitely enumerate a secret's recipient list.
- Repo-wide sweep for the same "mutation path fixed, sibling read path left on the old check" shape found two more instances in the same file family, both fixed here: `GetSecretSharingStatusWithIndicators` (also named in the finding) and `GetUserSecretPermission` (a direct sibling, discovered during the sweep). Both were currently unreachable (no wired caller) but cheap and low-risk to fix now rather than leave the pattern for a future caller to inherit unreviewed.
- One further candidate is flagged, not fixed: `secret_ownership.go`'s `transferOwnership` has its own bare `secretOwnedBy` check, but it's a different file/package boundary never covered by 676be17e's stated scope, and its authorization model (owner OR confirmed-gone) doesn't map onto `requireLiveOwnerAuthority` as a same-shape swap — needs its own design review.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/core/...` (full package)
- [x] `go test ./server/http/handlers/...` (full package, incl. `contracttest`)
- [x] `go test ./server/grpc/services/...`
- [x] `go test ./internal/cli/share/...`
- [x] Added a departed-owner-denied regression test for each of the three fixed functions; confirmed red against the pre-fix bare-ownership check and green after the `requireLiveOwnerAuthority` swap, in an isolated worktree off `origin/main`.