### PR TITLE
fix(auth): scope MFAStepUpGrant to an explicit purpose (confused-deputy reauth bypass)

### DIFF
--- a/internal/core/account.go
+++ b/internal/core/account.go
@@ -38,13 +38,19 @@ func (c *KeyorixCore) UpdateOwnProfile(ctx context.Context, userID uint, display
 			return nil, fmt.Errorf("%s: %w", i18n.T("ErrorUserNotFound", nil), err)
 		}
 		if email != user.Email {
-			// For MFA-enabled accounts, require a TOTP code or password via requireReauth
-			// (the same bar as DisableMFA / DeleteWebAuthnCredential). The email is the
-			// password-reset anchor and SSO linking key: redirecting it to an
-			// attacker-controlled address with only a stolen session suffices for full
-			// account takeover. Password-only re-auth is too weak when a second factor is
-			// enrolled. For non-MFA accounts, fall back to the bcrypt password check.
-			if user.MFAEnabled {
+			// For accounts with ANY second factor enrolled (TOTP or WebAuthn/passkey),
+			// require a TOTP code or password via requireReauth (the same bar as
+			// DisableMFA / DeleteWebAuthnCredential). The email is the password-reset
+			// anchor and SSO linking key: redirecting it to an attacker-controlled
+			// address with only a stolen session suffices for full account takeover.
+			// Password-only re-auth is too weak when a second factor is enrolled.
+			// Checking user.MFAEnabled alone (as this used to) let a WebAuthn-only
+			// account (MFAEnabled=false, WebAuthnEnabled=true) fall through to the
+			// bare bcrypt branch below, bypassing the second-factor requirement
+			// requireReauth's own doc comment says is mandatory once any second
+			// factor is enrolled. For accounts with no second factor at all, fall
+			// back to the bcrypt password check.
+			if user.MFAEnabled || user.WebAuthnEnabled {
 				if err := c.requireReauth(ctx, user, currentPassword, "email_change"); err != nil {
 					return nil, err
 				}

--- a/internal/core/classification_gate.go
+++ b/internal/core/classification_gate.go
@@ -102,8 +102,13 @@ func (c *KeyorixCore) mfaStepUpWindow() time.Duration {
 //     lookup, no per-secret DB query.
 //  2. restricted_requires_approval: the user must have an approved, secret-scoped
 //     access request. Checked second.
-//  3. restricted_requires_mfa_stepup: the user must have completed MFA within the
-//     configured step-up window (default 15 min), recorded by VerifyMFALogin.
+//  3. restricted_requires_mfa_stepup: the user must hold an active
+//     MFAStepUpGrant with Purpose == MFAStepUpPurposeRestrictedSecretRead,
+//     minted either by an explicit VerifyMFAStepUp call or ambiently by a
+//     WebAuthn login (FinishWebAuthnLogin/FinishWebAuthnPasswordlessLogin),
+//     within the configured step-up window (default 15 min). This purpose is
+//     distinct from MFAStepUpPurposeReauth (requireReauth's account-security-
+//     change gate) — the two never satisfy each other.
 //
 // userID identifies the acting human principal, if any. 0 means the read has no
 // identifiable user behind it — a machine/service-account credential, the
@@ -169,7 +174,7 @@ func (c *KeyorixCore) checkRestrictedApprovalGate(ctx context.Context, secret *m
 }
 
 func (c *KeyorixCore) checkRestrictedMFAGate(ctx context.Context, secret *models.SecretNode, userID uint) error {
-	grant, err := c.storage.GetActiveMFAStepUpGrant(ctx, userID, c.now())
+	grant, err := c.storage.GetActiveMFAStepUpGrant(ctx, userID, models.MFAStepUpPurposeRestrictedSecretRead, c.now())
 	if err != nil {
 		return fmt.Errorf("secret %q is restricted: could not verify MFA step-up: %w", secret.Name, err)
 	}

--- a/internal/core/classification_gate_test.go
+++ b/internal/core/classification_gate_test.go
@@ -400,7 +400,7 @@ func TestClassificationMFAStepUp_On_ActiveToken_Allowed(t *testing.T) {
 
 	// Directly seed the step-up grant (as VerifyMFAStepUp would).
 	expiresAt := c.now().Add(15 * time.Minute)
-	require.NoError(t, st.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: ownerID, ExpiresAt: expiresAt}))
+	require.NoError(t, st.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: ownerID, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: expiresAt}))
 
 	val, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
 	require.NoError(t, err, "active MFA step-up grant must allow the read")
@@ -416,7 +416,7 @@ func TestClassificationMFAStepUp_On_ExpiredToken_Denied(t *testing.T) {
 
 	// Seed an already-expired grant.
 	expiredAt := c.now().Add(-1 * time.Minute)
-	require.NoError(t, st.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: ownerID, ExpiresAt: expiredAt}))
+	require.NoError(t, st.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: ownerID, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: expiredAt}))
 
 	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)
 	require.Error(t, err, "expired step-up grant must not grant access")
@@ -450,7 +450,7 @@ func TestClassificationMFAStepUp_Combined_BothRequired(t *testing.T) {
 	c.SetClassificationRestrictedRequiresMFAStepUp(true, 0)
 
 	// Give the owner an active step-up grant.
-	require.NoError(t, st.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: ownerID, ExpiresAt: c.now().Add(15 * time.Minute)}))
+	require.NoError(t, st.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: ownerID, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: c.now().Add(15 * time.Minute)}))
 
 	// No approved access request yet → denied.
 	_, err := c.GetSecretValueWithPermissionCheck(ctx, secretID, ownerID)

