### PR TITLE
fix(core): close IsGlobalAdmin confused-deputy in last-admin lockout + inactivity sweep

### DIFF
--- a/docs/security-closures.tsv
+++ b/docs/security-closures.tsv
@@ -20,6 +20,7 @@ INV-1-grant-authority	./server/http	TestEveryDirectRoleGrantChecksAuthority	pre-
 GCP-CONN-PROJECTID	./internal/connect	TestGCPSM_RequiresProjectID	pending	unpinned gcp-secret-manager connector must refuse reads, not span any GCP project
 AWS-CONN-ACCOUNTID	./internal/connect	TestAWSSM_AccountPin	pending	pinned aws-secrets-manager connector must refuse an ARN naming a different AWS account
 G81-KEYPERM-REGISTRY	./internal/keyfiles	TestRegistry_IncludesWrappedKeyPathForEveryWriteCapableType	pending	TPM/cloud-KMS wrapped-KEK blob must be covered by the shared key-permission checker registry, not just DEK/salt
+LASTADMIN-PAT-CONFUSED-DEPUTY	./internal/core	TestGuardLastAdminDeactivation_NotFooledByActingCallersPATRestriction	pending	IsGlobalAdmin's PAT short-circuit answered a third-party question it wasn't built for; guardLastAdminDeactivation and SuspendInactiveUsers now use targetHasGlobalAdminRole instead
 
 # NOT LISTED, deliberately:
 #   FIX-1 actorID==0 fast-path (internal/core/authz.go:614). The eight-site reroute

--- a/internal/core/authz.go
+++ b/internal/core/authz.go
@@ -316,8 +316,10 @@ func (c *KeyorixCore) AuthorizeSecretPrincipal(ctx context.Context, actorType st
 	return c.AuthorizePrincipal(ctx, actorType, principalID, permission, scope)
 }
 
-// IsGlobalAdmin reports whether userID holds an admin role assigned globally
-// (project 0, environment 0). Used to short-circuit scope-filtered listing.
+// IsGlobalAdmin answers a SELF-CHECK: "should userID — always the ctx's own
+// acting principal — be treated as an unrestricted global admin for this
+// request." It must never be called with a userID other than the ctx's own
+// actor; see targetHasGlobalAdminRole for that different question.
 //
 // A request carrying a PAT least-privilege restriction (ADR-042) is never treated
 // as an unrestricted global admin: the token was deliberately scoped below its
