### PR TITLE
fix(http): gate admin/usage + admin/billing/report on audit.read, not system.read

### DIFF
--- a/server/http/deployment_disclosure_family_test.go
+++ b/server/http/deployment_disclosure_family_test.go
@@ -8,10 +8,17 @@
 // every account. This file proves, for each affected route: a baseline (system_viewer)
 // caller is denied (403) and an audit.read holder (system_auditor) succeeds (200) with
 // the expected payload shape.
+//
+// GET /admin/usage (7th+ confirmed instance of the same mistake, found in the same
+// campaign that produced server/http/permission_sweep_test.go's exhaustiveness guard) is
+// included in the table below. GET /admin/billing/report is the same bug but needs its
+// own license-gated fixture, so it gets a dedicated test,
+// TestAdminBillingReport_PermissionTiers, further down this file.
 package http
 
 import (
 	"context"
+	"crypto/ed25519"
 	"encoding/csv"
 	"encoding/json"
 	"net/http"
@@ -23,7 +30,9 @@ import (
 	"github.com/keyorixhq/keyorix/internal/config"
 	"github.com/keyorixhq/keyorix/internal/core"
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/license"
 	appstorage "github.com/keyorixhq/keyorix/internal/storage"
+	"github.com/keyorixhq/keyorix/internal/trust"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -190,7 +199,7 @@ func TestDeploymentDisclosureFamily_BaselineDeniedAuditorAllowed(t *testing.T) {
 	// the periodic scan is meant to still catch.
 	baselineToken := createLimitedToken(t, testCore) // system_viewer only (system.read)
 	auditorToken := createAuditorToken(t, testCore)  // system_auditor (audit.read, global)
-	seedFamilyFixtures(t, testCore)
+	fixtures := seedFamilyFixtures(t, testCore)
 
 	// Plant a non-conforming secret BEFORE the naming policy is enabled (naming policy
 	// is only enforced at create time — a policy tightened afterward leaves existing
@@ -329,6 +338,33 @@ func TestDeploymentDisclosureFamily_BaselineDeniedAuditorAllowed(t *testing.T) {
 				assert.NotEmpty(t, violations, "the system_auditor's own system.read+audit.read pair must show up as a violation")
 			},
 		},
+		{
+			// admin/usage: per-project secret counts + read activity, deployment-wide,
+			// with no per-project ownership check anywhere in the call chain — the
+			// confirmed HIGH bug this campaign's fix addresses (7th+ instance of the
+			// same system.read-as-sole-gate mistake). See admin_usage.go's header
+			// comment and server/http/permission_sweep_test.go's exhaustiveness guard.
+			name: "admin usage report",
+			path: "/api/v1/admin/usage",
+			check: func(t *testing.T, body []byte, _ string) {
+				m := jsonDataField(t, body)
+				projects, ok := m["projects"].([]interface{})
+				require.True(t, ok, "projects field must be a list")
+				found := false
+				for _, p := range projects {
+					proj, _ := p.(map[string]interface{})
+					if proj == nil {
+						continue
+					}
+					if id, _ := proj["project_id"].(float64); uint(id) == fixtures.projectID {
+						found = true
+						assert.GreaterOrEqual(t, proj["secret_count"], float64(1),
+							"the seeded canary secret must be counted for its project")
+					}
+				}
+				assert.True(t, found, "the seeded project must appear in the usage report for an audit.read holder")
+			},
+		},
 	}
 
 	client := &http.Client{Timeout: 10 * time.Second}
@@ -456,5 +492,103 @@ func TestDashboardStats_PermissionTiers(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		m := jsonDataField(t, body)
 		assert.Contains(t, m, "items")
+	})
+}
+
+// grantBillingLicense issues and installs a short-lived, self-signed "billing"-feature
+// license on c, mirroring server/http/handlers/admin_billing_test.go's
+// licensedBillingCore — GET /admin/billing/report 403s before ever reaching the
+// audit.read check if the deployment has no billing license, so the permission-tier
+// test below needs one installed to exercise the actual authz gate rather than the
+// license gate.
+func grantBillingLicense(t *testing.T, c *core.KeyorixCore) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	reg := trust.NewRegistry()
+	require.NoError(t, reg.Add(trust.PurposeLicense, "license-2026", pub))
+	token, err := license.Issue(license.License{
+		Licensee: "family-test GmbH", Plan: "enterprise",
+		Features: []string{license.FeatureBilling},
+		IssuedAt: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(365 * 24 * time.Hour),
+		KeyID: "license-2026",
+	}, priv)
+	require.NoError(t, err)
+	c.SetLicenseGate(license.NewGate(token, reg, "", 0))
+}
+
+// TestAdminBillingReport_PermissionTiers is the admin/billing/report half of the
+// admin_usage.go fix (same disclosure-family bug, same fix shape, split out only
+// because it needs a licensed deployment to reach the authz check at all — see
+// grantBillingLicense above). Proves: a system_viewer-baseline (system.read only)
+// caller is denied (403) and an audit.read holder (system_auditor) succeeds (200) with
+// the seeded project's real billing figures, not a zeroed/redacted stand-in.
+func TestAdminBillingReport_PermissionTiers(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	defer i18n.ResetForTesting()
+
+	cfg := &config.Config{}
+	testCore := newFullSchemaTestCore(t)
+	grantBillingLicense(t, testCore)
+	router, err := NewRouter(cfg, testCore)
+	require.NoError(t, err)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	createTestToken(t, testCore)
+	baselineToken := createLimitedToken(t, testCore) // system_viewer only (system.read)
+	auditorToken := createAuditorToken(t, testCore)  // system_auditor (audit.read, global)
+	fixtures := seedFamilyFixtures(t, testCore)
+
+	from := time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+	to := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	path := "/api/v1/admin/billing/report?from=" + from + "&to=" + to
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	get := func(token string) (*http.Response, []byte) {
+		req, err := http.NewRequest(http.MethodGet, server.URL+path, nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		var body []byte
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := resp.Body.Read(buf)
+			body = append(body, buf[:n]...)
+			if rerr != nil {
+				break
+			}
+		}
+		return resp, body
+	}
+
+	t.Run("baseline_denied", func(t *testing.T) {
+		resp, _ := get(baselineToken)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"a system_viewer-baseline (system.read only) caller must be denied at /admin/billing/report")
+	})
+
+	t.Run("auditor_allowed", func(t *testing.T) {
+		resp, body := get(auditorToken)
+		require.Equalf(t, http.StatusOK, resp.StatusCode,
+			"a system_auditor (audit.read) caller must succeed at /admin/billing/report (body: %s)", string(body))
+		m := jsonDataField(t, body)
+		projects, ok := m["projects"].([]interface{})
+		require.True(t, ok, "projects field must be a list")
+		found := false
+		for _, p := range projects {
+			proj, _ := p.(map[string]interface{})
+			if proj == nil {
+				continue
+			}
+			if id, _ := proj["project_id"].(float64); uint(id) == fixtures.projectID {
+				found = true
+				assert.GreaterOrEqual(t, proj["secret_count"], float64(1),
+					"the seeded canary secret must be counted for its project")
+			}
+		}
+		assert.True(t, found, "the seeded project must appear in the billing report for an audit.read holder")
 	})
 }

