### PR TITLE
fix(docs): make security-closures.tsv able to represent environment-gated proofs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # issues: read is for the informational report step only (gh issue list)
+      # -- nothing else in this job touches issues, and that step never fails
+      # the job (see its own step and script header for why).
+      issues: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -296,6 +300,11 @@ jobs:
       - name: Self-test the closure guard (must be able to go red)
         run: ./scripts/check-closures.sh --self-test
 
+      # This job never sets KEYORIX_TEST_PG_DSN, so every pg-gated row in
+      # docs/security-closures.tsv gate-skips here by design -- that is
+      # expected, not a failure (see the ledger's own header). The test-suite
+      # job's `core` leg below runs this SAME script again, WITH the DSN, and
+      # is what actually proves those rows.
       - name: Verify every security closure claim names a passing test
         run: ./scripts/check-closures.sh
 
@@ -304,6 +313,18 @@ jobs:
 
       - name: Verify every ADR conformance claim names a passing test
         run: ./scripts/check-adr-conformance.sh
+
+      # Informational only -- never fails this job (the script itself always
+      # exits 0, and continue-on-error is set as a second, belt-and-suspenders
+      # layer in case a future edit ever changes that). See the script's own
+      # header for why an issue missing from this report is not proof nothing
+      # is owed, and docs/security-closures.tsv's header for the same caveat
+      # on its `issue` column.
+      - name: Report closed security-labeled issues the ledger doesn't cite (informational)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/report-unlisted-security-issues.sh
 
   # Backstop for the actionlint pre-commit hook (.pre-commit-config.yaml) --
   # not a replacement for it. That hook is the PRIMARY guard: it runs on the
@@ -636,6 +657,19 @@ jobs:
           # the trade being proposed, whether or not the proposal names it.
           # shellcheck disable=SC2086
           go test -race -timeout ${{ matrix.timeout }}s -run "$run_filter" -coverprofile=${{ matrix.coverage-file }} -covermode=atomic $pkgs
+
+      # This job is the ONLY one with a Postgres service container (see this
+      # job's own KEYORIX_TEST_PG_DSN comment above), so it is the only place
+      # a pg-gated docs/security-closures.tsv row can ever be genuinely
+      # proven rather than gate-skipped. Restricted to the `core` leg: every
+      # pg-gated row today lives in ./internal/core, and running the full
+      # ledger sweep once per leg would just repeat the same ~17-row check 15
+      # times for no new coverage. adr-numbers already runs this same script
+      # without a DSN (every pg-gated row gate-skips there, by design) --
+      # this is the run that actually counts as evidence for those rows.
+      - name: Verify pg-gated security closures with a real Postgres DSN available (core leg only)
+        if: matrix.leg == 'core'
+        run: ./scripts/check-closures.sh
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,9 +281,35 @@ Reasoning and incidents behind these: `docs/g80-remediation-notes.md`.
 
 ## Closing a security fix
 