--- a/internal/core/mfa.go
+++ b/internal/core/mfa.go
@@ -458,12 +458,20 @@ func (c *KeyorixCore) auditMFAFailed(ctx context.Context, userID uint, phase str
 //     BeginMFAEnrollment/BeginWebAuthnRegistration themselves would already
 //     know). Anti-replay via MarkTOTPStepUsed, same as VerifyMFACredentials.
 //  2. codeOrPassword is the correct account password AND the user separately
-//     holds an active MFA step-up grant (HasActiveMFAStepUp) — an
-//     independent, time-limited proof that they recently re-verified their
-//     second factor (VerifyMFAStepUp for TOTP/recovery codes; a WebAuthn
-//     login also mints one, see FinishWebAuthnLogin/
-//     FinishWebAuthnPasswordlessLogin — a passkey assertion has no typable
-//     "code" to hand this function directly, so login itself is the proof).
+//     holds an active MFA step-up grant with Purpose ==
+//     MFAStepUpPurposeReauth (HasActiveMFAStepUp) — an independent,
+//     time-limited proof that they recently re-verified their second factor
+//     FOR THIS SPECIFIC PURPOSE. A passkey assertion has no typable "code" to
+//     hand this function directly, so a WebAuthn-only account proves this via
+//     FinishWebAuthnReauth (a fresh, live passkey assertion performed at the
+//     time of the sensitive action — see webauthn.go), not merely by having
+//     logged in recently. An ordinary login (VerifyMFALogin/FinishWebAuthnLogin/
+//     FinishWebAuthnPasswordlessLogin) mints only a
+//     MFAStepUpPurposeRestrictedSecretRead grant, which does NOT satisfy this
+//     branch — a purpose-agnostic grant would let anyone holding a merely
+//     leaked bearer token (plus the password) ride the account owner's own
+//     earlier login to authorize an account-security-factor takeover, which is
+//     exactly the confused-deputy bug this purpose separation closes.
 //
 // With no second factor enrolled at all, the account password alone remains
 // sufficient re-auth — unchanged from before this check existed.
@@ -493,11 +501,13 @@ func (c *KeyorixCore) requireReauth(ctx context.Context, user *models.User, code
 	if !ok && codeOrPassword != "" && bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(codeOrPassword)) == nil {
 		if !secondFactorEnrolled {
 			ok = true
-		} else if hasGrant, gerr := c.HasActiveMFAStepUp(ctx, user.ID); gerr == nil && hasGrant {
+		} else if hasGrant, gerr := c.HasActiveMFAStepUp(ctx, user.ID, models.MFAStepUpPurposeReauth); gerr == nil && hasGrant {
 			// The password is correct AND the caller independently proved they
-			// still hold the enrolled second factor recently — password alone
-			// would not be enough on its own, but password + a fresh, genuine
-			// step-up grant is equivalent proof to supplying the code directly.
+			// still hold the enrolled second factor recently, FOR THIS PURPOSE —
+			// password alone would not be enough on its own, but password + a
+			// fresh, genuine reauth-purpose step-up grant is equivalent proof to
+			// supplying the code directly. A restricted-secret-read-purpose grant
+			// (minted ambiently by login) does not match and is rejected here.
 			ok = true
 		}
 	}

--- a/internal/core/mfa_atomicity_test.go
+++ b/internal/core/mfa_atomicity_test.go
@@ -116,7 +116,7 @@ func TestDisableMFA_AtomicOnDeleteFailure(t *testing.T) {
 	// second-factor requirement (#372-follow-up); seed an active step-up grant so
 	// re-auth succeeds and the test actually reaches (and exercises) the injected
 	// storage failure below, rather than failing earlier at re-auth.
-	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
 
 	c.storage = &failingStorage{Storage: c.storage, failMethod: "DeleteMFAForUser"}
 	err := c.DisableMFA(ctx, 1, mfaTestPassword)
@@ -146,7 +146,7 @@ func TestRegenerateMFARecoveryCodes_AtomicOnCreateFailure(t *testing.T) {
 	// second-factor requirement (#372-follow-up); seed an active step-up grant so
 	// re-auth succeeds and the test actually reaches (and exercises) the injected
 	// storage failure below, rather than failing earlier at re-auth.
-	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
 
 	c.storage = &failingStorage{Storage: c.storage, failMethod: "CreateMFARecoveryCodes"}
 	_, err := c.RegenerateMFARecoveryCodes(ctx, 1, mfaTestPassword)

--- a/internal/core/mfa_stepup.go
+++ b/internal/core/mfa_stepup.go
@@ -46,6 +46,7 @@ func (c *KeyorixCore) VerifyMFAStepUp(ctx context.Context, userID uint, code str
 
 	grant := &models.MFAStepUpGrant{
 		UserID:    userID,
+		Purpose:   models.MFAStepUpPurposeRestrictedSecretRead,
 		ExpiresAt: c.now().Add(c.mfaStepUpWindow()),
 	}
 	if err := c.storage.CreateMFAStepUpGrant(ctx, grant); err != nil {
@@ -72,9 +73,12 @@ func (c *KeyorixCore) verifyMFAStepUpCode(ctx context.Context, userID uint, code
 }
 
 // HasActiveMFAStepUp reports whether userID holds a current, unexpired step-up
-// grant. Returns (false, nil) — not an error — when no grant exists.
-func (c *KeyorixCore) HasActiveMFAStepUp(ctx context.Context, userID uint) (bool, error) {
-	grant, err := c.storage.GetActiveMFAStepUpGrant(ctx, userID, c.authEffectiveNow())
+// grant for the exact purpose given. Returns (false, nil) — not an error —
+// when no matching grant exists. purpose is not optional: a grant minted for
+// one purpose (e.g. restricted-secret reads) must never be read as
+// authorizing a different one (e.g. an account-security-factor change).
+func (c *KeyorixCore) HasActiveMFAStepUp(ctx context.Context, userID uint, purpose models.MFAStepUpPurpose) (bool, error) {
+	grant, err := c.storage.GetActiveMFAStepUpGrant(ctx, userID, purpose, c.authEffectiveNow())
 	if err != nil {
 		return false, err
 	}

--- a/internal/core/mfa_stepup_gate_test.go
+++ b/internal/core/mfa_stepup_gate_test.go
@@ -45,7 +45,7 @@ func TestStepUpGate_On_ActiveGrant_Allowed(t *testing.T) {
 
 	// Seed an active step-up grant relative to the fixed clock.
 	future := fixed.Add(15 * time.Minute)
-	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: future}).Error)
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: future}).Error)
 
 	secret := &models.SecretNode{Name: "db-pass", Classification: ClassificationRestricted}
 	err := c.checkRestrictedSecretReadApproval(ctx, secret, 1)

--- a/internal/core/mfa_stepup_purpose_guard_test.go
+++ b/internal/core/mfa_stepup_purpose_guard_test.go
@@ -1,0 +1,363 @@
+// mfa_stepup_purpose_guard_test.go — regression guard for the confused-deputy
+// MFA step-up bypass fixed alongside this file (models.MFAStepUpGrant gained
+// an explicit Purpose field; every CURRENT consumption site now requires an
+// exact purpose match rather than accepting any live grant). Nothing
+// structurally stops a FUTURE consumption site from repeating the exact
+// mistake: calling the grant-lookup primitive and accepting whatever comes
+// back without pinning down which purpose is actually required for that
+// action -- that purpose-agnostic acceptance is precisely how the original
+// bug arose.
+//
+// This is an AST sweep (go/parser, not string/regex matching) over every
+// non-test *.go file in the repository for a call to HasActiveMFAStepUp or
+// GetActiveMFAStepUpGrant -- the two functions that turn a stored grant row
+// into an authorization decision (see internal/core/mfa_stepup.go and
+// internal/core/storage/interface.go). Both share the same argument shape
+// (ctx, userID, purpose, ...), so the purpose argument is always the third
+// (index 2).
+//
+// Every call site found must be in mfaStepUpPurposeAllowlist below with a
+// written justification, matching the house convention (see
+// internal/cli/writeguard/write_guard_test.go,
+// internal/core/g80_1530_machine_actor_attribution_guard_test.go). A call
+// site is safe when its purpose argument is a HARDCODED
+// models.MFAStepUpPurpose* constant matching the allowlist's recorded
+// expectation for that exact site -- not a variable, not a struct field, not
+// merely non-empty. A site whose purpose argument cannot be resolved to a
+// literal constant must say so explicitly in its allowlist entry (expected =
+// "") with a reason establishing it is not itself an authorization decision
+// (e.g. a storage-layer passthrough forwarding a value some OTHER,
+// separately-guarded call site already decided).
+//
+// This guard's own effectiveness was verified red-then-green: temporarily
+// changing internal/core/mfa.go's requireReauth call from
+// models.MFAStepUpPurposeReauth to models.MFAStepUpPurposeRestrictedSecretRead
+// (recreating the confused-deputy shape -- accepting the ambient
+// login-minted grant for an account-security-factor change) made
+// TestMFAStepUpConsumersUseExpectedPurpose fail with exactly that mismatch;
+// restoring the constant made it pass again.
+package core
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mfaStepUpGuardedFuncs is the set of functions this sweep treats as turning
+// a stored MFAStepUpGrant into an authorization decision. Both take
+// (ctx, userID, purpose, ...) -- the purpose argument is always at index 2.
+var mfaStepUpGuardedFuncs = map[string]bool{
+	"HasActiveMFAStepUp":      true,
+	"GetActiveMFAStepUpGrant": true,
+}
+
+// mfaPurposeArgIndex is the zero-based index of the purpose argument shared
+// by both guarded functions' signatures.
+const mfaPurposeArgIndex = 2
+
+// mfaStepUpAllowEntry records, for one call site (keyed "relpath:line" in
+// mfaStepUpPurposeAllowlist), the purpose constant that call site is
+// expected to hardcode -- or "" when the site intentionally does not pass a
+// literal, with reason explaining why that's still safe.
+type mfaStepUpAllowEntry struct {
+	expectedPurpose string // e.g. "MFAStepUpPurposeReauth"; "" means intentionally non-literal
+	reason          string
+}
+
+// mfaStepUpPurposeAllowlist is the exhaustive, reasoned inventory of every
+// call to HasActiveMFAStepUp/GetActiveMFAStepUpGrant in the repository. A
+// call site missing from this list, or one whose purpose argument no longer
+// matches its recorded expectedPurpose, fails
+// TestMFAStepUpConsumersUseExpectedPurpose -- exactly the shape a future
+// "accept any live grant" regression would take.
+var mfaStepUpPurposeAllowlist = map[string]mfaStepUpAllowEntry{
+	"internal/core/mfa.go:504": {
+		expectedPurpose: "MFAStepUpPurposeReauth",
+		reason: "requireReauth's account-security-factor-change gate (DisableMFA, " +
+			"RegenerateMFARecoveryCodes, ActivateMFA, WebAuthn credential register/delete, email change). " +
+			"Must reject the ambient MFAStepUpPurposeRestrictedSecretRead grant a plain login mints -- " +
+			"accepting it here is the exact confused-deputy shape this fix closed (a leaked bearer token " +
+			"plus the password would otherwise ride the account owner's own earlier login into an " +
+			"account takeover).",
+	},
+	"internal/core/classification_gate.go:177": {
+		expectedPurpose: "MFAStepUpPurposeRestrictedSecretRead",
+		reason: "checkRestrictedMFAGate, the classification_restricted_requires_mfa_stepup gate for " +
+			"reading a ClassificationRestricted secret's value. Must reject a MFAStepUpPurposeReauth grant " +
+			"(minted only for account-security changes) -- the two purposes must never satisfy each other.",
+	},
+	"internal/core/mfa_stepup.go:81": {
+		expectedPurpose: "",
+		reason: "HasActiveMFAStepUp's own implementation: forwards the `purpose` PARAMETER it was called " +
+			"with straight through to storage.GetActiveMFAStepUpGrant. This is the shared primitive, not a " +
+			"consumer -- it has no fixed purpose of its own to hardcode. Enforcement responsibility sits " +
+			"with HasActiveMFAStepUp's own callers, which this same allowlist enumerates separately " +
+			"(currently just mfa.go:504).",
+	},
+	"server/http/handlers/mfa_stepup_proxy.go:63": {
+		expectedPurpose: "",
+		reason: "GetActiveMFAStepUpGrantProxy: the server-side passthrough backing RemoteStorage's " +
+			"GetActiveMFAStepUpGrant for a storage.type: remote spoke node (ADR-049). Forwards the wire " +
+			"body's Purpose field verbatim -- it makes no policy decision itself (see this file's own doc " +
+			"comment: \"no policy decisions made here\"). The actual authorization decision, and the " +
+			"literal purpose constant used to make it, lives entirely on the calling core.KeyorixCore side " +
+			"(mfa.go:504 / classification_gate.go:177 above), which is unaffected by which storage backend " +
+			"(Local or Remote) it happens to be wired to.",
+	},
+}
+
+type mfaStepUpSite struct {
+	relPath string
+	line    int
+	fn      string
+	purpose string // "" when the purpose argument isn't a literal models.MFAStepUpPurpose* constant
+}
+
+func (s mfaStepUpSite) key() string { return s.relPath + ":" + strconv.Itoa(s.line) }
+
+// mfaStepUpGuardRepoRoot locates the repository root relative to this test
+// file's own location on disk (internal/core), not the test runner's cwd.
+func mfaStepUpGuardRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller must resolve this test file's path")
+	root, err := filepath.Abs(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	require.NoError(t, err)
+	return root
+}
+
+// mfaStepUpPurposeLiteral extracts the models.MFAStepUpPurpose* constant name
+// from expr, or "" if expr is not a bare `models.<Ident>` selector -- i.e.
+// not a literal, hardcoded reference (a variable, a struct field like
+// body.Purpose, a function call, etc. all yield "").
+func mfaStepUpPurposeLiteral(expr ast.Expr) string {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	pkgIdent, ok := sel.X.(*ast.Ident)
+	if !ok || pkgIdent.Name != "models" {
+		return ""
+	}
+	if !strings.HasPrefix(sel.Sel.Name, "MFAStepUpPurpose") {
+		return ""
+	}
+	return sel.Sel.Name
+}
+
+// scanMFAStepUpFile parses a single .go file and returns every call site to
+// a guarded function found in it, by AST inspection.
+func scanMFAStepUpFile(fset *token.FileSet, path string) ([]mfaStepUpSite, error) {
+	src, err := os.ReadFile(path) // #nosec G304 -- fixed repo-internal path built from filepath.WalkDir below, not external input
+	if err != nil {
+		return nil, err
+	}
+	f, err := parser.ParseFile(fset, path, src, 0)
+	if err != nil {
+		return nil, err
+	}
+	var sites []mfaStepUpSite
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if !mfaStepUpGuardedFuncs[sel.Sel.Name] {
+			return true
+		}
+		purpose := ""
+		if len(call.Args) > mfaPurposeArgIndex {
+			purpose = mfaStepUpPurposeLiteral(call.Args[mfaPurposeArgIndex])
+		}
+		pos := fset.Position(call.Pos())
+		sites = append(sites, mfaStepUpSite{relPath: path, line: pos.Line, fn: sel.Sel.Name, purpose: purpose})
+		return true
+	})
+	return sites, nil
+}
+
+// mfaStepUpGuardSkipDirs mirrors the skip list used by this campaign's other
+// repo-wide guards (e.g. g80_1530_machine_actor_attribution_guard_test.go).
+var mfaStepUpGuardSkipDirs = map[string]bool{
+	".git":         true,
+	".github":      true,
+	".githooks":    true,
+	".semgrep":     true,
+	".task":        true,
+	".scratch":     true,
+	"node_modules": true,
+	"web":          true,
+	"vendor":       true,
+}
+
+// findAllMFAStepUpSites walks every non-test *.go file in the repository and
+// returns every guarded-function call site found, keyed by path relative to
+// the repo root plus line number.
+func findAllMFAStepUpSites(t *testing.T, repo string) map[string]mfaStepUpSite {
+	t.Helper()
+	fset := token.NewFileSet()
+	found := map[string]mfaStepUpSite{}
+	err := filepath.WalkDir(repo, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if mfaStepUpGuardSkipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		sites, serr := scanMFAStepUpFile(fset, path)
+		if serr != nil {
+			return serr
+		}
+		for _, s := range sites {
+			rel, rerr := filepath.Rel(repo, path)
+			require.NoError(t, rerr)
+			s.relPath = filepath.ToSlash(rel)
+			found[s.key()] = s
+		}
+		return nil
+	})
+	require.NoError(t, err, "walking %s must not fail", repo)
+	return found
+}
+
+// TestMFAStepUpConsumersUseExpectedPurpose is the guard: every call to
+// HasActiveMFAStepUp/GetActiveMFAStepUpGrant repo-wide must be in
+// mfaStepUpPurposeAllowlist, and every allowlisted site with a non-empty
+// expectedPurpose must actually pass that exact literal constant as its
+// purpose argument. A site that used to pass the right constant and now
+// passes a different one (or a non-literal) fails here -- this is exactly
+// the shape a reintroduced "accept any live grant" bug takes: a call site
+// that no longer pins down which purpose it actually requires.
+func TestMFAStepUpConsumersUseExpectedPurpose(t *testing.T) {
+	found := findAllMFAStepUpSites(t, mfaStepUpGuardRepoRoot(t))
+
+	var unlisted []string
+	var mismatched []string
+	for key, s := range found {
+		entry, ok := mfaStepUpPurposeAllowlist[key]
+		if !ok {
+			unlisted = append(unlisted, key+" ("+s.fn+")")
+			continue
+		}
+		if entry.expectedPurpose == "" {
+			continue // intentionally non-literal / not a decision site; reason lives in the allowlist
+		}
+		if s.purpose != entry.expectedPurpose {
+			got := s.purpose
+			if got == "" {
+				got = "<not a hardcoded models.MFAStepUpPurpose* literal>"
+			}
+			mismatched = append(mismatched, key+": expected purpose "+entry.expectedPurpose+", found "+got)
+		}
+	}
+	sort.Strings(unlisted)
+	sort.Strings(mismatched)
+
+	assert.Empty(t, unlisted,
+		"call site(s) to HasActiveMFAStepUp/GetActiveMFAStepUpGrant found with no reviewed allowlist "+
+			"entry -- a new MFA step-up grant consumer must hardcode the exact models.MFAStepUpPurpose* "+
+			"constant it requires and add a justified entry to mfaStepUpPurposeAllowlist, or it risks "+
+			"repeating the confused-deputy bug this guard exists to catch: %v", unlisted)
+	assert.Empty(t, mismatched,
+		"call site(s) to HasActiveMFAStepUp/GetActiveMFAStepUpGrant no longer pass the purpose constant "+
+			"mfaStepUpPurposeAllowlist expects -- this is exactly the bug shape this guard exists to catch: "+
+			"a grant consumer accepting a purpose other than the one it actually requires: %v", mismatched)
+}
+
+// TestMFAStepUpPurposeAllowlistEntriesStillExist catches a stale allowlist
+// entry -- the call site moved, was renamed, or was deleted -- which would
+// otherwise silently stop protecting anything.
+func TestMFAStepUpPurposeAllowlistEntriesStillExist(t *testing.T) {
+	found := findAllMFAStepUpSites(t, mfaStepUpGuardRepoRoot(t))
+
+	var stale []string
+	for key := range mfaStepUpPurposeAllowlist {
+		if _, ok := found[key]; !ok {
+			stale = append(stale, key)
+		}
+	}
+	sort.Strings(stale)
+	assert.Empty(t, stale,
+		"mfaStepUpPurposeAllowlist entry no longer matches any real "+
+			"HasActiveMFAStepUp/GetActiveMFAStepUpGrant call site (the code moved, was renamed, or was "+
+			"removed, without updating this list): %v", stale)
+}
+
+// TestMFAStepUpPurposeAllowlistJustificationsAreNonEmpty guards against an
+// allowlist entry added with an empty/placeholder reason.
+func TestMFAStepUpPurposeAllowlistJustificationsAreNonEmpty(t *testing.T) {
+	for key, entry := range mfaStepUpPurposeAllowlist {
+		assert.NotEmpty(t, strings.TrimSpace(entry.reason), "allowlist entry %q has no justification", key)
+	}
+}
+
+// TestMFAStepUpPurposeScannerDetectsCallSites is a self-check on the AST
+// sweep: proves it actually extracts a hardcoded purpose constant when one
+// is present, and correctly reports "" (non-literal) for a dynamic argument
+// -- independent of the repository's current contents, so this guard can
+// never pass merely because it never finds anything.
+func TestMFAStepUpPurposeScannerDetectsCallSites(t *testing.T) {
+	dir := t.TempDir()
+	src := `package fixture
+
+import "github.com/keyorixhq/keyorix/internal/storage/models"
+
+func hardcoded(c interface{ HasActiveMFAStepUp(int, int, models.MFAStepUpPurpose) (bool, error) }) {
+	_, _ = c.HasActiveMFAStepUp(0, 0, models.MFAStepUpPurposeReauth)
+}
+
+func dynamic(c interface{ HasActiveMFAStepUp(int, int, models.MFAStepUpPurpose) (bool, error) }, p models.MFAStepUpPurpose) {
+	_, _ = c.HasActiveMFAStepUp(0, 0, p)
+}
+
+func other(c interface{ SomethingElse() }) {
+	c.SomethingElse()
+}
+`
+	path := filepath.Join(dir, "fixture.go")
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+
+	fset := token.NewFileSet()
+	sites, err := scanMFAStepUpFile(fset, path)
+	require.NoError(t, err)
+	require.Len(t, sites, 2, "scanner must find exactly the two HasActiveMFAStepUp calls, not SomethingElse")
+
+	byLine := map[int]mfaStepUpSite{}
+	for _, s := range sites {
+		byLine[s.line] = s
+	}
+	var gotHardcoded, gotDynamic bool
+	for _, s := range sites {
+		if s.purpose == "MFAStepUpPurposeReauth" {
+			gotHardcoded = true
+		}
+		if s.purpose == "" {
+			gotDynamic = true
+		}
+	}
+	assert.True(t, gotHardcoded, "scanner must extract the literal MFAStepUpPurposeReauth constant")
+	assert.True(t, gotDynamic, "scanner must report \"\" for a non-literal (variable) purpose argument")
+}

