### PR TITLE
fix(core): audit notification-channel and anomaly-config mutations

### DIFF
--- a/internal/core/actor_sentinel_completeness_test.go
+++ b/internal/core/actor_sentinel_completeness_test.go
@@ -113,6 +113,14 @@ var actorSentinelAllowlist = map[string]actorSentinelEntry{
 		class: classAuditOnly,
 		note:  "attribution-only: whether to attach a non-nil actor pointer to the notification/audit context.",
 	},
+	"config_change_audit.go:writeConfigChangeAuditEvent": {
+		class: classAuditOnly,
+		note: "attribution-only: whether to attach a non-nil actor pointer to the audit record for an admin " +
+			"config mutation (notification channel CRUD, anomaly config update). The write-permission gate " +
+			"(system.write) already authorized the call before reaching this shared writer; actorID==0 here " +
+			"just means the caller didn't have a numeric actor ID to attribute (e.g. a local CLI invocation), " +
+			"never a bypassed check.",
+	},
 	"groups.go:AddUserToGroup": {
 		class: classPerActorCeiling, status: statusEnforced,
 		note: "P1 (#1524 b): actorIsMachine parameter added; a machine actor is now denied instead of exempted alongside the trusted local-CLI case.",

--- a/internal/core/alert_escalation_test.go
+++ b/internal/core/alert_escalation_test.go
@@ -266,9 +266,10 @@ func TestRunAlertEscalation_DialTimeRefusesDNSRebind(t *testing.T) {
 	c := NewKeyorixCore(store)
 	c.now = fixedNow(now)
 	store.On("CreateNotificationChannel", mock.Anything, mock.Anything).Return(nil)
+	store.On("LogAuditEvent", mock.Anything, mock.Anything).Return(nil)
 	created, err := c.CreateNotificationChannel(context.Background(), &models.NotificationChannel{
 		Name: "rebind-channel", Type: "webhook", URL: "https://" + rebindHost + "/hook", Enabled: true,
-	}, "tester")
+	}, "tester", 1)
 	require.NoError(t, err, "channel creation sees a public address and must succeed")
 	require.GreaterOrEqual(t, callCount, 1)
 

--- a/internal/core/anomaly_config.go
+++ b/internal/core/anomaly_config.go
@@ -20,6 +20,15 @@ const (
 	maxAnomalyMLSampleSize  = 100000
 )
 
