### PR TITLE
fix(core): close SoD/access-review/dual-control cross-replica TOCTOU (#G04-HA)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,33 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # KEYORIX_TEST_PG_DSN (see internal/cli/encryption/rotate_e2e_test.go's own
+    # header comment) has existed as a developer opt-in gate since before this
+    # job ran against Postgres at all -- CI never set it, so every Postgres-
+    # gated test silently skipped here, indefinitely (the same shape as the 13
+    # HA-lock branches this container also exists to exercise: a mechanism
+    # that only ever runs against SQLite verifies nothing about the Postgres
+    # path it was written for). Declared job-level (not leg-conditional) to
+    # keep this diff to "add the container + the DSN," matching every other
+    # leg's already-generous-timeout precedent rather than hand-picking which
+    # legs need it -- a service container that isn't used by a given leg's
+    # tests costs only its own startup time, not the leg's.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: keyorix
+          POSTGRES_PASSWORD: keyorix123
+          POSTGRES_DB: keyorix
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      KEYORIX_TEST_PG_DSN: "host=localhost port=5432 dbname=keyorix user=keyorix sslmode=disable password=keyorix123"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,3 +47,52 @@ Reasoning and incidents behind these: `docs/g80-remediation-notes.md`.
 - A skip with a wrong reason is worse than no skip.
 - Timeouts detect hangs; they don't enforce speed. Set them generously, watch durations.
 - When determining whether something needs fixing costs more than fixing it, fix it.
+- On Postgres, catching a constraint violation after the failing statement is not
+  recovery — the transaction is already aborted at the protocol level, and a
+  subsequent COMMIT is silently downgraded to a ROLLBACK. Prevent the conflict
+  (`INSERT ... ON CONFLICT DO NOTHING`, then read back), don't catch it. A caught
+  violation that returns a non-nil error (triggering ROLLBACK) is fine — ROLLBACK
+  succeeds on an already-aborted transaction; only a caught violation that returns
+  `nil` (intending COMMIT) is dead code on Postgres. `TryAcquireSchedulerLock`
+  (`local_scheduler_lock_lease.go`) was the confirmed instance; a full-repo sweep of
+  every other `isUniqueViolation`/constraint-catch site found no other dead ones —
+  every other site either isn't inside a multi-statement transaction at all, or
+  returns a non-nil error.
+- A test named for a condition it does not create proves nothing. The original
+  `TestConcurrency_BootstrapSystem_CrossReplicaExactlyOneAdmin` handed every
+  simulated "replica" the SAME shared `storage.Storage` instance — one
+  `LocalStorage`, one process-local mutex — so it would have passed identically
+  even with the Postgres advisory lock deleted outright. The name asserted
+  cross-replica safety; the fixture could not structurally exercise it (multiple
+  independent `*gorm.DB` connections are required, not multiple wrapper objects
+  sharing one).
+- "Green when the lock is disabled" is ambiguous, and the ambiguity is unfalsifiable
+  from that observation alone: it is equally consistent with *the lock is redundant*
+  and with *this harness never exercised the lock*. Don't conclude redundancy from a
+  disabling-mutation result by itself — first confirm the harness reproduces the
+  production concurrency shape (same transaction boundaries as the real caller, same
+  call sequence), and that the assertion states an invariant that holds under EVERY
+  legal interleaving, not just the one the test author had in mind. The
+  machine-identity row-lock test failed both checks at once, and each one masked the
+  other: (1) it called `LockMachineIdentityForUpdate` and `TransitionMachineIdentityState`
+  standalone rather than inside the same `WithTransaction` the real caller
+  (`transitionMachineInTx`) uses — `SELECT ... FOR UPDATE` outside an explicit
+  transaction is a no-op on Postgres (the lock releases the instant that single
+  autocommit statement completes), so the "lock" was never actually held across the
+  read+write; (2) its assertion ("exactly one of two racing transitions may win")
+  was false as an invariant regardless of locking, because `active`→`revoked` is
+  itself a legal transition — if `active` wins the race to go first, `revoked`
+  legitimately gets a second, later, ALSO-successful write, and the assertion never
+  checked the one thing that actually mattered: that `revoked` must always win the
+  row's FINAL value. Fixing the transaction-wrapping bug alone made the flawed
+  assertion flaky (2/10); only fixing both together — real transaction boundaries AND
+  a correctly-derived invariant — made the lock's true load-bearing status visible
+  (red 13/15 runs without it). A `securefiles.safeRelComponents` vs `resolveInside`
+  case from earlier in this campaign IS genuine redundancy (confirmed by disabling
+  both layers, with a harness that correctly reproduced the real call path
+  throughout) — the lesson isn't "assume redundancy is always wrong," it's that the
+  observation alone never tells you which one you're looking at. A same-worktree
+  follow-up audit then traced every real production caller of all six FOR UPDATE
+  sites in `internal/storage/store` (not test callers) and confirmed every one
+  correctly shares one transaction with its guarded write — the standalone-lock bug
+  the test harness had was a test-only defect, not a production one.

--- a/docs/adr-052-secret-dependency-tracking.md
+++ b/docs/adr-052-secret-dependency-tracking.md
@@ -87,5 +87,10 @@ answer the two questions from it.
   rotation runs dependency-first automatically.
 - gRPC + CLI surfaces and a web/ graph visualisation (the API is the first
   vertical).
+- If a cycle is ever written despite the add-time guard (e.g. a future write path that
+  bypasses `CreateSecretDependencyExclusive`), `GetProjectRotationOrder` fails closed
+  permanently for that project with no code path to remove the offending edge — for a
+  secrets manager, rotation that has quietly stopped is a compliance problem worth a
+  detection/repair path even though it isn't a crash or a hang.
 - Cascade behaviour on secret soft-delete/restore (currently an edge to a deleted secret
   simply stops resolving a name; a future pass could prune or flag it).

--- a/internal/cli/secret/import.go
+++ b/internal/cli/secret/import.go
@@ -128,14 +128,26 @@ func runImport(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	// Only meaningful for --source imports (fetchFromSource resets it before
+	// each dispatch); zero for --file imports, which have no source-side skip
+	// concept of their own.
+	sourceSkipped := sourceSkipCount
 
 	if len(entries) == 0 {
-		fmt.Println("No secrets found.")
+		if sourceSkipped > 0 {
+			fmt.Printf("No secrets found (%d skipped — see above for details).\n", sourceSkipped)
+		} else {
+			fmt.Println("No secrets found.")
+		}
 		return nil
 	}
 
 	if importDryRun {
-		fmt.Printf("Dry run — would import %d secret(s):\n\n", len(entries))
+		fmt.Printf("Dry run — would import %d secret(s)", len(entries))
+		if sourceSkipped > 0 {
+			fmt.Printf(" (%d skipped at source — see above)", sourceSkipped)
+		}
+		fmt.Printf(":\n\n")
 		for _, e := range entries {
 			// #G58: a dry run must never put real secret bytes on the
 			// operator's terminal (scrollback, tmux/screen logging, screen
@@ -160,7 +172,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return doImport(ctx, rc, entries, nsID, envID)
+	return doImport(ctx, rc, entries, nsID, envID, sourceSkipped)
 }
 
 // collectEntries gathers the secrets to import from exactly one of the two
@@ -255,8 +267,8 @@ func resolveEnvironmentID(ctx context.Context, rc *common.RemoteClient, projectI
 
 // ── Import logic ──────────────────────────────────────────────────────────────
 
-func doImport(ctx context.Context, rc *common.RemoteClient, entries []secretEntry, nsID, envID uint) error {
-	imported, skipped, failed := 0, 0, 0
+func doImport(ctx context.Context, rc *common.RemoteClient, entries []secretEntry, nsID, envID uint, sourceSkipped int) error {
+	imported, skipped, failed := 0, sourceSkipped, 0
 
 	for _, e := range entries {
 		displayName := sanitizeForTerminal(e.Name)

--- a/internal/cli/secret/secret_s2_test.go
+++ b/internal/cli/secret/secret_s2_test.go
@@ -1789,8 +1789,37 @@ func TestDoImport_Success(t *testing.T) {
 	entries := []secretEntry{
 		{Name: "MY_SECRET", Value: "myvalue"},
 	}
-	err := doImport(context.Background(), rc, entries, 1, 1)
+	err := doImport(context.Background(), rc, entries, 1, 1, 0)
 	require.NoError(t, err)
+}
+
+// TestDoImport_SourceSkippedFoldsIntoSummary verifies that secrets a live
+// source already dropped (sourceSkipped, e.g. Azure/GCP entries with no
+// accessible value) are folded into the same final "imported N, skipped M"
+// summary as destination-side skips — a non-zero source-skip count must be
+// visible in doImport's own printed output, not just logged separately where
+// it could be missed.
+func TestDoImport_SourceSkippedFoldsIntoSummary(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"id":1,"name":"MY_SECRET","type":"generic","project_id":1,"environment_id":1,"created_by":"cli","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("KEYORIX_SERVER", srv.URL)
+	t.Setenv("KEYORIX_TOKEN", "tok")
+
+	rc, ok := common.NewRemoteClient()
+	require.True(t, ok)
+
+	entries := []secretEntry{
+		{Name: "MY_SECRET", Value: "myvalue"},
+	}
+	var err error
+	out := captureStdout(t, func() {
+		err = doImport(context.Background(), rc, entries, 1, 1, 2)
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out, "Imported 1/3 secrets", "total must include the 2 secrets skipped before doImport ever saw them")
+	assert.Contains(t, out, "2 skipped")
 }
 
 func TestDoImport_SkipExisting(t *testing.T) {
@@ -1814,7 +1843,7 @@ func TestDoImport_SkipExisting(t *testing.T) {
 		{Name: "MY_SECRET", Value: "myvalue"},
 	}
 	// With skip-existing=true and 409 → no error (skipped).
-	err := doImport(context.Background(), rc, entries, 1, 1)
+	err := doImport(context.Background(), rc, entries, 1, 1, 0)
 	_ = err // may succeed or fail depending on error message parsing
 }
 
@@ -1837,7 +1866,7 @@ func TestDoImport_FailedEntry(t *testing.T) {
 	entries := []secretEntry{
 		{Name: "FAIL_SECRET", Value: "value"},
 	}
-	err := doImport(context.Background(), rc, entries, 1, 1)
+	err := doImport(context.Background(), rc, entries, 1, 1, 0)
 	require.Error(t, err) // 1 failed
 	assert.Contains(t, err.Error(), "failed to import")
 }

--- a/internal/cli/secret/secret_s3_test.go
+++ b/internal/cli/secret/secret_s3_test.go
@@ -319,7 +319,7 @@ func TestDoImport_SkipExistingS3(t *testing.T) {
 	defer func() { importSkipExisting = origSkip }()
 	importSkipExisting = true
 
-	err := doImport(context.Background(), rc, []secretEntry{{Name: "EXISTING", Value: "v"}}, 1, 1)
+	err := doImport(context.Background(), rc, []secretEntry{{Name: "EXISTING", Value: "v"}}, 1, 1, 0)
 	require.NoError(t, err)
 }
 

--- a/internal/cli/secret/source.go
+++ b/internal/cli/secret/source.go
@@ -40,6 +40,19 @@ var (
 	gcpPrefix  string
 )
 
+// sourceSkipCount tallies secrets a live-source provider (collectAzure,
+// collectGCP) dropped before they ever became a secretEntry — e.g. a Key
+// Vault secret with no accessible value, or a Secret Manager entry with no
+// enabled version. Providers print each skip by name as it happens (never
+// silent); this counter lets runImport fold the total into the same
+// "imported N, skipped M" summary already used for destination-side skips
+// (already-exists), so a source-side drop is never invisible in the final
+// output either. Reset by fetchFromSource before each dispatch — safe as
+// plain package state because exactly one import runs per CLI process.
+// Tests that call collectAzure/collectGCP directly (bypassing
+// fetchFromSource) must reset it themselves before asserting on it.
+var sourceSkipCount int
+
 // fetchFromSource dispatches to the live provider named by --source and returns
 // the secrets it found, ready for the shared import path. The optional --prefix
 // is applied uniformly here so each provider need not know about it.
@@ -48,6 +61,7 @@ func fetchFromSource(ctx context.Context, source string) ([]secretEntry, error) 
 		entries []secretEntry
 		err     error
 	)
+	sourceSkipCount = 0
 	switch strings.ToLower(strings.TrimSpace(source)) {
 	case "vault":
 		entries, err = fetchFromVault(ctx)

--- a/internal/cli/secret/source_azure.go
+++ b/internal/cli/secret/source_azure.go
@@ -40,7 +40,11 @@ func fetchFromAzure(ctx context.Context) ([]secretEntry, error) {
 	return collectAzure(ctx, &azureClientAdapter{c: client})
 }
 
-// collectAzure lists and reads secrets from any azureSecretsAPI.
+// collectAzure lists and reads secrets from any azureSecretsAPI. A secret with
+// no accessible value (disabled, or a certificate-only secret with nothing in
+// resp.Value) is skipped rather than fatal — but every skip is printed by name
+// as it happens and tallied in sourceSkipCount, mirroring collectGCP's
+// reporting, so a dropped secret is never silent.
 func collectAzure(ctx context.Context, api azureSecretsAPI) ([]secretEntry, error) {
 	names, err := api.listNames(ctx)
 	if err != nil {
@@ -53,6 +57,8 @@ func collectAzure(ctx context.Context, api azureSecretsAPI) ([]secretEntry, erro
 			return nil, fmt.Errorf("read azure secret %q: %w", name, err)
 		}
 		if val == "" {
+			fmt.Printf("  ~ Skipped  %-30s (no accessible value)\n", name)
+			sourceSkipCount++
 			continue
 		}
 		entries = append(entries, explodeValue(name, val)...)

--- a/internal/cli/secret/source_azure_test.go
+++ b/internal/cli/secret/source_azure_test.go
@@ -48,3 +48,46 @@ func TestCollectAzure(t *testing.T) {
 	_, hasEmpty := got["empty"]
 	assert.False(t, hasEmpty, "empty values are skipped")
 }
+
+// TestCollectAzure_ValuelessSecretIsSkippedByNameAndCounted pins the fix for
+// the silent-drop finding: a Key Vault secret with no accessible value (e.g.
+// disabled, or a certificate-only secret where getValue returns "") must be
+// (a) reported by name at the point it's skipped, not silently dropped, and
+// (b) tallied in sourceSkipCount so the final import summary can report it.
+func TestCollectAzure_ValuelessSecretIsSkippedByNameAndCounted(t *testing.T) {
+	importNoExplode = false
+	sourceSkipCount = 0
+	api := &fakeAzure{values: map[string]string{
+		"disabled-secret": "",
+	}}
+
+	var entries []secretEntry
+	var err error
+	out := captureStdout(t, func() {
+		entries, err = collectAzure(context.Background(), api)
+	})
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+	assert.Equal(t, 1, sourceSkipCount, "the valueless secret must be counted as skipped")
+	assert.Contains(t, out, "disabled-secret", "the skip must name the secret, not just count it")
+	assert.Contains(t, out, "Skipped")
+}
+
+// TestCollectAzure_MixedBatch_SkipCountIsExact drives a batch with both kinds
+// of secret through collectAzure and checks the skip tally lands exactly on
+// the valueless ones — neither over- nor under-counting the imported entries.
+func TestCollectAzure_MixedBatch_SkipCountIsExact(t *testing.T) {
+	importNoExplode = false
+	sourceSkipCount = 0
+	api := &fakeAzure{values: map[string]string{
+		"good-1":     "value-1",
+		"good-2":     "value-2",
+		"disabled-1": "",
+		"disabled-2": "",
+	}}
+
+	entries, err := collectAzure(context.Background(), api)
+	require.NoError(t, err)
+	assert.Len(t, entries, 2, "only the two valued secrets become entries")
+	assert.Equal(t, 2, sourceSkipCount, "exactly the two valueless secrets are counted as skipped")
+}

--- a/internal/cli/secret/source_gcp.go
+++ b/internal/cli/secret/source_gcp.go
@@ -62,6 +62,7 @@ func collectGCP(ctx context.Context, api gcpSecretsAPI, project string) ([]secre
 		if !ok {
 			// No enabled/accessible version (e.g. all versions destroyed/disabled).
 			fmt.Printf("  ~ Skipped  %-30s (no accessible version)\n", short)
+			sourceSkipCount++
 			continue
 		}
 		entries = append(entries, explodeValue(short, val)...)
@@ -95,7 +96,7 @@ func (a gcpClientAdapter) accessLatest(ctx context.Context, name string) (string
 	})
 	if err != nil {
 		// A secret with no enabled latest version is skipped, not fatal.
-		if s, ok := status.FromError(err); ok && (s.Code() == codes.NotFound || s.Code() == codes.FailedPrecondition) {
+		if isNoAccessibleVersion(err) {
 			return "", false, nil
 		}
 		return "", false, err
@@ -104,4 +105,17 @@ func (a gcpClientAdapter) accessLatest(ctx context.Context, name string) (string
 		return "", false, nil
 	}
 	return string(resp.GetPayload().GetData()), true, nil
+}
+
+// isNoAccessibleVersion reports whether err is the gRPC status Secret Manager
+// returns for "this secret has no enabled/accessible version" (NotFound —
+// secret or version doesn't exist — or FailedPrecondition — e.g. the only
+// version is DESTROYED/DISABLED). accessLatest treats that as a skip, not an
+// import failure. Named and pulled out on its own so the mapping itself is
+// unit-testable without a live GCP client: any OTHER status (PermissionDenied,
+// Unavailable, …) must propagate as an error rather than silently vanish as a
+// skip, and this function is what pins that boundary.
+func isNoAccessibleVersion(err error) bool {
+	s, ok := status.FromError(err)
+	return ok && (s.Code() == codes.NotFound || s.Code() == codes.FailedPrecondition)
 }

--- a/internal/cli/secret/source_gcp_test.go
+++ b/internal/cli/secret/source_gcp_test.go
@@ -2,11 +2,14 @@ package secret
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // fakeGCP implements gcpSecretsAPI over in-memory maps keyed by the full secret
@@ -56,6 +59,62 @@ func TestCollectGCP(t *testing.T) {
 	assert.False(t, hasNoVers, "a secret with no accessible version is skipped")
 }
 
+// TestCollectGCP_SkipIsCounted verifies the no-accessible-version skip is
+// tallied in sourceSkipCount (not just printed), so runImport's final summary
+// can report it alongside destination-side skips.
+func TestCollectGCP_SkipIsCounted(t *testing.T) {
+	gcpPrefix = ""
+	importNoExplode = false
+	sourceSkipCount = 0
+	api := &fakeGCP{
+		names: []string{
+			"projects/p/secrets/kept",
+			"projects/p/secrets/novers-1",
+			"projects/p/secrets/novers-2",
+		},
+		values:    map[string]string{"projects/p/secrets/kept": "v"},
+		noVersion: map[string]bool{"projects/p/secrets/novers-1": true, "projects/p/secrets/novers-2": true},
+	}
+
+	entries, err := collectGCP(context.Background(), api, "p")
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, 2, sourceSkipCount, "both no-version secrets are counted as skipped")
+}
+
+func TestFetchFromGCP_RequiresProject(t *testing.T) {
+	gcpProject = ""
+	_, err := fetchFromGCP(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no GCP project")
+}
+
+// TestIsNoAccessibleVersion pins the gRPC-status-to-skip mapping that
+// accessLatest relies on to decide "skip this secret" vs "fail the whole
+// import". NotFound and FailedPrecondition are the two statuses Secret
+// Manager actually returns for "no accessible version" — anything else
+// (PermissionDenied, Unavailable, a non-status error) must NOT be treated as
+// a skip, or a transient/auth failure on one secret would silently drop it
+// instead of failing the import loudly.
+func TestIsNoAccessibleVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"NotFound is a skip", status.Error(codes.NotFound, "secret not found"), true},
+		{"FailedPrecondition is a skip", status.Error(codes.FailedPrecondition, "version destroyed"), true},
+		{"PermissionDenied is NOT a skip", status.Error(codes.PermissionDenied, "no access"), false},
+		{"Unavailable is NOT a skip", status.Error(codes.Unavailable, "transient"), false},
+		{"a plain non-status error is NOT a skip", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isNoAccessibleVersion(tc.err))
+		})
+	}
+}
+
 func TestCollectGCP_PrefixFilter(t *testing.T) {
 	gcpPrefix = "prod-"
 	importNoExplode = true
@@ -82,11 +141,4 @@ func TestCollectGCP_PrefixFilter(t *testing.T) {
 	sort.Strings(names)
 	assert.Equal(t, []string{"prod-y", "prod-z"}, names)
 	gcpPrefix = ""
-}
-
-func TestFetchFromGCP_RequiresProject(t *testing.T) {
-	gcpProject = ""
-	_, err := fetchFromGCP(context.Background())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no GCP project")
 }

--- a/internal/core/access_review_campaign.go
+++ b/internal/core/access_review_campaign.go
@@ -266,56 +266,59 @@ func (c *KeyorixCore) DecideAccessReviewItem(ctx context.Context, actorID, proje
 	if campaign.State != CampaignStateOpen {
 		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "campaign is closed; decisions can only be made on an open campaign")
 	}
-	// #G04: accessReviewDecisionMu holds from the pending-decision read through
-	// the actual attest/revoke side effect and its persisted stamp — see its
-	// doc comment in service.go for why persistItemDecision's conditional
-	// UPDATE alone isn't enough (it stops a second STAMP from persisting, not
-	// a second ACTION from executing).
-	c.accessReviewDecisionMu.Lock()
-	defer c.accessReviewDecisionMu.Unlock()
-	item, err := c.storage.GetAccessReviewItem(ctx, itemID)
-	if err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
-	}
-	if item.CampaignID != campaignID {
-		return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
-	}
-	// Decide once: an already-attested/revoked item must not be flipped. A revoke
-	// removes the real grant, so re-deciding it (revoke→attest) would record
-	// "attested" for access that no longer exists — false certification evidence.
-	if item.Decision != ReviewItemPending {
-		return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this item has already been decided")
-	}
-	if err := c.checkReviewerIndependence(ctx, actorID, item.PrincipalType, item.PrincipalID); err != nil {
-		return err
-	}
-	// ARC-001: a machine identity provisioned by the actor must not be self-certified
-	// by its creator. Fail closed on lookup error (can't prove independence → deny).
-	if item.PrincipalType == "machine" {
-		machine, err := c.storage.GetMachineIdentity(ctx, item.PrincipalID)
+	// #G04/HA: WithAccessReviewDecisionLock holds from the pending-decision read
+	// through the actual attest/revoke side effect and its persisted stamp —
+	// see its doc comment in internal/core/storage/interface.go for why
+	// persistItemDecision's conditional UPDATE alone isn't enough (it stops a
+	// second STAMP from persisting, not a second ACTION from executing), and
+	// why the former in-process-only accessReviewDecisionMu provided no
+	// serialization at all between two HA replicas sharing the same Postgres
+	// database (#G04-HA).
+	return c.storage.WithAccessReviewDecisionLock(ctx, func() error {
+		item, err := c.storage.GetAccessReviewItem(ctx, itemID)
 		if err != nil {
-			return fmt.Errorf("loading machine identity: %w", err)
+			return fmt.Errorf("%s: %w", i18n.T("ErrorNotFound", nil), err)
 		}
-		if machine.CreatedBy == actorID {
-			return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "independent reviewer required for machine identities you provisioned")
+		if item.CampaignID != campaignID {
+			return fmt.Errorf("%s", i18n.T("ErrorNotFound", nil))
 		}
-	}
-	decision := AccessReviewDecision{
-		Source:        item.Source,
-		PrincipalType: item.PrincipalType,
-		PrincipalID:   item.PrincipalID,
-		RoleID:        item.RoleID,
-		EnvironmentID: item.EnvironmentID,
-		SecretID:      item.SecretID,
-	}
-	if err := c.applyAccessDecision(ctx, actorID, projectID, item, action, decision); err != nil {
-		return err
-	}
-	now := c.now()
-	item.Reason = reason
-	item.DecidedBy = actorID
-	item.DecidedAt = &now
-	return c.persistItemDecision(ctx, item, itemID)
+		// Decide once: an already-attested/revoked item must not be flipped. A revoke
+		// removes the real grant, so re-deciding it (revoke→attest) would record
+		// "attested" for access that no longer exists — false certification evidence.
+		if item.Decision != ReviewItemPending {
+			return fmt.Errorf("%s: %s", i18n.T("ErrorValidation", nil), "this item has already been decided")
+		}
+		if err := c.checkReviewerIndependence(ctx, actorID, item.PrincipalType, item.PrincipalID); err != nil {
+			return err
+		}
+		// ARC-001: a machine identity provisioned by the actor must not be self-certified
+		// by its creator. Fail closed on lookup error (can't prove independence → deny).
+		if item.PrincipalType == "machine" {
+			machine, err := c.storage.GetMachineIdentity(ctx, item.PrincipalID)
+			if err != nil {
+				return fmt.Errorf("loading machine identity: %w", err)
+			}
+			if machine.CreatedBy == actorID {
+				return fmt.Errorf("%s: %s", i18n.T("ErrorPermissionDenied", nil), "independent reviewer required for machine identities you provisioned")
+			}
+		}
+		decision := AccessReviewDecision{
+			Source:        item.Source,
+			PrincipalType: item.PrincipalType,
+			PrincipalID:   item.PrincipalID,
+			RoleID:        item.RoleID,
+			EnvironmentID: item.EnvironmentID,
+			SecretID:      item.SecretID,
+		}
+		if err := c.applyAccessDecision(ctx, actorID, projectID, item, action, decision); err != nil {
+			return err
+		}
+		now := c.now()
+		item.Reason = reason
+		item.DecidedBy = actorID
+		item.DecidedAt = &now
+		return c.persistItemDecision(ctx, item, itemID)
+	})
 }
 
 // requireHumanReviewer rejects a recertification action by a non-human / unattributable

--- a/internal/core/concurrency_bootstrap_cross_replica_postgres_test.go
+++ b/internal/core/concurrency_bootstrap_cross_replica_postgres_test.go
@@ -1,0 +1,122 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	localstore "github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrency_BootstrapSystem_CrossReplicaPostgres_ExactlyOneAdmin is the
+// genuine multi-replica counterpart to
+// TestConcurrency_BootstrapSystem_CrossReplicaExactlyOneAdmin
+// (concurrency_bootstrap_cross_replica_test.go). That test's "replicas" all
+// share ONE storage.Storage instance and therefore one process-local
+// bootstrapMu — it would pass identically even if WithBootstrapLock's
+// pg_advisory_lock call were deleted, because the shared mutex alone already
+// serializes every goroutine in the test. It also never runs on Postgres at
+// all (in-memory SQLite), so the advisory-lock branch in
+// local_bootstrap_lock.go never even executes.
+//
+// This test instead gives each simulated replica its OWN *gorm.DB connection
+// (own LocalStorage, own bootstrapMu) into the SAME real Postgres schema —
+// the only thing left that can serialize BootstrapSystem's check-then-create
+// sequence across them is pg_advisory_lock. If it's missing or broken, two
+// replicas can both observe "not yet initialised" and each seed a first
+// admin (#core-auth-03) — a duplicate-admin race that silently corrupts the
+// RBAC seed until someone notices two admins exist.
+func TestConcurrency_BootstrapSystem_CrossReplicaPostgres_ExactlyOneAdmin(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	const token = "correct-token"
+	const replicas = 5
+	const callsPerReplica = 4
+
+	cores := make([]*KeyorixCore, replicas)
+	for i := 0; i < replicas; i++ {
+		db := pgOpen(t, dsn)
+		require.NoError(t, db.AutoMigrate(
+			&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+			&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+			&models.Project{}, &models.Environment{}, &models.SystemMetadata{},
+		))
+		ls := localstore.NewLocalStorage(db)
+		c := NewKeyorixCore(ls)
+		c.SetBootstrapToken(token)
+		cores[i] = c
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	type outcome struct {
+		created bool
+		err     error
+	}
+	results := make(chan outcome, replicas*callsPerReplica)
+	n := 0
+	for r := 0; r < replicas; r++ {
+		for i := 0; i < callsPerReplica; i++ {
+			n++
+			wg.Add(1)
+			go func(c *KeyorixCore, idx int) {
+				defer wg.Done()
+				<-start
+				req := &BootstrapRequest{
+					Username:    fmt.Sprintf("admin-%d", idx),
+					Email:       fmt.Sprintf("admin-%d@example.com", idx),
+					Password:    "BootstrapPass123!",
+					DisplayName: "Admin",
+					Token:       token,
+				}
+				res, err := c.BootstrapSystem(context.Background(), req)
+				if err != nil {
+					results <- outcome{err: err}
+					return
+				}
+				results <- outcome{created: !res.AlreadyInitialized}
+			}(cores[r], n)
+		}
+	}
+	close(start) // release every call, across every independent replica, at once
+	wg.Wait()
+	close(results)
+
+	created := 0
+	for res := range results {
+		assert.NoError(t, res.err, "no concurrent bootstrap call holding the valid token should error")
+		if res.created {
+			created++
+		}
+	}
+	assert.Equal(t, 1, created, "exactly one call across every independent replica may create the first admin")
+
+	// Verify from a fresh connection into the same schema, independent of any
+	// replica's own connection.
+	verifierDB := pgOpen(t, dsn)
+	verifier := localstore.NewLocalStorage(verifierDB)
+
+	_, total, err := verifier.ListUsers(context.Background(), &storage.UserFilter{Page: 1, PageSize: 100})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total, "exactly one admin user must exist, not one per racing replica")
+
+	roles, err := verifier.ListRoles(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, roles, len(defaultRoles), "roles must be seeded exactly once across every replica")
+
+	perms, err := verifier.ListPermissions(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, perms, len(defaultPermissions), "permissions must be seeded exactly once across every replica")
+
+	projects, err := verifier.ListProjects(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, projects, 1, "the default project must be created exactly once across every replica")
+}

--- a/internal/core/concurrency_row_lock_sites_postgres_test.go
+++ b/internal/core/concurrency_row_lock_sites_postgres_test.go
@@ -1,0 +1,157 @@
+package core
+
+// concurrency_row_lock_sites_postgres_test.go — the users and machine-identity
+// halves of the row-lock-site contention coverage, moved here from
+// internal/storage/store's TestConcurrency_RowLockSites_MultiInstancePostgres so
+// each one calls its REAL production entry point (recordFailedLogin,
+// TransitionMachineIdentity) instead of reconstructing the lock-then-write
+// sequence inside the test harness.
+//
+// Why this matters: a harness that hand-assembles
+// `WithTransaction(func(tx) { tx.LockXForUpdate(...); tx.WriteX(...) })` only
+// proves that SEQUENCE is safe — it says nothing about whether the real
+// production caller actually uses that sequence, and a future refactor that
+// moves the lock or the write out of its transaction (in production code)
+// would not be caught by a test that never calls the production code path at
+// all. Calling the real entry point means a transaction-boundary regression
+// breaks an actual test, not just an AST/line-number check. This is the
+// guard from the Postgres contention audit — see that report for the earlier,
+// reconstructed version of the machine-identity case and why its assertion
+// was also wrong (active->revoked being itself a legal transition).
+//
+// The webauthn subtest stayed in internal/storage/store: its production
+// caller, persistUpdatedCredential (webauthn.go), calls
+// storage.AdvanceWebAuthnCredentialCounter directly with no logic in
+// between — that storage-layer call already IS the production entry point,
+// not a reconstruction of one, so there was nothing to move.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	localstore "github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrency_RecordFailedLogin_MultiInstancePostgres_NoLostUpdates calls
+// the real c.recordFailedLogin (login_lockout.go) — same package, so the
+// unexported method is directly callable — across N independent KeyorixCore
+// instances (own LocalStorage, own *gorm.DB connection, own process-local
+// loginFailureLock shard) racing the SAME user row. LockUserForUpdate's row
+// lock is the only thing serializing the read-modify-write across them: the
+// write (UpdateLoginLockoutState) is a plain, unconditional `WHERE id = ?`
+// update with no compare-and-swap guard.
+func TestConcurrency_RecordFailedLogin_MultiInstancePostgres_NoLostUpdates(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	setupDB := pgOpen(t, dsn)
+	require.NoError(t, setupDB.AutoMigrate(&models.User{}))
+	require.NoError(t, setupDB.Create(&models.User{ID: 1, Username: "racer", Email: "racer@example.com"}).Error)
+
+	const n = 8
+	cores := make([]*KeyorixCore, n)
+	for i := 0; i < n; i++ {
+		db := pgOpen(t, dsn)
+		c := NewKeyorixCore(localstore.NewLocalStorage(db))
+		c.SetLoginLockoutPolicy(LoginLockoutPolicy{
+			Enabled:      true,
+			MaxAttempts:  1000, // high enough that no racer trips a lockout mid-test
+			Window:       time.Hour,
+			BaseCooldown: time.Minute,
+			MaxCooldown:  time.Hour,
+		})
+		cores[i] = c
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(c *KeyorixCore) {
+			defer wg.Done()
+			<-start
+			c.recordFailedLogin(context.Background(), &models.User{ID: 1})
+		}(cores[i])
+	}
+	close(start)
+	wg.Wait()
+
+	verifier := pgOpen(t, dsn)
+	var final models.User
+	require.NoError(t, verifier.First(&final, 1).Error)
+	assert.Equal(t, n, final.FailedLoginAttempts, "every racer's recordFailedLogin call must be reflected — a lost update means LockUserForUpdate isn't serializing the read-modify-write in production")
+}
+
+// TestConcurrency_TransitionMachineIdentity_MultiInstancePostgres_RevokedIsTerminal
+// calls the real c.TransitionMachineIdentity (exported, machine_identities.go)
+// across two independent KeyorixCore instances racing suspended->revoked
+// against suspended->active off the same row (#388's own example). Unlike a
+// flat "exactly one write succeeds" assertion (wrong here — active->revoked is
+// itself a legal transition, so if active wins the race to go first, revoked
+// legitimately gets a second, later, ALSO-successful write), the invariant
+// that holds under every legal interleaving is narrower: the racer targeting
+// revoked must always win, and the row must end revoked, never active. This
+// also removes the earlier reconstructed test's hand-rolled "revoked is
+// terminal" gate (a stand-in for canTransitionMachine that internal/storage/
+// store couldn't import due to the core->store dependency direction) — calling
+// production directly means the REAL canTransitionMachine gate runs.
+func TestConcurrency_TransitionMachineIdentity_MultiInstancePostgres_RevokedIsTerminal(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	setupDB := pgOpen(t, dsn)
+	require.NoError(t, setupDB.AutoMigrate(&models.MachineIdentity{}))
+	require.NoError(t, setupDB.Create(&models.MachineIdentity{
+		ID: 1, ProjectID: 1, Name: "ci-runner", State: MachineSuspended,
+	}).Error)
+
+	coreRevoke := NewKeyorixCore(localstore.NewLocalStorage(pgOpen(t, dsn)))
+	coreActivate := NewKeyorixCore(localstore.NewLocalStorage(pgOpen(t, dsn)))
+
+	type outcome struct {
+		target string
+		err    error
+	}
+	results := make(chan outcome, 2)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	race := func(c *KeyorixCore, target string) {
+		defer wg.Done()
+		<-start
+		_, err := c.TransitionMachineIdentity(context.Background(), 1, 1, target, 1)
+		results <- outcome{target: target, err: err}
+	}
+	wg.Add(2)
+	go race(coreRevoke, MachineRevoked)
+	go race(coreActivate, MachineActive)
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var revokedErr, activeErr error
+	for o := range results {
+		switch o.target {
+		case MachineRevoked:
+			revokedErr = o.err
+		case MachineActive:
+			activeErr = o.err
+		}
+	}
+	assert.NoError(t, revokedErr, "the transition targeting revoked must always succeed — either first (suspended->revoked) or second (active->revoked), never refused")
+	if activeErr == nil {
+		t.Log("active won the race to go first (suspended->active), then revoked legitimately followed (active->revoked) — both succeeding here is correct, not a fork")
+	}
+
+	verifier := localstore.NewLocalStorage(pgOpen(t, dsn))
+	final, err := verifier.GetMachineIdentity(context.Background(), 1)
+	require.NoError(t, err)
+	assert.Equal(t, MachineRevoked, final.State, "the row must end revoked regardless of race ordering — never left at active")
+}

--- a/internal/core/concurrency_sod_grant_cross_replica_postgres_test.go
+++ b/internal/core/concurrency_sod_grant_cross_replica_postgres_test.go
@@ -1,0 +1,123 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	localstore "github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrency_AssignUserRole_CrossReplicaPostgres_NeverCreatesSoDViolation is
+// the genuine multi-replica counterpart to TestAssignUserRole_BlocksNewSoDViolation
+// and friends (rbac_management_test.go/sod_test.go). Those tests — like every
+// other SoD-preventive-gate test in this package — drive a single *KeyorixCore
+// backed by one storage.Storage instance, so they all serialize through ONE
+// process-local mutex (the former sodGrantMu) regardless of whether the
+// underlying cross-replica primitive works at all: they would pass identically
+// even if WithSoDGrantLock's pg_advisory_lock call were deleted outright,
+// because the shared in-process mutex alone already serializes every goroutine
+// in the test. They also never run on Postgres (in-memory SQLite), so the
+// advisory-lock branch in local_sod_grant_lock.go never even executes.
+//
+// This test instead gives each simulated replica its OWN *gorm.DB connection
+// (own LocalStorage, own KeyorixCore) into the SAME real Postgres schema — the
+// only thing left that can serialize AssignUserRole's preventive
+// check-then-write sequence across them is pg_advisory_lock. If it's missing or
+// broken, two replicas granting the two individually-clean halves of a toxic
+// permission pair to the SAME user can each read "no violation yet" before
+// either write commits, both pass the check, and together hand that user both
+// sides of a combination a separation-of-duties policy exists specifically to
+// forbid.
+//
+// The assertion that actually matters is NOT "one call succeeds and one
+// fails" in isolation (a coincidental ordering could produce that outcome even
+// under a broken lock, e.g. if replica B's read happens to run before
+// replica A's write commits due to scheduling, then both would still race with
+// a real chance of BOTH passing) — it's the structural invariant checked at
+// the end, from a THIRD, independent connection: the user must never hold
+// both toxic-pair roles at once, only ever one or the other.
+func TestConcurrency_AssignUserRole_CrossReplicaPostgres_NeverCreatesSoDViolation(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	setupDB := pgOpen(t, dsn)
+	require.NoError(t, setupDB.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.Permission{}, &models.RolePermission{},
+		&models.UserRole{}, &models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+		&models.SoDPolicy{}, &models.AuditEvent{},
+	))
+
+	const (
+		userID   = uint(1)
+		roleAID  = uint(1)
+		roleBID  = uint(2)
+		permAID  = uint(1)
+		permBID  = uint(2)
+		policyID = uint(1)
+	)
+	require.NoError(t, setupDB.Create(&models.User{ID: userID, Username: "target", Email: "target@example.com"}).Error)
+	require.NoError(t, setupDB.Create(&models.Role{ID: roleAID, Name: "role_toxic_a"}).Error)
+	require.NoError(t, setupDB.Create(&models.Role{ID: roleBID, Name: "role_toxic_b"}).Error)
+	require.NoError(t, setupDB.Create(&models.Permission{ID: permAID, Name: "perm_toxic_a", Resource: "res", Action: "a"}).Error)
+	require.NoError(t, setupDB.Create(&models.Permission{ID: permBID, Name: "perm_toxic_b", Resource: "res", Action: "b"}).Error)
+	require.NoError(t, setupDB.Create(&models.RolePermission{RoleID: roleAID, PermissionID: permAID}).Error)
+	require.NoError(t, setupDB.Create(&models.RolePermission{RoleID: roleBID, PermissionID: permBID}).Error)
+	// A policy forbidding perm_toxic_a + perm_toxic_b together — role_toxic_a and
+	// role_toxic_b are each individually clean; only holding BOTH violates it.
+	require.NoError(t, setupDB.Create(&models.SoDPolicy{
+		ID: policyID, Name: "toxic-pair", PermissionA: "perm_toxic_a", PermissionB: "perm_toxic_b",
+	}).Error)
+
+	replicaA := NewKeyorixCore(localstore.NewLocalStorage(pgOpen(t, dsn)))
+	replicaB := NewKeyorixCore(localstore.NewLocalStorage(pgOpen(t, dsn)))
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		// actorID 0 = unauthenticated/local-CLI exemption from the grant-ceiling
+		// check (requireGranterHoldsRolePermissions) — this test is about the SoD
+		// preventive gate specifically, not the ceiling check.
+		results <- replicaA.AssignUserRole(context.Background(), 0, userID, roleAID, Scope{})
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		results <- replicaB.AssignUserRole(context.Background(), 0, userID, roleBID, Scope{})
+	}()
+	close(start) // release both replicas' grants at once
+	wg.Wait()
+	close(results)
+
+	succeeded, blocked := 0, 0
+	for err := range results {
+		switch {
+		case err == nil:
+			succeeded++
+		case strings.Contains(err.Error(), "separation-of-duties violation"):
+			blocked++
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	assert.Equal(t, 1, succeeded, "exactly one of the two concurrent grants may succeed")
+	assert.Equal(t, 1, blocked, "the other must be refused as a separation-of-duties violation, not silently applied")
+
+	// The invariant that actually matters: verified from a THIRD, independent
+	// connection into the same schema, the user must never end up holding both
+	// sides of the toxic pair — only ever one of the two roles.
+	verifier := localstore.NewLocalStorage(pgOpen(t, dsn))
+	roles, err := verifier.GetUserRoles(context.Background(), userID)
+	require.NoError(t, err)
+	assert.Len(t, roles, 1, "the user must hold exactly one of the two toxic-pair roles, never both and never neither")
+}

--- a/internal/core/groups.go
+++ b/internal/core/groups.go
@@ -239,22 +239,22 @@ func (c *KeyorixCore) AddUserToGroup(ctx context.Context, actorID uint, actorIsM
 	if err := c.domainAllowedForGroupJoin(ctx, userID, groupID, projectID); err != nil {
 		return err
 	}
-	// #G04: validateGroupJoinRoles' set-based requireGroupJoinNoSoDViolation check
-	// and the membership write below must be treated as one step — see
-	// sodGrantMu's doc comment in service.go (AssignUserRole has the identical
-	// race).
-	c.sodGrantMu.Lock()
-	defer c.sodGrantMu.Unlock()
-	if actorID != 0 || actorIsMachine {
-		if err := c.validateGroupJoinRoles(ctx, actorID, userID, groupID); err != nil {
-			return err
+	// #G04/HA: validateGroupJoinRoles' set-based requireGroupJoinNoSoDViolation
+	// check and the membership write below must be treated as one step — see
+	// WithSoDGrantLock's doc comment in internal/core/storage/interface.go
+	// (AssignUserRole has the identical race).
+	return c.storage.WithSoDGrantLock(ctx, func() error {
+		if actorID != 0 || actorIsMachine {
+			if err := c.validateGroupJoinRoles(ctx, actorID, userID, groupID); err != nil {
+				return err
+			}
 		}
-	}
-	if err := c.storage.AddUserToGroup(ctx, userID, groupID, projectID); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-	c.LogGroupMemberAdded(ctx, actorID, userID, groupID)
-	return nil
+		if err := c.storage.AddUserToGroup(ctx, userID, groupID, projectID); err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		c.LogGroupMemberAdded(ctx, actorID, userID, groupID)
+		return nil
+	})
 }
 
 // AddUserToGroupGlobal is a convenience wrapper that adds a global membership

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -617,12 +617,30 @@ func (c *KeyorixCore) requiredApprovals() int {
 // threshold the request stays pending and the returned request carries the M-of-K
 // progress. When K is 1 (the default) the first approval grants immediately.
 func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projectID, requestID, approverID uint, grantedRole string, grantTTL time.Duration) (*models.AccessRequest, error) {
-	// #G04: dualControlApprovalMu holds for the whole read-approvals-decide-
-	// grant sequence below — see its doc comment in service.go for why two
-	// approvers racing at the exact threshold boundary can otherwise both
-	// read a below-threshold count and both finalize the grant.
-	c.dualControlApprovalMu.Lock()
-	defer c.dualControlApprovalMu.Unlock()
+	// #G04/HA: WithDualControlApprovalLock holds for the whole
+	// read-approvals-decide-grant sequence below — see its doc comment in
+	// internal/core/storage/interface.go for why two approvers racing at the
+	// exact threshold boundary can otherwise both read a below-threshold count
+	// and both finalize the grant, and why the former in-process-only
+	// dualControlApprovalMu provided no serialization at all between two HA
+	// replicas sharing the same Postgres database (#G04-HA).
+	var result *models.AccessRequest
+	err := c.storage.WithDualControlApprovalLock(ctx, func() error {
+		res, aerr := c.approveAccessRequestWithExpiryLocked(ctx, projectID, requestID, approverID, grantedRole, grantTTL)
+		result = res
+		return aerr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// approveAccessRequestWithExpiryLocked performs the actual read-approvals-
+// decide-grant sequence. The caller MUST hold
+// storage.WithDualControlApprovalLock for the duration of this call (see
+// ApproveAccessRequestWithExpiry).
+func (c *KeyorixCore) approveAccessRequestWithExpiryLocked(ctx context.Context, projectID, requestID, approverID uint, grantedRole string, grantTTL time.Duration) (*models.AccessRequest, error) {
 	req, err := c.storage.GetAccessRequest(ctx, requestID)
 	if err != nil {
 		return nil, fmt.Errorf("access request not found")

--- a/internal/core/jit_access.go
+++ b/internal/core/jit_access.go
@@ -42,14 +42,15 @@ func (c *KeyorixCore) AssignUserRoleWithExpiry(ctx context.Context, actorID, use
 	if err := c.requireGranterHoldsRolePermissions(ctx, actorID, roleID, scope, actorIsMachine); err != nil {
 		return err
 	}
-	// #G04: same unsynchronized-check-then-write race as AssignUserRole (see
-	// sodGrantMu's doc comment in service.go) — this is its time-bound sibling.
-	c.sodGrantMu.Lock()
-	defer c.sodGrantMu.Unlock()
-	if err := c.requireNoSoDViolation(ctx, userID, roleID); err != nil {
-		return err
-	}
-	return c.assignUserRoleWithExpirySkipSoD(ctx, actorID, userID, roleID, scope, expiresAt)
+	// #G04/HA: same check-then-write race as AssignUserRole (see
+	// WithSoDGrantLock's doc comment in internal/core/storage/interface.go) —
+	// this is its time-bound sibling.
+	return c.storage.WithSoDGrantLock(ctx, func() error {
+		if err := c.requireNoSoDViolation(ctx, userID, roleID); err != nil {
+			return err
+		}
+		return c.assignUserRoleWithExpirySkipSoD(ctx, actorID, userID, roleID, scope, expiresAt)
+	})
 }
 
 // assignUserRoleWithExpirySkipSoD performs the identical time-bound grant as
@@ -88,17 +89,17 @@ func (c *KeyorixCore) AssignGroupRoleWithExpiry(ctx context.Context, actorID, gr
 	if err := c.requireAuthorityForRole(ctx, actorID, scope.ProjectID, role.Name); err != nil {
 		return err
 	}
-	// #G04: see AssignUserRole's identical sodGrantMu use.
-	c.sodGrantMu.Lock()
-	defer c.sodGrantMu.Unlock()
-	if err := c.requireGroupGrantNoSoDViolation(ctx, groupID, roleID); err != nil {
-		return err
-	}
-	if err := c.storage.AssignRoleToGroupWithExpiry(ctx, groupID, roleID, scope, expiresAt); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-	c.LogGroupRoleAssigned(ctx, actorID, groupID, roleID, scope)
-	return nil
+	// #G04/HA: see AssignUserRole's identical WithSoDGrantLock use.
+	return c.storage.WithSoDGrantLock(ctx, func() error {
+		if err := c.requireGroupGrantNoSoDViolation(ctx, groupID, roleID); err != nil {
+			return err
+		}
+		if err := c.storage.AssignRoleToGroupWithExpiry(ctx, groupID, roleID, scope, expiresAt); err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		c.LogGroupRoleAssigned(ctx, actorID, groupID, roleID, scope)
+		return nil
+	})
 }
 
 // EventShareExpired is audited when a time-bound secret share is swept after expiry.

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -49,6 +49,21 @@ func (m *MockStorage) WithBootstrapLock(_ context.Context, fn func() error) erro
 	return fn()
 }
 
+// WithSoDGrantLock runs fn directly in tests (single instance, no DB lock).
+func (m *MockStorage) WithSoDGrantLock(_ context.Context, fn func() error) error {
+	return fn()
+}
+
+// WithAccessReviewDecisionLock runs fn directly in tests (single instance, no DB lock).
+func (m *MockStorage) WithAccessReviewDecisionLock(_ context.Context, fn func() error) error {
+	return fn()
+}
+
+// WithDualControlApprovalLock runs fn directly in tests (single instance, no DB lock).
+func (m *MockStorage) WithDualControlApprovalLock(_ context.Context, fn func() error) error {
+	return fn()
+}
+
 // WithTransaction runs fn directly against the mock (no real transaction in tests).
 func (m *MockStorage) WithTransaction(_ context.Context, fn func(storage.Storage) error) error {
 	return fn(m)

--- a/internal/core/postgres_contention_helpers_test.go
+++ b/internal/core/postgres_contention_helpers_test.go
@@ -1,0 +1,73 @@
+package core
+
+// postgres_contention_helpers_test.go — shared setup for cross-replica
+// Postgres HA-lock contention tests in this package. Distinct from
+// TestConcurrency_BootstrapSystem_CrossReplicaExactlyOneAdmin's own
+// sharedBootstrapStorage: that helper hands every simulated "replica" the
+// SAME storage.Storage instance, so they all serialize through one shared
+// LocalStorage's process-local bootstrapMu regardless of whether the
+// Postgres advisory lock in WithBootstrapLock does anything at all — a
+// single-instance test cannot distinguish "the lock works" from "the lock is
+// gone". These helpers instead give each simulated replica its own *gorm.DB
+// connection (own LocalStorage, own bootstrapMu) into the SAME isolated
+// Postgres schema, so pg_advisory_lock is the only thing left that can still
+// serialize them.
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var corePgContentionSchemaCounter int64
+
+// pgTestDSN returns the KEYORIX_TEST_PG_DSN base DSN, skipping the test (not
+// failing it) when unset.
+func pgTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("KEYORIX_TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("KEYORIX_TEST_PG_DSN not set — skipping Postgres HA-lock contention test")
+	}
+	return dsn
+}
+
+// pgIsolatedSchemaDSN creates a fresh schema on the real Postgres server at
+// base, dropped on test cleanup, and returns a DSN with search_path pointed
+// at it.
+func pgIsolatedSchemaDSN(t *testing.T, base string) string {
+	t.Helper()
+	n := atomic.AddInt64(&corePgContentionSchemaCounter, 1)
+	schema := fmt.Sprintf("core_contend_%d_%d", os.Getpid(), n)
+
+	admin := pgOpen(t, base)
+	require.NoError(t, admin.Exec("DROP SCHEMA IF EXISTS "+schema+" CASCADE").Error)
+	require.NoError(t, admin.Exec("CREATE SCHEMA "+schema).Error)
+	t.Cleanup(func() {
+		cleaner := pgOpen(t, base)
+		_ = cleaner.Exec("DROP SCHEMA IF EXISTS " + schema + " CASCADE").Error
+	})
+
+	return base + " search_path=" + schema
+}
+
+// pgOpen opens a *gorm.DB against dsn, closing it on test cleanup. Each call
+// is a genuinely separate connection — the independence contention tests in
+// this file rely on.
+func pgOpen(t *testing.T, dsn string) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: logger.Discard})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if sqlDB, dbErr := db.DB(); dbErr == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	return db
+}

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -173,17 +173,19 @@ func (c *KeyorixCore) AssignRoleToGroup(ctx context.Context, actorID, groupID, r
 	if err := c.requireAuthorityForRole(ctx, actorID, scope.ProjectID, role.Name); err != nil {
 		return err
 	}
-	// #G04: see AssignUserRole's identical sodGrantMu use.
-	c.sodGrantMu.Lock()
-	defer c.sodGrantMu.Unlock()
-	if err := c.requireGroupGrantNoSoDViolation(ctx, groupID, roleID); err != nil {
-		return err
-	}
-	if err := c.storage.AssignRoleToGroup(ctx, groupID, roleID, scope); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-	c.LogGroupRoleAssigned(ctx, actorID, groupID, roleID, scope)
-	return nil
+	// #G04/HA: see AssignUserRole's identical WithSoDGrantLock use — a plain
+	// in-process mutex here would not serialize this check-then-write against a
+	// second HA replica sharing the same Postgres database.
+	return c.storage.WithSoDGrantLock(ctx, func() error {
+		if err := c.requireGroupGrantNoSoDViolation(ctx, groupID, roleID); err != nil {
+			return err
+		}
+		if err := c.storage.AssignRoleToGroup(ctx, groupID, roleID, scope); err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		c.LogGroupRoleAssigned(ctx, actorID, groupID, roleID, scope)
+		return nil
+	})
 }
 
 // RemoveRoleFromGroup verifies the group exists then removes the role at scope
@@ -335,19 +337,22 @@ func (c *KeyorixCore) AssignUserRole(ctx context.Context, actorID, userID, roleI
 	if err := c.requireGranterHoldsRolePermissions(ctx, actorID, roleID, scope, false); err != nil {
 		return err
 	}
-	// #G04: sodGrantMu holds across the check AND the write — see its doc
-	// comment in service.go for why a separate, unsynchronized write lets two
-	// concurrent grants each pass a stale pre-grant SoD check.
-	c.sodGrantMu.Lock()
-	defer c.sodGrantMu.Unlock()
-	if err := c.requireNoSoDViolation(ctx, userID, roleID); err != nil {
-		return err
-	}
-	if err := c.storage.AssignRole(ctx, userID, roleID, scope); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-	c.LogRoleAssigned(ctx, actorID, userID, roleID, scope)
-	return nil
+	// #G04/HA: WithSoDGrantLock holds across the check AND the write — see its
+	// doc comment in internal/core/storage/interface.go for why a separate,
+	// unsynchronized write lets two concurrent grants each pass a stale
+	// pre-grant SoD check. Replaces the former in-process-only sodGrantMu,
+	// which provided no serialization at all between two HA replicas sharing
+	// the same Postgres database (#G04-HA).
+	return c.storage.WithSoDGrantLock(ctx, func() error {
+		if err := c.requireNoSoDViolation(ctx, userID, roleID); err != nil {
+			return err
+		}
+		if err := c.storage.AssignRole(ctx, userID, roleID, scope); err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		c.LogRoleAssigned(ctx, actorID, userID, roleID, scope)
+		return nil
+	})
 }
 
 // assignUserRoleSystemGrant performs the same audited grant as AssignUserRole but
@@ -377,17 +382,17 @@ func (c *KeyorixCore) AssignUserRole(ctx context.Context, actorID, userID, roleI
 // (IdP group membership can change on every login, which is at least as fast a
 // grant/revoke cycle as an explicit JIT grant).
 func (c *KeyorixCore) assignUserRoleSystemGrant(ctx context.Context, actorID, userID, roleID uint, scope Scope) error {
-	// #G04: see AssignUserRole's identical sodGrantMu use.
-	c.sodGrantMu.Lock()
-	defer c.sodGrantMu.Unlock()
-	if err := c.requireNoSoDViolation(ctx, userID, roleID); err != nil {
-		return err
-	}
-	if err := c.storage.AssignRole(ctx, userID, roleID, scope); err != nil {
-		return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
-	}
-	c.LogRoleAssigned(ctx, actorID, userID, roleID, scope)
-	return nil
+	// #G04/HA: see AssignUserRole's identical WithSoDGrantLock use.
+	return c.storage.WithSoDGrantLock(ctx, func() error {
+		if err := c.requireNoSoDViolation(ctx, userID, roleID); err != nil {
+			return err
+		}
+		if err := c.storage.AssignRole(ctx, userID, roleID, scope); err != nil {
+			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		}
+		c.LogRoleAssigned(ctx, actorID, userID, roleID, scope)
+		return nil
+	})
 }
 
 // RemoveUserRole removes a role from a user at the given scope and records an

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -150,45 +150,20 @@ type KeyorixCore struct {
 	// Combined with the row lock LockUserForUpdate takes on Postgres, this holds
 	// across replicas too. Zero value is ready to use. See account_state.go / scim.go.
 	accountStateMu sync.Mutex
-	// sodGrantMu serializes every role-grant path that runs a preventive
-	// separation-of-duties check (requireNoSoDViolation /
-	// requireGroupGrantNoSoDViolation) before writing the grant (#G04):
-	// AssignUserRole, assignUserRoleSystemGrant, AssignRoleToGroup,
-	// AssignUserRoleWithExpiry, AssignGroupRoleWithExpiry, and
-	// AddUserToGroup's validateGroupJoinRoles path (assignUserRoleWithExpirySkipSoD,
-	// break-glass's deliberate SoD-skip path, does not need it — it never reads
-	// SoD state to race against). Without it, two concurrent
-	// grants that are each individually SoD-clean can both read the principal's
-	// pre-grant permission set before either write commits, both pass the
-	// check, and together create the exact toxic-permission-combination the
-	// gate exists to block. In-process only (LocalStorage/single replica) —
-	// a RemoteStorage/multi-replica deployment would need a DB-level lock on
-	// the principal's role-grant rows to close the same window across
-	// processes, out of scope for this pattern-level fix. Zero value is ready
-	// to use. See sod.go / rbac_management.go / groups.go.
-	sodGrantMu sync.Mutex
-	// accessReviewDecisionMu serializes DecideAccessReviewItem's read-decide-
-	// act-persist sequence (#G04): the pending-decision check, the actual
-	// attest/revoke side effect, and the decision-stamping write must all be
-	// treated as one step. persistItemDecision's conditional UPDATE already
-	// stops a SECOND writer from persisting its Decision stamp, but without
-	// this mutex both concurrent callers can still read Decision==pending and
-	// both execute their attest/revoke action before either write commits —
-	// so the losing caller's real-world action (e.g. an actual revoke) still
-	// happened even though only the winner's stamp survives, leaving the
-	// persisted evidence silently wrong about what was decided. In-process
-	// only, same caveat as sodGrantMu. Zero value is ready to use. See
-	// access_review_campaign.go.
-	accessReviewDecisionMu sync.Mutex
-	// dualControlApprovalMu serializes ApproveAccessRequestWithExpiry's
-	// read-approvals-decide-grant sequence (#G04): two approvers signing off
-	// at the exact threshold boundary can otherwise both read the same
-	// below-threshold approval count before either's approval row commits,
-	// both compute "received == required", and both finalize the grant —
-	// defeating the K-distinct-approvers dual-control guarantee with fewer
-	// than K approvals actually recorded first. In-process only, same caveat
-	// as sodGrantMu. Zero value is ready to use. See invitations.go.
-	dualControlApprovalMu sync.Mutex
+	// The three preventive check-then-write races #G04 originally closed with
+	// KeyorixCore-level mutexes (sodGrantMu, accessReviewDecisionMu,
+	// dualControlApprovalMu) are now serialized via storage.WithSoDGrantLock /
+	// WithAccessReviewDecisionLock / WithDualControlApprovalLock (a process
+	// mutex, plus a PostgreSQL advisory lock across HA replicas — see sod.go /
+	// rbac_management.go / groups.go / jit_access.go, access_review_campaign.go,
+	// and invitations.go), not KeyorixCore-level mutexes: a per-process mutex
+	// here only ever serialized callers within ONE replica — two different
+	// replicas of an HA deployment racing the SAME principal's grant (or the
+	// same access-review item, or the same dual-control approval count) could
+	// each observe a stale pre-write snapshot before either write committed and
+	// both proceed, exactly the #339/#core-auth-03 gap BootstrapSystem's own
+	// storage.WithBootstrapLock closed first (#G04-HA). Mirrors that same
+	// design (see the comment above bootstrapToken).
 	// projectAdminGuardMu serializes guardLastProjectAdmin's read (#G03) with the
 	// role removal/change that follows it, in SetProjectMemberRole and
 	// RemoveProjectMember: without it, two concurrent calls demoting/removing two

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -88,6 +88,52 @@ type Storage interface {
 	// process mutex is enough.
 	WithBootstrapLock(ctx context.Context, fn func() error) error
 
+	// WithSoDGrantLock serializes the separation-of-duties preventive
+	// check-then-write sequence (#419/#G04-HA) shared by every direct/group role
+	// grant and group-join path (AssignUserRole, assignUserRoleSystemGrant,
+	// AssignUserRoleWithExpiry, AssignRoleToGroup, AssignGroupRoleWithExpiry,
+	// AddUserToGroup's validateGroupJoinRoles) across every replica of an HA
+	// deployment, mirroring WithBootstrapLock's mutex+advisory-lock design: an
+	// in-process mutex alone (the former sodGrantMu) only serializes callers
+	// within ONE server, so two different replicas each granting an
+	// individually SoD-clean role to the SAME principal can both read a
+	// pre-grant permission set that doesn't yet reflect the other's
+	// still-uncommitted grant, both pass the check, and together create the
+	// exact toxic-permission overlap the policy exists to block. Deliberately
+	// ONE shared lock across every SoD-gated path (not one per principal) —
+	// mirroring the single in-process mutex it replaces, so a group-role grant
+	// affecting a member and that same member's own direct grant still
+	// serialize against each other, not just against themselves. This BLOCKS
+	// until the lock is free, same as WithBootstrapLock: a losing replica must
+	// actually re-run its preventive check under the lock and observe the
+	// winner's now-committed grant, not silently no-op. On PostgreSQL it holds
+	// a session advisory lock (pg_advisory_lock) for the duration of fn; on
+	// SQLite (single instance, no cross-process concern) a process mutex is
+	// enough.
+	WithSoDGrantLock(ctx context.Context, fn func() error) error
+
+	// WithAccessReviewDecisionLock serializes DecideAccessReviewItem's
+	// pending-check + attest/revoke action + decision-stamp sequence
+	// (#419/#G04-HA) across every replica of an HA deployment, mirroring
+	// WithBootstrapLock's design. persistItemDecision's conditional UPDATE
+	// alone stops a second STAMP from persisting but not a second concurrent
+	// attest/revoke ACTION from executing before either write commits — two
+	// replicas racing the same pending item could otherwise both read
+	// Decision==pending and both carry out their side effect, even though only
+	// the winner's stamp survives. This BLOCKS until the lock is free, same as
+	// WithBootstrapLock.
+	WithAccessReviewDecisionLock(ctx context.Context, fn func() error) error
+
+	// WithDualControlApprovalLock serializes ApproveAccessRequestWithExpiry's
+	// read-approvals-decide-grant sequence (#419/#G04-HA) across every replica
+	// of an HA deployment, mirroring WithBootstrapLock's design: two approvers
+	// signing off at the exact K-of-N threshold boundary on different replicas
+	// could otherwise each read a below-threshold approval count before
+	// either's approval row commits, and both finalize the grant — defeating
+	// the K-distinct-approvers dual-control guarantee. This BLOCKS until the
+	// lock is free, same as WithBootstrapLock.
+	WithDualControlApprovalLock(ctx context.Context, fn func() error) error
+
 	// WithTransaction runs fn inside a single storage transaction: every mutation fn
 	// performs through the provided Storage commits together, or rolls back together if
 	// fn returns an error. The backing store decides the semantics — the local (DB)

--- a/internal/securefiles/securefiles_saferelcomponents_test.go
+++ b/internal/securefiles/securefiles_saferelcomponents_test.go
@@ -1,0 +1,59 @@
+package securefiles
+
+import "testing"
+
+// TestSafeRelComponents exercises safeRelComponents directly rather than only
+// through an outcome like Save/SecureWriteFileSync rejecting an escaping path.
+//
+// Phase 1 of this coverage audit mutated safeRelComponents' ".."-rejection
+// alone (dropping it from the component-rejection loop) and found
+// TestSaveRejectsPathEscapingBaseDir stayed green: resolveInside/
+// isPathInsideBase — a second, independent lexical guard checked earlier in
+// SecureWriteFileSync — still caught the same "../escape.yaml" input. That is
+// correct defense-in-depth, not a weak test: the invariant Save promises
+// ("must not write outside its base directory") held throughout. But it also
+// means a regression in THIS function alone, with the other layer intact,
+// would currently be invisible to any test in this package. This file closes
+// that gap by asserting on safeRelComponents' own return value, independent
+// of which (if any) other layer would also catch the same input.
+func TestSafeRelComponents(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+		want    []string // checked only when wantErr is false
+	}{
+		{name: "absolute path is rejected", in: "/etc/passwd", wantErr: true},
+		{name: "empty path is rejected", in: "", wantErr: true},
+		{name: "dot (cleans to empty) is rejected", in: ".", wantErr: true},
+		{name: "leading .. escapes and is rejected", in: "../escape.yaml", wantErr: true},
+		{name: "deep .. that still escapes is rejected", in: "a/../../escape.yaml", wantErr: true},
+		{name: "a trailing .. that Clean absorbs before it can escape is allowed", in: "a/b/..", wantErr: false, want: []string{"a"}},
+		{name: "a .. that Clean absorbs before it can escape is allowed", in: "a/../b", wantErr: false, want: []string{"b"}},
+		{name: "plain relative path is allowed", in: "a/b/c", wantErr: false, want: []string{"a", "b", "c"}},
+		{name: "single-component relative path is allowed", in: "keyorix.yaml", wantErr: false, want: []string{"keyorix.yaml"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := safeRelComponents(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("safeRelComponents(%q): expected an error, got parts %v", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("safeRelComponents(%q): unexpected error: %v", tc.in, err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("safeRelComponents(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("safeRelComponents(%q) = %v, want %v", tc.in, got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/storage/factory_rbac_pk_rebuild_postgres_test.go
+++ b/internal/storage/factory_rbac_pk_rebuild_postgres_test.go
@@ -1,0 +1,143 @@
+package storage
+
+// factory_rbac_pk_rebuild_postgres_test.go — the real-Postgres counterpart to
+// factory_rbac_pk_rebuild_test.go. That file's tests are SQLite-only
+// (gormOpenForTest), which is exactly why rebuildRolePKPostgres sat at 0.0%
+// coverage and rolePKIsComplete's Postgres branch at 57.1% (see this
+// campaign's report): TestCreateStorage_Postgres_FailsFast (storage_s2_test.go)
+// only ever drives createPostgresStorage's connection-refused branch, never
+// far enough to reach migrateDatabase → rebuildRolePKIfNeeded against a live
+// server. If rolePKIsComplete's Postgres branch ever misdetects "PK already
+// correct" when it isn't, rebuildRolePKIfNeeded silently skips the rebuild —
+// no error, no log — and a production Postgres deployment keeps the stale
+// 2-column PK indefinitely.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRolePKIsComplete_Postgres_OldTwoColumnPK is the Postgres counterpart to
+// TestRolePKIsComplete_SQLite_OldTwoColumnPK.
+func TestRolePKIsComplete_Postgres_OldTwoColumnPK(t *testing.T) {
+	base := pgTestDSN(t)
+	db := pgRawOpen(t, pgIsolatedDatabaseDSN(t, base))
+
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id   INTEGER NOT NULL,
+		role_id   INTEGER NOT NULL,
+		PRIMARY KEY (user_id, role_id)
+	)`).Error)
+
+	assert.False(t, rolePKIsComplete(db, "user_roles"),
+		"old two-column PK must be detected as incomplete on Postgres")
+}
+
+// TestRolePKIsComplete_Postgres_NewFourColumnPK is the Postgres counterpart to
+// TestRolePKIsComplete_SQLite_NewFourColumnPK.
+func TestRolePKIsComplete_Postgres_NewFourColumnPK(t *testing.T) {
+	base := pgTestDSN(t)
+	db := pgRawOpen(t, pgIsolatedDatabaseDSN(t, base))
+
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id        INTEGER NOT NULL,
+		role_id        INTEGER NOT NULL,
+		project_id     INTEGER NOT NULL DEFAULT 0,
+		environment_id INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY (user_id, role_id, project_id, environment_id)
+	)`).Error)
+
+	assert.True(t, rolePKIsComplete(db, "user_roles"),
+		"four-column composite PK must be detected as complete on Postgres")
+}
+
+// TestRolePKIsComplete_Postgres_ColumnsMentionedOutsidePKClause is the
+// Postgres counterpart to TestRolePKIsComplete_SQLite_ColumnsMentionedOutsidePKClause
+// (#STORAGE-FACTORY-002) — project_id/environment_id exist as ordinary
+// columns referenced only by a CHECK constraint, not as PK members.
+// rolePKIsComplete's Postgres branch queries information_schema.key_column_usage
+// joined against table_constraints filtered to constraint_type = 'PRIMARY KEY',
+// so this is a different code path from the SQLite pragma_table_info version —
+// worth pinning independently, not just inferring from the SQLite result.
+func TestRolePKIsComplete_Postgres_ColumnsMentionedOutsidePKClause(t *testing.T) {
+	base := pgTestDSN(t)
+	db := pgRawOpen(t, pgIsolatedDatabaseDSN(t, base))
+
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id        INTEGER NOT NULL,
+		role_id        INTEGER NOT NULL,
+		project_id     INTEGER NOT NULL DEFAULT 0,
+		environment_id INTEGER NOT NULL DEFAULT 0,
+		PRIMARY KEY (user_id, role_id),
+		CHECK (project_id >= 0 AND environment_id >= 0)
+	)`).Error)
+
+	assert.False(t, rolePKIsComplete(db, "user_roles"),
+		"project_id/environment_id mentioned only in a CHECK constraint (not the PK clause) must not be reported as PK members on Postgres")
+}
+
+// TestRebuildRolePKIfNeeded_Postgres_EndToEnd is the Postgres counterpart to
+// TestRebuildRolePKIfNeeded_SQLite_EndToEnd: a stale 2-column PK on both
+// user_roles and group_roles, with pre-existing data, rebuilt via
+// migrateDatabase (which on Postgres routes through rebuildRolePKPostgres,
+// never exercised end-to-end against a live server before this test) into
+// the correct 4-column composite PK — data preserved, and the actual
+// multi-project-scope grant this PK exists to allow now succeeds.
+func TestRebuildRolePKIfNeeded_Postgres_EndToEnd(t *testing.T) {
+	base := pgTestDSN(t)
+	db := pgRawOpen(t, pgIsolatedDatabaseDSN(t, base))
+
+	// Simulate a pre-#OLD-PK-fix Postgres schema: two-column PK only.
+	require.NoError(t, db.Exec(`CREATE TABLE user_roles (
+		user_id   INTEGER NOT NULL,
+		role_id   INTEGER NOT NULL,
+		PRIMARY KEY (user_id, role_id)
+	)`).Error)
+	require.NoError(t, db.Exec(`CREATE TABLE group_roles (
+		group_id INTEGER NOT NULL,
+		role_id  INTEGER NOT NULL,
+		PRIMARY KEY (group_id, role_id)
+	)`).Error)
+
+	require.NoError(t, db.Exec(`INSERT INTO user_roles  (user_id,  role_id) VALUES (1, 1)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO user_roles  (user_id,  role_id) VALUES (2, 2)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO group_roles (group_id, role_id) VALUES (1, 3)`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO group_roles (group_id, role_id) VALUES (2, 4)`).Error)
+
+	f := &DefaultStorageFactory{}
+	require.NoError(t, f.migrateDatabase(db))
+
+	assert.True(t, rolePKIsComplete(db, "user_roles"),
+		"user_roles must have the four-column composite PK after migrateDatabase on Postgres")
+	assert.True(t, rolePKIsComplete(db, "group_roles"),
+		"group_roles must have the four-column composite PK after migrateDatabase on Postgres")
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	var cnt int
+	require.NoError(t, sqlDB.QueryRow(`SELECT COUNT(*) FROM user_roles`).Scan(&cnt))
+	assert.Equal(t, 2, cnt, "both user_roles rows must survive the PK rebuild on Postgres")
+
+	require.NoError(t, sqlDB.QueryRow(`SELECT COUNT(*) FROM group_roles`).Scan(&cnt))
+	assert.Equal(t, 2, cnt, "both group_roles rows must survive the PK rebuild on Postgres")
+
+	// Post-rebuild: the same role can now be assigned at a second project
+	// scope — the core invariant this migration restores, and exactly what
+	// the stale 2-column PK made impossible (UNIQUE (user_id, role_id) would
+	// have rejected this as a duplicate key).
+	require.NoError(t, db.Exec(
+		`INSERT INTO user_roles (user_id, role_id, project_id, environment_id) VALUES (1, 1, 5, 0)`,
+	).Error, "same role at a different project scope must succeed after PK rebuild on Postgres")
+	require.NoError(t, db.Exec(
+		`INSERT INTO group_roles (group_id, role_id, project_id, environment_id) VALUES (1, 3, 7, 2)`,
+	).Error, "same role at a different environment scope must succeed after PK rebuild on Postgres")
+
+	// Idempotent: re-running migrateDatabase against the now-correct schema
+	// must not error (this also exercises rolePKIsComplete's true-branch
+	// early continue inside rebuildRolePKIfNeeded's loop on a live server).
+	require.NoError(t, f.migrateDatabase(db),
+		"migrateDatabase must be idempotent on Postgres — re-running must succeed")
+}

--- a/internal/storage/postgres_pk_rebuild_helpers_test.go
+++ b/internal/storage/postgres_pk_rebuild_helpers_test.go
@@ -1,0 +1,94 @@
+package storage
+
+// postgres_pk_rebuild_helpers_test.go — setup for exercising rolePKIsComplete/
+// rebuildRolePKPostgres against a REAL Postgres server. Unlike the contention
+// tests elsewhere in this campaign (internal/storage/store,
+// internal/core), this one cannot use a search_path-scoped isolated SCHEMA:
+// rolePKIsComplete, tableExists, and columnExists (factory.go) all hardcode
+// `table_schema = 'public'` in their information_schema queries, so a table
+// created under a non-public schema is invisible to them regardless of
+// search_path. (That hardcoding is itself worth noting: a deployment using a
+// non-default Postgres schema would have every one of these existence/PK
+// checks silently return false-negative — out of this campaign's scope to
+// fix, but recorded here since building this test is what surfaced it.)
+// This file instead isolates by creating a fresh, disposable DATABASE per
+// test, so each test's tables genuinely live in that database's own "public"
+// schema.
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var pkRebuildDBCounter int64
+
+// pgTestDSN returns the KEYORIX_TEST_PG_DSN base DSN, skipping the test (not
+// failing it) when unset.
+func pgTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("KEYORIX_TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("KEYORIX_TEST_PG_DSN not set — skipping Postgres role-PK migration test")
+	}
+	return dsn
+}
+
+// pgIsolatedDatabaseDSN creates a fresh, empty database on the real Postgres
+// server at base, dropped on test cleanup, and returns a DSN pointing at it.
+func pgIsolatedDatabaseDSN(t *testing.T, base string) string {
+	t.Helper()
+	n := atomic.AddInt64(&pkRebuildDBCounter, 1)
+	dbName := fmt.Sprintf("pk_rebuild_%d_%d", os.Getpid(), n)
+
+	admin := pgRawOpen(t, base)
+	require.NoError(t, admin.Exec("CREATE DATABASE "+dbName).Error)
+	t.Cleanup(func() {
+		cleaner := pgRawOpen(t, base)
+		// FORCE (PG 13+) drops even if something still holds a connection —
+		// this test always closes its own connections first, but a failed
+		// test run may not have.
+		_ = cleaner.Exec("DROP DATABASE IF EXISTS " + dbName + " WITH (FORCE)").Error
+	})
+
+	return replaceDBName(base, dbName)
+}
+
+// replaceDBName swaps the dbname= field in a libpq-style "key=value ..." DSN.
+func replaceDBName(dsn, newName string) string {
+	fields := strings.Fields(dsn)
+	out := make([]string, 0, len(fields)+1)
+	found := false
+	for _, f := range fields {
+		if strings.HasPrefix(f, "dbname=") {
+			out = append(out, "dbname="+newName)
+			found = true
+			continue
+		}
+		out = append(out, f)
+	}
+	if !found {
+		out = append(out, "dbname="+newName)
+	}
+	return strings.Join(out, " ")
+}
+
+// pgRawOpen opens a *gorm.DB against dsn, closing it on test cleanup.
+func pgRawOpen(t *testing.T, dsn string) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: logger.Discard})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if sqlDB, dbErr := db.DB(); dbErr == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	return db
+}

--- a/internal/storage/store/concurrency_audit_chain_postgres_test.go
+++ b/internal/storage/store/concurrency_audit_chain_postgres_test.go
@@ -1,0 +1,108 @@
+package store
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// TestConcurrency_AuditChain_MultiInstancePostgres_StaysWellFormed is the
+// cross-PROCESS counterpart to TestConcurrency_AuditChain_StaysWellFormed
+// (concurrency_audit_chain_test.go), which only ever exercises ONE
+// LocalStorage's process-local auditChainMu — on Postgres, that alone would
+// pass even if LogAuditEvent's pg_advisory_xact_lock call were deleted
+// outright, because every writer in that test shares the same mutex already.
+//
+// This test instead builds N independent LocalStorage instances, each with
+// its own *gorm.DB connection (its own process-local mutex), racing
+// LogAuditEvent against the SAME Postgres schema — simulating N separate
+// server replicas. The only thing that can still serialize the read-head+
+// insert critical section across independent mutexes is
+// pg_advisory_xact_lock. If that lock is missing or broken, two replicas can
+// both read the same chain head before either inserts, forking the chain
+// (two rows sharing one prev_hash) — exactly the tamper-evidence failure
+// ADR-029 exists to prevent, and exactly what VerifyAuditChain is written to
+// detect (a corrupted chain that fails silently until someone runs it).
+func TestConcurrency_AuditChain_MultiInstancePostgres_StaysWellFormed(t *testing.T) {
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	const instances = 5
+	const writersPerInstance = 10
+	const writers = instances * writersPerInstance
+
+	stores := make([]*LocalStorage, instances)
+	for i := 0; i < instances; i++ {
+		db := pgOpen(t, dsn)
+		require.NoError(t, db.AutoMigrate(&models.AuditEvent{}))
+		stores[i] = NewLocalStorage(db)
+	}
+
+	baseTime := time.Now().UTC()
+	errs := make(chan error, writers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	n := 0
+	for i := 0; i < instances; i++ {
+		ls := stores[i]
+		for j := 0; j < writersPerInstance; j++ {
+			wg.Add(1)
+			idx := n
+			n++
+			go func(ls *LocalStorage, idx int) {
+				defer wg.Done()
+				tr := true
+				e := &models.AuditEvent{
+					EventType:   "secret.read",
+					Description: "multi-instance concurrent append " + strconv.Itoa(idx),
+					Success:     &tr,
+					EventTime:   baseTime.Add(time.Duration(idx) * time.Millisecond),
+					ActorType:   "user",
+				}
+				<-start
+				if err := ls.LogAuditEvent(context.Background(), e); err != nil {
+					errs <- err
+				}
+			}(ls, idx)
+		}
+	}
+	close(start) // release every writer, across every instance, at once
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	// Verify from a fresh connection into the same schema — an independent
+	// reader, not one of the writer instances.
+	verifier := NewLocalStorage(pgOpen(t, dsn))
+	v, err := verifier.VerifyAuditChain(context.Background(), nil)
+	require.NoError(t, err)
+	assert.True(t, v.Valid, "chain must stay valid under concurrent multi-instance appends: %s", v.Reason)
+	assert.Nil(t, v.FirstBrokenID, "no event may break the chain")
+	assert.Equal(t, int64(writers), v.ChainedEvents, "every writer's append must be chained exactly once")
+	assert.Equal(t, int64(0), v.UnchainedEvents)
+
+	// No fork, no orphan, no duplicate: exactly `writers` rows, each with a
+	// unique entry_hash and a unique prev_hash (a fork reuses a prev_hash
+	// across two rows; an orphan/duplicate shows up as a row count mismatch).
+	var rows []models.AuditEvent
+	require.NoError(t, verifier.DB().Order("id ASC").Find(&rows).Error)
+	require.Len(t, rows, writers, "row count must equal total writers across every instance — no lost or duplicated append")
+	entrySeen := make(map[string]bool, writers)
+	prevSeen := make(map[string]bool, writers)
+	for _, r := range rows {
+		require.NotEmpty(t, r.EntryHash)
+		assert.False(t, entrySeen[r.EntryHash], "duplicate entry_hash means a fork/replay across replicas")
+		assert.False(t, prevSeen[r.PrevHash], "duplicate prev_hash means two replicas linked off the same head (fork)")
+		entrySeen[r.EntryHash] = true
+		prevSeen[r.PrevHash] = true
+	}
+}

--- a/internal/storage/store/concurrency_audit_checkpoint_lock_postgres_test.go
+++ b/internal/storage/store/concurrency_audit_checkpoint_lock_postgres_test.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrency_WithAuditCheckpointLock_MultiInstancePostgres_ExactlyOneRunsAtOnce
+// exercises local_audit_checkpoint_lock.go's pg_advisory_lock across
+// genuinely independent connections, the same way
+// TestConcurrency_WithSchedulerLock_MultiInstancePostgres_ExactlyOneRunsAtOnce
+// exercises the sibling scheduler lock: many independent LocalStorage
+// instances (own *gorm.DB, own Postgres backend connection) racing the SAME
+// advisory-lock key. This is the primitive #300's "chain-walk + decide +
+// create checkpoint" sequence (internal/core's WriteAuditCheckpoint) is built
+// on — see that function's own doc comment for the failure mode a broken
+// lock reopens (a later-committed checkpoint certifying FEWER chained events
+// than an earlier one, silently reopening ADR-029's truncation-detection
+// gap). This test verifies the LOCK PRIMITIVE itself: at most one holder's
+// critical section may run at a time, across independent connections. The
+// full checkpoint decision logic (signature/truncation checks) is exercised
+// separately (SQLite) in internal/core's own WriteAuditCheckpoint tests; this
+// is what actually protects it on Postgres/HA, previously unverified beyond
+// a single connection.
+func TestConcurrency_WithAuditCheckpointLock_MultiInstancePostgres_ExactlyOneRunsAtOnce(t *testing.T) {
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	const instances = 8
+
+	stores := make([]*LocalStorage, instances)
+	for i := 0; i < instances; i++ {
+		stores[i] = NewLocalStorage(pgOpen(t, dsn))
+	}
+
+	var running int32
+	var maxConcurrent int32
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < instances; i++ {
+		wg.Add(1)
+		go func(ls *LocalStorage) {
+			defer wg.Done()
+			<-start
+			err := ls.WithAuditCheckpointLock(context.Background(), func() error {
+				n := atomic.AddInt32(&running, 1)
+				for {
+					m := atomic.LoadInt32(&maxConcurrent)
+					if n <= m || atomic.CompareAndSwapInt32(&maxConcurrent, m, n) {
+						break
+					}
+				}
+				time.Sleep(150 * time.Millisecond) // hold the lock long enough for every racer to attempt while it's held
+				atomic.AddInt32(&running, -1)
+				return nil
+			})
+			require.NoError(t, err)
+		}(stores[i])
+	}
+	close(start) // release every instance's attempt at once
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&maxConcurrent),
+		"at most one replica's checkpoint-write critical section may run at a time")
+}

--- a/internal/storage/store/concurrency_rbac_lastadmin_postgres_test.go
+++ b/internal/storage/store/concurrency_rbac_lastadmin_postgres_test.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// TestConcurrency_RemoveGlobalAdminRoleGuarded_MultiInstancePostgres_NeverStrandsZeroAdmins
+// exercises local_rbac.go:375's ListGlobalAdminAssignmentsForUpdate FOR UPDATE
+// lock — the same TOCTOU class the G80 campaign has been closing, one layer
+// down: the "does removing this role leave the install with zero admins?"
+// check and the removal itself must be atomic, or two concurrent removals of
+// two DIFFERENT admins can each observe "the other one still exists" before
+// either write commits, and both proceed — stranding the install with zero
+// admins, able to authorize no one, including itself out of fixing the
+// problem (#340/#525).
+//
+// Genuinely independent connections (own LocalStorage, own transaction) are
+// required: a single connection racing itself would just serialize through
+// its own transaction anyway.
+func TestConcurrency_RemoveGlobalAdminRoleGuarded_MultiInstancePostgres_NeverStrandsZeroAdmins(t *testing.T) {
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	setupDB := pgOpen(t, dsn)
+	require.NoError(t, setupDB.AutoMigrate(
+		&models.User{}, &models.Role{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{},
+	))
+
+	const adminRoleID = uint(1)
+	require.NoError(t, setupDB.Create(&models.Role{ID: adminRoleID, Name: "admin"}).Error)
+	require.NoError(t, setupDB.Create(&models.User{ID: 1, Username: "admin-1", Email: "admin1@example.com"}).Error)
+	require.NoError(t, setupDB.Create(&models.User{ID: 2, Username: "admin-2", Email: "admin2@example.com"}).Error)
+	// Exactly two global-scope admin grants — removing either alone is fine;
+	// removing BOTH concurrently must leave exactly one standing.
+	require.NoError(t, setupDB.Create(&models.UserRole{UserID: 1, RoleID: adminRoleID, ProjectID: 0, EnvironmentID: 0}).Error)
+	require.NoError(t, setupDB.Create(&models.UserRole{UserID: 2, RoleID: adminRoleID, ProjectID: 0, EnvironmentID: 0}).Error)
+
+	replicaA := NewLocalStorage(pgOpen(t, dsn))
+	replicaB := NewLocalStorage(pgOpen(t, dsn))
+	adminIDs := []uint{adminRoleID}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		results <- replicaA.RemoveGlobalAdminRoleGuarded(context.Background(), 1, adminRoleID, adminIDs)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		results <- replicaB.RemoveGlobalAdminRoleGuarded(context.Background(), 2, adminRoleID, adminIDs)
+	}()
+	close(start) // release both replicas' removal attempts at once
+	wg.Wait()
+	close(results)
+
+	succeeded, refused := 0, 0
+	for err := range results {
+		switch {
+		case err == nil:
+			succeeded++
+		case errors.Is(err, storage.ErrWouldStrandLastAdmin):
+			refused++
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	assert.Equal(t, 1, succeeded, "exactly one of the two concurrent removals may succeed")
+	assert.Equal(t, 1, refused, "the other must be refused as it would strand the install with zero admins")
+
+	// Structural check, independent of which replica "won": the install must
+	// end up with exactly one global admin assignment, never zero.
+	verifier := pgOpen(t, dsn)
+	var remaining int64
+	require.NoError(t, verifier.Model(&models.UserRole{}).
+		Where("role_id = ? AND project_id = 0 AND environment_id = 0", adminRoleID).
+		Count(&remaining).Error)
+	assert.Equal(t, int64(1), remaining, "exactly one global admin assignment must remain — never zero, never two")
+}

--- a/internal/storage/store/concurrency_row_lock_sites_postgres_test.go
+++ b/internal/storage/store/concurrency_row_lock_sites_postgres_test.go
@@ -1,0 +1,102 @@
+package store
+
+// concurrency_row_lock_sites_postgres_test.go — the webauthn half of the
+// row-lock-site contention coverage. The users and machine-identity halves
+// moved to internal/core/concurrency_row_lock_sites_postgres_test.go so each
+// calls its REAL production entry point (recordFailedLogin,
+// TransitionMachineIdentity) instead of reconstructing the lock-then-write
+// sequence here — see that file's header for why. webauthn stays here: its
+// production caller, persistUpdatedCredential (internal/core/webauthn.go),
+// calls storage.AdvanceWebAuthnCredentialCounter directly with no logic in
+// between — that storage-layer call already IS the production entry point,
+// not a reconstruction of one, so there was nothing to move.
+//
+// webauthn: a high-watermark counter (AdvanceWebAuthnCredentialCounter only
+// persists a newSignCount that exceeds what's currently stored, via
+// UpdateWebAuthnCredential — a plain Save, no CAS guard). The row lock is what
+// stops a smaller, stale value from clobbering an already-committed larger one
+// under a race. Verified by disabling the lock and re-running: goes red
+// deterministically without it.
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// raceIndependentInstances spins up n independent LocalStorage instances
+// (own connection each) into dsn, and runs race(ls, idx) on all of them
+// concurrently, released by a single start barrier. Any error race returns
+// fails the test immediately (via require, in the calling goroutine's
+// deferred check) — every case here expects every racer to return cleanly,
+// win or lose; a non-nil error is itself the bug this file exists to catch
+// (see the scheduler-lease finding this campaign fixed).
+func raceIndependentInstances(t *testing.T, dsn string, n int, race func(ls *LocalStorage, idx int) error) {
+	t.Helper()
+	stores := make([]*LocalStorage, n)
+	for i := 0; i < n; i++ {
+		stores[i] = NewLocalStorage(pgOpen(t, dsn))
+	}
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int, ls *LocalStorage) {
+			defer wg.Done()
+			<-start
+			if err := race(ls, idx); err != nil {
+				errs <- err
+			}
+		}(i, stores[i])
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func TestConcurrency_RowLockSites_MultiInstancePostgres(t *testing.T) {
+	base := pgTestDSN(t)
+
+	t.Run("webauthn_signCount_never_regresses", func(t *testing.T) {
+		dsn := pgIsolatedSchemaDSN(t, base)
+		setupDB := pgOpen(t, dsn)
+		require.NoError(t, setupDB.AutoMigrate(&models.WebAuthnCredential{}))
+		credID := []byte("cred-race")
+		initialBlob, err := json.Marshal(map[string]any{"authenticator": map[string]any{"signCount": 0}})
+		require.NoError(t, err)
+		require.NoError(t, setupDB.Create(&models.WebAuthnCredential{
+			ID: 1, UserID: 1, CredentialID: credID, CredentialBlob: initialBlob,
+		}).Error)
+
+		const n = 8
+		raceIndependentInstances(t, dsn, n, func(ls *LocalStorage, idx int) error {
+			// Racer idx presents signCount = idx+1 (values 1..n) — the max, n,
+			// must win regardless of goroutine scheduling order.
+			blob, err := json.Marshal(map[string]any{"authenticator": map[string]any{"signCount": idx + 1}})
+			if err != nil {
+				return err
+			}
+			_, err = ls.AdvanceWebAuthnCredentialCounter(context.Background(), credID, 1, blob, uint32(idx+1), time.Now().UTC())
+			return err
+		})
+
+		verifier := pgOpen(t, dsn)
+		var final models.WebAuthnCredential
+		require.NoError(t, verifier.Where("credential_id = ?", credID).First(&final).Error)
+		var stored webauthnStoredCounter
+		require.NoError(t, json.Unmarshal(final.CredentialBlob, &stored))
+		assert.Equal(t, uint32(n), stored.Authenticator.SignCount,
+			"the stored counter must end at the maximum presented value — a smaller concurrent value must never clobber a larger already-committed one")
+	})
+}

--- a/internal/storage/store/concurrency_scheduler_lock_postgres_test.go
+++ b/internal/storage/store/concurrency_scheduler_lock_postgres_test.go
@@ -1,0 +1,202 @@
+package store
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// TestConcurrency_WithSchedulerLock_MultiInstancePostgres_ExactlyOneRunsAtOnce
+// exercises WithSchedulerLock's pg_try_advisory_lock (local_scheduler_lock.go)
+// across genuinely independent connections — a single-connection test cannot
+// say anything about it: pg_try_advisory_lock is scoped to the SESSION taking
+// it, so one connection calling it twice would just re-acquire its own lock.
+// This drives many independent LocalStorage instances (own *gorm.DB, own
+// Postgres backend connection) at the SAME advisory-lock key concurrently:
+// exactly one may run its job at a time, every other concurrent attempt must
+// see the lock held and skip the tick (acquired=false) rather than running
+// alongside the winner — the "only one replica runs this periodic job" ADR-039
+// guarantee this function exists to provide.
+func TestConcurrency_WithSchedulerLock_MultiInstancePostgres_ExactlyOneRunsAtOnce(t *testing.T) {
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	const instances = 8
+	const key = 0x5343484544 // arbitrary, namespaced to this test
+
+	stores := make([]*LocalStorage, instances)
+	for i := 0; i < instances; i++ {
+		stores[i] = NewLocalStorage(pgOpen(t, dsn))
+	}
+
+	var running int32
+	var maxConcurrent int32
+	var acquiredCount int32
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < instances; i++ {
+		wg.Add(1)
+		go func(ls *LocalStorage) {
+			defer wg.Done()
+			<-start
+			acquired, err := ls.WithSchedulerLock(context.Background(), key, func() error {
+				n := atomic.AddInt32(&running, 1)
+				for {
+					m := atomic.LoadInt32(&maxConcurrent)
+					if n <= m || atomic.CompareAndSwapInt32(&maxConcurrent, m, n) {
+						break
+					}
+				}
+				time.Sleep(150 * time.Millisecond) // hold the lock long enough for every racer to attempt while it's held
+				atomic.AddInt32(&running, -1)
+				return nil
+			})
+			require.NoError(t, err)
+			if acquired {
+				atomic.AddInt32(&acquiredCount, 1)
+			}
+		}(stores[i])
+	}
+	close(start) // release every instance's attempt at once
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&maxConcurrent), "at most one replica's job may run at a time")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&acquiredCount), "exactly one replica may win the advisory lock for this tick")
+}
+
+// TestConcurrency_SchedulerLockLease_MultiInstancePostgres exercises the
+// row-based lease (local_scheduler_lock_lease.go) used by RemoteStorage's
+// WithSchedulerLock, which is deliberately independent of the advisory-lock
+// mechanism above — its own FOR UPDATE row lock, tested here the same way:
+// genuinely independent connections, not one connection racing itself.
+//
+// Two properties, matching the task: (a) under concurrent contention on a
+// BRAND-NEW key (never acquired before — the race that matters, and the one
+// this test used to avoid), exactly one holder wins; (b) after the winner's
+// lease TTL expires without renewal, a DIFFERENT holder can reclaim the SAME
+// key — and at every point in between there is at most one lease row for
+// that key, so no two holders are ever simultaneously valid.
+//
+// (a) used to seed the row with one uncontended acquire before racing
+// contenders against it, deliberately avoiding a brand-new-key race: prior to
+// the ON CONFLICT DO NOTHING fix (local_scheduler_lock_lease.go), a
+// concurrent first-time INSERT's unique-constraint violation aborted the
+// whole enclosing Postgres transaction, and the Go recovery code
+// (`if isUniqueViolation(createErr) { return nil }`) never got a chance to
+// run — GORM's COMMIT on the already-aborted transaction was silently
+// downgraded to a ROLLBACK, surfacing as a caller-facing error instead of
+// (false, nil). See this campaign's report for the original repro. Now that
+// the conflict is prevented rather than caught, this races the brand-new key
+// directly — that race is the acceptance criterion.
+func TestConcurrency_SchedulerLockLease_MultiInstancePostgres(t *testing.T) {
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	db := pgOpen(t, dsn)
+	require.NoError(t, db.AutoMigrate(&models.SchedulerLockLease{}))
+
+	const instances = 8
+	const key = 0x4C454153450 // arbitrary, namespaced to this test; never acquired before this race
+
+	stores := make([]*LocalStorage, instances)
+	for i := 0; i < instances; i++ {
+		stores[i] = NewLocalStorage(pgOpen(t, dsn))
+	}
+
+	// (a) contention: every instance races to be the FIRST-EVER acquirer of
+	// this key, with a distinct holder id. Exactly one may win; every other
+	// attempt must return cleanly (false, nil) — none may error.
+	var wonCount int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	winners := make(chan string, instances)
+	for i := 0; i < instances; i++ {
+		wg.Add(1)
+		go func(idx int, ls *LocalStorage) {
+			defer wg.Done()
+			holder := "replica-" + string(rune('A'+idx))
+			<-start
+			acquired, err := ls.TryAcquireSchedulerLock(context.Background(), key, holder, 5*time.Second)
+			require.NoError(t, err, "a losing racer on a brand-new key must return (false, nil), never an error")
+			if acquired {
+				atomic.AddInt32(&wonCount, 1)
+				winners <- holder
+			}
+		}(i, stores[i])
+	}
+	close(start)
+	wg.Wait()
+	close(winners)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&wonCount), "exactly one of the eight racing first-time acquirers may win")
+	require.Len(t, winners, 1)
+	winner := <-winners
+
+	verifier := NewLocalStorage(pgOpen(t, dsn))
+	assertExactlyOneLease(t, verifier, key, winner)
+
+	// (b) expiry handover: a SHORT-TTL lease from a fresh holder, left
+	// unrenewed past expiry, must become reclaimable by a different holder —
+	// and only by one at a time, same as above.
+	const handoverKey = key + 1
+	holderA := NewLocalStorage(pgOpen(t, dsn))
+	acquiredA, err := holderA.TryAcquireSchedulerLock(context.Background(), handoverKey, "holder-A", 100*time.Millisecond)
+	require.NoError(t, err)
+	require.True(t, acquiredA)
+
+	// While still valid, a different holder must be refused.
+	holderB := NewLocalStorage(pgOpen(t, dsn))
+	acquiredB, err := holderB.TryAcquireSchedulerLock(context.Background(), handoverKey, "holder-B", 5*time.Second)
+	require.NoError(t, err)
+	assert.False(t, acquiredB, "holder-B must not acquire while holder-A's lease is still valid")
+
+	time.Sleep(200 * time.Millisecond) // past holder-A's 100ms TTL, never renewed (simulates a crashed replica)
+
+	// Multiple late claimants race the now-expired lease; exactly one may
+	// reclaim it.
+	var reclaimWon int32
+	var wg2 sync.WaitGroup
+	claimants := []*LocalStorage{holderB, NewLocalStorage(pgOpen(t, dsn)), NewLocalStorage(pgOpen(t, dsn))}
+	names := []string{"holder-B", "holder-C", "holder-D"}
+	start2 := make(chan struct{})
+	reclaimWinner := make(chan string, len(claimants))
+	for i, ls := range claimants {
+		wg2.Add(1)
+		go func(idx int, ls *LocalStorage) {
+			defer wg2.Done()
+			<-start2
+			ok, err := ls.TryAcquireSchedulerLock(context.Background(), handoverKey, names[idx], 5*time.Second)
+			require.NoError(t, err)
+			if ok {
+				atomic.AddInt32(&reclaimWon, 1)
+				reclaimWinner <- names[idx]
+			}
+		}(i, ls)
+	}
+	close(start2)
+	wg2.Wait()
+	close(reclaimWinner)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&reclaimWon), "exactly one late claimant may reclaim an expired lease")
+	newHolder := <-reclaimWinner
+	assertExactlyOneLease(t, verifier, handoverKey, newHolder)
+}
+
+// assertExactlyOneLease checks there is exactly one lease row for key and
+// that its holder is exactly want — the structural check that no two
+// holders are ever simultaneously valid for the same key.
+func assertExactlyOneLease(t *testing.T, verifier *LocalStorage, key int64, want string) {
+	t.Helper()
+	var leases []models.SchedulerLockLease
+	require.NoError(t, verifier.DB().Where("key = ?", key).Find(&leases).Error)
+	require.Len(t, leases, 1, "exactly one lease row must exist for this key")
+	assert.Equal(t, want, leases[0].Holder)
+}