--- a/internal/core/mfa_stepup_test.go
+++ b/internal/core/mfa_stepup_test.go
@@ -127,7 +127,7 @@ func TestHasActiveMFAStepUp_NoGrant(t *testing.T) {
 	c, _, _ := newMFATestCore(t)
 	ctx := context.Background()
 
-	active, err := c.HasActiveMFAStepUp(ctx, 1)
+	active, err := c.HasActiveMFAStepUp(ctx, 1, models.MFAStepUpPurposeRestrictedSecretRead)
 	require.NoError(t, err)
 	assert.False(t, active, "no grant — HasActiveMFAStepUp must return false")
 }
@@ -141,9 +141,9 @@ func TestHasActiveMFAStepUp_ExpiredGrant(t *testing.T) {
 	// past), so use a time even further in the past to ensure it's expired
 	// relative to the fixed clock.
 	expiredAt := fixed.Add(-1 * time.Minute)
-	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: expiredAt}).Error)
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: expiredAt}).Error)
 
-	active, err := c.HasActiveMFAStepUp(ctx, 1)
+	active, err := c.HasActiveMFAStepUp(ctx, 1, models.MFAStepUpPurposeRestrictedSecretRead)
 	require.NoError(t, err)
 	assert.False(t, active, "expired grant must not be treated as active")
 }
@@ -155,9 +155,9 @@ func TestHasActiveMFAStepUp_ActiveGrant(t *testing.T) {
 
 	// Insert a future-expiring grant relative to the fixed clock.
 	future := fixed.Add(15 * time.Minute)
-	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: future}).Error)
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: future}).Error)
 
-	active, err := c.HasActiveMFAStepUp(ctx, 1)
+	active, err := c.HasActiveMFAStepUp(ctx, 1, models.MFAStepUpPurposeRestrictedSecretRead)
 	require.NoError(t, err)
 	assert.True(t, active, "active (non-expired) grant must return true")
 }