+// EventAnomalyConfigUpdated is the audit event type emitted when the
+// persisted anomaly detection config is replaced -- see config_change_audit.go
+// for the shared writer. Distinct from EventAnomalyBusinessHoursConfigured
+// (anomaly.go), which audits only the off-hours band as actually applied to
+// the live detector (change-deduped across scheduler ticks); this event
+// audits the raw admin PUT itself, including knobs (ML enable, lookback,
+// quarantine) that ApplyAnomalyConfig's dedup never covers.
+const EventAnomalyConfigUpdated = "anomaly_config.updated" // #nosec G101 -- audit event type, not a credential
+
 // validateAnomalyConfig bounds the knobs that drive per-scan detector cost.
 func validateAnomalyConfig(cfg *models.AnomalyConfigRecord) error {
 	if cfg.LookbackDays > maxAnomalyLookbackDays {
@@ -94,8 +103,10 @@ func (c *KeyorixCore) GetAnomalyConfig(ctx context.Context) (*models.AnomalyConf
 
 // UpdateAnomalyConfig persists a new anomaly detection config.  updatedBy is
 // the username of the operator making the change (stored on the row for audit
-// purposes); the caller is responsible for applying the new config to the live
-// detector via ApplyAnomalyConfig if one is running.
+// purposes); actorID is their numeric ID for audit-event attribution (0 when
+// unknown, e.g. a local CLI invocation); the caller is responsible for
+// applying the new config to the live detector via ApplyAnomalyConfig if one
+// is running.
 //
 // This is a full-replace write (cfg goes straight into storage.SaveAnomalyConfig's
 // unconditional Save), not the unfetched-struct-into-full-row-overwrite bug class
@@ -103,11 +114,30 @@ func (c *KeyorixCore) GetAnomalyConfig(ctx context.Context) (*models.AnomalyConf
 // Confirmed during that fix's repo-wide sweep as a deliberate, accepted tradeoff:
 // anomaly config is a small operator knob set with no partial-patch use case, and a
 // PUT is expected to carry the complete config, not a diff.
-func (c *KeyorixCore) UpdateAnomalyConfig(ctx context.Context, cfg *models.AnomalyConfigRecord, updatedBy string) error {
+//
+// Every write is audited (EventAnomalyConfigUpdated) with the before/after config
+// as the diff -- an admin who disables ML/off-hours detection deployment-wide,
+// acts, then restores the defaults must leave a permanent record of the
+// intervening window, not just the final restored row (#G-audit-notif-anomaly).
+// The before-state fetch is best-effort: a failure to read the PRIOR config must
+// not block persisting and auditing the new one (the write itself, and its audit
+// record, are the security-relevant guarantee here; a missing "before" snapshot
+// degrades the diff's usefulness but must never suppress the write's own record).
+func (c *KeyorixCore) UpdateAnomalyConfig(ctx context.Context, cfg *models.AnomalyConfigRecord, updatedBy string, actorID uint) error {
 	if err := validateAnomalyConfig(cfg); err != nil {
 		return err
 	}
+	var before any
+	if prior, err := c.storage.GetAnomalyConfig(ctx); err == nil {
+		before = prior
+	}
 	cfg.UpdatedBy = updatedBy
 	cfg.UpdatedAt = time.Now()
-	return c.storage.SaveAnomalyConfig(ctx, cfg)
+	if err := c.storage.SaveAnomalyConfig(ctx, cfg); err != nil {
+		return err
+	}
+	c.writeConfigChangeAuditEvent(ctx, EventAnomalyConfigUpdated, actorID,
+		fmt.Sprintf("anomaly detection config updated by %s (ml_enabled=%t off_hours_enabled=%t)", updatedBy, cfg.MLEnabled, cfg.OffHoursEnabled),
+		before, cfg)
+	return nil
 }

--- a/internal/core/anomaly_config_audit_test.go
+++ b/internal/core/anomaly_config_audit_test.go
@@ -1,0 +1,107 @@
+// anomaly_config_audit_test.go — regression coverage for the anomaly-config
+// audit-trail gap: UpdateAnomalyConfig stores UpdatedBy/UpdatedAt on the
+// singleton row (ID=1) but used to call no writeAuditEvent at all. An admin
+// could disable ML/off-hours detection deployment-wide, act while detection
+// was off, then restore the defaults -- the row would show only the final
+// restored state, with no audit-trail history of the intervening window.
+//
+// This is distinct from ApplyAnomalyConfig's existing
+// EventAnomalyBusinessHoursConfigured audit (anomaly.go/anomaly_config_test.go),
+// which only fires for the off-hours band as applied to the live detector
+// (change-deduped across scheduler ticks) and never covers ML enable/disable,
+// lookback, or quarantine. The tests here cover the raw admin PUT itself.
+//
+// Verified RED before the fix: reverting the writeConfigChangeAuditEvent call
+// in UpdateAnomalyConfig makes TestUpdateAnomalyConfig_AuditsMLDisable below
+// fail with 0 calls to LogAuditEvent (confirmed manually during development
+// of this fix -- see config_change_audit_guard_test.go for the permanent
+// structural guard).
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateAnomalyConfig_AuditsMLDisable is the core threat-model test: an
+// admin flips ml_enabled from true to false (disabling detection), which must
+// be on the permanent audit record with both the before and after state.
+func TestUpdateAnomalyConfig_AuditsMLDisable(t *testing.T) {
+	store := new(MockStorage)
+	c := newAnomalyConfigCore(store)
+	ctx := context.Background()
+
+	prior := &models.AnomalyConfigRecord{MLEnabled: true, MLThreshold: 0.6, OffHoursEnabled: true}
+	store.On("GetAnomalyConfig", ctx).Return(prior, nil)
+	store.On("SaveAnomalyConfig", ctx, mock.AnythingOfType("*models.AnomalyConfigRecord")).Return(nil)
+	var captured *models.AuditEvent
+	store.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).
+		Run(func(args mock.Arguments) { captured = args.Get(1).(*models.AuditEvent) }).
+		Return(nil)
+
+	const actorID = uint(9101)
+	next := &models.AnomalyConfigRecord{MLEnabled: false, MLThreshold: 0.6, OffHoursEnabled: true}
+	err := c.UpdateAnomalyConfig(ctx, next, "admin", actorID)
+	require.NoError(t, err)
+
+	require.NotNil(t, captured, "disabling anomaly detection must write an audit event")
+	assert.Equal(t, EventAnomalyConfigUpdated, captured.EventType)
+	require.NotNil(t, captured.UserID, "the acting admin must be attributed by numeric ID")
+	assert.Equal(t, actorID, *captured.UserID)
+	assert.Contains(t, captured.Diff, `"ml_enabled":true`, "the diff must carry the PRIOR (before) ml_enabled state")
+	assert.Contains(t, captured.Diff, `"ml_enabled":false`, "the diff must carry the NEW (after) ml_enabled state")
+	assert.Contains(t, captured.Description, "ml_enabled=false")
+}
+
+// TestUpdateAnomalyConfig_AuditsOffHoursDisable covers the other detection
+// knob named explicitly in the finding: off_hours_enabled.
+func TestUpdateAnomalyConfig_AuditsOffHoursDisable(t *testing.T) {
+	store := new(MockStorage)
+	c := newAnomalyConfigCore(store)
+	ctx := context.Background()
+
+	prior := &models.AnomalyConfigRecord{OffHoursEnabled: true, OffHoursStart: 22, OffHoursEnd: 6}
+	store.On("GetAnomalyConfig", ctx).Return(prior, nil)
+	store.On("SaveAnomalyConfig", ctx, mock.AnythingOfType("*models.AnomalyConfigRecord")).Return(nil)
+	var captured *models.AuditEvent
+	store.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).
+		Run(func(args mock.Arguments) { captured = args.Get(1).(*models.AuditEvent) }).
+		Return(nil)
+
+	next := &models.AnomalyConfigRecord{OffHoursEnabled: false}
+	err := c.UpdateAnomalyConfig(ctx, next, "admin", 9102)
+	require.NoError(t, err)
+
+	require.NotNil(t, captured)
+	assert.Contains(t, captured.Diff, `"off_hours_enabled":true`)
+	assert.Contains(t, captured.Diff, `"off_hours_enabled":false`)
+}
+
+// TestUpdateAnomalyConfig_BeforeFetchFailureStillAuditsWrite confirms the
+// best-effort "before" fetch: if reading the PRIOR config fails, the write
+// (and its audit event) must still happen -- a missing before-snapshot must
+// never suppress the record that the change occurred.
+func TestUpdateAnomalyConfig_BeforeFetchFailureStillAuditsWrite(t *testing.T) {
+	store := new(MockStorage)
+	c := newAnomalyConfigCore(store)
+	ctx := context.Background()
+
+	store.On("GetAnomalyConfig", ctx).Return(nil, errors.New("db unavailable"))
+	store.On("SaveAnomalyConfig", ctx, mock.AnythingOfType("*models.AnomalyConfigRecord")).Return(nil)
+	var captured *models.AuditEvent
+	store.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).
+		Run(func(args mock.Arguments) { captured = args.Get(1).(*models.AuditEvent) }).
+		Return(nil)
+
+	cfg := &models.AnomalyConfigRecord{MLEnabled: true}
+	err := c.UpdateAnomalyConfig(ctx, cfg, "admin", 9103)
+	require.NoError(t, err)
+	require.NotNil(t, captured, "a failed before-fetch must not suppress the audit write")
+	assert.Contains(t, captured.Diff, `"ml_enabled":true`)
+}

--- a/internal/core/anomaly_config_test.go
+++ b/internal/core/anomaly_config_test.go
@@ -47,14 +47,25 @@ func TestUpdateAnomalyConfig_SetsUpdatedByAndDelegatesToStorage(t *testing.T) {
 	ctx := context.Background()
 
 	cfg := &models.AnomalyConfigRecord{LookbackDays: 30}
+	store.On("GetAnomalyConfig", ctx).Return(&models.AnomalyConfigRecord{LookbackDays: 7}, nil)
 	store.On("SaveAnomalyConfig", ctx, mock.MatchedBy(func(r *models.AnomalyConfigRecord) bool {
 		return r.UpdatedBy == "admin" && r.LookbackDays == 30
 	})).Return(nil)
+	var captured *models.AuditEvent
+	store.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).
+		Run(func(args mock.Arguments) { captured = args.Get(1).(*models.AuditEvent) }).
+		Return(nil)
 
-	err := c.UpdateAnomalyConfig(ctx, cfg, "admin")
+	err := c.UpdateAnomalyConfig(ctx, cfg, "admin", 7)
 	require.NoError(t, err)
 	assert.Equal(t, "admin", cfg.UpdatedBy)
 	assert.False(t, cfg.UpdatedAt.IsZero())
+	require.NotNil(t, captured, "updating the anomaly config must write an audit event")
+	assert.Equal(t, EventAnomalyConfigUpdated, captured.EventType)
+	require.NotNil(t, captured.UserID)
+	assert.Equal(t, uint(7), *captured.UserID)
+	assert.Contains(t, captured.Diff, `"lookback_days":30`)
+	assert.Contains(t, captured.Diff, `"lookback_days":7`, "the diff must carry the PRIOR config too, not just the new one")
 }
 
 func TestUpdateAnomalyConfig_PropagatesStorageError(t *testing.T) {
@@ -63,11 +74,13 @@ func TestUpdateAnomalyConfig_PropagatesStorageError(t *testing.T) {
 	ctx := context.Background()
 
 	cfg := &models.AnomalyConfigRecord{}
+	store.On("GetAnomalyConfig", ctx).Return(&models.AnomalyConfigRecord{}, nil)
 	store.On("SaveAnomalyConfig", ctx, mock.AnythingOfType("*models.AnomalyConfigRecord")).
 		Return(errors.New("write failed"))
 
-	err := c.UpdateAnomalyConfig(ctx, cfg, "user")
+	err := c.UpdateAnomalyConfig(ctx, cfg, "user", 1)
 	require.Error(t, err)
+	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
 }
 
 func TestApplyAnomalyConfig_SetsLookback(t *testing.T) {

--- a/internal/core/config_change_audit.go
+++ b/internal/core/config_change_audit.go
@@ -1,0 +1,52 @@
+// config_change_audit.go — shared audit-emitting helper for admin-only
+// (system.write-gated) singleton/registry configuration mutations.
+//
+// Two independent call sites shared the same audit-trail gap: notification
+// channel CRUD (notification_channels.go) and the anomaly detection config
+// (anomaly_config.go) both let a system.write holder mutate the config with
+// zero audit_events record. The combined threat shape is identical in both
+// cases: an admin can silently redirect/disable the detection-and-alerting
+// layer, act while it's blind, then restore prior state -- leaving no
+// permanent record of the intervening window. Rather than adding two
+// independent writeAuditEvent calls (which the next similar config surface
+// would just re-duplicate), both route through this ONE helper, matching the
+// writeRBACAudit precedent in audit.go (a domain-specific wrapper over the
+// generic writeAuditEventDiff writer). config_change_audit_guard_test.go
+// statically asserts both call sites actually reach it.
+package core
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// configChangeDetail is the structured before/after payload stored in a config
+// change audit event's Diff field. Either side may be nil (Create has no
+// Before; Delete has no After).
+type configChangeDetail struct {
+	Before any `json:"before,omitempty"`
+	After  any `json:"after,omitempty"`
+}
+
+// writeConfigChangeAuditEvent persists an audit_events row for an admin config
+// mutation, carrying a structured before/after diff so an incident
+// investigation can see exactly what changed (e.g. a webhook URL repointed, or
+// anomaly detection disabled) and who made the change, not just that a change
+// occurred. actorID is the acting user's numeric ID (0 when unknown/no
+// authenticated principal, e.g. a local CLI invocation) -- mirrors every other
+// writeAuditEvent* helper's actor convention (see audit.go).
+func (c *KeyorixCore) writeConfigChangeAuditEvent(ctx context.Context, eventType string, actorID uint, description string, before, after any) {
+	detail := configChangeDetail{Before: before, After: after}
+	encoded, err := json.Marshal(detail)
+	if err != nil {
+		// Never let a marshal failure suppress the audit write outright -- an
+		// event with no diff is still a record that the change happened.
+		encoded = nil
+	}
+	var actor *uint
+	if actorID != 0 {
+		a := actorID
+		actor = &a
+	}
+	c.writeAuditEventDiff(ctx, eventType, actor, nil, nil, "", description, string(encoded))
+}

--- a/internal/core/config_change_audit_guard_test.go
+++ b/internal/core/config_change_audit_guard_test.go
@@ -1,0 +1,186 @@
+// config_change_audit_guard_test.go — choke-point guard, in the same family
+// as internal/cli/writeguard's raw-file-open sweep and
+// account_state_exhaustiveness_guard_test.go's switch-exhaustiveness check:
+// statically proves every enumerated admin config-mutation function below
+// actually calls the shared writeConfigChangeAuditEvent helper
+// (config_change_audit.go) somewhere in its body, by AST inspection of the
+// function's own source -- not by convention, and not by running the
+// function and hoping a test happens to assert on it.
+//
+// This is a small, explicit allowlist (not a repo-wide sweep): it enumerates
+// the two mutation surfaces this fix closes (notification channels +
+// anomaly config), the same shape as writeguard's own reviewed allowlist. A
+// future admin-only config mutation elsewhere in the package is NOT
+// automatically covered -- add it to guardedConfigMutations below with a
+// written reason, the same discipline writeguard's allowlist enforces for its
+// own entries.
+//
+// Verified red-then-green during development: temporarily removing the
+// writeConfigChangeAuditEvent call from UpdateNotificationChannel (and,
+// separately, from UpdateAnomalyConfig) made
+// TestGuardedConfigMutations_CallSharedAuditHelper fail for exactly that
+// function, restoring it made the test pass again -- confirming the guard
+// actually detects a reverted audit call, not just a hypothetical one.
+package core
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// configMutationSpec names the file a guarded function lives in and the
+// reason it must call writeConfigChangeAuditEvent.
+type configMutationSpec struct {
+	file   string
+	reason string
+}
+
+// guardedConfigMutations is the enumerated, reviewed set of admin-only
+// (system.write-gated) config-mutation functions that must route through
+// writeConfigChangeAuditEvent. See the package doc comment above for why this
+// is a small explicit list rather than a full-package AST sweep.
+var guardedConfigMutations = map[string]configMutationSpec{
+	"CreateNotificationChannel": {
+		file: "notification_channels.go",
+		reason: "creates a channel that receives anomaly/rotation/breach alerts -- an admin " +
+			"pointing delivery at an attacker-controlled endpoint from creation must be on the record",
+	},
+	"UpdateNotificationChannel": {
+		file: "notification_channels.go",
+		reason: "the URL/enabled state of an alert-delivery channel is exactly what an admin " +
+			"would silently change to intercept or suppress alerts",
+	},
+	"DeleteNotificationChannel": {
+		file:   "notification_channels.go",
+		reason: "deleting the channel is the most complete way to silence alert delivery",
+	},
+	"UpdateAnomalyConfig": {
+		file: "anomaly_config.go",
+		reason: "disables ML/off-hours anomaly detection deployment-wide; the pre-existing " +
+			"ApplyAnomalyConfig audit only covers the off-hours band as applied at scheduler-tick " +
+			"time (change-deduped), never the raw admin PUT or the ML enable/disable flag",
+	},
+}
+
+// TestGuardedConfigMutations_CallSharedAuditHelper is the guard itself: every
+// function named in guardedConfigMutations must call writeConfigChangeAuditEvent
+// somewhere in its body.
+func TestGuardedConfigMutations_CallSharedAuditHelper(t *testing.T) {
+	for name, spec := range guardedConfigMutations {
+		t.Run(name, func(t *testing.T) {
+			if !funcBodyCallsHelper(t, spec.file, name, "writeConfigChangeAuditEvent") {
+				t.Errorf("%s (%s) must call writeConfigChangeAuditEvent -- %s", name, spec.file, spec.reason)
+			}
+		})
+	}
+}
+
+// TestGuardedConfigMutations_EntriesStillExist is the flip side (mirroring
+// writeguard's TestAllowlistEntriesStillExist): an entry naming a function
+// that no longer exists in the stated file (renamed, deleted, or moved) would
+// silently stop being checked. A stale entry doesn't fail the guard above (it
+// only checks found functions), so it's checked here explicitly.
+func TestGuardedConfigMutations_EntriesStillExist(t *testing.T) {
+	for name, spec := range guardedConfigMutations {
+		t.Run(name, func(t *testing.T) {
+			if !funcExists(t, spec.file, name) {
+				t.Errorf("guardedConfigMutations entry %q claims to live in %s but no such function was found there "+
+					"-- update or remove this entry", name, spec.file)
+			}
+		})
+	}
+}
+
+// TestGuardedConfigMutations_ReasonsAreNonEmpty guards against an entry added
+// with an empty/placeholder justification -- same discipline as writeguard's
+// TestAllowlistJustificationsAreNonEmpty.
+func TestGuardedConfigMutations_ReasonsAreNonEmpty(t *testing.T) {
+	for name, spec := range guardedConfigMutations {
+		if spec.reason == "" {
+			t.Errorf("guardedConfigMutations entry %q has no written justification", name)
+		}
+	}
+}
+
+// TestFuncBodyCallsHelper_SelfCheck proves the AST scanner itself actually
+// distinguishes "calls the helper" from "doesn't call the helper" -- a guard
+// that has never been observed to fail on a genuinely bad input is not a
+// guard. GetAnomalyConfig is a read-only accessor in the same file as
+// UpdateAnomalyConfig and must NOT be detected as calling
+// writeConfigChangeAuditEvent; UpdateAnomalyConfig (checked above) must.
+func TestFuncBodyCallsHelper_SelfCheck(t *testing.T) {
+	if funcBodyCallsHelper(t, "anomaly_config.go", "GetAnomalyConfig", "writeConfigChangeAuditEvent") {
+		t.Fatal("GetAnomalyConfig is a read-only accessor and must not be detected as calling " +
+			"writeConfigChangeAuditEvent -- the scanner is vacuously true")
+	}
+	if !funcBodyCallsHelper(t, "anomaly_config.go", "UpdateAnomalyConfig", "writeConfigChangeAuditEvent") {
+		t.Fatal("UpdateAnomalyConfig must be detected as calling writeConfigChangeAuditEvent -- " +
+			"the scanner failed to find a call site known to exist")
+	}
+}
+
+// funcExists reports whether a top-level function named funcName is declared
+// in file.
+func funcExists(t *testing.T, file, funcName string) bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", file, err)
+	}
+	for _, decl := range f.Decls {
+		if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == funcName {
+			return true
+		}
+	}
+	return false
+}
+
+// funcBodyCallsHelper parses file, locates funcName's declaration, and
+// reports whether any call expression in its body invokes helperName --
+// either as a bare identifier (helperName(...)) or as a method/selector call
+// (x.helperName(...), matching c.writeConfigChangeAuditEvent(...)'s shape).
+func funcBodyCallsHelper(t *testing.T, file, funcName, helperName string) bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", file, err)
+	}
+	var fd *ast.FuncDecl
+	for _, decl := range f.Decls {
+		if cand, ok := decl.(*ast.FuncDecl); ok && cand.Name.Name == funcName {
+			fd = cand
+			break
+		}
+	}
+	if fd == nil {
+		t.Fatalf("function %s not found in %s", funcName, file)
+	}
+	if fd.Body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fn := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			if fn.Sel.Name == helperName {
+				found = true
+				return false
+			}
+		case *ast.Ident:
+			if fn.Name == helperName {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/internal/core/notification_channel_audit_test.go
+++ b/internal/core/notification_channel_audit_test.go
@@ -1,0 +1,167 @@
+// notification_channel_audit_test.go — regression coverage for the
+// notification-channel audit-trail gap: CreateNotificationChannel,
+// UpdateNotificationChannel, and DeleteNotificationChannel used to call no
+// writeAuditEvent/writeConfigChangeAuditEvent at all, unlike the sibling
+// retry-policy path (SetNotificationRetryPolicy, notification_retry.go),
+// which already audited as notification_channel.retry_policy_updated. An
+// admin repointing a webhook URL to an attacker-controlled endpoint, or
+// deleting the channel outright, left zero permanent record -- only a
+// self-overwriting UpdatedAt on the row (no UpdatedBy field even exists on
+// the model). Each test here performs the mutation and asserts the exact
+// audit event (type/actor/diff) that must now exist.
+//
+// Verified RED before the fix: reverting the writeConfigChangeAuditEvent call
+// in any of the three functions makes the corresponding test below fail with
+// "0 calls" to LogAuditEvent (confirmed manually during development of this
+// fix -- see config_change_audit_guard_test.go for the permanent structural
+// guard against a silent regression).
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateNotificationChannel_AuditsCreation(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	c.webhookURLValidator = noopWebhookURLValidator
+	ctx := context.Background()
+
+	store.On("CreateNotificationChannel", ctx, mock.AnythingOfType("*models.NotificationChannel")).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			args.Get(1).(*models.NotificationChannel).ID = 11
+		})
+	var captured *models.AuditEvent
+	store.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).
+		Run(func(args mock.Arguments) { captured = args.Get(1).(*models.AuditEvent) }).
+		Return(nil)
+
+	const actorID = uint(9001)
+	ch := &models.NotificationChannel{
+		Name: "siem-webhook", Type: "webhook", URL: "https://siem.example.com/hook",
+	}
+	created, err := c.CreateNotificationChannel(ctx, ch, "admin", actorID)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	require.NotNil(t, captured, "creating a notification channel must write an audit event")
+	assert.Equal(t, EventNotificationChannelCreated, captured.EventType)
+	require.NotNil(t, captured.UserID, "the acting admin must be attributed by numeric ID")
+	assert.Equal(t, actorID, *captured.UserID)
+	assert.Contains(t, captured.Diff, "siem-webhook", "the diff must carry the created channel's name")
+	assert.Contains(t, captured.Diff, "https://siem.example.com/hook", "the diff must carry the channel URL -- the security-relevant field an admin could redirect")
+	store.AssertExpectations(t)
+}
+
+func TestUpdateNotificationChannel_AuditsURLChange(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	c.webhookURLValidator = noopWebhookURLValidator
+	ctx := context.Background()
+
+	existing := &models.NotificationChannel{
+		ID: 22, Name: "ops-webhook", Type: "webhook",
+		URL: "https://legit.example.com/hook", Enabled: true,
+	}
+	store.On("GetNotificationChannel", ctx, uint(22)).Return(existing, nil)
+	store.On("UpdateNotificationChannel", ctx, mock.AnythingOfType("*models.NotificationChannel")).Return(nil)
+	var captured *models.AuditEvent
+	store.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).
+		Run(func(args mock.Arguments) { captured = args.Get(1).(*models.AuditEvent) }).
+		Return(nil)
+
+	const actorID = uint(9002)
+	// The threat this closes: an admin silently repoints where alerts are
+	// delivered, e.g. to an attacker-controlled endpoint.
+	updated, err := c.UpdateNotificationChannel(ctx, 22, map[string]any{
+		"url": "https://attacker.example.net/collect",
+	}, actorID)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	require.NotNil(t, captured, "updating a notification channel must write an audit event")
+	assert.Equal(t, EventNotificationChannelUpdated, captured.EventType)
+	require.NotNil(t, captured.UserID)
+	assert.Equal(t, actorID, *captured.UserID)
+	assert.Contains(t, captured.Diff, "https://legit.example.com/hook", "the diff must carry the PRIOR (before) URL")
+	assert.Contains(t, captured.Diff, "https://attacker.example.net/collect", "the diff must carry the NEW (after) URL")
+	store.AssertExpectations(t)
+}
+
+func TestUpdateNotificationChannel_AuditsEnabledFlagChange(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	c.webhookURLValidator = noopWebhookURLValidator
+	ctx := context.Background()
+
+	existing := &models.NotificationChannel{
+		ID: 23, Name: "siem-webhook", Type: "webhook",
+		URL: "https://siem.example.com/hook", Enabled: true,
+	}
+	store.On("GetNotificationChannel", ctx, uint(23)).Return(existing, nil)
+	store.On("UpdateNotificationChannel", ctx, mock.AnythingOfType("*models.NotificationChannel")).Return(nil)
+	var captured *models.AuditEvent
+	store.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).
+		Run(func(args mock.Arguments) { captured = args.Get(1).(*models.AuditEvent) }).
+		Return(nil)
+
+	// The threat this closes: an admin silently disables the channel (the
+	// alerts stop arriving) without ever changing the URL.
+	_, err := c.UpdateNotificationChannel(ctx, 23, map[string]any{"enabled": false}, 9003)
+	require.NoError(t, err)
+
+	require.NotNil(t, captured)
+	assert.Contains(t, captured.Diff, `"enabled":true`, "the diff must carry the PRIOR enabled state")
+	assert.Contains(t, captured.Diff, `"enabled":false`, "the diff must carry the NEW enabled state")
+}
+
+func TestDeleteNotificationChannel_AuditsDeletion(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	ctx := context.Background()
+
+	existing := &models.NotificationChannel{
+		ID: 33, Name: "siem-webhook", Type: "webhook", URL: "https://siem.example.com/hook",
+	}
+	store.On("GetNotificationChannel", ctx, uint(33)).Return(existing, nil)
+	store.On("DeleteNotificationChannel", ctx, uint(33)).Return(nil)
+	var captured *models.AuditEvent
+	store.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).
+		Run(func(args mock.Arguments) { captured = args.Get(1).(*models.AuditEvent) }).
+		Return(nil)
+
+	const actorID = uint(9004)
+	require.NoError(t, c.DeleteNotificationChannel(ctx, 33, actorID))
+
+	require.NotNil(t, captured, "deleting a notification channel must write an audit event")
+	assert.Equal(t, EventNotificationChannelDeleted, captured.EventType)
+	require.NotNil(t, captured.UserID)
+	assert.Equal(t, actorID, *captured.UserID)
+	assert.Contains(t, captured.Diff, "siem-webhook", "the diff must record what was deleted")
+	store.AssertExpectations(t)
+}
+
+// TestDeleteNotificationChannel_NotFound_NoAuditEvent confirms a delete
+// attempt on a nonexistent channel writes NO audit event (nothing was
+// actually deleted) -- the Get-before-Delete added by this fix must not
+// silently swallow the not-found error either.
+func TestDeleteNotificationChannel_NotFound_NoAuditEvent(t *testing.T) {
+	store := new(MockStorage)
+	c := NewKeyorixCore(store)
+	ctx := context.Background()
+
+	store.On("GetNotificationChannel", ctx, uint(404)).Return(nil, errors.New("not found"))
+
+	err := c.DeleteNotificationChannel(ctx, 404, 1)
+	require.Error(t, err)
+	store.AssertNotCalled(t, "LogAuditEvent", mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "DeleteNotificationChannel", mock.Anything, mock.Anything)
+}

