### PR TITLE
docs(adr-103): ratify -- Status: Accepted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,14 @@ Guidance for Claude Code (claude.ai/code) when working in this repository.
   refreshed by `SessionStart` and by every HEAD-moving git subcommand
   (`commit`/`checkout`/`switch`/`rebase`/`merge`/`reset`/`cherry-pick`/
   `revert`/`pull`/`worktree add`/`worktree remove`), timestamp-stale after
-  20 minutes rather than requiring PID liveness (no persistent PID exists
-  to check from inside a short-lived hook). Read-only git commands
-  (`status`/`log`/`diff`/`show`/etc.) are never gated — only the commands
-  that actually move HEAD or shared branch/worktree state are.
+  3 hours (widened from an initial 20 minutes after confirming the lock only
+  refreshes on a gated command, not on a timer or ordinary work, and agents
+  here routinely run 40-80 minutes between them) rather than requiring PID
+  liveness (no persistent PID exists to check from inside a short-lived
+  hook). Read-only git commands (`status`/`log`/`diff`/`show`/etc.) are
+  never gated; `git reset --`/`git checkout --` pathspec forms are exempt
+  even though the bare subcommand is guarded, since they never move HEAD.
+  Respects `-C <path>` in the command being gated.
 
 ## Engineering practices
 

--- a/docs/adr-103-tenancy-rls-second-layer.md
+++ b/docs/adr-103-tenancy-rls-second-layer.md
@@ -2,19 +2,29 @@
 
 ## Status
 
-**Proposed.** Not implemented. This ADR authorizes design only, including a
-measured correction to the original §1c injection point (the original
-`WithTransaction`-only mechanism left 99.4% of read traffic unprotected —
-see §1c for the measurement and the corrected mechanism), the mandatory
-`WITH CHECK` on every policy (§1b/§1f Test 4), explicit trigger security
-context (§1d), and the required latency measurement and context-propagation
-guard (Consequences, §1f). §1b's two product/security decisions
-(`audit_events` NULL-scope visibility, `notifications` global-scope
-visibility) are resolved (2026-09-07) — both platform-scoped, never
-blanket-visible to every tenant — and tracked in `QUEUE.md`. This ADR does
-**not** authorize migrations, policies, or code: see "Verification design"
-for what must exist and pass, red-then-green, before any of this ships or
-before Status can move to Accepted.
+**Accepted (2026-09-07).** Ratified by human review in the conversation that
+owns this document. Distinct from `096092d6`'s earlier self-assigned
+"Accepted" status — an autonomous session's own claim, with no human
+review — which a later commit on this same document correctly reset back to
+Proposed pending real ratification; this Status line is that ratification,
+not a repeat of the earlier claim.
+
+Authorizes the design in full: the §1c injection-point correction (the
+original `WithTransaction`-only mechanism would have left 99.4% of read
+traffic unprotected — see §1c for the measurement and the corrected
+mechanism), the mandatory `WITH CHECK` on every policy (§1b/§1f Test 4),
+explicit trigger security context (§1d), and the required latency
+measurement and context-propagation guard (Consequences, §1f). §1b's two
+product/security decisions (`audit_events` NULL-scope visibility,
+`notifications` global-scope visibility) are resolved (2026-09-07) — both
+platform-scoped, never blanket-visible to every tenant — and tracked in
+`QUEUE.md`.
+
+Accepted authorizes the design; it does not by itself authorize shipping
+migrations, policies, or code. Per "Verification design" and Consequences
+below, the §1f verification design (four tests plus the context-propagation
+guard, red-then-green) must exist and pass, and the required latency
+measurement must run, before an implementation PR ships.
 
 ## Context
 
@@ -675,10 +685,12 @@ work versus no-op.
   call sites go through this path today, and the decision to wrap
   unconditionally (§1c) means every write and every "deliberately global"
   table lookup pays it too. Before implementation ships, produce an actual
-  before/after comparison using `scripts/memory-measurement/` (does not exist
-  in this repo yet — create it as part of implementation, scoped to this
-  comparison, not built as a general-purpose benchmarking framework), run
-  against realistic data volumes and concurrency, not a synthetic
+  before/after comparison using `scripts/memory-measurement/` (recovered from
+  a stranded branch and landed via PR #1782 — it exists in this repo now, built
+  for ADR-100's memory sizing rather than Postgres round-trip latency, so it
+  needs extending, or a sibling scenario, for this comparison rather than
+  building from scratch), run against realistic data volumes and concurrency,
+  not a synthetic
   single-connection loop. These sizing numbers are also a go-to-market asset —
   "what does the second tenancy layer cost" is a conversation this product
   will have with customers evaluating Postgres/HA, so the measurement needs to


### PR DESCRIPTION
## Summary
- ADR-103's Status: **Proposed → Accepted (2026-09-07)**. Ratified by human review in the conversation that owns this document -- distinct from `096092d6`'s earlier self-assigned "Accepted" (an autonomous session's own claim, no human review), which a later commit correctly reset back to Proposed. This is the actual ratification, not a repeat of that earlier claim.
- Accepted authorizes the design; it does not by itself authorize shipping migrations, policies, or code -- the §1f verification design (four tests plus the context-propagation guard, red-then-green) must still exist and pass, and the required latency measurement must still run, before an implementation PR ships. That gate is unchanged by this PR.
- Two small staleness corrections found while touching the file:
  - `scripts/memory-measurement/` was described as "does not exist yet" -- it was recovered and landed via #1782 since the ADR was drafted; it exists now and needs extending for the Postgres round-trip comparison, not building from scratch.
  - CLAUDE.md's own description of the write-lock staleness window still said 20 minutes after #1784 widened it to 3 hours -- rule text and mechanism had drifted apart.

## Test plan
- N/A for content -- documentation-only change (Status line + two factual corrections), no code/schema/policy changes.