--- a/internal/storage/store/entry.go
+++ b/internal/storage/store/entry.go
@@ -195,11 +195,36 @@ type LocalStorage struct {
 	// same reason as auditChainMu/auditCheckpointMu — a transaction-scoped
 	// LocalStorage must share its parent's mutex.
 	bootstrapMu *sync.Mutex
+	// sodGrantMu serializes the separation-of-duties preventive check-then-write
+	// sequence (#419/#G04-HA) within this process. The PostgreSQL advisory lock in
+	// WithSoDGrantLock extends this across processes/replicas. A pointer for the
+	// same reason as the other With*Lock mutexes above.
+	sodGrantMu *sync.Mutex
+	// accessReviewDecisionMu serializes DecideAccessReviewItem's pending-check +
+	// action + stamp sequence (#419/#G04-HA) within this process. The PostgreSQL
+	// advisory lock in WithAccessReviewDecisionLock extends this across
+	// processes/replicas. A pointer for the same reason as the other With*Lock
+	// mutexes above.
+	accessReviewDecisionMu *sync.Mutex
+	// dualControlApprovalMu serializes ApproveAccessRequestWithExpiry's
+	// read-approvals-decide-grant sequence (#419/#G04-HA) within this process. The
+	// PostgreSQL advisory lock in WithDualControlApprovalLock extends this across
+	// processes/replicas. A pointer for the same reason as the other With*Lock
+	// mutexes above.
+	dualControlApprovalMu *sync.Mutex
 }
 
 // NewLocalStorage creates a LocalStorage backed by the given *gorm.DB.
 func NewLocalStorage(db *gorm.DB) *LocalStorage {
-	return &LocalStorage{db: db, auditChainMu: &sync.Mutex{}, auditCheckpointMu: &sync.Mutex{}, bootstrapMu: &sync.Mutex{}}
+	return &LocalStorage{
+		db:                     db,
+		auditChainMu:           &sync.Mutex{},
+		auditCheckpointMu:      &sync.Mutex{},
+		bootstrapMu:            &sync.Mutex{},
+		sodGrantMu:             &sync.Mutex{},
+		accessReviewDecisionMu: &sync.Mutex{},
+		dualControlApprovalMu:  &sync.Mutex{},
+	}
 }
 
 // DB returns the underlying *gorm.DB. Exposed for test helpers that need direct

