### PR TITLE
fix(web): unblock docker-publish's Trivy gate (util-linux + openssl CVEs in nginx:alpine)

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -24,7 +24,26 @@ RUN pnpm build
 
 # Production stage — nginx serves the static bundle and reverse-proxies the API
 # (/api/ and /auth/) to the backend service. See nginx.conf.
-FROM nginx:alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752 AS production
+#
+# 2026-09-08: bumped from sha256:4a73073b... (nginx 1.31.5-alpine, built
+# 2026-08-2x) to the current nginx:alpine digest below (same 1.31.5-alpine,
+# rebuilt 2026-09-02) to pick up the Alpine 3.24 openssl security update
+# (libcrypto3/libssl3 3.5.7-r0 -> 3.5.8-r0, CVE-2026-14456) baked into the
+# upstream image. That rebuild did NOT also pick up util-linux's fix
+# (libuuid stays 2.42.1-r0 in both digests) -- nginx's official image is a
+# point-in-time snapshot of whatever Alpine 3.24's main repo had at BUILD
+# time, and Alpine's own 3.24 branch had already shipped libuuid 2.42.3-r1
+# (verified directly against https://dl-cdn.alpinelinux.org/alpine/v3.24/
+# main/aarch64/APKINDEX.tar.gz) before upstream nginx's last rebuild picked
+# it up. Waiting on nginx's next rebuild has no defined timeline, so the
+# line below pulls the already-published fix from the SAME Alpine 3.24 repo
+# this base image already trusts, pinned to an exact version for the same
+# reproducibility reason the pnpm version above is pinned exactly rather
+# than left to float. Closes CVE-2026-53612/53613/53614/76642/78408/78409/
+# 78410 (util-linux, all in the libuuid sub-package this minimal image
+# actually installs -- nothing else from util-linux is present here).
+FROM nginx:alpine@sha256:72ba65eb42c10344912a84ff42408db7d34f2feb642204570ab8fc5ffd29f1d3 AS production
+RUN apk update && apk add --no-cache --upgrade libuuid=2.42.3-r1
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 


### PR DESCRIPTION
## Summary

`build-and-push-web` has failed on every `main` run since at least 2026-09-06T20:45 on the Trivy HIGH/CRITICAL gate — 9 findings in the `nginx:alpine` production-stage base image. The server image and every other published image (k8s-sync, operator, mcp) build clean; only the frontend image hasn't published in days. This blocks cutting any release, since there's no clean pipeline run to tag.

## Route taken, and why the other was rejected

Took the **base-image-bump route**, not a `.trivyignore`: a real fix was available for every single finding, so there was no honest "not exploitable" argument to make — that argument requires showing the vulnerable code path is unreachable, and here the vulnerable package versions were simply stale, with patches already sitting unused in the same Alpine branch this image tracks.

Two different findings, two different reasons they were stuck:

- **openssl** (`libcrypto3`/`libssl3` 3.5.7-r0 → 3.5.8-r0, CVE-2026-14456): the currently-pinned digest predates upstream nginx's own rebuild that already picked this fix up. Bumped to the current `nginx:alpine` digest (same `1.31.5-alpine`, rebuilt 2026-09-02) — verified via `docker buildx imagetools inspect` that the fresh digest already ships 3.5.8-r0 before making the change.
- **util-linux** (`libuuid` 2.42.1-r0 → 2.42.3-r1, CVE-2026-53612/53613/53614/76642/78408/78409/78410): staler. Verified directly against Alpine's own `v3.24/main/aarch64` APKINDEX that 2.42.3-r1 is already published in the exact Alpine branch this image tracks — but neither the digest bump above nor any other published `nginx:alpine`-family tag (checked every `alpine3.24` variant on Docker Hub; none newer exists) has rebuilt to pick it up, and that rebuild has no defined timeline. Pulls the already-published patch directly instead: `apk add --no-cache --upgrade libuuid=2.42.3-r1`, pinned to an exact version for the same reproducibility reason the pnpm version above it is pinned exactly.

## Verification

- Built the image locally and ran the **exact** CI gate command (`trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1`) against it: **0 findings, exit 0**.
- `hadolint` clean on the changed Dockerfile.
- This local check is not a substitute for a real CI run — `docker-publish.yml` only triggers on `push: branches: [main]` or a `v*` tag, so the actual verification is the run this PR's merge to `main` will trigger. I'll confirm that run goes green before treating this as closed.