### PR TITLE
fix(semgrep): suppress reviewed dynamic-urllib findings, document alert #818's engine quirk

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -51,6 +51,21 @@ jobs:
         # shouldn't fail the build. Deliberately excludes .semgrep/keyorix-nudges.yml --
         # those rules match every occurrence of a pattern by design (old and new) and
         # must never be uploaded as SARIF/code-scanning alerts, see that file's header.
+        #
+        # KNOWN ENGINE QUIRK (found investigating alerts #816-818, 2026-09-08): at
+        # this repo's full scale (--config=auto pulls ~650 rules across ~1600
+        # tracked files), Semgrep 1.172-1.175 sometimes drops an inline `# nosemgrep`
+        # / `// nosemgrep: <rule-id>` suppression that DOES work on a smaller/
+        # single-file scan of the exact same rule+line -- reproduced with
+        # --config=auto ALONE (no custom ruleset involved at all), so it is not
+        # this repo's config combining two sources, it is auto's rule count. Before
+        # treating a surfaced alert here as a real regression: rerun
+        # `semgrep scan --config=<same config> <that one file>` -- if that finds
+        # nothing and the line already carries a correctly-formatted, reasoned
+        # nosemgrep comment, it's this quirk, not a new finding; dismiss the alert
+        # as a false positive citing this comment rather than re-suppressing (the
+        # comment already exists and already works everywhere except this
+        # specific full-scale advisory run).
         if: always()
         run: semgrep scan --config=auto --config=.semgrep/keyorix-rules.yml --sarif --output=semgrep.sarif . || true
 

--- a/scripts/memory-measurement/container_env.py
+++ b/scripts/memory-measurement/container_env.py
@@ -112,7 +112,9 @@ def wait_healthy(base_url: str, container: str = None, timeout_s: int = 60):
     last_err = None
     while time.time() < deadline:
         try:
-            urllib.request.urlopen(base_url + "/health", timeout=2)
+            # base_url is always this script's own f"http://localhost:{PORT}" (matrix_runner.py, the
+            # container this same process just started) -- no external input reaches this URL.
+            urllib.request.urlopen(base_url + "/health", timeout=2)  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             return
         except Exception as e:
             last_err = e

--- a/scripts/memory-measurement/load_driver.py
+++ b/scripts/memory-measurement/load_driver.py
@@ -30,7 +30,9 @@ class Client:
             headers["Authorization"] = f"Bearer {token}"
         data = json.dumps(body).encode() if body is not None else None
         req = urllib.request.Request(url, data=data, method=method, headers=headers)
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        # base_url is this same script's own f"http://localhost:{PORT}" (matrix_runner.py), path is
+        # always a literal endpoint string at every call site below; no external input reaches this URL.
+        with urllib.request.urlopen(req, timeout=30) as resp:  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             return resp.read()
 
     def login(self, username: str, password: str) -> str:


### PR DESCRIPTION
## Summary

Closes alerts #816, #817, #818.

- **#817** (`scripts/memory-measurement/load_driver.py:33`) and **#816**
  (`scripts/memory-measurement/container_env.py:115`):
  `python.lang.security.audit.dynamic-urllib-use-detected`. Both build a
  `urllib.request` URL from `base_url`, which is always this same script's own
  `f"http://localhost:{PORT}"` (`matrix_runner.py`) — a container the script
  just started itself, never external/network input. Annotated with an
  inline `# nosemgrep: <rule-id>` plus a same-line reason, matching the
  convention already used throughout `internal/core/*.go` for this class of
  reviewed finding. Verified locally against the exact rule.

- **#818** (`internal/core/sod.go:680`,
  `semgrep.keyorix-unbounded-bulk-slice-param`): no code change needed. That
  line already carries a correct, reasoned `nosemgrep` suppression (landed in
  #1797, confirmed via `git log -S`), and the *blocking* Semgrep gate
  (`.github/workflows/semgrep.yml`'s custom-rules-only step) already respects
  it — verified by running the exact pinned CI image
  (`semgrep/semgrep:1.172.0`) against this exact file: 0 findings.

  Investigating why the GitHub alert kept firing anyway found a genuine
  Semgrep engine quirk, not a code or workflow-config defect: at this repo's
  full scale, `--config=auto` **alone** (no custom ruleset involved at all)
  can drop an inline `nosemgrep` suppression that reliably holds on a
  single-file rerun of the identical rule+line. Reproduced directly:
  - `semgrep scan --config=.semgrep/keyorix-rules.yml` (the blocking config,
    matching CI) on `sod.go` alone → 0 findings.
  - Same config, full repo (`.`) → 0 findings.
  - `--config=auto` added, full repo → the finding reappears at `sod.go:680`
    **and** at `sod.go:751` — a second, independently-reasoned,
    already-suppressed instance of the same rule that isn't even a
    GitHub-tracked alert.
  - Cross-checked all 9 currently-suppressed instances of this rule
    repo-wide (`access_review.go`, `rotation_executor.go` ×2,
    `scim_groups.go`, `secret_dependencies.go`, `secret_listing_query.go`,
    `service.go`, plus the two in `sod.go`): every one is correctly
    annotated already, and every one reappeared under the same
    `--config=auto` + full-repo combination.
  - Confirmed it isn't specific to *our* custom rule interacting with
    `auto`: `--config=auto` by itself (no custom config loaded) also
    transiently dropped the two Python suppressions above during testing.

  This isn't fixable by editing rule YAML or restructuring which configs
  combine — `--config=auto` alone reproduces it. Documented the repro recipe
  directly in `semgrep.yml`'s advisory-scan step so a future recurrence is
  immediately diagnosable (rerun the single file against the exact rule; if
  clean and already annotated, it's this quirk) rather than re-investigated
  from scratch each time.

All 3 alerts will be dismissed via the code-scanning API as false positives
once this merges, citing this PR.

## Test plan

- [x] `semgrep scan --config=.semgrep/keyorix-rules.yml` (blocking config) on
  `internal/core/sod.go` alone and full-repo: 0 findings, before and after
- [x] `semgrep scan --config=auto` on each fixed Python file alone: 0
  findings after the fix (was 1 before)
- [x] `python3 -m py_compile` on both modified Python files: clean
- [x] `actionlint .github/workflows/semgrep.yml`: clean
- [x] Confirmed via the pinned CI image (`semgrep/semgrep:1.172.0`), not just
  local Semgrep, for the sod.go verification