### PR TITLE
docs(tooling): land the ADR-100 memory-measurement harness

### DIFF
--- a/scripts/memory-measurement/README.md
+++ b/scripts/memory-measurement/README.md
@@ -1,0 +1,105 @@
+# Memory-measurement harness
+
+Regenerates the measurement tables in
+[`docs/adr-100-mlockall-removal-deployment-swap-control.md`](../../docs/adr-100-mlockall-removal-deployment-swap-control.md)
+against a real `keyorix-server` binary in a real container, driven by real
+HTTP calls — not synthetic in-process allocation, and not hand-maintained
+prose. Built because the original measurement pass existed only as commands
+run once in a session transcript; the numbers could not be regenerated or
+independently checked without redoing that work from scratch.
+
+## What this covers
+
+Four scenario shapes, defined as data in [`scenarios.tsv`](scenarios.tsv),
+not hardcoded per-scenario Python:
+
+- **`create_burst`** — create N secrets of a given size at a given client
+  concurrency. Used for both the secret-count axis (concurrency held at 1)
+  and the concurrency axis (count/size held fixed) — see ADR-100's
+  "Concurrency is the dominant driver, not count" finding.
+- **`bulk_endpoint`** — hit one HTTP endpoint (paginated list, the unbounded
+  deployment-wide CSV inventory export, the capped audit-log CSV export) at
+  whatever secret count the store currently holds.
+- **`oom_check`** — replay a burst against a container capped with
+  `docker run --memory`, matching a specific `values.yaml` limit, and check
+  `docker inspect .State.OOMKilled` afterward.
+- **`sustained`** — mixed create/list/read load at fixed concurrency for a
+  fixed wall-clock duration, sampling `/proc/<pid>/status` periodically to
+  show whether resident memory plateaus or keeps climbing.
+
+Add a new scenario by adding a row to `scenarios.tsv`; `matrix_runner.py`
+does not need to change unless the new scenario needs a genuinely new
+*kind* of orchestration (see the file's own header comment for the column
+schema).
+
+## Running it
+
+```
+python3 scripts/memory-measurement/matrix_runner.py
+```
+
+Requires `docker` on `PATH` and enough free disk/memory to build and run the
+real `server/Dockerfile` image locally. Run from anywhere inside the repo —
+the repo root is resolved via `git rev-parse --show-toplevel`.
+
+- `--out results.md` — write the generated table to a file instead of
+  stdout.
+- `--only id1,id2` — run a subset of `scenarios.tsv`'s rows (by `id` column)
+  instead of the full matrix, useful while iterating on the harness itself
+  or re-checking one specific finding.
+- `--skip-build` — reuse an already-built `keyorix-server-memory-measurement`
+  image instead of rebuilding.
+
+**The full default matrix takes over 30 minutes** — the `sustained-25` row
+alone is a real 30-minute wall-clock pass by design (that duration is the
+point: a shorter run would not have shown the climb ADR-100 documents). Use
+`--only` for anything shorter while developing.
+
+Output is Markdown, formatted to paste directly into ADR-100 (or any other
+doc) as a replacement for a stale table — this is meant to make "regenerate
+the numbers" a single command, not a research project.
+
+## Portability — these numbers are not absolute
+
+Every number this harness produces is tied to the host and container
+runtime that produced it, same as ADR-100 states for the original pass:
+
+- **Container CPU architecture and runtime.** The baseline numbers currently
+  in ADR-100 were produced on **OrbStack** (`linux/aarch64`), not stock
+  Docker Desktop, not bare metal, and not the `linux/amd64` architecture the
+  shipped `ghcr.io/keyorixhq/keyorix-server` image and most production
+  Kubernetes nodes actually run. Re-running this harness on a different
+  runtime/architecture will produce different absolute numbers — the
+  *shape* of the findings (concurrency dominates over row count, sustained
+  load doesn't plateau within 30 minutes, a 512Mi cap gets OOM-killed under
+  a large concurrent burst) is expected to reproduce; the exact kB figures
+  are not.
+- **Host CPU/memory pressure from anything else running at measurement
+  time** — this harness makes no attempt to pin CPU, disable other
+  processes, or otherwise isolate the measurement host. Treat absolute
+  numbers as directional unless re-measured on a quiet, dedicated machine.
+- **SQLite is the default storage backend measured here.** The `oom_check`
+  and `sustained` scenarios' findings (SQLite write-lock contention, WAL
+  growth under concurrent load) are specific to the shipped default
+  (`storage.type: local`); they do not apply to a Postgres-backed
+  deployment, which was out of scope for this harness's first pass.
+
+## Not wired into CI
+
+This is a long-running manual harness (see "Running it" above), not a
+per-PR or even nightly check — the sustained scenario alone would blow any
+reasonable CI job budget on its own, the same tradeoff this repo already
+makes for `scripts/fuzzing/` and `scripts/mutation-testing/` (continuous,
+dedicated-box tooling for a similar reason: too slow for CI, too valuable to
+skip). Unlike those two, this harness doesn't need a dedicated always-on
+box — it's meant to be run by hand before a `values.yaml` resource-sizing
+decision, not continuously.
+
+**Follow-up, not done here:** if this needs to run on a schedule later (e.g.
+after every resource-sizing-relevant change, or monthly to catch drift),
+this repo already has the `workflow_dispatch` (manual trigger from the
+Actions tab) pattern established in `.github/workflows/dast.yml` and
+`.github/workflows/mis-based-merge-detector.yml` — a
+`workflow_dispatch`-triggered job wrapping `matrix_runner.py` would fit that
+existing convention. Not added in this pass, since nothing here requires it
+yet and an unused workflow is one more thing to keep working.

