### PR TITLE
fix(store): make two proxy-checking guards state their own denominators (issue #1786)

### DIFF
--- a/internal/storage/store/remote_proxy_correctness_audit_test.go
+++ b/internal/storage/store/remote_proxy_correctness_audit_test.go
@@ -26,6 +26,63 @@
 // is the same lesson remote_unsupported_widened_registry_test.go already
 // paid for once (five distinct stub-signaling shapes, found by cross-checking
 // two independent scans).
+//
+// # KNOWN NON-COVERAGE (read before trusting a green result)
+//
+// A historical-positive validation (run after this file's checks first
+// merged, PR #1800) searched this repository's own git history for real,
+// already-fixed defects in this exact proxy population. It found 9
+// candidates and replayed the checks below against the pre-fix tree for
+// each: 1 was directly executed and missed; the other 8 were established by
+// code inspection but were not replayable (the checks depend on scanner
+// helpers introduced later than those commits — see the validation report
+// for the full methodology). The checks below caught ZERO of the 9.
+//
+// Seven defect classes came out of that search, none of which the checks in
+// this file can see:
+//
+//  1. wrong response-envelope assumption — Health checked resp.Success on
+//     /health, a route with no {success,data} envelope at all. No check
+//     here inspects response semantics.
+//  2. blank-identifier parameter drop — RemoveRoleFromGroup's scope
+//     parameter was declared `_`. NOW COVERED — see check 5 below, added
+//     directly from this evidence (issue #1786 part 3).
+//  3. wire-struct field omission — AllowedCIDRs, ParentID: a struct-typed
+//     parameter is referenced in full (so check 1 sees it as "used"), but
+//     only some of its fields are copied into the wire type. Field-level
+//     completeness is not identifier-level presence.
+//  4. wrong endpoint string — LogAuditEvent, GetAuditLogs,
+//     GetRBACAuditLogs, GetSecretByName all 404'd against routes that were
+//     never registered server-side. No check here inspects a URL/path
+//     literal's validity.
+//  5. whole-struct JSON-tag mismatch — CreateUser/CreateSecret/UpdateSecret
+//     marshaled a raw, untagged Go struct; encoding/json silently dropped
+//     every underscore-named field. The struct IS referenced, in full —
+//     invisible to any identifier-presence check by construction.
+//  6. cache staleness against a compare-and-swap need — LockUserForUpdate
+//     delegated to GetUser, inheriting its 5-minute response cache and
+//     defeating the anti-TOCTOU recheck the method exists for. A runtime
+//     behavior, not a source shape.
+//  7. context lifetime, not identity — LogAuditEvent forwarded the
+//     triggering request's own cancellable context into an audit write
+//     instead of detaching. Check 3 does not merely miss this class: check
+//     3's condition for "correct" is that ctx IS forwarded verbatim, so on
+//     an audit-emitting endpoint where forwarding is exactly the bug,
+//     check 3 CERTIFIES the defect as correct. A green check-3 result on an
+//     audit-emitting path is not neutral silence about context lifetime —
+//     it is an affirmative, and here wrong, verdict.
+//
+// Classes 1, 3, 4, 5, 6, and 7 are behavioral, not structural — they need a
+// differential conformance harness (RemoteStorage.M(x) vs LocalStorage.M(x)
+// through a real server) to see, not a smarter static check. See issue
+// #1808 for that harness, using this same seven-class list as its test
+// plan. Do NOT add static checks for classes 1, 3, 4, 5, or 6 here: a
+// static check that appears to cover a behavioral class is worse than no
+// check, because it looks like coverage without being coverage — exactly
+// the framing mistake this file's own history (issue #1786) was filed
+// over. A green TestLayer1StaticFindingsAreAllowlisted result means exactly
+// one thing: no unexplained hit on five narrow, syntactic properties.
+// Nothing more — it is not evidence these proxies are correct.
 package store
 
 import (
@@ -442,10 +499,11 @@ func TestRealProxiesAreThinPassthroughs(t *testing.T) {
 }
 
 // ============================================================================
-// Layer 1 static checks (issue #1786 part 2, step 2).
+// Layer 1 static checks (issue #1786 parts 2 and 3).
 //
-// Four checks, each scoped to what it can decide SOUNDLY from source text
-// alone, over one proxyCallSite at a time:
+// Five checks, each scoped to what it can decide SOUNDLY from source text
+// alone, over one proxyCallSite at a time (checks 1-4 from part 2; check 5
+// from part 3, see the KNOWN NON-COVERAGE section above for why it exists):
 //
 //   1. dropped input   — a method parameter never referenced anywhere in the
 //      body cannot possibly be part of the request; this is a hard fact, not
@@ -459,6 +517,10 @@ func TestRealProxiesAreThinPassthroughs(t *testing.T) {
 //   4. silent zero return — a failure guard's return statement returns a
 //      literal `nil` in the error position, contradicting the guard's own
 //      condition.
+//   5. blank-identifier parameter — a parameter declared `_` in a real
+//      proxy method's own signature. Derived from a confirmed historical
+//      defect (RemoveRoleFromGroup, #1394), not from imagination — see
+//      blankParams' own doc comment.
 //
 // Each is validated red-then-green in remote_proxy_correctness_checks_test.go
 // against small in-memory source snippets (not real files) before this file's
@@ -537,6 +599,32 @@ func droppedInputs(fn *ast.FuncDecl) []string {
 		}
 	}
 	return dropped
+}
+
+// blankParams is check 5 (issue #1786 part 3): every parameter declared with
+// the blank identifier `_` in a real proxy method's signature — added
+// directly from a confirmed historical defect, not from imagination:
+// RemoteStorage.RemoveRoleFromGroup (#1394) declared its scope parameter
+// `_ storage.Scope`, so it satisfied storage.Storage's interface, compiled
+// clean, and never sent the value anywhere. Check 1 (droppedInputs) cannot
+// see this BY CONSTRUCTION: methodParams skips blank names before
+// droppedInputs ever runs (there is no identifier for identUsed to search
+// for) — this check looks at the declaration itself instead of at usage,
+// which is the only way to see a value the language itself lets a method
+// discard without comment.
+func blankParams(fn *ast.FuncDecl) []string {
+	if fn.Type.Params == nil {
+		return nil
+	}
+	var blanks []string
+	for _, field := range fn.Type.Params.List {
+		for _, n := range field.Names {
+			if n.Name == "_" {
+				blanks = append(blanks, exprString(field.Type))
+			}
+		}
+	}
+	return blanks
 }
 
 // contextSubstituted is check 3: reports a description of site's first
@@ -768,11 +856,11 @@ type proxyFinding struct {
 	Method string
 	File   string
 	Line   int
-	Check  string // "dropped-input" | "swallowed-error" | "context-substitution" | "silent-zero-return"
+	Check  string // "dropped-input" | "swallowed-error" | "context-substitution" | "silent-zero-return" | "blank-identifier-param"
 	Detail string
 }
 
-// checkCallSite runs all 4 checks against one proxy method + its one call
+// checkCallSite runs all 5 checks against one proxy method + its one call
 // site, returning every finding. Called once per proxyCallSite — for the two
 // fan-out-loop methods this still means once (each has exactly one call
 // site, per TestRealProxiesAreThinPassthroughs), evaluated with the
@@ -788,6 +876,12 @@ func checkCallSite(info methodInfo, site proxyCallSite) []proxyFinding {
 	// Check 1: dropped inputs.
 	for _, p := range droppedInputs(fn) {
 		add("dropped-input", "parameter "+p+" is never referenced anywhere in the method body")
+	}
+
+	// Check 5: blank-identifier parameters (issue #1786 part 3).
+	for _, typ := range blankParams(fn) {
+		add("blank-identifier-param", "a parameter of type "+typ+" is declared with the blank identifier _ — "+
+			"guaranteed unused by construction, and invisible to the dropped-input check above")
 	}
 
 	// Check 3: context substitution.
@@ -880,7 +974,7 @@ func runProxyCorrectnessAudit(t *testing.T) []proxyFinding {
 
 // TestRemoteProxyStaticAuditReport runs the Layer 1 static audit and reports
 // every finding, unconditionally passing. Kept alongside the real gate below
-// (TestRemoteProxyStaticAuditIsClean) purely so `go test -v -run
+// (TestLayer1StaticFindingsAreAllowlisted) purely so `go test -v -run
 // TestRemoteProxyStaticAuditReport` gives a human a full findings dump
 // without needing to fail a test to see it.
 func TestRemoteProxyStaticAuditReport(t *testing.T) {
@@ -894,7 +988,7 @@ func TestRemoteProxyStaticAuditReport(t *testing.T) {
 // proxyCorrectnessAllowlist is the exhaustive, reasoned inventory of every
 // Layer 1 static-check finding reviewed and confirmed NOT a bug — mirroring
 // remoteUnsupportedAllowlist's own shape (same file, same completeness-guard
-// idiom): a finding not listed here fails TestRemoteProxyStaticAuditIsClean
+// idiom): a finding not listed here fails TestLayer1StaticFindingsAreAllowlisted
 // immediately; an entry that stops firing (fixed, or the checker regressed)
 // also fails it, so this can't accumulate stale "known issue" entries that no
 // longer reflect reality. Keyed by "Method:Check".
@@ -904,17 +998,63 @@ var proxyCorrectnessAllowlist = map[string]string{
 		"The one caller (the rotation planner's risk-scoring batch, #409) already treats an ID missing from " +
 		"the result the same conservative way a single GetSecret error is treated for that ID — never a " +
 		"silent zero-risk score — so skipping here loses no safety margin. Reviewed, not a bug.",
+
+	// The 8 entries below are check 5's first real run (issue #1786 part 3) —
+	// found live, not hypothesized, and every one is the OPPOSITE shape from
+	// the RemoveRoleFromGroup defect the check was built to catch: there, a
+	// value the SERVER needed was silently blanked and never sent. Here, the
+	// blanked value is one the server must NOT trust from the client at all
+	// (a caller-supplied clock, or a caller-supplied identity the server
+	// already derives authoritatively from the request's own auth context) —
+	// blanking it is the correct, secure choice, kept only for interface
+	// parity with LocalStorage's signature. Each already had a doc comment
+	// saying so before this check existed.
+	"ConsumeMFAChallenge:blank-identifier-param": "the blanked time.Time is \"now\": remote_mfa.go's own doc " +
+		"comment says the upstream server ignores any caller-supplied current time and always uses its own " +
+		"clock (mfaChallengeLookupWire) — accepting a client clock here would let a compromised/skewed client " +
+		"manipulate expiry checks. Kept only for interface parity with LocalStorage. Reviewed, not a bug.",
+	"GetActiveMFAChallenge:blank-identifier-param": "same reasoning and doc comment as ConsumeMFAChallenge " +
+		"above (remote_mfa.go) — the blanked time.Time is a caller-supplied \"now\" the server must not trust. " +
+		"Reviewed, not a bug.",
+	"GetActiveMFAStepUpGrant:blank-identifier-param": "remote_mfa_stepup_grant.go's own doc comment: \"now is " +
+		"accepted only for interface parity with LocalStorage — the upstream server ignores any caller-" +
+		"supplied current time and always uses its own clock.\" Reviewed, not a bug.",
+	"ConsumeWebAuthnSession:blank-identifier-param": "remote_webauthn.go's own doc comment: same \"now ignored, " +
+		"server uses its own clock\" reasoning as the MFA challenge methods above (webAuthnSessionConsumeWire). " +
+		"Reviewed, not a bug.",
+	"ListNotifications:blank-identifier-param": "remote_notifications.go's own doc comment: GET /notifications " +
+		"is self-scoped by the caller's authenticated session — \"userID is implicit in the endpoint\" " +
+		"(fetchNotifications). A caller-supplied userID here would be a confused-deputy risk if the server " +
+		"trusted it instead; blanking it is correct. Kept only for interface parity with LocalStorage. " +
+		"Reviewed, not a bug.",
+	"CountUnreadNotifications:blank-identifier-param": "same self-scoped-by-session reasoning as " +
+		"ListNotifications above (remote_notifications.go, fetchNotifications). Reviewed, not a bug.",
+	"MarkNotificationRead:blank-identifier-param": "remote_notifications.go's own doc comment: \"the server " +
+		"scopes the mark to the authenticated user ... so userID is implicit in the endpoint.\" Same reasoning " +
+		"as ListNotifications above. Reviewed, not a bug.",
+	"MarkAllNotificationsRead:blank-identifier-param": "same self-scoped-by-session reasoning as " +
+		"MarkNotificationRead above (remote_notifications.go). Reviewed, not a bug.",
 }
 
-// TestRemoteProxyStaticAuditIsClean is the CI gate (issue #1786 part 2, step
-// 5): every Layer 1 finding across the 214-method real-proxy population must
-// be explained by proxyCorrectnessAllowlist above, or this fails and forces
-// the same real investigation this tranche did — trace the method, read its
-// doc comment and callers, decide whether it's a genuine gap — before it can
-// be merged. No new CI workflow wiring is needed for this: it runs as part
-// of the existing `go test ./...` leg for this package, the same way every
-// other completeness guard in this file already does.
-func TestRemoteProxyStaticAuditIsClean(t *testing.T) {
+// TestLayer1StaticFindingsAreAllowlisted is the CI gate (issue #1786 parts 2
+// and 3): every Layer 1 finding across the 214-method real-proxy population
+// must be explained by proxyCorrectnessAllowlist above, or this fails and
+// forces the same real investigation this tranche did — trace the method,
+// read its doc comment and callers, decide whether it's a genuine gap —
+// before it can be merged. No new CI workflow wiring is needed for this: it
+// runs as part of the existing `go test ./...` leg for this package, the
+// same way every other completeness guard in this file already does.
+//
+// Renamed from TestRemoteProxyStaticAuditIsClean (issue #1786 part 2): that
+// name's own word "Audit" and "IsClean" read as "the proxies were audited
+// and found correct." They were not — see this file's own KNOWN NON-COVERAGE
+// section above. What this test actually verifies is narrower and stated
+// directly in the new name: every finding the five checks above produce is
+// EXPLAINED (allowlisted, with a reason), nothing more. A green result here
+// says "no unexplained hit on five narrow syntactic properties" — it does
+// not say "these proxies are correct," and a name implying otherwise is
+// exactly the framing mistake issue #1786 was filed to fix.
+func TestLayer1StaticFindingsAreAllowlisted(t *testing.T) {
 	findings := runProxyCorrectnessAudit(t)
 
 	seen := map[string]bool{}

--- a/internal/storage/store/remote_proxy_correctness_checks_test.go
+++ b/internal/storage/store/remote_proxy_correctness_checks_test.go
@@ -1,6 +1,8 @@
 // remote_proxy_correctness_checks_test.go — red-then-green validation for
-// each of the 4 static checks in remote_proxy_correctness_audit_test.go
-// (issue #1786 part 2, step 3).
+// each of the 5 static checks in remote_proxy_correctness_audit_test.go
+// (checks 1-4: issue #1786 part 2, step 3; check 5: issue #1786 part 3,
+// added directly from a confirmed historical defect — see blankParams' own
+// doc comment).
 //
 // Every check below is exercised against a small in-memory source snippet —
 // never a real file — so validating the checker never risks leaving planted
@@ -243,5 +245,43 @@ func TestCheck4_SilentZeroReturn_SilentOnCorrect(t *testing.T) {
 	findings := checksFor(t, src)
 	if hasCheck(findings, "silent-zero-return") {
 		t.Fatalf("expected no silent-zero-return finding — both guards return a real error, got: %+v", findings)
+	}
+}
+
+// --- Check 5: blank-identifier parameters (issue #1786 part 3) ---
+
+func TestCheck5_BlankIdentifierParam_FiresOnViolation(t *testing.T) {
+	src := checkSnippetPreamble + `func (rs *RemoteStorage) BlankIdentifierParamRed(ctx context.Context, id uint, _ string) (string, error) {
+	resp, err := rs.client.Get(ctx, fmt.Sprintf("/api/v1/thing/%d", id))
+	if err != nil {
+		return "", fmt.Errorf("failed: %w", err)
+	}
+	if !resp.Success {
+		return "", fmt.Errorf("failed")
+	}
+	return "", nil
+}
+`
+	findings := checksFor(t, src)
+	if !hasCheck(findings, "blank-identifier-param") {
+		t.Fatalf("expected a blank-identifier-param finding — the third parameter is declared _, got: %+v", findings)
+	}
+}
+
+func TestCheck5_BlankIdentifierParam_SilentOnCorrect(t *testing.T) {
+	src := checkSnippetPreamble + `func (rs *RemoteStorage) BlankIdentifierParamGreen(ctx context.Context, id uint, filter string) (string, error) {
+	resp, err := rs.client.Get(ctx, fmt.Sprintf("/api/v1/thing/%d?filter=%s", id, filter))
+	if err != nil {
+		return "", fmt.Errorf("failed: %w", err)
+	}
+	if !resp.Success {
+		return "", fmt.Errorf("failed")
+	}
+	return "", nil
+}
+`
+	findings := checksFor(t, src)
+	if hasCheck(findings, "blank-identifier-param") {
+		t.Fatalf("expected no blank-identifier-param finding — every parameter is named, got: %+v", findings)
 	}
 }

--- a/internal/storage/store/remote_reachability_registry_test.go
+++ b/internal/storage/store/remote_reachability_registry_test.go
@@ -11,7 +11,7 @@
 // without re-review; this codebase has a concrete instance of exactly that
 // (RequireNodeCredentialOrPermission's node arm, ADR-085). This registry
 // closes the gap: every currently-registered RemoteStorage stub method has an
-// entry here, and TestEveryStructuralStubHasReachabilityVerdict below fails
+// entry here, and TestRemoteUnsupportedStubsHaveReachabilityVerdicts below fails
 // the build the moment a NEW stub-shaped method is added without one — same
 // discipline as remote_unsupported_completeness_test.go's own guard, and the
 // same "no third state, no silent additions" shape as scripts/ci-test-legs.sh's
@@ -34,7 +34,7 @@
 // population, remote_unsupported_completeness_test.go) never includes them in
 // the first place -- they are not stub-shaped by the structural definition
 // this whole registry exists to track. Adding a map entry for a genuinely
-// non-stub method breaks TestEveryStructuralStubHasReachabilityVerdict's own
+// non-stub method breaks TestRemoteUnsupportedStubsHaveReachabilityVerdicts's own
 // staleness check below (verified empirically: a probe entry for
 // CreateSoDPolicy fails with "no longer correspond[s] to a structural stub").
 // Every other correctly-implemented remote_*.go proxy file (remote_invitations.go,
@@ -298,15 +298,45 @@ var remoteReachabilityRegistry = map[string]reachabilityEntry{
 	"WithTransaction":                           {reachabilityLive, "G80 158-method classification pass: Reached from the same `user update --active=false` path. No real cross-call atomicity (each sub-call is its own HTTP round trip) but verified safe for this one confirmed live use — internal/core/users.go's own doc comment already reasons through exactly this remote-mode scenario. Standing architectural limitation, not a fix target. #1589."},
 }
 
-// TestEveryStructuralStubHasReachabilityVerdict is Task 4's guard: every
+// TestRemoteUnsupportedStubsHaveReachabilityVerdicts is Task 4's guard: every
 // method actualRemoteUnsupportedStubs finds (the same structural-stub
 // population remoteUnsupportedAllowlist's own completeness guard uses) must
 // have an entry in remoteReachabilityRegistry, and every registry entry must
 // still correspond to a real structural stub — no third state, no silent
 // additions, same shape as that guard and as scripts/ci-test-legs.sh's C5
 // ratchet.
-func TestEveryStructuralStubHasReachabilityVerdict(t *testing.T) {
+//
+// Named (and renamed from TestEveryStructuralStubHasReachabilityVerdict,
+// issue #1786) to put the population in the SUBJECT position rather than
+// behind "Every": "RemoteUnsupportedStubs" is this file's population, full
+// stop — a name built as "Every X Has Y" reads, to anyone skimming past it
+// without the header, as a claim about coverage of X in general, with the
+// qualifier easy to skate past. The population is genuinely narrow — see the
+// denominator this test logs below — and real (non-stub) RemoteStorage
+// proxies, the ones actually doing work, get NO reachability verdict from
+// this file at all; that is correct scope, not a gap, but a name shaped like
+// "every method" invites exactly the wrong inference. Mirrors
+// TestRemoteUnsupportedStubsAreAllowlisted's own naming shape
+// (remote_unsupported_completeness_test.go) for the identical reason: same
+// population, same "subject first" convention.
+func TestRemoteUnsupportedStubsHaveReachabilityVerdicts(t *testing.T) {
+	total := remoteStorageMethods(t)
 	actual := actualRemoteUnsupportedStubs(t)
+	proxies := realProxyMethods(t)
+
+	// Denominator computed at runtime, not hand-copied into this comment —
+	// reused from remote_proxy_correctness_audit_test.go's own population
+	// derivation (remoteStorageMethods/realProxyMethods) rather than
+	// re-derived here: two independent counts of the same population would
+	// drift, exactly the failure mode issue #1786 itself was filed over (its
+	// own "158 stubs, ~209 real proxies, 418 total" were already wrong when
+	// filed — see TestReportRemoteStorageProxyPopulation for the corrected,
+	// live figures).
+	t.Logf("=== denominator: this guard covers ONLY structurally-stub RemoteStorage methods ===")
+	t.Logf("total RemoteStorage methods: %d", len(total))
+	t.Logf("  structurally-stub (this guard's population — every one gets a reachability verdict below): %d", len(actual))
+	t.Logf("  real proxies (NOT this guard's population — NO reachability verdict exists here for these; "+
+		"see remote_proxy_correctness_audit_test.go for real-proxy correctness checks): %d", len(proxies))
 
 	var missing []string
 	for name := range actual {


### PR DESCRIPTION
## Summary

Closes the naming half of #1786. Opens #1808 for the correctness half, which is not resolved by this PR.

Two guards in `internal/storage/store` had names that promised more coverage than they deliver — one is #1786's stated ask, the other was created by #1800 while working on it. Same defect, one PR.

**Part 1 — the reachability guard.** `TestEveryStructuralStubHasReachabilityVerdict` → renamed `TestRemoteUnsupportedStubsHaveReachabilityVerdicts`, putting the population ("RemoteUnsupportedStubs") in subject position instead of behind "Every", mirroring `TestRemoteUnsupportedStubsAreAllowlisted`'s own naming shape. Now logs its denominator at runtime — total RemoteStorage methods, stubs covered, real proxies NOT covered — reusing `remoteStorageMethods`/`realProxyMethods` from `remote_proxy_correctness_audit_test.go` rather than re-deriving the population (two independent counts would drift, exactly #1786's own failure mode). The registry's scope itself is unchanged and correct. Both failure paths (a stub with no verdict, a non-stub entry) were manually red-then-green verified by temporarily mutating the registry map and observing the test fail, then restoring — not assumed.

**Part 2 — the #1800 static audit gate.** `TestRemoteProxyStaticAuditIsClean` → renamed `TestLayer1StaticFindingsAreAllowlisted`. A historical-positive validation (run after #1800 merged) found 9 real historical proxy defects in this repo's own git history; the checks caught 0 — 1 confirmed by direct execution, 8 established by inspection but not replayable (the checks depend on scanner helpers introduced later than those commits). "IsClean"/"Audit" implied a verdict the checks cannot support. The file's own doc comment now lists all 7 empirically-confirmed defect classes the checks cannot see, including that check 3 does not merely *miss* context-lifetime bugs (`LogAuditEvent` forwarding a cancellable context into an audit write) — it **certifies** them, since its correctness condition is precisely that ctx *is* forwarded verbatim.

**Part 3 — one evidence-backed check.** Added check 5 (blank-identifier parameter), derived directly from the one class in that list that IS structural: `RemoveRoleFromGroup`'s `_ storage.Scope` (#1394). Check 1 (dropped input) is identifier-based and cannot see a parameter with no identifier — by construction, not by oversight. Red-then-green validated individually, plus a mutation-kill spot check, matching #1800's existing check tests. First real run against the repo found 8 genuine blank-identifier parameters, all reviewed and allowlisted: every one is the *opposite* shape from the `RemoveRoleFromGroup` bug — a value the server must **not** trust from the client (a caller-supplied clock the server's own doc comments say it ignores, or a caller-supplied identity the server already derives from the authenticated session) — each already documented as such before this check existed.

Nothing else added. Six of the seven defect classes are behavioral, not structural, and belong to a differential conformance harness — opened as **#1808**, using the seven-class list as its test plan. A static check that appears to cover a behavioral class is worse than no check.

**Population correction, for the record:** #1786 cited "158 stubs, ~209 real proxies, 418 total". #1800 derived the actual figures: 427 total → 209 stubs, 4 helpers, 214 real proxies (now 428/210/214 after later, unrelated commits). The issue's "209" was the stub count, recorded in the real-proxy column.

## Test plan

- [x] `go vet ./internal/storage/store/...` clean
- [x] All check-validation tests pass, including 2 new ones for check 5 (`TestCheck5_BlankIdentifierParam_{FiresOnViolation,SilentOnCorrect}`)
- [x] Mutation-kill spot check on check 5: disabled its firing logic, confirmed the RED test failed, restored it
- [x] Red-then-green manually verified for both `TestRemoteUnsupportedStubsHaveReachabilityVerdicts` failure paths (missing verdict, stale non-stub entry) by temporarily mutating the registry map
- [x] `TestLayer1StaticFindingsAreAllowlisted` green after triaging and allowlisting check 5's 8 real findings
- [x] Full `internal/storage/store` package test suite (`go test -timeout 900s ./...`) passes clean: `ok ... 867.599s`