-- Add a row to `docs/security-closures.tsv`: claim id, package, proving test, commit.
-  `scripts/check-closures.sh` fails the build if the named test does not exist,
-  skips, or fails. Verify by test, never by commit — this repo squash-merges.
+- Add a row to `docs/security-closures.tsv`: claim id, package, proving test,
+  **verification**, commit, **issue**. `scripts/check-closures.sh` fails the
+  build if the named test does not exist, or does not produce a `--- PASS`
+  line in the environment its `verification` column claims. Verify by test,
+  never by commit — this repo squash-merges.
+- `verification` is `default-ci` (runs and passes with no special environment
+  — a skip is always a failure), `pg-gated` (needs `KEYORIX_TEST_PG_DSN`, e.g.
+  a cross-replica race only real Postgres can demonstrate — a skip is
+  expected and NOT a failure when the checker itself has no DSN, but IS one
+  the moment it does; `.github/workflows/ci.yml`'s `test-suite` job, `core`
+  leg, is the one job that actually proves these), or `manual` (no automated
+  test can exist — `note` must cite a specific artefact; this is an escape
+  hatch, not a shortcut, and CI cannot verify it). Added 2026-09-08 after
+  #1646 and #1780 — both real, both Postgres-race closures — sat with no row
+  for the same reason each time: their proving test could only skip in a
+  DSN-less run, and the checker treated a skip as a failure unconditionally,
+  so a row could not be added without either breaking CI or weakening the
+  check for every other claim. See `scripts/check-closures.sh`'s own header
+  for the full reasoning, and its `--self-test` for the calibration cases
+  (red AND green) that prove this doesn't silently accept an unproven claim.
+- `issue` is the GitHub issue number this closes, or `-` when there isn't a
+  single corresponding one. `scripts/report-unlisted-security-issues.sh`
+  cross-references closed issues carrying the `security` label against this
+  column, as an informational CI step — it never fails the build and never
+  should: the label is empirically unreliable (confirmed 2026-09-08: #1646,
+  #1780, #1551, and #1572 all carry zero labels), so its silence is not
+  completeness. Read that script's own header before trusting either its
+  output or a bare `-` in this column as proof nothing is owed — no known
+  reliable way exists in this repo today to derive that automatically.
 - If the root cause has sibling call sites, the fix is an invariant test, not a
   site patch. Extend an existing registry test
   (`TestEveryDirectRoleGrantChecksAuthority`, `remote_reachability_registry_test.go`)

--- a/docs/adr-conformance-enforced.tsv
+++ b/docs/adr-conformance-enforced.tsv
@@ -2,8 +2,9 @@
 # with the test that proves it stays true. Verified by
 # scripts/check-adr-conformance.sh (a thin wrapper around the existing
 # scripts/check-closures.sh mechanism — same verification discipline: a named
-# test must produce a literal `--- PASS:` line, not just a nonzero go-test
-# exit code, or the claim doesn't count).
+# test must produce a literal `--- PASS:` line in the environment its own
+# verification column claims, not just a nonzero go-test exit code, or the
+# claim doesn't count).
 #
 # This is the generated half of the 2026-09-07 ADR conformance pass
 # (keyorix-private/adversarial-review/ADR-CONFORMANCE-MATRIX-2026-09-07.md,
@@ -20,16 +21,21 @@
 # security property, add a row here — same discipline as
 # docs/security-closures.tsv's "Closing a security fix" convention
 # (CLAUDE.md), extended to ADR conformance claims generally, not just
-# incident closures.
+# incident closures. See that file's own header for what `verification` and
+# `issue` mean — this ledger shares the exact same schema and checker logic,
+# reused unchanged via CLOSURE_LEDGER, not forked. Every row below is
+# default-ci (none of this ledger's current claims are Postgres-race-gated);
+# a future ADR conformance claim that IS would use pg-gated exactly like
+# security-closures.tsv's G04-HA-1646/G04-HA-1780 rows.
 #
-# claim_id	package	proving_test	landed_commit	description
-ADR-034-MFA-VERIFY-RATELIMIT	./server/http/handlers	TestVerifyMFA_RateLimited_S13B	pre-existing	/auth/mfa/verify shares the cluster-wide DB-backed login rate limiter (ADR-040), not unlimited
-ADR-042-LASTADMIN-NOT-PAT-CONFUSED	./internal/core	TestGuardLastAdminDeactivation_NotFooledByActingCallersPATRestriction	pending	guardLastAdminDeactivation asks about the TARGET's admin status, not the acting caller's PAT restriction
-ADR-042-INACTIVITY-SWEEP-NOT-PAT-CONFUSED	./internal/core	TestSuspendInactiveUsers_NotFooledByCallersPATRestriction	pending	SuspendInactiveUsers' admin-skip check is immune to the triggering caller's own PAT restriction
-ADR-102-BLASTRADIUS-TRIPWIRE-LIVE	./internal/core	TestADR102_SystemWriteBlastRadiusStillOpen	pending	the system.write (a)/(b) blast-radius decision has a live age-based tripwire, not just prose
-ADR-040-RATELIMIT-BUDGET-WINDOW	./internal/core	TestRateLimit_BlocksAtBudgetAndExpiresWithWindow	pre-existing	login rate limiting blocks at LoginMaxAttempts within LoginWindow and expires correctly
-ADR-040-RATELIMIT-REMOTESTORAGE	./internal/core	TestRateLimit_RemoteStorageGenuinelyThrottles	pre-existing	the cluster-wide login rate limit genuinely throttles across a real RemoteStorage hop, not just locally
-ADR-097-SCHEMA-EPOCH-REFUSES-DOWNGRADE	./internal/storage	TestSchemaEpoch_NewerRecordedEpoch_RefusesToStart	pre-existing	an older binary refuses to start against a database migrated by a newer schema epoch
-ADR-101-SCHEMA-EPOCH-STILL-ONE	./internal/storage	TestCurrentSchemaEpoch_StillOne_SeeADR101	pre-existing	currentSchemaEpoch has not silently bumped without the accompanying compatibility-floor work landing
-ADR-091-MACHINE-NEVER-GLOBAL-SCOPE	./internal/core	TestAssignMachineRole_GlobalScopeRejected	pre-existing	a machine identity can never be granted a role at global scope
-ADR-100-MLOCKALL-STAYS-REMOVED	./internal/hardening	TestMlockallRemovalGuard_NoMlockallSyscallReachableFromStartup	pre-existing	no tracked source reintroduces the removed mlockall syscall from server startup
+# claim_id	package	proving_test	verification	landed_commit	issue	note
+ADR-034-MFA-VERIFY-RATELIMIT	./server/http/handlers	TestVerifyMFA_RateLimited_S13B	default-ci	pre-existing	-	/auth/mfa/verify shares the cluster-wide DB-backed login rate limiter (ADR-040), not unlimited
+ADR-042-LASTADMIN-NOT-PAT-CONFUSED	./internal/core	TestGuardLastAdminDeactivation_NotFooledByActingCallersPATRestriction	default-ci	pending	-	guardLastAdminDeactivation asks about the TARGET's admin status, not the acting caller's PAT restriction
+ADR-042-INACTIVITY-SWEEP-NOT-PAT-CONFUSED	./internal/core	TestSuspendInactiveUsers_NotFooledByCallersPATRestriction	default-ci	pending	-	SuspendInactiveUsers' admin-skip check is immune to the triggering caller's own PAT restriction
+ADR-102-BLASTRADIUS-TRIPWIRE-LIVE	./internal/core	TestADR102_SystemWriteBlastRadiusStillOpen	default-ci	pending	-	the system.write (a)/(b) blast-radius decision has a live age-based tripwire, not just prose
+ADR-040-RATELIMIT-BUDGET-WINDOW	./internal/core	TestRateLimit_BlocksAtBudgetAndExpiresWithWindow	default-ci	pre-existing	-	login rate limiting blocks at LoginMaxAttempts within LoginWindow and expires correctly
+ADR-040-RATELIMIT-REMOTESTORAGE	./internal/core	TestRateLimit_RemoteStorageGenuinelyThrottles	default-ci	pre-existing	-	the cluster-wide login rate limit genuinely throttles across a real RemoteStorage hop, not just locally
+ADR-097-SCHEMA-EPOCH-REFUSES-DOWNGRADE	./internal/storage	TestSchemaEpoch_NewerRecordedEpoch_RefusesToStart	default-ci	pre-existing	-	an older binary refuses to start against a database migrated by a newer schema epoch
+ADR-101-SCHEMA-EPOCH-STILL-ONE	./internal/storage	TestCurrentSchemaEpoch_StillOne_SeeADR101	default-ci	pre-existing	-	currentSchemaEpoch has not silently bumped without the accompanying compatibility-floor work landing
+ADR-091-MACHINE-NEVER-GLOBAL-SCOPE	./internal/core	TestAssignMachineRole_GlobalScopeRejected	default-ci	pre-existing	-	a machine identity can never be granted a role at global scope
+ADR-100-MLOCKALL-STAYS-REMOVED	./internal/hardening	TestMlockallRemovalGuard_NoMlockallSyscallReachableFromStartup	default-ci	pre-existing	-	no tracked source reintroduces the removed mlockall syscall from server startup

--- a/docs/security-closures.tsv
+++ b/docs/security-closures.tsv
@@ -1,26 +1,74 @@
-# Security closure ledger. Verified by scripts/check-closures.sh, which fails the
-# build if a named test does not exist, skips, or fails.
+# Security closure ledger. Verified by scripts/check-closures.sh, which fails
+# the build if a named test does not exist, or does not produce a literal
+# `--- PASS: <name>` line in the environment its own verification column
+# claims.
 #
-# claim_id	package	proving_test	landed_commit	note
+# claim_id	package	proving_test	verification	landed_commit	issue	note
+#
+# verification is one of:
+#   default-ci   the proving test runs and passes in every invocation of this
+#                script, no special environment required. A SKIP here is
+#                ALWAYS a closure-verification failure.
+#   pg-gated     the proving test is gated behind KEYORIX_TEST_PG_DSN (a race
+#                that can only be demonstrated against a real multi-connection
+#                Postgres, not SQLite/mocks — see
+#                internal/core/postgres_contention_helpers_test.go). When this
+#                script runs WITHOUT the DSN set (its default invocation, in
+#                the adr-numbers job), a SKIP here is expected and does NOT
+#                fail the check — there is nothing else that invocation could
+#                show. When it runs WITH the DSN set (.github/workflows/ci.yml
+#                test-suite job, `core` leg — the one job with a Postgres
+#                service container — runs this same script a second time, see
+#                that job for why), a SKIP or failure here IS real and DOES
+#                fail the check: the DSN is available, so "gated" stops being
+#                an excuse. The test's plain EXISTENCE (a real compiled test
+#                symbol, not a typo'd/renamed/deleted name) is checked
+#                unconditionally either way — a SKIP line only ever appears
+#                for a test that exists and ran; "no tests to run" is the
+#                separate, always-fatal non-existence case.
+#   manual       no automated regression test exists or can exist for this
+#                claim; closure rests on a cited artefact instead. `note` MUST
+#                cite the artefact precisely enough that a skeptical reader
+#                could go look (a file path + line, a PR review comment URL, a
+#                dated manual test log — not "verified manually" on its own).
+#                This is an ESCAPE HATCH, not a shortcut: "self-reported
+#                verification is a claim, not evidence" applies in full here —
+#                CI accepts the row because it is honestly labeled unverified,
+#                not because anything was proven. Prefer default-ci or
+#                pg-gated whenever a real test is possible.
+#
+# issue is the GitHub issue number this closes (bare, no '#'), or `-` when the
+# claim is an internal structural invariant with no single corresponding issue
+# (e.g. G01, INV-1) or the note already cites more than one ambiguously
+# (FIX-4-sentinel). This column is best-effort cross-referenced by
+# scripts/report-unlisted-security-issues.sh against closed issues carrying
+# the `security` label — read that script's own header before trusting its
+# silence: the label it keys off is empirically under-applied (verified
+# 2026-09-08 — #1646, #1780, #1551, and #1572 all carry ZERO labels, including
+# the two rows already correctly in this ledger before this column existed),
+# so a `-` here or an issue missing from that report's output is not proof
+# nothing is owed.
 #
 # landed_commit is INFORMATIONAL. This repo squash-merges, so ancestry checks
 # return false for every correctly landed PR. Closure is verified by test.
 
-G01	./internal/core	TestCheckGroupPermissions_ProjectScopedMembershipDoesNotCrossProjects	e6f018a0	project-scoped group membership must not grant cross-project secret read
-FIX-2-primitive	./internal/core	TestRemoveUserRole_RefusesLastProjectAdminAtThePrimitive	6b512b90	last-admin refused at the primitive, not only at entry points
-FIX-2-sso	./internal/core	TestReconcileSSOGroups_RefusesStrandingLastProjectAdmin	6b512b90	the SSO path must not bypass the group guards
-FIX-3-1551	./server/http	TestRemoteStorageMachineIdentities_RevokeCredential_UnauthorizedCallerRejected_RealServer	6b512b90	#1551 cross-tenant credential revoke must be refused
-FIX-3-1572	./server/http/handlers	TestUpdateUserIfActiveStateMatchesProxy_DeactivationRevokesCredentialsEvenWithoutUsersWrite_RealServer	6b512b90	#1572 deactivation must not leave tokens live
-FIX-4-sentinel	./server/grpc/services	TestMapRoleError_ValidationTextWithoutSentinel_NotEchoed	6b512b90	#1668/#1669 sentinel must survive adjacent commits
-FIX-5-namedlock	./internal/storage/store	TestWithNamedLock_NestedDifferentKey_StillSerializesAgainstOtherHolder	fca6d401	reentrancy guard keys on lockKey, not "any lock held"
-FIX-6-sod-oracle	./internal/core	TestDeleteSoDPolicy_NonAdmin_NonExistentAndNonOwned_IdenticalDenial	6b512b90	403/404 split must not be an existence oracle
-FIX-7-breakglass	./internal/storage/store	TestDeleteExpiredBreakGlassBefore_ReconciledRowStillRevocable	d1b93444	purge must not hard-delete a row mid-reconciliation
-FIX-8-csv	./internal/core	TestCSVWriters_EncodeAgainstFormulaInjection	d1b93444	structural: every CSV writer applies an encoder
-INV-1-grant-authority	./server/http	TestEveryDirectRoleGrantChecksAuthority	pre-existing	structural: every direct role grant checks authority
-GCP-CONN-PROJECTID	./internal/connect	TestGCPSM_RequiresProjectID	pending	unpinned gcp-secret-manager connector must refuse reads, not span any GCP project
-AWS-CONN-ACCOUNTID	./internal/connect	TestAWSSM_AccountPin	pending	pinned aws-secrets-manager connector must refuse an ARN naming a different AWS account
-G81-KEYPERM-REGISTRY	./internal/keyfiles	TestRegistry_IncludesWrappedKeyPathForEveryWriteCapableType	pending	TPM/cloud-KMS wrapped-KEK blob must be covered by the shared key-permission checker registry, not just DEK/salt
-LASTADMIN-PAT-CONFUSED-DEPUTY	./internal/core	TestGuardLastAdminDeactivation_NotFooledByActingCallersPATRestriction	pending	IsGlobalAdmin's PAT short-circuit answered a third-party question it wasn't built for; guardLastAdminDeactivation and SuspendInactiveUsers now use targetHasGlobalAdminRole instead
+G01	./internal/core	TestCheckGroupPermissions_ProjectScopedMembershipDoesNotCrossProjects	default-ci	e6f018a0	-	project-scoped group membership must not grant cross-project secret read
+FIX-2-primitive	./internal/core	TestRemoveUserRole_RefusesLastProjectAdminAtThePrimitive	default-ci	6b512b90	-	last-admin refused at the primitive, not only at entry points
+FIX-2-sso	./internal/core	TestReconcileSSOGroups_RefusesStrandingLastProjectAdmin	default-ci	6b512b90	-	the SSO path must not bypass the group guards
+FIX-3-1551	./server/http	TestRemoteStorageMachineIdentities_RevokeCredential_UnauthorizedCallerRejected_RealServer	default-ci	6b512b90	1551	cross-tenant credential revoke must be refused
+FIX-3-1572	./server/http/handlers	TestUpdateUserIfActiveStateMatchesProxy_DeactivationRevokesCredentialsEvenWithoutUsersWrite_RealServer	default-ci	6b512b90	1572	deactivation must not leave tokens live
+FIX-4-sentinel	./server/grpc/services	TestMapRoleError_ValidationTextWithoutSentinel_NotEchoed	default-ci	6b512b90	-	#1668/#1669 sentinel must survive adjacent commits
+FIX-5-namedlock	./internal/storage/store	TestWithNamedLock_NestedDifferentKey_StillSerializesAgainstOtherHolder	default-ci	fca6d401	-	reentrancy guard keys on lockKey, not "any lock held"
+FIX-6-sod-oracle	./internal/core	TestDeleteSoDPolicy_NonAdmin_NonExistentAndNonOwned_IdenticalDenial	default-ci	6b512b90	-	403/404 split must not be an existence oracle
+FIX-7-breakglass	./internal/storage/store	TestDeleteExpiredBreakGlassBefore_ReconciledRowStillRevocable	default-ci	d1b93444	-	purge must not hard-delete a row mid-reconciliation
+FIX-8-csv	./internal/core	TestCSVWriters_EncodeAgainstFormulaInjection	default-ci	d1b93444	-	structural: every CSV writer applies an encoder
+INV-1-grant-authority	./server/http	TestEveryDirectRoleGrantChecksAuthority	default-ci	pre-existing	-	structural: every direct role grant checks authority
+GCP-CONN-PROJECTID	./internal/connect	TestGCPSM_RequiresProjectID	default-ci	pending	-	unpinned gcp-secret-manager connector must refuse reads, not span any GCP project
+AWS-CONN-ACCOUNTID	./internal/connect	TestAWSSM_AccountPin	default-ci	pending	-	pinned aws-secrets-manager connector must refuse an ARN naming a different AWS account
+G81-KEYPERM-REGISTRY	./internal/keyfiles	TestRegistry_IncludesWrappedKeyPathForEveryWriteCapableType	default-ci	pending	-	TPM/cloud-KMS wrapped-KEK blob must be covered by the shared key-permission checker registry, not just DEK/salt
+LASTADMIN-PAT-CONFUSED-DEPUTY	./internal/core	TestGuardLastAdminDeactivation_NotFooledByActingCallersPATRestriction	default-ci	pending	-	IsGlobalAdmin's PAT short-circuit answered a third-party question it wasn't built for; guardLastAdminDeactivation and SuspendInactiveUsers now use targetHasGlobalAdminRole instead
+G04-HA-1646	./internal/core	TestConcurrency_AssignUserRole_CrossReplicaPostgres_SoDBypass	pg-gated	37911f8a	1646	SoD direct-grant race across independent Postgres connections: two replicas each pass a stale pre-grant check and both write, live-reproduced; closed by WithNamedLock keyed per target principal
+G04-HA-1780	./internal/core	TestConcurrency_GroupRoleGrant_CrossReplicaPostgres_SoDBypass	pg-gated	f306ed7a	1780	SoD group-grant race: a group-role grant and a direct grant to one of its members took different lock keys and never serialized against each other; closed by taking each active member's own lock, ordered, before the group grant's check-then-write
 
 # NOT LISTED, deliberately:
 #   FIX-1 actorID==0 fast-path (internal/core/authz.go:614). The eight-site reroute

--- a/internal/core/check_closures_selftest_fixture_test.go
+++ b/internal/core/check_closures_selftest_fixture_test.go
@@ -1,0 +1,37 @@
+package core
+
+import (
+	"os"
+	"testing"
+)
+
+// This file exists ONLY to give scripts/check-closures.sh --self-test real,
+// stable test names to point calibration ledger rows at, so it can prove its
+// pg-gated verification logic actually rejects a bad row and accepts a good
+// one — not just the pre-existing "test does not exist" case. None of these
+// are, or should ever become, a real closure's proving test: they assert
+// nothing about product behavior, only about their own skip/pass shape.
+// Never delete or rename one without updating the matching case in
+// check-closures.sh's --self-test block.
+
+// TestCheckClosuresSelfTestFixture_AlwaysSkip always skips, unconditionally.
+// Used to prove: (1) a default-ci row naming a test that skips is rejected,
+// and (2) a pg-gated row is ALSO rejected once KEYORIX_TEST_PG_DSN is set —
+// "gated" stops being an excuse the moment the gate condition the row itself
+// claims is actually met.
+func TestCheckClosuresSelfTestFixture_AlwaysSkip(t *testing.T) {
+	t.Skip("check-closures.sh self-test fixture -- this test is SUPPOSED to skip")
+}
+
+// TestCheckClosuresSelfTestFixture_SkipsWithoutPGDSN mirrors the real
+// pg-gated tests' own gate (KEYORIX_TEST_PG_DSN presence, see
+// postgres_contention_helpers_test.go's pgTestDSN) without actually opening a
+// connection, so the self-test stays hermetic and fast in every environment.
+// Used to prove a pg-gated row honestly declaring its gate is NOT rejected
+// when the DSN genuinely isn't available in this environment — the one
+// behavior this whole ledger change exists to add.
+func TestCheckClosuresSelfTestFixture_SkipsWithoutPGDSN(t *testing.T) {
+	if os.Getenv("KEYORIX_TEST_PG_DSN") == "" {
+		t.Skip("check-closures.sh self-test fixture -- SUPPOSED to skip without a DSN")
+	}
+}

--- a/scripts/check-closures.sh
+++ b/scripts/check-closures.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # check-closures.sh — fails if any security closure claim lacks a proving test
-# that actually runs and passes.
+# that actually runs and passes IN THE ENVIRONMENT ITS ROW CLAIMS.
 #
 # Caught missing: G01 was recorded in REMEDIATION-STATUS.md as "merged, fully
 # addressed — 8 of 8 members" for three weeks. Five members had landed; the other
@@ -8,7 +8,7 @@
 # re-exploited the gap live, spending a full exploit build to learn what this
 # check learns in one second.
 #
-# Two design rules, each from a failure:
+# Three design rules, each from a failure:
 #
 #   1. Verify by test, not by commit. This repo squash-merges, so
 #      `git merge-base --is-ancestor <branch> origin/main` returns false for
@@ -23,17 +23,43 @@
 #      requires a literal `--- PASS: <name>` line and reports SKIP, no-match and
 #      unrecognised output as three distinct failures.
 #
+#   3. A race that can only be demonstrated against a real multi-connection
+#      Postgres (not SQLite/mocks) genuinely CANNOT produce a `--- PASS` line
+#      in every environment — #1646 and #1780 were left OUT of this ledger
+#      entirely for exactly that reason: rule 2 makes any Postgres-gated test
+#      SKIP here (this script's own invocations never set KEYORIX_TEST_PG_DSN),
+#      which rule 2 then treats as a failure, so a row for either could not be
+#      added without either breaking CI or weakening rule 2 for everyone. Two
+#      real closures with no row, indistinguishable from closures that never
+#      happened — the ledger's completeness became a function of which
+#      environment it runs in, not of what was actually fixed. The
+#      `verification` column (see docs/security-closures.tsv's own header)
+#      fixes this by making the row say which environment its proof requires,
+#      so a skip can be judged against that claim instead of against a single
+#      hardcoded assumption. This script still does not set the DSN itself —
+#      .github/workflows/ci.yml's test-suite job (`core` leg) runs this SAME
+#      script a second time, in the one job that already has Postgres — that
+#      second run is what actually proves a pg-gated row; this rule just stops
+#      the DSN-less run from reporting a false failure for it.
+#
 # Usage:
 #   ./scripts/check-closures.sh              # verify every row in the ledger
-#   ./scripts/check-closures.sh --self-test  # prove the check can go red
+#   ./scripts/check-closures.sh --self-test  # prove the check can go red (and
+#                                             # that it can go green honestly)
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LEDGER="${CLOSURE_LEDGER:-$REPO_ROOT/docs/security-closures.tsv}"
 fail=0
 checked=0
+gated_skips=0
 die()  { echo "FAIL: $*" >&2; fail=1; }
 note() { echo "  $*"; }
+
+pg_available=false
+if [ -n "${KEYORIX_TEST_PG_DSN:-}" ]; then
+    pg_available=true
+fi
 
 if [ ! -f "$LEDGER" ]; then
     echo "FAIL: closure ledger not found at $LEDGER" >&2; exit 1
@@ -51,17 +77,46 @@ if [ -n "$dupes" ]; then
     die "duplicate claim_id in ledger:"; for d in $dupes; do note "$d"; done
 fi
 
-while IFS=$'\t' read -r claim pkg test commit rest; do
+# Column order: claim_id  package  proving_test  verification  landed_commit  issue  note
+while IFS=$'\t' read -r claim pkg test verification commit issue rest; do
     [ -z "${claim:-}" ] && continue
-    if [ -z "${pkg:-}" ] || [ -z "${test:-}" ]; then
-        die "$claim: missing package or proving_test — a closure without a citation is not a closure"
-    fi
+    case "${verification:-}" in
+        default-ci|pg-gated)
+            if [ -z "${pkg:-}" ] || [ -z "${test:-}" ]; then
+                die "$claim: missing package or proving_test — a closure without a citation is not a closure"
+            fi
+            ;;
+        manual)
+            if [ -z "${rest:-}" ]; then
+                die "$claim: verification=manual requires a note citing the artefact a skeptical reader could go check"
+            fi
+            ;;
+        *)
+            die "$claim: verification column must be default-ci, pg-gated, or manual (got '${verification:-<empty>}')"
+            ;;
+    esac
     [ -z "${commit:-}" ] && die "$claim: missing landed_commit"
