### PR TITLE
fix(core): close secret-ownership read-to-owner privilege escalation

### DIFF
--- a/internal/core/secret_ownership.go
+++ b/internal/core/secret_ownership.go
@@ -2,8 +2,9 @@
 // owner is the only principal that can manage/share it (CheckSecretPermission grants
 // PermissionOwner only to the owner), so when an owner leaves the org their secrets
 // are effectively orphaned. Transfer hands ownership to another user — either by the
-// current owner, or (for recovery) by any authorized writer when the current owner is
-// gone (ownerless or a deleted account).
+// current owner, or (for recovery, gated on roles.assign) when the current owner is
+// gone (ownerless or a deleted account). The new owner must already hold write-tier
+// access. See transferOwnership's doc comment for the full authorization model.
 package core
 
 import (
@@ -35,11 +36,14 @@ type ownershipTransferDetail struct {
 
 // TransferSecretOwnership sets secretID's owner to newOwnerID. The caller (transport)
 // must have enforced scoped secrets.write. Authorization here: the actor must be the
-// current owner, OR the current owner must be gone (ownerless, or an account that no
-// longer exists) — so an active owner's secret can't be taken from under them, while a
-// departed owner's secrets can be recovered. newOwnerID must be an existing user.
-func (c *KeyorixCore) TransferSecretOwnership(ctx context.Context, secretID, newOwnerID, actorID uint) (*models.SecretNode, error) {
-	updated, err := c.transferOwnership(ctx, secretID, newOwnerID, actorID)
+// current owner, OR (with roles.assign at this scope) the current owner may be gone
+// (ownerless, or an account that no longer exists) — so an active owner's secret can't
+// be taken from under them, while a departed owner's secrets can still be recovered,
+// but only by someone with authority to grant authority. The new owner must already
+// hold write-tier access. See transferOwnership's doc comment for why (G-secret-
+// ownership-ceiling). newOwnerID must be an existing user.
+func (c *KeyorixCore) TransferSecretOwnership(ctx context.Context, secretID, newOwnerID, actorID uint, actorKind string) (*models.SecretNode, error) {
+	updated, err := c.transferOwnership(ctx, secretID, newOwnerID, actorID, actorKind)
 	if err != nil {
 		return nil, err
 	}
@@ -50,8 +54,39 @@ func (c *KeyorixCore) TransferSecretOwnership(ctx context.Context, secretID, new
 }
 
 // transferOwnership performs the validated, audited ownership change without the
-// new-owner notification — the shared primitive for single and bulk transfer.
-func (c *KeyorixCore) transferOwnership(ctx context.Context, secretID, newOwnerID, actorID uint) (*models.SecretNode, error) {
+// new-owner notification — the ONE shared, authorization-checked primitive for both
+// the single-secret path (TransferSecretOwnership) and the bulk path
+// (ReassignOwnedSecrets, secret_reassign_owner.go). Every caller of either of those
+// two routes through this function; do not add a third function that mutates
+// SecretNode.OwnerID directly — secret_ownership_guard_test.go's AST sweep fails the
+// build if one appears.
+//
+// Ownership is an AUTHORITY GRANT, not a data write: CheckSecretPermission's owner
+// branch (permissions.go) gives the owner every permission on the secret, and
+// permissionLevelToRBACPerm documents PermissionOwner as secrets.delete-equivalent —
+// "the most restrictive mutation the RBAC model expresses." Two checks follow from
+// that, matching how this codebase gates every other authority grant (roles.assign,
+// e.g. router.go's RestoreProject comment: "same blast radius as a role grant... gate
+// on roles.assign, not secrets.write") and stacked router+core double-gating
+// elsewhere:
+//
+//  1. New-owner ceiling: the new owner must already hold secrets.write (or
+//     secrets.manage) at the secret's scope, not merely secrets.read. Without this, a
+//     secrets.write-tier actor could hand full owner/delete/re-share authority to any
+//     project_viewer/project_auditor (seeded with secrets.read alone) — bypassing the
+//     roles.assign gate every other privilege grant in this codebase goes through.
+//  2. Actor ceiling on the RECOVERY path: when the current owner is gone (ownerless —
+//     the ROUTINE state for machine-created secrets per ADR-023/030, not a rare edge
+//     case — or a deleted account), re-homing the secret on their behalf is an
+//     administrative action, not a routine self-service handoff, so the actor must
+//     hold roles.assign at this scope. Without this, ANY secrets.write-tier actor
+//     could claim (or hand off) ownership of every orphaned secret in a project with
+//     no admin-tier check at all — the concrete exploit this closes. A LIVE owner
+//     handing off their own secret does not need roles.assign: they already hold
+//     owner-tier authority over this one secret, so handing it to another
+//     already-write-tier principal (check 1) is not an escalation of what they could
+//     already do with it.
+func (c *KeyorixCore) transferOwnership(ctx context.Context, secretID, newOwnerID, actorID uint, actorKind string) (*models.SecretNode, error) {
 	if secretID == 0 || newOwnerID == 0 || actorID == 0 {
 		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "secret ID, new owner ID and actor ID are required")
 	}
@@ -67,21 +102,39 @@ func (c *KeyorixCore) transferOwnership(ctx context.Context, secretID, newOwnerI
 		return nil, fmt.Errorf("%s: new owner %d not found", i18n.T("ErrorValidation", nil), newOwnerID)
 	}
 
-	// Authorize: the current owner may hand it off; otherwise it must be ownerless or
-	// owned by an account that no longer exists (recovery).
-	if !secretOwnedBy(secret.OwnerID, actorID) && !c.currentOwnerGone(ctx, secret.OwnerID) {
-		return nil, fmt.Errorf("%s: only the current owner can transfer this secret", i18n.T("ErrorPermissionDenied", nil))
+	scope := Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}
+
+	// Authorize the ACTOR. The live current owner may hand it off; otherwise this is
+	// the recovery path, gated on roles.assign (see doc comment above).
+	if !secretOwnedBy(secret.OwnerID, actorID) {
+		if !c.currentOwnerGone(ctx, secret.OwnerID) {
+			return nil, fmt.Errorf("%s: only the current owner can transfer this secret", i18n.T("ErrorPermissionDenied", nil))
+		}
+		if ok, aerr := c.AuthorizePrincipal(ctx, actorKind, actorID, permRolesAssign, scope); aerr != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), aerr)
+		} else if !ok {
+			return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
+				"recovering an orphaned or departed-owner secret requires roles.assign at this scope")
+		}
 	}
 
-	// The NEW owner must already have access to the secret's scope. Ownership grants
-	// full control (incl. re-share), so without this an authorized writer could hand a
-	// secret to a user with no role in its project — granting access out of band.
-	// Evaluate the new owner's OWN roles, not gated by the actor's PAT restriction.
-	if ok, perr := c.principalHasScopedPermission(ctx, newOwnerID, "secrets.read",
-		Scope{ProjectID: secret.ProjectID, EnvironmentID: secret.EnvironmentID}); perr != nil {
-		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), perr)
-	} else if !ok {
-		return nil, fmt.Errorf("%s: the new owner has no access to this secret's project/environment", i18n.T("ErrorPermissionDenied", nil))
+	// The NEW owner must already hold write-tier (or manage-tier) access to the
+	// secret's scope — see doc comment above (new-owner ceiling). Evaluate the new
+	// owner's OWN roles, not gated by the actor's PAT restriction.
+	hasWrite, werr := c.principalHasScopedPermission(ctx, newOwnerID, permSecretsWrite, scope)
+	if werr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), werr)
+	}
+	if !hasWrite {
+		hasManage, merr := c.principalHasScopedPermission(ctx, newOwnerID, permSecretsManage, scope)
+		if merr != nil {
+			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), merr)
+		}
+		hasWrite = hasManage
+	}
+	if !hasWrite {
+		return nil, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil),
+			"the new owner must already hold secrets.write (or secrets.manage) access to this secret's project/environment")
 	}
 
 	oldOwner := secret.OwnerID

