### PR TITLE
feat(hooks): enforce one-writer-per-repo operating model at session start

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,50 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git worktree add *)",
+      "Bash(git worktree remove *)",
+      "Bash(git worktree list *)",
+      "Bash(git -C * log *)",
+      "Bash(git -C * status *)",
+      "Bash(git -C * status)",
+      "Bash(git -C * diff *)",
+      "Bash(git -C * branch *)",
+      "Bash(git -C * rev-parse *)",
+      "Bash(git -C * show *)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "out=$(bash scripts/worktree-branch-health.sh --worktrees-only 2>&1); jq -n --arg ctx \"$out\" '{hookSpecificOutput:{hookEventName:\"SessionStart\",additionalContext:$ctx}}'",
+            "timeout": 30,
+            "statusMessage": "Checking worktree health..."
+          },
+          {
+            "type": "command",
+            "command": "bash scripts/git-write-guard.sh session-start",
+            "timeout": 15,
+            "statusMessage": "Checking repo write-lock..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git *)",
+            "command": "bash scripts/git-write-guard.sh gate",
+            "timeout": 15,
+            "statusMessage": "Checking one-writer-per-repo lock..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,40 @@ Guidance for Claude Code (claude.ai/code) when working in this repository.
   PR outright if its base is not `main`, unless explicitly labeled
   `stacked-pr`. Prefer fixing this class of mistake at merge time, not by
   writing down one more sentence to remember to check.
+- **An agent's last act before finishing is to commit and push its branch** —
+  alongside "start in a worktree" and "run tests in the foreground." Found
+  2026-09-07: a worktree with real, uncommitted single-use-grant follow-up
+  work sat unpushed and un-flagged until a `git worktree remove` attempt
+  happened to fail on it; a separate worktree's own commit landed on an
+  `worktree-agent-*` branch, not the shared branch it was meant to reconcile
+  onto, and was only confirmed safe by tracing it to an already-merged PR
+  after the fact. Removal is only safe to make routine (see
+  `scripts/worktree-branch-health.sh`, run at session start for uncommitted/
+  unpushed work and on demand for the full stranded/duplicate-branch sweep)
+  once every agent's own last step already got its work to a remote ref —
+  don't rely on detection to catch what creation should have prevented.
+- **One session with write access per repository at a time. Others read, or
+  work in a separate `git clone` — not a worktree off the shared tree.**
+  Found 2026-09-07: two sessions in this exact repo raced each other's
+  branch checkouts in the shared main checkout (`git branch --show-current`
+  returned a different branch across two consecutive commands, seconds
+  apart), one session's own accidental test commit landed on whatever branch
+  a *different* session happened to have checked out at that instant, and a
+  background daemon session committed directly over another session's
+  in-progress ADR draft, self-assigning "Accepted" status that was never
+  actually ratified. Worktrees do **not** isolate against this — they share
+  one `.git`, and this incident was specifically about HEAD moving inside
+  that shared state, not about worktree-vs-worktree collisions. Enforced by
+  `scripts/git-write-guard.sh`: a lock file at `$(git rev-parse
+  --git-common-dir)/write-lock.json` (shared by a main checkout and all its
+  worktrees; distinct for a separate clone by construction), claimed/
+  refreshed by `SessionStart` and by every HEAD-moving git subcommand
+  (`commit`/`checkout`/`switch`/`rebase`/`merge`/`reset`/`cherry-pick`/
+  `revert`/`pull`/`worktree add`/`worktree remove`), timestamp-stale after
+  20 minutes rather than requiring PID liveness (no persistent PID exists
+  to check from inside a short-lived hook). Read-only git commands
+  (`status`/`log`/`diff`/`show`/etc.) are never gated — only the commands
+  that actually move HEAD or shared branch/worktree state are.
 
 ## Engineering practices
 

--- a/scripts/git-write-guard.sh
+++ b/scripts/git-write-guard.sh
@@ -13,34 +13,49 @@
 #
 # No persistent PID is available to check liveness (hooks are short-lived
 # subprocesses; the Claude Code session that invokes them isn't). This uses
-# timestamp-based staleness instead: a lock claimed/refreshed within the last
-# 20 minutes counts as active. An honest limitation, not a bug -- a crashed
-# session's lock self-clears in <=20 minutes rather than wedging the repo
-# forever, and an active session keeps its lock warm simply by doing anything
-# (every SessionStart and every git commit/checkout/rebase attempt refreshes
-# it).
+# timestamp-based staleness instead. The refresh only happens on a GATED git
+# subcommand (see below) -- NOT on a timer, and NOT on ordinary Edit/Write/
+# Bash-non-git activity. Confirmed 2026-09-07: agents here routinely run
+# 40-80 minutes and can go long stretches without touching a gated git
+# subcommand at all (e.g. one commit at the start of a session, then 60+
+# minutes of pure editing/testing before the next one) -- during that gap
+# the lock is NOT being refreshed, so a 20-minute window would silently
+# expire mid-work and let a second session claim it, arriving without any
+# warning to either party until the first session's next gated git call
+# gets denied (loud, but only after the collision already happened at the
+# file-editing level). STALE_SECONDS is set well past the longest observed
+# single-session runtime for this reason -- widening the window, not adding
+# a timer-based refresh (a hook can't run on a timer; it only runs when
+# something invokes it), is the actual fix for that gap. A crashed/abandoned
+# session's lock still self-clears, just on a multi-hour horizon instead of
+# a 20-minute one -- an accepted tradeoff given the alternative is a silent
+# collision, not a merely slower one.
 set -uo pipefail
 
 MODE="${1:?usage: git-write-guard.sh session-start|gate}"
-STALE_SECONDS=1200
-
-lock="$(git rev-parse --git-common-dir 2>/dev/null)/write-lock.json"
-[ -z "$lock" ] && exit 0
+STALE_SECONDS=10800
 
 payload="$(cat)"
 sid="$(echo "$payload" | jq -r '.session_id // empty')"
 [ -z "$sid" ] && exit 0
 
+# Parse the actual command being gated (gate mode only -- session-start has
+# no tool_input.command, and runs in the harness's own ambient cwd, which is
+# already correct). Extract both the git subcommand AND any `-C <path>`
+# target: the subcommand determines WHETHER this call is guarded at all; the
+# -C target determines WHERE the guard's own git rev-parse calls must run --
+# using plain ambient cwd here would silently mis-check any command of the
+# form `git -C <worktree> ...`, which is this repo's own dominant idiom for
+# operating on a worktree from a shell whose cwd is the main checkout (the -C
+# flag changes what path GIT operates on; it does not change the shell's own
+# cwd, so a naive `git rev-parse` inside this hook -- unaware of the -C in
+# the command it's gating -- would resolve against the wrong tree entirely).
+GIT_C=""
+subcmd=""
+is_worktree_cmd=0
 if [ "$MODE" = "gate" ]; then
-    # Only HEAD/branch-state-mutating subcommands are guarded -- this is the
-    # documented incident class ("HEAD moving inside a shared .git"), not
-    # "every git invocation." Gating git status/log/diff/show etc. would just
-    # break normal read-only work for no safety gain. Parses past leading
-    # flags that take a value (-C <path>, -c <key=val>) to find the real
-    # subcommand rather than matching the first token literally.
     cmd_str="$(echo "$payload" | jq -r '.tool_input.command // empty')"
     set -- $cmd_str
-    subcmd=""
     found_git=0
     while [ "$#" -gt 0 ]; do
         tok="$1"; shift
@@ -49,14 +64,33 @@ if [ "$MODE" = "gate" ]; then
             continue
         fi
         case "$tok" in
-            -C|-c|--git-dir|--work-tree) shift ;;
+            -C) GIT_C="$1"; shift ;;
+            -c|--git-dir|--work-tree) shift ;;
             -*) ;;
             *) subcmd="$tok"; break ;;
         esac
     done