--- a/internal/core/notification_channels.go
+++ b/internal/core/notification_channels.go
@@ -49,6 +49,7 @@ func (c *KeyorixCore) GetNotificationChannel(ctx context.Context, id uint) (*mod
 //   - Type must be one of: webhook, slack, teams, email.
 //   - URL is required for webhook/slack/teams types.
 //   - Email is required for email type.
+//
 // actorID is the acting user's numeric ID for audit attribution (0 when
 // unknown, e.g. a local CLI invocation) -- see writeConfigChangeAuditEvent.
 func (c *KeyorixCore) CreateNotificationChannel(ctx context.Context, ch *models.NotificationChannel, createdBy string, actorID uint) (*models.NotificationChannel, error) {

--- a/internal/core/notification_channels.go
+++ b/internal/core/notification_channels.go
@@ -23,6 +23,16 @@ var validChannelTypes = map[string]struct{}{
 	"email":   {},
 }
 
+// Notification channel audit event types -- see config_change_audit.go for the
+// shared writer. An admin repointing/disabling where alerts are delivered is
+// the same threat shape as disabling anomaly detection (anomaly_config.go):
+// silently remove the alarm, then act.
+const (
+	EventNotificationChannelCreated = "notification_channel.created"
+	EventNotificationChannelUpdated = "notification_channel.updated"
+	EventNotificationChannelDeleted = "notification_channel.deleted"
+)
+
 // ListNotificationChannels returns all configured notification channels.
 func (c *KeyorixCore) ListNotificationChannels(ctx context.Context) ([]*models.NotificationChannel, error) {
 	return c.storage.ListNotificationChannels(ctx)
@@ -39,7 +49,9 @@ func (c *KeyorixCore) GetNotificationChannel(ctx context.Context, id uint) (*mod
 //   - Type must be one of: webhook, slack, teams, email.
 //   - URL is required for webhook/slack/teams types.
 //   - Email is required for email type.
-func (c *KeyorixCore) CreateNotificationChannel(ctx context.Context, ch *models.NotificationChannel, createdBy string) (*models.NotificationChannel, error) {
+// actorID is the acting user's numeric ID for audit attribution (0 when
+// unknown, e.g. a local CLI invocation) -- see writeConfigChangeAuditEvent.
+func (c *KeyorixCore) CreateNotificationChannel(ctx context.Context, ch *models.NotificationChannel, createdBy string, actorID uint) (*models.NotificationChannel, error) {
 	if err := c.validateNotificationChannel(ch); err != nil {
 		return nil, err
 	}
@@ -49,16 +61,23 @@ func (c *KeyorixCore) CreateNotificationChannel(ctx context.Context, ch *models.
 	if err := c.storage.CreateNotificationChannel(ctx, ch); err != nil {
 		return nil, err
 	}
+	after := *ch
+	c.writeConfigChangeAuditEvent(ctx, EventNotificationChannelCreated, actorID,
+		fmt.Sprintf("notification channel %d (%q, type=%s) created by %s", ch.ID, ch.Name, ch.Type, createdBy),
+		nil, after)
 	return ch, nil
 }
 
 // UpdateNotificationChannel applies the given map of field updates to the channel
 // identified by id and returns the updated channel.
-func (c *KeyorixCore) UpdateNotificationChannel(ctx context.Context, id uint, updates map[string]any) (*models.NotificationChannel, error) {
+// actorID is the acting user's numeric ID for audit attribution (0 when
+// unknown, e.g. a local CLI invocation) -- see writeConfigChangeAuditEvent.
+func (c *KeyorixCore) UpdateNotificationChannel(ctx context.Context, id uint, updates map[string]any, actorID uint) (*models.NotificationChannel, error) {
 	ch, err := c.storage.GetNotificationChannel(ctx, id)
 	if err != nil {
 		return nil, err
 	}
+	before := *ch
 	if v, ok := updates["name"].(string); ok && v != "" {
 		ch.Name = v
 	}
@@ -84,12 +103,29 @@ func (c *KeyorixCore) UpdateNotificationChannel(ctx context.Context, id uint, up
 	if err := c.storage.UpdateNotificationChannel(ctx, ch); err != nil {
 		return nil, err
 	}
+	after := *ch
+	c.writeConfigChangeAuditEvent(ctx, EventNotificationChannelUpdated, actorID,
+		fmt.Sprintf("notification channel %d (%q) updated", id, ch.Name),
+		before, after)
 	return ch, nil
 }
 
 // DeleteNotificationChannel permanently removes the channel with the given id.
-func (c *KeyorixCore) DeleteNotificationChannel(ctx context.Context, id uint) error {
-	return c.storage.DeleteNotificationChannel(ctx, id)
+// actorID is the acting user's numeric ID for audit attribution (0 when
+// unknown, e.g. a local CLI invocation) -- see writeConfigChangeAuditEvent.
+func (c *KeyorixCore) DeleteNotificationChannel(ctx context.Context, id uint, actorID uint) error {
+	ch, err := c.storage.GetNotificationChannel(ctx, id)
+	if err != nil {
+		return err
+	}
+	if err := c.storage.DeleteNotificationChannel(ctx, id); err != nil {
+		return err
+	}
+	before := *ch
+	c.writeConfigChangeAuditEvent(ctx, EventNotificationChannelDeleted, actorID,
+		fmt.Sprintf("notification channel %d (%q, type=%s) deleted", id, ch.Name, ch.Type),
+		before, nil)
+	return nil
 }
 
 // validateNotificationChannel enforces invariants for create and update paths.

--- a/internal/core/notification_channels_test.go
+++ b/internal/core/notification_channels_test.go
@@ -19,14 +19,14 @@ func TestCreateNotificationChannel_Validation(t *testing.T) {
 
 	t.Run("invalid type returns error", func(t *testing.T) {
 		ch := &models.NotificationChannel{Name: "bad-type", Type: "sms", URL: "https://example.com"}
-		_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+		_, err := c.CreateNotificationChannel(ctx, ch, "admin", 1)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid notification channel type")
 	})
 
 	t.Run("empty name returns error", func(t *testing.T) {
 		ch := &models.NotificationChannel{Name: "", Type: "webhook", URL: "https://example.com"}
-		_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+		_, err := c.CreateNotificationChannel(ctx, ch, "admin", 1)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "name is required")
 	})
@@ -39,21 +39,21 @@ func TestCreateNotificationChannel_WebhookRequiresURL(t *testing.T) {
 
 	t.Run("webhook without URL returns error", func(t *testing.T) {
 		ch := &models.NotificationChannel{Name: "my-hook", Type: "webhook", URL: ""}
-		_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+		_, err := c.CreateNotificationChannel(ctx, ch, "admin", 1)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "URL is required")
 	})
 
 	t.Run("email type without email returns error", func(t *testing.T) {
 		ch := &models.NotificationChannel{Name: "my-email", Type: "email", Email: ""}
-		_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+		_, err := c.CreateNotificationChannel(ctx, ch, "admin", 1)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "email is required")
 	})
 
 	t.Run("slack without URL returns error", func(t *testing.T) {
 		ch := &models.NotificationChannel{Name: "my-slack", Type: "slack", URL: ""}
-		_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+		_, err := c.CreateNotificationChannel(ctx, ch, "admin", 1)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "URL is required")
 	})
@@ -84,16 +84,25 @@ func TestNotificationChannel_CRUD(t *testing.T) {
 		ch := args.Get(1).(*models.NotificationChannel)
 		ch.ID = 1
 	})
+	var auditEvents []*models.AuditEvent
+	store.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).
+		Run(func(args mock.Arguments) { auditEvents = append(auditEvents, args.Get(1).(*models.AuditEvent)) }).
+		Return(nil)
 
 	result, err := c.CreateNotificationChannel(ctx, &models.NotificationChannel{
 		Name:   "webhook-siem",
 		Type:   "webhook",
 		URL:    "https://siem.example.com/hook",
 		Events: "anomaly.detected,secret.expiring",
-	}, "admin")
+	}, "admin", 42)
 	require.NoError(t, err)
 	assert.Equal(t, uint(1), result.ID)
 	assert.Equal(t, "admin", result.CreatedBy)
+	require.Len(t, auditEvents, 1, "create must write one audit event")
+	assert.Equal(t, EventNotificationChannelCreated, auditEvents[0].EventType)
+	require.NotNil(t, auditEvents[0].UserID)
+	assert.Equal(t, uint(42), *auditEvents[0].UserID)
+	assert.Contains(t, auditEvents[0].Diff, "webhook-siem")
 
 	// List
 	store.On("ListNotificationChannels", ctx).Return([]*models.NotificationChannel{created}, nil)
@@ -114,14 +123,18 @@ func TestNotificationChannel_CRUD(t *testing.T) {
 	updated, err := c.UpdateNotificationChannel(ctx, 1, map[string]interface{}{
 		"events":  "secret.rotated",
 		"enabled": false,
-	})
+	}, 42)
 	require.NoError(t, err)
 	assert.Equal(t, "secret.rotated", updated.Events)
 	assert.False(t, updated.Enabled)
+	require.Len(t, auditEvents, 2, "update must write one more audit event")
+	assert.Equal(t, EventNotificationChannelUpdated, auditEvents[1].EventType)
 
 	// Delete
 	store.On("DeleteNotificationChannel", ctx, uint(1)).Return(nil)
-	require.NoError(t, c.DeleteNotificationChannel(ctx, 1))
+	require.NoError(t, c.DeleteNotificationChannel(ctx, 1, 42))
+	require.Len(t, auditEvents, 3, "delete must write one more audit event")
+	assert.Equal(t, EventNotificationChannelDeleted, auditEvents[2].EventType)
 
 	store.AssertExpectations(t)
 }
@@ -138,7 +151,7 @@ func TestCreateNotificationChannel_StorageError(t *testing.T) {
 		Return(fmt.Errorf("db: connection refused"))
 
 	ch := &models.NotificationChannel{Name: "hook", Type: "webhook", URL: "https://hook.example.com"}
-	_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+	_, err := c.CreateNotificationChannel(ctx, ch, "admin", 1)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connection refused")
 	st.AssertExpectations(t)
@@ -154,7 +167,7 @@ func TestUpdateNotificationChannel_GetError(t *testing.T) {
 	st.On("GetNotificationChannel", ctx, uint(99)).
 		Return(nil, fmt.Errorf("record not found"))
 
-	_, err := c.UpdateNotificationChannel(ctx, 99, map[string]interface{}{"events": "secret.rotated"})
+	_, err := c.UpdateNotificationChannel(ctx, 99, map[string]interface{}{"events": "secret.rotated"}, 1)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 	st.AssertExpectations(t)
@@ -178,7 +191,7 @@ func TestUpdateNotificationChannel_UpdateStorageError(t *testing.T) {
 	st.On("UpdateNotificationChannel", ctx, mock.AnythingOfType("*models.NotificationChannel")).
 		Return(fmt.Errorf("db: disk full"))
 
-	_, err := c.UpdateNotificationChannel(ctx, 2, map[string]interface{}{"events": "secret.rotated"})
+	_, err := c.UpdateNotificationChannel(ctx, 2, map[string]interface{}{"events": "secret.rotated"}, 1)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "disk full")
 	st.AssertExpectations(t)
@@ -192,7 +205,7 @@ func TestValidateNotificationChannel_TeamsRequiresURL(t *testing.T) {
 	ctx := context.Background()
 
 	ch := &models.NotificationChannel{Name: "teams-ch", Type: "teams", URL: ""}
-	_, err := c.CreateNotificationChannel(ctx, ch, "admin")
+	_, err := c.CreateNotificationChannel(ctx, ch, "admin", 1)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "URL is required")
 	assert.Contains(t, err.Error(), "teams")
@@ -215,6 +228,7 @@ func TestUpdateNotificationChannel_AllFieldUpdates(t *testing.T) {
 	}
 	st.On("GetNotificationChannel", ctx, uint(3)).Return(existing, nil)
 	st.On("UpdateNotificationChannel", ctx, mock.AnythingOfType("*models.NotificationChannel")).Return(nil)
+	st.On("LogAuditEvent", ctx, mock.AnythingOfType("*models.AuditEvent")).Return(nil)
 
 	updated, err := c.UpdateNotificationChannel(ctx, 3, map[string]interface{}{
 		"name":    "new-name",
@@ -223,7 +237,7 @@ func TestUpdateNotificationChannel_AllFieldUpdates(t *testing.T) {
 		"email":   "ops@example.com",
 		"events":  "secret.expiring",
 		"enabled": true,
-	})
+	}, 1)
 	require.NoError(t, err)
 	assert.Equal(t, "new-name", updated.Name)
 	assert.Equal(t, "https://new.example.com", updated.URL)
@@ -251,7 +265,7 @@ func TestUpdateNotificationChannel_ValidationFails(t *testing.T) {
 	// Clearing the URL of a webhook should fail validation.
 	_, err := c.UpdateNotificationChannel(ctx, 4, map[string]interface{}{
 		"url": "",
-	})
+	}, 1)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "URL is required")
 	st.AssertExpectations(t)