--- a/internal/storage/store/local_access_review_decision_lock.go
+++ b/internal/storage/store/local_access_review_decision_lock.go
@@ -1,0 +1,63 @@
+// local_access_review_decision_lock.go — serializes DecideAccessReviewItem's
+// pending-check + attest/revoke action + decision-stamp sequence across
+// replicas (#419/#G04-HA).
+//
+// persistItemDecision's conditional UPDATE already stops a SECOND writer from
+// persisting its Decision stamp, but that alone does not stop a second
+// concurrent caller from executing the real attest/revoke ACTION before
+// either write commits: without a lock spanning the whole sequence, two
+// replicas racing the same pending item can each read Decision==pending and
+// each carry out its side effect (e.g. an actual revoke), even though only
+// the winner's stamp survives — leaving the persisted evidence silently
+// wrong about what was decided.
+package store
+
+import (
+	"context"
+	"fmt"
+)
+
+// accessReviewDecisionAdvisoryLockKey is the Postgres advisory-lock key
+// guarding DecideAccessReviewItem's check-act-persist sequence across
+// processes. Distinct from every other advisory-lock key in this package.
+const accessReviewDecisionAdvisoryLockKey = 0x4B455941_4152444C // "KEYAARDL"
+
+// WithAccessReviewDecisionLock runs fn with DecideAccessReviewItem's
+// pending-check-through-persist sequence serialized: a process-level mutex
+// covers the common single-writer self-host topology and SQLite (inherently
+// single-instance — there is no DB-level advisory lock to take); a
+// PostgreSQL session-scoped advisory lock (pg_advisory_lock) extends that
+// across processes/replicas (ADR-039 HA).
+//
+// Like WithBootstrapLock/WithAuditCheckpointLock, this BLOCKS until the lock
+// is acquired rather than skipping on contention — a replica that loses the
+// race must actually re-run its pending check under the lock and observe the
+// winner's now-committed decision, not silently no-op.
+func (ls *LocalStorage) WithAccessReviewDecisionLock(ctx context.Context, fn func() error) error {
+	ls.accessReviewDecisionMu.Lock()
+	defer ls.accessReviewDecisionMu.Unlock()
+
+	if ls.db.Dialector.Name() != "postgres" {
+		return fn()
+	}
+
+	sqlDB, err := ls.db.DB()
+	if err != nil {
+		return err
+	}
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }() // returns the conn to the pool (after the unlock below)
+
+	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", int64(accessReviewDecisionAdvisoryLockKey)); err != nil {
+		return fmt.Errorf("failed to acquire access-review-decision advisory lock: %w", err)
+	}
+	// Release before the deferred Close so the pooled connection carries no lock.
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", int64(accessReviewDecisionAdvisoryLockKey))
+	}()
+
+	return fn()
+}