@@ -329,7 +331,28 @@ func (c *KeyorixCore) IsGlobalAdmin(ctx context.Context, userID uint) (bool, err
 	if patRestrictionFromContext(ctx) != nil {
 		return false, nil
 	}
-	roleIDs, err := c.scopedRoleIDs(ctx, userID, Scope{})
+	return c.targetHasGlobalAdminRole(ctx, userID)
+}
+
+// targetHasGlobalAdminRole answers a THIRD-PARTY QUESTION: "does targetID
+// currently hold a global admin-tier role" — a fact about targetID, never
+// about whoever is asking. Deliberately does NOT consult
+// patRestrictionFromContext(ctx): that check exists solely to stop the
+// CALLER's own scoped PAT from being treated as unrestricted-admin authority
+// (see IsGlobalAdmin) and is meaningless here, since the question isn't about
+// the caller at all.
+//
+// Found 2026-09-07 (ADR conformance review, HIGH): guardLastAdminDeactivation
+// and SuspendInactiveUsers both reused IsGlobalAdmin to ask this third-party
+// question, so an admin acting through their own ordinary scoped PAT made
+// IsGlobalAdmin's short-circuit fire on the ACTOR's restriction rather than
+// the TARGET's actual role — silently reporting every target as "not an
+// admin" regardless of truth, which let the last-global-admin lockout guard
+// (and the inactivity-suspend admin-skip check) both no-op. Use this function
+// for any "is THIS OTHER PRINCIPAL an admin" query; use IsGlobalAdmin only
+// for "should THE CALLER be treated as one."
+func (c *KeyorixCore) targetHasGlobalAdminRole(ctx context.Context, targetID uint) (bool, error) {
+	roleIDs, err := c.scopedRoleIDs(ctx, targetID, Scope{})
 	if err != nil {
 		return false, err
 	}

--- a/internal/core/inactivity_suspend.go
+++ b/internal/core/inactivity_suspend.go
@@ -75,8 +75,13 @@ func (c *KeyorixCore) SuspendInactiveUsers(ctx context.Context, cfg InactivitySu
 			continue
 		}
 
-		// Skip global admins.
-		isAdmin, err := c.IsGlobalAdmin(ctx, u.ID)
+		// Skip global admins. targetHasGlobalAdminRole, not IsGlobalAdmin: this
+		// asks whether u (the loop's current target) is an admin, not whether
+		// the caller triggering this sweep is — see targetHasGlobalAdminRole's
+		// doc comment (internal/core/authz.go). This sweep is reachable via a
+		// live HTTP endpoint (AdminJobsHandler.SuspendInactiveUsers) carrying
+		// the triggering admin's own ctx, including any PAT restriction on it.
+		isAdmin, err := c.targetHasGlobalAdminRole(ctx, u.ID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check admin status for user %d: %w", u.ID, err)
 		}

--- a/internal/core/last_admin_pat_confused_deputy_test.go
+++ b/internal/core/last_admin_pat_confused_deputy_test.go
@@ -1,0 +1,136 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keyorixhq/keyorix/internal/storage/sqlitedialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// TestGuardLastAdminDeactivation_NotFooledByActingCallersPATRestriction is the
+// regression for the 2026-09-07 ADR-conformance review's HIGH finding:
+// guardLastAdminDeactivation asked IsGlobalAdmin(ctx, targetID) whether the
+// TARGET is the last admin, but IsGlobalAdmin's PAT short-circuit
+// (`patRestrictionFromContext(ctx) != nil { return false, nil }`) answers a
+// different question -- "should the ACTOR on this ctx be treated as an
+// unrestricted admin" -- and fires on the ACTOR's own restriction regardless
+// of which targetID was asked about. An admin authenticating via their own,
+// ordinary, legitimately-scoped PAT could therefore suspend/deactivate the
+// install's last remaining global admin with this guard silently no-op'ing.
+func TestGuardLastAdminDeactivation_NotFooledByActingCallersPATRestriction(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	setup := func(t *testing.T) (*KeyorixCore, *gorm.DB) {
+		db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+		require.NoError(t, err)
+		require.NoError(t, db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{},
+			&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Session{},
+			&models.PersonalAccessToken{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}))
+		ls := store.NewLocalStorage(db)
+		return NewKeyorixCore(ls), db
+	}
+
+	t.Run("acting admin's own scoped PAT must not blind the guard to the target being the last admin", func(t *testing.T) {
+		c, db := setup(t)
+
+		// User 1 is the install's sole global admin.
+		require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin", NameFolded: "admin", BypassesPermissionChecks: true}).Error)
+		require.NoError(t, db.Create(&models.User{ID: 1, Username: "lastadmin", IsActive: true, AccountState: AccountActive}).Error)
+		require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 0, EnvironmentID: 0}).Error)
+
+		// User 2 is the acting caller -- authenticated via their own, ordinary,
+		// least-privilege scoped PAT (ADR-042). This is not an attack: any admin
+		// who routinely uses a scoped PAT for automation would carry this ctx.
+		require.NoError(t, db.Create(&models.User{ID: 2, Username: "actingadmin", IsActive: true, AccountState: AccountActive}).Error)
+		ctx := WithPATRestriction(context.Background(), &PATRestriction{Permissions: []string{"users.write"}})
+
+		err := c.SuspendUser(ctx, 2, 1)
+		require.Error(t, err, "must refuse to suspend the install's last global admin, regardless of the acting caller's own PAT restriction")
+		assert.Contains(t, err.Error(), "last install administrator")
+
+		var target models.User
+		require.NoError(t, db.First(&target, 1).Error)
+		assert.NotEqual(t, AccountSuspended, NormalizeAccountState(target.AccountState),
+			"the last admin must not actually be suspended when the guard correctly refuses")
+	})
+
+	t.Run("positive control: a genuine second admin still permits the suspend, PAT-restricted ctx included", func(t *testing.T) {
+		c, db := setup(t)
+
+		require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin", NameFolded: "admin", BypassesPermissionChecks: true}).Error)
+		require.NoError(t, db.Create(&models.User{ID: 1, Username: "admin-one", IsActive: true, AccountState: AccountActive}).Error)
+		require.NoError(t, db.Create(&models.User{ID: 3, Username: "admin-two", IsActive: true, AccountState: AccountActive}).Error)
+		require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 0, EnvironmentID: 0}).Error)
+		require.NoError(t, db.Create(&models.UserRole{UserID: 3, RoleID: 1, ProjectID: 0, EnvironmentID: 0}).Error)
+
+		require.NoError(t, db.Create(&models.User{ID: 2, Username: "actingadmin", IsActive: true, AccountState: AccountActive}).Error)
+		ctx := WithPATRestriction(context.Background(), &PATRestriction{Permissions: []string{"users.write"}})
+
+		require.NoError(t, c.SuspendUser(ctx, 2, 1),
+			"a second live admin exists, so the guard must still permit this suspend")
+	})
+
+	t.Run("positive control: an ordinary (non-admin) target is unaffected by the guard", func(t *testing.T) {
+		c, db := setup(t)
+
+		require.NoError(t, db.Create(&models.User{ID: 4, Username: "regularuser", IsActive: true, AccountState: AccountActive}).Error)
+		require.NoError(t, db.Create(&models.User{ID: 2, Username: "actingadmin", IsActive: true, AccountState: AccountActive}).Error)
+		ctx := WithPATRestriction(context.Background(), &PATRestriction{Permissions: []string{"users.write"}})
+
+		require.NoError(t, c.SuspendUser(ctx, 2, 4))
+	})
+}
+
+// TestSuspendInactiveUsers_NotFooledByCallersPATRestriction is the second
+// confirmed instance of the same confused-deputy shape, found by the sweep
+// this fix's review required: SuspendInactiveUsers's "skip global admins"
+// check (internal/core/inactivity_suspend.go) is reachable from a live HTTP
+// endpoint (AdminJobsHandler.SuspendInactiveUsers) carrying the triggering
+// admin's own r.Context() -- including any PAT restriction on it. Before the
+// fix, an admin who triggers this sweep via their own scoped PAT would see
+// EVERY inactive global admin wrongly suspended instead of skipped, because
+// IsGlobalAdmin's short-circuit fires on the CALLER's restriction, not the
+// per-iteration target user's actual role.
+func TestSuspendInactiveUsers_NotFooledByCallersPATRestriction(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.User{}, &models.Role{}, &models.UserRole{},
+		&models.Group{}, &models.UserGroup{}, &models.GroupRole{}, &models.Session{},
+		&models.PersonalAccessToken{}, &models.AuditEvent{}, &models.Project{}, &models.Environment{}))
+	ls := store.NewLocalStorage(db)
+	c := NewKeyorixCore(ls)
+
+	staleTime := c.now().AddDate(0, 0, -90)
+
+	require.NoError(t, db.Create(&models.Role{ID: 1, Name: "admin", NameFolded: "admin", BypassesPermissionChecks: true}).Error)
+	require.NoError(t, db.Create(&models.User{
+		ID: 1, Username: "inactive-admin", IsActive: true, AccountState: AccountActive,
+		LastLoginAt: &staleTime,
+	}).Error)
+	require.NoError(t, db.Create(&models.UserRole{UserID: 1, RoleID: 1, ProjectID: 0, EnvironmentID: 0}).Error)
+
+	// The triggering caller's ctx carries a scoped PAT restriction, exactly as
+	// an admin invoking this sweep via automation with their own least-privilege
+	// token would.
+	ctx := WithPATRestriction(context.Background(), &PATRestriction{Permissions: []string{"users.write"}})
+
+	result, err := c.SuspendInactiveUsers(ctx, InactivitySuspendConfig{InactiveDays: 30, DryRun: false})
+	require.NoError(t, err)
+
+	assert.NotContains(t, result.Suspended, uint(1),
+		"the sweep must skip a genuine global admin regardless of the triggering caller's own PAT restriction")
+	assert.Equal(t, 1, result.Skipped, "the admin must be counted as skipped, not silently suspended")
+
+	var target models.User
+	require.NoError(t, db.First(&target, 1).Error)
+	assert.NotEqual(t, AccountSuspended, NormalizeAccountState(target.AccountState))
+}