-    is_worktree_cmd=0
+
+    # Only HEAD/branch-state-mutating subcommands are guarded -- this is the
+    # documented incident class ("HEAD moving inside a shared .git"), not
+    # "every git invocation." Gating git status/log/diff/show etc. would just
+    # break normal read-only work for no safety gain.
     case "$subcmd" in
-        commit|checkout|switch|rebase|merge|reset|cherry-pick|revert|pull|am) ;;
+        reset|checkout)
+            # `git reset -- <paths>` / `git checkout -- <paths>` are
+            # pathspec-scoped: they touch only the index/working-tree
+            # content for those paths and never move HEAD or the current
+            # branch pointer -- functionally a bulk unstage/restore, not
+            # the HEAD-moving operation this guard exists for. Only the
+            # bare/commit-target form (no `--`) is guarded. Checked via a
+            # literal `--` in the remaining args, which is the form both
+            # subcommands require to disambiguate a pathspec from a
+            # revision anyway.
+            for a in "$@"; do
+                [ "$a" = "--" ] && exit 0
+            done
+            ;;
+        commit|switch|rebase|merge|cherry-pick|revert|pull|am) ;;
         worktree)
             # only add/remove/prune/move mutate the shared registry; list
             # and lock/unlock are read-only-equivalent for this purpose.
