### PR TITLE
feat(hooks): move destructive-git invariants from release-steward into the PreToolUse gate

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "out=$(bash scripts/worktree-branch-health.sh --worktrees-only 2>&1); jq -n --arg ctx \"$out\" '{hookSpecificOutput:{hookEventName:\"SessionStart\",additionalContext:$ctx}}'",
+            "command": "if out=$(bash scripts/worktree-branch-health.sh --worktrees-only 2>&1); then jq -n --arg ctx \"$out\" '{hookSpecificOutput:{hookEventName:\"SessionStart\",additionalContext:$ctx}}'; else st=$?; jq -n --arg ctx \"$out\" --arg st \"$st\" '{hookSpecificOutput:{hookEventName:\"SessionStart\",systemMessage:(\"worktree-branch-health.sh FAILED (exit \" + $st + \") -- session state is unverified, this is NOT a health report\"),additionalContext:(\"worktree-branch-health.sh FAILED (exit \" + $st + \"); the text below is captured output, NOT a health report: \" + $ctx)}}'; echo \"worktree-branch-health.sh FAILED (exit $st): $out\" >&2; exit 2; fi",
             "timeout": 30,
             "statusMessage": "Checking worktree health..."
           },

--- a/scripts/git-write-guard.sh
+++ b/scripts/git-write-guard.sh
@@ -52,7 +52,7 @@ sid="$(echo "$payload" | jq -r '.session_id // empty')"
 # the command it's gating -- would resolve against the wrong tree entirely).
 GIT_C=""
 subcmd=""
-is_worktree_cmd=0
+skip_worktree_check=0
 if [ "$MODE" = "gate" ]; then
     cmd_str="$(echo "$payload" | jq -r '.tool_input.command // empty')"
     set -- $cmd_str
@@ -70,7 +70,44 @@ if [ "$MODE" = "gate" ]; then
             *) subcmd="$tok"; break ;;
         esac
     done
+fi
 
+# Hoisted above the subcommand case below: check 3 (worktree prune) needs it
+# during classification, before the write-lock section that used to be its
+# only caller.
+#
+# --path-format=absolute is deliberate, not decoration: plain
+# `rev-parse --git-common-dir` returns a path relative to THIS PROCESS'S OWN
+# cwd, not to the -C target -- confirmed empirically (git 2.50.1, both a
+# `-C <path>` target and a bare invocation from a non-repo cwd return the
+# literal string ".git"). That relative string, used unmodified as a
+# filesystem path elsewhere in this script (the lock path below, and the
+# worktree-prune resolution check), silently resolves against the HOOK
+# PROCESS's ambient cwd instead of the repo actually being gated -- the
+# exact "-C changes what git operates on, not the shell's own cwd" trap this
+# file's own header comment already warns about for git_at, just not (until
+# now) applied to its own output. --path-format=absolute forces an absolute
+# result regardless of invocation context (git >=2.31, well below this
+# repo's floor).
+git_at() {
+    if [ -n "$GIT_C" ]; then
+        git -C "$GIT_C" "$@"
+    else
+        git "$@"
+    fi
+}
+
+# deny prints the standard PreToolUse block payload and exits. Every call
+# site below MUST exit 0 regardless of allow/deny -- this hook's contract
+# communicates the decision entirely through hookSpecificOutput.
+# permissionDecision, never through the process exit code (matching every
+# other deny path already in this file).
+deny() {
+    jq -n --arg reason "$1" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
+    exit 0
+}
+
+if [ "$MODE" = "gate" ]; then
     # Only HEAD/branch-state-mutating subcommands are guarded -- this is the
     # documented incident class ("HEAD moving inside a shared .git"), not
     # "every git invocation." Gating git status/log/diff/show etc. would just
@@ -91,27 +128,122 @@ if [ "$MODE" = "gate" ]; then
             done
             ;;
         commit|switch|rebase|merge|cherry-pick|revert|pull|am) ;;