--- a/internal/core/secret_ownership_guard_test.go
+++ b/internal/core/secret_ownership_guard_test.go
@@ -1,0 +1,168 @@
+// secret_ownership_guard_test.go — structural guard against a third, divergent
+// ownership-transfer implementation (the "variant B" mistake called out in this fix's
+// history: G10/#1413 added actor authorization to the bulk reassign path but left the
+// shared transferOwnership primitive itself unpatched — a partial fix at ONE call site
+// instead of the shared check both call sites route through). This test takes the
+// opposite structural approach: rather than trusting every future call site to
+// remember to re-derive transferOwnership's authorization rules, it parses this
+// package's own source and fails the build the moment ANY function other than
+// transferOwnership assigns directly to a SecretNode's OwnerID field.
+//
+// Modeled on internal/storage/store/g81_guard_test.go's AST-freshness sweep: parse
+// every non-test .go file in this package, walk each function body, and flag a bare
+// `<expr>.OwnerID = ...` assignment whose enclosing function isn't in the allowlist
+// below. A fully unexported-boundary refactor (making the field unreachable except
+// through one function, a compile-time guarantee) was considered and rejected: GORM
+// requires OwnerID to stay exported for column mapping, and dozens of legitimate
+// read-only call sites across this package compare secret.OwnerID directly (ownership
+// checks, filters, audit payloads) — hiding the field would require touching all of
+// them for no safety gain, since reads aren't the risk. An AST sweep on writes alone
+// is the smaller, equally load-bearing guard.
+package core
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ownerIDMutationAllowlist maps "file.go:FuncName" to why that function is allowed to
+// assign SecretNode.OwnerID directly. transferOwnership (secret_ownership.go) is the
+// ONE shared, authorization-checked primitive both TransferSecretOwnership (single) and
+// ReassignOwnedSecrets (bulk, secret_reassign_owner.go) route through — see that
+// function's doc comment for the two checks it enforces (new-owner write-tier ceiling,
+// actor roles.assign on the recovery path). A new function assigning OwnerID directly
+// anywhere else reimplements ownership transfer outside those checks; add it here only
+// with a reasoned justification for why it independently satisfies the same
+// authorization invariants — a bare grep would find a new one too, but a red CI run is
+// a much stronger backstop than "somebody remembers to grep."
+var ownerIDMutationAllowlist = map[string]string{
+	"secret_ownership.go:transferOwnership": "the one shared, authorization-checked " +
+		"ownership-transfer primitive; TransferSecretOwnership and ReassignOwnedSecrets " +
+		"both call it rather than mutating OwnerID themselves",
+}
+
+// TestNoUntrackedOwnerIDMutations is the AST freshness check described above.
+func TestNoUntrackedOwnerIDMutations(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("failed to list package directory: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(".", name)
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", path, err)
+		}
+		file, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("failed to parse %s: %v", path, err)
+		}
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			key := name + ":" + fn.Name.Name
+			_, allowed := ownerIDMutationAllowlist[key]
+
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				assign, ok := n.(*ast.AssignStmt)
+				if !ok {
+					return true
+				}
+				for i, lhs := range assign.Lhs {
+					sel, ok := lhs.(*ast.SelectorExpr)
+					if !ok || sel.Sel.Name != "OwnerID" {
+						continue
+					}
+					// storage.SecretFilter.OwnerID is a *uint (pointer) query filter field,
+					// not models.SecretNode's uint OwnerID column — a structurally distinct
+					// shape (assigned via &localVar, never a bare value) that AST alone can't
+					// tell apart from the real target by field name alone. Excluding an
+					// address-of RHS filters out that one legitimate, unrelated call shape
+					// (secret_listing_query.go's filter construction) without an allowlist
+					// entry that would otherwise read as "this function may transfer
+					// ownership," which it does not.
+					if i < len(assign.Rhs) {
+						if u, ok := assign.Rhs[i].(*ast.UnaryExpr); ok && u.Op == token.AND {
+							continue
+						}
+					}
+					if !allowed {
+						pos := fset.Position(sel.Pos())
+						t.Errorf("%s:%d: %s assigns SecretNode.OwnerID directly, outside the "+
+							"shared transferOwnership primitive (secret_ownership.go) — route "+
+							"ownership changes through core.transferOwnership instead of "+
+							"reimplementing the authorization checks, or add a justified entry "+
+							"to ownerIDMutationAllowlist in secret_ownership_guard_test.go if "+
+							"this genuinely is a new, equally-guarded primitive", pos.Filename, pos.Line, key)
+					}
+				}
+				return true
+			})
+		}
+	}
+}
+
+// TestOwnerIDMutationAllowlist_NoStaleEntries is the inverse check: every allowlist
+// entry must name a function that still exists and still assigns OwnerID, so a rename
+// or refactor doesn't leave a stale, misleadingly-permissive entry behind.
+func TestOwnerIDMutationAllowlist_NoStaleEntries(t *testing.T) {
+	fset := token.NewFileSet()
+	found := make(map[string]bool, len(ownerIDMutationAllowlist))
+
+	for key := range ownerIDMutationAllowlist {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) != 2 {
+			t.Fatalf("malformed allowlist key %q: expected \"file.go:FuncName\"", key)
+		}
+		fileName, funcName := parts[0], parts[1]
+
+		src, err := os.ReadFile(fileName)
+		if err != nil {
+			t.Errorf("allowlist entry %q: %v", key, err)
+			continue
+		}
+		file, err := parser.ParseFile(fset, fileName, src, parser.ParseComments)
+		if err != nil {
+			t.Errorf("allowlist entry %q: failed to parse %s: %v", key, fileName, err)
+			continue
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name != funcName || fn.Body == nil {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				assign, ok := n.(*ast.AssignStmt)
+				if !ok {
+					return true
+				}
+				for _, lhs := range assign.Lhs {
+					if sel, ok := lhs.(*ast.SelectorExpr); ok && sel.Sel.Name == "OwnerID" {
+						found[key] = true
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	for key := range ownerIDMutationAllowlist {
+		if !found[key] {
+			t.Errorf("allowlist entry %q no longer assigns SecretNode.OwnerID (or no longer exists) — remove the stale entry", key)
+		}
+	}
+}

--- a/internal/core/secret_ownership_history_test.go
+++ b/internal/core/secret_ownership_history_test.go
@@ -181,8 +181,10 @@ func newOwnershipHistoryFixture(t *testing.T) (*KeyorixCore, uint) {
 	} {
 		require.NoError(t, db.Create(&u).Error)
 	}
-	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "reader"}).Error)
-	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	// User 2 needs secrets.write (not merely secrets.read) to be an eligible
+	// transfer target under the write-tier ownership ceiling.
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "writer"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.write", Resource: "secrets", Action: "write"}).Error)
 	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
 	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
 	st := store.NewLocalStorage(db)
@@ -221,7 +223,7 @@ func TestGetSecretOwnershipHistory_MaliciousSecretNameCannotForgeTransferIDs(t *
 
 	// A REAL transfer now happens: user 1 (current owner) hands the secret to
 	// user 2.
-	_, err = c.TransferSecretOwnership(ctx, secretID, 2, 1)
+	_, err = c.TransferSecretOwnership(ctx, secretID, 2, 1, ActorTypeUser)
 	require.NoError(t, err)
 
 	records, err := c.GetSecretOwnershipHistory(ctx, secretID, 2)

--- a/internal/core/secret_ownership_test.go
+++ b/internal/core/secret_ownership_test.go
@@ -32,8 +32,15 @@ func (t *transientOwnerLookup) GetUser(ctx context.Context, id uint) (*models.Us
 	return t.LocalStorage.GetUser(ctx, id)
 }
 
-// newOwnershipFixture builds an in-memory core with users 1 (owner), 2, 3 and a
-// secret owned by user 1.
+// newOwnershipFixture builds an in-memory core with a secret owned by user 1, plus:
+//   - user 2 (alice): holds secrets.write at project 1 — a valid, already-privileged
+//     transfer target and a valid recovery-path actor once ALSO granted roles.assign.
+//   - user 3 (bob): holds secrets.write AND roles.assign at project 1 — a valid
+//     recovery-path actor as well as a valid transfer target.
+//   - user 4 (carol): holds no role at all — an invalid transfer target (no access).
+//   - user 5 (dave): holds ONLY secrets.read at project 1 — the exploit's target
+//     profile (project_viewer/project_auditor's exact permission shape): must be
+//     rejected as a transfer target despite having SOME access to the scope.
 func newOwnershipFixture(t *testing.T) (*KeyorixCore, uint) {
 	t.Helper()
 	require.NoError(t, i18n.InitializeForTesting())
@@ -51,16 +58,26 @@ func newOwnershipFixture(t *testing.T) (*KeyorixCore, uint) {
 		{ID: 2, Username: "alice", Email: "a@test.com"},
 		{ID: 3, Username: "bob", Email: "b@test.com"},
 		{ID: 4, Username: "carol", Email: "c@test.com"}, // no role — a transfer target with no project access
+		{ID: 5, Username: "dave", Email: "d@test.com"},  // secrets.read ONLY — the exploit's target profile
 	} {
 		require.NoError(t, db.Create(&u).Error)
 	}
-	// A reader role with secrets.read, granted to users 2 and 3 in project 1 (the
-	// secret's scope) so they're eligible to become the owner; user 4 holds nothing.
-	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "reader"}).Error)
 	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 2, Name: "secrets.write", Resource: "secrets", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 3, Name: "roles.assign", Resource: "roles", Action: "assign"}).Error)