@@ -68,6 +102,17 @@ if [ "$MODE" = "gate" ]; then
         *) exit 0 ;;
     esac
 fi
+
+git_at() {
+    if [ -n "$GIT_C" ]; then
+        git -C "$GIT_C" "$@"
+    else
+        git "$@"
+    fi
+}
+
+lock="$(git_at rev-parse --git-common-dir 2>/dev/null)/write-lock.json"
+[ -z "$lock" ] && exit 0
 
 now="$(date -u +%s)"
 other_sid=""
@@ -118,8 +163,8 @@ if [ "$MODE" = "gate" ]; then
     # unworktreed, is still the other half of this week's incident -- HEAD
     # moving under a concurrent read/inspection from anyone else, even a
     # well-behaved second session that's only ever reading.
-    gd="$(git rev-parse --absolute-git-dir 2>/dev/null)"
-    gc="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd -P)"
+    gd="$(git_at rev-parse --absolute-git-dir 2>/dev/null)"
+    gc="$(cd "$(git_at rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd -P)"
     gd_r="$(cd "$gd" 2>/dev/null && pwd -P)"
     if [ -n "$gd_r" ] && [ "$gd_r" = "$gc" ]; then
         jq -n '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:"Commits/checkouts/rebases must happen in a dedicated worktree, not the shared main checkout -- run EnterWorktree (or git worktree add) first. See CLAUDE.md: start in a worktree, commit+push as your last act."}}'

