### PR TITLE
fix(core): serialize group role grants against member SoD locks (#1780)

### DIFF
--- a/internal/core/concurrency_sod_group_grant_postgres_test.go
+++ b/internal/core/concurrency_sod_group_grant_postgres_test.go
@@ -1,0 +1,255 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/identity"
+	localstore "github.com/keyorixhq/keyorix/internal/storage/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrency_GroupRoleGrant_CrossReplicaPostgres_SoDBypass is issue #1780's
+// regression: AssignRoleToGroup/AssignGroupRoleWithExpiry serialize their
+// check-then-write on sodGrantLockKey("group", groupID), but
+// requireGroupGrantNoSoDViolation evaluates each MEMBER's held-permission set --
+// a different resource than the group key covers. AssignUserRole/
+// AssignUserRoleWithExpiry serialize on sodGrantLockKey("user", userID)
+// directly. Two different keys for what is, from the SoD invariant's point of
+// view, the same resource (member U's effective permission set) -- so a
+// group-role grant to a group containing U and a direct role grant to U can
+// each read U's pre-grant state clean and both commit, leaving U holding both
+// halves of a toxic pair.
+//
+// Same shape as TestConcurrency_AssignUserRole_CrossReplicaPostgres_SoDBypass
+// (concurrency_sod_grant_postgres_test.go), reached through the group edge
+// instead of two direct grants.
+func TestConcurrency_GroupRoleGrant_CrossReplicaPostgres_SoDBypass(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	setupDB := pgOpen(t, dsn)
+	require.NoError(t, setupDB.AutoMigrate(sodGrantModels...))
+	setupStorage := localstore.NewLocalStorage(setupDB)
+	setupCore := NewKeyorixCore(setupStorage)
+	setupCore.SetBootstrapToken("sod-group-race-token")
+	ctx := context.Background()
+
+	bootRes, err := setupCore.BootstrapSystem(ctx, &BootstrapRequest{
+		Username: "admin", Email: "admin@example.com", Password: "BootstrapPass123!",
+		DisplayName: "Admin", Token: "sod-group-race-token",
+	})
+	require.NoError(t, err)
+
+	perms, err := setupCore.ListPermissions(ctx)
+	require.NoError(t, err)
+	var rolesAssignID, secretsDeleteID uint
+	for _, p := range perms {
+		switch p.Name {
+		case "roles.assign":
+			rolesAssignID = p.ID
+		case "secrets.delete":
+			secretsDeleteID = p.ID
+		}
+	}
+	require.NotZero(t, rolesAssignID, "roles.assign must be seeded")
+	require.NotZero(t, secretsDeleteID, "secrets.delete must be seeded")
+
+	roleAName, err := identity.NewFoldedName("sod-group-race-role-a")
+	require.NoError(t, err)
+	roleA, err := setupCore.Storage().CreateRole(ctx, roleAName, "grants roles.assign")
+	require.NoError(t, err)
+	require.NoError(t, setupCore.AssignPermissionToRole(ctx, 0, roleA.ID, rolesAssignID, false))
+	roleBName, err := identity.NewFoldedName("sod-group-race-role-b")
+	require.NoError(t, err)
+	roleB, err := setupCore.Storage().CreateRole(ctx, roleBName, "grants secrets.delete")
+	require.NoError(t, err)
+	require.NoError(t, setupCore.AssignPermissionToRole(ctx, 0, roleB.ID, secretsDeleteID, false))
+
+	_, err = setupCore.CreateSoDPolicy(ctx, bootRes.User.ID, "group-race-policy", "roles.assign + secrets.delete is toxic", "roles.assign", "secrets.delete")
+	require.NoError(t, err)
+
+	// Target U is a member of group G. Group G will receive roleA; U will
+	// separately receive roleB directly.
+	target, err := setupCore.CreateUser(ctx, &CreateUserRequest{
+		Username: "sod-group-target", Email: "sod-group-target@example.com", Password: "Qr7#Kp2$Lm5@Vn9!",
+	})
+	require.NoError(t, err)
+	group, err := setupCore.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "sod-race-group"})
+	require.NoError(t, err)
+	require.NoError(t, setupCore.AddUserToGroup(ctx, bootRes.User.ID, false, target.ID, group.ID, 0))
+
+	// Two independent replicas, own connections into the SAME schema.
+	dbA := pgOpen(t, dsn)
+	coreA := NewKeyorixCore(localstore.NewLocalStorage(dbA))
+	dbB := pgOpen(t, dsn)
+	coreB := NewKeyorixCore(localstore.NewLocalStorage(dbB))
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	var errA, errB error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		// Replica A: grant roleA (roles.assign) to the GROUP.
+		errA = coreA.AssignRoleToGroup(ctx, bootRes.User.ID, group.ID, roleA.ID, Scope{}, false)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		// Replica B: grant roleB (secrets.delete) directly to the MEMBER.
+		errB = coreB.AssignUserRole(ctx, bootRes.User.ID, target.ID, roleB.ID, Scope{}, false)
+	}()
+	close(start)
+	wg.Wait()
+
+	t.Logf("grant A (group roleA/roles.assign) result: %v", errA)
+	t.Logf("grant B (direct roleB/secrets.delete) result: %v", errB)
+
+	// Verify from a fresh connection, independent of either racing replica.
+	// The target's EFFECTIVE permission set includes roleA only via group
+	// membership, so check both the direct grant (roleB) and the group's own
+	// role (roleA) -- GetUserRoleIDsAt only returns direct grants, so read the
+	// group's role set separately to determine whether roleA actually landed.
+	verifierDB := pgOpen(t, dsn)
+	verifier := localstore.NewLocalStorage(verifierDB)
+
+	directGrants, err := verifier.GetUserRoleIDsAt(ctx, target.ID, storage.Scope{})
+	require.NoError(t, err)
+	hasB := false
+	for _, rid := range directGrants {
+		if rid == roleB.ID {
+			hasB = true
+		}
+	}
+
+	groupRoles, err := verifier.GetGroupRoles(ctx, group.ID)
+	require.NoError(t, err)
+	hasA := false
+	for _, r := range groupRoles {
+		if r.ID == roleA.ID {
+			hasA = true
+		}
+	}
+
+	t.Logf("target effectively holds roleA(via group)=%v roleB(direct)=%v", hasA, hasB)
+
+	if hasA && hasB {
+		t.Errorf("SoD BYPASS CONFIRMED (issue #1780): target effectively holds BOTH roleA "+
+			"(roles.assign, via group membership) and roleB (secrets.delete, direct) -- the "+
+			"toxic combination the preventive gate exists to block, granted by two racing "+
+			"replicas that each passed an individually-clean check (errA=%v errB=%v)", errA, errB)
+	}
+	assert.False(t, hasA && hasB, "at most one of the two toxic-pair roles may be live on the target, whether held directly or via group membership")
+	assert.True(t, hasA || hasB, "at least one of the two racing grants should have succeeded")
+}
+
+// TestConcurrency_TwoGroupGrants_SharedMember_NoDeadlock is the deadlock-safety
+// check for #1780's fix: withGroupMemberSoDLocks (rbac_management.go) acquires
+// every member's sodGrantLockKey("user", ...) lock, sorted ascending, so that
+// two concurrent group-role grants locking an OVERLAPPING member set always
+// acquire in the same relative order and can only ever contend, never cycle.
+// Two groups sharing a member, each granted a non-toxic role concurrently,
+// must both complete -- this test hangs (caught by go test's own timeout, not
+// a custom one, so a real deadlock fails loudly rather than silently) if the
+// lock-ordering discipline is ever broken.
+func TestConcurrency_TwoGroupGrants_SharedMember_NoDeadlock(t *testing.T) {
+	require.NoError(t, i18n.InitializeForTesting())
+	base := pgTestDSN(t)
+	dsn := pgIsolatedSchemaDSN(t, base)
+
+	setupDB := pgOpen(t, dsn)
+	require.NoError(t, setupDB.AutoMigrate(sodGrantModels...))
+	setupStorage := localstore.NewLocalStorage(setupDB)
+	setupCore := NewKeyorixCore(setupStorage)
+	setupCore.SetBootstrapToken("sod-deadlock-token")
+	ctx := context.Background()
+
+	bootRes, err := setupCore.BootstrapSystem(ctx, &BootstrapRequest{
+		Username: "admin", Email: "admin@example.com", Password: "BootstrapPass123!",
+		DisplayName: "Admin", Token: "sod-deadlock-token",
+	})
+	require.NoError(t, err)
+
+	perms, err := setupCore.ListPermissions(ctx)
+	require.NoError(t, err)
+	var secretsReadID uint
+	for _, p := range perms {
+		if p.Name == "secrets.read" {
+			secretsReadID = p.ID
+		}
+	}
+	require.NotZero(t, secretsReadID, "secrets.read must be seeded")
+
+	// No SoD policy at all -- this test is purely about lock ordering, not
+	// about the SoD check's own outcome.
+	roleName, err := identity.NewFoldedName("sod-deadlock-role")
+	require.NoError(t, err)
+	role, err := setupCore.Storage().CreateRole(ctx, roleName, "grants secrets.read")
+	require.NoError(t, err)
+	require.NoError(t, setupCore.AssignPermissionToRole(ctx, 0, role.ID, secretsReadID, false))
+
+	// Two users, M1 (the shared member) and M2/M3. Group1 = {M1, M2}, sorted
+	// ascending would visit M1 before M2 if M1.ID < M2.ID. Group2 = {M3, M1} --
+	// deliberately listed in an order that would visit M1 SECOND if this
+	// function didn't sort, to actually exercise the sort rather than
+	// coincidentally pass because storage happens to return members in ID order.
+	m1, err := setupCore.CreateUser(ctx, &CreateUserRequest{Username: "shared-member", Email: "shared@example.com", Password: "Qr7#Kp2$Lm5@Vn9!"})
+	require.NoError(t, err)
+	m2, err := setupCore.CreateUser(ctx, &CreateUserRequest{Username: "group1-only", Email: "g1only@example.com", Password: "Qr7#Kp2$Lm5@Vn9!"})
+	require.NoError(t, err)
+	m3, err := setupCore.CreateUser(ctx, &CreateUserRequest{Username: "group2-only", Email: "g2only@example.com", Password: "Qr7#Kp2$Lm5@Vn9!"})
+	require.NoError(t, err)
+
+	group1, err := setupCore.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "deadlock-group-1"})
+	require.NoError(t, err)
+	require.NoError(t, setupCore.AddUserToGroup(ctx, bootRes.User.ID, false, m1.ID, group1.ID, 0))
+	require.NoError(t, setupCore.AddUserToGroup(ctx, bootRes.User.ID, false, m2.ID, group1.ID, 0))
+
+	group2, err := setupCore.CreateGroup(ctx, 0, &CreateGroupRequest{Name: "deadlock-group-2"})
+	require.NoError(t, err)
+	require.NoError(t, setupCore.AddUserToGroup(ctx, bootRes.User.ID, false, m3.ID, group2.ID, 0))
+	require.NoError(t, setupCore.AddUserToGroup(ctx, bootRes.User.ID, false, m1.ID, group2.ID, 0))
+
+	dbA := pgOpen(t, dsn)
+	coreA := NewKeyorixCore(localstore.NewLocalStorage(dbA))
+	dbB := pgOpen(t, dsn)
+	coreB := NewKeyorixCore(localstore.NewLocalStorage(dbB))
+
+	done := make(chan struct{})
+	var errA, errB error
+	go func() {
+		defer close(done)
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			errA = coreA.AssignRoleToGroup(ctx, bootRes.User.ID, group1.ID, role.ID, Scope{}, false)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			errB = coreB.AssignGroupRoleWithExpiry(ctx, bootRes.User.ID, group2.ID, role.ID, Scope{}, time.Now().Add(time.Hour), false)
+		}()
+		close(start)
+		wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		require.NoError(t, errA, "group1 grant must succeed -- no SoD policy exists to block it")
+		require.NoError(t, errB, "group2 grant must succeed -- no SoD policy exists to block it")
+	case <-time.After(15 * time.Second):
+		t.Fatal("DEADLOCK: two group-role grants sharing member M1 never completed within 15s -- " +
+			"withGroupMemberSoDLocks's lock-ordering discipline is broken")
+	}
+}