+
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "reader"}).Error)
 	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
-	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 1, ProjectID: 1}).Error)
-	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 1, ProjectID: 1}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "writer"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 2}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 3, Name: "assigner"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 3, PermissionID: 3}).Error)
+
+	require.NoError(t, db.Create(&models.UserRole{UserID: 2, RoleID: 2, ProjectID: 1}).Error) // alice: writer
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 2, ProjectID: 1}).Error) // bob: writer
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 3, ProjectID: 1}).Error) // bob: assigner
+	require.NoError(t, db.Create(&models.UserRole{UserID: 5, RoleID: 1, ProjectID: 1}).Error) // dave: reader only
+
 	st := store.NewLocalStorage(db)
 	c := &KeyorixCore{storage: st, now: time.Now}
 	secret, err := st.CreateSecret(context.Background(), &models.SecretNode{
@@ -74,9 +91,9 @@ func newOwnershipFixture(t *testing.T) (*KeyorixCore, uint) {
 func TestTransferSecretOwnership(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("owner transfers to another user", func(t *testing.T) {
+	t.Run("owner transfers to an already-privileged user", func(t *testing.T) {
 		c, id := newOwnershipFixture(t)
-		updated, err := c.TransferSecretOwnership(ctx, id, 2, 1)
+		updated, err := c.TransferSecretOwnership(ctx, id, 2, 1, ActorTypeUser)
 		require.NoError(t, err)
 		assert.EqualValues(t, 2, updated.OwnerID)
 		// The new owner now has owner permission; the old owner does not.
@@ -88,16 +105,77 @@ func TestTransferSecretOwnership(t *testing.T) {
 
 	t.Run("non-owner cannot transfer an actively-owned secret", func(t *testing.T) {
 		c, id := newOwnershipFixture(t)
-		_, err := c.TransferSecretOwnership(ctx, id, 3, 2) // actor 2 is not the owner
+		_, err := c.TransferSecretOwnership(ctx, id, 3, 2, ActorTypeUser) // actor 2 is not the owner
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "only the current owner")
 	})
 
-	t.Run("recovery: a departed owner's secret can be transferred by anyone authorized", func(t *testing.T) {
+	t.Run("recovery: a departed owner's secret can be transferred by a roles.assign-holding actor", func(t *testing.T) {
 		c, id := newOwnershipFixture(t)
 		// Simulate the owner (user 1) leaving: delete the account.
 		require.NoError(t, c.storage.DeleteUser(ctx, 1))
-		updated, err := c.TransferSecretOwnership(ctx, id, 2, 3) // actor 3, owner gone
+		// Actor 3 (bob) holds roles.assign AND the new owner (2, alice) holds secrets.write.
+		updated, err := c.TransferSecretOwnership(ctx, id, 2, 3, ActorTypeUser)
+		require.NoError(t, err)
+		assert.EqualValues(t, 2, updated.OwnerID)
+	})
+
+	// --- Confirmed HIGH exploit regression: read→owner privilege escalation ---
+
+	t.Run("EXPLOIT CLOSED: rejects a new owner who holds only secrets.read", func(t *testing.T) {
+		c, id := newOwnershipFixture(t)
+		// User 5 (dave) has ONLY secrets.read — exactly the project_viewer/
+		// project_auditor permission shape the confirmed exploit targeted. The
+		// current owner (1) attempting to hand off ownership to a read-only
+		// colleague must be rejected: ownership grants full (delete/re-share)
+		// authority, which secrets.read alone must never reach.
+		_, err := c.TransferSecretOwnership(ctx, id, 5, 1, ActorTypeUser)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must already hold secrets.write")
+	})
+
+	t.Run("EXPLOIT CLOSED: a secrets.write-only actor cannot claim an orphaned secret without roles.assign", func(t *testing.T) {
+		c, id := newOwnershipFixture(t)
+		// Simulate the routine ADR-023/030 orphaned state directly (OwnerID==0),
+		// not merely a deleted account.
+		secret, err := c.storage.GetSecret(ctx, id)
+		require.NoError(t, err)
+		secret.OwnerID = 0
+		_, err = c.storage.UpdateSecret(ctx, secret)
+		require.NoError(t, err)
+
+		// Actor 2 (alice) holds secrets.write but NOT roles.assign, and targets a
+		// valid write-tier new owner (3, bob) — even so, the recovery path itself
+		// must be denied: re-homing an orphaned secret is an administrative action
+		// gated on roles.assign, not on secrets.write.
+		_, err = c.TransferSecretOwnership(ctx, id, 3, 2, ActorTypeUser)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "roles.assign")
+
+		// Confirm the concrete "names themselves as the new owner" variant is
+		// ALSO rejected (actor 2 tries to self-elevate to owner over the same
+		// orphaned secret).
+		_, err = c.TransferSecretOwnership(ctx, id, 2, 2, ActorTypeUser)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "roles.assign")
+	})
+
+	t.Run("recovery succeeds for a roles.assign-holding actor even with a read-only target rejected", func(t *testing.T) {
+		c, id := newOwnershipFixture(t)
+		secret, err := c.storage.GetSecret(ctx, id)
+		require.NoError(t, err)
+		secret.OwnerID = 0
+		_, err = c.storage.UpdateSecret(ctx, secret)
+		require.NoError(t, err)
+
+		// Actor 3 (bob) holds roles.assign, but targets user 5 (dave, read-only) —
+		// the actor-side gate passing must not waive the new-owner ceiling.
+		_, err = c.TransferSecretOwnership(ctx, id, 5, 3, ActorTypeUser)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must already hold secrets.write")
+
+		// The same actor targeting a write-tier user succeeds.
+		updated, err := c.TransferSecretOwnership(ctx, id, 2, 3, ActorTypeUser)
 		require.NoError(t, err)
 		assert.EqualValues(t, 2, updated.OwnerID)
 	})
@@ -105,21 +183,21 @@ func TestTransferSecretOwnership(t *testing.T) {
 	t.Run("rejects a new owner with no access to the secret's scope", func(t *testing.T) {
 		c, id := newOwnershipFixture(t)
 		// User 4 holds no role in project 1, so it must not be handed ownership.
-		_, err := c.TransferSecretOwnership(ctx, id, 4, 1)
+		_, err := c.TransferSecretOwnership(ctx, id, 4, 1, ActorTypeUser)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no access")
+		assert.Contains(t, err.Error(), "must already hold secrets.write")
 	})
 
 	t.Run("rejects a non-existent new owner", func(t *testing.T) {
 		c, id := newOwnershipFixture(t)
-		_, err := c.TransferSecretOwnership(ctx, id, 999, 1)
+		_, err := c.TransferSecretOwnership(ctx, id, 999, 1, ActorTypeUser)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "new owner")
 	})
 
 	t.Run("rejects transferring to the current owner", func(t *testing.T) {
 		c, id := newOwnershipFixture(t)
-		_, err := c.TransferSecretOwnership(ctx, id, 1, 1)
+		_, err := c.TransferSecretOwnership(ctx, id, 1, 1, ActorTypeUser)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "already owned")
 	})
@@ -130,7 +208,7 @@ func TestTransferSecretOwnership(t *testing.T) {
 		// while other users resolve normally.
 		base := c.storage.(*store.LocalStorage)
 		c.storage = &transientOwnerLookup{LocalStorage: base, failID: 1}
-		_, err := c.TransferSecretOwnership(ctx, id, 2, 3) // non-owner actor, owner "errors"
+		_, err := c.TransferSecretOwnership(ctx, id, 2, 3, ActorTypeUser) // non-owner actor, owner "errors"
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "only the current owner",
 			"a transient lookup error must be treated as owner-present (fail closed)")
@@ -145,9 +223,9 @@ func TestTransferSecretOwnership(t *testing.T) {
 
 	t.Run("validates ids", func(t *testing.T) {
 		c, id := newOwnershipFixture(t)
-		_, err := c.TransferSecretOwnership(ctx, id, 0, 1)
+		_, err := c.TransferSecretOwnership(ctx, id, 0, 1, ActorTypeUser)
 		require.Error(t, err)
-		_, err = c.TransferSecretOwnership(ctx, 0, 2, 1)
+		_, err = c.TransferSecretOwnership(ctx, 0, 2, 1, ActorTypeUser)
 		require.Error(t, err)
 	})
 }

--- a/internal/core/secret_reassign_owner.go
+++ b/internal/core/secret_reassign_owner.go
@@ -16,16 +16,30 @@ import (
 // ReassignOwnedSecrets transfers every secret in projectID currently owned by
 // fromOwnerID to toOwnerID, returning the number reassigned. Secrets whose individual
 // transfer is unauthorized or fails are skipped (best-effort, like the project-wide
-// suspend), so a partial failure does not abort the rest. The actor must satisfy the
-// per-secret transfer rule for each (it does for the offboarding case: the old owner is
-// gone). Each reassignment is audited as secret.owner_transferred.
+// suspend), so a partial failure does not abort the rest. Each reassignment goes
+// through transferOwnership (secret_ownership.go) — the same shared primitive
+// TransferSecretOwnership uses — so it is subject to the SAME authorization rules,
+// including the new-owner write-tier ceiling and the recovery-path roles.assign
+// requirement. Each reassignment is audited as secret.owner_transferred.
 //
 // #G10: this had no independent authorization of its own — for the offboarding case the
 // old owner is gone, so transferOwnership's per-secret rule ("actor is current owner, OR
 // the current owner is gone") passed for every secret with no check on the actor's own
 // relationship to the project at all, and the per-secret continue-on-error masked any
-// denial that DID occur. It now requires the actor hold secrets.write at the project's
-// scope up front, matching the HTTP router's own gate for this route.
+// denial that DID occur. It required the actor hold secrets.write at the project's
+// scope up front, matching the HTTP router's own gate for this route at the time.
+//
+// That fix addressed the ACTOR-authorization gap but left transferOwnership's own
+// new-owner ceiling (secrets.read was enough to become owner) and its unconditional
+// recovery path (any secrets.write actor, no admin-tier check) unpatched — the sibling
+// half of the same privilege-escalation bug reported against the single-secret path.
+// This function's own actor check is now roles.assign, not secrets.write: bulk
+// reassignment is ALWAYS the offboarding/recovery case (the very definition of "gone
+// owner"), so transferOwnership's per-secret roles.assign requirement on that path
+// would otherwise make every non-admin caller's per-secret calls fail and get silently
+// skipped by the continue-on-error below — exactly the "denial masked as a silent
+// no-op" failure mode #G10 already called out once. Checking it up front, loudly, here
+// too avoids repeating that.
 func (c *KeyorixCore) ReassignOwnedSecrets(ctx context.Context, actorKind string, actorID, projectID, fromOwnerID, toOwnerID uint) (int, error) {
 	if projectID == 0 || fromOwnerID == 0 || toOwnerID == 0 || actorID == 0 {
 		return 0, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "project ID, from-owner, to-owner and actor ID are required")
@@ -33,7 +47,7 @@ func (c *KeyorixCore) ReassignOwnedSecrets(ctx context.Context, actorKind string
 	if fromOwnerID == toOwnerID {
 		return 0, fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "from-owner and to-owner must differ")
 	}
-	if allowed, err := c.AuthorizePrincipal(ctx, actorKind, actorID, permSecretsWrite, Scope{ProjectID: projectID}); err != nil {
+	if allowed, err := c.AuthorizePrincipal(ctx, actorKind, actorID, permRolesAssign, Scope{ProjectID: projectID}); err != nil {
 		return 0, fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)
 	} else if !allowed {
 		return 0, fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "not authorized to reassign secrets in this project")
@@ -54,7 +68,7 @@ func (c *KeyorixCore) ReassignOwnedSecrets(ctx context.Context, actorKind string
 			continue
 		}
 		// Use the primitive (no per-secret notification) — one summary is sent below.
-		if _, err := c.transferOwnership(ctx, s.ID, toOwnerID, actorID); err != nil {
+		if _, err := c.transferOwnership(ctx, s.ID, toOwnerID, actorID, actorKind); err != nil {
 			continue // skip per-secret failures; keep going
 		}
 		reassigned++

--- a/internal/core/secret_reassign_owner_test.go
+++ b/internal/core/secret_reassign_owner_test.go
@@ -26,10 +26,13 @@ func TestReassignOwnedSecrets(t *testing.T) {
 	c := &KeyorixCore{storage: store.NewLocalStorage(db), now: time.Now}
 	ctx := context.Background()
 
-	// admin (actor), leaver (departing owner), heir (new owner), bystander.
+	// admin (actor), leaver (departing owner), heir (new owner), reader-only (invalid
+	// new-owner target — the exploit's target profile).
 	require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin", Email: "a@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 2, Username: "leaver", Email: "l@t.com"}).Error)
 	require.NoError(t, db.Create(&models.User{ID: 3, Username: "heir", Email: "h@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 4, Username: "writeronly", Email: "w@t.com"}).Error)
+	require.NoError(t, db.Create(&models.User{ID: 5, Username: "readeronly", Email: "r@t.com"}).Error)
 
 	p1, err := c.storage.CreateProject(ctx, &models.Project{Name: "p1"})
 	require.NoError(t, err)
@@ -40,17 +43,32 @@ func TestReassignOwnedSecrets(t *testing.T) {
 	e2, err := c.storage.CreateEnvironment(ctx, &models.Environment{Name: "production", ProjectID: p2.ID})
 	require.NoError(t, err)
 
-	// The heir must have access to the secrets' scope to become their owner.
-	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "reader"}).Error)
 	require.NoError(t, db.Create(&models.Permission{ID: 1, Name: "secrets.read", Resource: "secrets", Action: "read"}).Error)
-	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
-	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 1, ProjectID: p1.ID}).Error)
-	// #G10: the actor (admin) must independently hold secrets.write at the project's
-	// scope — ReassignOwnedSecrets now checks this itself instead of trusting the caller.
-	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "writer"}).Error)
 	require.NoError(t, db.Create(&models.Permission{ID: 2, Name: "secrets.write", Resource: "secrets", Action: "write"}).Error)
+	require.NoError(t, db.Create(&models.Permission{ID: 3, Name: "roles.assign", Resource: "roles", Action: "assign"}).Error)
+
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "reader"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 1, PermissionID: 1}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 2, Name: "writer"}).Error)
 	require.NoError(t, db.Create(&models.RolePermission{RoleID: 2, PermissionID: 2}).Error)