--- a/server/http/handlers/admin_billing.go
+++ b/server/http/handlers/admin_billing.go
@@ -1,9 +1,16 @@
 // admin_billing.go — GET /api/v1/admin/billing/report handler.
 //
 // Returns a per-project FinOps billing report (secret counts, read/write
-// activity, machine vs. human breakdowns) for a configurable date range.
-// Gated by system.read permission in the router and the "billing" license
-// feature in core.GenerateBillingReport.
+// activity, machine vs. human breakdowns) for a configurable date range, for
+// every project or a caller-supplied ?project_id= list, with no ownership
+// check anywhere in the call chain. Gated by audit.read in the router (NOT
+// system.read — see admin_usage.go's header comment for why: system.read is
+// the universal system_viewer baseline every user holds, so it is equivalent
+// to no gate at all for a disclosure-sensitive, deployment-wide report; same
+// family as CP-001/CP-008) and the "billing" license feature in
+// core.GenerateBillingReport — the license check is a deployment capability
+// gate, not a per-caller authorization check, so it does not substitute for
+// the audit.read requirement.
 package handlers
 
 import (

--- a/server/http/handlers/admin_usage.go
+++ b/server/http/handlers/admin_usage.go
@@ -1,7 +1,15 @@
 // admin_usage.go — GET /api/v1/admin/usage handler.
 //
 // Returns a per-project usage report (secret counts + read activity) for the
-// requested time window. Gated by system.read permission in the router.
+// requested time window, for every project or one named via ?project_id=, with
+// no ownership check anywhere in the call chain (core.GetUsageReport ->
+// storage.GetProjectUsageStats). Gated by audit.read in the router. Do not gate
+// this — or any new caller — on system.read: that permission is granted to
+// every user via the baseline system_viewer role (CreateUser, SSO/JIT and SCIM
+// provisioning all assign it), so it is equivalent to no gate at all for this
+// disclosure-sensitive, deployment-wide report. Gating on system.read was a
+// real, fixed vulnerability, same family as CP-001/CP-008; see
+// server/http/deployment_disclosure_family_test.go.
 package handlers
 
 import (

--- a/server/http/permission_sweep_test.go
+++ b/server/http/permission_sweep_test.go
@@ -1,0 +1,270 @@
+// permission_sweep_test.go — the CP-001/CP-008 disclosure-family guard, structural
+// counterpart to deployment_disclosure_family_test.go's behavioral regression tests.
+//
+// admin_usage.go and admin_billing.go were the 7th+ confirmed instance of the same
+// mistake: gating a deployment-wide, cross-project/cross-user disclosure report on
+// system.read (RequirePermission(permSystemRead) or
+// RequireScopedPermission(permSystemRead, ...)) in server/http/router.go, when
+// system.read is the universal system_viewer baseline auto-assigned to every user at
+// creation (CreateUser), every SSO/JIT-provisioned user, and every SCIM-provisioned
+// user — see control_framework.go, compliance_posture.go, deployment_hygiene.go,
+// machine_token_hygiene.go, pat_hygiene.go, secrets_name_conformance_deployment.go,
+// dashboard.go, admin_usage.go, and admin_billing.go's own header comments for the
+// full list of prior instances.
+//
+// This is an AST sweep over server/http/router.go's source text (not the compiled
+// package — the point is to catch a regression in the router WIRING itself, before
+// any test that spins up the router even runs), asserting that every
+// RequirePermission(permSystemRead)/RequireScopedPermission(permSystemRead, ...) call
+// site found is explicitly reviewed and justified in the allowlist below. Mirrors
+// internal/cli/writeguard's allowlist-with-reasoning convention: a call site the sweep
+// finds must either not exist (gated on something stronger instead) or be justified
+// here with a written reason, not just a line number. An empty justification, or an
+// allowlist entry whose call site the sweep can no longer find, fails the test — see
+// TestPermissionSweepAllowlistJustificationsAreNonEmpty and
+// TestPermissionSweepAllowlistEntriesStillExist below.
+//
+// Verified RED against a reverted admin_usage.go/admin_billing.go fix (both routes
+// put back on permSystemRead) — TestNoUnjustifiedSystemReadOnlyGates failed with both
+// call sites reported as unallowed; GREEN once the fix (audit.read) was restored.
+package http
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// permissionSweepAllowlist maps "server/http/router.go:LINE" (the line of the
+// RequirePermission/RequireScopedPermission call itself) to a written justification
+// for why that route is safe to leave gated on the universal system_viewer baseline
+// (system.read) alone, reviewed as part of the admin/usage + admin/billing/report fix.
+// Every entry here was traced to its handler (and, where relevant, its core-layer
+// implementation) to confirm it returns no cross-tenant/cross-user disclosure that
+// system.read's universal grant would expose.
+var permissionSweepAllowlist = map[string]string{
+	"server/http/router.go:381": "GET /notification-channels/{id}/retry-policy returns only " +
+		"max_retries/retry_backoff_ms for one channel ID -- numeric tuning knobs, no secret " +
+		"values, no PII, no cross-tenant project/user enumeration. Weaker than the parent " +
+		"resource's own read (system.write), a pre-existing minor inconsistency, but not the " +
+		"cross-tenant-disclosure bug shape this sweep guards against.",
+	"server/http/router.go:404": "GET /dashboard/stats is the caller's OWN home dashboard. " +
+		"core.GetDashboardStats (internal/core/dashboard.go) separately scopes the " +
+		"deployment-wide aggregate fields (active users, audit-event counts, failed-auth " +
+		"counts) to audit.read INSIDE the handler -- a baseline caller gets their own numbers " +
+		"with the org-wide aggregates zeroed, not the real deployment-wide figures. See " +
+		"TestDashboardStats_PermissionTiers in deployment_disclosure_family_test.go.",
+	"server/http/router.go:414": "GET /system/auth-config returns a deliberately redacted, " +
+		"non-per-tenant summary of server-wide auth config (session TTLs, password policy " +
+		"shape, SSO provider names/types). No secrets (client secrets/SAML metadata/OIDC " +
+		"details excluded by MakeAuthConfigHandler's own doc comment), no per-user or " +
+		"per-project data to disclose cross-tenant.",
+	"server/http/router.go:415": "GET /system/encryption-config returns a deliberately " +
+		"redacted, non-per-tenant summary (encryption enabled + KEK provider TYPE only). Key " +
+		"material locations (file paths, exec commands, env var names, KMS key IDs) are " +
+		"explicitly excluded by MakeEncryptionConfigHandler's own doc comment.",
+	"server/http/router.go:422": "GET /system/info returns server version/build/runtime info " +
+		"(no per-tenant data) -- the same deployment-wide, non-disclosure-sensitive shape as " +
+		"auth-config/encryption-config above.",
+	"server/http/router.go:423": "GET /system/metrics returns process-level runtime metrics " +
+		"(memory/GC/goroutines) with HTTP/Database/Secrets counters explicitly zeroed (not " +
+		"instrumented at this layer per GetMetrics's own comment) -- no per-tenant data.",
+	"server/http/router.go:1062": "GET /audit/anomalies sits inside r.Route(\"/audit\", ...) " +
+		"which calls r.Use(RequirePermission(permAuditRead)) as a GROUP-level middleware " +
+		"(router.go:1044). chi's With() on a route registered inside that group ADDS to, " +
+		"never replaces, the group's Use() middleware (verified against go-chi/chi/v5's " +
+		"Mux.With/Route/handle: the group's non-inline Mux builds its own handler chain via " +
+		"updateRouteHandler, and every route registered inside it -- inline or not -- is " +
+		"dispatched through that chain first). So this route actually requires BOTH " +
+		"audit.read AND system.read (AND, not OR) -- effectively gated at audit.read, the " +
+		"stronger requirement, exactly as router.go's own ANOMALY-04 comment there intends. " +
+		"Not a case of \"solely permSystemRead\" despite the literal string match.",
+	"server/http/router.go:2069": "GET /license/status returns deployment-wide license " +
+		"metadata (plan/features/seat count/expiry) -- not scoped to any tenant/project/user, " +
+		"nothing to cross-tenant-disclose.",
+	"server/http/router.go:2165": "GET /sod/policies returns policy DEFINITIONS (name + the " +
+		"permission-a/permission-b pair) only -- no PII, no violator names. router.go's own " +
+		"adjacent comment is explicit that this stays baseline while /sod/violations (which " +
+		"DOES disclose violator names/emails) is separately gated on audit.read.",
+	"server/http/router.go:2212": "GET /admin/anomaly-config returns the DB-persisted anomaly " +
+		"detection THRESHOLDS (config), not any user/project/alert data -- deployment-wide " +
+		"config in the same non-disclosure-sensitive family as auth-config/encryption-config " +
+		"above. Actual alert data (which does disclose SecretName/AccessedBy/IPAddress " +
+		"deployment-wide) is the separate /audit/anomalies route (line 1062 above), already " +
+		"gated at effective audit.read.",
+}
+
+// site is one RequirePermission(permSystemRead)/RequireScopedPermission(permSystemRead,
+// ...) call site found in server/http/router.go.
+type site struct {
+	line int
+	fn   string // "RequirePermission" or "RequireScopedPermission"
+}
+
+func (s site) key() string { return "server/http/router.go:" + strconv.Itoa(s.line) }
+
+// repoRoot resolves the repository root relative to THIS test file's own location (not
+// the process cwd), so the sweep works regardless of how `go test` is invoked.
+func permissionSweepRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller must resolve this test file's path")
+	// this file lives at server/http/permission_sweep_test.go
+	root, err := filepath.Abs(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	require.NoError(t, err)
+	return root
+}
+
+// scanRouterForSystemReadOnlyGates parses server/http/router.go's AST and returns
+// every call site where customMiddleware.RequirePermission or
+// customMiddleware.RequireScopedPermission is invoked with permSystemRead as its first
+// argument (by AST inspection, not string/regex matching, so it isn't fooled by the
+// identifier appearing in a comment or string literal).
+func scanRouterForSystemReadOnlyGates(t *testing.T, routerGoPath string) map[string]site {
+	t.Helper()
+	src, err := os.ReadFile(routerGoPath) // #nosec G304 -- fixed repo-internal path, not external input
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, routerGoPath, src, 0)
+	require.NoError(t, err)
+
+	found := map[string]site{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkgIdent, ok := sel.X.(*ast.Ident)
+		if !ok || pkgIdent.Name != "customMiddleware" {
+			return true
+		}
+		if sel.Sel.Name != "RequirePermission" && sel.Sel.Name != "RequireScopedPermission" {
+			return true
+		}
+		if len(call.Args) == 0 {
+			return true
+		}
+		argIdent, ok := call.Args[0].(*ast.Ident)
+		if !ok || argIdent.Name != "permSystemRead" {
+			return true
+		}
+		pos := fset.Position(call.Pos())
+		s := site{line: pos.Line, fn: sel.Sel.Name}
+		found[s.key()] = s
+		return true
+	})
+	return found
+}
+
+// TestNoUnjustifiedSystemReadOnlyGates is the guard itself: every
+// RequirePermission(permSystemRead)/RequireScopedPermission(permSystemRead, ...) call
+// site in server/http/router.go must appear in permissionSweepAllowlist. Reverting the
+// admin_usage.go/admin_billing.go fix (putting either route back on permSystemRead)
+// must fail this test -- verified RED against exactly that revert; see this file's
+// package doc comment.
+func TestNoUnjustifiedSystemReadOnlyGates(t *testing.T) {
+	routerGoPath := filepath.Join(permissionSweepRepoRoot(t), "server", "http", "router.go")
+	found := scanRouterForSystemReadOnlyGates(t, routerGoPath)
+
+	var unallowed []string
+	for key, s := range found {
+		if _, ok := permissionSweepAllowlist[key]; !ok {
+			unallowed = append(unallowed, key+" ("+s.fn+"(permSystemRead))")
+		}
+	}
+	sort.Strings(unallowed)
+	assert.Empty(t, unallowed,
+		"server/http/router.go gates a route SOLELY on permSystemRead (the universal "+
+			"system_viewer baseline every user holds) with no reviewed justification -- "+
+			"either require a stricter permission (audit.read for any deployment-wide/"+
+			"cross-tenant disclosure -- see admin_usage.go's header comment for why) or add "+
+			"a reviewed allowlist entry here with a written justification: %v", unallowed)
+}
+
+// TestPermissionSweepAllowlistEntriesStillExist is the flip side of the guard above: an
+// allowlist entry for a call site that no longer exists (renamed, deleted, or --
+// worse -- silently regressed back onto permSystemRead at a DIFFERENT line, which
+// would leave the OLD line's stale entry masking the fact that the sweep no longer
+// covers the real site) would hide a regression. A stale entry doesn't fail the sweep
+// above (which only checks found-but-unallowed sites), so it's checked here
+// explicitly.
+func TestPermissionSweepAllowlistEntriesStillExist(t *testing.T) {
+	routerGoPath := filepath.Join(permissionSweepRepoRoot(t), "server", "http", "router.go")
+	found := scanRouterForSystemReadOnlyGates(t, routerGoPath)
+
+	var stale []string
+	for key := range permissionSweepAllowlist {
+		if _, ok := found[key]; !ok {
+			stale = append(stale, key)
+		}
+	}
+	sort.Strings(stale)
+	assert.Empty(t, stale,
+		"allowlist entry no longer matches any real RequirePermission(permSystemRead)/"+
+			"RequireScopedPermission(permSystemRead, ...) call site in server/http/router.go "+
+			"(the code moved, was fixed, or regressed at a different line, without updating "+
+			"this list): %v", stale)
+}
+
+// TestPermissionSweepAllowlistJustificationsAreNonEmpty guards against an allowlist
+// entry added with an empty/placeholder reason, per this campaign's standing rule that
+// an exemption needs a written justification, not just a line number.
+func TestPermissionSweepAllowlistJustificationsAreNonEmpty(t *testing.T) {
+	for key, reason := range permissionSweepAllowlist {
+		assert.NotEmpty(t, reason, "allowlist entry %q has no justification", key)
+	}
+}
+
+// TestPermissionSweepScannerDetectsSystemReadOnlyGates is a self-check on the AST
+// sweep itself: a guard that has never been observed to fail on a genuinely bad input
+// is not a guard (a test asserting emptiness of a possibly-always-empty scan would
+// pass even if the AST matching logic were broken, e.g. matching the wrong selector or
+// missing RequireScopedPermission entirely). This proves the scanner actually detects
+// both flagged call shapes when present, and does NOT flag permAuditRead or an
+// unrelated call, independent of router.go's current contents.
+func TestPermissionSweepScannerDetectsSystemReadOnlyGates(t *testing.T) {
+	dir := t.TempDir()
+	src := `package fixture
+
+type mw struct{}
+
+func (mw) RequirePermission(perm string) func() {return nil}
+func (mw) RequireScopedPermission(perm string, scoper func()) func() {return nil}
+
+var customMiddleware mw
+var permSystemRead = "system.read"
+var permAuditRead = "audit.read"
+
+func bad1() { customMiddleware.RequirePermission(permSystemRead) }
+func bad2() { customMiddleware.RequireScopedPermission(permSystemRead, nil) }
+func fine1() { customMiddleware.RequirePermission(permAuditRead) }
+func fine2() { customMiddleware.RequireScopedPermission(permAuditRead, nil) }
+`
+	path := filepath.Join(dir, "fixture.go")
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+
+	found := scanRouterForSystemReadOnlyGates(t, path)
+
+	require.Len(t, found, 2, "scanner must find exactly the two permSystemRead call sites, not the two permAuditRead ones")
+	var fns []string
+	for _, s := range found {
+		fns = append(fns, s.fn)
+	}
+	sort.Strings(fns)
+	assert.Equal(t, []string{"RequirePermission", "RequireScopedPermission"}, fns,
+		"scanner must detect both RequirePermission and RequireScopedPermission call shapes")
+}

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -2167,13 +2167,25 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		r.With(customMiddleware.RequirePermission(permSystemWrite)).Delete("/sod/policies/{id}", catalogHandler.DeleteSoDPolicy)
 		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/sod/violations", catalogHandler.ListSoDViolations)
 