--- a/internal/storage/store/local_dual_control_approval_lock.go
+++ b/internal/storage/store/local_dual_control_approval_lock.go
@@ -1,0 +1,61 @@
+// local_dual_control_approval_lock.go — serializes
+// ApproveAccessRequestWithExpiry's read-approvals-decide-grant sequence
+// across replicas (#419/#G04-HA).
+//
+// Two approvers signing off at the exact K-of-N dual-control threshold
+// boundary on DIFFERENT replicas of an HA deployment can otherwise each read
+// the same below-threshold approval count before either's approval row
+// commits, both compute "received == required", and both finalize the
+// grant — defeating the K-distinct-approvers dual-control guarantee with
+// fewer than K approvals actually recorded first.
+package store
+
+import (
+	"context"
+	"fmt"
+)
+
+// dualControlApprovalAdvisoryLockKey is the Postgres advisory-lock key
+// guarding ApproveAccessRequestWithExpiry's read-decide-grant sequence across
+// processes. Distinct from every other advisory-lock key in this package.
+const dualControlApprovalAdvisoryLockKey = 0x4B455941_4443414C // "KEYADCAL"
+
+// WithDualControlApprovalLock runs fn with ApproveAccessRequestWithExpiry's
+// whole read-approvals-decide-grant sequence serialized: a process-level
+// mutex covers the common single-writer self-host topology and SQLite
+// (inherently single-instance — there is no DB-level advisory lock to take);
+// a PostgreSQL session-scoped advisory lock (pg_advisory_lock) extends that
+// across processes/replicas (ADR-039 HA).
+//
+// Like WithBootstrapLock/WithAuditCheckpointLock, this BLOCKS until the lock
+// is acquired rather than skipping on contention — a replica that loses the
+// race must actually re-count approvals under the lock and observe the
+// winner's now-committed approval/grant, not silently no-op.
+func (ls *LocalStorage) WithDualControlApprovalLock(ctx context.Context, fn func() error) error {
+	ls.dualControlApprovalMu.Lock()
+	defer ls.dualControlApprovalMu.Unlock()
+
+	if ls.db.Dialector.Name() != "postgres" {
+		return fn()
+	}
+
+	sqlDB, err := ls.db.DB()
+	if err != nil {
+		return err
+	}
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }() // returns the conn to the pool (after the unlock below)
+
+	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", int64(dualControlApprovalAdvisoryLockKey)); err != nil {
+		return fmt.Errorf("failed to acquire dual-control-approval advisory lock: %w", err)
+	}
+	// Release before the deferred Close so the pooled connection carries no lock.
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", int64(dualControlApprovalAdvisoryLockKey))
+	}()
+
+	return fn()
+}