--- a/server/http/handlers/anomaly_config.go
+++ b/server/http/handlers/anomaly_config.go
@@ -48,11 +48,13 @@ func UpdateAnomalyConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var updatedBy string
+	var actorID uint
 	if u := middleware.GetUserFromContext(r.Context()); u != nil {
 		updatedBy = u.Username
+		actorID = u.UserID
 	}
 
-	if err := coreService.UpdateAnomalyConfig(r.Context(), &cfg, updatedBy); err != nil {
+	if err := coreService.UpdateAnomalyConfig(r.Context(), &cfg, updatedBy, actorID); err != nil {
 		// core.UpdateAnomalyConfig returns a plain (unwrapped) validation error
 		// from validateAnomalyConfig when a knob exceeds its ceiling (#G44) --
 		// e.g. "lookback_days exceeds the maximum of 365" -- before ever

--- a/server/http/handlers/notification_channel_crud_handler_test.go
+++ b/server/http/handlers/notification_channel_crud_handler_test.go
@@ -172,7 +172,7 @@ func TestNCUpdate_BadJSON(t *testing.T) {
 	h := NewNotificationChannelHandler(cs)
 
 	req := withChiParam(
-		httptest.NewRequest(http.MethodPut, "/", bytes.NewReader([]byte("not-json"))),
+		withUserCtx(httptest.NewRequest(http.MethodPut, "/", bytes.NewReader([]byte("not-json")))),
 		"id", "1",
 	)
 	req.Header.Set("Content-Type", "application/json")
@@ -228,7 +228,7 @@ func TestNCDelete_NotFound(t *testing.T) {
 	h := NewNotificationChannelHandler(cs)
 
 	req := withChiParam(
-		httptest.NewRequest(http.MethodDelete, "/", nil),
+		withUserCtx(httptest.NewRequest(http.MethodDelete, "/", nil)),
 		"id", "9999",
 	)
 	w := httptest.NewRecorder()
@@ -455,7 +455,7 @@ func TestNCUpdate_BadID(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]any{"events": "anomaly.detected"})
 	req := withChiParam(
-		httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body)),
+		withUserCtx(httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))),
 		"id", "not-a-number",
 	)
 	req.Header.Set("Content-Type", "application/json")