--- a/internal/core/scim.go
+++ b/internal/core/scim.go
@@ -452,7 +452,10 @@ func applySCIMActiveState(user *models.User, active *bool, deactivated *bool) {
 // the same change) -- filed as an explicit follow-up, not silently carried
 // forward as already covered.
 func (c *KeyorixCore) guardLastAdminDeactivation(ctx context.Context, targetID uint) error {
-	isAdmin, err := c.IsGlobalAdmin(ctx, targetID)
+	// targetHasGlobalAdminRole, not IsGlobalAdmin: this asks whether targetID
+	// is an admin, not whether the acting caller is — see targetHasGlobalAdminRole's
+	// doc comment (internal/core/authz.go) for the confused-deputy this avoids.
+	isAdmin, err := c.targetHasGlobalAdminRole(ctx, targetID)
 	if err != nil {
 		// #337: "can't tell" is NOT the same as "confirmed not an admin". The previous
 		// code treated an IsGlobalAdmin lookup error identically to a confirmed non-admin


### PR DESCRIPTION
## Summary
- `IsGlobalAdmin`'s PAT-restriction short-circuit answers "should the ctx's own actor be treated as an unrestricted admin" — correct for its two genuine self-check callers, wrong when reused to ask "is this OTHER user an admin."
- `guardLastAdminDeactivation` (backing `SuspendUser`/`UpdateUser`/SCIM deactivation, and the `/system` proxy `UpdateUserIfActiveStateMatchesProxy`) and `SuspendInactiveUsers` both reused it for that third-party question, so an admin authenticating via their own ordinary scoped PAT could silently bypass the last-admin lockout guard, and the inactivity sweep would wrongly suspend a genuine admin instead of skipping them.
- Adds `targetHasGlobalAdminRole` — the same lookup without the PAT check — for third-party queries, and switches both vulnerable call sites to it. `IsGlobalAdmin` is now documented as self-check-only.
- Full sweep of every `IsGlobalAdmin` call site: the two remaining callers (`requireGlobalAdminToReinstateAdminRoles`, `RequireMachinePrivilegeCeiling`) confirmed to always pass the ctx's own actor — genuine self-checks, left unchanged.

## Test plan
- [x] Red-then-green: both regressions (`TestGuardLastAdminDeactivation_NotFooledByActingCallersPATRestriction`, `TestSuspendInactiveUsers_NotFooledByCallersPATRestriction`) reproduced the bug against pre-fix code, confirmed passing after the fix.
- [x] Positive controls: a genuine second admin still permits the suspend; an ordinary target is unaffected.
- [x] `go build ./...`, `go vet ./internal/core/...`, `gofmt -l` clean on touched files.
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` clean (0 issues).
- [x] Full `internal/core` + `internal/core/storage` suites pass (`go test ./internal/core/... -count=1`).
- [x] `docs/security-closures.tsv` entry added (`LASTADMIN-PAT-CONFUSED-DEPUTY`), verified by `scripts/check-closures.sh`.
