### PR TITLE
fix(core): the 5 Shape-B conformance findings, decided individually

### DIFF
--- a/docs/adr-056-certificate-hygiene-posture.md
+++ b/docs/adr-056-certificate-hygiene-posture.md
@@ -30,8 +30,15 @@ Add a **Certificate expiry hygiene** control and a `CertificatePosture` figure, 
   column read, no decryption. It is wired into `GetCompliancePosture`.
 - **Control.** A `certificate-hygiene` control in the matrix: a **gap** when any
   certificate is expired, with a detail line that also surfaces expiring-soon and
-  not-yet-evaluated counts. Mapped to ISO 27001 A.5.15/A.8.24, SOC 2 CC6.1, NIS2
-  Art.21(2)(h), ENS `op.exp.11`.
+  not-yet-evaluated counts. **Fixed 2026-09-07**: a population with some
+  certificates evaluated and some not previously read as a clean Pass whenever
+  none of the evaluated ones were expired — the unevaluated ones were only
+  visible in the free-text detail line, invisible to the status itself. A new
+  status, `ControlStatusPartiallyEvaluated`, is now returned for exactly this
+  case (a confirmed expired certificate still wins as Gap regardless of how
+  much of the population remains unscanned) — see
+  `TestCertificateHygieneControl_MixedEvaluationIsNotPass`. Mapped to ISO
+  27001 A.5.15/A.8.24, SOC 2 CC6.1, NIS2 Art.21(2)(h), ENS `op.exp.11`.
 - **Coverage.** A certificate that has never been inspected or scanned has a nil cache
   and is reported as **not yet evaluated** (honestly, not silently "healthy"). Full
   coverage comes from enabling the ADR-055 certificate-expiry scan, which refreshes the

--- a/docs/adr-073-release-sbom-frontend-coverage.md
+++ b/docs/adr-073-release-sbom-frontend-coverage.md
@@ -426,6 +426,12 @@ frontend SBOM, keeping the two targets in the parity they already have.**
    verification must recompute the frontend SBOM's SHA-256 and assert it
    matches the hash embedded in all four server SBOMs — not merely that the
    `hashes` field is populated, which would pass a build-order bug silently.
+   **Status (corrected 2026-09-07): not implemented.** Build order is
+   correct by construction today (the Makefile generates the frontend SBOM
+   first), but no automated recompute-and-assert step exists — a future
+   build-order regression would go undetected. Filed as issue #1792. This
+   decision asserts a control that does not exist yet; treat this bullet as
+   a requirement, not a description of current behavior, until #1792 closes.
 6. The CLI SBOMs are unchanged in content, deliberately, because they're
    already accurate — only their count changes (1 → 4, matching the 4 CLI
    binaries), not what they describe.

--- a/docs/adr-091-machine-createdby-attribution-classification.md
+++ b/docs/adr-091-machine-createdby-attribution-classification.md
@@ -86,7 +86,10 @@ machine, nonzero `ProjectID`, can never be granted a role at
 the creation-side half that makes the write-side check meaningful (no
 production path can ever produce the `ProjectID == 0` `MachineIdentity` row
 that would otherwise defeat it);