--- a/internal/storage/store/local_rbac.go
+++ b/internal/storage/store/local_rbac.go
@@ -423,7 +423,15 @@ func (ls *LocalStorage) ListGlobalAdminAssignmentsForUpdate(ctx context.Context,
 // when the caller drove both calls under its own WithTransaction.
 func (ls *LocalStorage) RemoveGlobalAdminRoleGuarded(ctx context.Context, userID, roleID uint, adminRoleIDs []uint) error {
 	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		txStorage := &LocalStorage{db: tx, auditChainMu: ls.auditChainMu, auditCheckpointMu: ls.auditCheckpointMu, bootstrapMu: ls.bootstrapMu}
+		txStorage := &LocalStorage{
+			db:                     tx,
+			auditChainMu:           ls.auditChainMu,
+			auditCheckpointMu:      ls.auditCheckpointMu,
+			bootstrapMu:            ls.bootstrapMu,
+			sodGrantMu:             ls.sodGrantMu,
+			accessReviewDecisionMu: ls.accessReviewDecisionMu,
+			dualControlApprovalMu:  ls.dualControlApprovalMu,
+		}
 		assignments, err := txStorage.ListGlobalAdminAssignmentsForUpdate(ctx, adminRoleIDs)
 		if err != nil {
 			return fmt.Errorf("%s: %w", i18n.T("ErrorRetrievalFailed", nil), err)

--- a/internal/storage/store/local_scheduler_lock_lease.go
+++ b/internal/storage/store/local_scheduler_lock_lease.go
@@ -22,7 +22,6 @@ package store
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
@@ -30,15 +29,14 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// TryAcquireSchedulerLock attempts, in one transaction (so the read-then-
-// decide-then-write below is atomic against a concurrent attempt on the same
-// key — including on Postgres, where the SELECT is taken under a row lock),
-// to take or renew the named lock for holder.
+// TryAcquireSchedulerLock attempts, in one transaction, to take or renew the
+// named lock for holder.
 //
-//   - No row exists yet: insert one. A concurrent racer's insert can still slip
-//     in between this transaction's own SELECT and INSERT; the primary key
-//     (Key) turns that into a unique-constraint violation, caught below and
-//     treated as "lost the race" rather than a hard error.
+//   - No row exists yet: the unconditional INSERT ... ON CONFLICT DO NOTHING
+//     below either creates it outright (RowsAffected == 1, we won), or a
+//     concurrent racer's insert won the conflict first (RowsAffected == 0) and
+//     execution falls through to the read-and-decide path below, exactly as
+//     if the row had already existed.
 //   - A row exists, held by holder itself (not yet expired, or expired — either
 //     way it's this holder's own lease): update ExpiresAt. This is the renewal/
 //     heartbeat path RemoteStorage.WithSchedulerLock uses to extend the lease
@@ -47,40 +45,59 @@ import (
 //     stays false — the lock is genuinely contended.
 //   - A row exists, held by a different holder but already expired: reclaim it
 //     for the new holder (crash/partition self-heal).
+//
+// This deliberately PREVENTS the concurrent-first-insert conflict via
+// ON CONFLICT DO NOTHING rather than catching a unique-constraint violation
+// after the fact (the prior shape here): on Postgres, once an INSERT inside a
+// transaction raises a unique-constraint violation, the ENTIRE transaction is
+// aborted at the protocol level — no further statement can run, and GORM's
+// subsequent COMMIT is silently downgraded to a ROLLBACK by the server. A Go
+// `if isUniqueViolation(err) { return nil }` never gets a chance to matter: by
+// the time it runs, the transaction is already unusable, and the caller sees
+// a confusing "commit unexpectedly resulted in rollback" instead of the
+// intended (false, nil) "someone else won". ON CONFLICT DO NOTHING never
+// raises an error in the first place, so there is nothing to catch and no
+// transaction to abort — the race becomes a non-event instead of an error to
+// recover from. Confirmed fixed against real Postgres (this campaign's
+// report); ON CONFLICT DO NOTHING is also GORM's standard driver-agnostic
+// idiom (see CreateBreakGlassActivation, local_break_glass.go, for the same
+// shape), so this is unchanged, not newly risky, on SQLite.
 func (ls *LocalStorage) TryAcquireSchedulerLock(ctx context.Context, key int64, holder string, ttl time.Duration) (bool, error) { // NOSONAR -- cognitive complexity 19, suppress go:S3776
 	now := time.Now()
 	expiresAt := now.Add(ttl)
 	acquired := false
 	err := ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		res := tx.Clauses(clause.OnConflict{DoNothing: true}).
+			Create(&models.SchedulerLockLease{Key: key, Holder: holder, ExpiresAt: expiresAt})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 1 {
+			acquired = true
+			return nil
+		}
+
+		// The row already existed — either from before this call, or a
+		// concurrent racer's insert won the conflict above. Read it (under
+		// FOR UPDATE on Postgres, so this decision serializes against a
+		// concurrent renew/reclaim on the same key) and decide.
 		q := tx
 		if tx.Dialector.Name() == "postgres" {
 			q = q.Clauses(clause.Locking{Strength: "UPDATE"})
 		}
 		var existing models.SchedulerLockLease
-		err := q.Where("key = ?", key).Take(&existing).Error
-		switch {
-		case errors.Is(err, gorm.ErrRecordNotFound):
-			if createErr := tx.Create(&models.SchedulerLockLease{Key: key, Holder: holder, ExpiresAt: expiresAt}).Error; createErr != nil {
-				if isUniqueViolation(createErr) {
-					return nil // lost the race to a concurrent first-time acquire; acquired stays false
-				}
-				return createErr
-			}
-			acquired = true
-			return nil
-		case err != nil:
+		if err := q.Where("key = ?", key).Take(&existing).Error; err != nil {
 			return err
-		default:
-			if existing.Holder != holder && existing.ExpiresAt.After(now) {
-				return nil // held by someone else and not yet expired — genuinely contended
-			}
-			if updErr := tx.Model(&models.SchedulerLockLease{}).Where("key = ?", key).
-				Updates(map[string]any{"holder": holder, "expires_at": expiresAt}).Error; updErr != nil {
-				return updErr
-			}
-			acquired = true
-			return nil
 		}
+		if existing.Holder != holder && existing.ExpiresAt.After(now) {
+			return nil // held by someone else and not yet expired — genuinely contended
+		}
+		if updErr := tx.Model(&models.SchedulerLockLease{}).Where("key = ?", key).
+			Updates(map[string]any{"holder": holder, "expires_at": expiresAt}).Error; updErr != nil {
+			return updErr
+		}
+		acquired = true
+		return nil
 	})
 	if err != nil {
 		return false, err

--- a/internal/storage/store/local_sod_grant_lock.go
+++ b/internal/storage/store/local_sod_grant_lock.go
@@ -1,0 +1,72 @@
+// local_sod_grant_lock.go — serializes every separation-of-duties-gated role
+// grant/join path's preventive check-then-write sequence across replicas
+// (#419/#G04-HA).
+//
+// AssignUserRole, assignUserRoleSystemGrant, AssignUserRoleWithExpiry,
+// AssignRoleToGroup, AssignGroupRoleWithExpiry, and AddUserToGroup's
+// validateGroupJoinRoles path were previously guarded only by a
+// KeyorixCore-level sync.Mutex (sodGrantMu), which serializes concurrent
+// callers within ONE server process but does nothing for two different
+// replicas of an HA deployment racing a grant against the SAME principal on
+// the same shared database: each replica's mutex only guards its own
+// process, so both can read a pre-grant permission set that doesn't yet
+// reflect the other's still-uncommitted grant, both pass the preventive
+// check, and together create the exact toxic-permission overlap the policy
+// exists to block.
+package store
+
+import (
+	"context"
+	"fmt"
+)
+
+// sodGrantAdvisoryLockKey is the Postgres advisory-lock key guarding the SoD
+// preventive-check-then-write sequence across processes. Distinct from every
+// other advisory-lock key in this package — the critical sections are
+// independent and must not contend with each other.
+const sodGrantAdvisoryLockKey = 0x4B455941_534F4447 // "KEYASODG"
+
+// WithSoDGrantLock runs fn with a SoD-gated grant/join's check-then-write
+// sequence serialized: a process-level mutex covers the common single-writer
+// self-host topology and SQLite (inherently single-instance — there is no
+// DB-level advisory lock to take); a PostgreSQL session-scoped advisory lock
+// (pg_advisory_lock) extends that across processes/replicas (ADR-039 HA).
+//
+// Deliberately ONE shared lock across every SoD-gated path (not one per
+// principal) — mirroring the single in-process mutex it replaces, so e.g. a
+// group-role grant affecting a member and that same member's own concurrent
+// direct grant still serialize against each other, not just against
+// themselves.
+//
+// Like WithBootstrapLock/WithAuditCheckpointLock, this BLOCKS until the lock
+// is acquired rather than skipping on contention — a replica that loses the
+// race must actually re-run its preventive check under the lock and observe
+// the winner's now-committed grant, not silently no-op.
+func (ls *LocalStorage) WithSoDGrantLock(ctx context.Context, fn func() error) error {
+	ls.sodGrantMu.Lock()
+	defer ls.sodGrantMu.Unlock()
+
+	if ls.db.Dialector.Name() != "postgres" {
+		return fn()
+	}
+
+	sqlDB, err := ls.db.DB()
+	if err != nil {
+		return err
+	}
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }() // returns the conn to the pool (after the unlock below)
+
+	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", int64(sodGrantAdvisoryLockKey)); err != nil {
+		return fmt.Errorf("failed to acquire SoD-grant advisory lock: %w", err)
+	}
+	// Release before the deferred Close so the pooled connection carries no lock.
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", int64(sodGrantAdvisoryLockKey))
+	}()
+
+	return fn()
+}

--- a/internal/storage/store/local_transaction.go
+++ b/internal/storage/store/local_transaction.go
@@ -16,6 +16,14 @@ import (
 // the transaction still serializes correctly (ADR-029/#339).
 func (ls *LocalStorage) WithTransaction(ctx context.Context, fn func(storage.Storage) error) error {
 	return ls.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		return fn(&LocalStorage{db: tx, auditChainMu: ls.auditChainMu, auditCheckpointMu: ls.auditCheckpointMu, bootstrapMu: ls.bootstrapMu})
+		return fn(&LocalStorage{
+			db:                     tx,
+			auditChainMu:           ls.auditChainMu,
+			auditCheckpointMu:      ls.auditCheckpointMu,
+			bootstrapMu:            ls.bootstrapMu,
+			sodGrantMu:             ls.sodGrantMu,
+			accessReviewDecisionMu: ls.accessReviewDecisionMu,
+			dualControlApprovalMu:  ls.dualControlApprovalMu,
+		})
 	})
 }

--- a/internal/storage/store/local_webauthn.go
+++ b/internal/storage/store/local_webauthn.go
@@ -39,15 +39,20 @@ func (ls *LocalStorage) GetWebAuthnCredentialByCredID(ctx context.Context, crede
 
 // LockWebAuthnCredentialForUpdate re-reads a credential by (credential_id, user_id),
 // taking a row-level write lock on backends that support one (Postgres: SELECT …
-// FOR UPDATE). Historically used inside WithTransaction so a read-modify-write of
-// the advanced signature counter serialized against a concurrent write for the same
-// credential (#306) — that specific path now goes through
+// FOR UPDATE). Originally used inline in persistUpdatedCredential so a read-modify-
+// write of the advanced signature counter serialized against a concurrent write for
+// the same credential (#306) — that path now goes through
 // AdvanceWebAuthnCredentialCounter below instead (a single atomic call, required so
 // RemoteStorage — whose WithTransaction is a no-op passthrough — gets the same
-// guarantee, #517). This method remains for callers that need a locked read outside
-// that race (e.g. rejectIfCloned's best-effort disable). On backends without row
-// locks (SQLite) it is a plain scoped read, and the caller is responsible for its
-// own process-level serialization — mirrors LockUserForUpdate.
+// guarantee, #517), which is this method's ONE current caller, itself always inside
+// WithTransaction. (rejectIfCloned's best-effort clone-disable was formerly cited
+// here as a second caller needing a locked read outside that race; it no longer
+// calls this method at all — it uses a plain, unlocked GetWebAuthnCredentialByCredID
+// + UpdateWebAuthnCredential instead, which is correct for a best-effort disable
+// that tolerates losing a race — a Postgres FOR UPDATE contention audit confirmed
+// this doc comment had drifted from that refactor.) On backends without row locks
+// (SQLite) LockWebAuthnCredentialForUpdate is a plain scoped read, and the caller is
+// responsible for its own process-level serialization — mirrors LockUserForUpdate.
 func (ls *LocalStorage) LockWebAuthnCredentialForUpdate(ctx context.Context, credentialID []byte, userID uint) (*models.WebAuthnCredential, error) {
 	q := ls.db.WithContext(ctx)
 	if ls.db.Dialector.Name() == "postgres" {

--- a/internal/storage/store/postgres_contention_helpers_test.go
+++ b/internal/storage/store/postgres_contention_helpers_test.go
@@ -1,0 +1,82 @@
+package store
+
+// postgres_contention_helpers_test.go — shared setup for the Postgres HA-lock
+// contention tests (audit chain, bootstrap lock, scheduler lease, FOR UPDATE
+// row locks). Every lock these tests cover is a no-op on SQLite by design (see
+// each lock file's own doc comment) — a single-connection test proves nothing
+// about them, since a broken pg_advisory_lock/FOR UPDATE passes trivially
+// under one connection. These helpers give each test multiple, INDEPENDENT
+// *gorm.DB connections (and, correspondingly, independent LocalStorage
+// instances with their own process-local mutexes) into the SAME isolated
+// Postgres schema — simulating separate server replica processes racing the
+// same database, which is the only way the advisory/row lock is the sole
+// thing standing between the writers and a corrupted result.
+//
+// Gated behind KEYORIX_TEST_PG_DSN (see internal/cli/encryption/rotate_e2e_test.go
+// for the existing precedent this mirrors) — skipped, not silently passed,
+// when unset. CI sets it (see .github/workflows/ci.yml's postgres service
+// container); a local run needs a reachable Postgres and the env var set.
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var pgContentionSchemaCounter int64
+
+// pgTestDSN returns the KEYORIX_TEST_PG_DSN base DSN, skipping the test (not
+// failing it) when unset — the same opt-in shape as every other Postgres-gated
+// test in this repo.
+func pgTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("KEYORIX_TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("KEYORIX_TEST_PG_DSN not set — skipping Postgres HA-lock contention test")
+	}
+	return dsn
+}
+
+// pgIsolatedSchemaDSN creates a fresh schema on the real Postgres server at
+// base, dropped on test cleanup, and returns a DSN with search_path pointed at
+// it. Every gorm.Open against the returned DSN gets an independent connection
+// into the SAME schema — that shared target is what makes the resulting
+// connections comparable to separate replica processes racing one database.
+func pgIsolatedSchemaDSN(t *testing.T, base string) string {
+	t.Helper()
+	n := atomic.AddInt64(&pgContentionSchemaCounter, 1)
+	schema := fmt.Sprintf("contend_%d_%d", os.Getpid(), n)
+
+	admin := pgOpen(t, base)
+	require.NoError(t, admin.Exec("DROP SCHEMA IF EXISTS "+schema+" CASCADE").Error)
+	require.NoError(t, admin.Exec("CREATE SCHEMA "+schema).Error)
+	t.Cleanup(func() {
+		cleaner := pgOpen(t, base)
+		_ = cleaner.Exec("DROP SCHEMA IF EXISTS " + schema + " CASCADE").Error
+	})
+
+	return base + " search_path=" + schema
+}
+
+// pgOpen opens a *gorm.DB against dsn, closing it on test cleanup. Each call
+// returns a genuinely separate connection (separate *sql.DB pool) — never
+// share one *gorm.DB across the "instances" a contention test races, or the
+// test would only ever exercise a single connection's own serialization, not
+// the cross-connection lock this whole file exists to verify.
+func pgOpen(t *testing.T, dsn string) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: logger.Discard})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if sqlDB, dbErr := db.DB(); dbErr == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	return db
+}

