### PR TITLE
fix(core): serialize dual-control approvals per request across replicas (#G04-HA)

### DIFF
--- a/internal/core/concurrency_dual_control_approval_postgres_test.go
+++ b/internal/core/concurrency_dual_control_approval_postgres_test.go
@@ -24,11 +24,11 @@ var dualControlModels = []interface{}{
 // TestConcurrency_ApproveAccessRequestWithExpiry_CrossReplicaPostgres_ThresholdRace
 // is #1646's dual-control residual, reproduced (not just inspected) before deciding
 // whether to fix it -- per this campaign's own rule that a race which doesn't exist
-// costs a database constraint for nothing. dualControlApprovalMu (service.go) is a
-// KeyorixCore-level sync.Mutex, so it only serializes callers within ONE
-// process/replica. This test gives two independent, distinct approvers their OWN
-// *gorm.DB connection (own LocalStorage, own KeyorixCore, own dualControlApprovalMu)
-// into the SAME real Postgres schema, then races them both submitting the
+// costs a database constraint for nothing. At the time, dualControlApprovalMu
+// (service.go) was a KeyorixCore-level sync.Mutex, so it only serialized callers
+// within ONE process/replica. This test gives two independent, distinct approvers
+// their OWN *gorm.DB connection (own LocalStorage, own KeyorixCore) into the SAME
+// real Postgres schema, then races them both submitting the
 // THRESHOLD-CROSSING (2nd of a 2-of-N) approval on the identical request at the same
 // instant.
 //
@@ -40,9 +40,21 @@ var dualControlModels = []interface{}{
 // target the identical tuple). The losing racer's AssignUserRole INSERT fails
 // OUTRIGHT with a primary-key violation, before finalizeAccessRequestApproval ever
 // reaches CreateAccessRequestApproval -- so neither approval-row inflation nor a live
-// double-grant is possible, independent of dualControlApprovalMu. No DB constraint
+// double-grant is possible, independent of any in-process mutex. No DB constraint
 // was added for this residual; this test is kept as the permanent record of that
 // conclusion, asserting the invariant it confirms rather than a defect it found.
+//
+// #G04-HA CORRECTION TO SCOPE: that conclusion is sound but does NOT generalize to
+// dual control as a whole, and reading it as "the dual-control threshold needs no
+// cross-replica serialization" is the mistake this note exists to prevent. It
+// holds only for racers that BOTH cross the threshold — which is true here solely
+// because the fixture below seeds one approval first. Racers that STRADDLE the
+// K-th approval instead both take recordPartialApproval, grant no role (so
+// UserRole's primary key is never consulted) and are distinct approvers (so
+// ux_access_request_approver is never consulted), leaving a request stranded
+// pending while holding K valid approvals. That variant is a real defect, is
+// covered by concurrency_dual_control_subthreshold_postgres_test.go, and is why
+// ApproveAccessRequestWithExpiry now runs under a per-request WithNamedLock.
 //
 // What that guard does NOT prevent is checked here anyway, as a durable regression
 // check: (1) whether BOTH racers' CreateAccessRequestApproval calls land (recording
@@ -106,10 +118,10 @@ func TestConcurrency_ApproveAccessRequestWithExpiry_CrossReplicaPostgres_Thresho
 	_, err = setupCore.ApproveAccessRequestWithExpiry(ctx, projectID, req.ID, approverC.ID, 0, "", 0)
 	require.NoError(t, err)
 
-	// Two independent replicas, own connections into the SAME schema -- own
-	// dualControlApprovalMu, unable to serialize against each other. Each must also
-	// set the SAME dual-control policy (an in-memory KeyorixCore field, not
-	// persisted) so both agree K=2.
+	// Two independent replicas, own connections into the SAME schema -- sharing no
+	// in-process state, so nothing but a DB-level guard can serialize them. Each
+	// must also set the SAME dual-control policy (an in-memory KeyorixCore field,
+	// not persisted) so both agree K=2.
 	dbA := pgOpen(t, dsn)
 	coreA := NewKeyorixCore(localstore.NewLocalStorage(dbA))
 	coreA.SetDualControlPolicy(2)

--- a/internal/core/concurrency_dual_control_subthreshold_postgres_test.go
+++ b/internal/core/concurrency_dual_control_subthreshold_postgres_test.go
@@ -1,0 +1,153 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	localstore "github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrency_ApproveAccessRequestWithExpiry_CrossReplicaPostgres_SubThresholdStraddle
+// is the #G04-HA regression test: the dual-control race variant that neither
+// constraint #1646 relied on can catch.
+//
+// #1646's own race test (concurrency_dual_control_approval_postgres_test.go)
+// deliberately seeds one approval first, so BOTH racers cross the threshold and
+// both reach AssignUserRole -- where UserRole's composite primary key resolves the
+// race structurally. That seeding is what hides this variant. Here the racers
+// STRADDLE the K-th approval instead: a 2-of-N request with NO prior approvals,
+// approved by two distinct people at the same instant. Both read approvals=[],
+// both compute received=1 < 2, and both take recordPartialApproval -- granting no
+// role, so UserRole's primary key is never consulted, and being distinct
+// approvers, so AccessRequestApproval's ux_access_request_approver unique index is
+// never consulted either. Neither guard fires.
+//
+// The pre-fix outcome is not a double-grant but a STRANDED request: two valid
+// approvals recorded against a 2-of-N policy, state still pending, and nothing
+// that ever reconciles it (the only sweep over pending requests expires them at
+// their TTL). The threshold silently becomes 3-of-N and a legitimately-approved
+// break-glass grant lapses instead of landing. It fails closed, never open --
+// approval rows are unique per approver and the finalizing caller is by
+// construction not already among them, so distinct approvers at finalize is always
+// len(approvals)+1 >= K -- but availability and the A.5.3/SOX evidence trail both
+// suffer: each racer also emits the same "approval 1 of 2" audit ordinal, and the
+// 2nd is never recorded at all.
+//
+// Two independent replicas (own *gorm.DB, own LocalStorage, own KeyorixCore) share
+// one real Postgres schema, exactly as the #1646 test does, so the per-request
+// WithNamedLock advisory lock is what has to serialize them -- there is no shared
+// in-process mutex left to accidentally paper over the gap.
+func TestConcurrency_ApproveAccessRequestWithExpiry_CrossReplicaPostgres_SubThresholdStraddle(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	setupDB := pgOpen(t, dsn)
+	require.NoError(t, setupDB.AutoMigrate(dualControlModels...))
+	setupStorage := localstore.NewLocalStorage(setupDB)
+	setupCore := NewKeyorixCore(setupStorage)
+	setupCore.SetBootstrapToken("dual-control-straddle-token")
+	setupCore.SetDualControlPolicy(2)
+	ctx := context.Background()
+
+	bootRes, err := setupCore.BootstrapSystem(ctx, &BootstrapRequest{
+		Username: "admin", Email: "admin@example.com", Password: "BootstrapPass123!",
+		DisplayName: "Admin", Token: "dual-control-straddle-token",
+	})
+	require.NoError(t, err)
+	projectID := bootRes.Project.ID
+
+	target, err := setupCore.CreateUser(ctx, &CreateUserRequest{
+		Username: "dcs-target", Email: "dcs-target@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	approverA, err := setupCore.CreateUser(ctx, &CreateUserRequest{
+		Username: "dcs-approver-a", Email: "dcs-approver-a@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	approverB, err := setupCore.CreateUser(ctx, &CreateUserRequest{
+		Username: "dcs-approver-b", Email: "dcs-approver-b@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+
+	// Grant ceiling: each approver must already hold project_viewer's own
+	// permissions at this project to be eligible to approve granting it to someone
+	// else (authz.go). Same fixture requirement as the #1646 race test.
+	viewerRoleForApprovers, err := setupCore.Storage().GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	for _, u := range []*models.User{approverA, approverB} {
+		require.NoError(t, setupCore.Storage().AssignRole(ctx, u.ID, viewerRoleForApprovers.ID, Scope{ProjectID: projectID}))
+	}
+
+	req, err := setupCore.RequestProjectAccess(ctx, projectID, target.ID, "project_viewer", "need read access")
+	require.NoError(t, err)
+
+	// No approval is seeded: the request sits at received=0, required=2. A and B
+	// racing next each independently compute received=1 -- one short of the
+	// threshold -- which is precisely the straddle #1646's seeding skipped.
+	dbA := pgOpen(t, dsn)
+	coreA := NewKeyorixCore(localstore.NewLocalStorage(dbA))
+	coreA.SetDualControlPolicy(2)
+	dbB := pgOpen(t, dsn)
+	coreB := NewKeyorixCore(localstore.NewLocalStorage(dbB))
+	coreB.SetDualControlPolicy(2)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	var errA, errB error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, errA = coreA.ApproveAccessRequestWithExpiry(ctx, projectID, req.ID, approverA.ID, 0, "", 0)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		_, errB = coreB.ApproveAccessRequestWithExpiry(ctx, projectID, req.ID, approverB.ID, 0, "", 0)
+	}()
+	close(start)
+	wg.Wait()
+
+	t.Logf("approver A result: %v", errA)
+	t.Logf("approver B result: %v", errB)
+
+	// Both approvals are legitimate and distinct: neither may be rejected. Under
+	// the lock one records the partial sign-off and the other, reading it, crosses
+	// the threshold and finalizes.
+	require.NoError(t, errA, "approver A's legitimate sign-off was rejected")
+	require.NoError(t, errB, "approver B's legitimate sign-off was rejected")
+
+	// Verify from a fresh connection, independent of either racing replica.
+	verifierDB := pgOpen(t, dsn)
+	verifier := localstore.NewLocalStorage(verifierDB)
+
+	finalReq, err := verifier.GetAccessRequest(ctx, req.ID)
+	require.NoError(t, err)
+	approvals, err := verifier.ListAccessRequestApprovals(ctx, req.ID)
+	require.NoError(t, err)
+	viewerRole, err := verifier.GetRoleByName(ctx, "project_viewer")
+	require.NoError(t, err)
+	grantCount := countUserRoleGrants(t, verifierDB, target.ID, viewerRole.ID, projectID)
+	t.Logf("final state=%s approvals=%d grants=%d", finalReq.State, len(approvals), grantCount)
+
+	// (1) The defect itself: two distinct approvers satisfied a 2-of-N policy, so
+	// the request must be APPROVED. Left pending, it now needs a third approver
+	// policy never asked for and will lapse at its TTL instead of granting.
+	assert.Equal(t, AccessRequestApproved, finalReq.State,
+		"SUB-THRESHOLD STRADDLE: both racers recorded a partial approval and neither crossed the threshold -- a 2-of-N request with 2 distinct approvals is stranded pending, silently requiring a 3rd approver")
+
+	// (2) The grant the approvals authorized must actually be live, exactly once.
+	assert.Equal(t, 1, grantCount,
+		"SUB-THRESHOLD STRADDLE: the target does not hold the granted role exactly once after a fully-approved 2-of-N request")
+
+	// (3) The evidence trail must show exactly the two sign-offs that happened --
+	// no inflation, and no missing K-th record.
+	assert.Equal(t, 2, len(approvals),
+		"SUB-THRESHOLD STRADDLE: the recorded approval count does not match the two distinct sign-offs that occurred")
+}

--- a/internal/core/concurrency_g04_threshold_race_test.go
+++ b/internal/core/concurrency_g04_threshold_race_test.go
@@ -196,10 +196,16 @@ func newDualControlFixture(t *testing.T, dbFile string) (c *core.KeyorixCore, db
 // regression for invitations.go's ApproveAccessRequestWithExpiry: with one
 // approval already recorded and a threshold of 2, two DIFFERENT new approvers
 // racing to cast the second, threshold-crossing sign-off must not both
-// finalize. Without dualControlApprovalMu, both can read the same
-// below-threshold approval count before either's row commits and both
-// finalize — granting the role and recording the approval twice, defeating
-// the "K distinct approvers" guarantee.
+// finalize. Unserialized, both can read the same below-threshold approval count
+// before either's row commits and both finalize — granting the role and
+// recording the approval twice, defeating the "K distinct approvers" guarantee.
+//
+// #G04-HA: the serializing guard is now storage.WithNamedLock keyed per request,
+// not the KeyorixCore-level dualControlApprovalMu this test was written against
+// (that field is gone — it never serialized anything across replicas). Both
+// callers here share one KeyorixCore and one SQLite store, where WithNamedLock
+// is a process mutex, so this in-process assertion is unchanged; the
+// cross-replica half lives in the Postgres tests alongside it.
 func TestConcurrency_ApproveAccessRequestWithExpiry_ThresholdRace(t *testing.T) {
 	const trials = 30
 	for trial := 0; trial < trials; trial++ {
@@ -220,7 +226,7 @@ func TestConcurrency_ApproveAccessRequestWithExpiry_ThresholdRace(t *testing.T) 
 				case err == nil:
 					finalized.Add(1)
 				case strings.Contains(err.Error(), "only a pending request can be approved"):
-					// expected loser outcome: dualControlApprovalMu made this caller
+					// expected loser outcome: the per-request named lock made this caller
 					// re-read the request AFTER the winner's finalize committed, so it
 					// sees the request is no longer pending and gets a clean rejection —
 					// never touching the grant/approval-count logic at all.

--- a/internal/core/invitations.go
+++ b/internal/core/invitations.go
@@ -641,12 +641,64 @@ func (c *KeyorixCore) requiredApprovals() int {
 // threshold the request stays pending and the returned request carries the M-of-K
 // progress. When K is 1 (the default) the first approval grants immediately.
 func (c *KeyorixCore) ApproveAccessRequestWithExpiry(ctx context.Context, projectID, requestID, approverID, approverMachineID uint, grantedRole string, grantTTL time.Duration) (*models.AccessRequest, error) {
-	// #G04: dualControlApprovalMu holds for the whole read-approvals-decide-
-	// grant sequence below — see its doc comment in service.go for why two
-	// approvers racing at the exact threshold boundary can otherwise both
-	// read a below-threshold count and both finalize the grant.
-	c.dualControlApprovalMu.Lock()
-	defer c.dualControlApprovalMu.Unlock()
+	// #G04-HA: the read-approvals-decide-record sequence must be serialized per
+	// REQUEST across every replica, not merely within this process. What #1646
+	// established still holds and is not re-litigated here: two racing
+	// THRESHOLD-CROSSING approvals cannot double-grant (UserRole's composite
+	// primary key makes the loser's AssignUserRole INSERT fail outright, and the
+	// grant deliberately precedes CreateAccessRequestApproval), and one approver
+	// cannot inflate the count by racing themselves (models.AccessRequestApproval's
+	// ux_access_request_approver unique index). Neither constraint covers a pair of
+	// DISTINCT approvers that straddles the K-th approval: both read the same
+	// below-threshold count, both take recordPartialApproval, and — being distinct
+	// approvers granting no role — collide with neither constraint. The request is
+	// then left pending holding K valid approvals, needing a (K+1)-th approver that
+	// policy never asked for, and nothing ever reconciles it: the only sweep over
+	// pending requests expires them at their TTL. A 2-of-N request approved by
+	// exactly two people at the same instant lapses instead of granting.
+	//
+	// It fails CLOSED, never open — approval rows are unique per approver and the
+	// finalizing caller is by construction not already among them, so the distinct
+	// approver count at finalize is always len(approvals)+1 >= K. The cost is
+	// availability (a legitimately-approved break-glass grant that never lands) and
+	// audit fidelity (both racers emit the same "approval M of K" ordinal, and the
+	// K-th is never recorded) — the latter directly undercutting the ISO 27001
+	// A.5.3 / SOX evidence this threshold exists to produce.
+	//
+	// WithNamedLock is #1646's own general-purpose primitive rather than a bespoke
+	// one: a Postgres advisory lock keyed per request, and a process mutex on
+	// SQLite where there is no cross-replica concern. Keying on the request (not a
+	// single global mutex, as dualControlApprovalMu was) also lets approvals of
+	// DIFFERENT requests proceed concurrently, which the mutex it replaces did not.
+	var approved *models.AccessRequest
+	if err := c.storage.WithNamedLock(ctx, dualControlLockKey(requestID), func(ctx context.Context) error {
+		// fn receives the lock-marked ctx and MUST thread it onward: the grant path
+		// below reaches AssignUserRole, which takes its own WithNamedLock on
+		// sodGrantLockKey. Passing a closed-over ctx instead would drop the
+		// reentrancy marker (see store.namedLockHeldCtxKey).
+		res, err := c.approveAccessRequestWithExpiryLocked(ctx, projectID, requestID, approverID, approverMachineID, grantedRole, grantTTL)
+		if err != nil {
+			return err
+		}
+		approved = res
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return approved, nil
+}
+
+// dualControlLockKey names the per-request lock serializing an access request's
+// M-of-K approval sequence across replicas. Mirrors sodGrantLockKey's convention
+// (rbac_management.go): a stable, collision-free string per protected subject.
+func dualControlLockKey(requestID uint) string {
+	return fmt.Sprintf("dual-control-approval:request:%d", requestID)
+}
+
+// approveAccessRequestWithExpiryLocked is ApproveAccessRequestWithExpiry's body,
+// running under the per-request named lock its caller holds. ctx is the
+// lock-marked context and must be used for every downstream call.
+func (c *KeyorixCore) approveAccessRequestWithExpiryLocked(ctx context.Context, projectID, requestID, approverID, approverMachineID uint, grantedRole string, grantTTL time.Duration) (*models.AccessRequest, error) {
 	req, err := c.storage.GetAccessRequest(ctx, requestID)
 	if err != nil {
 		return nil, fmt.Errorf("access request not found")

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -168,18 +168,14 @@ type KeyorixCore struct {
 	// race across independent replicas was live-reproduced with it as the sole
 	// guard. See access_review_campaign.go.
 	accessReviewDecisionMu sync.Mutex
-	// dualControlApprovalMu serializes ApproveAccessRequestWithExpiry's
-	// read-approvals-decide-grant sequence in-process (#G04). #1646: reproduced
-	// live across independent replicas (concurrency_dual_control_approval_
-	// postgres_test.go) before deciding whether this needed a DB-level fix like
-	// sodGrantMu's replacement got — it did not: UserRole's composite primary key
-	// (UserID, RoleID, ProjectID, EnvironmentID) already makes the threshold race
-	// structurally impossible (dual control always targets one locked-in role for
-	// the same principal, so two racing finalizers always collide on that exact
-	// key; the loser's grant INSERT fails outright, before it ever records an
-	// extra approval or leaves a live double-grant). This mutex is kept as-is,
-	// unmodified. Zero value is ready to use. See invitations.go.
-	dualControlApprovalMu sync.Mutex
+	// (#G04-HA) dualControlApprovalMu used to serialize
+	// ApproveAccessRequestWithExpiry's read-approvals-decide-grant sequence
+	// in-process. It is gone: a KeyorixCore-level mutex never serialized anything
+	// across replicas, and the sub-threshold straddle it failed to prevent is a
+	// real defect (see ApproveAccessRequestWithExpiry's doc comment). That sequence
+	// now runs under storage.WithNamedLock keyed per request — strictly stronger
+	// cross-replica, and strictly more concurrent in-process, since distinct
+	// requests no longer serialize against one another. Nothing replaces the field.
 	// rateLimitUnsupportedWarnOnce guards the #452 operator warning logged the
 	// first time IsLoginRateLimited/IsPasswordResetRateLimited observe that the
 	// active storage backend can never satisfy CountRecentLoginAttempts (as

--- a/server/http/permission_sweep_test.go
+++ b/server/http/permission_sweep_test.go
@@ -54,35 +54,35 @@ import (
 // implementation) to confirm it returns no cross-tenant/cross-user disclosure that
 // system.read's universal grant would expose.
 var permissionSweepAllowlist = map[string]string{
-	"server/http/router.go:381": "GET /notification-channels/{id}/retry-policy returns only " +
+	"server/http/router.go:388": "GET /notification-channels/{id}/retry-policy returns only " +
 		"max_retries/retry_backoff_ms for one channel ID -- numeric tuning knobs, no secret " +
 		"values, no PII, no cross-tenant project/user enumeration. Weaker than the parent " +
 		"resource's own read (system.write), a pre-existing minor inconsistency, but not the " +
 		"cross-tenant-disclosure bug shape this sweep guards against.",
-	"server/http/router.go:404": "GET /dashboard/stats is the caller's OWN home dashboard. " +
+	"server/http/router.go:411": "GET /dashboard/stats is the caller's OWN home dashboard. " +
 		"core.GetDashboardStats (internal/core/dashboard.go) separately scopes the " +
 		"deployment-wide aggregate fields (active users, audit-event counts, failed-auth " +
 		"counts) to audit.read INSIDE the handler -- a baseline caller gets their own numbers " +
 		"with the org-wide aggregates zeroed, not the real deployment-wide figures. See " +
 		"TestDashboardStats_PermissionTiers in deployment_disclosure_family_test.go.",
-	"server/http/router.go:414": "GET /system/auth-config returns a deliberately redacted, " +
+	"server/http/router.go:421": "GET /system/auth-config returns a deliberately redacted, " +
 		"non-per-tenant summary of server-wide auth config (session TTLs, password policy " +
 		"shape, SSO provider names/types). No secrets (client secrets/SAML metadata/OIDC " +
 		"details excluded by MakeAuthConfigHandler's own doc comment), no per-user or " +
 		"per-project data to disclose cross-tenant.",
-	"server/http/router.go:415": "GET /system/encryption-config returns a deliberately " +
+	"server/http/router.go:422": "GET /system/encryption-config returns a deliberately " +
 		"redacted, non-per-tenant summary (encryption enabled + KEK provider TYPE only). Key " +
 		"material locations (file paths, exec commands, env var names, KMS key IDs) are " +
 		"explicitly excluded by MakeEncryptionConfigHandler's own doc comment.",
-	"server/http/router.go:422": "GET /system/info returns server version/build/runtime info " +
+	"server/http/router.go:429": "GET /system/info returns server version/build/runtime info " +
 		"(no per-tenant data) -- the same deployment-wide, non-disclosure-sensitive shape as " +
 		"auth-config/encryption-config above.",
-	"server/http/router.go:423": "GET /system/metrics returns process-level runtime metrics " +
+	"server/http/router.go:430": "GET /system/metrics returns process-level runtime metrics " +
 		"(memory/GC/goroutines) with HTTP/Database/Secrets counters explicitly zeroed (not " +
 		"instrumented at this layer per GetMetrics's own comment) -- no per-tenant data.",
-	"server/http/router.go:1067": "GET /audit/anomalies sits inside r.Route(\"/audit\", ...) " +
+	"server/http/router.go:1074": "GET /audit/anomalies sits inside r.Route(\"/audit\", ...) " +
 		"which calls r.Use(RequirePermission(permAuditRead)) as a GROUP-level middleware " +
-		"(router.go:1044). chi's With() on a route registered inside that group ADDS to, " +
+		"(router.go:1056). chi's With() on a route registered inside that group ADDS to, " +
 		"never replaces, the group's Use() middleware (verified against go-chi/chi/v5's " +
 		"Mux.With/Route/handle: the group's non-inline Mux builds its own handler chain via " +
 		"updateRouteHandler, and every route registered inside it -- inline or not -- is " +
@@ -90,18 +90,18 @@ var permissionSweepAllowlist = map[string]string{
 		"audit.read AND system.read (AND, not OR) -- effectively gated at audit.read, the " +
 		"stronger requirement, exactly as router.go's own ANOMALY-04 comment there intends. " +
 		"Not a case of \"solely permSystemRead\" despite the literal string match.",
-	"server/http/router.go:2074": "GET /license/status returns deployment-wide license " +
+	"server/http/router.go:2081": "GET /license/status returns deployment-wide license " +
 		"metadata (plan/features/seat count/expiry) -- not scoped to any tenant/project/user, " +
 		"nothing to cross-tenant-disclose.",
-	"server/http/router.go:2170": "GET /sod/policies returns policy DEFINITIONS (name + the " +
+	"server/http/router.go:2177": "GET /sod/policies returns policy DEFINITIONS (name + the " +
 		"permission-a/permission-b pair) only -- no PII, no violator names. router.go's own " +
 		"adjacent comment is explicit that this stays baseline while /sod/violations (which " +
 		"DOES disclose violator names/emails) is separately gated on audit.read.",
-	"server/http/router.go:2217": "GET /admin/anomaly-config returns the DB-persisted anomaly " +
+	"server/http/router.go:2224": "GET /admin/anomaly-config returns the DB-persisted anomaly " +
 		"detection THRESHOLDS (config), not any user/project/alert data -- deployment-wide " +
 		"config in the same non-disclosure-sensitive family as auth-config/encryption-config " +
 		"above. Actual alert data (which does disclose SecretName/AccessedBy/IPAddress " +
-		"deployment-wide) is the separate /audit/anomalies route (line 1062 above), already " +
+		"deployment-wide) is the separate /audit/anomalies route (line 1074 above), already " +
 		"gated at effective audit.read.",
 }
 
@@ -421,8 +421,8 @@ var noPermissionGateAllowlist = map[string]string{
 	"server/http/router.go:240":  justPublicInfra + " /metrics is Prometheus scrape target; optionally protected by a separate static-bearer-token check (cfg.Server.HTTP.MetricsToken) when configured -- a deployment-perimeter control, not RBAC.",
 	"server/http/router.go:243":  justPublicInfra + " GET /status serves the public status dashboard (or falls back to the health check).",
 	"server/http/router.go:259":  justPublicInfra + " GET /status-es is the Spanish-language mirror of /status immediately above.",
-	"server/http/router.go:2228": justPublicInfra + " Swagger UI is gated by cfg.Server.HTTP.SwaggerEnabled (a deployment config flag, not a per-caller permission) -- see the adjacent comment; the machine-readable API surface it exposes is the same shape /openapi.yaml exposes below.",
-	"server/http/router.go:2229": justPublicInfra + " GET /openapi.yaml is the raw OpenAPI spec, gated by the same cfg.Server.HTTP.SwaggerEnabled flag as the Swagger UI immediately above (#224 fixed the two having diverging on/off behavior; they must stay paired).",
+	"server/http/router.go:2235": justPublicInfra + " Swagger UI is gated by cfg.Server.HTTP.SwaggerEnabled (a deployment config flag, not a per-caller permission) -- see the adjacent comment; the machine-readable API surface it exposes is the same shape /openapi.yaml exposes below.",
+	"server/http/router.go:2236": justPublicInfra + " GET /openapi.yaml is the raw OpenAPI spec, gated by the same cfg.Server.HTTP.SwaggerEnabled flag as the Swagger UI immediately above (#224 fixed the two having diverging on/off behavior; they must stay paired).",
 
 	"server/http/router.go:330": justSelfServiceOwnAccount + " GET/PUT /auth/profile.",
 	"server/http/router.go:331": justSelfServiceOwnAccount + " GET/PUT /auth/profile.",
@@ -437,28 +437,30 @@ var noPermissionGateAllowlist = map[string]string{
 	"server/http/router.go:349": justSelfServiceOwnAccount + " POST webauthn/register/finish completes the same ceremony as register/begin above.",
 	"server/http/router.go:350": justSelfServiceOwnAccount + " GET webauthn/credentials lists only the caller's OWN passkeys.",
 	"server/http/router.go:355": justSelfServiceOwnAccount + " DELETE webauthn/credentials/{id} deletes only the caller's OWN passkey (there is no admin API to remove another user's passkey); same impersonation block, since deleting the last passkey is the same durable MFA-downgrade /auth/mfa/disable is blocked from doing.",
-	"server/http/router.go:356": justSelfServiceOwnAccount + " GET /auth/sessions lists only the caller's OWN sessions.",
-	"server/http/router.go:357": justSelfServiceOwnAccount + " DELETE /auth/sessions/{id} revokes only one of the caller's OWN sessions.",
-	"server/http/router.go:358": justSelfServiceOwnAccount + " GET /auth/tokens lists only the caller's OWN PATs.",
-	"server/http/router.go:361": justSelfServiceOwnAccount + " POST /auth/tokens mints a PAT for the caller's OWN account; blocked under impersonation so an admin acting as a user cannot plant a durable token.",
-	"server/http/router.go:362": justSelfServiceOwnAccount + " DELETE /auth/tokens/{id} revokes only one of the caller's OWN PATs.",
-	"server/http/router.go:364": justSelfServiceOwnAccount + " GET tokens/expired lists only the caller's OWN expired PATs.",
-	"server/http/router.go:365": justSelfServiceOwnAccount + " DELETE tokens/expired bulk-revokes only the caller's OWN expired PATs.",
-	"server/http/router.go:367": justSelfServiceOwnAccount + " POST /auth/end-impersonation ends only the CALLER'S OWN impersonation session.",
-	"server/http/router.go:370": justSelfServiceOwnAccount + " GET /notifications lists only the caller's OWN in-app notifications (ADR-024).",
-	"server/http/router.go:371": justSelfServiceOwnAccount + " POST notifications/read-all marks only the caller's OWN notifications read.",
-	"server/http/router.go:372": justSelfServiceOwnAccount + " POST notifications/{id}/read marks one of the caller's OWN notifications read.",
+	"server/http/router.go:361": justSelfServiceOwnAccount + " POST /auth/webauthn/reauth/begin starts a live passkey re-assertion for the caller's OWN account (the WebAuthn-only path to satisfy requireReauth); same impersonation block as the other WebAuthn/MFA self-service routes.",
+	"server/http/router.go:362": justSelfServiceOwnAccount + " POST /auth/webauthn/reauth/finish completes the same ceremony as reauth/begin immediately above.",
+	"server/http/router.go:363": justSelfServiceOwnAccount + " GET /auth/sessions lists only the caller's OWN sessions.",
+	"server/http/router.go:364": justSelfServiceOwnAccount + " DELETE /auth/sessions/{id} revokes only one of the caller's OWN sessions.",
+	"server/http/router.go:365": justSelfServiceOwnAccount + " GET /auth/tokens lists only the caller's OWN PATs.",
+	"server/http/router.go:368": justSelfServiceOwnAccount + " POST /auth/tokens mints a PAT for the caller's OWN account; blocked under impersonation so an admin acting as a user cannot plant a durable token.",
+	"server/http/router.go:369": justSelfServiceOwnAccount + " DELETE /auth/tokens/{id} revokes only one of the caller's OWN PATs.",
+	"server/http/router.go:371": justSelfServiceOwnAccount + " GET tokens/expired lists only the caller's OWN expired PATs.",
+	"server/http/router.go:372": justSelfServiceOwnAccount + " DELETE tokens/expired bulk-revokes only the caller's OWN expired PATs.",
+	"server/http/router.go:374": justSelfServiceOwnAccount + " POST /auth/end-impersonation ends only the CALLER'S OWN impersonation session.",
+	"server/http/router.go:377": justSelfServiceOwnAccount + " GET /notifications lists only the caller's OWN in-app notifications (ADR-024).",
+	"server/http/router.go:378": justSelfServiceOwnAccount + " POST notifications/read-all marks only the caller's OWN notifications read.",
+	"server/http/router.go:379": justSelfServiceOwnAccount + " POST notifications/{id}/read marks one of the caller's OWN notifications read.",
 
-	"server/http/router.go:499": "Self-service (ADR-024): POST /projects/{id}/access-requests lets an " +
+	"server/http/router.go:506": "Self-service (ADR-024): POST /projects/{id}/access-requests lets an " +
 		"authenticated user request access to a project THEY DO NOT YET HAVE -- by definition they " +
 		"cannot hold a project-scoped permission on it yet, so no permission check can gate the " +
 		"request itself (core.RequestProjectAccess scopes the created row to the caller's own " +
 		"user ID). See router.go's own adjacent comment (\"requesting + withdrawing are self-" +
 		"service\") and handlers/invitations.go's CreateAccessRequest.",
-	"server/http/router.go:501": "Self-service (ADR-024): POST access-requests/{requestId}/withdraw withdraws " +
+	"server/http/router.go:508": "Self-service (ADR-024): POST access-requests/{requestId}/withdraw withdraws " +
 		"only the CALLER'S OWN pending request (core.WithdrawAccessRequest scopes to the requester). " +
 		"Same reasoning as CreateAccessRequest immediately above.",
-	"server/http/router.go:517": "Self-service by design: POST /projects/{id}/break-glass activates " +
+	"server/http/router.go:524": "Self-service by design: POST /projects/{id}/break-glass activates " +
 		"emergency access the caller currently LACKS -- the entire point of break-glass is bypassing " +
 		"the normal grant path, so gating it on a permission would defeat its purpose. Controlled " +
 		"instead by deployment config + a mandatory justification + full audit trail + automatic " +
@@ -466,36 +468,36 @@ var noPermissionGateAllowlist = map[string]string{
 		"so an admin acting as a user cannot mint a durable emergency role grant attributed to the " +
 		"target. See router.go's own adjacent comment.",
 
-	"server/http/router.go:615": "GET /secrets (ListSecrets) performs its own authorization INSIDE the " +
+	"server/http/router.go:622": "GET /secrets (ListSecrets) performs its own authorization INSIDE the " +
 		"handler so a project-scoped reader gets the union of their accessible scopes rather than a " +
 		"403 on an unfiltered request -- see router.go's own adjacent comment and secrets_list.go. " +
 		"An unscoped/no-permission caller still only ever sees the empty-or-narrowed result their " +
 		"own scopes permit, never another caller's secrets.",
-	"server/http/router.go:617": "GET /secrets/policy returns the deployment's ACTIVE create-time naming/" +
+	"server/http/router.go:624": "GET /secrets/policy returns the deployment's ACTIVE create-time naming/" +
 		"value policy -- deployment-wide, non-per-tenant configuration every authenticated caller " +
 		"needs visibility into before they can even attempt a create (the same policy a create " +
 		"request would be validated against). No secret values, no per-tenant data. See router.go's " +
 		"own adjacent comment (\"any authenticated caller\").",
-	"server/http/router.go:711": "POST /secrets (CreateSecret) is authorized INSIDE the handler: scope " +
+	"server/http/router.go:718": "POST /secrets (CreateSecret) is authorized INSIDE the handler: scope " +
 		"(project/environment) comes from the request body, not a URL path param a scope resolver " +
 		"middleware could resolve ahead of the handler. See router.go's own adjacent comment " +
 		"(\"Create: authorized inside the handler (scope comes from the body)\").",
-	"server/http/router.go:732": "DELETE /secrets/{id}/self-share (RemoveSelfFromShare) removes only the " +
+	"server/http/router.go:739": "DELETE /secrets/{id}/self-share (RemoveSelfFromShare) removes only the " +
 		"CALLER'S OWN direct share (core only removes a share whose RecipientID == the caller) -- " +
 		"self-service on the caller's own grant, needs just authentication. See router.go's own " +
 		"adjacent comment.",
-	"server/http/router.go:757": "POST /folders (CreateFolder) is authorized INSIDE the handler: scope " +
+	"server/http/router.go:764": "POST /folders (CreateFolder) is authorized INSIDE the handler: scope " +
 		"comes from the request body, the same in-handler-authorization pattern as CreateSecret " +
 		"above. See router.go's own adjacent comment (\"Create authorizes in-handler (scope from the " +
 		"body)\").",
-	"server/http/router.go:779": "POST /rotation-policies (Create) is authorized INSIDE the handler: scope " +
+	"server/http/router.go:786": "POST /rotation-policies (Create) is authorized INSIDE the handler: scope " +
 		"comes from the request body, the same in-handler pattern as CreateSecret/CreateFolder above. " +
 		"See router.go's own adjacent comment (\"create authorizes in-handler against the body\").",
-	"server/http/router.go:808": "POST /dynamic-secrets/configs (CreateConfig) is authorized INSIDE the " +
+	"server/http/router.go:815": "POST /dynamic-secrets/configs (CreateConfig) is authorized INSIDE the " +
 		"handler -- traced to the actual code, not just the group's header comment: " +
 		"DynamicSecretHandler.CreateConfig (server/http/handlers/dynamic_secrets.go) calls " +
 		"h.authorize(r, permSecretsWrite, scope) itself before creating the config.",
-	"server/http/router.go:809": "GET /dynamic-secrets/configs (ListConfigs) is authorized INSIDE the " +
+	"server/http/router.go:816": "GET /dynamic-secrets/configs (ListConfigs) is authorized INSIDE the " +
 		"handler -- traced to the actual code: DynamicSecretHandler.ListConfigs " +
 		"(server/http/handlers/dynamic_secrets.go) calls h.authorize(r, permSecretsRead, " +
 		"core.Scope{ProjectID: projectID, EnvironmentID: environmentID}) itself before listing.",


### PR DESCRIPTION
## Summary

Supersedes #1773. `ApproveAccessRequestWithExpiry`'s read-approvals-decide-record
sequence was serialized only by `dualControlApprovalMu`, a `*KeyorixCore`-level
`sync.Mutex` — so two replicas of an HA deployment were never serialized against
each other at all.

**What #1646 established still holds and is not re-litigated here.** Verified
against the code, not assumed:

- **Double-grant at the threshold — impossible.** `assignUserRole`
  (`local_rbac.go`) reads the composite key inside a transaction and returns
  `ErrorRoleAlreadyAssigned` for any live row, and
  `finalizeAccessRequestApproval` grants *before* recording the approval, so the
  losing racer aborts leaving neither a grant nor an approval row.
- **Same-approver count inflation — impossible.** Though the real backstop is not
  `UserRole`'s primary key, as #1646's comment says: it is the unique index
  `ux_access_request_approver` on `(RequestID, ApproverID,
  ApproverMachineIdentityID)` (`models.go`), whose own doc comment names itself
  as the M-of-K race backstop.

## The gap neither constraint covers

A pair of **distinct** approvers that **straddles** the K-th approval.

K=2, no prior approvals, two approvers on two replicas at the same instant. Both
read `approvals=[]`, both compute `received = 1 < 2`, and both take
`recordPartialApproval`. They are distinct approvers, so
`ux_access_request_approver` never fires; they grant no role, so `UserRole`'s
primary key is never consulted. Neither guard sees anything.

The request is left `pending` holding K valid approvals, silently requiring a
(K+1)-th approver, and nothing reconciles it: the only sweep over pending
requests (`invitations.go`, `compliance_posture.go`) expires them at their TTL. A
2-of-N request approved by exactly two people at the same instant lapses instead
of granting.

#1646's own race test hides this variant — it seeds one approval first, so both
racers cross the threshold and both reach `AssignUserRole`, where the composite
primary key resolves things structurally.

**It fails closed, never open.** Approval rows are unique per approver and the
finalizing caller is by construction not already among them, so the distinct
approver count at finalize is always `len(approvals)+1 >= K`. No escalation, no
under-approval. The costs are availability (a legitimately-approved break-glass
grant that never lands) and audit fidelity — both racers emit the same
`"approval M of K"` ordinal from their stale count and the K-th is never
recorded, which undercuts the ISO 27001 A.5.3 / SOX evidence the threshold exists
to produce.

HA-only: `dualControlApprovalMu` handled the single-replica case correctly.

## Fix

- The sequence now runs under `storage.WithNamedLock(dualControlLockKey(requestID), …)`
  — #1646's own general-purpose primitive, **not** a new bespoke one (#1773 added
  `WithDualControlApprovalLock`; that is dropped).
- `dualControlApprovalMu` is **removed** rather than kept as a redundant
  in-process fast path. Keying per request also lets approvals of *different*
  requests proceed concurrently, which the single global mutex did not.
- The lock-marked ctx is threaded through `approveAccessRequestWithExpiryLocked`
  so `AssignUserRole`'s nested `WithNamedLock(sodGrantLockKey(...))` keeps its
  reentrancy marker (`store.namedLockHeldCtxKey`).

`ApproveSecretAccessRequest` (`classification_gate.go`) is single-approver with no
M-of-K threshold — out of scope.

## Regression test

`internal/core/concurrency_dual_control_subthreshold_postgres_test.go`
(`KEYORIX_TEST_PG_DSN`-gated, same CI wiring as the existing cross-replica tests).
Two independent replicas — own `*gorm.DB`, own `LocalStorage`, own `KeyorixCore` —
into one real Postgres schema, racing the two approvals of a 2-of-N request with
**no seeded prior approval**, so they straddle rather than cross. Asserts the
request ends `approved`, the grant is live exactly once, and exactly two approval
rows exist.

Also corrects the scope note on #1646's test so its conclusion is not read as
covering dual control as a whole — that misreading is what let this variant sit.

## Test plan

- [x] `gofmt` clean, `go vet ./internal/core/...` clean, `go build ./...` clean
- [x] `internal/core` full package green (Go 1.27)
- [x] `internal/core/storage`, `internal/storage`, `models`, `remote`,
      `sqlitedialect` green
- [ ] New cross-replica test against a real Postgres — **not yet run**, no
      `KEYORIX_TEST_PG_DSN` available in this environment. Needs CI or a local
      run before merge.

## Follow-up, not in this PR

#1773's design note argued for one lock per *mechanism* rather than per
*principal*, on the grounds that "a group-role grant affecting a member still
serializes against that member's own concurrent direct grant." That objection
looks correct and unaddressed for SoD: `AssignRoleToGroup` locks
`sodGrantLockKey("group", groupID)` while `requireGroupGrantNoSoDViolation`
(`sod.go`) evaluates each *member's* held permissions, and `AssignUserRole` locks
`sodGrantLockKey("user", userID)` — different keys, no serialization, so two
replicas can grant the two halves of a toxic pair through the group edge and the
direct edge concurrently. Postgres-only (on SQLite `WithNamedLock` is one shared
process mutex). Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183ovoDXdSZQai5J3UZQFjG