+    [ -z "${issue:-}" ] && die "$claim: missing issue column (use '-' explicitly when there is no single corresponding GitHub issue)"
 done <<<"$rows"
 [ "$fail" -eq 0 ] || exit 1
 
-for pkg in $(cut -f2 <<<"$rows" | sort -u); do
-    tests=$(awk -F'\t' -v p="$pkg" '$2==p {print $3}' <<<"$rows")
+# manual rows have no test to run — report them once, loudly, as unverified by
+# CI (a claim, not evidence), then leave them out of the go-test loop below.
+manual_claims=$(awk -F'\t' '$4=="manual" {print $1}' <<<"$rows")
+if [ -n "$manual_claims" ]; then
+    echo "==> manual (no automated test exists — verified by cited artefact only)"
+    while IFS= read -r claim; do
+        [ -z "$claim" ] && continue
+        artefact=$(awk -F'\t' -v c="$claim" '$1==c {print $NF}' <<<"$rows")
+        checked=$((checked + 1))
+        note "UNVERIFIED-BY-CI $claim -> $artefact"
+        note "   a self-reported artefact is a claim, not evidence — CI cannot check this row;"
+        note "   it is accepted only because it says so honestly, not because it was proven"
+    done <<<"$manual_claims"
+fi
+
+for pkg in $(awk -F'\t' '$4=="default-ci" || $4=="pg-gated" {print $2}' <<<"$rows" | sort -u); do
+    tests=$(awk -F'\t' -v p="$pkg" '($4=="default-ci" || $4=="pg-gated") && $2==p {print $3}' <<<"$rows")
     pattern=$(paste -sd'|' - <<<"$tests")
     echo "==> $pkg"
     set +e