-	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 2, ProjectID: p1.ID}).Error)
+	require.NoError(t, db.Create(&models.Role{ID: 3, Name: "assigner"}).Error)
+	require.NoError(t, db.Create(&models.RolePermission{RoleID: 3, PermissionID: 3}).Error)
+
+	// The heir must hold secrets.write (not merely secrets.read) at the secrets'
+	// scope to become their owner — the write-tier ownership ceiling.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 2, ProjectID: p1.ID}).Error)
+	// #G10 (partial fix): the actor (admin) independently holding secrets.write at the
+	// project's scope was the original G10 check. That closed the "no actor check at
+	// all" gap but NOT this bug's ceiling gap (see secret_ownership.go's doc comment):
+	// bulk reassignment is always the offboarding/recovery case, so it now requires
+	// roles.assign — the same administrative tier transferOwnership's recovery path
+	// requires per-secret.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 3, ProjectID: p1.ID}).Error)
+	// writeronly: secrets.write but NOT roles.assign — used to prove the actor-side
+	// gate is enforced independently of the (unrelated) new-owner ceiling.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 4, RoleID: 2, ProjectID: p1.ID}).Error)
+	// readeronly: secrets.read only — an invalid new-owner target.
+	require.NoError(t, db.Create(&models.UserRole{UserID: 5, RoleID: 1, ProjectID: p1.ID}).Error)
 
 	mk := func(name string, projectID, envID, ownerID uint) uint {
 		s, err := c.storage.CreateSecret(ctx, &models.SecretNode{
@@ -68,6 +86,45 @@ func TestReassignOwnedSecrets(t *testing.T) {
 
 	// Offboard the leaver so the owner-gone recovery path authorizes the transfer.
 	require.NoError(t, c.storage.DeleteUser(ctx, 2))
+
+	// --- Confirmed HIGH exploit regression: the sibling bulk path must route through
+	// the SAME shared transferOwnership check the single-secret path does, not a
+	// re-derived one (the "variant B" mistake this fix's history explicitly avoids
+	// repeating: G10 added actor authorization to only this bulk call site, leaving
+	// the shared primitive itself — and so this call site too — still exploitable). ---
+
+	t.Run("EXPLOIT CLOSED: a secrets.write-only actor cannot bulk-reassign without roles.assign", func(t *testing.T) {
+		// User 4 (writeronly) holds secrets.write at p1 but NOT roles.assign — exactly
+		// the actor profile the confirmed exploit used. Rejected up front, loudly, not
+		// silently no-op'd via the per-secret continue-on-error.
+		n, err := c.ReassignOwnedSecrets(ctx, ActorTypeUser, 4, p1.ID, 2, 3)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not authorized")
+		assert.Equal(t, 0, n)
+
+		// Confirm nothing was silently reassigned despite the error.
+		for _, id := range []uint{a, b} {
+			s, _ := c.storage.GetSecret(ctx, id)
+			assert.Equal(t, uint(2), s.OwnerID, "leaver's secrets must be untouched when the actor lacks roles.assign")
+		}
+	})
+
+	t.Run("EXPLOIT CLOSED: a roles.assign actor cannot bulk-reassign onto a read-only heir", func(t *testing.T) {
+		// Admin (1) holds roles.assign, but the target (5, readeronly) holds only
+		// secrets.read — the same shared transferOwnership ceiling that rejects this
+		// for the single-secret path applies per-secret here too. Every per-secret
+		// transfer fails the ceiling check and is skipped, so the count is 0 — but
+		// critically, nothing is silently promoted to owner despite the actor-level
+		// check having passed.
+		n, err := c.ReassignOwnedSecrets(ctx, ActorTypeUser, 1, p1.ID, 2, 5)
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+
+		for _, id := range []uint{a, b} {
+			s, _ := c.storage.GetSecret(ctx, id)
+			assert.Equal(t, uint(2), s.OwnerID, "leaver's secrets must be untouched when the new owner is read-only")
+		}
+	})
 
 	t.Run("reassigns only the leaver's secrets in the project", func(t *testing.T) {
 		n, err := c.ReassignOwnedSecrets(ctx, ActorTypeUser, 1, p1.ID, 2, 3)

--- a/internal/storage/models/secret_sharing.go
+++ b/internal/storage/models/secret_sharing.go
@@ -24,15 +24,6 @@ func (s *SecretNode) CanWrite(userID uint) bool {
 	return s.CanAccess(userID)
 }
 
-// SetOwner sets the owner of the secret
-func (s *SecretNode) SetOwner(userID uint) error {
-	if userID == 0 {
-		return errors.New("owner ID cannot be zero")
-	}
-	s.OwnerID = userID
-	return nil
-}
-
 // ValidateOwnership ensures the secret has a valid owner
 func (s *SecretNode) ValidateOwnership() error {
 	if s.OwnerID == 0 {

--- a/internal/storage/models/secret_sharing_test.go
+++ b/internal/storage/models/secret_sharing_test.go
@@ -46,42 +46,6 @@ func TestSecretNode_IsOwner(t *testing.T) {
 	}
 }
 
-func TestSecretNode_SetOwner(t *testing.T) {
-	tests := []struct {
-		name    string
-		secret  *SecretNode
-		userID  uint
-		wantErr bool
-	}{
-		{
-			name:    "valid owner ID",
-			secret:  &SecretNode{},
-			userID:  1,
-			wantErr: false,
-		},
-		{
-			name:    "zero owner ID",
-			secret:  &SecretNode{},
-			userID:  0,
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.secret.SetOwner(tt.userID)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("SecretNode.SetOwner() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
-			if err == nil && tt.secret.OwnerID != tt.userID {
-				t.Errorf("SecretNode.SetOwner() did not set OwnerID correctly, got = %v, want %v", tt.secret.OwnerID, tt.userID)
-			}
-		})
-	}
-}
-
 func TestSecretNode_ValidateOwnership(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/server/http/handlers/secrets_ownership.go
+++ b/server/http/handlers/secrets_ownership.go
@@ -41,13 +41,17 @@ func (h *SecretHandler) TransferOwnership(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	secret, err := h.coreService.TransferSecretOwnership(r.Context(), uint(id), reqBody.NewOwnerID, userCtx.UserID)
+	secret, err := h.coreService.TransferSecretOwnership(r.Context(), uint(id), reqBody.NewOwnerID, userCtx.UserID, userCtx.ActorKind())
 	if err != nil {
 		switch {
 		case strings.Contains(err.Error(), "not found"):
 			h.sendError(w, "NotFound", err.Error(), http.StatusNotFound, nil)
 		case strings.Contains(err.Error(), "only the current owner"):
 			h.sendError(w, "Forbidden", "Only the current owner can transfer this secret", http.StatusForbidden, nil)
+		case strings.Contains(err.Error(), "roles.assign"),
+			strings.Contains(err.Error(), "must already hold"),
+			strings.Contains(err.Error(), "no access to this secret's project/environment"):
+			h.sendError(w, "Forbidden", err.Error(), http.StatusForbidden, nil)
 		case strings.Contains(err.Error(), "already owned"):
 			h.sendError(w, "ValidationError", err.Error(), http.StatusBadRequest, nil)
 		default:

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -555,7 +555,12 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequireScopedPermission(permSecretsRead, projectScope)).Get("/projects/{id}/secrets/name-conformance", secretHandler.SecretNameConformance)
 		r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, projectScope)).Post("/projects/{id}/secrets/suspend-all", secretHandler.SuspendProjectSecrets)
 		r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, projectScope)).Post("/projects/{id}/secrets/resume-all", secretHandler.ResumeProjectSecrets)
-		r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, projectScope)).Post("/projects/{id}/secrets/reassign-owner", secretHandler.ReassignOwner)
+		// Bulk reassignment is always the offboarding/recovery case (re-homing a departed
+		// owner's secrets), which core.ReassignOwnedSecrets/transferOwnership now gate on
+		// roles.assign — the same blast radius as a role grant (mirroring RestoreProject's
+		// gate above) — so the router matches rather than admitting secrets.write callers
+		// core will always then reject.
+		r.With(customMiddleware.RequireScopedPermission(permRolesAssign, projectScope)).Post("/projects/{id}/secrets/reassign-owner", secretHandler.ReassignOwner)
 		// Bulk expiry renewal — push out the expiration of every expiring/expired secret.
 		r.With(customMiddleware.RequireScopedPermission(permSecretsWrite, projectScope)).Post("/projects/{id}/secrets/extend-expiring", secretHandler.ExtendExpiringSecrets)
 		// Bulk rename toward naming-policy conformance — remediation for name-conformance.

--- a/server/http/secret_ownership_history_handler_test.go
+++ b/server/http/secret_ownership_history_handler_test.go
@@ -64,12 +64,14 @@ func doOwnershipHistoryRequest(t *testing.T, client *http.Client, baseURL, token
 	return resp, body
 }
 
-// grantViewerRoleAtProject assigns the "viewer" role to userID at project 1 so
-// they satisfy secrets.read for transfer eligibility.
-func grantViewerRoleAtProject(t *testing.T, c *core.KeyorixCore, userID uint) {
+// grantWriterRoleAtProject assigns the "editor" role to userID at project 1 so they
+// hold secrets.write — the write-tier ceiling a transfer target must already meet
+// (secrets.read alone, e.g. "viewer", is no longer sufficient — see
+// secret_ownership_test.go's exploit-closure regression tests for why).
+func grantWriterRoleAtProject(t *testing.T, c *core.KeyorixCore, userID uint) {
 	t.Helper()
 	ctx := context.Background()
-	role, err := c.Storage().GetRoleByName(ctx, "viewer")
+	role, err := c.Storage().GetRoleByName(ctx, "editor")
 	require.NoError(t, err)
 	require.NoError(t, c.Storage().AssignRole(ctx, userID, role.ID, core.Scope{ProjectID: 1}))
 }
@@ -114,20 +116,21 @@ func TestOwnershipHistory_OneTransfer(t *testing.T) {
 	ctx := context.Background()
 	secretID := seedSecretForOwnershipTest(t, client, srv.URL, token, "one-transfer-secret")
 
-	// Create a second user and give them project-scoped secrets.read so they are a
-	// valid transfer target.
+	// Create a second user and give them project-scoped secrets.write so they are a
+	// valid transfer target (the ownership ceiling requires write-tier, not merely
+	// read-tier, access).
 	user2, err := c.CreateUser(ctx, &core.CreateUserRequest{
 		Username: "transferee", Email: "transferee@example.com", Password: "Transfer99!PassValid",
 	})
 	require.NoError(t, err)
-	grantViewerRoleAtProject(t, c, user2.ID)
+	grantWriterRoleAtProject(t, c, user2.ID)
 
 	// Resolve admin user ID.
 	admin, err := c.Storage().GetUserByUsername(ctx, "testadmin")
 	require.NoError(t, err)
 
 	// Perform a real ownership transfer via the core (seeds the audit event).
-	_, err = c.TransferSecretOwnership(ctx, secretID, user2.ID, admin.ID)
+	_, err = c.TransferSecretOwnership(ctx, secretID, user2.ID, admin.ID, core.ActorTypeUser)
 	require.NoError(t, err)
 
 	// Log in as user2 (the new owner) to view the history: CheckSecretPermission
@@ -166,28 +169,28 @@ func TestOwnershipHistory_MultipleTransfers(t *testing.T) {
 	ctx := context.Background()
 	secretID := seedSecretForOwnershipTest(t, client, srv.URL, token, "multi-transfer-secret")
 
-	// Create two additional users, both with project-scoped read access.
+	// Create two additional users, both with project-scoped write access.
 	user2, err := c.CreateUser(ctx, &core.CreateUserRequest{
 		Username: "user2mt", Email: "user2mt@example.com", Password: "Multi99!PassValid1",
 	})
 	require.NoError(t, err)
-	grantViewerRoleAtProject(t, c, user2.ID)
+	grantWriterRoleAtProject(t, c, user2.ID)
 
 	user3, err := c.CreateUser(ctx, &core.CreateUserRequest{
 		Username: "user3mt", Email: "user3mt@example.com", Password: "Multi99!PassValid2",
 	})
 	require.NoError(t, err)
-	grantViewerRoleAtProject(t, c, user3.ID)
+	grantWriterRoleAtProject(t, c, user3.ID)
 
 	admin, err := c.Storage().GetUserByUsername(ctx, "testadmin")
 	require.NoError(t, err)
 
 	// Transfer 1: admin → user2
-	_, err = c.TransferSecretOwnership(ctx, secretID, user2.ID, admin.ID)
+	_, err = c.TransferSecretOwnership(ctx, secretID, user2.ID, admin.ID, core.ActorTypeUser)
 	require.NoError(t, err)
 
 	// Transfer 2: user2 → user3
-	_, err = c.TransferSecretOwnership(ctx, secretID, user3.ID, user2.ID)
+	_, err = c.TransferSecretOwnership(ctx, secretID, user3.ID, user2.ID, core.ActorTypeUser)
 	require.NoError(t, err)
 
 	// Log in as user3 (the final owner) to view the history.


### PR DESCRIPTION
## Summary

Confirmed HIGH privilege-escalation bug: `POST /secrets/{id}/transfer-ownership`
and the bulk `POST /projects/{id}/secrets/reassign-owner` both route through
`transferOwnership` (`internal/core/secret_ownership.go`), which only checked
(a) the actor is the current owner or the owner is "gone" (`OwnerID==0` — the
routine state for machine-created secrets, ADR-023/030, not a rare edge case),
and (b) the new owner holds `secrets.read`. Since ownership grants every
permission on a secret (`CheckSecretPermission`'s owner branch — documented as
`secrets.delete`-equivalent, "the most restrictive mutation the RBAC model
expresses"), this let:

- any `secrets.write`-tier user (e.g. `project_developer`) hand full
  owner/delete/re-share authority to a `secrets.read`-only colleague
  (`project_viewer`/`project_auditor`), bypassing the `roles.assign` gate every
  other privilege grant in this codebase goes through, and
- that same actor claim (or hand off) ownership of any orphaned secret with no
  admin-tier check at all.

A prior partial fix (G10/#1413) added actor authorization to the bulk
reassign-owner path only, leaving the shared `transferOwnership` primitive —
and so the single-secret path, and in fact the bulk path's own per-secret
ceiling — still exploitable. This fix closes it at the shared primitive
instead of re-patching one call site again.

## Fix shape

Both checks now live in `transferOwnership`, the one function both
`TransferSecretOwnership` (single) and `ReassignOwnedSecrets` (bulk) call:

1. **New-owner ceiling**: the new owner must already hold `secrets.write` (or
   `secrets.manage`) at the secret's scope, not merely `secrets.read` — closes
   the read→owner escalation while still allowing routine reassignment among
   already-privileged users.
2. **Actor ceiling on the recovery path**: when the current owner is gone,
   re-homing the secret is an administrative action (comparable to
   `RestoreProject` reinstating role grants, gated on `roles.assign` rather
   than `secrets.write`), so the actor must hold `roles.assign` at that scope.
   A live owner handing off their own secret does NOT need `roles.assign` —
   they already hold owner-tier authority over that one secret, so handing it
   to an already-write-tier principal (check 1) isn't an escalation.

Both checks apply together (defense in depth, matching this codebase's
router+core double-gate pattern elsewhere). `ReassignOwnedSecrets`'s own
up-front actor check moves from `secrets.write` to `roles.assign` to match —
bulk reassignment is *always* the recovery case, so leaving it at
`secrets.write` would make every non-admin caller's per-secret calls silently
fail-and-skip inside the continue-on-error loop, exactly the "denial masked as
a silent no-op" failure mode #G10 already called out once. The router gate for
`/projects/{id}/secrets/reassign-owner` moves to `roles.assign` to match.

## Guard against a third path

- Deleted `models.SecretNode.SetOwner`, an unused (zero production callers)
  direct `OwnerID` setter with no authorization of its own — exactly the kind
  of landmine a future call site could reach for instead of the shared
  primitive.
- Added `internal/core/secret_ownership_guard_test.go`, an AST sweep (modeled
  on `internal/storage/store/g81_guard_test.go`) asserting no function in
  package `core` other than `transferOwnership` assigns `SecretNode.OwnerID`
  directly — a maintained allowlist with a reasoned entry, so a new
  divergent implementation fails CI instead of silently landing.
- A full unexported-boundary refactor was considered and rejected: GORM
  requires `OwnerID` to stay exported, and dozens of legitimate read-only call
  sites compare it directly — hiding the field for no safety gain (reads
  aren't the risk).

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/core/...` — full package green, including the new
      guard tests and exploit-closure regressions
- [x] `go test ./internal/storage/models/...` green
- [x] `go test ./server/http/...` (ownership/transfer/reassign-scoped runs)
      green — the full unscoped `server/http/...` run hangs locally on
      pre-existing, unrelated flakes (tracked separately, not touched here)
- [x] Red-then-green: the new `EXPLOIT CLOSED` tests in
      `secret_ownership_test.go`/`secret_reassign_owner_test.go` reproduce the
      exact scenario (orphaned secret, `secrets.write`-tier actor,
      `secrets.read`-only target) and fail against the pre-fix code; they pass
      post-fix. The bulk path's own `EXPLOIT CLOSED` tests prove it hits the
      same shared check, not a re-derived one.