### PR TITLE
docs(adr-084): correct Status to Implemented + redesign tripwire to check premises, not just age

### DIFF
--- a/docs/adr-084-admin-bypass-structural-marker.md
+++ b/docs/adr-084-admin-bypass-structural-marker.md
@@ -2,11 +2,29 @@
 
 ## Status
 
-**Accepted.** This ADR records the decision on *what mechanism* should
-replace name-based admin-role recognition. It makes **no code changes** —
-implementation is deferred to its own follow-up work now that this is
-accepted, and depends on one prerequisite that has already landed. Two
-verifications (immutability of the proposed column; fail-closed behavior
+**Accepted and implemented (PR #1671, merged 2026-09-02).** This ADR's core
+decision — `bypasses_permission_checks` as a structural, non-name column on
+`models.Role`, resolved by ID, no runtime mutation path — has shipped.
+`roleSetContainsAdmin` (`internal/core/authz.go`) now resolves the flag via
+`storage.RoleSetBypassesPermissionChecks`, not `GetRoleByName`; `CreateRole`/
+`UpdateRole` still never accept the field from a request DTO, exactly as
+decided in "Verification" §1. **Corrected 2026-09-07**: this Status section
+previously read "makes no code changes... implementation is deferred," which
+was already stale by 5 days at the time of that correction — the fix landed
+before this document was updated to say so, the opposite direction from a
+premature claim. The 2026-09-07 tripwire this staleness triggered
+(`TestADR084_AdminBypassStructuralMarkerStillDeferred`) is removed below,
+since the decision it existed to force is no longer open.
+
+**Not yet done**: `installAdminRoleIDSet` (`internal/core/rbac_management.go:608`)
+is still the second, separately-maintained name list this ADR's Consequences
+section proposed simplifying into a scope-aware flag query — verified still
+name-based as of this correction, `GetRoleByName` calls unchanged. This is a
+real residual item, not a blocker to calling the ADR's core decision
+implemented; tracked here so it isn't silently assumed done by a future
+reader of "Implemented" above.
+
+Two verifications (immutability of the proposed column; fail-closed behavior
 at all call sites) were run before acceptance — see "Verification" below.
 The fail-closed verification surfaced a genuine defect
 (`roleSetContainsAdmin` silently swallowed real storage errors, not just
@@ -437,16 +455,22 @@ every site twice.
 
 ## Consequences
 
-- **Enforced, not just written down (added 2026-09-07)**: this ADR was
-  accepted 2026-08-19 with implementation deferred and no target date, owner,
-  or tripwire — 19 days of no enforcement mechanism forcing the deferred work
-  to surface, the same "accepted decision, nothing forcing resolution" shape
-  ADR-102 was found in. `TestADR084_AdminBypassStructuralMarkerStillDeferred`
-  (`internal/core/adr_open_decisions_tripwire_test.go`) now fails CI once this
-  has sat unimplemented past its threshold age, using the same general
-  "open decision" registry ADR-102's tripwire uses — see that test's doc
-  comment for the mechanism, modeled on ADR-101's
-  `TestCurrentSchemaEpoch_StillOne_SeeADR101`.
+- **Tripwire added 2026-09-07, removed the same day its own premise turned
+  out to be false.** A tripwire test
+  (`TestADR084_AdminBypassStructuralMarkerStillDeferred`) was added to force
+  this decision to surface if left unimplemented past a threshold age — but
+  the decision had already been implemented 5 days earlier (PR #1671,
+  2026-09-02), and nobody checked before adding the tripwire. Removed from
+  `internal/core/adr_open_decisions_tripwire_test.go`'s registry along with
+  this correction. Worth naming as a process gap, not just a doc fix: a
+  duration-based tripwire checks whether TIME has passed, never whether the
+  underlying claim is still true — it would not have caught this staleness
+  either way, only a fixed check against actual implementation state would
+  have. ADR-101's `TestCurrentSchemaEpoch_StillOne_SeeADR101`, which this
+  mechanism was modeled on, avoids the gap by checking a live code constant,
+  not a calendar date — duration-based tripwires for a *decision* (as opposed
+  to a *value*) don't have an equivalent live signal to check, which is the
+  actual gap this ADR's tripwire attempt exposed.
 - `roleSetContainsAdmin`'s eight call sites (see "Prerequisite" above)
   change from up to four `GetRoleByName` calls to an ID-based lookup of the
   resolved role set's flag — no behavior change at any of them beyond

--- a/docs/adr-084-admin-bypass-structural-marker.md
+++ b/docs/adr-084-admin-bypass-structural-marker.md
@@ -455,22 +455,24 @@ every site twice.
 
 ## Consequences
 
-- **Tripwire added 2026-09-07, removed the same day its own premise turned
-  out to be false.** A tripwire test
-  (`TestADR084_AdminBypassStructuralMarkerStillDeferred`) was added to force
-  this decision to surface if left unimplemented past a threshold age — but
-  the decision had already been implemented 5 days earlier (PR #1671,
-  2026-09-02), and nobody checked before adding the tripwire. Removed from
-  `internal/core/adr_open_decisions_tripwire_test.go`'s registry along with
-  this correction. Worth naming as a process gap, not just a doc fix: a
-  duration-based tripwire checks whether TIME has passed, never whether the
-  underlying claim is still true — it would not have caught this staleness
-  either way, only a fixed check against actual implementation state would
-  have. ADR-101's `TestCurrentSchemaEpoch_StillOne_SeeADR101`, which this
-  mechanism was modeled on, avoids the gap by checking a live code constant,
-  not a calendar date — duration-based tripwires for a *decision* (as opposed
-  to a *value*) don't have an equivalent live signal to check, which is the
-  actual gap this ADR's tripwire attempt exposed.
+- **Tripwire added 2026-09-07, corrected the same day.** A duration-based
+  tripwire test (`TestADR084_AdminBypassStructuralMarkerStillDeferred`) was
+  added claiming this decision was still "deferred" — but it had already
+  been implemented 5 days earlier (PR #1671, 2026-09-02), and nobody checked
+  before writing the entry, because the check only asked whether TIME had
+  passed, never whether the underlying claim was still true. Fixed two ways,
+  not just reverted: the stale entry itself was removed from
+  `internal/core/adr_open_decisions_tripwire_test.go`'s registry, and the
+  general mechanism was redesigned to check a decision's PREMISE — a live
+  code fact — ahead of elapsed time wherever one is expressible.
+  `TestADRDecisionRoleSetContainsAdminIsStructural` (same file) is the
+  worked example for this ADR specifically: it asserts
+  `models.Role.BypassesPermissionChecks` exists, which would have failed the
+  moment #1671 shipped rather than sitting silently wrong in a registry
+  entry. ADR-102's own tripwire remains duration-only, correctly — its
+  (a)/(b) policy choice produces no code artifact in either unresolved
+  branch, so there is no premise to check there; age is genuinely the only
+  available signal for that one, not an oversight.
 - `roleSetContainsAdmin`'s eight call sites (see "Prerequisite" above)
   change from up to four `GetRoleByName` calls to an ID-based lookup of the
   resolved role set's flag — no behavior change at any of them beyond

--- a/internal/core/adr_open_decisions_tripwire_test.go
+++ b/internal/core/adr_open_decisions_tripwire_test.go
@@ -10,28 +10,43 @@
 // undated) and ADR-084 (admin-bypass structural marker, Accepted but
 // deferred, no target date/owner/tripwire).
 //
-// ADR-084's entry was removed the same day it was added (2026-09-07,
-// corrected): its decision had already been implemented 5 days earlier
-// (PR #1671, 2026-09-02), a fact nobody checked before writing "deferred,
-// no target date" into the registry. This is the actual gap a duration-based
-// tripwire has: it checks whether TIME has passed, never whether the
-// underlying claim is still true, so it would not have caught this
-// staleness either way, only a check against live implementation state
-// would have. Kept as a documented lesson, not silently dropped from this
-// comment: before adding an entry here, confirm the decision is still open
-// against current code, not just against the ADR's own text.
+// REDESIGNED 2026-09-07, same day, after the first version's own entry for
+// ADR-084 went stale on arrival: it claimed the decision was still "deferred,
+// no code changes" when PR #1671 had already implemented it 5 days earlier,
+// because the check was purely age-based (elapsed time since openedDate) and
+// never asked whether the decision was ACTUALLY still open in code. A
+// duration-based check answers "has time passed," never "is the claim still
+// true" — those are different questions, and only the second one is what a
+// reader actually wants to know.
+//
+// A registry entry MUST assert the decision's PREMISE — a live, checkable
+// fact about current code that would change the moment the decision is
+// resolved — whenever one is expressible. ADR-084's premise was directly
+// checkable ("does roleSetContainsAdmin still resolve by name") and would
+// have caught the staleness immediately, the day #1671 merged, instead of
+// sitting wrong in a registry entry that was itself only hours old.
+// Age-based expiry is kept ONLY as a fallback for decisions whose
+// unresolved state produces no code artifact in either branch — ADR-102's
+// (a)/(b) policy choice (alerting vs. permission-scoping) is the current
+// example: neither un-chosen branch leaves anything in the codebase for a
+// premise function to inspect, so there is nothing to check except elapsed
+// time. Do not add an age-only entry without first asking whether a premise
+// exists — leave premise nil with a comment stating why not, so the omission
+// reads as considered, not overlooked the way ADR-084's was.
+//
+// When a premise IS expressible, the check still also runs the age fallback
+// underneath it (see evaluateOpenDecision) — a resolved premise fires
+// immediately regardless of age (catching a stale-in-the-safe-direction
+// entry like ADR-084's), and an unresolved premise still ages out on its own
+// threshold (catching a decision that's genuinely still open and has simply
+// been forgotten). The two checks are complementary, not alternatives.
 //
 // Each registry entry names: the ADR, a one-line statement of what remains
-// undecided, the date the decision was opened (from `git log --follow
-// --diff-filter=A`, not a guess), and a threshold duration chosen per-entry
-// with its own stated reasoning — not a single global number, since these
-// decisions differ in urgency and don't share a natural deadline the way
-// ADR-101's schema-epoch bump does. Deliberately duration-based (age since
-// opened), not event-triggered like ADR-101's own tripwire: these two ADRs
-// have no single triggering code event to hook a test to (no "the moment X
-// happens" like a schema-epoch bump) — the failure mode this guards against
-// is calendar time passing with nobody revisiting the decision, so the
-// tripwire has to be calendar-based too.
+// undecided, an optional premise function, the date the decision was opened
+// (from `git log --follow --diff-filter=A`, not a guess), and a threshold
+// duration chosen per-entry with its own stated reasoning — not a single
+// global number, since these decisions differ in urgency and don't share a
+// natural deadline the way ADR-101's schema-epoch bump does.
 //
 // When this fires: read the named ADR, make the (a)/(b)-shaped decision it
 // declines to make (or confirm it's already been made elsewhere and update
@@ -41,8 +56,11 @@
 package core
 
 import (
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // adrOpenDecision is one entry in the open-decision registry.
@@ -52,6 +70,13 @@ type adrOpenDecision struct {
 	openedDate string // RFC3339 date the decision was first recorded, from git history
 	threshold  time.Duration
 	reasoning  string // why this specific threshold, not a different one
+	// premise, when non-nil, checks whether the decision is ACTUALLY still
+	// open in code today — takes priority over the age check. Returns
+	// stillOpen=false the moment the underlying code fact that would prove
+	// the decision resolved is observed, with detail explaining what was
+	// found. Leave nil (with a comment explaining why no premise is
+	// expressible) rather than omitting it silently — see file header.
+	premise func() (stillOpen bool, detail string)
 }
 
 // adrOpenDecisionRegistry is the extensible list task 2 of the 2026-09-07 ADR
@@ -61,8 +86,14 @@ type adrOpenDecision struct {
 // next time this shape recurs.
 var adrOpenDecisionRegistry = []adrOpenDecision{
 	{
-		adr:        "ADR-102",
-		decision:   "system.write's blast radius: is it (a) intentionally break-glass/root-equivalent (fix = alerting) or (b) a routine operator role (fix = permission-scoping migration)? docs/adr-102-system-write-blast-radius.md explicitly declines to choose.",
+		adr:      "ADR-102",
+		decision: "system.write's blast radius: is it (a) intentionally break-glass/root-equivalent (fix = alerting) or (b) a routine operator role (fix = permission-scoping migration)? docs/adr-102-system-write-blast-radius.md explicitly declines to choose.",
+		// No premise is expressible: unlike ADR-084's structural flag (whose
+		// presence directly proves the decision resolved), neither (a) nor
+		// (b) leaves a code artifact in its UNRESOLVED state for a premise
+		// function to check against — the decision is a pure product/policy
+		// choice with no interim code shape either fork would produce before
+		// someone actually builds it. Age is the only available signal.
 		openedDate: "2026-09-05",
 		threshold:  30 * 24 * time.Hour,
 		reasoning: "30 days: long enough for a real product/threat-model decision (this " +
@@ -79,32 +110,170 @@ func TestADR102_SystemWriteBlastRadiusStillOpen(t *testing.T) {
 	checkADROpenDecisionNotStale(t, "ADR-102")
 }
 
+// TestADRDecisionRoleSetContainsAdminIsStructural is the worked example of a
+// premise function, kept live rather than only demonstrated in the self-test
+// below: it directly answers "has ADR-084's decision been implemented,"
+// independent of any registry entry or age. If this codebase ever
+// regresses roleSetContainsAdmin back to name-based resolution, this test
+// documents what a premise check for that regression would look like —
+// exercised for real here, not just simulated.
+func TestADRDecisionRoleSetContainsAdminIsStructural(t *testing.T) {
+	stillOpen, detail := adr084Premise()
+	if stillOpen {
+		t.Fatalf("ADR-084's decision reads as unresolved again: %s", detail)
+	}
+}
+
+// adr084Premise checks whether ADR-084's decision — "bypasses_permission_checks
+// as a structural, non-name column" — is actually implemented, by asserting
+// the column exists on models.Role. This is the premise ADR-084's original
+// registry entry should have used from the start: it would have failed the
+// moment PR #1671 shipped, 5 days before the entry was written claiming
+// otherwise.
+func adr084Premise() (stillOpen bool, detail string) {
+	// A compile-time assertion, not a runtime one: if BypassesPermissionChecks
+	// is ever removed from models.Role, this line itself fails to compile,
+	// which is a louder and earlier signal than a runtime test failure. The
+	// runtime call below exists so this still reads as a normal premise
+	// function callable from the registry shape, for the next ADR that needs
+	// one.
+	var r models.Role
+	_ = r.BypassesPermissionChecks
+	return false, "models.Role.BypassesPermissionChecks exists — ADR-084's structural flag is implemented"
+}
+
+// checkADROpenDecisionNotStale is the thin per-test entrypoint: find the
+// named registry entry and fail loudly via evaluateOpenDecision if either
+// check fires.
 func checkADROpenDecisionNotStale(t *testing.T, adr string) {
 	t.Helper()
 	for _, d := range adrOpenDecisionRegistry {
 		if d.adr != adr {
 			continue
 		}
-		opened, err := time.Parse("2006-01-02", d.openedDate)
-		if err != nil {
-			t.Fatalf("%s: openedDate %q does not parse as YYYY-MM-DD: %v", d.adr, d.openedDate, err)
-		}
-		age := time.Since(opened)
-		if age > d.threshold {
-			t.Fatalf(
-				"%s has been open %s (threshold %s, opened %s) with nothing forcing its "+
-					"resolution -- STOP: this is exactly the 'accepted decision, no enforcement "+
-					"mechanism' pattern the 2026-09-07 ADR review flagged. Decision still undecided: "+
-					"%s\n\nResolve the decision and update the ADR's Status, or if a genuine reason "+
-					"exists to keep it open longer, extend this entry's threshold in "+
-					"adr_open_decisions_tripwire_test.go with a fresh, stated reason -- do not "+
-					"silently bump the number.",
-				d.adr, age.Round(time.Hour), d.threshold, d.openedDate, d.decision,
-			)
+		if err := evaluateOpenDecision(d, time.Now()); err != nil {
+			t.Fatal(err.Error())
 		}
 		return
 	}
 	t.Fatalf("no registry entry found for %s in adrOpenDecisionRegistry -- this test's own "+
 		"name promises to check that ADR; the registry entry was removed without removing "+
 		"the test, or renamed without updating it", adr)
+}
+
+// evaluateOpenDecision is the pure logic behind checkADROpenDecisionNotStale,
+// extracted so it can be exercised directly by the self-test below with
+// synthetic entries — the same reason mlockall_removal_guard_test.go and
+// other guards in this codebase pair a real check with a red/green
+// self-test proving the check mechanism itself actually detects both
+// outcomes, not just the one case it happened to run against here.
+// now is passed in (not time.Now() called internally) so the self-test can
+// exercise "age past threshold" deterministically without sleeping.
+func evaluateOpenDecision(d adrOpenDecision, now time.Time) error {
+	if d.premise != nil {
+		if stillOpen, detail := d.premise(); !stillOpen {
+			return fmt.Errorf(
+				"%s: registry says this decision is still open, but its premise check reports "+
+					"it has already been resolved in code (%s) -- this is exactly ADR-084's original "+
+					"mistake (an entry claiming 'deferred' 5 days after the fix actually shipped). "+
+					"Update the ADR's Status and remove this registry entry.",
+				d.adr, detail,
+			)
+		}
+	}
+	opened, err := time.Parse("2006-01-02", d.openedDate)
+	if err != nil {
+		return fmt.Errorf("%s: openedDate %q does not parse as YYYY-MM-DD: %v", d.adr, d.openedDate, err)
+	}
+	age := now.Sub(opened)
+	if age > d.threshold {
+		return fmt.Errorf(
+			"%s has been open %s (threshold %s, opened %s) with nothing forcing its "+
+				"resolution -- STOP: this is exactly the 'accepted decision, no enforcement "+
+				"mechanism' pattern the 2026-09-07 ADR review flagged. Decision still undecided: "+
+				"%s\n\nResolve the decision and update the ADR's Status, or if a genuine reason "+
+				"exists to keep it open longer, extend this entry's threshold in "+
+				"adr_open_decisions_tripwire_test.go with a fresh, stated reason -- do not "+
+				"silently bump the number.",
+			d.adr, age.Round(time.Hour), d.threshold, d.openedDate, d.decision,
+		)
+	}
+	return nil
+}
+
+// TestEvaluateOpenDecision_MechanismSelfTest is the red/green proof that
+// evaluateOpenDecision actually detects both failure modes it exists to
+// catch, and does not over-fire on the cases it should pass — run against
+// synthetic entries, not the real registry, so it exercises the MECHANISM
+// deterministically rather than depending on real ADRs' real ages.
+func TestEvaluateOpenDecision_MechanismSelfTest(t *testing.T) {
+	fixedNow, err := time.Parse("2006-01-02", "2026-09-07")
+	if err != nil {
+		t.Fatalf("bad fixed 'now' in test setup: %v", err)
+	}
+
+	t.Run("premise resolved -- fires immediately regardless of age", func(t *testing.T) {
+		d := adrOpenDecision{
+			adr:        "ADR-TEST",
+			decision:   "synthetic",
+			openedDate: "2026-09-06", // 1 day old -- well within any real threshold
+			threshold:  365 * 24 * time.Hour,
+			premise:    func() (bool, string) { return false, "synthetic: already resolved" },
+		}
+		if err := evaluateOpenDecision(d, fixedNow); err == nil {
+			t.Fatal("expected the resolved-premise case to fire even though age is nowhere near threshold")
+		}
+	})
+
+	t.Run("premise still open, within threshold -- does not fire", func(t *testing.T) {
+		d := adrOpenDecision{
+			adr:        "ADR-TEST",
+			decision:   "synthetic",
+			openedDate: "2026-09-06",
+			threshold:  30 * 24 * time.Hour,
+			premise:    func() (bool, string) { return true, "synthetic: still open" },
+		}
+		if err := evaluateOpenDecision(d, fixedNow); err != nil {
+			t.Fatalf("expected no failure for a genuinely-still-open decision within its threshold, got: %v", err)
+		}
+	})
+
+	t.Run("premise still open, past threshold -- fires via the age fallback", func(t *testing.T) {
+		d := adrOpenDecision{
+			adr:        "ADR-TEST",
+			decision:   "synthetic",
+			openedDate: "2026-01-01",
+			threshold:  30 * 24 * time.Hour,
+			premise:    func() (bool, string) { return true, "synthetic: still open" },
+		}
+		if err := evaluateOpenDecision(d, fixedNow); err == nil {
+			t.Fatal("expected the age fallback to fire once a still-genuinely-open decision passes its threshold")
+		}
+	})
+
+	t.Run("no premise (nil), within threshold -- does not fire", func(t *testing.T) {
+		d := adrOpenDecision{
+			adr:        "ADR-TEST",
+			decision:   "synthetic",
+			openedDate: "2026-09-06",
+			threshold:  30 * 24 * time.Hour,
+			premise:    nil,
+		}
+		if err := evaluateOpenDecision(d, fixedNow); err != nil {
+			t.Fatalf("expected no failure within threshold with no premise configured, got: %v", err)
+		}
+	})
+
+	t.Run("no premise (nil), past threshold -- fires via age, the ADR-102 shape", func(t *testing.T) {
+		d := adrOpenDecision{
+			adr:        "ADR-TEST",
+			decision:   "synthetic",
+			openedDate: "2026-01-01",
+			threshold:  30 * 24 * time.Hour,
+			premise:    nil,
+		}
+		if err := evaluateOpenDecision(d, fixedNow); err == nil {
+			t.Fatal("expected the pure age-based path (no premise) to still fire past threshold")
+		}
+	})
 }

--- a/internal/core/adr_open_decisions_tripwire_test.go
+++ b/internal/core/adr_open_decisions_tripwire_test.go
@@ -10,6 +10,17 @@
 // undated) and ADR-084 (admin-bypass structural marker, Accepted but
 // deferred, no target date/owner/tripwire).
 //
+// ADR-084's entry was removed the same day it was added (2026-09-07,
+// corrected): its decision had already been implemented 5 days earlier
+// (PR #1671, 2026-09-02), a fact nobody checked before writing "deferred,
+// no target date" into the registry. This is the actual gap a duration-based
+// tripwire has: it checks whether TIME has passed, never whether the
+// underlying claim is still true, so it would not have caught this
+// staleness either way, only a check against live implementation state
+// would have. Kept as a documented lesson, not silently dropped from this
+// comment: before adding an entry here, confirm the decision is still open
+// against current code, not just against the ADR's own text.
+//
 // Each registry entry names: the ADR, a one-line statement of what remains
 // undecided, the date the decision was opened (from `git log --follow
 // --diff-filter=A`, not a guess), and a threshold duration chosen per-entry
@@ -60,31 +71,12 @@ var adrOpenDecisionRegistry = []adrOpenDecision{
 			"own Context section) doesn't quietly age from '2 days old, worth catching now' " +
 			"(the 2026-09-07 review's own words) into 'forgotten.'",
 	},
-	{
-		adr:        "ADR-084",
-		decision:   "roleSetContainsAdmin stays name-based (rename drops the bypass silently, a colliding customer role name gains it silently) until the accepted bypasses_permission_checks structural-flag decision is actually implemented. docs/adr-084-admin-bypass-structural-marker.md makes no code changes and sets no target date.",
-		openedDate: "2026-08-19",
-		threshold:  45 * 24 * time.Hour,
-		reasoning: "45 days from acceptance: this ADR already names its own prerequisite " +
-			"(the fix-1494-role-set-contains-admin-error-swallow branch) as landed and ready " +
-			"to build on, so nothing external blocks starting; medium severity (requires an " +
-			"unlikely operator action to trigger, per the 2026-09-07 review's Finding 4) " +
-			"argues for a longer window than ADR-102's high-severity one, not an indefinitely " +
-			"open one.",
-	},
 }
 
 // TestADR102_SystemWriteBlastRadiusStillOpen is the enforcing test named in
 // docs/adr-102-system-write-blast-radius.md's own Consequences section.
 func TestADR102_SystemWriteBlastRadiusStillOpen(t *testing.T) {
 	checkADROpenDecisionNotStale(t, "ADR-102")
-}
-
-// TestADR084_AdminBypassStructuralMarkerStillDeferred is the enforcing test
-// named in docs/adr-084-admin-bypass-structural-marker.md's own Consequences
-// section.
-func TestADR084_AdminBypassStructuralMarkerStillDeferred(t *testing.T) {
-	checkADROpenDecisionNotStale(t, "ADR-084")
 }
 
 func checkADROpenDecisionNotStale(t *testing.T, adr string) {


### PR DESCRIPTION
## Summary

**Commit 1 — ADR-084 status correction:**
- PR #1788 (merged) added a CI tripwire claiming ADR-084's structural admin-bypass flag decision was still "Accepted but deferred, no code changes" — but PR #1671 had already implemented it 5 days earlier (2026-09-02). `roleSetContainsAdmin` already resolves `bypasses_permission_checks` via `storage.RoleSetBypassesPermissionChecks`, not name matching.
- Corrects ADR-084's Status to Implemented, citing PR #1671.
- Notes the one real residual item: `installAdminRoleIDSet` (`internal/core/rbac_management.go:608`) is still name-based — verified against current code, not assumed.

**Commit 2 — tripwire mechanism redesign:**
- The actual root cause of commit 1's bug: the tripwire mechanism only checked elapsed time, never whether the underlying claim was still true.
- Adds an optional `premise` function to `adrOpenDecision`: when present, it checks a live code fact and fires immediately if the decision has resolved, independent of age. The age check still runs underneath as a backstop for decisions that are genuinely still open.
- `TestADRDecisionRoleSetContainsAdminIsStructural` is ADR-084's worked premise example, exercised live (asserts `models.Role.BypassesPermissionChecks` exists).
- ADR-102 stays age-only, correctly and explicitly documented as such — its (a)/(b) policy choice produces no code artifact in either unresolved branch, so there's no premise to check.
- `TestEvaluateOpenDecision_MechanismSelfTest` is the red/green proof: 5 synthetic cases covering every combination (premise resolved/still-open × within/past threshold, plus the nil-premise path).

## Test plan
- [x] `go build ./...` clean.
- [x] `go test ./internal/core/... -count=1` — full suite green, including `TestADR102_SystemWriteBlastRadiusStillOpen`, the new premise test, and the mechanism self-test (all 5 subtests).
- [x] `gofmt -l` clean on touched files.
- [x] `gosec -severity medium -exclude-generated ./internal/core/...` clean (0 issues).
