### PR TITLE
feat(sbom): verify frontend SBOM hash matches all four server SBOM links (ADR-073 #5, closes #1792)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,13 @@ _sbom-generate:
 	node scripts/link-sbom.mjs dist/$(BINARY_SERVER)_linux_arm64_sbom.cdx.json  dist/$(BINARY_SERVER)_frontend_sbom.cdx.json
 	node scripts/link-sbom.mjs dist/$(BINARY_SERVER)_darwin_amd64_sbom.cdx.json dist/$(BINARY_SERVER)_frontend_sbom.cdx.json
 	node scripts/link-sbom.mjs dist/$(BINARY_SERVER)_darwin_arm64_sbom.cdx.json dist/$(BINARY_SERVER)_frontend_sbom.cdx.json
+	@echo "→ Verifying frontend SBOM hash matches all four server SBOM links (ADR-073 decision #5)"
+	node scripts/verify-sbom-links.mjs \
+		dist/$(BINARY_SERVER)_frontend_sbom.cdx.json \
+		dist/$(BINARY_SERVER)_linux_amd64_sbom.cdx.json \
+		dist/$(BINARY_SERVER)_linux_arm64_sbom.cdx.json \
+		dist/$(BINARY_SERVER)_darwin_amd64_sbom.cdx.json \
+		dist/$(BINARY_SERVER)_darwin_arm64_sbom.cdx.json
 
 clean:
 	rm -rf $(BUILD_DIR) dist/

--- a/docs/adr-073-release-sbom-frontend-coverage.md
+++ b/docs/adr-073-release-sbom-frontend-coverage.md
@@ -431,12 +431,16 @@ frontend SBOM, keeping the two targets in the parity they already have.**
    verification must recompute the frontend SBOM's SHA-256 and assert it
    matches the hash embedded in all four server SBOMs — not merely that the
    `hashes` field is populated, which would pass a build-order bug silently.
-   **Status (corrected 2026-09-07): not implemented.** Build order is
-   correct by construction today (the Makefile generates the frontend SBOM
-   first), but no automated recompute-and-assert step exists — a future
-   build-order regression would go undetected. Filed as issue #1792. This
-   decision asserts a control that does not exist yet; treat this bullet as
-   a requirement, not a description of current behavior, until #1792 closes.
+   **Status (implemented 2026-09-08, closes #1792):**
+   `scripts/verify-sbom-links.mjs` recomputes the frontend SBOM's SHA-256
+   from the bytes on disk and asserts it matches the hash embedded in each
+   of the four server SBOMs, wired as the last step of `_sbom-generate`
+   (shared by `make sbom` and `make release`). Verified against a full,
+   real `make sbom` run, not synthetic fixtures: passes clean; fails and
+   names the file when the frontend SBOM is modified after linking
+   (embedded-vs-actual hash mismatch); fails and names the file when a
+   server SBOM's `bom`-type reference is stripped entirely (a distinct code
+   path from the mismatch case).
 6. The CLI SBOMs are unchanged in content, deliberately, because they're
    already accurate — only their count changes (1 → 4, matching the 4 CLI
    binaries), not what they describe.

--- a/scripts/verify-sbom-links.mjs
+++ b/scripts/verify-sbom-links.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Verifies the ADR-073 build-order constraint (decision #5, issue #1792):
+ * recomputes the shipped frontend SBOM's SHA-256 from the bytes on disk and
+ * asserts it matches the hash embedded in each of the four server Go SBOMs'
+ * `bom`-type externalReferences entry.
+ *
+ * This is deliberately NOT "does the hashes field exist" — that would pass a
+ * build-order regression silently (a stale/absent-file hash still populates
+ * the field, it's just wrong). Recompute-and-compare is the only check that
+ * actually proves the link is trustworthy. See ADR-073 decision #5 and
+ * scripts/link-sbom.mjs's own header for why the hash exists at all.
+ *
+ * Usage: node scripts/verify-sbom-links.mjs <frontend-sbom-file> <server-sbom-file>...
+ * Exits non-zero on any failure. Prints one distinct, file-named message per
+ * failure and keeps checking the rest rather than stopping at the first.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync, existsSync } from 'node:fs';
+
+const [frontendSbomFile, ...serverSbomFiles] = process.argv.slice(2);
+
+if (!frontendSbomFile || serverSbomFiles.length === 0) {
+    console.error(
+        '[verify-sbom-links] usage: verify-sbom-links.mjs <frontend-sbom-file> <server-sbom-file>...',
+    );
+    process.exit(1);
+}
+
+const REQUIRED_LINKED_COUNT = 4;
+const errors = [];
+
+if (!existsSync(frontendSbomFile)) {
+    console.error(
+        `[verify-sbom-links] FAIL: ${frontendSbomFile} does not exist -- cannot verify links ` +
+            `against a frontend SBOM that was never generated`,
+    );
+    process.exit(1);
+}
+
+const frontendBytes = readFileSync(frontendSbomFile);
+const actualHash = createHash('sha256').update(frontendBytes).digest('hex');
+
+let linkedCount = 0;
+
+for (const serverSbomFile of serverSbomFiles) {
+    if (!existsSync(serverSbomFile)) {
+        errors.push(`${serverSbomFile}: file does not exist`);
+        continue;
+    }
+
+    let serverSbom;
+    try {
+        serverSbom = JSON.parse(readFileSync(serverSbomFile, 'utf8'));
+    } catch (err) {
+        errors.push(`${serverSbomFile}: could not parse JSON (${err.message})`);
+        continue;
+    }
+
+    const refs = serverSbom.metadata?.component?.externalReferences ?? [];
+    const bomRef = refs.find(r => r.type === 'bom');
+
+    if (!bomRef) {
+        errors.push(
+            `${serverSbomFile}: no 'bom'-type externalReferences entry -- this SBOM is not ` +
+                `linked to the frontend SBOM at all`,
+        );
+        continue;
+    }
+
+    const sha256Entry = (bomRef.hashes ?? []).find(h => h.alg === 'SHA-256');
+    if (!sha256Entry || !sha256Entry.content) {
+        errors.push(
+            `${serverSbomFile}: 'bom' externalReferences entry exists but carries no SHA-256 ` +
+                `hash (hashes: ${JSON.stringify(bomRef.hashes ?? [])})`,
+        );
+        continue;
+    }
+
+    if (sha256Entry.content !== actualHash) {
+        errors.push(
+            `${serverSbomFile}: embedded hash does not match the frontend SBOM's actual ` +
+                `SHA-256 -- embedded=${sha256Entry.content} actual=${actualHash} ` +
+                `(build-order regression: the frontend SBOM was generated/modified after ` +
+                `this link was written)`,
+        );
+        continue;
+    }
+
+    linkedCount++;
+}
+
+if (linkedCount < REQUIRED_LINKED_COUNT) {
+    errors.push(
+        `only ${linkedCount} of ${REQUIRED_LINKED_COUNT} required server SBOMs carry a ` +
+            `verified link to the frontend SBOM (checked: ${serverSbomFiles.join(', ')})`,
+    );
+}
+
+if (errors.length > 0) {
+    console.error(`[verify-sbom-links] FAIL (${errors.length} problem(s)):`);
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+}
+
+console.log(
+    `[verify-sbom-links] OK: ${linkedCount} server SBOMs correctly linked to ` +
+        `${frontendSbomFile} (sha256:${actualHash})`,
+);


### PR DESCRIPTION
## What

Implements ADR-073 decision #5 (issue #1792): `scripts/verify-sbom-links.mjs`
recomputes the shipped frontend SBOM's SHA-256 from the bytes on disk and
asserts it matches the hash embedded in each of the four server Go SBOMs'
`bom`-type `externalReferences` entry — not merely that the `hashes` field is
populated, which would pass a build-order regression silently. That
distinction is the entire point of decision #5's own wording.

Wired as the last step of `_sbom-generate`, which `make sbom` and
`make release` both call — that shared target exists precisely so the two
can't drift, and this check now covers both.

## Tool choice: Node script, not a Go test

`scripts/link-sbom.mjs` — the mechanism this verifies — is already a Node
script, reads/writes the exact same CycloneDX JSON shape this one reads,
and there's no reason to duplicate the hashing/JSON-walking logic in Go or
add a cross-language dependency for a check whose subject is entirely
JSON files on disk.

## Failure modes covered, each named individually

- Absent `bom`-type reference
- Reference present but `hashes` is empty / has no SHA-256 entry
- Hash present but doesn't match the recomputed value (the build-order
  regression this whole thing exists to catch)
- Fewer than four server SBOMs carry a verified link

Exits non-zero on any failure; keeps checking every file rather than
stopping at the first problem, so one run reports everything wrong at once.

## Red-then-green — observed against a full, real `make sbom` run

Not synthetic fixtures: real `cyclonedx-gomod` v1.10.0, real `cdxgen`
12.8.2, real `pnpm`, in a disposable clone. Reported separately per the
task's own requirement:

- **GREEN**: clean `make sbom` — 8 Go SBOMs + 1 frontend SBOM generated,
  all four linked, verifier passes (`exit 0`).
- **RED — hash mismatch**: appended one byte to the frontend SBOM after
  linking. Verifier failed, named all four mismatched files with
  embedded-vs-actual hashes, `exit 1`.
- **RED — absent reference** (a distinct code path from the mismatch case,
  required separately by the task): stripped the `bom`-type
  `externalReferences` entry from one server SBOM entirely. Verifier
  failed, named that file specifically, correctly still passed the other
  three unmodified files, `exit 1`.

## Toolchain note (unrelated to this change, worth recording)

`cyclonedx-gomod` fails with `failed to determine version of main module:
git: reference not found` when run from inside a linked git worktree
specifically — confirmed by running the identical command from a plain
checkout of the same commit, which succeeds. This is a `go-git` limitation
resolving refs across the `commondir`/`worktrees` split, not anything
related to ADR-073 or this PR. Testing here was done in a disposable
`git clone` instead of the worktree for that reason.

## Also

Corrects ADR-073 decision #5's own status note, which explicitly said to
treat it as "a requirement, not a description of current behavior, until
#1792 closes" — now that it's closed, the note is updated in place rather
than left stale.

## Scope

- SBOM generation, build order, and `link-sbom.mjs`'s hashing are
  untouched — they were already correct; this only adds the missing
  verification.
- No VEX, signing, or bundle work — separate concerns per the task.

Closes #1792.