@@ -74,12 +129,29 @@ for pkg in $(cut -f2 <<<"$rows" | sort -u); do
         [ -z "$test" ] && continue
         checked=$((checked + 1))
         claim=$(awk -F'\t' -v p="$pkg" -v t="$test" '$2==p && $3==t {print $1}' <<<"$rows")
+        verification=$(awk -F'\t' -v p="$pkg" -v t="$test" '$2==p && $3==t {print $4}' <<<"$rows")
         if grep -qE "^--- PASS: ${test}([[:space:]]|$)" <<<"$out"; then
-            note "ok   $claim -> $test"
+            note "ok   $claim -> $test ($verification)"
         elif grep -qE "^--- SKIP: ${test}([[:space:]]|$)" <<<"$out"; then
-            die "$claim: proving test $test SKIPPED, not passed."
-            note "     A skipped test proves nothing. If it needs a DSN or build tag,"
-            note "     CI must supply it, or this closure has no evidence."
+            if [ "$verification" = "pg-gated" ] && [ "$pg_available" = false ]; then
+                gated_skips=$((gated_skips + 1))
+                note "gated-skip $claim -> $test (pg-gated, KEYORIX_TEST_PG_DSN not set in this"
+                note "   invocation — expected, not evidence either way; a DIFFERENT CI job must"
+                note "   run this script WITH the DSN for this claim to ever actually be proven)"
+            else
+                die "$claim: proving test $test SKIPPED, not passed."
+                if [ "$verification" = "pg-gated" ]; then
+                    note "     verification=pg-gated but KEYORIX_TEST_PG_DSN IS set in THIS"
+                    note "     invocation, and the test skipped anyway — the gate condition this"
+                    note "     row claims is met, so 'gated' is no longer an excuse: either the"
+                    note "     test's own skip guard doesn't match what the row claims, or the"
+                    note "     row is lying about being provable here."
+                else
+                    note "     A skipped test proves nothing. If it genuinely needs a DSN, mark"
+                    note "     this row verification=pg-gated (and confirm a CI job actually runs"
+                    note "     this script WITH that DSN, or the closure still has no evidence)."
+                fi
+            fi
         elif grep -q "no tests to run" <<<"$out"; then
             die "$claim: proving test $test DOES NOT EXIST (go test matched nothing, exited 0)."
             note "     The false-green case: a renamed, deleted or never-written test"