+        push)
+            # Bare --force overwrites work whose existence the pusher never
+            # checked -- --force-with-lease at least fails closed when the
+            # remote ref moved since the pusher's own last fetch. Tracks
+            # LAST-WINS across the arg list (matching git's own option
+            # precedence: a later --force-with-lease after an earlier
+            # --force makes the push safe again, and vice versa), not mere
+            # presence -- a presence-only check would wrongly clear a
+            # trailing bare --force just because --force-with-lease also
+            # appears earlier on the line. A single-dash cluster containing
+            # `f` (e.g. `-fu`, `-nf`) counts as --force: push's other short
+            # flags (v,q,n,u,d,o,4,6) don't collide with that letter, so
+            # this doesn't false-positive on them.
+            force_mode=""
+            for a in "$@"; do
+                case "$a" in
+                    --force-with-lease|--force-with-lease=*|--force-if-includes) force_mode="lease" ;;
+                    --force) force_mode="bare" ;;
+                    --no-force) force_mode="" ;;
+                    -[a-zA-Z]*) case "$a" in *f*) force_mode="bare" ;; esac ;;
+                esac
+            done
+            if [ "$force_mode" = "bare" ]; then
+                deny "Bare --force on push overwrites whatever is on the remote right now, sight unseen -- the pusher never checked what's there. Use --force-with-lease instead: it still force-pushes, but fails closed if the remote ref moved since your last fetch, instead of silently discarding it."
+            fi
+            # push doesn't move local HEAD or the current branch pointer --
+            # the downstream "must be in a dedicated worktree" check below
+            # exists for a different, unrelated invariant (two sessions'
+            # HEAD-moving operations colliding in a shared main checkout)
+            # that a remote-ref push was never subject to before this
+            # subcommand had any case arm at all. Exempt via the same
+            # mechanism worktree add/remove/prune/move already use, once
+            # this check itself has passed -- still subject to the write-
+            # lock contestation check above this exemption, just not the
+            # worktree-specific one below it.
+            skip_worktree_check=1
+            ;;
+        branch)
+            # A local branch may be an active working checkout (this repo's
+            # own worktree model) carrying uncommitted work -- there is no
+            # recovery path for what was never committed. Unconditional:
+            # this blocks deleting ANY local branch through this gate, not
+            # just the currently-checked-out one, matching CLAUDE.md's
+            # standing "never delete a local branch" rule -- judgment about
+            # which branches are safe to remove belongs to a human or an
+            # explicit instruction, not a heuristic in this hook.
+            # -r/--remote(s) is exempted: `git branch -d -r <name>` deletes
+            # a REMOTE-TRACKING ref (refs/remotes/...), not a local branch a
+            # worktree could have checked out -- a different, lower-risk
+            # operation this rule was never about.
+            has_delete=0
+            has_remote=0
+            for a in "$@"; do
+                case "$a" in
+                    --delete) has_delete=1 ;;
+                    --remotes|--remote) has_remote=1 ;;
+                    -[a-zA-Z]*)
+                        case "$a" in *[dD]*) has_delete=1 ;; esac
+                        case "$a" in *r*) has_remote=1 ;; esac
+                        ;;
+                esac
+            done
+            if [ "$has_delete" -eq 1 ] && [ "$has_remote" -eq 0 ]; then
+                deny "git branch -d/-D/--delete refused: a local branch may be an active working checkout (this repo runs on worktrees) carrying uncommitted work, and there is no recovery path for what was never committed. Leave the branch -- if it's genuinely unneeded, that is a decision for a human, not this gate."
+            fi
+            # Same reasoning as push above: branch (list/create/delete-of-a-
+            # non-HEAD-ref) doesn't move THIS process's own HEAD, so the
+            # downstream worktree-specific check is unrelated and was never
+            # applied to it before this subcommand had a case arm.
+            skip_worktree_check=1
+            ;;
         worktree)
             # only add/remove/prune/move mutate the shared registry; list
             # and lock/unlock are read-only-equivalent for this purpose.
-            case "${1:-}" in
-                add|remove|prune|move) is_worktree_cmd=1 ;;
+            wt_subcmd="${1:-}"
+            case "$wt_subcmd" in
+                add|remove|prune|move) skip_worktree_check=1 ;;
                 *) exit 0 ;;
             esac
+            if [ "$wt_subcmd" = "prune" ]; then
+                # In a mounted or containerised view, worktrees registered
+                # at HOST paths are invisible from this process, and git
+                # reports them as prunable -- a prune there deregisters
+                # every live worktree at once (this has already happened at
+                # scale in this repository). Mechanical test: for each
+                # registered worktree's gitdir file, does the recorded
+                # path's PARENT directory (the worktree's own root, not the
+                # .git file itself) exist from THIS process's view? If any
+                # do not, this view cannot see host worktrees and prune
+                # must be refused outright -- not just for the specific
+                # unresolvable entries, since the same blind spot could
+                # just as easily be hiding others that happen to look
+                # resolvable by coincidence (e.g. a reused path).
+                gc_abs="$(git_at rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+                unresolvable=""
+                if [ -n "$gc_abs" ] && [ -d "$gc_abs/worktrees" ]; then
+                    for gd_file in "$gc_abs"/worktrees/*/gitdir; do
+                        [ -f "$gd_file" ] || continue
+                        recorded="$(cat "$gd_file" 2>/dev/null)"
+                        [ -z "$recorded" ] && continue
+                        parent="$(dirname "$recorded")"
+                        if [ ! -e "$parent" ]; then
+                            unresolvable="${unresolvable}${unresolvable:+, }$parent"
+                        fi
+                    done
+                fi
+                if [ -n "$unresolvable" ]; then
+                    deny "git worktree prune refused: at least one registered worktree's path does not resolve from this process's view ($unresolvable) -- in a mounted or containerised view that means the host's own worktrees are simply invisible here, not actually gone, and prune would deregister them all. Verify gitdir resolution (does every path under \$(git rev-parse --git-common-dir)/worktrees/*/gitdir actually exist from here?) before pruning, or run prune from the view that can actually see those paths."
+                fi
+            fi
             ;;
         *) exit 0 ;;
     esac
 fi
 