-		// Usage report — per-project secret counts + read activity over a time window.
-		// Deployment-wide aggregation, gated by system.read.
-		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/admin/usage", adminUsageHandler.GetUsageReport)
+		// Usage report — per-project secret counts + read activity over a time window,
+		// with no per-project ownership check anywhere in the call chain (any project_id
+		// can be requested). Gated by audit.read, NOT system.read: system.read is the
+		// universal system_viewer baseline auto-assigned to every user at creation
+		// (CreateUser), every SSO/JIT-provisioned user, and every SCIM-provisioned user, so
+		// gating a deployment-wide, cross-project disclosure report on it alone is
+		// equivalent to no gate at all. Same disclosure family as CP-001/CP-008 (see
+		// control_framework.go's package comment) — this is the 7th+ confirmed instance of
+		// the identical mistake.
+		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/admin/usage", adminUsageHandler.GetUsageReport)
 
-		// Billing report — per-project FinOps usage breakdown for a date range.
-		// Requires the "billing" license feature (gated in core.GenerateBillingReport).
-		r.With(customMiddleware.RequirePermission(permSystemRead)).Get("/admin/billing/report", adminBillingHandler.GetBillingReport)
+		// Billing report — per-project FinOps usage breakdown for a date range, with no
+		// per-project ownership check (project_id list is caller-supplied, unchecked
+		// against any membership). Requires the "billing" license feature (gated in
+		// core.GenerateBillingReport) as well, but a license feature flag is a deployment
+		// capability check, not a per-caller authorization check — it does not substitute
+		// for one. Gated by audit.read, NOT system.read, for the same reason as
+		// /admin/usage immediately above (same disclosure family, same fix).
+		r.With(customMiddleware.RequirePermission(permAuditRead)).Get("/admin/billing/report", adminBillingHandler.GetBillingReport)
 
 		// On-demand triggers for the notification/alert jobs that otherwise run only on
 		// their background schedulers — dispatch immediately after an incident or config