-`TestAssignMachineRole_GlobalScopeRejected_EvenIfMachineLookupSomehowReturnedGlobal`
+`TestAssignMachineRole_SucceedsIfMachineLookupSomehowReturnedGlobal`
+(**renamed 2026-09-07** — was `..._GlobalScopeRejected_EvenIfMachineLookupSomehowReturnedGlobal`,
+which claimed the opposite of what the test actually asserts: it proves the
+grant SUCCEEDS given a corrupted row, not that it's rejected)
 documents — rather than silently assumes — that `machineInProject`'s
 comparison alone would NOT catch a corrupted `ProjectID == 0` row; the
 creation-side guard is the sole thing preventing that. Verified red by

--- a/internal/core/certificate_expiry_test.go
+++ b/internal/core/certificate_expiry_test.go
@@ -150,6 +150,27 @@ func TestCertificateHygieneControl(t *testing.T) {
 	assert.Equal(t, ControlStatusPass, ok.Status, "expiring-soon is a warning in the detail, not a hard gap")
 }
 
+// TestCertificateHygieneControl_MixedEvaluationIsNotPass is the regression for the
+// 2026-09-07 fix: a population with SOME unevaluated certificates must never read as
+// a clean Pass just because none of the EVALUATED ones happen to be expired -- the
+// unevaluated ones are an unknown, not an implicit pass, and previously fell through
+// silently to Pass alongside a genuinely fully-scanned-and-clean population.
+func TestCertificateHygieneControl_MixedEvaluationIsNotPass(t *testing.T) {
+	partial := findControl(t, EvaluateControls(&CompliancePosture{
+		Certificates: CertificatePosture{TotalCertificates: 3, NotEvaluated: 1},
+	}), "certificate-hygiene")
+	assert.Equal(t, ControlStatusPartiallyEvaluated, partial.Status)
+	assert.Contains(t, partial.Detail, "not yet evaluated")
+
+	// A confirmed expired certificate must still win over partial coverage -- Gap,
+	// never downgraded to PartiallyEvaluated just because part of the population
+	// hasn't been scanned yet.
+	gapWithPartial := findControl(t, EvaluateControls(&CompliancePosture{
+		Certificates: CertificatePosture{TotalCertificates: 3, NotEvaluated: 1, Expired: 1},
+	}), "certificate-hygiene")
+	assert.Equal(t, ControlStatusGap, gapWithPartial.Status)
+}
+
 func TestCertificateExpiryMessage(t *testing.T) {
 	assert.Contains(t, certificateExpiryMessage("p", 2, 3), "2 certificate(s) expired and 3 expiring soon")
 	assert.Contains(t, certificateExpiryMessage("p", 2, 0), "2 certificate(s) have expired")

--- a/internal/core/compliance_digest.go
+++ b/internal/core/compliance_digest.go
@@ -40,7 +40,7 @@ func formatComplianceDigest(p *CompliancePosture, controls []ControlState) (titl
 		case ControlStatusGap:
 			gap++
 			gaps = append(gaps, ctrl.Name)
-		case ControlStatusUnknown:
+		case ControlStatusUnknown, ControlStatusPartiallyEvaluated:
 			unknown++
 			unknowns = append(unknowns, ctrl.Name)
 		}

--- a/internal/core/compliance_posture.go
+++ b/internal/core/compliance_posture.go
@@ -440,7 +440,9 @@ func buildCompliancePostureSnapshot(p *CompliancePosture, snapshotDate time.Time
 			passed++
 		case ControlStatusGap:
 			failed++
-		case ControlStatusUnknown:
+		case ControlStatusUnknown, ControlStatusPartiallyEvaluated:
+			// Partial coverage is genuine uncertainty, not a clean pass -- same
+			// bucket as Unknown, not Pass, so it doesn't inflate the passed count.
 			degraded++
 		}
 	}

--- a/internal/core/control_framework.go
+++ b/internal/core/control_framework.go
@@ -34,6 +34,14 @@ const (
 	// clean — an auditor relying on this matrix needs to see "unknown", not a false
 	// "pass".
 	ControlStatusUnknown ControlStatus = "unknown"
+	// ControlStatusPartiallyEvaluated marks a control whose population is a mix of
+	// evaluated and not-yet-evaluated members — distinct from Pass (everything
+	// evaluated, nothing failing) and from NotConfigured (nothing evaluated at
+	// all). Added 2026-09-07: certificateHygieneStatus previously had no way to
+	// express this state, so a certificate-typed secret nobody has scanned yet
+	// silently fell through to Pass alongside the ones that genuinely passed —
+	// false assurance on a compliance surface an auditor reads at face value.
+	ControlStatusPartiallyEvaluated ControlStatus = "partially_evaluated"
 )
 
 // FrameworkRefs maps a control to clauses across the regimes Keyorix targets.
@@ -67,6 +75,10 @@ type ControlsSummary struct {
 	// Unknown counts controls whose signal could not be collected this run (#136) —
 	// a non-zero value here means the matrix is incomplete, not fully passing.
 	Unknown int `json:"unknown"`
+	// PartiallyEvaluated counts controls whose population is a mix of evaluated and
+	// not-yet-evaluated members (added 2026-09-07) — distinct from Pass and from
+	// NotConfigured; see ControlStatusPartiallyEvaluated.
+	PartiallyEvaluated int `json:"partially_evaluated"`
 }
 
 // ComplianceControls is the evaluated control matrix at a point in time.
@@ -95,6 +107,8 @@ func (c *KeyorixCore) GetComplianceControls(ctx context.Context) (*ComplianceCon
 			out.Summary.NotConfigured++
 		case ControlStatusUnknown:
 			out.Summary.Unknown++
+		case ControlStatusPartiallyEvaluated:
+			out.Summary.PartiallyEvaluated++
 		}
 	}
 	return out, nil