--- a/internal/core/mfa_test.go
+++ b/internal/core/mfa_test.go
@@ -189,8 +189,11 @@ func TestMFA_FullFlow(t *testing.T) {
 	// ── Disable via password → MFA off, secret cleared ──
 	// MFA is enrolled, so password alone no longer satisfies requireReauth's
 	// second-factor requirement (#372-follow-up): the caller must also hold an
-	// active step-up grant, proving they recently re-verified the second factor.
-	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
+	// active MFAStepUpPurposeReauth grant, proving they recently re-verified the
+	// second factor FOR THIS SPECIFIC PURPOSE (a restricted-secret-read-purpose
+	// grant, e.g. from an ordinary login, would not satisfy this gate — see
+	// TestUpdateOwnProfile_EmailChange_AmbientLoginPurposeGrantRejected).
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
 	require.NoError(t, c.DisableMFA(ctx, 1, mfaTestPassword))
 	require.NoError(t, db.First(&user, 1).Error)
 	assert.False(t, user.MFAEnabled)
@@ -315,9 +318,10 @@ func TestMFA_RegenerateRecoveryCodes(t *testing.T) {
 
 	// Regenerate with the password → a fresh distinct set; the old codes stop working.
 	// MFA is enrolled, so password alone no longer satisfies requireReauth's
-	// second-factor requirement (#372-follow-up): also seed an active step-up
-	// grant, proving the caller recently re-verified the second factor.
-	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
+	// second-factor requirement (#372-follow-up): also seed an active
+	// MFAStepUpPurposeReauth grant, proving the caller recently re-verified the
+	// second factor FOR THIS SPECIFIC PURPOSE.
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
 	fresh, err := c.RegenerateMFARecoveryCodes(ctx, 1, mfaTestPassword)
 	require.NoError(t, err)
 	require.Len(t, fresh, 10)
@@ -578,9 +582,10 @@ func TestDisableMFA_SuccessClearsLoginFailures(t *testing.T) {
 
 	// A correct password succeeds and resets the accrued failures. MFA is
 	// enrolled, so password alone no longer satisfies requireReauth's
-	// second-factor requirement (#372-follow-up): also seed an active step-up
-	// grant, proving the caller recently re-verified the second factor.
-	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
+	// second-factor requirement (#372-follow-up): also seed an active
+	// MFAStepUpPurposeReauth grant, proving the caller recently re-verified the
+	// second factor FOR THIS SPECIFIC PURPOSE.
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
 	require.NoError(t, c.DisableMFA(ctx, 1, mfaTestPassword))
 	var after models.User
 	require.NoError(t, db.First(&after, 1).Error)
@@ -726,21 +731,53 @@ func TestUpdateOwnProfile_EmailChange_ValidTOTPCodeSucceeds(t *testing.T) {
 	assert.Equal(t, "alice-new@b.com", u.Email)
 }
 
-// Companion positive case #2: the correct password PLUS an active, independent
-// MFA step-up grant (proof the caller recently re-verified the second factor,
-// e.g. via VerifyMFAStepUp or a WebAuthn login) DOES satisfy re-auth — password
-// alone is insufficient, but password + a genuine step-up grant is equivalent
-// proof to supplying the code directly.
-func TestUpdateOwnProfile_EmailChange_PasswordPlusActiveStepUpGrantSucceeds(t *testing.T) {
+// Companion positive case #2: the correct password PLUS an active MFA step-up
+// grant minted FOR THIS SPECIFIC PURPOSE (MFAStepUpPurposeReauth — e.g. by
+// FinishWebAuthnReauth's live passkey re-assertion) DOES satisfy re-auth —
+// password alone is insufficient, but password + a genuine, correctly-purposed
+// step-up grant is equivalent proof to supplying the code directly.
+func TestUpdateOwnProfile_EmailChange_PasswordPlusReauthPurposeGrantSucceeds(t *testing.T) {
 	c, db, fixed := newMFATestCore(t)
 	ctx := context.Background()
 	activateMFAForTest(t, c, fixed)
 
-	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
 
 	u, err := c.UpdateOwnProfile(ctx, 1, "", "alice-new@b.com", mfaTestPassword)
-	require.NoError(t, err, "password + an active step-up grant must satisfy re-auth")
+	require.NoError(t, err, "password + an active MFAStepUpPurposeReauth grant must satisfy re-auth")
 	assert.Equal(t, "alice-new@b.com", u.Email)
+}
+
+// Confused-deputy regression (this fix): a step-up grant minted for a
+// DIFFERENT purpose — MFAStepUpPurposeRestrictedSecretRead, the kind an
+// ordinary WebAuthn login mints ambiently on every successful sign-in — must
+// NOT satisfy requireReauth's account-security-factor-change gate, even
+// though it is a genuinely active, unexpired grant for the same user. Before
+// this fix, MFAStepUpGrant carried no Purpose at all and HasActiveMFAStepUp
+// accepted ANY live grant regardless of what minted it — so anyone holding a
+// merely-leaked bearer token (plus the password) could ride the account
+// owner's own earlier WebAuthn login to authorize an account-security-factor
+// takeover (disable MFA, delete a passkey, change the recovery email) with no
+// fresh proof of second-factor possession at the time of the sensitive
+// action. This must fail RED against the pre-purpose-tagging code and GREEN
+// after it.
+func TestUpdateOwnProfile_EmailChange_AmbientLoginPurposeGrantRejected(t *testing.T) {
+	c, db, fixed := newMFATestCore(t)
+	ctx := context.Background()
+	activateMFAForTest(t, c, fixed)
+
+	// Exactly what FinishWebAuthnLogin/FinishWebAuthnPasswordlessLogin mint on an
+	// ordinary, successful login — NOT an explicit re-authentication at the time
+	// of this sensitive action.
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: fixed.Add(15 * time.Minute)}).Error)
+
+	_, err := c.UpdateOwnProfile(ctx, 1, "", "alice-new@b.com", mfaTestPassword)
+	require.Error(t, err, "a restricted-secret-read-purpose grant must NOT satisfy the account-security-factor-change re-auth gate")
+	assert.Contains(t, err.Error(), "invalid code or password")
+
+	u, gerr := c.storage.GetUser(ctx, 1)
+	require.NoError(t, gerr)
+	assert.Equal(t, "a@b.com", u.Email, "a refused re-auth must not change the email")
 }
 
 // The fix closes the gap at the SHARED requireReauth helper, not just the

--- a/internal/core/mock_storage_classification_mfa_stepup_test.go
+++ b/internal/core/mock_storage_classification_mfa_stepup_test.go
@@ -19,7 +19,7 @@ func (m *MockStorage) CreateMFAStepUpGrant(_ context.Context, _ *models.MFAStepU
 	return nil
 }
 
-func (m *MockStorage) GetActiveMFAStepUpGrant(_ context.Context, _ uint, _ time.Time) (*models.MFAStepUpGrant, error) {
+func (m *MockStorage) GetActiveMFAStepUpGrant(_ context.Context, _ uint, _ models.MFAStepUpPurpose, _ time.Time) (*models.MFAStepUpGrant, error) {
 	return nil, nil
 }
 

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1493,11 +1493,17 @@ type Storage interface {
 	// gate and MFA step-up token both live on the same server node.
 	HasActiveMFAStepup(ctx context.Context, userID uint) (bool, error)
 
-	// CreateMFAStepUpGrant persists a new MFA step-up grant for userID.
+	// CreateMFAStepUpGrant persists a new MFA step-up grant for userID. The
+	// grant's Purpose field must be set by the caller (core) — it is what
+	// GetActiveMFAStepUpGrant matches on, so a grant minted for one purpose can
+	// never be misread as authorizing a different one.
 	CreateMFAStepUpGrant(ctx context.Context, grant *models.MFAStepUpGrant) error
 	// GetActiveMFAStepUpGrant returns the most recent non-expired MFA step-up
-	// grant for userID as of now, or (nil, nil) when none exists.
-	GetActiveMFAStepUpGrant(ctx context.Context, userID uint, now time.Time) (*models.MFAStepUpGrant, error)
+	// grant for userID AND purpose as of now, or (nil, nil) when none exists.
+	// purpose is a required exact match, not a filter of convenience: a grant
+	// minted for models.MFAStepUpPurposeRestrictedSecretRead must never satisfy
+	// a query for models.MFAStepUpPurposeReauth or vice versa.
+	GetActiveMFAStepUpGrant(ctx context.Context, userID uint, purpose models.MFAStepUpPurpose, now time.Time) (*models.MFAStepUpGrant, error)
 	// DeleteMFAStepUpGrantsFor removes all step-up grants for userID (used on
 	// session revocation or security-incident response).
 	DeleteMFAStepUpGrantsFor(ctx context.Context, userID uint) error

--- a/internal/core/webauthn.go
+++ b/internal/core/webauthn.go
@@ -252,6 +252,114 @@ func (c *KeyorixCore) DeleteWebAuthnCredential(ctx context.Context, userID, id u
 	return nil
 }
 
+// webauthnReauthSessionPurpose is the WebAuthnSession.Purpose value for the
+// step-up re-authentication ceremony below — distinct from "register",
+// "login", and "passwordless".
+const webauthnReauthSessionPurpose = "reauth"
+
+// BeginWebAuthnReauth starts a live passkey re-assertion for an already
+// authenticated caller who holds no TOTP factor (WebAuthn-only account) and
+// needs to satisfy requireReauth for an account-security-factor change
+// (DisableMFA/RegenerateMFARecoveryCodes/ActivateMFA/FinishWebAuthnRegistration/
+// DeleteWebAuthnCredential/account email change). Unlike BeginWebAuthnLogin,
+// this operates directly on an authenticated userID — there is no pre-login
+// MFA challenge to resolve the user from, since the caller is already logged
+// in and merely proving they still hold the second factor right now.
+func (c *KeyorixCore) BeginWebAuthnReauth(ctx context.Context, userID uint) (*protocol.CredentialAssertion, string, error) {
+	if c.webauthnRP == nil {
+		return nil, "", ErrWebAuthnDisabled
+	}
+	wu, err := c.loadWebAuthnUser(ctx, userID)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(wu.creds) == 0 {
+		return nil, "", fmt.Errorf("no passkeys registered")
+	}
+	if err := c.checkWebAuthnAccountGates(wu); err != nil {
+		return nil, "", err
+	}
+	// WAUN-001: require user-verification, matching BeginWebAuthnLogin — a
+	// stolen/found hardware key must not satisfy re-authentication without the
+	// user's own PIN/biometric.
+	assertion, sd, err := c.webauthnRP.BeginLogin(wu,
+		webauthn.WithUserVerification(protocol.VerificationRequired),
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to begin reauth: %w", err)
+	}
+	token, err := c.storeWebAuthnSession(ctx, userID, webauthnReauthSessionPurpose, sd)
+	if err != nil {
+		return nil, "", err
+	}
+	return assertion, token, nil
+}
+
+// FinishWebAuthnReauth verifies the assertion begun by BeginWebAuthnReauth and,
+// on success, mints an MFAStepUpGrant with Purpose == MFAStepUpPurposeReauth —
+// the ONLY way a WebAuthn-only account can satisfy requireReauth's
+// second-factor branch (HasActiveMFAStepUp), since an ambient login-time grant
+// is deliberately scoped to MFAStepUpPurposeRestrictedSecretRead and does not
+// match. The caller must separately call e.g. DisableMFA/DeleteWebAuthnCredential
+// afterward (with the account password) to actually perform the
+// account-security-factor change; this function only proves the second factor,
+// mirroring how VerifyMFAStepUp+checkRestrictedMFAGate are two separate calls
+// for the restricted-secret-read flow.
+func (c *KeyorixCore) FinishWebAuthnReauth(ctx context.Context, userID uint, sessionToken string, parsed *protocol.ParsedCredentialAssertionData) error {
+	if c.webauthnRP == nil {
+		return ErrWebAuthnDisabled
+	}
+	user, err := c.storage.GetUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("user not found")
+	}
+	if c.loginLocked(user) {
+		return fmt.Errorf("account temporarily locked due to repeated failed logins; try again later")
+	}
+	sess, err := c.storage.ConsumeWebAuthnSession(ctx, sha256Hex(sessionToken), c.now())
+	if err != nil {
+		return fmt.Errorf("invalid or expired webauthn session")
+	}
+	if sess.Purpose != webauthnReauthSessionPurpose || sess.UserID != userID {
+		return fmt.Errorf("webauthn session mismatch")
+	}
+	var sd webauthn.SessionData
+	if err := json.Unmarshal(sess.Data, &sd); err != nil {
+		return err
+	}
+	wu, err := c.loadWebAuthnUser(ctx, userID)
+	if err != nil {
+		return err
+	}
+	cred, err := c.webauthnRP.ValidateLogin(wu, sd, parsed)
+	if err != nil {
+		c.auditWebAuthnFailed(ctx, userID, "reauth")
+		c.recordFailedLogin(ctx, user) // count the failed re-auth attempt toward the lockout, mirroring requireReauth
+		return fmt.Errorf("assertion verification failed: %w", err)
+	}
+	// Clone-detection (#212), same as FinishWebAuthnLogin: refuse before treating
+	// this as a successful re-auth in any way.
+	if err := c.rejectIfCloned(ctx, userID, cred, ""); err != nil {
+		return err
+	}
+	if err := c.checkLockAndClearLoginFailures(ctx, user); err != nil {
+		return err
+	}
+	c.persistUpdatedCredential(ctx, userID, cred)
+	grant := &models.MFAStepUpGrant{
+		UserID:    userID,
+		Purpose:   models.MFAStepUpPurposeReauth,
+		ExpiresAt: c.now().Add(c.mfaStepUpWindow()),
+	}
+	if err := c.storage.CreateMFAStepUpGrant(ctx, grant); err != nil {
+		return fmt.Errorf("failed to record MFA reauth step-up: %w", err)
+	}
+	uid := userID
+	c.writeAuditEventFull(ctx, "mfa.reauth_verified", &uid, nil, nil, "",
+		fmt.Sprintf("user %s completed WebAuthn re-authentication", user.Username))
+	return nil
+}
+
 // BeginWebAuthnLogin starts the assertion ceremony for the second login step. It
 // resolves the user from the (still-unconsumed) MFA challenge minted by the
 // password step, and returns the CredentialAssertion options plus an opaque
@@ -369,22 +477,27 @@ func (c *KeyorixCore) FinishWebAuthnLogin(ctx context.Context, challenge, sessio
 		return nil, nil, err
 	}
 	// Record the MFA step-up window when the classification gate requires it,
-	// matching the existing TOTP path in VerifyMFALogin. WebAuthn (possession +
-	// user-verification) is at least as strong as TOTP, so it must satisfy the
-	// same restricted_requires_mfa_stepup gate. Best-effort: a write failure
-	// does not block the login.
+	// matching the existing TOTP path in VerifyMFALogin.
 	if c.classificationRestrictedRequiresMFAStepUp {
 		_ = c.storage.UpsertMFAStepupToken(ctx, ch.UserID, c.now().Add(c.mfaStepUpWindow()))
 	}
 	// Also mint a genuine MFAStepUpGrant, unconditionally (not gated behind
-	// classificationRestrictedRequiresMFAStepUp): a WebAuthn login is itself proof
-	// of possessing the second factor, but — unlike TOTP, which requireReauth can
-	// verify directly against a freshly-typed code — a passkey assertion has no
-	// typable "code" to hand a later self-service re-auth call. Without this,
-	// requireReauth's second-factor requirement (#372-follow-up) would have no
-	// path at all for a WebAuthn-only account. Best-effort: a write failure does
-	// not block the login.
-	_ = c.storage.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: ch.UserID, ExpiresAt: c.now().Add(c.mfaStepUpWindow())})
+	// classificationRestrictedRequiresMFAStepUp, matching the pre-existing
+	// behavior this fix does not change): a WebAuthn login is itself proof of
+	// possessing the second factor, sufficient for reading a restricted secret
+	// without a separate re-prompt. Best-effort. Scoped to Purpose ==
+	// MFAStepUpPurposeRestrictedSecretRead ONLY — this grant must never be read
+	// by requireReauth's account-security-factor-change gate, which requires
+	// the distinct MFAStepUpPurposeReauth purpose (see FinishWebAuthnReauth
+	// below); an ambient login-time grant is not equivalent to actively
+	// proving possession of the second factor at the moment of a
+	// takeover-grade change. THIS purpose separation — not gating the write —
+	// is the fix for the confused-deputy bug this grant used to enable.
+	_ = c.storage.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
+		UserID:    ch.UserID,
+		Purpose:   models.MFAStepUpPurposeRestrictedSecretRead,
+		ExpiresAt: c.now().Add(c.mfaStepUpWindow()),
+	})
 	uid := ch.UserID
 	c.writeAuditEventFull(ctx, "webauthn.login_verified", &uid, nil, nil, ip,
 		fmt.Sprintf("user %s passed WebAuthn", wu.user.Username))