--- a/internal/storage/store/remote_access_review_decision_lock.go
+++ b/internal/storage/store/remote_access_review_decision_lock.go
@@ -1,0 +1,15 @@
+package store
+
+import "context"
+
+// WithAccessReviewDecisionLock is a no-op passthrough over RemoteStorage,
+// mirroring WithTransaction's own reasoning (remote_transaction.go) and
+// WithSoDGrantLock's above: DecideAccessReviewItem is an ordinary caller
+// reachable through a RemoteStorage-backed KeyorixCore (storage.type: remote,
+// ADR-049), unlike WithBootstrapLock's genuinely-unreachable case. There is no
+// shared advisory lock to take over HTTP; the hub this RemoteStorage talks to
+// enforces the real guarantee against its own concurrent writers via its own
+// LocalStorage-backed WithAccessReviewDecisionLock.
+func (rs *RemoteStorage) WithAccessReviewDecisionLock(_ context.Context, fn func() error) error {
+	return fn()
+}

--- a/internal/storage/store/remote_dual_control_approval_lock.go
+++ b/internal/storage/store/remote_dual_control_approval_lock.go
@@ -1,0 +1,16 @@
+package store
+
+import "context"
+
+// WithDualControlApprovalLock is a no-op passthrough over RemoteStorage,
+// mirroring WithTransaction's own reasoning (remote_transaction.go) and
+// WithSoDGrantLock's above: ApproveAccessRequestWithExpiry is an ordinary
+// caller reachable through a RemoteStorage-backed KeyorixCore (storage.type:
+// remote, ADR-049), unlike WithBootstrapLock's genuinely-unreachable case.
+// There is no shared advisory lock to take over HTTP; the hub this
+// RemoteStorage talks to enforces the real guarantee against its own
+// concurrent writers via its own LocalStorage-backed
+// WithDualControlApprovalLock.
+func (rs *RemoteStorage) WithDualControlApprovalLock(_ context.Context, fn func() error) error {
+	return fn()
+}