@@ -92,24 +164,77 @@ for pkg in $(cut -f2 <<<"$rows" | sort -u); do
 done
 
 if [ "${1:-}" = "--self-test" ]; then
-    echo; echo "==> self-test: the check must reject a closure naming a nonexistent test"
-    tmp=$(mktemp)
-    printf 'SELF-TEST\t./internal/core\tTestThisNameDoesNotExistAnywhere\tdeadbeef\tcalibration row\n' > "$tmp"
-    set +e
-    CLOSURE_LEDGER="$tmp" "$0" >/dev/null 2>&1; selfrc=$?
-    set -e
-    rm -f "$tmp"
-    if [ "$selfrc" -eq 0 ]; then
-        echo "FAIL: self-test PASSED when it must fail — this check cannot detect a" >&2
-        echo "      missing proving test and is therefore worthless." >&2
+    echo; echo "==> self-test: the check must reject every bad row below, and accept every good one"
+    selffail=0
+
+    run_case() {
+        # $1=description  $2=expected(reject|accept)  $3=row(s), one per line
+        # $4=forced KEYORIX_TEST_PG_DSN for this sub-invocation ("" = unset, "-" = inherit ambient)
+        local desc="$1" expect="$2" body="$3" dsn="$4" out rc
+        local tmp; tmp=$(mktemp)
+        printf '%s\n' "$body" > "$tmp"
+        set +e
+        if [ "$dsn" = "-" ]; then
+            out=$(CLOSURE_LEDGER="$tmp" "$0" 2>&1)
+        elif [ -z "$dsn" ]; then
+            out=$(CLOSURE_LEDGER="$tmp" env -u KEYORIX_TEST_PG_DSN "$0" 2>&1)
+        else
+            out=$(CLOSURE_LEDGER="$tmp" KEYORIX_TEST_PG_DSN="$dsn" "$0" 2>&1)
+        fi
+        rc=$?
+        set -e
+        rm -f "$tmp"
+        if [ "$expect" = "reject" ] && [ "$rc" -eq 0 ]; then
+            echo "FAIL: self-test case '$desc' PASSED when it must be REJECTED — the checker" >&2
+            echo "      cannot detect this bad row and is therefore worthless for it." >&2
+            sed -n '1,40p' <<<"$out" | sed 's/^/      /' >&2
+            selffail=1
+        elif [ "$expect" = "accept" ] && [ "$rc" -ne 0 ]; then
+            echo "FAIL: self-test case '$desc' was REJECTED when it must be ACCEPTED — the" >&2
+            echo "      checker is too strict and will block an honest, correctly-gated row." >&2
+            sed -n '1,40p' <<<"$out" | sed 's/^/      /' >&2
+            selffail=1
+        else
+            echo "  ok: '$desc' correctly ${expect}ed (exit $rc)"
+        fi
+    }
+
+    run_case "nonexistent test" "reject" \
+        'SELF-TEST-1	./internal/core	TestThisNameDoesNotExistAnywhere	default-ci	deadbeef	-	calibration row' \
+        "-"
+
+    run_case "default-ci row whose test skips" "reject" \
+        'SELF-TEST-2	./internal/core	TestCheckClosuresSelfTestFixture_AlwaysSkip	default-ci	deadbeef	-	calibration row' \
+        ""
+
+    run_case "pg-gated row, no DSN available, test skips" "accept" \
+        'SELF-TEST-3	./internal/core	TestCheckClosuresSelfTestFixture_SkipsWithoutPGDSN	pg-gated	deadbeef	-	calibration row' \
+        ""
+
+    run_case "pg-gated row, DSN available, test skips anyway" "reject" \
+        'SELF-TEST-4	./internal/core	TestCheckClosuresSelfTestFixture_AlwaysSkip	pg-gated	deadbeef	-	calibration row' \
+        "host=localhost port=1 dbname=x user=x sslmode=disable password=x"
+
+    run_case "invalid verification value" "reject" \
+        'SELF-TEST-5	./internal/core	TestCheckClosuresSelfTestFixture_AlwaysSkip	sometimes	deadbeef	-	calibration row' \
+        "-"
+
+    run_case "manual row with no artefact note" "reject" \
+        'SELF-TEST-6	-	-	manual	deadbeef	-	' \
+        "-"
+
+    run_case "manual row with an artefact note, no pkg/test needed" "accept" \
+        'SELF-TEST-7	-	-	manual	deadbeef	-	calibration row citing a fake artefact' \
+        "-"
+
+    if [ "$selffail" -ne 0 ]; then
         exit 1
     fi