@@ -473,17 +586,20 @@ func (c *KeyorixCore) FinishWebAuthnPasswordlessLogin(ctx context.Context, sessi
 		return nil, nil, err
 	}
 	// Record the MFA step-up window when the classification gate requires it,
-	// matching both VerifyMFALogin and FinishWebAuthnLogin. A passkey satisfies
-	// user-verification and is at minimum as strong as TOTP. Best-effort.
+	// matching both VerifyMFALogin and FinishWebAuthnLogin.
 	if c.classificationRestrictedRequiresMFAStepUp {
 		_ = c.storage.UpsertMFAStepupToken(ctx, resolved.ID, c.now().Add(c.mfaStepUpWindow()))
 	}
-	// Also mint a genuine MFAStepUpGrant, unconditionally — see the identical
-	// comment in FinishWebAuthnLogin: this is the only way a WebAuthn-only
-	// account can ever satisfy requireReauth's second-factor requirement, since a
-	// passkey assertion has no typable "code" equivalent to a TOTP code.
-	// Best-effort: a write failure does not block the login.
-	_ = c.storage.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: resolved.ID, ExpiresAt: c.now().Add(c.mfaStepUpWindow())})
+	// Also mint a genuine MFAStepUpGrant, unconditionally (matching the
+	// pre-existing behavior this fix does not change) — see the identical
+	// comment in FinishWebAuthnLogin for why this purpose does NOT satisfy
+	// requireReauth (that requires MFAStepUpPurposeReauth, minted only by
+	// FinishWebAuthnReauth's live re-assertion). Best-effort.
+	_ = c.storage.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
+		UserID:    resolved.ID,
+		Purpose:   models.MFAStepUpPurposeRestrictedSecretRead,
+		ExpiresAt: c.now().Add(c.mfaStepUpWindow()),
+	})
 	uid := resolved.ID
 	c.writeAuditEventFull(ctx, "webauthn.passwordless_login", &uid, nil, nil, ip,
 		fmt.Sprintf("user %s logged in passwordlessly via WebAuthn", resolved.Username))

--- a/internal/core/webauthn_test.go
+++ b/internal/core/webauthn_test.go
@@ -55,15 +55,33 @@ func seedCredential(t *testing.T, c *KeyorixCore, db *gorm.DB, userID uint, cred
 	require.NoError(t, c.storage.SetUserWebAuthnEnabled(context.Background(), userID, true))
 }
 