--- a/scripts/memory-measurement/container_env.py
+++ b/scripts/memory-measurement/container_env.py
@@ -1,0 +1,174 @@
+"""container_env.py — build/run/reset the real keyorix-server container this
+harness measures against, matching server/Dockerfile and the shipped Helm
+chart's default storage backend (SQLite, config.storage.type: local).
+
+Every measurement this harness produces depends on the container runtime's
+own resource-accounting behavior (see README.md's Portability section) --
+this module exists to make that setup reproducible, not to hide it.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+
+IMAGE_TAG = "keyorix-server-memory-measurement"
+
+_KEYORIX_YAML = """\
+storage:
+  type: local
+  database:
+    path: data/keyorix.db
+  encryption:
+    enabled: true
+    dek_path: keys/dek.key
+    salt_path: keys/kek.salt
+server:
+  http:
+    enabled: true
+    port: 8080
+locale:
+  language: en
+  fallback_language: en
+"""
+
+ADMIN_PASSWORD = "Zk9-Repro-Harness-Bootstrap"  # policy: upper+digit, and must not overlap username/email/display name
+MASTER_PASSWORD = "measurement-harness-master-pass"
+BOOTSTRAP_TOKEN = "measurement-harness-bootstrap-token"
+
+
+def repo_root() -> str:
+    out = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True)
+    return out.strip()
+
+
+def build_image():
+    root = repo_root()
+    subprocess.run(
+        ["docker", "build", "-t", IMAGE_TAG, "-f", os.path.join(root, "server", "Dockerfile"), root],
+        check=True,
+    )
+
+
+class Workdir:
+    """A fresh keys/+data/ + keyorix.yaml on disk, torn down on exit."""
+
+    def __init__(self):
+        self.path = tempfile.mkdtemp(prefix="keyorix-memory-measurement-")
+        os.makedirs(os.path.join(self.path, "keys"), exist_ok=True)
+        os.makedirs(os.path.join(self.path, "data"), exist_ok=True)
+        with open(os.path.join(self.path, "keyorix.yaml"), "w") as f:
+            f.write(_KEYORIX_YAML)
+
+    def reset_data(self):
+        """Wipe the DB/key material so the next container boots fresh,
+        without tearing down and recreating the whole temp directory."""
+        for sub in ("keys", "data"):
+            d = os.path.join(self.path, sub)
+            shutil.rmtree(d)
+            os.makedirs(d)
+
+    def cleanup(self):
+        shutil.rmtree(self.path, ignore_errors=True)
+
+
+def run_container(name: str, workdir: Workdir, host_port: int, memory_cap: str = None,
+                   with_admin_bootstrap: bool = True) -> None:
+    """Start a fresh container named `name`, publishing host_port -> 8080.
+    memory_cap, if given, is passed straight to `docker run --memory`
+    (e.g. "512m")."""
+    subprocess.run(["docker", "rm", "-f", name], check=False, capture_output=True)
+    # `docker rm -f` returning doesn't guarantee the host port it held is
+    # immediately rebindable -- back-to-back oom_check/sustained scenarios
+    # reusing the same name+port in quick succession (as the matrix runner
+    # does) intermittently failed to become healthy within their boot
+    # timeout, traced to exactly this: the new container starts, but its
+    # publish binding races the just-removed container's own teardown. A
+    # short, fixed settle avoids the race without needing to detect it.
+    time.sleep(3)
+    cmd = [
+        "docker", "run", "-d", "--name", name,
+        "-v", f"{workdir.path}/keyorix.yaml:/app/keyorix.yaml:ro",
+        "-v", f"{workdir.path}/keys:/app/keys",
+        "-v", f"{workdir.path}/data:/app/data",
+        "-e", f"KEYORIX_MASTER_PASSWORD={MASTER_PASSWORD}",
+        "-p", f"{host_port}:8080",
+    ]
+    if with_admin_bootstrap:
+        cmd += [
+            "-e", f"KEYORIX_ADMIN_PASSWORD={ADMIN_PASSWORD}",
+            "-e", f"KEYORIX_BOOTSTRAP_TOKEN={BOOTSTRAP_TOKEN}",
+        ]
+    if memory_cap:
+        cmd += ["--memory", memory_cap]
+    cmd.append(IMAGE_TAG)
+    subprocess.run(cmd, check=True, capture_output=True)
+
+
+def wait_healthy(base_url: str, container: str = None, timeout_s: int = 60):
+    import urllib.request
+    deadline = time.time() + timeout_s
+    last_err = None
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(base_url + "/health", timeout=2)
+            return
+        except Exception as e:
+            last_err = e
+            # If the container itself already exited, waiting out the rest
+            # of timeout_s just to report the same network error is
+            # pointless -- fail immediately with the real reason (crash,
+            # or OOM-killed before ever becoming healthy) instead.
+            if container is not None:
+                try:
+                    running = subprocess.check_output(
+                        ["docker", "inspect", "-f", "{{.State.Running}}", container], text=True
+                    ).strip()
+                    if running != "true":
+                        exit_code = subprocess.check_output(
+                            ["docker", "inspect", "-f", "{{.State.ExitCode}}", container], text=True
+                        ).strip()
+                        oom = subprocess.check_output(
+                            ["docker", "inspect", "-f", "{{.State.OOMKilled}}", container], text=True
+                        ).strip()
+                        raise RuntimeError(
+                            f"container {container} exited before becoming healthy "
+                            f"(exit code {exit_code}, OOMKilled={oom}): {e}"
+                        )
+                except subprocess.CalledProcessError:
+                    pass  # container may not exist yet this early -- keep polling
+            time.sleep(1)
+    raise TimeoutError(f"server never became healthy within {timeout_s}s: {last_err}")
+
+
+def wait_admin_ready(client, max_attempts: int = 4, retry_delay_s: int = 3) -> str:
+    """/health passing only means the HTTP listener is up -- entrypoint.sh's
+    admin-bootstrap POST /system/init runs AFTER that, asynchronously, so a
+    login attempted immediately after wait_healthy() can 401 against an
+    admin user that doesn't exist yet.
+
+    Deliberately NOT a tight retry-until-timeout poll: the login endpoint
+    has per-account brute-force lockout (max_attempts=5 within a 15-minute
+    window, server default), and a 1s-interval poll blows through that
+    budget in 5 seconds flat, triggering a 429 that then locks this
+    harness out of its own freshly-booted container for 15 minutes. A small
+    number of attempts spaced 3s apart comfortably covers the real
+    bootstrap latency (observed ~250-550ms in this harness's own manual
+    predecessor) while staying well under the lockout threshold."""
+    last_err = None
+    for _ in range(max_attempts):
+        try:
+            return client.login("admin", ADMIN_PASSWORD)
+        except Exception as e:
+            last_err = e
+            time.sleep(retry_delay_s)
+    raise TimeoutError(f"admin login never succeeded after {max_attempts} attempts: {last_err}")
+
+
+def remove_container(name: str):
+    subprocess.run(["docker", "rm", "-f", name], check=False, capture_output=True)
+
+
+def remove_image():
+    subprocess.run(["docker", "rmi", IMAGE_TAG], check=False, capture_output=True)

--- a/scripts/memory-measurement/load_driver.py
+++ b/scripts/memory-measurement/load_driver.py
@@ -1,0 +1,139 @@
+"""load_driver.py — real HTTP load generation against a running keyorix-server
+container, for scripts/memory-measurement/matrix_runner.py. No synthetic
+in-process allocation anywhere here: every scenario drives the actual
+/auth/login, POST /api/v1/secrets, and GET endpoints a real client would
+call, matching the methodology in
+docs/adr-100-mlockall-removal-deployment-swap-control.md.
+
+Stdlib only (urllib, concurrent.futures) -- no third-party dependency for a
+harness whose whole point is measuring the server's own footprint, not
+adding one of its own.
+"""
+
+import base64
+import concurrent.futures
+import json
+import random
+import time
+import urllib.error
+import urllib.request
+
+
+class Client:
+    def __init__(self, base_url: str):
+        self.base_url = base_url
+
+    def _call(self, method: str, path: str, token: str = None, body: dict = None) -> bytes:
+        url = self.base_url + path
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.read()
+
+    def login(self, username: str, password: str) -> str:
+        body = json.loads(self._call("POST", "/auth/login", body={"username": username, "password": password}))
+        return body["data"]["token"]
+
+    def create_secret(self, token: str, name: str, size_bytes: int, project_id: int = 1, environment_id: int = 1):
+        val = base64.b64encode(b"x" * size_bytes).decode()
+        self._call("POST", "/api/v1/secrets", token=token, body={
+            "name": name, "value": val, "project_id": project_id,
+            "environment_id": environment_id, "type": "password",
+        })
+
+    def get(self, token: str, path: str) -> bytes:
+        return self._call("GET", path, token=token)
+
+    def health(self):
+        try:
+            self._call("GET", "/health")
+        except Exception:
+            pass
+
+
+def create_burst(client: Client, token: str, count: int, size_bytes: int, concurrency: int, prefix: str) -> dict:
+    """Create `count` secrets of `size_bytes` each, at the given client
+    concurrency. Returns {"elapsed_s", "succeeded", "failed"}."""
+    names = [f"{prefix}-{i}" for i in range(count)]
+    succeeded = 0
+    failed = 0
+    t0 = time.time()
+
+    def _one(name):
+        client.create_secret(token, name, size_bytes)
+
+    if concurrency <= 1:
+        for n in names:
+            try:
+                _one(n)
+                succeeded += 1
+            except Exception:
+                failed += 1
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as ex:
+            futs = [ex.submit(_one, n) for n in names]
+            for f in concurrent.futures.as_completed(futs):
+                try:
+                    f.result()
+                    succeeded += 1
+                except Exception:
+                    failed += 1
+
+    return {"elapsed_s": time.time() - t0, "succeeded": succeeded, "failed": failed}
+
+
+def hit_endpoint(client: Client, token: str, path: str) -> dict:
+    t0 = time.time()
+    body = client.get(token, path)
+    return {"elapsed_s": time.time() - t0, "bytes": len(body)}
+
+
+def sustained_mixed_load(client: Client, token: str, concurrency: int, duration_s: int,
+                          on_sample=None, sample_every_s: int = 120):
+    """Mixed create(~300B)/list/get workload at fixed concurrency for
+    duration_s wall-clock seconds. Calls on_sample(elapsed_s, iterations)
+    every sample_every_s if given, so a caller can interleave RSS sampling
+    without this module needing to know about proc_status/docker at all."""
+
+    def _one_iteration(i):
+        op = random.choice(["create", "list", "get_by_list"])
+        if op == "create":
+            client.create_secret(token, f"sustained-{i}-{time.time()}", 300)
+        elif op == "list":
+            client.get(token, "/api/v1/secrets?project_id=1&environment_id=1&page_size=20")
+        else:
+            body = json.loads(client.get(token, "/api/v1/secrets?project_id=1&environment_id=1&page_size=20"))
+            secs = body.get("data", {}).get("secrets") or []
+            if secs:
+                try:
+                    client.get(token, f"/api/v1/secrets/{secs[0]['ID']}")
+                except Exception:
+                    pass
+
+    t_start = time.time()
+    t_last_sample = t_start
+    i = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as ex:
+        futs = set()
+        while time.time() - t_start < duration_s:
+            while len(futs) < concurrency:
+                i += 1
+                futs.add(ex.submit(_one_iteration, i))
+            done, futs = concurrent.futures.wait(futs, timeout=1, return_when=concurrent.futures.FIRST_COMPLETED)
+            for f in done:
+                try:
+                    f.result()
+                except Exception:
+                    pass
+            if on_sample and time.time() - t_last_sample >= sample_every_s:
+                t_last_sample = time.time()
+                on_sample(time.time() - t_start, i)
+        for f in futs:
+            try:
+                f.result()
+            except Exception:
+                pass
+    return {"elapsed_s": time.time() - t_start, "iterations": i}

--- a/scripts/memory-measurement/matrix_runner.py
+++ b/scripts/memory-measurement/matrix_runner.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""matrix_runner.py — read scenarios.tsv, drive real load against a real
+keyorix-server container for each row, sample /proc/<pid>/status, and emit
+the results as a generated Markdown table (stdout, or --out FILE).
+
+This is what docs/adr-100-mlockall-removal-deployment-swap-control.md's
+measurement tables should be regenerated from -- see this directory's
+README.md for the full methodology and the portability caveat (numbers are
+tied to the host/container-runtime that produced them, not portable as
+absolute values across environments).
+
+Usage:
+    python3 scripts/memory-measurement/matrix_runner.py
+    python3 scripts/memory-measurement/matrix_runner.py --out results.md
+    python3 scripts/memory-measurement/matrix_runner.py --only count-50,count-1000
+
+Requires: a working `docker` on PATH, run from anywhere inside the repo
+(resolves the repo root via `git rev-parse --show-toplevel`).
+
+Runtime: the full default matrix takes over 30 minutes (the sustained-*
+scenario alone is a real 30-minute wall-clock pass by design -- see Step 3
+of the #1679 follow-up round this harness was built for). Use --only to run
+a subset while iterating.
+"""
+
+import argparse
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import container_env  # noqa: E402
+import load_driver  # noqa: E402
+import proc_status  # noqa: E402
+
+MAIN_CONTAINER = "keyorix-memory-measurement-main"
+SIDE_CONTAINER = "keyorix-memory-measurement-side"
+MAIN_PORT = 18180
+SIDE_PORT = 18181
+
+
+def read_scenarios(path: str, only: set) -> list:
+    rows = []
+    with open(path, newline="") as f:
+        for line in f:
+            if line.startswith("#") or not line.strip():
+                continue
+            fields = line.rstrip("\n").split("\t")
+            if fields[0] == "id":
+                continue  # header line, if present without a leading '#'
+            row = dict(zip(
+                ["id", "kind", "secret_count", "secret_size", "concurrency",
+                 "duration_s", "endpoint", "memory_cap", "description"],
+                fields,
+            ))
+            if only and row["id"] not in only:
+                continue
+            rows.append(row)
+    return rows
+
+
+def fmt_row(label: str, rss: int, hwm: int, extra: str = "") -> str:
+    return f"| {label} | {rss} kB | {hwm} kB | {extra} |"
+
+
+def run_create_burst(row, client, token, results):
+    r = load_driver.create_burst(
+        client, token, int(row["secret_count"]), int(row["secret_size"]),
+        int(row["concurrency"]), row["id"],
+    )
+    st = proc_status.sample(MAIN_CONTAINER)
+    results.append((row["id"], row["description"], st["VmRSS"], st["VmHWM"],
+                     f"{r['succeeded']} ok, {r['failed']} failed, {r['elapsed_s']:.1f}s"))
+
+
+def run_bulk_endpoint(row, client, token, results):
+    r = load_driver.hit_endpoint(client, token, row["endpoint"])
+    st = proc_status.sample(MAIN_CONTAINER)
+    results.append((row["id"], row["description"], st["VmRSS"], st["VmHWM"],
+                     f"{r['bytes']} bytes, {r['elapsed_s']:.2f}s"))
+
+
+def run_oom_check(row, workdir):
+    # Everything from container start onward is inside the try, not just the
+    # burst itself: a container capped tightly enough to OOM-kill under load
+    # can just as plausibly die while still booting/bootstrapping (e.g. an
+    # escalated concurrency row run right after a prior row that already
+    # pushed the same image close to its cap) -- an exception at ANY of
+    # these steps is this scenario's own finding (the container didn't
+    # survive), not a harness crash that should lose every scenario's
+    # results that already ran before this row.
+    try:
+        container_env.run_container(SIDE_CONTAINER, workdir, SIDE_PORT,
+                                     memory_cap=row["memory_cap"].replace("Mi", "m"))
+        base_url = f"http://localhost:{SIDE_PORT}"
+        container_env.wait_healthy(base_url, container=SIDE_CONTAINER)
+        client = load_driver.Client(base_url)
+        token = container_env.wait_admin_ready(client)
+        load_driver.create_burst(client, token, int(row["secret_count"]),
+                                  int(row["secret_size"]), int(row["concurrency"]), row["id"])
+        st = proc_status.sample(SIDE_CONTAINER)
+        killed = proc_status.oom_killed(SIDE_CONTAINER)
+        return (row["id"], row["description"], st["VmRSS"], st["VmHWM"], f"OOMKilled={killed}")
+    except Exception as e:
+        try:
+            killed = proc_status.oom_killed(SIDE_CONTAINER)
+        except Exception:
+            killed = "unknown (container inspect also failed)"
+        return (row["id"], row["description"], "-", "-", f"OOMKilled={killed} (failed at: {e})")
+    finally:
+        container_env.remove_container(SIDE_CONTAINER)
+
+
+def run_sustained(row, workdir, out_lines):
+    container_env.run_container(SIDE_CONTAINER, workdir, SIDE_PORT)
+    base_url = f"http://localhost:{SIDE_PORT}"
+    container_env.wait_healthy(base_url)
+    client = load_driver.Client(base_url)
+    token = container_env.wait_admin_ready(client)
+
+    samples = []
+
+    def on_sample(elapsed_s, iterations):
+        st = proc_status.sample(SIDE_CONTAINER)
+        samples.append((elapsed_s, iterations, st["VmRSS"], st["VmHWM"]))
+        print(f"  t+{elapsed_s/60:.1f}min iter={iterations} VmRSS={st['VmRSS']}kB VmHWM={st['VmHWM']}kB",
+              file=sys.stderr)
+
+    r = load_driver.sustained_mixed_load(
+        client, token, int(row["concurrency"]), int(row["duration_s"]), on_sample=on_sample,
+    )
+    st_end = proc_status.sample(SIDE_CONTAINER)
+    container_env.remove_container(SIDE_CONTAINER)
+
+    out_lines.append(f"\n### {row['id']}: {row['description']}\n")
+    out_lines.append("| t | iterations | VmRSS | VmHWM (peak) |")
+    out_lines.append("|---|---|---|---|")
+    for elapsed_s, iterations, rss, hwm in samples:
+        out_lines.append(f"| +{elapsed_s/60:.1f}min | {iterations} | {rss} kB | {hwm} kB |")
+    out_lines.append(f"| end ({r['elapsed_s']/60:.1f}min) | {r['iterations']} | {st_end['VmRSS']} kB | {st_end['VmHWM']} kB |")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=None, help="write generated Markdown here instead of stdout")
+    ap.add_argument("--only", default=None, help="comma-separated scenario ids to run")
+    ap.add_argument("--skip-build", action="store_true", help="reuse an already-built image")
+    args = ap.parse_args()
+
+    only = set(args.only.split(",")) if args.only else set()
+    scenarios_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "scenarios.tsv")
+    rows = read_scenarios(scenarios_path, only)
+    if not rows:
+        print("no scenarios matched", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.skip_build:
+        print("building server image...", file=sys.stderr)
+        container_env.build_image()
+
+    main_workdir = container_env.Workdir()
+    side_workdir = container_env.Workdir()
+    table_rows = []
+    sustained_sections = []
+
+    try:
+        main_started = False
+        main_client = None
+        main_token = None
+
+        for row in rows:
+            print(f"=> {row['id']} ({row['kind']})", file=sys.stderr)
+
+            # Each row is caught individually (except oom_check, which
+            # already handles its own failure as a FINDING, not an error --
+            # a container that dies is exactly what that scenario kind is
+            # testing for). A scenario failing partway through must not
+            # discard every OTHER scenario's already-collected results --
+            # confirmed the hard way: oom-200-2m-512m's container failed to
+            # become healthy in an early run of this harness (the prior
+            # row's 512Mi-capped container had just been pushed close to
+            # its limit) and an uncaught exception there lost all 13
+            # already-successful rows before it, with nothing written.
+            try:
+                if row["kind"] in ("create_burst", "bulk_endpoint"):
+                    if not main_started:
+                        container_env.run_container(MAIN_CONTAINER, main_workdir, MAIN_PORT)
+                        container_env.wait_healthy(f"http://localhost:{MAIN_PORT}", container=MAIN_CONTAINER)
+                        main_client = load_driver.Client(f"http://localhost:{MAIN_PORT}")
+                        main_token = container_env.wait_admin_ready(main_client)
+                        main_started = True
+                    if row["kind"] == "create_burst":
+                        run_create_burst(row, main_client, main_token, table_rows)
+                    else:
+                        run_bulk_endpoint(row, main_client, main_token, table_rows)
+
+                elif row["kind"] == "oom_check":
+                    side_workdir.reset_data()
+                    table_rows.append(run_oom_check(row, side_workdir))
+
+                elif row["kind"] == "sustained":
+                    side_workdir.reset_data()
+                    run_sustained(row, side_workdir, sustained_sections)
+
+                else:
+                    print(f"unknown scenario kind {row['kind']!r} for {row['id']}", file=sys.stderr)
+            except Exception as e:
+                print(f"!! {row['id']} failed, continuing with remaining scenarios: {e}", file=sys.stderr)
+                table_rows.append((row["id"], row["description"], "-", "-", f"SCENARIO FAILED: {e}"))
+
+        lines = [
+            f"<!-- generated by scripts/memory-measurement/matrix_runner.py on {time.strftime('%Y-%m-%d %H:%M:%S %Z')} -->",
+            "",
+            "| Scenario | Description | VmRSS | VmHWM (peak) | Notes |",
+            "|---|---|---|---|---|",
+        ]
+        for row_id, desc, rss, hwm, notes in table_rows:
+            lines.append(f"| {row_id} | {desc} | {rss} kB | {hwm} kB | {notes} |")
+        lines.extend(sustained_sections)
+        output = "\n".join(lines) + "\n"
+
+        if args.out:
+            with open(args.out, "w") as f:
+                f.write(output)
+            print(f"wrote {args.out}", file=sys.stderr)
+        else:
+            print(output)
+
+    finally:
+        container_env.remove_container(MAIN_CONTAINER)
+        container_env.remove_container(SIDE_CONTAINER)
+        main_workdir.cleanup()
+        side_workdir.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/memory-measurement/proc_status.py
+++ b/scripts/memory-measurement/proc_status.py
@@ -1,0 +1,56 @@
+"""proc_status.py — sample and parse a container's real server process's
+/proc/<pid>/status, the same way every number in ADR-100
+(docs/adr-100-mlockall-removal-deployment-swap-control.md) was obtained:
+docker exec into the container and read the kernel's own accounting for the
+process, not an estimate or a Go-runtime-reported figure.
+
+PID 6 is the real `keyorix-server` process inside the image built from
+server/Dockerfile (PID 1 is entrypoint.sh, which backgrounds the server and
+waits on it) -- confirmed by `docker exec <container> ps aux` matching this
+every time this harness (and the manual measurements that preceded it) has
+been run. If a future Dockerfile change alters the process tree, update
+SERVER_PID below and re-verify with `ps aux` before trusting new numbers.
+"""
+
+import re
+import subprocess
+
+SERVER_PID = 6
+
+_FIELDS = ("VmSize", "VmLck", "VmRSS", "VmHWM")
+
+
+def sample(container: str) -> dict:
+    """Return {field: kilobytes} for VmSize/VmLck/VmRSS/VmHWM, read live from
+    the container's real server process. Raises CalledProcessError if the
+    container isn't running or the process is gone (e.g. OOM-killed --
+    callers checking for that should catch this, not treat it as zero)."""
+    out = subprocess.check_output(
+        ["docker", "exec", container, "sh", "-c",
+         f"grep -E '^({'|'.join(_FIELDS)}):' /proc/{SERVER_PID}/status"],
+        text=True,
+    )
+    values = {}
+    for line in out.splitlines():
+        m = re.match(r"^(\w+):\s+(\d+) kB$", line.strip())
+        if m:
+            values[m.group(1)] = int(m.group(2))
+    missing = [f for f in _FIELDS if f not in values]
+    if missing:
+        raise RuntimeError(f"proc_status.sample: missing fields {missing} in output: {out!r}")
+    return values
+
+
+def oom_killed(container: str) -> bool:
+    """True if docker reports this container's process was OOM-killed."""
+    out = subprocess.check_output(
+        ["docker", "inspect", "-f", "{{.State.OOMKilled}}", container], text=True
+    )
+    return out.strip() == "true"
+
+
+def container_exit_code(container: str) -> int:
+    out = subprocess.check_output(
+        ["docker", "inspect", "-f", "{{.State.ExitCode}}", container], text=True
+    )
+    return int(out.strip())

--- a/scripts/memory-measurement/scenarios.tsv
+++ b/scripts/memory-measurement/scenarios.tsv
@@ -1,0 +1,37 @@
+# Memory-measurement scenario matrix. Consumed by matrix_runner.py -- edit
+# this file to add/change scenarios, not the runner's Python logic. Columns:
+#
+#   id            unique, used as the row label in generated output
+#   kind          create_burst | bulk_endpoint | oom_check | sustained
+#   secret_count  secrets to create (create_burst, oom_check) or already
+#                 present before hitting the endpoint (bulk_endpoint)
+#   secret_size   bytes per secret value (create_burst, oom_check)
+#   concurrency   simultaneous HTTP clients
+#   duration_s    wall-clock duration, sustained only (0 for everything else)
+#   endpoint      HTTP path, bulk_endpoint only (empty otherwise)
+#   memory_cap    docker --memory value, oom_check only (empty otherwise --
+#                 create_burst/bulk_endpoint/sustained run uncapped, matching
+#                 how the ADR-100 measurements characterize true peak/growth
+#                 rather than a specific limit's survival)
+#   description
+#
+# Every row has exactly 9 tab-separated fields, empty fields included --
+# generated with a script, not hand-typed, after a hand-typed version
+# silently dropped a column on several rows (missing tab = fields shift
+# left = wrong data read into the wrong column, no error). Verify with:
+#   awk -F'\t' '!/^#/ && NF && NF!=9 {print NR": "NF" fields: "$0}' scenarios.tsv
+rest	create_burst	0	0	1	0			fresh-boot baseline, no secrets created
+count-50	create_burst	50	500000	1	0			count axis: 50 secrets, one client
+count-1000	create_burst	950	200	1	0			count axis: +950 small secrets (cumulative, reaches 1,000)
+count-10000	create_burst	9000	200	1	0			count axis: +9,000 small secrets (cumulative, reaches 10,000)
+bulk-list	bulk_endpoint	0	0	1	0	/api/v1/secrets?project_id=1&environment_id=1&page_size=100		paginated list at the 10,000-secret tier
+bulk-inventory	bulk_endpoint	0	0	1	0	/api/v1/secrets/inventory.csv		unbounded deployment-wide CSV export at the 10,000-secret tier
+bulk-audit-export	bulk_endpoint	0	0	1	0	/api/v1/audit/export.csv?limit=10000		capped audit-log CSV export at its row-count ceiling
+conc-1-100k	create_burst	100	100000	1	0			concurrency axis: 100 secrets @ 100KB, 1 client
+conc-25-100k	create_burst	100	100000	25	0			concurrency axis: 100 secrets @ 100KB, 25 clients
+conc-100-100k	create_burst	100	100000	100	0			concurrency axis: 100 secrets @ 100KB, 100 clients
+conc-100-500k	create_burst	100	500000	100	0			concurrency + payload: 100 secrets @ 500KB, 100 clients
+conc-100-2m	create_burst	100	2000000	100	0			concurrency + payload worst case: 100 secrets @ 2MB, 100 clients
+oom-100-2m-512m	oom_check	100	2000000	100	0		512Mi	replay the worst-case burst against a container capped at the shipped Helm limit
+oom-200-2m-512m	oom_check	200	2000000	200	0		512Mi	escalated burst against the same 512Mi cap -- expected to OOM-kill on today's default
+sustained-25	sustained	0	300	25	1800			30-minute sustained pass, moderate concurrency, mixed create/list/read


### PR DESCRIPTION
## Summary
- Recovers `scripts/memory-measurement/` from `wip/1709-followup-preservation` (commit `d14f0548`), a branch stranded since 2026-09-04.
- Reconciled against main first: the ADR-100 GOMEMLIMIT/Guaranteed-QoS correction that commit also carried is already on main (PR #1726 and later revisions), and the audit-persist-loss repro test now exists at `internal/storage/store/concurrency_audit_persist_loss_test.go` as the green invariant test for the #1727 fix (PR #1740), evolved from the red repro the stranded branch had. Only the harness itself was missing, so only the harness lands here.
- The harness regenerates ADR-100's measurement tables against a real server binary in a real container over real HTTP calls, so the numbers backing that ADR's resource-sizing recommendation can be independently reproduced rather than trusted from a session transcript.

## Test plan
- [ ] `python3 scripts/memory-measurement/matrix_runner.py --only <one scenario id>` runs against a locally built `server/Dockerfile` image and produces a Markdown table
- Not wired into CI (manual/on-demand tooling, documented in the harness's own README)