@@ -272,6 +286,12 @@ func supplyChainDetail(p *CompliancePosture) string {
 // a false "pass" even though not a single certificate was ever checked (#397). Mirror the
 // supply-chain-integrity escape hatch above: "never enabled" is not-configured, distinct
 // from "enabled but this run's collection failed", which is Unknown (#136).
+//
+// Corrected 2026-09-07: a MIX of evaluated and not-yet-evaluated certificates previously
+// fell through to Pass whenever none of the evaluated ones were expired — the unevaluated
+// ones were silently invisible to the status, only surfacing in the free-text Detail line.
+// A partially-scanned population and a fully-clean one are not the same claim; the former
+// is now ControlStatusPartiallyEvaluated, never Pass.
 func certificateHygieneStatus(p *CompliancePosture) ControlStatus {
 	if p.DegradedArea("certificates") {
 		return ControlStatusUnknown
@@ -280,7 +300,16 @@ func certificateHygieneStatus(p *CompliancePosture) ControlStatus {
 	if c.NotEvaluated == c.TotalCertificates {
 		return ControlStatusNotConfigured
 	}
-	return gapIf(c.Expired > 0)
+	if c.Expired > 0 {
+		// A confirmed expired certificate is a Gap regardless of how much of the
+		// rest of the population remains unevaluated — this must never be masked
+		// by, or downgraded to, the partial-coverage state below.
+		return ControlStatusGap
+	}
+	if c.NotEvaluated > 0 {
+		return ControlStatusPartiallyEvaluated
+	}
+	return ControlStatusPass
 }
 
 func certificateHygieneDetail(p *CompliancePosture) string {

--- a/internal/core/control_framework_test.go
+++ b/internal/core/control_framework_test.go
@@ -133,7 +133,7 @@ func TestGetComplianceControls_SummaryTallies(t *testing.T) {
 	got, err := c.GetComplianceControls(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, len(got.Controls), got.Summary.Total)
-	assert.Equal(t, got.Summary.Total, got.Summary.Pass+got.Summary.Gap+got.Summary.NotConfigured+got.Summary.Unknown)
+	assert.Equal(t, got.Summary.Total, got.Summary.Pass+got.Summary.Gap+got.Summary.NotConfigured+got.Summary.Unknown+got.Summary.PartiallyEvaluated)
 	assert.False(t, got.GeneratedAt.IsZero())
 }
 
@@ -257,12 +257,17 @@ func TestEvaluateControls_CertificateHygiene_ScanningEnabled(t *testing.T) {
 	ce := findControl(t, expired, "certificate-hygiene")
 	assert.Equal(t, ControlStatusGap, ce.Status)
 
-	// Partially scanned (some evaluated, some not) still uses real data rather than
-	// falling back to not-configured, since the scan clearly IS enabled here.
+	// Partially scanned (some evaluated, some not) uses real data rather than
+	// falling back to not-configured, since the scan clearly IS enabled here --
+	// but it is NOT Pass (corrected 2026-09-07): this test previously asserted
+	// Pass for this exact case, which was the bug this fix closes -- an
+	// unevaluated certificate is a genuine unknown, not an implicit pass. See
+	// TestCertificateHygieneControl_MixedEvaluationIsNotPass for the dedicated
+	// regression.
 	partial := EvaluateControls(&CompliancePosture{
 		Certificates: CertificatePosture{TotalCertificates: 3, Expired: 0, NotEvaluated: 1},
 	})
 	cp := findControl(t, partial, "certificate-hygiene")
-	assert.Equal(t, ControlStatusPass, cp.Status)
+	assert.Equal(t, ControlStatusPartiallyEvaluated, cp.Status)
 	assert.Contains(t, cp.Detail, "1 not yet evaluated")
 }

--- a/internal/core/machine_global_scope_invariant_test.go
+++ b/internal/core/machine_global_scope_invariant_test.go
@@ -51,19 +51,23 @@ func TestAssignMachineRole_GlobalScopeRejected(t *testing.T) {
 	ms.AssertNotCalled(t, "AssignMachineRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
-// TestAssignMachineRole_GlobalScopeRejected_EvenIfMachineLookupSomehowReturnedGlobal
-// covers the theoretical case where GetMachineIdentity itself returned a row
-// with ProjectID 0 (should never happen in practice — every creation path
-// requires a nonzero project — but machineInProject's own comparison is what
-// this test pins, not the creation invariant, since a storage-layer bug
-// producing such a row is a different failure mode this check should still
-// catch defensively... except it wouldn't: matching ProjectIDs of 0 and 0
-// legitimately passes machineInProject. This is intentional and documented
-// here rather than silently assumed: the SOLE thing preventing a global-scope
-// machine grant is that no real MachineIdentity row ever has ProjectID 0, not
-// a second independent check. See TestCreateMachineIdentity_RejectsZeroProject
-// for the creation-side half of this invariant.
-func TestAssignMachineRole_GlobalScopeRejected_EvenIfMachineLookupSomehowReturnedGlobal(t *testing.T) {
+// TestAssignMachineRole_SucceedsIfMachineLookupSomehowReturnedGlobal documents
+// a gap, not an invariant — renamed 2026-09-07 (was
+// ..._GlobalScopeRejected_EvenIfMachineLookupSomehowReturnedGlobal, which
+// claimed the opposite of what this test actually asserts). It covers the
+// theoretical case where GetMachineIdentity itself returned a row with
+// ProjectID 0 (should never happen in practice — every creation path requires
+// a nonzero project — but machineInProject's own comparison is what this test
+// pins, not the creation invariant, since a storage-layer bug producing such a
+// row is a different failure mode this check should still catch
+// defensively... except it wouldn't: matching ProjectIDs of 0 and 0
+// legitimately passes machineInProject, so the grant SUCCEEDS here, not gets
+// rejected. This is intentional and documented here rather than silently
+// assumed: the SOLE thing preventing a global-scope machine grant is that no
+// real MachineIdentity row ever has ProjectID 0, not a second independent
+// check. See TestCreateMachineIdentity_RejectsZeroProject for the
+// creation-side half of this invariant.
+func TestAssignMachineRole_SucceedsIfMachineLookupSomehowReturnedGlobal(t *testing.T) {
 	ms := new(MockStorage)
 	machine := &models.MachineIdentity{ID: 1, ProjectID: 0, Name: "corrupted-fixture", State: MachineActive}
 	ms.On("GetMachineIdentity", mock.Anything, uint(1)).Return(machine, nil)

--- a/web/src/pages/compliance/CompliancePage.tsx
+++ b/web/src/pages/compliance/CompliancePage.tsx
@@ -477,6 +477,9 @@ const STATUS_META: Record<string, { label: string; color: string; bg: string }> 
     pass: { label: 'Pass', color: 'var(--success)', bg: 'var(--success-subtle)' },
     gap: { label: 'Gap', color: 'var(--error)', bg: 'var(--error-subtle)' },
     not_configured: NA_META,
+    // Added 2026-09-07 alongside the backend's ControlStatusPartiallyEvaluated:
+    // a mix of evaluated/not-yet-evaluated members, distinct from a clean Pass.
+    partially_evaluated: { label: 'Partial', color: 'var(--warning)', bg: 'var(--warning-subtle)' },
 };
 
 type FrameworkKey = 'all' | 'iso27001' | 'soc2' | 'nis2' | 'dora' | 'ens';


### PR DESCRIPTION
Item 4 from the ADR conformance follow-up: a=confirmed deliberate (doc-only, in Shape-A #1791), b=filed as #1792 + ADR marked not-implemented, c=real code fix (adds ControlStatusPartiallyEvaluated, fixes a pre-existing test that had encoded the bug as its happy path), d=already in #1791, e=test renamed to match its actual assertion. go build/vet/gofmt/gosec (0 issues) and the full internal/core suite all clean.