-// seedStepUpGrant inserts an active MFAStepUpGrant for userID, mirroring what a
-// recent VerifyMFAStepUp call (TOTP) or WebAuthn login (FinishWebAuthnLogin/
-// FinishWebAuthnPasswordlessLogin) would produce. Since a WebAuthn-only account
-// has no typable "code" to hand requireReauth directly, this is the only way
-// such an account can satisfy requireReauth's password-plus-second-factor-proof
-// requirement in a unit test that doesn't drive a full login ceremony.
+// seedStepUpGrant inserts an active MFAStepUpGrant with Purpose ==
+// MFAStepUpPurposeReauth for userID, mirroring what FinishWebAuthnReauth's live
+// passkey re-assertion (or a fresh TOTP code, for MFA-enabled accounts) would
+// produce. Since a WebAuthn-only account has no typable "code" to hand
+// requireReauth directly, this is the only way such an account can satisfy
+// requireReauth's password-plus-second-factor-proof requirement in a unit test
+// that doesn't drive a full FinishWebAuthnReauth ceremony. Deliberately
+// distinct from seedAmbientLoginGrant below, which mints the OTHER purpose
+// (MFAStepUpPurposeRestrictedSecretRead) that an ordinary login produces —
+// this purpose separation is the fix; see TestWebAuthn_DeleteRequiresReauth's
+// and TestWebAuthn_FinishRegistrationRequiresReauth's "ambient login grant is
+// rejected" cases.
 func seedStepUpGrant(t *testing.T, db *gorm.DB, userID uint, now time.Time) {
 	t.Helper()
-	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: userID, ExpiresAt: now.Add(15 * time.Minute)}).Error)
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: userID, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: now.Add(15 * time.Minute)}).Error)
+}
+
+// seedAmbientLoginGrant inserts an active MFAStepUpGrant with Purpose ==
+// MFAStepUpPurposeRestrictedSecretRead for userID — exactly what
+// FinishWebAuthnLogin/FinishWebAuthnPasswordlessLogin mint on every ordinary,
+// successful login (ambiently, with no explicit re-authentication intent).
+// Used to prove this purpose does NOT satisfy requireReauth's
+// account-security-factor-change gate (the confused-deputy bug this purpose
+// separation closes).
+func seedAmbientLoginGrant(t *testing.T, db *gorm.DB, userID uint, now time.Time) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: userID, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: now.Add(15 * time.Minute)}).Error)
 }
 
 func TestWebAuthn_LoginGateRequiresSecondFactor(t *testing.T) {
@@ -227,6 +245,40 @@ func TestWebAuthn_DeleteRequiresReauth(t *testing.T) {
 	// they still hold the second factor) → succeeds.
 	seedStepUpGrant(t, db, 1, c.now())
 	require.NoError(t, c.DeleteWebAuthnCredential(ctx, 1, cred.ID, webauthnTestPassword))
+}
+
+// Confused-deputy regression (this fix): TestWebAuthn_DeleteRequiresReauth's
+// final positive case used to be satisfied by ANY live MFAStepUpGrant,
+// including one minted ambiently by an ordinary WebAuthn login
+// (FinishWebAuthnLogin/FinishWebAuthnPasswordlessLogin), not one that proves
+// the caller actively re-authenticated at the time of THIS sensitive action.
+// That let anyone holding a merely-leaked bearer token (plus the password)
+// ride the account owner's own earlier login to delete every passkey (and,
+// once the last one is gone, silently disable WebAuthn account-wide) with no
+// fresh proof of second-factor possession. Must fail RED against the
+// pre-purpose-tagging code (where any grant satisfied HasActiveMFAStepUp) and
+// GREEN after it (only a MFAStepUpPurposeReauth grant satisfies it).
+func TestWebAuthn_DeleteRequiresReauth_AmbientLoginGrantRejected(t *testing.T) {
+	c, db := newWebAuthnTestCore(t, true)
+	ctx := context.Background()
+	seedCredential(t, c, db, 1, "cred-1")
+
+	var cred models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ?", 1).First(&cred).Error)
+
+	// Exactly what a recent, successful WebAuthn login mints — NOT an explicit
+	// re-authentication performed at the time of this delete.
+	seedAmbientLoginGrant(t, db, 1, c.now())
+	err := c.DeleteWebAuthnCredential(ctx, 1, cred.ID, webauthnTestPassword)
+	require.Error(t, err, "a restricted-secret-read-purpose grant (from an ordinary login) must NOT satisfy DeleteWebAuthnCredential's re-auth gate")
+	assert.Contains(t, err.Error(), "invalid code or password")
+
+	var stillThere models.WebAuthnCredential
+	require.NoError(t, db.Where("user_id = ? AND id = ?", 1, cred.ID).First(&stillThere).Error,
+		"a refused re-auth must not remove the credential")
+	var user models.User
+	require.NoError(t, db.First(&user, 1).Error)
+	assert.True(t, user.WebAuthnEnabled, "a refused re-auth must not touch the WebAuthnEnabled flag")
 }
 
 // #372: FinishWebAuthnRegistration must reject completion of the ceremony without

--- a/internal/storage/models/models.go
+++ b/internal/storage/models/models.go
@@ -556,17 +556,48 @@ func (t *MFAStepupToken) BeforeSave(_ *gorm.DB) error {
 	return nil
 }
 
-// MFAStepUpGrant records that a user explicitly re-verified their second factor
-// (via VerifyMFAStepUp) to gain a time-limited window for reading
-// restricted-classified secrets. Unlike MFAStepupToken (which is upserted on
-// every MFA login), grants are created per-verification and queried by
-// the classification gate. One active grant per user at any time is enough;
-// expired rows are left in place for audit purposes.
+// MFAStepUpPurpose discriminates WHAT an MFAStepUpGrant proves the holder
+// verified for — a grant is a capability token, and a purpose-agnostic
+// capability token is a confused-deputy vulnerability by construction (a
+// grant minted for one purpose must never silently authorize a different,
+// higher-stakes one). Every consumption site must require an exact match, not
+// merely "any live grant for this user."
+type MFAStepUpPurpose string
+
+const (
+	// MFAStepUpPurposeRestrictedSecretRead is minted by an explicit
+	// VerifyMFAStepUp (TOTP/recovery code) call, or ambiently by a WebAuthn
+	// login (FinishWebAuthnLogin/FinishWebAuthnPasswordlessLogin) — a passkey
+	// login is itself strong proof of second-factor possession, sufficient to
+	// let the classification gate permit reading a "restricted" secret for the
+	// configured window without a separate re-prompt. Consumed exclusively by
+	// checkRestrictedMFAGate.
+	MFAStepUpPurposeRestrictedSecretRead MFAStepUpPurpose = "restricted_secret_read"
+	// MFAStepUpPurposeReauth is minted only by an action that proves the caller
+	// holds the second factor AT THE TIME of an account-security-factor change
+	// (DisableMFA, RegenerateMFARecoveryCodes, ActivateMFA, WebAuthn credential
+	// register/delete, account email change) — an ambient grant from a login
+	// that happened up to mfaStepUpWindow() ago is deliberately NOT proof
+	// enough here, since that would let anyone holding a merely-leaked bearer
+	// token (plus the password) ride the account owner's own earlier login to
+	// authorize a takeover-grade change. Consumed exclusively by requireReauth.
+	MFAStepUpPurposeReauth MFAStepUpPurpose = "account_reauth"
+)
+
+// MFAStepUpGrant records that a user verified their second factor for a
+// specific Purpose (VerifyMFAStepUp for restricted-secret reads, a WebAuthn
+// login for restricted-secret reads, or FinishWebAuthnReauth/a fresh TOTP code
+// for requireReauth) to gain a time-limited window for that purpose alone.
+// Unlike MFAStepupToken (which is upserted on every MFA login), grants are
+// created per-verification and queried by purpose-specific consumers. One
+// active grant per (user, purpose) at any time is enough; expired rows are
+// left in place for audit purposes.
 type MFAStepUpGrant struct {
-	ID        uint      `gorm:"primarykey" json:"id"`
-	UserID    uint      `gorm:"not null;index" json:"user_id"`
-	ExpiresAt time.Time `gorm:"not null" json:"expires_at"`
-	CreatedAt time.Time `json:"created_at"`
+	ID        uint             `gorm:"primarykey" json:"id"`
+	UserID    uint             `gorm:"not null;index" json:"user_id"`
+	Purpose   MFAStepUpPurpose `gorm:"not null;default:'';index" json:"purpose"`
+	ExpiresAt time.Time        `gorm:"not null" json:"expires_at"`
+	CreatedAt time.Time        `json:"created_at"`
 }
 
 // BeforeSave normalises ExpiresAt to UTC so SQLite string comparisons are

--- a/internal/storage/store/local_mfa_stepup_grant.go
+++ b/internal/storage/store/local_mfa_stepup_grant.go
@@ -19,10 +19,10 @@ func (ls *LocalStorage) CreateMFAStepUpGrant(ctx context.Context, grant *models.
 	return ls.db.WithContext(ctx).Create(grant).Error
 }
 
-func (ls *LocalStorage) GetActiveMFAStepUpGrant(ctx context.Context, userID uint, now time.Time) (*models.MFAStepUpGrant, error) {
+func (ls *LocalStorage) GetActiveMFAStepUpGrant(ctx context.Context, userID uint, purpose models.MFAStepUpPurpose, now time.Time) (*models.MFAStepUpGrant, error) {
 	var g models.MFAStepUpGrant
 	err := ls.db.WithContext(ctx).
-		Where("user_id = ? AND expires_at > ?", userID, now.UTC()).
+		Where("user_id = ? AND purpose = ? AND expires_at > ?", userID, purpose, now.UTC()).
 		Order("expires_at DESC").
 		First(&g).Error
 	if err != nil {

--- a/internal/storage/store/local_mfa_stepup_grant_test.go
+++ b/internal/storage/store/local_mfa_stepup_grant_test.go
@@ -26,28 +26,28 @@ func TestMFAStepUpGrant_CreateAndDeleteFor(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
-		UserID: 1, ExpiresAt: time.Now().Add(10 * time.Minute),
+		UserID: 1, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: time.Now().Add(10 * time.Minute),
 	}))
 	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
-		UserID: 1, ExpiresAt: time.Now().Add(20 * time.Minute),
+		UserID: 1, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: time.Now().Add(20 * time.Minute),
 	}))
 	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
-		UserID: 2, ExpiresAt: time.Now().Add(10 * time.Minute),
+		UserID: 2, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: time.Now().Add(10 * time.Minute),
 	}))
 
-	g, err := ls.GetActiveMFAStepUpGrant(ctx, 1, time.Now())
+	g, err := ls.GetActiveMFAStepUpGrant(ctx, 1, models.MFAStepUpPurposeRestrictedSecretRead, time.Now())
 	require.NoError(t, err)
 	require.NotNil(t, g)
 	assert.Equal(t, uint(1), g.UserID)
 
 	require.NoError(t, ls.DeleteMFAStepUpGrantsFor(ctx, 1))
 
-	g, err = ls.GetActiveMFAStepUpGrant(ctx, 1, time.Now())
+	g, err = ls.GetActiveMFAStepUpGrant(ctx, 1, models.MFAStepUpPurposeRestrictedSecretRead, time.Now())
 	require.NoError(t, err)
 	assert.Nil(t, g, "all of user 1's grants were deleted")
 
 	// User 2's grant must be untouched.
-	g2, err := ls.GetActiveMFAStepUpGrant(ctx, 2, time.Now())
+	g2, err := ls.GetActiveMFAStepUpGrant(ctx, 2, models.MFAStepUpPurposeRestrictedSecretRead, time.Now())
 	require.NoError(t, err)
 	require.NotNil(t, g2)
 }
@@ -59,22 +59,22 @@ func TestMFAStepUpGrant_PruneRemovesOnlyExpired(t *testing.T) {
 	past := time.Now().Add(-time.Hour)
 	future := time.Now().Add(time.Hour)
 
-	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: 1, ExpiresAt: past}))
-	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: 2, ExpiresAt: past}))
-	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: 3, ExpiresAt: future}))
+	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: past}))
+	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: 2, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: past}))
+	require.NoError(t, ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{UserID: 3, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: future}))
 
 	deleted, err := ls.PruneMFAStepUpGrants(ctx, time.Now())
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), deleted)
 
-	g3, err := ls.GetActiveMFAStepUpGrant(ctx, 3, time.Now())
+	g3, err := ls.GetActiveMFAStepUpGrant(ctx, 3, models.MFAStepUpPurposeRestrictedSecretRead, time.Now())
 	require.NoError(t, err)
 	require.NotNil(t, g3, "the not-yet-expired grant must survive the prune")
 }
 
 func TestMFAStepUpGrant_GetActiveNoneReturnsNilNil(t *testing.T) {
 	ls := newMFAStepUpGrantStore(t)
-	g, err := ls.GetActiveMFAStepUpGrant(context.Background(), 99, time.Now())
+	g, err := ls.GetActiveMFAStepUpGrant(context.Background(), 99, models.MFAStepUpPurposeRestrictedSecretRead, time.Now())
 	require.NoError(t, err)
 	assert.Nil(t, g)
 }

--- a/internal/storage/store/local_misc_error_sweep_test.go
+++ b/internal/storage/store/local_misc_error_sweep_test.go
@@ -75,7 +75,7 @@ func TestConsumeMFAChallenge_LoadFails(t *testing.T) {
 func TestGetActiveMFAStepUpGrant_DBError(t *testing.T) {
 	t.Parallel()
 	ls := newBrokenDB(t)
-	_, err := ls.GetActiveMFAStepUpGrant(context.Background(), 1, time.Now())
+	_, err := ls.GetActiveMFAStepUpGrant(context.Background(), 1, models.MFAStepUpPurposeRestrictedSecretRead, time.Now())
 	require.Error(t, err)
 }
 

--- a/internal/storage/store/remote_group_c_mfa_error_sweep_test.go
+++ b/internal/storage/store/remote_group_c_mfa_error_sweep_test.go
@@ -281,7 +281,7 @@ func TestRemoteStorage_GetActiveMFAStepUpGrant_DecodeError_GroupC(t *testing.T) 
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	_, err = rs.GetActiveMFAStepUpGrant(context.Background(), 1, time.Now().UTC())
+	_, err = rs.GetActiveMFAStepUpGrant(context.Background(), 1, models.MFAStepUpPurposeRestrictedSecretRead, time.Now().UTC())
 	assert.Error(t, err)
 }
 

