### PR TITLE
feat(ci): start the regenerating ADR-conformance ledger (item 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,12 @@ jobs:
       - name: Verify every security closure claim names a passing test
         run: ./scripts/check-closures.sh
 
+      - name: Self-test the ADR conformance guard (must be able to go red)
+        run: ./scripts/check-adr-conformance.sh --self-test
+
+      - name: Verify every ADR conformance claim names a passing test
+        run: ./scripts/check-adr-conformance.sh
+
   # Backstop for the actionlint pre-commit hook (.pre-commit-config.yaml) --
   # not a replacement for it. That hook is the PRIMARY guard: it runs on the
   # contributor's own machine before a broken workflow file is ever pushed,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,3 +290,20 @@ Reasoning and incidents behind these: `docs/g80-remediation-notes.md`.
   rather than adding a one-off.
 - Reasoning and the failures behind these:
   `keyorix-private/adversarial-review/LESSONS-LEARNED.md` and `SECURITY-INVARIANTS.md`.
+
+## Closing/confirming an ADR-claimed security property (not an incident)
+
+Same discipline as above, separate ledger: `docs/adr-conformance-enforced.tsv`
+(`scripts/check-adr-conformance.sh`, a thin wrapper reusing
+`check-closures.sh`'s exact verification logic). Use this one for an ongoing
+architectural property an ADR asserts (e.g. "PBKDF2 uses 600k iterations",
+"a machine identity can never hold a role at global scope") — properties that
+were never an incident, just a design claim that needs to stay true. Add a row
+whenever you land or touch a test that enforces one. Started 2026-09-07 from
+the full-corpus ADR conformance pass
+(`keyorix-private/adversarial-review/ADR-CONFORMANCE-MATRIX-2026-09-07.md`,
+260 ENFORCED properties found, ~10 seeded here so far — see that file's own
+tranche detail for the rest, and QUEUE.md for the incremental-population
+follow-up). Don't transcribe a row from that matrix without re-running its
+test first — a property verified during that pass is not the same claim as
+"this test exists and passes right now."

--- a/docs/adr-conformance-enforced.tsv
+++ b/docs/adr-conformance-enforced.tsv
@@ -1,0 +1,35 @@
+# ADR conformance ledger — every row is a security property an ADR claims,
+# with the test that proves it stays true. Verified by
+# scripts/check-adr-conformance.sh (a thin wrapper around the existing
+# scripts/check-closures.sh mechanism — same verification discipline: a named
+# test must produce a literal `--- PASS:` line, not just a nonzero go-test
+# exit code, or the claim doesn't count).
+#
+# This is the generated half of the 2026-09-07 ADR conformance pass
+# (keyorix-private/adversarial-review/ADR-CONFORMANCE-MATRIX-2026-09-07.md,
+# 260 ENFORCED rows found across the full corpus). This ledger starts with
+# the rows this session personally executed and confirmed passing — NOT a
+# transcription of all 260, which would require re-running each one to avoid
+# recording a stale or renamed test as if it were still verified. Populating
+# the rest is tracked as its own follow-up (see QUEUE.md) so this file grows
+# incrementally, the same way docs/security-closures.tsv does, rather than
+# being hand-maintained as a point-in-time snapshot that immediately starts
+# rotting.
+#
+# When you close a PR that lands or changes a test enforcing an ADR-claimed
+# security property, add a row here — same discipline as
+# docs/security-closures.tsv's "Closing a security fix" convention
+# (CLAUDE.md), extended to ADR conformance claims generally, not just
+# incident closures.
+#
+# claim_id	package	proving_test	landed_commit	description
+ADR-034-MFA-VERIFY-RATELIMIT	./server/http/handlers	TestVerifyMFA_RateLimited_S13B	pre-existing	/auth/mfa/verify shares the cluster-wide DB-backed login rate limiter (ADR-040), not unlimited
+ADR-042-LASTADMIN-NOT-PAT-CONFUSED	./internal/core	TestGuardLastAdminDeactivation_NotFooledByActingCallersPATRestriction	pending	guardLastAdminDeactivation asks about the TARGET's admin status, not the acting caller's PAT restriction
+ADR-042-INACTIVITY-SWEEP-NOT-PAT-CONFUSED	./internal/core	TestSuspendInactiveUsers_NotFooledByCallersPATRestriction	pending	SuspendInactiveUsers' admin-skip check is immune to the triggering caller's own PAT restriction
+ADR-102-BLASTRADIUS-TRIPWIRE-LIVE	./internal/core	TestADR102_SystemWriteBlastRadiusStillOpen	pending	the system.write (a)/(b) blast-radius decision has a live age-based tripwire, not just prose
+ADR-040-RATELIMIT-BUDGET-WINDOW	./internal/core	TestRateLimit_BlocksAtBudgetAndExpiresWithWindow	pre-existing	login rate limiting blocks at LoginMaxAttempts within LoginWindow and expires correctly
+ADR-040-RATELIMIT-REMOTESTORAGE	./internal/core	TestRateLimit_RemoteStorageGenuinelyThrottles	pre-existing	the cluster-wide login rate limit genuinely throttles across a real RemoteStorage hop, not just locally
+ADR-097-SCHEMA-EPOCH-REFUSES-DOWNGRADE	./internal/storage	TestSchemaEpoch_NewerRecordedEpoch_RefusesToStart	pre-existing	an older binary refuses to start against a database migrated by a newer schema epoch
+ADR-101-SCHEMA-EPOCH-STILL-ONE	./internal/storage	TestCurrentSchemaEpoch_StillOne_SeeADR101	pre-existing	currentSchemaEpoch has not silently bumped without the accompanying compatibility-floor work landing
+ADR-091-MACHINE-NEVER-GLOBAL-SCOPE	./internal/core	TestAssignMachineRole_GlobalScopeRejected	pre-existing	a machine identity can never be granted a role at global scope
+ADR-100-MLOCKALL-STAYS-REMOVED	./internal/hardening	TestMlockallRemovalGuard_NoMlockallSyscallReachableFromStartup	pre-existing	no tracked source reintroduces the removed mlockall syscall from server startup

--- a/scripts/check-adr-conformance.sh
+++ b/scripts/check-adr-conformance.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# check-adr-conformance.sh — verifies docs/adr-conformance-enforced.tsv the
+# same way scripts/check-closures.sh verifies docs/security-closures.tsv: a
+# named test must produce a literal `--- PASS:` line, not just a nonzero
+# go-test exit code, or the claim doesn't count. This is a thin wrapper, not
+# a fork — the actual verification logic (duplicate-claim detection, SKIP/
+# no-match/unrecognised-output handling, the --self-test mode) lives in
+# check-closures.sh and is reused unchanged via CLOSURE_LEDGER, so a fix to
+# that logic benefits both ledgers automatically instead of drifting apart.
+#
+# Usage:
+#   ./scripts/check-adr-conformance.sh              # verify every row
+#   ./scripts/check-adr-conformance.sh --self-test   # prove the check can go red
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec env CLOSURE_LEDGER="$REPO_ROOT/docs/adr-conformance-enforced.tsv" "$REPO_ROOT/scripts/check-closures.sh" "$@"


### PR DESCRIPTION
Item 5 of the ADR conformance follow-up: the 260 ENFORCED properties must be a generated artifact, not a hand-maintained snapshot. Reuses check-closures.sh's exact verification mechanism (unchanged) via a new docs/adr-conformance-enforced.tsv ledger + scripts/check-adr-conformance.sh wrapper, wired into CI with its own --self-test step. Seeded with 10 rows personally executed and confirmed passing on this branch (not transcribed from the matrix -- several matrix rows cite tests only on today's still-unmerged sibling PRs). Remaining ~250 rows tracked in QUEUE.md as an incremental, batched-by-tranche follow-up. go build clean, actionlint clean, check-adr-conformance.sh and its self-test both pass.