-    echo "  ok: self-test correctly went red (exit $selfrc)"
 fi
 
 echo
 if [ "$fail" -eq 0 ]; then
-    echo "ok: $checked closure claim(s) verified — each names a test that ran and passed"
+    echo "ok: $checked closure claim(s) verified ($gated_skips gate-skipped in this invocation — see above)"
 else
     echo "CLOSURE VERIFICATION FAILED — do not treat the ledger as accurate" >&2; exit 1
 fi

--- a/scripts/report-unlisted-security-issues.sh
+++ b/scripts/report-unlisted-security-issues.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# report-unlisted-security-issues.sh — lists closed GitHub issues carrying the
+# `security` label that docs/security-closures.tsv does not cite by number in
+# its `issue` column, so an omitted closure at least becomes VISIBLE instead
+# of silently indistinguishable from a defect that never existed.
+#
+# THIS IS A REPORT, NOT A GATE. It never fails the build (see the bottom of
+# this file) and it must not be mistaken for a completeness check. Two
+# empirically-confirmed reasons:
+#
+#   1. The `security` label is under-applied in this repo, badly enough that
+#      it would have missed the exact closures that motivated this script.
+#      Checked 2026-09-08: #1646 and #1780 (the SoD cross-replica races this
+#      ledger's pg-gated rows now cite) carry ZERO labels, and neither does
+#      #1551 or #1572 -- two closures that were ALREADY correctly cited in
+#      this ledger before this script existed. A detector keyed on this label
+#      alone would not have caught the case it exists to catch.
+#   2. GitHub's own structural "closed by PR" linkage isn't a reliable
+#      fallback either: #1780 was closed via a PR body's "Closes #1780" (so it
+#      has a real, structural closer), but #1646 was closed by hand despite
+#      two PRs cross-referencing it (closer: null) -- the same issue, same
+#      severity, same ledger, one traceable this way and one not.
+#
+# So an issue missing from this script's output is not proof nothing is
+# owed -- it is proof only that this ONE weak signal didn't flag it. A `-` in
+# the ledger's own `issue` column carries the identical caveat. Treat both as
+# a floor, never a ceiling. There is no known reliable derivation source for
+# "is this closed issue a security closure" in this repo today; shipping a
+# hand-maintained list of issue numbers here would rot exactly the way the
+# ledger itself did, so this queries live GitHub state instead of hardcoding
+# one -- its only weakness is input-label completeness, not staleness.
+#
+# Usage: ./scripts/report-unlisted-security-issues.sh
+#   Requires: gh CLI, authenticated (GH_TOKEN/GITHUB_TOKEN), issues:read.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LEDGER="${CLOSURE_LEDGER:-$REPO_ROOT/docs/security-closures.tsv}"
+REPO="${GH_REPO:-keyorixhq/keyorix}"
+
+if [ ! -f "$LEDGER" ]; then
+    echo "FAIL: closure ledger not found at $LEDGER" >&2; exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "SKIP: gh CLI not available -- cannot query GitHub, nothing reported this run." >&2
+    exit 0
+fi
+
+issues_json=$(gh issue list --repo "$REPO" --label security --state closed --limit 500 \
+    --json number,title,url 2>&1) || {
+    echo "SKIP: could not query closed security-labeled issues (network/auth?) -- nothing" >&2
+    echo "      reported this run. Not treated as a failure: this script is informational." >&2
+    echo "$issues_json" >&2
+    exit 0
+}
+
+total=$(jq 'length' <<<"$issues_json")
+echo "==> $total closed issue(s) carry the 'security' label (denominator for this sweep only --"
+echo "    see this script's own header for why it is not the true denominator of closures)"
+
+if [ "$total" -eq 0 ]; then
+    echo "ok: nothing to cross-reference this run."
+    exit 0
+fi
+
+cited=0
+uncited=0
+uncited_list=""
+for i in $(seq 0 $((total - 1))); do
+    number=$(jq -r ".[$i].number" <<<"$issues_json")
+    title=$(jq -r ".[$i].title" <<<"$issues_json")
+    url=$(jq -r ".[$i].url" <<<"$issues_json")
+    if awk -F'\t' -v n="$number" '$6==n {found=1} END{exit !found}' "$LEDGER"; then
+        cited=$((cited + 1))
+    else
+        uncited=$((uncited + 1))
+        uncited_list="${uncited_list}  #${number}	${title}	${url}\n"
+    fi
+done
+
+echo "    $cited already cited in $LEDGER by issue number"
+echo "    $uncited NOT cited -- candidates for a follow-up ledger row (or a reason each is"
+echo "    deliberately absent, matching this ledger's own \"NOT LISTED, deliberately\" section):"
+if [ "$uncited" -gt 0 ]; then
+    printf '%b' "$uncited_list"
+fi
+
+echo
+echo "report only -- see header. Exiting 0 regardless of the counts above."
+exit 0