--- a/internal/core/jit_access.go
+++ b/internal/core/jit_access.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/keyorixhq/keyorix/internal/i18n"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
 )
 
 // AssignUserRoleWithExpiry assigns a time-bound role to a user at scope (the grant
@@ -90,15 +91,30 @@ func (c *KeyorixCore) AssignGroupRoleWithExpiry(ctx context.Context, actorID, gr
 		return err
 	}
 	// #1646: see AssignUserRole's identical WithNamedLock use.
+	// #1780: the group key alone does not serialize against a concurrent DIRECT
+	// grant to one of this group's members — see withGroupMemberSoDLocks
+	// (rbac_management.go).
 	return c.storage.WithNamedLock(ctx, sodGrantLockKey("group", groupID), func(ctx context.Context) error {
-		if err := c.requireGroupGrantNoSoDViolation(ctx, groupID, roleID); err != nil {
+		write := func(ctx context.Context) error {
+			if err := c.storage.AssignRoleToGroupWithExpiry(ctx, groupID, roleID, scope, expiresAt); err != nil {
+				return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+			}
+			c.LogGroupRoleAssigned(ctx, actorID, groupID, roleID, scope)
+			return nil
+		}
+		policies, adding, needed, err := c.groupGrantSoDContext(ctx, roleID)
+		if err != nil {
 			return err
 		}
-		if err := c.storage.AssignRoleToGroupWithExpiry(ctx, groupID, roleID, scope, expiresAt); err != nil {
-			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		if !needed {
+			return write(ctx)
 		}
-		c.LogGroupRoleAssigned(ctx, actorID, groupID, roleID, scope)
-		return nil
+		return c.withGroupMemberSoDLocks(ctx, groupID, func(ctx context.Context, members []*models.User) error {
+			if err := c.requireGroupGrantNoSoDViolation(ctx, members, policies, adding); err != nil {
+				return err
+			}
+			return write(ctx)
+		})
 	})
 }
 

--- a/internal/core/rbac_management.go
+++ b/internal/core/rbac_management.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 
 	"github.com/keyorixhq/keyorix/internal/core/storage"
 	"github.com/keyorixhq/keyorix/internal/i18n"
@@ -207,15 +208,29 @@ func (c *KeyorixCore) AssignRoleToGroup(ctx context.Context, actorID, groupID, r
 		return err
 	}
 	// #1646: see AssignUserRole's identical WithNamedLock use.
+	// #1780: the group key alone does not serialize against a concurrent DIRECT
+	// grant to one of this group's members — see withGroupMemberSoDLocks.
 	return c.storage.WithNamedLock(ctx, sodGrantLockKey("group", groupID), func(ctx context.Context) error {
-		if err := c.requireGroupGrantNoSoDViolation(ctx, groupID, roleID); err != nil {
+		write := func(ctx context.Context) error {
+			if err := c.storage.AssignRoleToGroup(ctx, groupID, roleID, scope); err != nil {
+				return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+			}
+			c.LogGroupRoleAssigned(ctx, actorID, groupID, roleID, scope)
+			return nil
+		}
+		policies, adding, needed, err := c.groupGrantSoDContext(ctx, roleID)
+		if err != nil {
 			return err
 		}
-		if err := c.storage.AssignRoleToGroup(ctx, groupID, roleID, scope); err != nil {
-			return fmt.Errorf("%s: %w", i18n.T("ErrorStorageFailed", nil), err)
+		if !needed {
+			return write(ctx)
 		}
-		c.LogGroupRoleAssigned(ctx, actorID, groupID, roleID, scope)
-		return nil
+		return c.withGroupMemberSoDLocks(ctx, groupID, func(ctx context.Context, members []*models.User) error {
+			if err := c.requireGroupGrantNoSoDViolation(ctx, members, policies, adding); err != nil {
+				return err
+			}
+			return write(ctx)
+		})
 	})
 }
 
@@ -375,6 +390,67 @@ func (c *KeyorixCore) SetUserRoles(ctx context.Context, actorID, userID uint, ro
 // unrelated principals' grants contending on the same lock.
 func sodGrantLockKey(principalType string, principalID uint) string {
 	return fmt.Sprintf("sod-grant:%s:%d", principalType, principalID)
+}
+
+// withGroupMemberSoDLocks lists groupID's current members, then acquires each
+// active member's sodGrantLockKey("user", ...) lock — sorted ascending by
+// ID — before invoking fn with that exact membership snapshot.
+//
+// #1780: AssignRoleToGroup/AssignGroupRoleWithExpiry already hold
+// sodGrantLockKey("group", groupID), which serializes two concurrent grants
+// to the SAME group against each other — but requireGroupGrantNoSoDViolation
+// evaluates each MEMBER's held-permission set, a different resource the group
+// key does not cover. A concurrent DIRECT grant to one of those members
+// (AssignUserRole, locked on sodGrantLockKey("user", memberID)) can read that
+// member's pre-grant state as clean and commit while this call's own
+// check-then-write is still in flight, reproducing the exact cross-replica
+// SoD bypass #1646 closed for two direct grants. Taking each member's lock
+// for the duration of this call closes it the same way, without widening the
+// lock to unrelated principals the way a single coarse SoD-wide key would.
+//
+// fn MUST use the membership snapshot passed to it for its own SoD check
+// (requireGroupGrantNoSoDViolation takes it as a parameter for exactly this
+// reason) rather than re-listing membership — a second listing could observe
+// a member added after this snapshot was taken and lock set acquired, which
+// would then be checked without its own lock held.
+//
+// Sorting ascending is the deadlock-avoidance discipline: any two call chains
+// that need to lock an overlapping set of member/user keys — two
+// group-role grants to different groups sharing a member, in particular —
+// always acquire them in the same relative order this way, so one chain can
+// only ever block waiting for the other to finish, never form a cycle.
+func (c *KeyorixCore) withGroupMemberSoDLocks(ctx context.Context, groupID uint, fn func(ctx context.Context, members []*models.User) error) error {
+	members, err := c.storage.ListGroupMembers(ctx, groupID)
+	if err != nil {
+		return fmt.Errorf("failed to list group members: %w", err)
+	}
+	ids := make([]uint, 0, len(members))
+	for _, m := range members {
+		if m.IsActive {
+			ids = append(ids, m.ID)
+		}
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return c.withOrderedUserSoDLocks(ctx, ids, func(ctx context.Context) error {
+		return fn(ctx, members)
+	})
+}
+
+// withOrderedUserSoDLocks acquires sodGrantLockKey("user", id) for each id in
+// ids IN ORDER, nesting WithNamedLock calls one per key. ids MUST already be
+// sorted ascending (see withGroupMemberSoDLocks) — this function does not sort
+// them itself, since a caller locking a single already-known ID (none exist
+// today, but a future one might) has no list to sort. WithNamedLock's own
+// per-call-chain connection reuse (internal/storage/store/local_named_lock.go)
+// means nesting N distinct keys this way costs exactly one pooled connection,
+// not one per key, on the Postgres path.
+func (c *KeyorixCore) withOrderedUserSoDLocks(ctx context.Context, ids []uint, fn func(ctx context.Context) error) error {
+	if len(ids) == 0 {
+		return fn(ctx)
+	}
+	return c.storage.WithNamedLock(ctx, sodGrantLockKey("user", ids[0]), func(ctx context.Context) error {
+		return c.withOrderedUserSoDLocks(ctx, ids[1:], fn)
+	})
 }
 
 // AssignUserRole assigns a role to a user at the given scope and records an RBAC

--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -617,6 +617,43 @@ func (c *KeyorixCore) requireNoSoDViolation(ctx context.Context, userID, roleID 
 	return nil
 }
 
+// groupGrantSoDContext resolves everything requireGroupGrantNoSoDViolation
+// needs to know BEFORE the caller decides whether it's even worth listing
+// group membership and acquiring a lock per member (withGroupMemberSoDLocks,
+// rbac_management.go — issue #1780): the policy set and roleID's own
+// permission set, plus needed=false for every early-out
+// requireGroupGrantNoSoDViolation used to apply internally (no policies
+// configured at all, roleID is itself admin-bypass, or roleID grants no
+// permissions) — cases where no member's held-permission set could possibly
+// matter. Splitting this out means a deployment with no SoD policies (the
+// common case) never pays for a ListGroupMembers call or a single member
+// lock on every group-role grant; the member-lock dance only runs when a
+// policy could genuinely be affected.
+func (c *KeyorixCore) groupGrantSoDContext(ctx context.Context, roleID uint) (policies []*models.SoDPolicy, adding map[string]bool, needed bool, err error) {
+	policies, err = c.storage.ListSoDPolicies(ctx)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if len(policies) == 0 {
+		return nil, nil, false, nil
+	}
+	role, err := c.storage.GetRole(ctx, roleID)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if isAdminRoleName(role.Name) {
+		return nil, nil, false, nil
+	}
+	adding, err = c.rolePermissionNameSet(ctx, roleID)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
+	}
+	if len(adding) == 0 {
+		return nil, nil, false, nil
+	}
+	return policies, adding, true, nil
+}
+
 // requireGroupGrantNoSoDViolation is requireNoSoDViolation's GROUP-grant
 // counterpart: a role assigned to a group is inherited by every member, so it
 // can complete a policy for a member exactly as a direct grant would. Checks
@@ -625,32 +662,22 @@ func (c *KeyorixCore) requireNoSoDViolation(ctx context.Context, userID, roleID 
 // stays cheap even run synchronously on every group-role assignment). A member
 // who already holds admin-bypass is skipped, not treated as a block (see
 // package doc above).
-func (c *KeyorixCore) requireGroupGrantNoSoDViolation(ctx context.Context, groupID, roleID uint) error {
-	policies, err := c.storage.ListSoDPolicies(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
-	}
-	if len(policies) == 0 {
-		return nil
-	}
-	role, err := c.storage.GetRole(ctx, roleID)
-	if err != nil {
-		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
-	}
-	if isAdminRoleName(role.Name) {
-		return nil
-	}
-	adding, err := c.rolePermissionNameSet(ctx, roleID)
-	if err != nil {
-		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
-	}
-	if len(adding) == 0 {
-		return nil
-	}
-	members, err := c.storage.ListGroupMembers(ctx, groupID)
-	if err != nil {
-		return fmt.Errorf("failed to evaluate separation-of-duties policy: %w", err)
-	}
+//
+// members is the caller's ALREADY-FETCHED membership snapshot (see
+// withGroupMemberSoDLocks, rbac_management.go), not re-listed here —
+// issue #1780: this function used to list membership itself, but the caller
+// needs that exact same list to know which members' sodGrantLockKey("user", ...)
+// locks to hold for the duration of the check-then-write (otherwise a
+// concurrent direct grant to a member reads this function's pre-grant state
+// as clean and commits before this function's own caller writes the group
+// grant — the two operations never serialize against each other at all,
+// since they use different lock keys). Passing the same snapshot through
+// guarantees the locks taken and the members checked are identical.
+//
+// policies/adding come from groupGrantSoDContext, called by the caller BEFORE
+// it decides whether to acquire member locks at all — this function no
+// longer re-derives them (or re-applies their early-outs) itself.
+func (c *KeyorixCore) requireGroupGrantNoSoDViolation(ctx context.Context, members []*models.User, policies []*models.SoDPolicy, adding map[string]bool) error {
 	for _, m := range members {
 		if !m.IsActive || c.isGlobalAdminRoleName(ctx, m.ID) != "" {
 			continue

--- a/internal/core/sod.go
+++ b/internal/core/sod.go
@@ -677,7 +677,7 @@ func (c *KeyorixCore) groupGrantSoDContext(ctx context.Context, roleID uint) (po
 // policies/adding come from groupGrantSoDContext, called by the caller BEFORE
 // it decides whether to acquire member locks at all — this function no
 // longer re-derives them (or re-applies their early-outs) itself.
-func (c *KeyorixCore) requireGroupGrantNoSoDViolation(ctx context.Context, members []*models.User, policies []*models.SoDPolicy, adding map[string]bool) error {
+func (c *KeyorixCore) requireGroupGrantNoSoDViolation(ctx context.Context, members []*models.User, policies []*models.SoDPolicy, adding map[string]bool) error { // nosemgrep: keyorix-unbounded-bulk-slice-param -- members is withGroupMemberSoDLocks's own ListGroupMembers(ctx, groupID) result (that group's actual membership), not a raw client-supplied array in one request
 	for _, m := range members {
 		if !m.IsActive || c.isGlobalAdminRoleName(ctx, m.ID) != "" {
 			continue


### PR DESCRIPTION
## Summary

Closes #1780 — a cross-replica separation-of-duties (SoD) bypass in group role grants.

`AssignRoleToGroup`/`AssignGroupRoleWithExpiry` held only the group's own `sodGrantLockKey("group", groupID)` lock, which never serializes against a concurrent DIRECT role grant to one of that group's members (`sodGrantLockKey("user", memberID)`) — two different lock keys for two operations that both need to observe each other's effect on the same principal's held-permission set. Under real cross-replica concurrency (independent Postgres connections, not a shared in-process mock), a group-role grant and a direct grant to a member could each read the member's pre-grant state as clean and both commit, landing a toxic permission pair the SoD preventive gate exists to block.

## Fix

- Each active group member's own `sodGrantLockKey("user", ...)` lock is now acquired — sorted ascending by ID for deadlock-avoidance — for the duration of the group grant's check-then-write, using the exact membership snapshot the SoD check evaluates (`requireGroupGrantNoSoDViolation` now takes that snapshot as a parameter instead of re-listing it internally).
- A new `groupGrantSoDContext` pre-check resolves whether a grant could affect any policy at all (no policies configured, an admin-bypass role, or a permission-less role) *before* paying for a `ListGroupMembers` call or any member lock — both a performance win for policy-free deployments and what keeps the existing mock-based unit tests working (they don't stub `ListGroupMembers`, and the call used to happen unconditionally).

## Test plan

- [x] `TestConcurrency_GroupRoleGrant_CrossReplicaPostgres_SoDBypass` (new) — races a group-role grant on replica A against a direct grant to a member on replica B via two independent Postgres connections. Fails 10/10 without the fix; passes 20/20 with it.
- [x] `TestConcurrency_TwoGroupGrants_SharedMember_NoDeadlock` (new) — two groups sharing a member, granted concurrently via `AssignRoleToGroup`/`AssignGroupRoleWithExpiry`; completes within a 15s timeout on all 15 runs, confirming the ascending-ID lock ordering avoids a deadlock.
- [x] `TestConcurrency_AssignUserRole_CrossReplicaPostgres_SoDBypass` (sibling direct-grant test) — 10/10, no regression.
- [x] Full `internal/core` suite green, both with `MockStorage` and with `KEYORIX_TEST_PG_DSN` set against a real Postgres 16 instance.
- [x] `gofmt`, `go vet`, `gosec -severity medium` all clean on touched files.