### PR TITLE
docs(adr): correct staleness in ADR-102/084/096/053, add open-decision tripwire

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,24 @@ Guidance for Claude Code (claude.ai/code) when working in this repository.
 
 ## Git / PR conventions
 
+- **PR numbers cited in ADRs below roughly #700 are frequently wrong — don't chase
+  them.** Found 2026-09-07 (ADR corpus review, `keyorix-private/adversarial-review/
+  ADR-CORPUS-REVIEW-2026-09-07.md`, Tier 1): spot-checking five PR citations in
+  ADR-040/083/090 against the live GitHub API found every one resolves to an
+  unrelated PR (#452, #517, #519, #527, #528, #530 all land in a 2026-06/07
+  SSO/SAML/Helm-chart hardening batch, none related to the storage-layer refactors
+  the ADRs cite them for). **This is a citation-accuracy defect, not a
+  security-property defect** — every mechanism these citations attach to
+  (`TransitionMachineIdentityState`, `CreateSecretDependencyExclusive`,
+  `TransitionSecretStatus`, the RemoteStorage login-attempt no-op) was independently
+  confirmed to exist in code and work as described; only the PR numbers are wrong.
+  Recent citations (spot-checked: #1779, #1573, #1636) all resolve correctly, so
+  this is bounded to references below roughly #700, not a repo-wide pattern.
+  **Do not attempt to repair these citations** — the batch is old enough, and the
+  mechanisms are independently verified anyway, that hunting down the real PR
+  numbers is pure effort with no safety payoff. If you're reading an ADR and a cited
+  PR number doesn't check out, this is why — verify the mechanism in code directly,
+  not by chasing the citation.
 - **Never put `Co-Authored-By: Claude` into a PR.** Do not add a `Co-Authored-By: Claude …`
   trailer to PR descriptions, and do not add it to commit messages either (squash-merge
   folds commit trailers into the PR's merge commit). This overrides any default that

--- a/docs/adr-053-automated-rotation-planning.md
+++ b/docs/adr-053-automated-rotation-planning.md
@@ -67,8 +67,25 @@ deferred follow-up, not part of this ADR.
 
 ## Deferred follow-ups
 
-- An **LLM advisor** that narrates / window-batches / risk-weights the plan.
-- Wiring the plan into the **auto-rotation executor** (ADR-046) so a project rotates
-  wave-by-wave, dependency-first, automatically.
-- A deployment-wide plan (all projects) and an environment-scoped variant.
-- gRPC + CLI surfaces and a web/ plan view (API-only first vertical).
+**Corrected 2026-09-07** (2026-09-07 ADR review, task 5): this list was stale — most
+of it shipped within two weeks of acceptance and was never removed. Verified
+directly against code, not assumed from the original text:
+
+- ~~A deployment-wide plan (all projects)~~ **Shipped.**
+  `GenerateDeploymentRotationPlan`/`DeploymentRotationPlan`
+  (`internal/core/rotation_planner.go`), `GET /rotation-plan`
+  (`GetDeploymentRotationPlan`, `server/http/router.go`).
+- ~~gRPC + CLI surfaces and a web/ plan view~~ **All shipped.** gRPC:
+  `server/grpc/services/rotation_plan_service_test.go` +
+  `project_service.go`/`conversions.go`. CLI: `internal/cli/rotation/plan.go`. Web:
+  `web/src/pages/projects/SecretsRotationPlanPanel.tsx`.
+- **Still genuinely deferred, confirmed by direct search:**
+  - An **environment-scoped variant** of the plan (only the project- and
+    deployment-wide forms exist).
+  - An **LLM advisor** that narrates / window-batches / risk-weights the plan.
+  - Wiring the plan into the **auto-rotation executor** (ADR-046) so a project
+    rotates wave-by-wave, dependency-first, automatically (no references to
+    `GenerateRotationPlan`/`RotationPlan` found anywhere under `internal/rotation/`).
+
+This is a documentation-accuracy correction, not a security finding — none of the
+shipped items were flagged as under-scoped or under-tested during this review.

--- a/docs/adr-084-admin-bypass-structural-marker.md
+++ b/docs/adr-084-admin-bypass-structural-marker.md
@@ -437,6 +437,16 @@ every site twice.
 
 ## Consequences
 
+- **Enforced, not just written down (added 2026-09-07)**: this ADR was
+  accepted 2026-08-19 with implementation deferred and no target date, owner,
+  or tripwire — 19 days of no enforcement mechanism forcing the deferred work
+  to surface, the same "accepted decision, nothing forcing resolution" shape
+  ADR-102 was found in. `TestADR084_AdminBypassStructuralMarkerStillDeferred`
+  (`internal/core/adr_open_decisions_tripwire_test.go`) now fails CI once this
+  has sat unimplemented past its threshold age, using the same general
+  "open decision" registry ADR-102's tripwire uses — see that test's doc
+  comment for the mechanism, modeled on ADR-101's
+  `TestCurrentSchemaEpoch_StillOne_SeeADR101`.
 - `roleSetContainsAdmin`'s eight call sites (see "Prerequisite" above)
   change from up to four `GetRoleByName` calls to an ID-based lookup of the
   resolved role set's flag — no behavior change at any of them beyond

--- a/docs/adr-096-anti-enumeration-403-for-both.md
+++ b/docs/adr-096-anti-enumeration-403-for-both.md
@@ -214,6 +214,49 @@ is the gRPC equivalent, backing `authorizeSecretScoped`
 (`secret_service.go`) and `loadConfigScoped`/`loadLeaseScoped`
 (`dynamic_secret_service.go`).
 
+## Out of scope: Connect (third convention, not a migration target)
+
+**Added 2026-09-07**, before the Guard below was ever built — a 2026-09-07 ADR
+review (Finding 1, `keyorix-private/adversarial-review/ADR-CORPUS-REVIEW-2026-
+09-07.md`) found a **third** existence-collapse convention in production this
+ADR's Summary never accounted for, on routes this ADR's own scope language
+("a scoped-resource endpoint... a secret, project, user, role, dynamic-secret
+config") is broad enough to cover. ADR-082 §E (Connect connector tenant
+scoping, predates this ADR) has Connect's own convention: a read denied by
+ownership returns the **exact same shape as an unknown connector**
+(`ErrConnectUnknownConnector` — `502`/HTTP, `codes.FailedPrecondition`/gRPC,
+identical message text) — always-collapse, with **no privilege-based
+exception at all**, on a different status-code family than either Convention
+A (403) or Convention B (404).
+
+**Deliberately excluded from this ADR's migration, recorded here so the Guard
+below enumerates three buckets, not two:**
+
+- Connect's collapse is at least as conservative as this ADR's own
+  403-for-both — it has no real-404-exception oracle to close, since it
+  never grants a privileged caller a distinguishable "genuinely not found"
+  response at all (unlike Convention A's narrow global-permission exception,
+  see "The convention, precisely" §1 above). Migrating it to 403-for-both
+  would be a status-code change with no security improvement.
+- Convention A's exception logic (§1) does not apply to Connect's ownership
+  model unchanged — Connect's wildcard/ownership resolution (ADR-082 §E) is
+  its own mechanism, not `handleScopeResolutionError`, and forcing it through
+  that function would need its own translation layer for no proven benefit.
+- This is a **naming and enumeration gap in this ADR's Guard, not a live
+  vulnerability** — ADR-082 §E's own text is explicit that the collapse is
+  "a deliberate choice, not an oversight," made for the identical
+  existence-hiding reason this ADR exists for.
+
+**Consequence for the Guard below**: a route-enumeration guard built against
+only two known conventions (403-via-shared-resolver, or an explicit
+exception) would either misfire on every Connect route, or need a silent
+third bucket discovered ad hoc — exactly the "enumeration is only as
+complete as the idioms it knows about" failure mode this codebase's own
+engineering notes name as a recurring defect class. Any future implementation
+of the Guard below must enumerate Connect's `ErrConnectUnknownConnector`
+collapse as its own named, explicit bucket from the start, not add it after
+the guard already misfires once.
+
 ## Guard
 
 An assertion that every handler touching a scoped resource returns denial
@@ -222,10 +265,13 @@ once the migration lands — otherwise this drifts back to two conventions the
 same way it happened the first time. `handleScopeResolutionError`/
 `RequireScopedPermission` is the thing to grep for; a guard test enumerating
 every route registered against a `{id}`-shaped scoped-resource path and
-confirming it's wired through one of the shared resolvers (or is on an
-explicit, individually-justified exception list, mirroring
-`raw_storage_bypass_guard_test.go`'s own allowlist pattern) is the cheapest
-way to enforce this going forward.
+confirming it's wired through one of **three** buckets — a shared resolver
+(Convention A), an explicit individually-justified exception (mirroring
+`raw_storage_bypass_guard_test.go`'s own allowlist pattern), or Connect's own
+`ErrConnectUnknownConnector` collapse (see "Out of scope: Connect" above) —
+is the cheapest way to enforce this going forward. **This guard is not built
+yet** (as of 2026-09-07) — the enumeration above is a precondition for
+building it correctly the first time, not a description of an existing test.
 
 ## Explicitly deferred: timing side-channel
 

--- a/docs/adr-102-system-write-blast-radius.md
+++ b/docs/adr-102-system-write-blast-radius.md
@@ -148,13 +148,34 @@ is the right model determines whether the fix for this class of finding is
 alerting on the pattern or narrowing the grant that makes the pattern
 possible.
 
-This specific chain is already closed on the reactivation-mechanics side: the
-route now fetches the existing row before writing, so a request that doesn't
-carry `PasswordHash`/`AccountState` no longer zeroes them. Closing
-`AccountLoginBlocked`'s fail-open itself — the account-state gate's deny-list
-shape — is a separate, still-in-progress migration. It is recorded here as
-evidence of what the flat capability already demonstrated once fixed, not as
-an open, exploitable path.
+This specific chain is now closed on **both** halves, not just one — corrected
+here on 2026-09-07 (Tier 2 review of this ADR found this section stale: it was
+written earlier in the day on 2026-09-05, hours before the second half landed
+the same day, and nobody updated it after). The reactivation-mechanics side
+closed first: the route now fetches the existing row before writing, so a
+request that doesn't carry `PasswordHash`/`AccountState` no longer zeroes
+them. `AccountLoginBlocked`'s fail-open itself — the account-state gate's
+deny-list shape this section originally called "a separate, still-in-progress
+migration" — shipped the same day, PR #1742 ("G4"): `AccountLoginBlocked`
+(`internal/core/account_state.go`) now fails **closed** on any blank or
+unrecognized `account_state`, sequenced behind (1) a one-time backfill of
+every existing blank row to an explicit `"active"`
+(`internal/storage/account_state_backfill.go`'s `backfillBlankAccountState`,
+idempotent, runs first) and (2) a Postgres `CHECK` constraint
+(`guardAccountStateValid`) that refuses any future non-canonical value at the
+schema level and **aborts server startup** (`log.Fatalf`) if existing rows
+would violate it — a genuine startup guard, not just a code-level check. A
+static exhaustiveness test
+(`TestAccountLoginBlocked_ExhaustsStateRegistry`) fails CI if a new
+`AccountXxx` state constant is ever added without being handled in the
+switch. Both fixes are on `main` as of 2026-09-05T18:42:19Z, well before this
+review.
+
+This is recorded here as evidence of what the flat capability already
+demonstrated once fixed, not as an open, exploitable path — **there is no
+longer an open item from this specific chain**. The one thing this ADR still
+leaves genuinely undecided is the broader (a)/(b) blast-radius question
+below, not this chain.
 
 ## The two candidate positions
 
@@ -220,6 +241,14 @@ declines to make unilaterally.
 
 ## Consequences
 
+- **Enforced, not just written down**: `TestADR102_SystemWriteBlastRadiusStillOpen`
+  (`internal/core/adr_open_decisions_tripwire_test.go`) fails CI once this
+  decision has sat open past its threshold age, mirroring the mechanism
+  ADR-101 already uses for its own deferred decision
+  (`TestCurrentSchemaEpoch_StillOne_SeeADR101`). Contrast with the state
+  before 2026-09-07: this ADR had no enforcing test at all, unlike ADR-101 —
+  see that test's own doc comment for the general "open decision" registry
+  this belongs to (also covers ADR-084).
 - Until this is decided, every future `/system` route addition should be
   read as adding to an already-root-equivalent surface, not a narrow one —
   reviewers should weigh new routes accordingly regardless of which position

--- a/internal/core/adr_open_decisions_tripwire_test.go
+++ b/internal/core/adr_open_decisions_tripwire_test.go
@@ -1,0 +1,118 @@
+// adr_open_decisions_tripwire_test.go — general mechanism for "an ADR records
+// a security-relevant decision, declines to resolve it, and nothing forces
+// that resolution to happen." ADR-101 already proves the specific shape works
+// (TestCurrentSchemaEpoch_StillOne_SeeADR101, internal/storage/schema_epoch_
+// tripwire_test.go) — this generalizes it to an explicit, extensible registry
+// rather than one bespoke test per ADR, after a 2026-09-07 review
+// (keyorix-private/adversarial-review/ADR-CORPUS-REVIEW-2026-09-07.md,
+// Findings 3 and 4) found two more ADRs in exactly this shape with no
+// enforcing test at all: ADR-102 (system.write blast radius, Proposed,
+// undated) and ADR-084 (admin-bypass structural marker, Accepted but
+// deferred, no target date/owner/tripwire).
+//
+// Each registry entry names: the ADR, a one-line statement of what remains
+// undecided, the date the decision was opened (from `git log --follow
+// --diff-filter=A`, not a guess), and a threshold duration chosen per-entry
+// with its own stated reasoning — not a single global number, since these
+// decisions differ in urgency and don't share a natural deadline the way
+// ADR-101's schema-epoch bump does. Deliberately duration-based (age since
+// opened), not event-triggered like ADR-101's own tripwire: these two ADRs
+// have no single triggering code event to hook a test to (no "the moment X
+// happens" like a schema-epoch bump) — the failure mode this guards against
+// is calendar time passing with nobody revisiting the decision, so the
+// tripwire has to be calendar-based too.
+//
+// When this fires: read the named ADR, make the (a)/(b)-shaped decision it
+// declines to make (or confirm it's already been made elsewhere and update
+// the ADR's Status), and either remove the entry below or push its
+// openedDate/threshold out with a fresh, stated justification for the
+// extension — do not just bump the threshold silently.
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+// adrOpenDecision is one entry in the open-decision registry.
+type adrOpenDecision struct {
+	adr        string // e.g. "ADR-102"
+	decision   string // one-line statement of what remains undecided
+	openedDate string // RFC3339 date the decision was first recorded, from git history
+	threshold  time.Duration
+	reasoning  string // why this specific threshold, not a different one
+}
+
+// adrOpenDecisionRegistry is the extensible list task 2 of the 2026-09-07 ADR
+// review asked for: "any ADR at Proposed (or Accepted-but-deferred) status
+// carrying a security-relevant open decision gets a CI check that fails past
+// a threshold age." Add an entry here, not a new bespoke test function, the
+// next time this shape recurs.
+var adrOpenDecisionRegistry = []adrOpenDecision{
+	{
+		adr:        "ADR-102",
+		decision:   "system.write's blast radius: is it (a) intentionally break-glass/root-equivalent (fix = alerting) or (b) a routine operator role (fix = permission-scoping migration)? docs/adr-102-system-write-blast-radius.md explicitly declines to choose.",
+		openedDate: "2026-09-05",
+		threshold:  30 * 24 * time.Hour,
+		reasoning: "30 days: long enough for a real product/threat-model decision (this " +
+			"touches every /system route and every role holding system.write), short enough " +
+			"that the already-confirmed account-takeover chain motivating this ADR (see its " +
+			"own Context section) doesn't quietly age from '2 days old, worth catching now' " +
+			"(the 2026-09-07 review's own words) into 'forgotten.'",
+	},
+	{
+		adr:        "ADR-084",
+		decision:   "roleSetContainsAdmin stays name-based (rename drops the bypass silently, a colliding customer role name gains it silently) until the accepted bypasses_permission_checks structural-flag decision is actually implemented. docs/adr-084-admin-bypass-structural-marker.md makes no code changes and sets no target date.",
+		openedDate: "2026-08-19",
+		threshold:  45 * 24 * time.Hour,
+		reasoning: "45 days from acceptance: this ADR already names its own prerequisite " +
+			"(the fix-1494-role-set-contains-admin-error-swallow branch) as landed and ready " +
+			"to build on, so nothing external blocks starting; medium severity (requires an " +
+			"unlikely operator action to trigger, per the 2026-09-07 review's Finding 4) " +
+			"argues for a longer window than ADR-102's high-severity one, not an indefinitely " +
+			"open one.",
+	},
+}
+
+// TestADR102_SystemWriteBlastRadiusStillOpen is the enforcing test named in
+// docs/adr-102-system-write-blast-radius.md's own Consequences section.
+func TestADR102_SystemWriteBlastRadiusStillOpen(t *testing.T) {
+	checkADROpenDecisionNotStale(t, "ADR-102")
+}
+
+// TestADR084_AdminBypassStructuralMarkerStillDeferred is the enforcing test
+// named in docs/adr-084-admin-bypass-structural-marker.md's own Consequences
+// section.
+func TestADR084_AdminBypassStructuralMarkerStillDeferred(t *testing.T) {
+	checkADROpenDecisionNotStale(t, "ADR-084")
+}
+
+func checkADROpenDecisionNotStale(t *testing.T, adr string) {
+	t.Helper()
+	for _, d := range adrOpenDecisionRegistry {
+		if d.adr != adr {
+			continue
+		}
+		opened, err := time.Parse("2006-01-02", d.openedDate)
+		if err != nil {
+			t.Fatalf("%s: openedDate %q does not parse as YYYY-MM-DD: %v", d.adr, d.openedDate, err)
+		}
+		age := time.Since(opened)
+		if age > d.threshold {
+			t.Fatalf(
+				"%s has been open %s (threshold %s, opened %s) with nothing forcing its "+
+					"resolution -- STOP: this is exactly the 'accepted decision, no enforcement "+
+					"mechanism' pattern the 2026-09-07 ADR review flagged. Decision still undecided: "+
+					"%s\n\nResolve the decision and update the ADR's Status, or if a genuine reason "+
+					"exists to keep it open longer, extend this entry's threshold in "+
+					"adr_open_decisions_tripwire_test.go with a fresh, stated reason -- do not "+
+					"silently bump the number.",
+				d.adr, age.Round(time.Hour), d.threshold, d.openedDate, d.decision,
+			)
+		}
+		return
+	}
+	t.Fatalf("no registry entry found for %s in adrOpenDecisionRegistry -- this test's own "+
+		"name promises to check that ADR; the registry entry was removed without removing "+
+		"the test, or renamed without updating it", adr)
+}


### PR DESCRIPTION
## Summary
- ADR-102: corrects a stale account-takeover narrative (PR #1742/G4 flipped AccountLoginBlocked to fail-closed the same day the ADR was written, just hours later); the only genuinely open item is the (a)/(b) system.write blast-radius decision itself.
- New `internal/core/adr_open_decisions_tripwire_test.go`: generalizes ADR-101's own enforcing-test mechanism to any ADR with an unresolved security-relevant decision. Seeded with ADR-102 (30-day threshold) and ADR-084 (45-day threshold, already 19 days old with no prior tripwire).
- ADR-096: corrects its Guard section's enumeration to name Connect's third existence-collapse convention (ADR-082 §E) before any guard is built against it.
- ADR-053: corrects a stale "Deferred follow-ups" list (deployment-wide plan, gRPC/CLI/web surfaces all shipped within two weeks of acceptance).
- CLAUDE.md: standing note that PR citations below roughly #700 in ADRs resolve to unrelated PRs (spot-checked against the GitHub API) — mechanisms are independently verified correct, only the citations are wrong, not worth repairing.

Source: `keyorix-private/adversarial-review/ADR-CORPUS-REVIEW-2026-09-07.md` (Tier 1/2 findings) plus a same-day follow-up request.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/core/... -run "TestADR102|TestADR084"` — both pass
- [x] `gofmt -l` clean on the new test file