### PR DESCRIPTION
## Summary

`docs/security-closures.tsv` could not represent a closure whose proof requires a real Postgres connection. `check-closures.sh` treated any skipped test as a failure, unconditionally — so a row for #1646 or #1780 (both real, both closed, both cross-replica race fixes only provable against a live multi-connection Postgres, not SQLite/mocks) could not be added without breaking CI the moment the checker ran without a DSN, which is every existing invocation. No row was added. The ledger's completeness silently became a function of which environment it ran in, not of what was actually fixed.

## What changed

- **New `verification` column** (`default-ci` / `pg-gated` / `manual`) on both `docs/security-closures.tsv` and `docs/adr-conformance-enforced.tsv` (the latter is a thin wrapper reusing the same checker logic, migrated to match). A row now states which environment its proof requires; `check-closures.sh` judges a skip against that claim instead of one hardcoded assumption. A `default-ci` skip is still always a failure. A `pg-gated` skip is expected (not evidence either way) when the checker's own invocation has no DSN, and a real failure the instant it does.
- **A second, real proof, not just permission to skip**: `.github/workflows/ci.yml`'s `test-suite` job (`core` leg — the one job with a Postgres service container) now runs `check-closures.sh` a second time, with the DSN present. That run is what actually proves a `pg-gated` row; the DSN-less `adr-numbers` job no longer reports a false failure for one.
- **Backfilled `G04-HA-1646` and `G04-HA-1780`** as `pg-gated` rows, citing `TestConcurrency_AssignUserRole_CrossReplicaPostgres_SoDBypass` and `TestConcurrency_GroupRoleGrant_CrossReplicaPostgres_SoDBypass`. Verified locally against a live `postgres:16` container: both gate-skip cleanly with no DSN, both genuinely `PASS` with one.
- **New `issue` column** + `scripts/report-unlisted-security-issues.sh`, a non-blocking informational CI step cross-referencing closed issues carrying the `security` label against it. Deliberately a report, not a gate — see below.