--- a/internal/storage/store/remote_mfa_stepup_grant.go
+++ b/internal/storage/store/remote_mfa_stepup_grant.go
@@ -15,16 +15,18 @@ import (
 
 // mfaStepUpGrantWire mirrors models.MFAStepUpGrant on the wire.
 type mfaStepUpGrantWire struct {
-	ID        uint      `json:"id"`
-	UserID    uint      `json:"user_id"`
-	ExpiresAt time.Time `json:"expires_at"`
-	CreatedAt time.Time `json:"created_at"`
+	ID        uint                    `json:"id"`
+	UserID    uint                    `json:"user_id"`
+	Purpose   models.MFAStepUpPurpose `json:"purpose"`
+	ExpiresAt time.Time               `json:"expires_at"`
+	CreatedAt time.Time               `json:"created_at"`
 }
 
 func (w mfaStepUpGrantWire) toModel() *models.MFAStepUpGrant {
 	return &models.MFAStepUpGrant{
 		ID:        w.ID,
 		UserID:    w.UserID,
+		Purpose:   w.Purpose,
 		ExpiresAt: w.ExpiresAt,
 		CreatedAt: w.CreatedAt,
 	}
@@ -44,7 +46,8 @@ func decodeMFAStepUpGrantResponse(data []byte) (*models.MFAStepUpGrant, error) {
 // its own clock for the expiry comparison instead of trusting a
 // caller-supplied value.
 type mfaStepUpGrantActiveWire struct {
-	UserID uint `json:"user_id"`
+	UserID  uint                    `json:"user_id"`
+	Purpose models.MFAStepUpPurpose `json:"purpose"`
 }
 
 // CreateMFAStepUpGrant used to proxy onto POST /api/v1/system/mfa/stepup-grants
@@ -57,14 +60,16 @@ func (rs *RemoteStorage) CreateMFAStepUpGrant(_ context.Context, _ *models.MFASt
 }
 
 // GetActiveMFAStepUpGrant returns the most recent non-expired MFA step-up
-// grant for userID via POST /api/v1/system/mfa/stepup-grants/active.
-// Returns (nil, nil) when the server returns null data (no active grant).
-// now is accepted only for interface parity with LocalStorage — the
-// upstream server ignores any caller-supplied "current time" and always
-// uses its own clock (see mfaStepUpGrantActiveWire's doc comment).
-func (rs *RemoteStorage) GetActiveMFAStepUpGrant(ctx context.Context, userID uint, _ time.Time) (*models.MFAStepUpGrant, error) {
+// grant for userID AND purpose via POST
+// /api/v1/system/mfa/stepup-grants/active. Returns (nil, nil) when the server
+// returns null data (no active grant for that exact purpose). now is accepted
+// only for interface parity with LocalStorage — the upstream server ignores
+// any caller-supplied "current time" and always uses its own clock (see
+// mfaStepUpGrantActiveWire's doc comment).
+func (rs *RemoteStorage) GetActiveMFAStepUpGrant(ctx context.Context, userID uint, purpose models.MFAStepUpPurpose, _ time.Time) (*models.MFAStepUpGrant, error) {
 	resp, err := rs.client.Post(ctx, "/api/v1/system/mfa/stepup-grants/active", mfaStepUpGrantActiveWire{
-		UserID: userID,
+		UserID:  userID,
+		Purpose: purpose,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get active MFA step-up grant: %w", err)

--- a/internal/storage/store/remote_mfa_stepup_grant_test.go
+++ b/internal/storage/store/remote_mfa_stepup_grant_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ func TestRemoteStorage_GetActiveMFAStepUpGrant_Success(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, now)
+	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, models.MFAStepUpPurposeRestrictedSecretRead, now)
 	require.NoError(t, err)
 	require.NotNil(t, g)
 	assert.Equal(t, uint(3), g.ID)
@@ -47,7 +48,7 @@ func TestRemoteStorage_GetActiveMFAStepUpGrant_NullResponse(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, time.Now().UTC())
+	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, models.MFAStepUpPurposeRestrictedSecretRead, time.Now().UTC())
 	require.NoError(t, err)
 	assert.Nil(t, g, "null data must decode as (nil, nil)")
 }
@@ -62,7 +63,7 @@ func TestRemoteStorage_GetActiveMFAStepUpGrant_APIError(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, time.Now().UTC())
+	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, models.MFAStepUpPurposeRestrictedSecretRead, time.Now().UTC())
 	require.Error(t, err)
 	assert.Nil(t, g)
 }
@@ -77,7 +78,7 @@ func TestRemoteStorage_GetActiveMFAStepUpGrant_SuccessFalse(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, time.Now().UTC())
+	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, models.MFAStepUpPurposeRestrictedSecretRead, time.Now().UTC())
 	require.Error(t, err)
 	assert.Nil(t, g)
 	assert.Contains(t, err.Error(), "get active MFA step-up grant failed")
@@ -93,7 +94,7 @@ func TestRemoteStorage_GetActiveMFAStepUpGrant_BadJSON(t *testing.T) {
 	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
 	require.NoError(t, err)
 
-	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, time.Now().UTC())
+	g, err := rs.GetActiveMFAStepUpGrant(context.Background(), 42, models.MFAStepUpPurposeRestrictedSecretRead, time.Now().UTC())
 	require.Error(t, err)
 	assert.Nil(t, g)
 }

--- a/server/http/handlers/mfa_clock_trust_test.go
+++ b/server/http/handlers/mfa_clock_trust_test.go
@@ -188,11 +188,11 @@ func TestAuthHandler_GetActiveMFAStepUpGrantProxy_ExpiredStaysExpiredDespiteClie
 	// models.MFAStepUpGrant.BeforeSave normalizes ExpiresAt to UTC; write it
 	// pre-normalized here for clarity.
 	require.NoError(t, db.Create(&models.MFAStepUpGrant{
-		UserID: 1, ExpiresAt: realNow.Add(-1 * time.Hour), CreatedAt: realNow.Add(-2 * time.Hour),
+		UserID: 1, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: realNow.Add(-1 * time.Hour), CreatedAt: realNow.Add(-2 * time.Hour),
 	}).Error)
 
 	spoofedNow := realNow.Add(-2 * time.Hour)
-	body, err := json.Marshal(map[string]any{"user_id": 1, "now": spoofedNow})
+	body, err := json.Marshal(map[string]any{"user_id": 1, "purpose": models.MFAStepUpPurposeRestrictedSecretRead, "now": spoofedNow})
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
@@ -213,11 +213,11 @@ func TestAuthHandler_GetActiveMFAStepUpGrantProxy_ActiveStaysActiveDespiteFarFut
 	_, ah, db := setupMFAClockTrustTest(t)
 	realNow := time.Now().UTC()
 	require.NoError(t, db.Create(&models.MFAStepUpGrant{
-		UserID: 1, ExpiresAt: realNow.Add(5 * time.Minute), CreatedAt: realNow,
+		UserID: 1, Purpose: models.MFAStepUpPurposeRestrictedSecretRead, ExpiresAt: realNow.Add(5 * time.Minute), CreatedAt: realNow,
 	}).Error)
 
 	spoofedNow := realNow.Add(365 * 24 * time.Hour)
-	body, err := json.Marshal(map[string]any{"user_id": 1, "now": spoofedNow})
+	body, err := json.Marshal(map[string]any{"user_id": 1, "purpose": models.MFAStepUpPurposeRestrictedSecretRead, "now": spoofedNow})
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))

--- a/server/http/handlers/mfa_stepup_proxy.go
+++ b/server/http/handlers/mfa_stepup_proxy.go
@@ -20,6 +20,8 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // mfaStepUpGrantActiveProxyBody is the wire body for
@@ -31,7 +33,8 @@ import (
 // step-up grant is still active, defeating the step-up TTL. This server now
 // always uses its own clock for that comparison.
 type mfaStepUpGrantActiveProxyBody struct {
-	UserID uint `json:"user_id"`
+	UserID  uint                    `json:"user_id"`
+	Purpose models.MFAStepUpPurpose `json:"purpose"`
 }
 
 // GetActiveMFAStepUpGrantProxy handles POST
@@ -48,12 +51,16 @@ func (h *AuthHandler) GetActiveMFAStepUpGrantProxy(w http.ResponseWriter, r *htt
 		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "user_id is required")
 		return
 	}
+	if body.Purpose == "" {
+		writeRemoteAPIError(w, http.StatusBadRequest, "INVALID_BODY", "purpose is required")
+		return
+	}
 	// This server's own clock, never a caller-supplied value — see
 	// mfaStepUpGrantActiveProxyBody's doc comment. LocalStorage's
 	// GetActiveMFAStepUpGrant already normalizes this to .UTC() itself
 	// (local_mfa_stepup_grant.go), matching models.MFAStepUpGrant's
 	// BeforeSave UTC-normalization hook, so a plain time.Now() here is fine.
-	grant, err := h.coreService.Storage().GetActiveMFAStepUpGrant(r.Context(), body.UserID, time.Now())
+	grant, err := h.coreService.Storage().GetActiveMFAStepUpGrant(r.Context(), body.UserID, body.Purpose, time.Now())
 	if err != nil {
 		log.Printf("mfa stepup proxy: get active grant failed: %v", err)
 		writeRemoteAPIError(w, http.StatusInternalServerError, "STORAGE_ERROR", clientSafe(err))

--- a/server/http/handlers/mfa_stepup_proxy_test.go
+++ b/server/http/handlers/mfa_stepup_proxy_test.go
@@ -39,6 +39,7 @@ func freshCoreWithStepUpGrant(t *testing.T, expiry time.Time) (*AuthHandler, *go
 	))
 	require.NoError(t, db.Create(&models.MFAStepUpGrant{
 		UserID:    1,
+		Purpose:   models.MFAStepUpPurposeRestrictedSecretRead,
 		ExpiresAt: expiry,
 	}).Error)
 