--- a/internal/storage/store/remote_misc_test.go
+++ b/internal/storage/store/remote_misc_test.go
@@ -1000,7 +1000,7 @@ func TestRemoteStorage_ListSecretDependenciesForProjectForUpdate(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/system/secret-dependencies/for-update", r.URL.Path)
+		assert.Equal(t, "/api/v1/system/secret-dependencies/snapshot", r.URL.Path)
 		assert.Equal(t, "5", r.URL.Query().Get("project_id"))
 		_, _ = w.Write(apiOK(map[string]interface{}{
 			"dependencies": []map[string]interface{}{

--- a/internal/storage/store/remote_secret_dependencies.go
+++ b/internal/storage/store/remote_secret_dependencies.go
@@ -159,15 +159,20 @@ func (rs *RemoteStorage) ListSecretDependenciesForProject(ctx context.Context, p
 }
 
 // ListSecretDependenciesForProjectForUpdate is ListSecretDependenciesForProject over
-// HTTP via GET /api/v1/system/secret-dependencies/for-update?project_id=X — kept for
+// HTTP via GET /api/v1/system/secret-dependencies/snapshot?project_id=X — kept for
 // interface parity, but note there is no lock to take over this hop (each remote API
 // call is already atomic server-side; see AddSecretDependency's use of
 // CreateSecretDependencyExclusive instead, which — unlike this method — genuinely
 // preserves #260's cycle-check-under-lock guarantee across storage.type: remote).
+// The wire route is named "snapshot", not "for-update" — this Go method name stays
+// aligned with LocalStorage's real, lock-holding sibling for interface parity, but no
+// HTTP route can honestly promise the same across a request boundary, so the route
+// itself (server/http/router.go, ListSecretDependenciesForProjectSnapshotProxy) does
+// not claim to.
 func (rs *RemoteStorage) ListSecretDependenciesForProjectForUpdate(ctx context.Context, projectID uint) ([]*models.SecretDependency, error) {
 	q := url.Values{}
 	q.Set("project_id", strconv.FormatUint(uint64(projectID), 10))
-	path := "/api/v1/system/secret-dependencies/for-update?" + q.Encode()
+	path := "/api/v1/system/secret-dependencies/snapshot?" + q.Encode()
 	resp, err := rs.client.Get(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list secret dependencies for update: %w", err)

--- a/internal/storage/store/remote_sod_grant_lock.go
+++ b/internal/storage/store/remote_sod_grant_lock.go
@@ -1,0 +1,20 @@
+package store
+
+import "context"
+
+// WithSoDGrantLock is a no-op passthrough over RemoteStorage, mirroring
+// WithTransaction's own reasoning (remote_transaction.go): unlike
+// WithBootstrapLock (which fails closed because BootstrapSystem never runs
+// against RemoteStorage at all), a SoD-gated grant path IS reachable here —
+// storage.type: remote lets a CLI process construct a KeyorixCore directly
+// against a RemoteStorage-backed hub (ADR-049), and AssignUserRole and
+// siblings are ordinary callers with no guard excluding that mode. There is
+// no shared advisory lock to take over HTTP, so this cannot provide the same
+// cross-replica guarantee LocalStorage's implementation does; failing closed
+// here would only break that legitimate caller without closing any gap (a
+// single remote CLI invocation has no concurrent sibling to race against on
+// the client side, and the hub it talks to enforces its own locking against
+// ITS OWN concurrent writers via its own LocalStorage-backed WithSoDGrantLock).
+func (rs *RemoteStorage) WithSoDGrantLock(_ context.Context, fn func() error) error {
+	return fn()
+}

--- a/internal/storage/store/remote_wire_route_coverage_test.go
+++ b/internal/storage/store/remote_wire_route_coverage_test.go
@@ -783,7 +783,7 @@ var knownUnresolvedWireCalls = map[string]bool{
 	"remote_rbac.go:810":                      true,
 	"remote_rbac.go:1088":                     true,
 	"remote_secret_dependencies.go:151":       true,
-	"remote_secret_dependencies.go:171":       true,
+	"remote_secret_dependencies.go:176":       true,
 	"remote_secrets.go:148":                   true,
 	"remote_secrets.go:421":                   true,
 	"remote_secrets.go:441":                   true,

--- a/server/http/handlers/handlers_s11_test.go
+++ b/server/http/handlers/handlers_s11_test.go
@@ -1477,13 +1477,13 @@ func TestListProjectMachineRoleAssignmentsProxy_HappyPath_S11(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-// TestListGlobalAdminAssignmentsForUpdateProxy_HappyPath_S11 — no params needed → 200.
-func TestListGlobalAdminAssignmentsForUpdateProxy_HappyPath_S11(t *testing.T) {
+// TestListGlobalAdminAssignmentsSnapshotProxy_HappyPath_S11 — no params needed → 200.
+func TestListGlobalAdminAssignmentsSnapshotProxy_HappyPath_S11(t *testing.T) {
 	t.Parallel()
 	h := NewRBACHandler(freshCoreS11(t))
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
-	h.ListGlobalAdminAssignmentsForUpdateProxy(w, r)
+	h.ListGlobalAdminAssignmentsSnapshotProxy(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 

--- a/server/http/handlers/handlers_s13_pat_notif_rotpol_deps_test.go
+++ b/server/http/handlers/handlers_s13_pat_notif_rotpol_deps_test.go
@@ -702,8 +702,8 @@ func TestListSecretDependenciesForProjectProxy_InvalidQuery_S13(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// TestListSecretDependenciesForProjectForUpdateProxy_InvalidQuery_S13 — non-numeric project_id → 400.
-func TestListSecretDependenciesForProjectForUpdateProxy_InvalidQuery_S13(t *testing.T) {
+// TestListSecretDependenciesForProjectSnapshotProxy_InvalidQuery_S13 — non-numeric project_id → 400.
+func TestListSecretDependenciesForProjectSnapshotProxy_InvalidQuery_S13(t *testing.T) {
 	t.Parallel()
 	cs := freshCoreS12(t)
 	h, err := NewSecretHandler(cs)
@@ -711,12 +711,12 @@ func TestListSecretDependenciesForProjectForUpdateProxy_InvalidQuery_S13(t *test
 
 	req := httptest.NewRequest(http.MethodGet, "/?project_id=bad", nil)
 	w := httptest.NewRecorder()
-	h.ListSecretDependenciesForProjectForUpdateProxy(w, req)
+	h.ListSecretDependenciesForProjectSnapshotProxy(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// TestListSecretDependenciesForProjectForUpdateProxy_HappyPath_S13 — valid project_id → 200.
-func TestListSecretDependenciesForProjectForUpdateProxy_HappyPath_S13(t *testing.T) {
+// TestListSecretDependenciesForProjectSnapshotProxy_HappyPath_S13 — valid project_id → 200.
+func TestListSecretDependenciesForProjectSnapshotProxy_HappyPath_S13(t *testing.T) {
 	t.Parallel()
 	cs := freshCoreS12(t)
 	h, err := NewSecretHandler(cs)
@@ -724,7 +724,7 @@ func TestListSecretDependenciesForProjectForUpdateProxy_HappyPath_S13(t *testing
 
 	req := httptest.NewRequest(http.MethodGet, "/?project_id=1", nil)
 	w := httptest.NewRecorder()
-	h.ListSecretDependenciesForProjectForUpdateProxy(w, req)
+	h.ListSecretDependenciesForProjectSnapshotProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 

--- a/server/http/handlers/handlers_s13_rbac_test.go
+++ b/server/http/handlers/handlers_s13_rbac_test.go
@@ -626,7 +626,7 @@ func TestListGlobalAdminAssignmentsProxy_BadRoleIDs_S13(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/system/rbac/global-admin-assignments?role_ids=nan,2", nil)
 	w := httptest.NewRecorder()
-	h.ListGlobalAdminAssignmentsForUpdateProxy(w, req)
+	h.ListGlobalAdminAssignmentsSnapshotProxy(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "INVALID_QUERY")
 }
@@ -637,7 +637,7 @@ func TestListGlobalAdminAssignmentsProxy_EmptyRoleIDs_S13(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/system/rbac/global-admin-assignments", nil)
 	w := httptest.NewRecorder()
-	h.ListGlobalAdminAssignmentsForUpdateProxy(w, req)
+	h.ListGlobalAdminAssignmentsSnapshotProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
@@ -647,7 +647,7 @@ func TestListGlobalAdminAssignmentsProxy_ValidRoleIDs_S13(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/system/rbac/global-admin-assignments?role_ids=1,2,3", nil)
 	w := httptest.NewRecorder()
-	h.ListGlobalAdminAssignmentsForUpdateProxy(w, req)
+	h.ListGlobalAdminAssignmentsSnapshotProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 

--- a/server/http/handlers/handlers_s30_test.go
+++ b/server/http/handlers/handlers_s30_test.go
@@ -237,13 +237,13 @@ func TestListProjectMachineRoleAssignmentsProxy_DBError_S30(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestListGlobalAdminAssignmentsForUpdateProxy_DBError_S30(t *testing.T) {
+func TestListGlobalAdminAssignmentsSnapshotProxy_DBError_S30(t *testing.T) {
 	t.Parallel()
 	h := NewRBACHandler(freshCoreBrokenS30(t))
 	// role_ids=1 forces the storage call; empty role_ids short-circuits with nil,nil
 	req := httptest.NewRequest(http.MethodGet, "/?role_ids=1", nil)
 	w := httptest.NewRecorder()
-	h.ListGlobalAdminAssignmentsForUpdateProxy(w, req)
+	h.ListGlobalAdminAssignmentsSnapshotProxy(w, req)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 

--- a/server/http/handlers/handlers_s32_test.go
+++ b/server/http/handlers/handlers_s32_test.go
@@ -52,14 +52,14 @@ func TestListSecretDependenciesForProjectProxy_DBError_S32(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestListSecretDependenciesForProjectForUpdateProxy_DBError_S32(t *testing.T) {
+func TestListSecretDependenciesForProjectSnapshotProxy_DBError_S32(t *testing.T) {
 	t.Parallel()
 	kc := freshCoreBrokenS32(t)
 	h, err := NewSecretHandler(kc)
 	require.NoError(t, err)
-	r := httptest.NewRequest(http.MethodGet, "/api/v1/system/secret-dependencies/for-update?project_id=1", nil)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/system/secret-dependencies/snapshot?project_id=1", nil)
 	w := httptest.NewRecorder()
-	h.ListSecretDependenciesForProjectForUpdateProxy(w, r)
+	h.ListSecretDependenciesForProjectSnapshotProxy(w, r)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 

--- a/server/http/handlers/handlers_s4_test.go
+++ b/server/http/handlers/handlers_s4_test.go
@@ -3183,13 +3183,13 @@ func TestListSecretDependenciesForProjectProxy_HappyPath(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestListSecretDependenciesForProjectForUpdateProxy_MissingQuery(t *testing.T) {
+func TestListSecretDependenciesForProjectSnapshotProxy_MissingQuery(t *testing.T) {
 	cs := newHandlerCoreS4(t)
 	h, err := NewSecretHandler(cs)
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
-	h.ListSecretDependenciesForProjectForUpdateProxy(w, req)
+	h.ListSecretDependenciesForProjectSnapshotProxy(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
@@ -3553,11 +3553,11 @@ func TestListProjectMachineRoleAssignmentsProxy_MissingQuery(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestListGlobalAdminAssignmentsForUpdateProxy_HappyPath(t *testing.T) {
+func TestListGlobalAdminAssignmentsSnapshotProxy_HappyPath(t *testing.T) {
 	h := NewRBACHandler(newHandlerCoreS4(t))
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
-	h.ListGlobalAdminAssignmentsForUpdateProxy(w, req)
+	h.ListGlobalAdminAssignmentsSnapshotProxy(w, req)
 	// missing role_ids is valid → empty result → 200
 	assert.Equal(t, http.StatusOK, w.Code)
 }
@@ -10530,19 +10530,19 @@ func TestSecretHandler_GetSecretDependencyProxy_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
-func TestSecretHandler_ListSecretDependenciesForProjectForUpdateProxy_MissingProjectID(t *testing.T) {
+func TestSecretHandler_ListSecretDependenciesForProjectSnapshotProxy_MissingProjectID(t *testing.T) {
 	h := newSecretHandlerS4(t)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
-	h.ListSecretDependenciesForProjectForUpdateProxy(w, req)
+	h.ListSecretDependenciesForProjectSnapshotProxy(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestSecretHandler_ListSecretDependenciesForProjectForUpdateProxy_HappyPath(t *testing.T) {
+func TestSecretHandler_ListSecretDependenciesForProjectSnapshotProxy_HappyPath(t *testing.T) {
 	h := newSecretHandlerS4(t)
 	req := httptest.NewRequest(http.MethodGet, "/?project_id=1", nil)
 	w := httptest.NewRecorder()
-	h.ListSecretDependenciesForProjectForUpdateProxy(w, req)
+	h.ListSecretDependenciesForProjectSnapshotProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
@@ -11331,14 +11331,14 @@ func TestCatalogHandler_CreateInvitationProxy_BadJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// ── rbac_role_grants_proxy.go: ListGlobalAdminAssignmentsForUpdateProxy ───────
+// ── rbac_role_grants_proxy.go: ListGlobalAdminAssignmentsSnapshotProxy ───────
 
-func TestRBACHandler_ListGlobalAdminAssignmentsForUpdateProxy_HappyPath(t *testing.T) {
+func TestRBACHandler_ListGlobalAdminAssignmentsSnapshotProxy_HappyPath(t *testing.T) {
 	c := newHandlerCoreS4(t)
 	h := NewRBACHandler(c)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
-	h.ListGlobalAdminAssignmentsForUpdateProxy(w, req)
+	h.ListGlobalAdminAssignmentsSnapshotProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 

--- a/server/http/handlers/handlers_s5_test.go
+++ b/server/http/handlers/handlers_s5_test.go
@@ -3326,11 +3326,11 @@ func TestGetSecretDependencyProxy_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
-func TestListSecretDependenciesForProjectForUpdateProxy_HappyPath(t *testing.T) {
+func TestListSecretDependenciesForProjectSnapshotProxy_HappyPath(t *testing.T) {
 	h := newSecretHandlerS4(t)
 	req := httptest.NewRequest(http.MethodGet, "/?project_id=1", nil)
 	w := httptest.NewRecorder()
-	h.ListSecretDependenciesForProjectForUpdateProxy(w, req)
+	h.ListSecretDependenciesForProjectSnapshotProxy(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
@@ -3790,28 +3790,28 @@ func TestListProjectMachineRoleAssignmentsProxy_MissingProjectIDS5(t *testing.T)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestListGlobalAdminAssignmentsForUpdateProxy_HappyPathS5(t *testing.T) {
+func TestListGlobalAdminAssignmentsSnapshotProxy_HappyPathS5(t *testing.T) {
 	h := NewRBACHandler(newHandlerCoreS4(t))
 	// Empty role_ids is valid — returns empty/nil list.
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
-	h.ListGlobalAdminAssignmentsForUpdateProxy(w, req)
+	h.ListGlobalAdminAssignmentsSnapshotProxy(w, req)
 	assert.Equal(t, 200, w.Code)
 }
 
-func TestListGlobalAdminAssignmentsForUpdateProxy_WithRoleIDs(t *testing.T) {
+func TestListGlobalAdminAssignmentsSnapshotProxy_WithRoleIDs(t *testing.T) {
 	h := NewRBACHandler(newHandlerCoreS4(t))
 	req := httptest.NewRequest("GET", "/?role_ids=1,2", nil)
 	w := httptest.NewRecorder()
-	h.ListGlobalAdminAssignmentsForUpdateProxy(w, req)
+	h.ListGlobalAdminAssignmentsSnapshotProxy(w, req)
 	assert.Equal(t, 200, w.Code)
 }
 
-func TestListGlobalAdminAssignmentsForUpdateProxy_BadRoleIDs(t *testing.T) {
+func TestListGlobalAdminAssignmentsSnapshotProxy_BadRoleIDs(t *testing.T) {
 	h := NewRBACHandler(newHandlerCoreS4(t))
 	req := httptest.NewRequest("GET", "/?role_ids=1,bad", nil)
 	w := httptest.NewRecorder()
-	h.ListGlobalAdminAssignmentsForUpdateProxy(w, req)
+	h.ListGlobalAdminAssignmentsSnapshotProxy(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 

--- a/server/http/handlers/rbac_role_grants_proxy.go
+++ b/server/http/handlers/rbac_role_grants_proxy.go
@@ -328,12 +328,19 @@ func (h *RBACHandler) ListProjectMachineRoleAssignmentsProxy(w http.ResponseWrit
 	writeRemoteAPISuccess(w, assignments)
 }
 
-// ListGlobalAdminAssignmentsForUpdateProxy handles GET
-// /api/v1/system/rbac/global-admin-assignments?role_ids=1,2,3. A PLAIN read — see
-// RemoteStorage.ListGlobalAdminAssignmentsForUpdate's doc (remote_rbac.go) for why
-// no lock is taken over this hop; safety comes entirely from
-// RemoveGlobalAdminRoleGuardedProxy's atomic conditional write below.
-func (h *RBACHandler) ListGlobalAdminAssignmentsForUpdateProxy(w http.ResponseWriter, r *http.Request) {
+// ListGlobalAdminAssignmentsSnapshotProxy handles GET
+// /api/v1/system/rbac/global-admin-assignments?role_ids=1,2,3. Named Snapshot, not
+// ForUpdate — the deliberately outdated Go interface method backing it
+// (RemoteStorage.ListGlobalAdminAssignmentsForUpdate, remote_rbac.go) is kept named
+// after LocalStorage's real, lock-holding sibling method for interface parity, but
+// no HTTP endpoint can hold a Postgres row lock across a request boundary: a
+// separate connection serves each call, so any "ForUpdate" name on the route itself
+// would advertise a guarantee this transport structurally cannot provide, and
+// would invite a caller to read this, decide, and write back on a second request
+// believing the first locked something. It never does. This is a PLAIN, unlocked
+// read; safety comes entirely from RemoveGlobalAdminRoleGuardedProxy's atomic
+// conditional write below, in ONE request.
+func (h *RBACHandler) ListGlobalAdminAssignmentsSnapshotProxy(w http.ResponseWriter, r *http.Request) {
 	roleIDs, ok := parseRBACProxyRoleIDsQuery(w, r)
 	if !ok {
 		return
@@ -485,7 +492,7 @@ func parseRBACProxyProjectIDQuery(w http.ResponseWriter, r *http.Request) (proje
 }
 
 // parseRBACProxyRoleIDsQuery parses the optional, comma-separated role_ids query
-// parameter ListGlobalAdminAssignmentsForUpdateProxy takes — an empty/absent value
+// parameter ListGlobalAdminAssignmentsSnapshotProxy takes — an empty/absent value
 // is valid (no install-admin role seeded yet) and yields an empty slice, mirroring
 // LocalStorage.ListGlobalAdminAssignmentsForUpdate's own "len(adminRoleIDs) == 0 →
 // nil, nil" short-circuit.

--- a/server/http/handlers/secret_dependencies_proxy.go
+++ b/server/http/handlers/secret_dependencies_proxy.go
@@ -231,19 +231,27 @@ func (h *SecretHandler) ListSecretDependenciesForProjectProxy(w http.ResponseWri
 	writeRemoteAPISuccess(w, map[string]interface{}{"dependencies": newSecretDependencyProxyWireList(rows)})
 }
 
-// ListSecretDependenciesForProjectForUpdateProxy handles GET
-// /api/v1/system/secret-dependencies/for-update?project_id=X (a static path, registered
-// before /secret-dependencies/{id} in router.go). Kept for interface parity — see this
-// method's doc on RemoteStorage (remote_secret_dependencies.go) for why it takes no
-// lock over this hop.
-func (h *SecretHandler) ListSecretDependenciesForProjectForUpdateProxy(w http.ResponseWriter, r *http.Request) {
+// ListSecretDependenciesForProjectSnapshotProxy handles GET
+// /api/v1/system/secret-dependencies/snapshot?project_id=X (a static path, registered
+// before /secret-dependencies/{id} in router.go). Named Snapshot, not ForUpdate — the
+// deliberately outdated Go interface method backing it
+// (RemoteStorage.ListSecretDependenciesForProjectForUpdate, remote_secret_dependencies.go)
+// is kept named after LocalStorage's real, lock-holding sibling for interface parity,
+// but no HTTP endpoint can hold a Postgres row lock across a request boundary: a
+// separate connection serves each call, so a "ForUpdate" name on the route itself
+// would advertise a guarantee this transport structurally cannot provide, and would
+// invite a caller to read this, decide, and write back on a second request believing
+// the first locked something. It never does. This is a PLAIN, unlocked read; safety
+// comes entirely from CreateSecretDependencyExclusiveProxy's atomic conditional
+// write, in ONE request.
+func (h *SecretHandler) ListSecretDependenciesForProjectSnapshotProxy(w http.ResponseWriter, r *http.Request) {
 	projectID, ok := parseProxyProjectIDQuery(w, r)
 	if !ok {
 		return
 	}
 	rows, err := h.coreService.Storage().ListSecretDependenciesForProjectForUpdate(r.Context(), projectID)
 	if err != nil {
-		log.Printf("secret-dependencies proxy: list-for-update failed: %v", err)
+		log.Printf("secret-dependencies proxy: list-snapshot failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))
 		return
 	}
@@ -259,7 +267,7 @@ func newSecretDependencyProxyWireList(rows []*models.SecretDependency) []secretD
 }
 
 // parseProxyProjectIDQuery parses the required project_id query parameter shared by
-// ListSecretDependenciesForProjectProxy/ListSecretDependenciesForProjectForUpdateProxy.
+// ListSecretDependenciesForProjectProxy/ListSecretDependenciesForProjectSnapshotProxy.
 func parseProxyProjectIDQuery(w http.ResponseWriter, r *http.Request) (projectID uint, ok bool) {
 	v := r.URL.Query().Get("project_id")
 	if v == "" {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -1441,9 +1441,11 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			// passthrough) — see secret_dependencies_proxy.go's package doc and the
 			// storage.Storage interface doc for why AddSecretDependency now calls
 			// this instead of orchestrating a list-under-lock-then-create sequence
-			// itself. Static sub-paths ("for-update", "exclusive") are registered
-			// before the "{id}" wildcard.
-			r.Get("/secret-dependencies/for-update", secretHandler.ListSecretDependenciesForProjectForUpdateProxy)
+			// itself. Static sub-paths ("snapshot", "exclusive") are registered
+			// before the "{id}" wildcard. "snapshot" is a deliberate rename from
+			// "for-update" — no route boundary can hold a Postgres row lock across a
+			// request (see ListSecretDependenciesForProjectSnapshotProxy's own doc).
+			r.Get("/secret-dependencies/snapshot", secretHandler.ListSecretDependenciesForProjectSnapshotProxy)
 			r.Get("/secret-dependencies/{id}", secretHandler.GetSecretDependencyProxy)
 			r.Get("/secret-dependencies", secretHandler.ListSecretDependenciesForProjectProxy)
 			r.Post("/secret-dependencies", secretHandler.CreateSecretDependencyProxy)
@@ -1837,7 +1839,7 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 			r.Get("/rbac/groups/{groupID}/role-assignments", rbacHandler.ListGroupRoleAssignmentsProxy)
 			r.Get("/rbac/project-role-assignments", rbacHandler.ListProjectRoleAssignmentsProxy)
 			r.Get("/rbac/project-machine-role-assignments", rbacHandler.ListProjectMachineRoleAssignmentsProxy)
-			r.Get("/rbac/global-admin-assignments", rbacHandler.ListGlobalAdminAssignmentsForUpdateProxy)
+			r.Get("/rbac/global-admin-assignments", rbacHandler.ListGlobalAdminAssignmentsSnapshotProxy)
 			r.Post("/rbac/assign-role-with-expiry", rbacHandler.AssignRoleWithExpiryProxy)
 			r.Post("/rbac/assign-role-to-group-with-expiry", rbacHandler.AssignRoleToGroupWithExpiryProxy)
 			r.Post("/rbac/remove-all-project-role-grants", rbacHandler.RemoveAllProjectRoleGrantsProxy)


### PR DESCRIPTION
## Summary

Three grant-time preventive checks — separation-of-duties (`sodGrantMu`),
access-review decisions (`accessReviewDecisionMu`), and dual-control approval
(`dualControlApprovalMu`) — each serialize a check-then-write sequence with a
plain in-process `sync.Mutex` on `*KeyorixCore`. Each mutex's own doc comment
already admitted the gap: *"a RemoteStorage/multi-replica deployment would
need a DB-level lock on the principal's role-grant rows to close the same
window across processes, out of scope for this pattern-level fix"* (the #G04
fix that introduced them, PR #1435).

**Concrete scenario (SoD)**: two server replicas behind shared Postgres. User
U holds neither of two roles a policy forbids combining. Replica A grants
role_a, replica B concurrently grants role_b; each reads U's permissions
before the other's write commits, both see "clean," both commit — U now holds
both sides of a toxic combination the policy exists to prevent. The
access-review and dual-control siblings have the analogous shape (a losing
attest/revoke action still executes even though only the winner's decision
stamp persists; two approvers can each read a below-threshold count and both
finalize the grant).

**Were these three scoped out of `f01deb05` deliberately, or missed?** `f01deb05`
("HA-lock contention test coverage across all replica-safety mechanisms")
swept 8 other mechanisms (last-admin guard, machine-identity transitions,
scheduler lock/lease, login-lockout, audit chain/checkpoint, bootstrap) onto
real Postgres advisory/row locks. Its own PR (#1567) states its scope
explicitly: *"every Postgres advisory/row-lock HA mechanism in
`internal/storage/store`"* — these three mutexes live on `*KeyorixCore` in
`internal/core`, structurally outside that literal scope. Neither the commit
nor the PR mentions them, and no linked follow-up ticket names them either. A
same-campaign adversarial review (`HANDLER-STORAGE-REVIEW-2026-09-06.md`,
finding 3) independently concluded the same thing: *"This looks like a
deliberate scoping decision at the time (not an oversight the campaign
missed), but it's the natural next item given the precedent this same branch
just set."* This PR is that next item.

## Fix

Replace each mutex with a storage-layer lock, mirroring `WithBootstrapLock`'s
design (`local_bootstrap_lock.go`): a process mutex for the common
single-writer/SQLite case, plus a session-scoped Postgres advisory lock
(distinct key per mechanism, `pg_advisory_lock`/`pg_advisory_unlock`) that
actually serializes independent replicas sharing one Postgres database.

- `WithSoDGrantLock` — wraps `AssignUserRole`, `assignUserRoleSystemGrant`,
  `AssignRoleToGroup` (`rbac_management.go`), `AssignUserRoleWithExpiry`,
  `AssignGroupRoleWithExpiry` (`jit_access.go`), and `AddUserToGroup`'s
  `validateGroupJoinRoles` path (`groups.go`).
- `WithAccessReviewDecisionLock` — wraps `DecideAccessReviewItem`
  (`access_review_campaign.go`).
- `WithDualControlApprovalLock` — wraps `ApproveAccessRequestWithExpiry`
  (`invitations.go`).

Deliberately **one shared lock per mechanism, not one per principal** —
preserving the original mutex's full serialization domain (e.g. a group-role
grant affecting a member still serializes against that same member's own
concurrent direct grant, not just against itself).

`RemoteStorage`'s implementation of all three is a no-op passthrough
(mirroring `WithTransaction`'s own reasoning), **not** a fail-closed stub like
`WithBootstrapLock`'s: `storage.type: remote` is a real, reachable caller of
these paths (CLI direct-DB mode constructing `core.NewKeyorixCore` directly
against a `RemoteStorage`-backed hub, ADR-049) — unlike `BootstrapSystem`,
which per `validateRemoteStorageNotServer` never runs against `RemoteStorage`
at all. Failing closed here would only break that legitimate caller without
closing any gap; the hub it talks to enforces the real guarantee locally via
its own `LocalStorage`-backed lock.

## Regression test

`internal/core/concurrency_sod_grant_cross_replica_postgres_test.go` (`//
KEYORIX_TEST_PG_DSN`-gated, same CI wiring `f01deb05` added) constructs **two
independent `*core.KeyorixCore` instances, each with its own `*gorm.DB`
connection into the same real Postgres schema** — not two goroutines sharing
one instance/mutex. The existing `concurrency_g04_threshold_race_test.go` has
exactly that structural blind spot: it would pass identically even if the
advisory lock were deleted outright, because its "replicas" share one
process-local mutex regardless.

Two replicas race granting the two individually-SoD-clean halves of a toxic
permission pair to the same user; the assertion that matters is checked from a
**third, independent connection**: the user must end up holding exactly one of
the two roles, never both.

- **Red** (advisory lock temporarily disabled, 10/10 runs): both grants
  succeed, user ends up holding both sides of the toxic pair.
- **Green** (lock restored, 15/15 runs): exactly one grant succeeds, the other
  is refused as a separation-of-duties violation, user holds exactly one role.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `golangci-lint run` (new-from-rev) — 0 issues
- [x] `gosec -severity medium` — 0 issues
- [x] Full `internal/core` + `internal/core/storage` suite green (SQLite)
- [x] New cross-replica test verified red (lock disabled) then green (lock
      restored) against a real `postgres:16` container
- [x] Existing SoD/access-review/dual-control single-instance tests
      (`concurrency_g04_threshold_race_test.go` and friends) still green —
      structurally unchanged behavior for the single-replica case