@@ -486,7 +486,7 @@ func TestNCUpdate_StorageError(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]any{"events": "anomaly.detected"})
 	req := withChiParam(
-		httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body)),
+		withUserCtx(httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))),
 		"id", fmt.Sprintf("%d", ch.ID),
 	)
 	req.Header.Set("Content-Type", "application/json")
@@ -504,7 +504,7 @@ func TestNCUpdate_Success(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]any{"events": "secret.rotated"})
 	req := withChiParam(
-		httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body)),
+		withUserCtx(httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))),
 		"id", fmt.Sprintf("%d", chanID),
 	)
 	req.Header.Set("Content-Type", "application/json")
@@ -527,7 +527,7 @@ func TestNCDelete_BadID(t *testing.T) {
 	h := NewNotificationChannelHandler(cs)
 
 	req := withChiParam(
-		httptest.NewRequest(http.MethodDelete, "/", nil),
+		withUserCtx(httptest.NewRequest(http.MethodDelete, "/", nil)),
 		"id", "not-a-number",
 	)
 	w := httptest.NewRecorder()
@@ -555,7 +555,7 @@ func TestNCDelete_StorageError(t *testing.T) {
 	h := NewNotificationChannelHandler(cs)
 
 	req := withChiParam(
-		httptest.NewRequest(http.MethodDelete, "/", nil),
+		withUserCtx(httptest.NewRequest(http.MethodDelete, "/", nil)),
 		"id", fmt.Sprintf("%d", ch.ID),
 	)
 	w := httptest.NewRecorder()
@@ -571,7 +571,7 @@ func TestNCDelete_Success(t *testing.T) {
 	h := NewNotificationChannelHandler(cs)
 
 	req := withChiParam(
-		httptest.NewRequest(http.MethodDelete, "/", nil),
+		withUserCtx(httptest.NewRequest(http.MethodDelete, "/", nil)),
 		"id", fmt.Sprintf("%d", chanID),
 	)
 	w := httptest.NewRecorder()

--- a/server/http/handlers/notification_channels.go
+++ b/server/http/handlers/notification_channels.go
@@ -91,7 +91,7 @@ func (h *NotificationChannelHandler) Create(w http.ResponseWriter, r *http.Reque
 	} else {
 		ch.Enabled = true
 	}
-	created, err := h.coreService.CreateNotificationChannel(r.Context(), ch, u.Username)
+	created, err := h.coreService.CreateNotificationChannel(r.Context(), ch, u.Username, u.UserID)
 	if err != nil {
 		if isValidationError(err) {
 			sendError(w, "BadRequest", err.Error(), http.StatusBadRequest, nil)
@@ -125,6 +125,11 @@ func (h *NotificationChannelHandler) Get(w http.ResponseWriter, r *http.Request)
 
 // Update handles PUT /api/v1/notification-channels/{id}.
 func (h *NotificationChannelHandler) Update(w http.ResponseWriter, r *http.Request) {
+	u := middleware.GetUserFromContext(r.Context())
+	if u == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
 	id, ok := parseUintParam(w, r, "id")
 	if !ok {
 		return
@@ -134,7 +139,7 @@ func (h *NotificationChannelHandler) Update(w http.ResponseWriter, r *http.Reque
 		sendError(w, "BadRequest", errInvalidRequestBody, http.StatusBadRequest, nil)
 		return
 	}
-	updated, err := h.coreService.UpdateNotificationChannel(r.Context(), id, body)
+	updated, err := h.coreService.UpdateNotificationChannel(r.Context(), id, body, u.UserID)
 	if err != nil {
 		if strings.Contains(err.Error(), channelNotFound) {
 			sendError(w, "NotFound", channelNotFoundMessage, http.StatusNotFound, nil)
@@ -153,11 +158,16 @@ func (h *NotificationChannelHandler) Update(w http.ResponseWriter, r *http.Reque
 
 // Delete handles DELETE /api/v1/notification-channels/{id}.
 func (h *NotificationChannelHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	u := middleware.GetUserFromContext(r.Context())
+	if u == nil {
+		sendError(w, "Unauthorized", errUserContext, http.StatusUnauthorized, nil)
+		return
+	}
 	id, ok := parseUintParam(w, r, "id")
 	if !ok {
 		return
 	}
-	if err := h.coreService.DeleteNotificationChannel(r.Context(), id); err != nil {
+	if err := h.coreService.DeleteNotificationChannel(r.Context(), id, u.UserID); err != nil {
 		if strings.Contains(err.Error(), channelNotFound) {
 			sendError(w, "NotFound", channelNotFoundMessage, http.StatusNotFound, nil)
 			return

--- a/server/http/handlers/notification_channels_handler_test.go
+++ b/server/http/handlers/notification_channels_handler_test.go
@@ -235,7 +235,7 @@ func TestNotifChannel_Update_Found(t *testing.T) {
 
 	body := map[string]interface{}{"url": "https://new.url", "name": "update-me", "type": "slack"}
 	b, _ := json.Marshal(body)
-	req := withChiParam(httptest.NewRequest(http.MethodPut, "/x", bytes.NewReader(b)), "id", itoa(ch.ID))
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodPut, "/x", bytes.NewReader(b))), "id", itoa(ch.ID))
 	w := httptest.NewRecorder()
 	h.Update(w, req)
 
@@ -247,11 +247,26 @@ func TestNotifChannel_Update_NotFound(t *testing.T) {
 
 	body := map[string]interface{}{"name": "x", "type": "slack", "url": "https://x"}
 	b, _ := json.Marshal(body)
-	req := withChiParam(httptest.NewRequest(http.MethodPut, "/x", bytes.NewReader(b)), "id", "99999")
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodPut, "/x", bytes.NewReader(b))), "id", "99999")
 	w := httptest.NewRecorder()
 	h.Update(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNotifChannel_Update_Unauthorized(t *testing.T) {
+	h, db := newNotifChannelHandler(t)
+
+	ch := models.NotificationChannel{Name: "upd-noauth", Type: "webhook", URL: "https://x", Enabled: true}
+	require.NoError(t, db.Create(&ch).Error)
+
+	body := map[string]interface{}{"name": "x"}
+	b, _ := json.Marshal(body)
+	req := withChiParam(httptest.NewRequest(http.MethodPut, "/x", bytes.NewReader(b)), "id", itoa(ch.ID))
+	w := httptest.NewRecorder()
+	h.Update(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestNotifChannel_Update_BadJSON(t *testing.T) {
@@ -260,8 +275,8 @@ func TestNotifChannel_Update_BadJSON(t *testing.T) {
 	ch := models.NotificationChannel{Name: "upd-bad", Type: "webhook", URL: "https://x", Enabled: true}
 	require.NoError(t, db.Create(&ch).Error)
 
-	req := withChiParam(httptest.NewRequest(http.MethodPut, "/x",
-		bytes.NewReader([]byte("not-json"))), "id", itoa(ch.ID))
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodPut, "/x",
+		bytes.NewReader([]byte("not-json")))), "id", itoa(ch.ID))
 	w := httptest.NewRecorder()
 	h.Update(w, req)
 
@@ -277,7 +292,7 @@ func TestNotifChannel_Update_ValidationError(t *testing.T) {
 	// set an invalid type → validation error (non-empty type gets applied, then fails validation)
 	body := map[string]interface{}{"type": "fax"}
 	b, _ := json.Marshal(body)
-	req := withChiParam(httptest.NewRequest(http.MethodPut, "/x", bytes.NewReader(b)), "id", itoa(ch.ID))
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodPut, "/x", bytes.NewReader(b))), "id", itoa(ch.ID))
 	w := httptest.NewRecorder()
 	h.Update(w, req)
 
@@ -292,7 +307,7 @@ func TestNotifChannel_Delete_Found(t *testing.T) {
 	ch := models.NotificationChannel{Name: "del-me", Type: "webhook", URL: "https://example.com", Enabled: true}
 	require.NoError(t, db.Create(&ch).Error)
 
-	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/x", nil), "id", itoa(ch.ID))
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodDelete, "/x", nil)), "id", itoa(ch.ID))
 	w := httptest.NewRecorder()
 	h.Delete(w, req)
 
@@ -304,7 +319,7 @@ func TestNotifChannel_Delete_Found(t *testing.T) {
 func TestNotifChannel_Delete_NotFound(t *testing.T) {
 	h, _ := newNotifChannelHandler(t)
 
-	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/x", nil), "id", "99999")
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodDelete, "/x", nil)), "id", "99999")
 	w := httptest.NewRecorder()
 	h.Delete(w, req)
 
@@ -314,11 +329,24 @@ func TestNotifChannel_Delete_NotFound(t *testing.T) {
 func TestNotifChannel_Delete_BadID(t *testing.T) {
 	h, _ := newNotifChannelHandler(t)
 
-	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/x", nil), "id", "bad")
+	req := withChiParam(withUserCtx(httptest.NewRequest(http.MethodDelete, "/x", nil)), "id", "bad")
 	w := httptest.NewRecorder()
 	h.Delete(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNotifChannel_Delete_Unauthorized(t *testing.T) {
+	h, db := newNotifChannelHandler(t)
+
+	ch := models.NotificationChannel{Name: "del-noauth", Type: "webhook", URL: "https://x", Enabled: true}
+	require.NoError(t, db.Create(&ch).Error)
+
+	req := withChiParam(httptest.NewRequest(http.MethodDelete, "/x", nil), "id", itoa(ch.ID))
+	w := httptest.NewRecorder()
+	h.Delete(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 // ── isValidationError ─────────────────────────────────────────────────────────

--- a/server/http/permission_sweep_test.go
+++ b/server/http/permission_sweep_test.go
@@ -54,35 +54,35 @@ import (
 // implementation) to confirm it returns no cross-tenant/cross-user disclosure that
 // system.read's universal grant would expose.
 var permissionSweepAllowlist = map[string]string{
-	"server/http/router.go:381": "GET /notification-channels/{id}/retry-policy returns only " +
+	"server/http/router.go:388": "GET /notification-channels/{id}/retry-policy returns only " +
 		"max_retries/retry_backoff_ms for one channel ID -- numeric tuning knobs, no secret " +
 		"values, no PII, no cross-tenant project/user enumeration. Weaker than the parent " +
 		"resource's own read (system.write), a pre-existing minor inconsistency, but not the " +
 		"cross-tenant-disclosure bug shape this sweep guards against.",
-	"server/http/router.go:404": "GET /dashboard/stats is the caller's OWN home dashboard. " +
+	"server/http/router.go:411": "GET /dashboard/stats is the caller's OWN home dashboard. " +
 		"core.GetDashboardStats (internal/core/dashboard.go) separately scopes the " +
 		"deployment-wide aggregate fields (active users, audit-event counts, failed-auth " +
 		"counts) to audit.read INSIDE the handler -- a baseline caller gets their own numbers " +
 		"with the org-wide aggregates zeroed, not the real deployment-wide figures. See " +
 		"TestDashboardStats_PermissionTiers in deployment_disclosure_family_test.go.",
-	"server/http/router.go:414": "GET /system/auth-config returns a deliberately redacted, " +
+	"server/http/router.go:421": "GET /system/auth-config returns a deliberately redacted, " +
 		"non-per-tenant summary of server-wide auth config (session TTLs, password policy " +
 		"shape, SSO provider names/types). No secrets (client secrets/SAML metadata/OIDC " +
 		"details excluded by MakeAuthConfigHandler's own doc comment), no per-user or " +
 		"per-project data to disclose cross-tenant.",
-	"server/http/router.go:415": "GET /system/encryption-config returns a deliberately " +
+	"server/http/router.go:422": "GET /system/encryption-config returns a deliberately " +
 		"redacted, non-per-tenant summary (encryption enabled + KEK provider TYPE only). Key " +
 		"material locations (file paths, exec commands, env var names, KMS key IDs) are " +
 		"explicitly excluded by MakeEncryptionConfigHandler's own doc comment.",
-	"server/http/router.go:422": "GET /system/info returns server version/build/runtime info " +
+	"server/http/router.go:429": "GET /system/info returns server version/build/runtime info " +
 		"(no per-tenant data) -- the same deployment-wide, non-disclosure-sensitive shape as " +
 		"auth-config/encryption-config above.",
-	"server/http/router.go:423": "GET /system/metrics returns process-level runtime metrics " +
+	"server/http/router.go:430": "GET /system/metrics returns process-level runtime metrics " +
 		"(memory/GC/goroutines) with HTTP/Database/Secrets counters explicitly zeroed (not " +
 		"instrumented at this layer per GetMetrics's own comment) -- no per-tenant data.",
-	"server/http/router.go:1067": "GET /audit/anomalies sits inside r.Route(\"/audit\", ...) " +
+	"server/http/router.go:1074": "GET /audit/anomalies sits inside r.Route(\"/audit\", ...) " +
 		"which calls r.Use(RequirePermission(permAuditRead)) as a GROUP-level middleware " +
-		"(router.go:1044). chi's With() on a route registered inside that group ADDS to, " +
+		"(router.go:1056). chi's With() on a route registered inside that group ADDS to, " +
 		"never replaces, the group's Use() middleware (verified against go-chi/chi/v5's " +
 		"Mux.With/Route/handle: the group's non-inline Mux builds its own handler chain via " +
 		"updateRouteHandler, and every route registered inside it -- inline or not -- is " +
@@ -90,18 +90,18 @@ var permissionSweepAllowlist = map[string]string{
 		"audit.read AND system.read (AND, not OR) -- effectively gated at audit.read, the " +
 		"stronger requirement, exactly as router.go's own ANOMALY-04 comment there intends. " +
 		"Not a case of \"solely permSystemRead\" despite the literal string match.",
-	"server/http/router.go:2074": "GET /license/status returns deployment-wide license " +
+	"server/http/router.go:2081": "GET /license/status returns deployment-wide license " +
 		"metadata (plan/features/seat count/expiry) -- not scoped to any tenant/project/user, " +
 		"nothing to cross-tenant-disclose.",
-	"server/http/router.go:2170": "GET /sod/policies returns policy DEFINITIONS (name + the " +
+	"server/http/router.go:2177": "GET /sod/policies returns policy DEFINITIONS (name + the " +
 		"permission-a/permission-b pair) only -- no PII, no violator names. router.go's own " +
 		"adjacent comment is explicit that this stays baseline while /sod/violations (which " +
 		"DOES disclose violator names/emails) is separately gated on audit.read.",
-	"server/http/router.go:2217": "GET /admin/anomaly-config returns the DB-persisted anomaly " +
+	"server/http/router.go:2224": "GET /admin/anomaly-config returns the DB-persisted anomaly " +
 		"detection THRESHOLDS (config), not any user/project/alert data -- deployment-wide " +
 		"config in the same non-disclosure-sensitive family as auth-config/encryption-config " +
 		"above. Actual alert data (which does disclose SecretName/AccessedBy/IPAddress " +
-		"deployment-wide) is the separate /audit/anomalies route (line 1062 above), already " +
+		"deployment-wide) is the separate /audit/anomalies route (line 1074 above), already " +
 		"gated at effective audit.read.",
 }
 
@@ -421,8 +421,8 @@ var noPermissionGateAllowlist = map[string]string{
 	"server/http/router.go:240":  justPublicInfra + " /metrics is Prometheus scrape target; optionally protected by a separate static-bearer-token check (cfg.Server.HTTP.MetricsToken) when configured -- a deployment-perimeter control, not RBAC.",
 	"server/http/router.go:243":  justPublicInfra + " GET /status serves the public status dashboard (or falls back to the health check).",
 	"server/http/router.go:259":  justPublicInfra + " GET /status-es is the Spanish-language mirror of /status immediately above.",
-	"server/http/router.go:2228": justPublicInfra + " Swagger UI is gated by cfg.Server.HTTP.SwaggerEnabled (a deployment config flag, not a per-caller permission) -- see the adjacent comment; the machine-readable API surface it exposes is the same shape /openapi.yaml exposes below.",
-	"server/http/router.go:2229": justPublicInfra + " GET /openapi.yaml is the raw OpenAPI spec, gated by the same cfg.Server.HTTP.SwaggerEnabled flag as the Swagger UI immediately above (#224 fixed the two having diverging on/off behavior; they must stay paired).",
+	"server/http/router.go:2235": justPublicInfra + " Swagger UI is gated by cfg.Server.HTTP.SwaggerEnabled (a deployment config flag, not a per-caller permission) -- see the adjacent comment; the machine-readable API surface it exposes is the same shape /openapi.yaml exposes below.",
+	"server/http/router.go:2236": justPublicInfra + " GET /openapi.yaml is the raw OpenAPI spec, gated by the same cfg.Server.HTTP.SwaggerEnabled flag as the Swagger UI immediately above (#224 fixed the two having diverging on/off behavior; they must stay paired).",
 
 	"server/http/router.go:330": justSelfServiceOwnAccount + " GET/PUT /auth/profile.",
 	"server/http/router.go:331": justSelfServiceOwnAccount + " GET/PUT /auth/profile.",
@@ -437,28 +437,30 @@ var noPermissionGateAllowlist = map[string]string{
 	"server/http/router.go:349": justSelfServiceOwnAccount + " POST webauthn/register/finish completes the same ceremony as register/begin above.",
 	"server/http/router.go:350": justSelfServiceOwnAccount + " GET webauthn/credentials lists only the caller's OWN passkeys.",
 	"server/http/router.go:355": justSelfServiceOwnAccount + " DELETE webauthn/credentials/{id} deletes only the caller's OWN passkey (there is no admin API to remove another user's passkey); same impersonation block, since deleting the last passkey is the same durable MFA-downgrade /auth/mfa/disable is blocked from doing.",
-	"server/http/router.go:356": justSelfServiceOwnAccount + " GET /auth/sessions lists only the caller's OWN sessions.",
-	"server/http/router.go:357": justSelfServiceOwnAccount + " DELETE /auth/sessions/{id} revokes only one of the caller's OWN sessions.",
-	"server/http/router.go:358": justSelfServiceOwnAccount + " GET /auth/tokens lists only the caller's OWN PATs.",
-	"server/http/router.go:361": justSelfServiceOwnAccount + " POST /auth/tokens mints a PAT for the caller's OWN account; blocked under impersonation so an admin acting as a user cannot plant a durable token.",
-	"server/http/router.go:362": justSelfServiceOwnAccount + " DELETE /auth/tokens/{id} revokes only one of the caller's OWN PATs.",
-	"server/http/router.go:364": justSelfServiceOwnAccount + " GET tokens/expired lists only the caller's OWN expired PATs.",
-	"server/http/router.go:365": justSelfServiceOwnAccount + " DELETE tokens/expired bulk-revokes only the caller's OWN expired PATs.",
-	"server/http/router.go:367": justSelfServiceOwnAccount + " POST /auth/end-impersonation ends only the CALLER'S OWN impersonation session.",
-	"server/http/router.go:370": justSelfServiceOwnAccount + " GET /notifications lists only the caller's OWN in-app notifications (ADR-024).",
-	"server/http/router.go:371": justSelfServiceOwnAccount + " POST notifications/read-all marks only the caller's OWN notifications read.",
-	"server/http/router.go:372": justSelfServiceOwnAccount + " POST notifications/{id}/read marks one of the caller's OWN notifications read.",
+	"server/http/router.go:361": justSelfServiceOwnAccount + " POST /auth/webauthn/reauth/begin starts a live passkey re-assertion for the caller's OWN account (the WebAuthn-only path to satisfy requireReauth); same impersonation block as the other WebAuthn/MFA self-service routes.",
+	"server/http/router.go:362": justSelfServiceOwnAccount + " POST /auth/webauthn/reauth/finish completes the same ceremony as reauth/begin immediately above.",
+	"server/http/router.go:363": justSelfServiceOwnAccount + " GET /auth/sessions lists only the caller's OWN sessions.",
+	"server/http/router.go:364": justSelfServiceOwnAccount + " DELETE /auth/sessions/{id} revokes only one of the caller's OWN sessions.",
+	"server/http/router.go:365": justSelfServiceOwnAccount + " GET /auth/tokens lists only the caller's OWN PATs.",
+	"server/http/router.go:368": justSelfServiceOwnAccount + " POST /auth/tokens mints a PAT for the caller's OWN account; blocked under impersonation so an admin acting as a user cannot plant a durable token.",
+	"server/http/router.go:369": justSelfServiceOwnAccount + " DELETE /auth/tokens/{id} revokes only one of the caller's OWN PATs.",
+	"server/http/router.go:371": justSelfServiceOwnAccount + " GET tokens/expired lists only the caller's OWN expired PATs.",
+	"server/http/router.go:372": justSelfServiceOwnAccount + " DELETE tokens/expired bulk-revokes only the caller's OWN expired PATs.",
+	"server/http/router.go:374": justSelfServiceOwnAccount + " POST /auth/end-impersonation ends only the CALLER'S OWN impersonation session.",
+	"server/http/router.go:377": justSelfServiceOwnAccount + " GET /notifications lists only the caller's OWN in-app notifications (ADR-024).",
+	"server/http/router.go:378": justSelfServiceOwnAccount + " POST notifications/read-all marks only the caller's OWN notifications read.",
+	"server/http/router.go:379": justSelfServiceOwnAccount + " POST notifications/{id}/read marks one of the caller's OWN notifications read.",
 
-	"server/http/router.go:499": "Self-service (ADR-024): POST /projects/{id}/access-requests lets an " +
+	"server/http/router.go:506": "Self-service (ADR-024): POST /projects/{id}/access-requests lets an " +
 		"authenticated user request access to a project THEY DO NOT YET HAVE -- by definition they " +
 		"cannot hold a project-scoped permission on it yet, so no permission check can gate the " +
 		"request itself (core.RequestProjectAccess scopes the created row to the caller's own " +
 		"user ID). See router.go's own adjacent comment (\"requesting + withdrawing are self-" +
 		"service\") and handlers/invitations.go's CreateAccessRequest.",
-	"server/http/router.go:501": "Self-service (ADR-024): POST access-requests/{requestId}/withdraw withdraws " +
+	"server/http/router.go:508": "Self-service (ADR-024): POST access-requests/{requestId}/withdraw withdraws " +
 		"only the CALLER'S OWN pending request (core.WithdrawAccessRequest scopes to the requester). " +
 		"Same reasoning as CreateAccessRequest immediately above.",
-	"server/http/router.go:517": "Self-service by design: POST /projects/{id}/break-glass activates " +
+	"server/http/router.go:524": "Self-service by design: POST /projects/{id}/break-glass activates " +
 		"emergency access the caller currently LACKS -- the entire point of break-glass is bypassing " +
 		"the normal grant path, so gating it on a permission would defeat its purpose. Controlled " +
 		"instead by deployment config + a mandatory justification + full audit trail + automatic " +
@@ -466,36 +468,36 @@ var noPermissionGateAllowlist = map[string]string{
 		"so an admin acting as a user cannot mint a durable emergency role grant attributed to the " +
 		"target. See router.go's own adjacent comment.",
 
-	"server/http/router.go:615": "GET /secrets (ListSecrets) performs its own authorization INSIDE the " +
+	"server/http/router.go:622": "GET /secrets (ListSecrets) performs its own authorization INSIDE the " +
 		"handler so a project-scoped reader gets the union of their accessible scopes rather than a " +
 		"403 on an unfiltered request -- see router.go's own adjacent comment and secrets_list.go. " +
 		"An unscoped/no-permission caller still only ever sees the empty-or-narrowed result their " +
 		"own scopes permit, never another caller's secrets.",
-	"server/http/router.go:617": "GET /secrets/policy returns the deployment's ACTIVE create-time naming/" +
+	"server/http/router.go:624": "GET /secrets/policy returns the deployment's ACTIVE create-time naming/" +
 		"value policy -- deployment-wide, non-per-tenant configuration every authenticated caller " +
 		"needs visibility into before they can even attempt a create (the same policy a create " +
 		"request would be validated against). No secret values, no per-tenant data. See router.go's " +
 		"own adjacent comment (\"any authenticated caller\").",
-	"server/http/router.go:711": "POST /secrets (CreateSecret) is authorized INSIDE the handler: scope " +
+	"server/http/router.go:718": "POST /secrets (CreateSecret) is authorized INSIDE the handler: scope " +
 		"(project/environment) comes from the request body, not a URL path param a scope resolver " +
 		"middleware could resolve ahead of the handler. See router.go's own adjacent comment " +
 		"(\"Create: authorized inside the handler (scope comes from the body)\").",
-	"server/http/router.go:732": "DELETE /secrets/{id}/self-share (RemoveSelfFromShare) removes only the " +
+	"server/http/router.go:739": "DELETE /secrets/{id}/self-share (RemoveSelfFromShare) removes only the " +
 		"CALLER'S OWN direct share (core only removes a share whose RecipientID == the caller) -- " +
 		"self-service on the caller's own grant, needs just authentication. See router.go's own " +
 		"adjacent comment.",
-	"server/http/router.go:757": "POST /folders (CreateFolder) is authorized INSIDE the handler: scope " +
+	"server/http/router.go:764": "POST /folders (CreateFolder) is authorized INSIDE the handler: scope " +
 		"comes from the request body, the same in-handler-authorization pattern as CreateSecret " +
 		"above. See router.go's own adjacent comment (\"Create authorizes in-handler (scope from the " +
 		"body)\").",
-	"server/http/router.go:779": "POST /rotation-policies (Create) is authorized INSIDE the handler: scope " +
+	"server/http/router.go:786": "POST /rotation-policies (Create) is authorized INSIDE the handler: scope " +
 		"comes from the request body, the same in-handler pattern as CreateSecret/CreateFolder above. " +
 		"See router.go's own adjacent comment (\"create authorizes in-handler against the body\").",
-	"server/http/router.go:808": "POST /dynamic-secrets/configs (CreateConfig) is authorized INSIDE the " +
+	"server/http/router.go:815": "POST /dynamic-secrets/configs (CreateConfig) is authorized INSIDE the " +
 		"handler -- traced to the actual code, not just the group's header comment: " +
 		"DynamicSecretHandler.CreateConfig (server/http/handlers/dynamic_secrets.go) calls " +
 		"h.authorize(r, permSecretsWrite, scope) itself before creating the config.",
-	"server/http/router.go:809": "GET /dynamic-secrets/configs (ListConfigs) is authorized INSIDE the " +
+	"server/http/router.go:816": "GET /dynamic-secrets/configs (ListConfigs) is authorized INSIDE the " +
 		"handler -- traced to the actual code: DynamicSecretHandler.ListConfigs " +
 		"(server/http/handlers/dynamic_secrets.go) calls h.authorize(r, permSecretsRead, " +
 		"core.Scope{ProjectID: projectID, EnvironmentID: environmentID}) itself before listing.",


### PR DESCRIPTION
## Summary

Two admin-only (`system.write`-gated) mutation paths silently skipped audit logging, and the combined effect is the same threat shape: an admin can disable the detection/alerting layer, act, then leave no permanent record.

- **Notification channels** (`internal/core/notification_channels.go`): `CreateNotificationChannel`/`UpdateNotificationChannel`/`DeleteNotificationChannel` called no `writeAuditEvent`-equivalent, unlike the sibling retry-policy path (`SetNotificationRetryPolicy`, already audited as `notification_channel.retry_policy_updated`). An admin could silently redirect where anomaly/rotation/breach alerts are delivered, or delete the channel outright, with zero permanent audit-trail record.
- **Anomaly config** (`internal/core/anomaly_config.go`): `UpdateAnomalyConfig` stores `UpdatedBy`/`UpdatedAt` on the singleton row but never audited. An admin could disable ML/off-hours detection deployment-wide, act, then restore the defaults, leaving only the final restored state with no history of the intervening window. This is distinct from `ApplyAnomalyConfig`'s existing `anomaly.business_hours_configured` audit, which only covers the off-hours band as applied to the live detector (change-deduped across scheduler ticks) — never the raw admin PUT or the ML enable/disable flag.

## Fix

- Both paths now route through one shared helper, `writeConfigChangeAuditEvent` (`internal/core/config_change_audit.go`), which records the acting user, an event-type discriminator (`notification_channel.created`/`.updated`/`.deleted`, `anomaly_config.updated`), and a structured before/after diff.
- `UpdateNotificationChannel`/`DeleteNotificationChannel` gained an `actorID` parameter; the HTTP handlers now require an authenticated user context for Update/Delete (matching Create's existing check) so the audit record can attribute the change.
- `DeleteNotificationChannel` now fetches the channel before removing it so the audit event records what was deleted.
- `UpdateAnomalyConfig` best-effort fetches the prior config for the diff's "before" side — a failed fetch never suppresses the write or its audit record.

## Choke-point guard

`internal/core/config_change_audit_guard_test.go` is a new AST-based guard (same family as `internal/cli/writeguard`'s allowlist sweep and `account_state_exhaustiveness_guard_test.go`): it enumerates the four guarded functions and statically asserts each one's body calls `writeConfigChangeAuditEvent`. A future edit that removes the audit call fails this test, independent of the functional regression tests.

Also added an entry to the existing `actorSentinelAllowlist` (`internal/core/actor_sentinel_completeness_test.go`) classifying the new helper's `actorID != 0` check as `classAuditOnly` (attribution metadata, not an authorization decision).

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `gosec -severity medium -exclude-generated ./internal/core/... ./server/http/handlers/...` — 0 issues
- [x] `go test ./internal/core/...` and `go test ./server/http/...` (isolated run) both green
- [x] Red-then-green verified manually for all four guarded functions (Create/Update/Delete notification channel, UpdateAnomalyConfig): reverting each `writeConfigChangeAuditEvent` call independently made both the dedicated regression test and `TestGuardedConfigMutations_CallSharedAuditHelper` fail for exactly that function; restoring made both pass again
- [x] Guard test's own AST scanner self-checked (`TestFuncBodyCallsHelper_SelfCheck`) against a known non-calling function (`GetAnomalyConfig`) to rule out a vacuously-true sweep