--- a/scripts/git-write-guard.sh
+++ b/scripts/git-write-guard.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# git-write-guard.sh -- one-writer-per-repo enforcement (CLAUDE.md operating
+# model, added 2026-09-07 after a week of concurrent sessions silently moving
+# HEAD in a shared main checkout, racing each other's commits, and one
+# session's autonomous daemon committing over another's in-progress ADR draft).
+#
+# The lock lives at $(git rev-parse --git-common-dir)/write-lock.json -- that
+# path is IDENTICAL for a main checkout and every one of its linked worktrees
+# (they share one .git), and DIFFERENT for an independent `git clone` of the
+# same repo. That's deliberate: this repo's operating model is one writer per
+# .git (main checkout + all its worktrees combined), not one writer per
+# directory -- a separate clone is a different .git and is exempt by design.
+#
+# No persistent PID is available to check liveness (hooks are short-lived
+# subprocesses; the Claude Code session that invokes them isn't). This uses
+# timestamp-based staleness instead: a lock claimed/refreshed within the last
+# 20 minutes counts as active. An honest limitation, not a bug -- a crashed
+# session's lock self-clears in <=20 minutes rather than wedging the repo
+# forever, and an active session keeps its lock warm simply by doing anything
+# (every SessionStart and every git commit/checkout/rebase attempt refreshes
+# it).
+set -uo pipefail
+
+MODE="${1:?usage: git-write-guard.sh session-start|gate}"
+STALE_SECONDS=1200
+
+lock="$(git rev-parse --git-common-dir 2>/dev/null)/write-lock.json"
+[ -z "$lock" ] && exit 0
+
+payload="$(cat)"
+sid="$(echo "$payload" | jq -r '.session_id // empty')"
+[ -z "$sid" ] && exit 0
+
+if [ "$MODE" = "gate" ]; then
+    # Only HEAD/branch-state-mutating subcommands are guarded -- this is the
+    # documented incident class ("HEAD moving inside a shared .git"), not
+    # "every git invocation." Gating git status/log/diff/show etc. would just
+    # break normal read-only work for no safety gain. Parses past leading
+    # flags that take a value (-C <path>, -c <key=val>) to find the real
+    # subcommand rather than matching the first token literally.
+    cmd_str="$(echo "$payload" | jq -r '.tool_input.command // empty')"
+    set -- $cmd_str
+    subcmd=""
+    found_git=0
+    while [ "$#" -gt 0 ]; do
+        tok="$1"; shift
+        if [ "$found_git" -eq 0 ]; then
+            [ "$tok" = "git" ] && found_git=1
+            continue
+        fi
+        case "$tok" in
+            -C|-c|--git-dir|--work-tree) shift ;;
+            -*) ;;
+            *) subcmd="$tok"; break ;;
+        esac
+    done
+    is_worktree_cmd=0
+    case "$subcmd" in
+        commit|checkout|switch|rebase|merge|reset|cherry-pick|revert|pull|am) ;;
+        worktree)
+            # only add/remove/prune/move mutate the shared registry; list
+            # and lock/unlock are read-only-equivalent for this purpose.
+            case "${1:-}" in
+                add|remove|prune|move) is_worktree_cmd=1 ;;
+                *) exit 0 ;;
+            esac
+            ;;
+        *) exit 0 ;;
+    esac
+fi
+
+now="$(date -u +%s)"
+other_sid=""
+other_age=0
+if [ -f "$lock" ]; then
+    other_sid="$(jq -r '.sessionId // empty' "$lock" 2>/dev/null)"
+    other_ts="$(jq -r '.claimedAtEpoch // 0' "$lock" 2>/dev/null)"
+    other_age=$(( now - other_ts ))
+fi
+
+contested=0
+if [ -n "$other_sid" ] && [ "$other_sid" != "$sid" ] && [ "$other_age" -lt "$STALE_SECONDS" ]; then
+    contested=1
+fi
+
+reason="Another session ($other_sid) claimed write access to this repo ${other_age}s ago (<${STALE_SECONDS}s = active). Per CLAUDE.md's one-writer-per-repo operating model: work read-only here, or use a separate 'git clone' (not a worktree -- worktrees share this .git and this lock)."
+
+if [ "$MODE" = "session-start" ]; then
+    if [ "$contested" -eq 1 ]; then
+        jq -n --arg ctx "ACTIVE-WRITER-LOCK: $reason" '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$ctx}}'
+        exit 0
+    fi
+    jq -n --arg sid "$sid" --argjson ts "$now" '{sessionId:$sid, claimedAtEpoch:$ts}' > "$lock"
+    exit 0
+fi
+
+if [ "$MODE" = "gate" ]; then
+    if [ "$contested" -eq 1 ]; then
+        jq -n --arg reason "$reason" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
+        exit 0
+    fi
+
+    # Not contested -- this session is (or becomes) the writer. Refresh the
+    # lock so it stays warm while this session keeps acting.
+    jq -n --arg sid "$sid" --argjson ts "$now" '{sessionId:$sid, claimedAtEpoch:$ts}' > "$lock"
+
+    # worktree add/remove/prune/move are exempt from the "must already be in
+    # a worktree" check below -- they're inherently main-checkout-
+    # administrative (worktree add FROM the main checkout is how you GET a
+    # worktree in the first place; requiring one first is a bootstrapping
+    # deadlock, not a safety property). The lock check above still applies
+    # to them, since they do mutate the shared .git/worktrees/ registry.
+    if [ "$is_worktree_cmd" -eq 1 ]; then
+        exit 0
+    fi
+
+    # A live single writer working directly in the main checkout,
+    # unworktreed, is still the other half of this week's incident -- HEAD
+    # moving under a concurrent read/inspection from anyone else, even a
+    # well-behaved second session that's only ever reading.
+    gd="$(git rev-parse --absolute-git-dir 2>/dev/null)"
+    gc="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd -P)"
+    gd_r="$(cd "$gd" 2>/dev/null && pwd -P)"
+    if [ -n "$gd_r" ] && [ "$gd_r" = "$gc" ]; then
+        jq -n '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:"Commits/checkouts/rebases must happen in a dedicated worktree, not the shared main checkout -- run EnterWorktree (or git worktree add) first. See CLAUDE.md: start in a worktree, commit+push as your last act."}}'
+    fi
+    exit 0
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/git-write-guard.sh`: a session-scoped write lock (timestamp-based, 3-hour staleness -- widened from an initial 20min after confirming the lock only refreshes on gated git commands, not on a timer, and agents here routinely run 40-80 minutes between them) shared by a main checkout and all its worktrees, keyed at `$(git rev-parse --git-common-dir)/write-lock.json` -- distinct for an independent clone by construction.
- Wired via `SessionStart` (claims/warns) and `PreToolUse` (denies HEAD-moving git subcommands -- `commit`/`checkout`/`switch`/`rebase`/`merge`/`reset`/`cherry-pick`/`revert`/`pull`/`worktree add`/`worktree remove` -- when a different session's lock is still fresh). Read-only git commands are never gated; `git reset --`/`git checkout --` pathspec forms (never move HEAD) are exempt even though the bare subcommand is guarded.
- `worktree add/remove/prune/move` are exempt from the separate "must already be in a worktree" check (that check targets content-mutating commands in the shared main checkout; worktree management is inherently done from the main checkout -- requiring a worktree first is a bootstrapping deadlock).
- Respects `-C <path>` in the command being gated (this repo's own dominant idiom for operating on a worktree from a shell whose cwd is the main checkout) -- an earlier version of this guard ignored it and incorrectly denied legitimate `git -C <worktree> commit` calls.
- CLAUDE.md: the one-writer-per-repo rule text, plus a separate standing rule (an agent's last act is to commit and push its branch).

## Finding worth keeping findable
**`.claude/settings.json` had never been tracked in this repo before this PR.** Every hook this repo has ever had -- whatever existed before this PR, and this PR's own hooks until it merges -- was machine-local: it only protected whichever single machine happened to have that exact local file. This PR is the first time repo-level hook configuration becomes shared/version-controlled here. Until it merges, the enforcement it adds exists on one machine only, which is the same defect class it was built to fix.

## Why
Found 2026-09-07 during a live stabilisation effort: two sessions raced each other's branch checkouts in this exact shared main checkout (`git branch --show-current` returned a different branch across two consecutive commands, seconds apart); a background daemon session committed directly over another session's in-progress ADR draft and self-assigned "Accepted" status that was never actually ratified. Worktrees alone don't prevent this -- they share one `.git`, and the incident was specifically about HEAD moving inside that shared state.

## Test plan
- [x] Pipe-tested every branch directly against synthesized stdin payloads: contested lock denies write commands, read-only commands pass through even under a contested lock, `worktree add` is exempt from the worktree-only check, pathspec `reset --`/`checkout --` are exempt, `-C <worktree>` is respected, `-C <main-checkout>` is still denied.
- [x] Verified live twice: the hook actually fired and blocked a real commit attempt from the main checkout during this session; fixing that surfaced the `-C`-blindness bug, which was then also verified live-fixed.
- [ ] `/hooks` or a fresh session needed to load these hooks for any currently-running session (documented limitation -- standing rules don't reach a session that was already running).