@@ -74,6 +75,7 @@ func TestGetActiveMFAStepUpGrantProxy_StorageError(t *testing.T) {
 	h := freshClosedCoreS21(t)
 	body, _ := json.Marshal(map[string]interface{}{
 		"user_id": 1,
+		"purpose": models.MFAStepUpPurposeRestrictedSecretRead,
 		"now":     time.Now().UTC(),
 	})
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants/active",
@@ -88,6 +90,7 @@ func TestGetActiveMFAStepUpGrantProxy_NoActiveGrant(t *testing.T) {
 	// Ask for user 99 — no grant exists.
 	body, _ := json.Marshal(map[string]interface{}{
 		"user_id": 99,
+		"purpose": models.MFAStepUpPurposeRestrictedSecretRead,
 		"now":     time.Now().UTC(),
 	})
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants/active",
@@ -110,6 +113,7 @@ func TestGetActiveMFAStepUpGrantProxy_ActiveGrant(t *testing.T) {
 	h, _ := freshCoreWithStepUpGrant(t, future)
 	body, _ := json.Marshal(map[string]interface{}{
 		"user_id": 1,
+		"purpose": models.MFAStepUpPurposeRestrictedSecretRead,
 		"now":     time.Now().UTC(),
 	})
 	r := httptest.NewRequest(http.MethodPost, "/api/v1/system/mfa/stepup-grants/active",

--- a/server/http/handlers/mfa_test.go
+++ b/server/http/handlers/mfa_test.go
@@ -131,7 +131,7 @@ func TestDisableMFA_DBErrorSanitized(t *testing.T) {
 	// step-up grant (the same proof VerifyMFAStepUp/a WebAuthn login would
 	// produce) so password re-auth succeeds and the failure below genuinely
 	// comes from DeleteMFAForUser, not re-auth.
-	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: time.Now().Add(15 * time.Minute)}).Error)
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: time.Now().Add(15 * time.Minute)}).Error)
 
 	logBuf := captureLogBuf(t)
 
@@ -164,7 +164,7 @@ func TestRegenerateRecoveryCodes_DBErrorSanitized(t *testing.T) {
 	// second-factor requirement (#372-follow-up). Seed an active step-up grant so
 	// password re-auth succeeds and the failure below genuinely comes from
 	// DeleteMFARecoveryCodes, not re-auth.
-	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, ExpiresAt: time.Now().Add(15 * time.Minute)}).Error)
+	require.NoError(t, db.Create(&models.MFAStepUpGrant{UserID: 1, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: time.Now().Add(15 * time.Minute)}).Error)
 
 	logBuf := captureLogBuf(t)
 

--- a/server/http/handlers/webauthn.go
+++ b/server/http/handlers/webauthn.go
@@ -146,6 +146,63 @@ func (h *AuthHandler) DeleteWebAuthnCredential(w http.ResponseWriter, r *http.Re
 	sendSuccess(w, map[string]interface{}{"id": id, "deleted": true}, "Passkey removed.")
 }
 
+// BeginWebAuthnReauth starts a live passkey re-assertion for the authenticated
+// caller, used to satisfy requireReauth's second-factor requirement
+// (DisableMFA/RegenerateMFARecoveryCodes/ActivateMFA/FinishWebAuthnRegistration/
+// DeleteWebAuthnCredential/account email change) when the account has no TOTP
+// factor to type a code from. Unlike BeginWebAuthnLogin, this operates on the
+// already-authenticated caller directly, not a pre-login MFA challenge.
+func (h *AuthHandler) BeginWebAuthnReauth(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+	assertion, sessionToken, err := h.coreService.BeginWebAuthnReauth(r.Context(), userCtx.UserID)
+	if err != nil {
+		h.writeWebAuthnErr(w, err)
+		return
+	}
+	sendSuccess(w, map[string]interface{}{
+		"publicKey":        assertion.Response,
+		"webauthn_session": sessionToken,
+	}, "Complete the passkey assertion to re-authenticate.")
+}
+
+// FinishWebAuthnReauth verifies the assertion begun by BeginWebAuthnReauth and,
+// on success, records a step-up grant scoped ONLY to re-authentication
+// (MFAStepUpPurposeReauth) — it does not by itself perform any account change.
+// The caller must separately call the actual mutating endpoint (e.g.
+// /auth/mfa/disable, DELETE /auth/webauthn/credentials/{id}) with the account
+// password afterward, mirroring how /auth/mfa/stepup and a restricted-secret
+// read are two separate calls.
+// Body: { webauthn_session, credential: <PublicKeyCredential> }.
+func (h *AuthHandler) FinishWebAuthnReauth(w http.ResponseWriter, r *http.Request) {
+	userCtx := middleware.GetUserFromContext(r.Context())
+	if userCtx == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
+	var body struct {
+		WebAuthnSession string          `json:"webauthn_session"`
+		Credential      json.RawMessage `json:"credential"`
+	}
+	if err := decodeJSON(r, &body); err != nil || len(body.Credential) == 0 {
+		sendError(w, "BadRequest", errInvalidRequestBody, http.StatusBadRequest, nil)
+		return
+	}
+	parsed, err := protocol.ParseCredentialRequestResponseBytes(body.Credential)
+	if err != nil {
+		sendError(w, "BadRequest", "Invalid assertion", http.StatusBadRequest, nil)
+		return
+	}
+	if err := h.coreService.FinishWebAuthnReauth(r.Context(), userCtx.UserID, body.WebAuthnSession, parsed); err != nil {
+		h.writeWebAuthnErr(w, err)
+		return
+	}
+	sendSuccess(w, nil, "Re-authentication verified.")
+}
+
 // BeginWebAuthnLogin starts the assertion ceremony for the second login step.
 // Body: { mfa_challenge }. Public (the challenge from /auth/login is the bearer).
 func (h *AuthHandler) BeginWebAuthnLogin(w http.ResponseWriter, r *http.Request) {

--- a/server/http/router.go
+++ b/server/http/router.go
@@ -353,6 +353,13 @@ func NewRouter(cfg *config.Config, coreService *core.KeyorixCore) (http.Handler,
 		// impersonation. There is no admin API to remove another user's passkey, so without
 		// this guard impersonation would be the one path to weaken a user's second factor.
 		r.With(customMiddleware.BlockWhenImpersonating).Delete("/auth/webauthn/credentials/{id}", authHandler.DeleteWebAuthnCredential)
+		// WebAuthn step-up re-authentication: a live passkey re-assertion for a
+		// WebAuthn-only account (no TOTP factor) to satisfy requireReauth's
+		// account-security-factor-change gate -- mints an MFAStepUpGrant scoped
+		// to MFAStepUpPurposeReauth only, distinct from the ambient login-time
+		// grant. Blocked under impersonation, same reasoning as the step-up above.
+		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/webauthn/reauth/begin", authHandler.BeginWebAuthnReauth)
+		r.With(customMiddleware.BlockWhenImpersonating).Post("/auth/webauthn/reauth/finish", authHandler.FinishWebAuthnReauth)
 		r.Get("/auth/sessions", authHandler.ListSessions)
 		r.Delete("/auth/sessions/{id}", authHandler.RevokeSession)
 		r.Get("/auth/tokens", patHandler.ListPATs)

--- a/server/mfa_stepup_grant_prune_scheduler_test.go
+++ b/server/mfa_stepup_grant_prune_scheduler_test.go
@@ -38,12 +38,14 @@ func TestStartSchedulers_MFAStepUpGrantPrune_RemovesExpiredRow(t *testing.T) {
 	now := time.Now().UTC()
 	if err := coreService.Storage().CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
 		UserID:    1,
+		Purpose:   models.MFAStepUpPurposeRestrictedSecretRead,
 		ExpiresAt: now.Add(-400 * 24 * time.Hour), // long expired, past any sane retention
 	}); err != nil {
 		t.Fatalf("seed long-expired grant: %v", err)
 	}
 	if err := coreService.Storage().CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
 		UserID:    2,
+		Purpose:   models.MFAStepUpPurposeRestrictedSecretRead,
 		ExpiresAt: now.Add(time.Hour), // not expired at all
 	}); err != nil {
 		t.Fatalf("seed unexpired grant: %v", err)
@@ -77,7 +79,7 @@ func TestStartSchedulers_MFAStepUpGrantPrune_RemovesExpiredRow(t *testing.T) {
 	}
 
 	// The unexpired grant must never have been touched.
-	active, err := coreService.HasActiveMFAStepUp(ctx, 2)
+	active, err := coreService.HasActiveMFAStepUp(ctx, 2, models.MFAStepUpPurposeRestrictedSecretRead)
 	if err != nil {
 		t.Fatalf("HasActiveMFAStepUp: %v", err)
 	}


### PR DESCRIPTION
## Summary

- `MFAStepUpGrant` carried no purpose: any live grant satisfied both `checkRestrictedMFAGate` (restricted-secret reads) and `requireReauth` (DisableMFA, RegenerateMFARecoveryCodes, ActivateMFA, WebAuthn credential register/delete, account email change). `FinishWebAuthnLogin`/`FinishWebAuthnPasswordlessLogin` mint a genuine grant on **every** successful WebAuthn login, unconditionally — confirmed by tracing both functions and `requireReauth`'s exact acceptance logic line by line.
- For any WebAuthn-enabled account this left an ambient ~15-minute post-login window in which a leaked bearer token plus the account password (no fresh second-factor proof) could disable MFA, delete every passkey, or take over the account via email change — exactly the confused-deputy shape `requireReauth`'s own doc comment says it exists to prevent.
- Fix: add `MFAStepUpPurpose` (`restricted_secret_read` / `account_reauth`) to the grant model; every consumption site now requires an exact purpose match instead of "any live grant." The ambient login-time grant only satisfies restricted-secret reads now; `requireReauth` requires a grant minted specifically for reauth.
- Since a WebAuthn-only account has no typable code to hand `requireReauth` directly, added `BeginWebAuthnReauth`/`FinishWebAuthnReauth` (`POST /auth/webauthn/reauth/begin|finish`) — a live passkey re-assertion performed at the time of the sensitive action, mirroring the existing TOTP step-up flow — so these accounts retain a legitimate self-service path once the ambient grant no longer qualifies for reauth.
- Sibling gap closed in the same investigation: `UpdateOwnProfile`'s email-change re-auth checked `user.MFAEnabled` only, so a WebAuthn-only account fell through to a bare password check instead of `requireReauth`. Now checks `user.MFAEnabled || user.WebAuthnEnabled`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/core/...` — all pass
- [x] `go test ./internal/storage/store/... -run MFAStepUp` — all pass
- [x] `go test ./server/http/handlers/... -run 'MFA|WebAuthn|Reauth'` — all pass
- [x] Red-then-green verified: temporarily reverted the purpose filter in `local_mfa_stepup_grant.go` (simulating pre-fix behavior) — `TestWebAuthn_DeleteRequiresReauth_AmbientLoginGrantRejected` and `TestUpdateOwnProfile_EmailChange_AmbientLoginPurposeGrantRejected` both failed (red); restored the fix — both pass (green)
- [x] Confirmed the legitimate restricted-secret-read step-up flow still works (`TestStepUpGate_On_ActiveGrant_Allowed` et al., unchanged)