-git_at() {
-    if [ -n "$GIT_C" ]; then
-        git -C "$GIT_C" "$@"
-    else
-        git "$@"
-    fi
-}
-
-lock="$(git_at rev-parse --git-common-dir 2>/dev/null)/write-lock.json"
+lock="$(git_at rev-parse --path-format=absolute --git-common-dir 2>/dev/null)/write-lock.json"
 [ -z "$lock" ] && exit 0
 
 now="$(date -u +%s)"
@@ -149,13 +281,17 @@ if [ "$MODE" = "gate" ]; then
     # lock so it stays warm while this session keeps acting.
     jq -n --arg sid "$sid" --argjson ts "$now" '{sessionId:$sid, claimedAtEpoch:$ts}' > "$lock"
 
-    # worktree add/remove/prune/move are exempt from the "must already be in
-    # a worktree" check below -- they're inherently main-checkout-
-    # administrative (worktree add FROM the main checkout is how you GET a
-    # worktree in the first place; requiring one first is a bootstrapping
-    # deadlock, not a safety property). The lock check above still applies
-    # to them, since they do mutate the shared .git/worktrees/ registry.
-    if [ "$is_worktree_cmd" -eq 1 ]; then
+    # worktree add/remove/prune/move, push, and branch are all exempt from
+    # the "must already be in a worktree" check below -- none of them move
+    # THIS process's own HEAD, which is the specific incident class that
+    # check exists for. worktree add/remove/prune/move are inherently main-
+    # checkout-administrative (worktree add FROM the main checkout is how
+    # you GET a worktree in the first place; requiring one first is a
+    # bootstrapping deadlock, not a safety property). push writes a remote
+    # ref; branch list/create/delete touches a ref, not HEAD. The lock check
+    # above still applies to all of them -- this exemption only narrows
+    # which DOWNSTREAM check applies, not whether the write-lock does.
+    if [ "$skip_worktree_check" -eq 1 ]; then
         exit 0
     fi
 
@@ -164,7 +300,7 @@ if [ "$MODE" = "gate" ]; then
     # moving under a concurrent read/inspection from anyone else, even a
     # well-behaved second session that's only ever reading.
     gd="$(git_at rev-parse --absolute-git-dir 2>/dev/null)"