### PR DESCRIPTION
## Summary

- `GET /api/v1/admin/usage` and `GET /api/v1/admin/billing/report` were gated
  solely on `system.read` (`RequirePermission(permSystemRead)` in
  `server/http/router.go`) -- the universal `system_viewer` baseline every
  user holds from creation (`CreateUser`), SSO/JIT provisioning, and SCIM
  provisioning. Both handlers return deployment-wide, per-project data
  (secret counts, read/write activity, machine-vs-human breakdowns) with no
  ownership check anywhere in their call chains, so any authenticated
  account -- including a brand-new zero-role SSO user -- could enumerate
  every project's usage/billing figures via `?project_id=`.
- This is the 7th+ confirmed instance of the same mistake already fixed for
  compliance posture, hygiene rollups, PAT/machine-token hygiene, and secrets
  inventory (CP-001/CP-008 family). Both routes now require `audit.read`,
  matching the rest of that family.
- Swept every other `RequirePermission(permSystemRead)`/
  `RequireScopedPermission(permSystemRead, ...)` call site in `router.go`.
  The remaining ten are genuinely baseline-appropriate (redacted config
  summaries, the caller's own dashboard with aggregates separately scoped,
  non-PII policy definitions, or -- for `/audit/anomalies` -- already
  effectively gated at `audit.read` via the enclosing route group's chi
  middleware) and are documented with a written justification in
  `permission_sweep_test.go`'s allowlist.
- Added an AST-based exhaustiveness guard (`permission_sweep_test.go`)
  mirroring `internal/cli/writeguard`'s allowlist-with-reasoning convention:
  any future route gated solely on `system.read` fails CI unless explicitly
  allowlisted with a reason. Verified red against a reverted fix, green
  after.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on all changed/added files
- [x] `gosec -severity medium -exclude-generated ./server/http/...` — 0 issues
- [x] `internal/core` usage/billing unit tests pass unchanged
- [x] `server/http/handlers` (incl. `admin_usage_test.go`/`admin_billing_test.go`) full package green
- [x] `server/http/handlers/contracttest` full package green
- [x] New/updated `server/http` regression tests green: extended
      `TestDeploymentDisclosureFamily_BaselineDeniedAuditorAllowed`, new
      `TestAdminBillingReport_PermissionTiers`
- [x] New guard `TestNoUnjustifiedSystemReadOnlyGates` + its 3 self-checks green
- [x] Red-then-green verified by hand: reverted both router.go lines back to
      `permSystemRead`, confirmed both the behavioral regression tests AND
      the guard test fail; restored the fix, confirmed all green again