## Why the omission-detection mechanism is a report, not a gate

Investigated three candidate "authoritative source" signals for deriving the full closure set automatically, and tested each against the two closures that motivated this change:

- **The `security` GitHub label**: 21 closed issues carry it; **zero** overlap with this ledger's actual rows. #1646, #1780, and — more tellingly — #1551 and #1572 (already correctly cited in this ledger *before* this change) all carry **zero** labels.
- **GitHub's structural "closed by PR" linkage**: #1780 has one (closed via a `Closes #1780` PR body). #1646 does not — closed by hand despite two PRs cross-referencing it.
- A detector keyed on either signal would not have caught the case that motivated this task.

No reliable automatic derivation source for "is this closed issue a security closure" exists in this repo today. `scripts/report-unlisted-security-issues.sh` queries live GitHub state (never a hand-maintained list, so it can't go stale the way the ledger itself did) and surfaces candidates — currently 21, none yet cited — as a floor, explicitly caveated as not a ceiling, exiting 0 unconditionally so it can never block a PR.

## Test plan

- [x] `./scripts/check-closures.sh` — 15 `default-ci` rows pass, 2 `pg-gated` rows gate-skip cleanly, no DSN.
- [x] Same, with a real Postgres DSN — all 17 genuinely `PASS`, 0 gate-skipped.
- [x] `./scripts/check-closures.sh --self-test` — all 7 calibration cases (1 pre-existing + 6 new) correctly reject every bad row and accept every honest one, run both with and without an ambient DSN.
- [x] `./scripts/check-adr-conformance.sh` + `--self-test` — confirms the thin-wrapper reuse still works against the migrated schema.
- [x] `./scripts/report-unlisted-security-issues.sh` — runs against live GitHub state, exits 0, correctly lists the current 21-issue gap.
- [x] `actionlint`, `shellcheck` on the new/changed scripts (one pre-existing SC2013 info-note, unchanged from before this PR).
- [x] Full `internal/core` suite green, both with and without a Postgres DSN. `gofmt`/`go vet`/`gosec` clean on the new fixture file.