-    gc="$(cd "$(git_at rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd -P)"
+    gc="$(cd "$(git_at rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" 2>/dev/null && pwd -P)"
     gd_r="$(cd "$gd" 2>/dev/null && pwd -P)"
     if [ -n "$gd_r" ] && [ "$gd_r" = "$gc" ]; then
         jq -n '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:"Commits/checkouts/rebases must happen in a dedicated worktree, not the shared main checkout -- run EnterWorktree (or git worktree add) first. See CLAUDE.md: start in a worktree, commit+push as your last act."}}'


### PR DESCRIPTION
## Summary

`.claude/agents/release-steward.md` (#1801) documents seven rules for release mechanics, but a subagent is delegation-only — it gates nothing. If the main agent runs a destructive command directly, none of those rules apply. That's opt-in correctness: a convention that works only when remembered, and fails silently when not.

This moves the subset of those rules that must hold at every call site — where the violation is silent and the consequence severe — into `scripts/git-write-guard.sh`'s existing `PreToolUse` gate (#1784), where they're enforced rather than advised. Three qualify, per the guard economics named in the task: **bare `--force` on push**, **local branch deletion**, and **`git worktree prune` from a view where registered paths don't resolve**. Rules requiring judgement (base inspection, branch triage, containment proofs, worktree scanning, report shape) stay in the subagent, not attempted here.

## The three checks

1. **Bare `--force` on push** → requires `--force-with-lease`. Tracks last-wins across the arg list (matching git's own option precedence — a later `--force-with-lease` after an earlier `--force` makes the push safe again, and a presence-only check would have missed the reverse case), and treats a single-dash cluster containing `f` (`-fu`, `-nf`) as `--force` too.
2. **`git branch -d/-D/--delete`** → unconditionally refused. A local branch may be an active worktree checkout carrying uncommitted work with no recovery path — this isn't conditional on it being the *currently checked out* branch. `-r`/`--remote(s)` is exempted: that deletes a remote-tracking ref, a different, lower-risk operation this rule was never about.
3. **`git worktree prune`** → mechanical test: for each `$(git rev-parse --git-common-dir)/worktrees/*/gitdir`, does the recorded path's *parent* (the worktree's own root) exist from this process's view? Any single miss refuses the whole prune, not just the unresolvable entries — the same blind spot could be hiding others that happen to look resolvable by coincidence.

## A bug found and fixed along the way

While implementing check 3, I found that `git_at rev-parse --git-common-dir` — used for the write-lock path, the pre-existing "must be in a worktree" check, and now check 3 — returns a path **relative to the hook process's own ambient cwd, not the `-C` target**. Confirmed empirically (git 2.50.1: both a `-C`-targeted and a bare invocation return the literal string `.git`). A gated command with a `-C` target different from the hook's own ambient cwd had its write-lock check silently applied to the *wrong repository* — live-reproduced during this task's own scratch-clone testing, where a `-C <scratch>` worktree command got denied by a write-lock belonging to an entirely unrelated checkout.

Fixed at all three call sites via `--path-format=absolute` (git ≥2.31, well below this repo's floor) — a one-flag addition, not a redesign. I didn't go looking for this; my own new check 3 needed correct resolution to function at all, and leaving the pre-existing call sites broken while adding a fourth, correct one would have been inconsistent and worse than fixing all three together. Verified via a reverse test: a `-C`-targeted non-force push now correctly writes its lock to the scratch repo, not the ambient cwd's.

## SessionStart fail-open (item 4)

`worktree-branch-health.sh`'s output was captured into `additionalContext` unconditionally — a missing or failing script's error text got treated as a normal report, and the hook still reported success. Now checks the script's actual exit status: success is unchanged; failure emits `systemMessage` (user-visible), an explicitly `FAILED`-prefixed `additionalContext` (can't be mistaken for a real report even without reading closely), writes to stderr, and exits 2 — the documented non-`additionalContext` failure signal for `SessionStart` (it has no `permissionDecision` object of its own).

## Verification

Everything below ran in an isolated scratch clone (`git init --bare` + two working clones + a manually-constructed worktree registry, entirely outside this repository), invoking the script directly with a piped JSON payload matching the hook's real stdin contract — never against this repository's own live git state, per the task's own "test in a scratch clone before relying on the live gate" instruction. One live-hook `-C`-targeted push confirmed the path-resolution fix specifically.

- **Check 1**: RED (bare `--force` → denied, names the rule and `--force-with-lease`) / GREEN (`--force-with-lease` → passes) — separately confirmed.
- **Check 2**: RED (`-D` → denied) / GREEN (`-a` list → passes; bonus: `-d -r` on a remote-tracking ref → passes) — separately confirmed.
- **Check 3**: RED (a worktree's `gitdir` rewritten to an unresolvable path → whole prune denied) / GREEN (prune passes once resolvable) — separately confirmed.
- **Regression**: commit outside a worktree still denied; commit inside a worktree still allowed; `worktree add` still exempt from the worktree check; `git status` still ungated; a non-force push / non-delete branch command is still subject to write-lock contestation (denied when another session's lock is active) — confirming checks 1/2 narrow what's gated without silently exempting push/branch from the lock mechanism entirely.
- **SessionStart fix**: tested with the health script moved aside (exit 127) and present-but-failing (exit 1) — both produce `systemMessage` + flagged `additionalContext` + stderr + exit 2. Restored and reconfirmed the success path unchanged.
- `bash -n` and `shellcheck` clean (one pre-existing SC2086 info-note on line 58, unchanged from before this PR).
- This PR's own branch was pushed through the live, self-edited gate as its final step — no self-lockout.

## What I did not do

- Did not add a `--self-test` mode to `git-write-guard.sh` (no such convention existed for this script before this PR) — the scratch-clone transcript above is the verification record instead.
- Did not weaken any existing check to make a new one pass.
- Did not attempt to encode any of release-steward.md's judgement-requiring rules (1, 2, 3, 4, 6) into the gate.