### PR TITLE
fix(cli): replace exact-name env denylist with prefix families (CLI-RUN-001)

### DIFF
--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -343,28 +343,83 @@ func setEnvKey(result map[string]string, envKeySources map[string]string, name, 
 	return nil
 }
 
-// dangerousEnvVarNames names environment variables that affect dynamic-linker,
-// interpreter, or shell behavior for the CHILD PROCESS `keyorix run` launches — not
-// Keyorix's own credentials (see sensitiveEnvSuffixes below, a separate concern).
-// #G39: toEnvKey derives the child's env var keys directly from a project secret's
-// NAME (uppercased, non-alphanumeric → '_'), with no filtering at all — a secret
-// named "path" or "ld_preload" becomes an env key that collides with (and, since
-// buildChildEnv appends the injected secrets LAST, overrides) one of these,
-// letting a project-level secret WRITER hijack or control code execution in
-// whatever `keyorix run` launches, without ever needing direct system access
-// themselves. Matches the detection_idea's own required-coverage list exactly.
-var dangerousEnvVarNames = map[string]bool{
-	"LD_PRELOAD":      true,
-	"BASH_ENV":        true,
-	"NODE_OPTIONS":    true,
-	"PATH":            true,
-	"PERL5OPT":        true,
-	"RUBYOPT":         true,
-	"GIT_SSH_COMMAND": true,
+// dangerousEnvPrefixes and dangerousEnvExact together replace what used to be a
+// single exact-name map (dangerousEnvVarNames). That map was itself the #G39 fix
+// for toEnvKey deriving child env keys straight from an untrusted secret NAME with
+// no filtering at all — but an exact-name list in a code-execution path is the
+// same defect shape one layer down: it fails open on every name it doesn't happen
+// to enumerate. Verification against a real dylib-injection PoC (2026-09-09,
+// CLI-RUN-001 release-gate re-check) confirmed this: DYLD_INSERT_LIBRARIES —
+// macOS's LD_PRELOAD equivalent, named in the ORIGINAL finding's own exploit
+// scenario — was never in the list, and a secret literally named
+// "dyld_insert_libraries" reached the child process and ran an attacker
+// constructor. The fix is not "add DYLD_INSERT_LIBRARIES" (that just reproduces
+// the same gap for the next sibling — LD_LIBRARY_PATH, GCONV_PATH, ... — one CVE
+// at a time); it's covering the FAMILY each dangerous name belongs to.
+//
+// dangerousEnvPrefixes: any env key starting with one of these is dropped.
+//   - LD_      the ELF/Mach-O dynamic linker's whole tunable surface (LD_PRELOAD,
+//              LD_LIBRARY_PATH, LD_AUDIT, ...) — linker behavior, not app config.
+//   - DYLD_    macOS dyld's equivalent of LD_ (DYLD_INSERT_LIBRARIES,
+//              DYLD_LIBRARY_PATH, ...) — the exact family the live PoC used.
+//   - NODE_    Node.js process-wide behavior flags (NODE_OPTIONS, NODE_PATH, ...).
+//              Deliberate tradeoff: this also blocks the legitimate NODE_ENV: a
+//              project secret writer controlling arbitrary NODE_OPTIONS content
+//              outweighs a launched Node app not getting NODE_ENV from a secret
+//              (operators can still set NODE_ENV as an ordinary shell/CI env var —
+//              `keyorix run` inherits the parent environment unchanged; only
+//              secret-derived keys are filtered here).
+//   - PYTHON   CPython interpreter startup/path control (PYTHONPATH,
+//              PYTHONSTARTUP, PYTHONHOME, ...). No trailing '_': some real names
+//              (PYTHONDONTWRITEBYTECODE) don't have one after PYTHON.
+//   - PERL5    Perl 5's interpreter option/library-path family (PERL5OPT,
+//              PERL5LIB). No trailing '_', matching Perl's own naming.
+//   - BASH_    bash's own startup-file control (BASH_ENV and siblings).
+//   - GCONV_   glibc's character-conversion module loader (GCONV_PATH) — a
+//              second, less-known arbitrary-code-loading primitive alongside
+//              LD_PRELOAD.
+//   - MALLOC_  glibc/macOS malloc tunables (MALLOC_CHECK_, MALLOC_CONF, ...),
+//              usable for heap-exploitation primitives.
+var dangerousEnvPrefixes = []string{
+	"LD_", "DYLD_", "NODE_", "PYTHON", "PERL5", "BASH_", "GCONV_", "MALLOC_",
+}
+
+// dangerousEnvExact names variables that control shell/process behavior directly
+// but don't belong to any linker/interpreter prefix family above:
+//   - IFS    shell field-splitting; corrupting it can turn plain arguments into
+//            separate words/code.
+//   - ENV    sh's (non-bash) startup-file equivalent of BASH_ENV.
+//   - HOME   many tools (git, ssh, npm, ...) resolve config/credentials relative
+//            to HOME; redirecting it can hijack that resolution.
+//   - SHELL  some tools shell out via `$SHELL -c ...` rather than a fixed
+//            interpreter.
+//   - PATH   executable resolution order for the whole child process tree.
+//
+// RUBYOPT and GIT_SSH_COMMAND (in the old exact list) are still covered: neither
+// has siblings that would justify a prefix family of their own, so they stay
+// exact entries rather than being dropped.
+var dangerousEnvExact = map[string]bool{
+	"IFS": true, "ENV": true, "HOME": true, "SHELL": true, "PATH": true,
+	"RUBYOPT": true, "GIT_SSH_COMMAND": true,
+}
+
+// isDangerousEnvKey reports whether key is a reserved dynamic-linker/
+// interpreter/shell control variable — see dangerousEnvPrefixes and
+// dangerousEnvExact above for the two ways a key can match.
+func isDangerousEnvKey(key string) bool {
+	if dangerousEnvExact[key] {
+		return true
+	}
+	for _, prefix := range dangerousEnvPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // dropDangerousEnvKeys removes any entry keyed on a dynamic-linker/interpreter/
-// shell control variable name (dangerousEnvVarNames) — envVars is already keyed by
+// shell control variable name (isDangerousEnvKey) — envVars is already keyed by
 // the DERIVED env var key (toEnvKey(secret.Name)), not the raw secret name; see
 // fetchSecretsEmbedded/fetchSecretsRemote. Warns on stderr for each one dropped so
 // the operator can see why a secret they expected didn't reach the child process
@@ -373,7 +428,7 @@ var dangerousEnvVarNames = map[string]bool{
 func dropDangerousEnvKeys(envVars map[string]string) map[string]string {
 	out := make(map[string]string, len(envVars))
 	for key, value := range envVars {
-		if dangerousEnvVarNames[key] {
+		if isDangerousEnvKey(key) {
 			fmt.Fprintf(os.Stderr, "⚠️  a secret maps to the reserved environment variable %q — refusing to inject it (would override %s in the launched process)\n", key, key)
 			continue
 		}

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -359,27 +359,27 @@ func setEnvKey(result map[string]string, envKeySources map[string]string, name, 
 //
 // dangerousEnvPrefixes: any env key starting with one of these is dropped.
 //   - LD_      the ELF/Mach-O dynamic linker's whole tunable surface (LD_PRELOAD,
-//              LD_LIBRARY_PATH, LD_AUDIT, ...) — linker behavior, not app config.
+//     LD_LIBRARY_PATH, LD_AUDIT, ...) — linker behavior, not app config.
 //   - DYLD_    macOS dyld's equivalent of LD_ (DYLD_INSERT_LIBRARIES,
-//              DYLD_LIBRARY_PATH, ...) — the exact family the live PoC used.
+//     DYLD_LIBRARY_PATH, ...) — the exact family the live PoC used.
 //   - NODE_    Node.js process-wide behavior flags (NODE_OPTIONS, NODE_PATH, ...).
-//              Deliberate tradeoff: this also blocks the legitimate NODE_ENV: a
-//              project secret writer controlling arbitrary NODE_OPTIONS content
-//              outweighs a launched Node app not getting NODE_ENV from a secret
-//              (operators can still set NODE_ENV as an ordinary shell/CI env var —
-//              `keyorix run` inherits the parent environment unchanged; only
-//              secret-derived keys are filtered here).
+//     Deliberate tradeoff: this also blocks the legitimate NODE_ENV: a
+//     project secret writer controlling arbitrary NODE_OPTIONS content
+//     outweighs a launched Node app not getting NODE_ENV from a secret
+//     (operators can still set NODE_ENV as an ordinary shell/CI env var —
+//     `keyorix run` inherits the parent environment unchanged; only
+//     secret-derived keys are filtered here).
 //   - PYTHON   CPython interpreter startup/path control (PYTHONPATH,
-//              PYTHONSTARTUP, PYTHONHOME, ...). No trailing '_': some real names
-//              (PYTHONDONTWRITEBYTECODE) don't have one after PYTHON.
+//     PYTHONSTARTUP, PYTHONHOME, ...). No trailing '_': some real names
+//     (PYTHONDONTWRITEBYTECODE) don't have one after PYTHON.
 //   - PERL5    Perl 5's interpreter option/library-path family (PERL5OPT,
-//              PERL5LIB). No trailing '_', matching Perl's own naming.
+//     PERL5LIB). No trailing '_', matching Perl's own naming.
 //   - BASH_    bash's own startup-file control (BASH_ENV and siblings).
 //   - GCONV_   glibc's character-conversion module loader (GCONV_PATH) — a
-//              second, less-known arbitrary-code-loading primitive alongside
-//              LD_PRELOAD.
+//     second, less-known arbitrary-code-loading primitive alongside
+//     LD_PRELOAD.
 //   - MALLOC_  glibc/macOS malloc tunables (MALLOC_CHECK_, MALLOC_CONF, ...),
-//              usable for heap-exploitation primitives.
+//     usable for heap-exploitation primitives.
 var dangerousEnvPrefixes = []string{
 	"LD_", "DYLD_", "NODE_", "PYTHON", "PERL5", "BASH_", "GCONV_", "MALLOC_",
 }
@@ -387,12 +387,12 @@ var dangerousEnvPrefixes = []string{
 // dangerousEnvExact names variables that control shell/process behavior directly
 // but don't belong to any linker/interpreter prefix family above:
 //   - IFS    shell field-splitting; corrupting it can turn plain arguments into
-//            separate words/code.
+//     separate words/code.
 //   - ENV    sh's (non-bash) startup-file equivalent of BASH_ENV.
 //   - HOME   many tools (git, ssh, npm, ...) resolve config/credentials relative
-//            to HOME; redirecting it can hijack that resolution.
+//     to HOME; redirecting it can hijack that resolution.
 //   - SHELL  some tools shell out via `$SHELL -c ...` rather than a fixed
-//            interpreter.
+//     interpreter.
 //   - PATH   executable resolution order for the whole child process tree.
 //
 // RUBYOPT and GIT_SSH_COMMAND (in the old exact list) are still covered: neither

--- a/internal/cli/run/run_dangerous_env_test.go
+++ b/internal/cli/run/run_dangerous_env_test.go
@@ -33,6 +33,53 @@ func TestDropDangerousEnvKeys_DropsEveryReservedName(t *testing.T) {
 	}
 }
 
+// TestDropDangerousEnvKeys_CoversFamiliesNotJustPriorInstances is the CLI-RUN-001
+// release-gate re-verification (2026-09-09) regression test: the original
+// dangerousEnvVarNames exact list missed DYLD_INSERT_LIBRARIES (named in the
+// finding's own exploit scenario, confirmed live via a real dylib-injection PoC)
+// and every other sibling of an already-covered mechanism family. This asserts
+// the FAMILY is covered, not just the one instance that happened to get reported.
+func TestDropDangerousEnvKeys_CoversFamiliesNotJustPriorInstances(t *testing.T) {
+	reserved := []string{
+		// Already covered by the pre-2026-09-09 exact list:
+		"LD_PRELOAD", "BASH_ENV", "NODE_OPTIONS", "PATH", "PERL5OPT", "RUBYOPT", "GIT_SSH_COMMAND",
+		// Missing siblings the prefix-family fix must now catch:
+		"DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "LD_LIBRARY_PATH", "LD_AUDIT",
+		"NODE_PATH", "PYTHONPATH", "PYTHONSTARTUP", "PYTHONHOME", "PERL5LIB",
+		"GCONV_PATH", "MALLOC_CONF", "IFS", "ENV", "HOME", "SHELL",
+	}
+	envVars := map[string]string{"DATABASE_URL": "postgres://x"}
+	for _, name := range reserved {
+		envVars[name] = "attacker-controlled-value"
+	}
+
+	got := dropDangerousEnvKeys(envVars)
+
+	if _, ok := got["DATABASE_URL"]; !ok {
+		t.Error("an unrelated, legitimate secret must survive the filter")
+	}
+	for _, name := range reserved {
+		if _, ok := got[name]; ok {
+			t.Errorf("reserved name %q must be dropped, not passed through to the child process", name)
+		}
+	}
+	if len(got) != 1 {
+		t.Errorf("expected exactly 1 surviving entry, got %d: %v", len(got), got)
+	}
+}
+
+// TestIsDangerousEnvKey_LegitimateNamesSurvive confirms the fix is a filter, not
+// a denylist so broad it blocks everything — a handful of ordinary, unrelated
+// secret-derived env keys must still pass through untouched.
+func TestIsDangerousEnvKey_LegitimateNamesSurvive(t *testing.T) {
+	legit := []string{"DATABASE_URL", "STRIPE_API_KEY", "REDIS_URL", "APP_PORT", "LOG_LEVEL"}
+	for _, name := range legit {
+		if isDangerousEnvKey(name) {
+			t.Errorf("isDangerousEnvKey(%q) = true, want false — a legitimate secret name must not be blocked", name)
+		}
+	}
+}
+
 func TestDropDangerousEnvKeys_EmptyMapNoop(t *testing.T) {
 	got := dropDangerousEnvKeys(map[string]string{})
 	if len(got) != 0 {
@@ -55,8 +102,8 @@ func TestToEnvKey_SecretNameCollidesWithReservedVar(t *testing.T) {
 		if got := toEnvKey(secretName); got != wantKey {
 			t.Errorf("toEnvKey(%q) = %q, want %q", secretName, got, wantKey)
 		}
-		if !dangerousEnvVarNames[wantKey] {
-			t.Errorf("dangerousEnvVarNames must cover %q (derived from secret name %q)", wantKey, secretName)
+		if !isDangerousEnvKey(wantKey) {
+			t.Errorf("isDangerousEnvKey must cover %q (derived from secret name %q)", wantKey, secretName)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

CLI-RUN-001 (HIGH) was re-verified against current `main` on 2026-09-09 as part of a nine-finding v0.92.0 release-gate check, and confirmed **LIVE** with a real dylib-injection PoC: a project secret named e.g. `dyld_insert_libraries` reaches `keyorix run`'s child process unfiltered and executes an attacker-controlled constructor.

The prior fix (#1434/#1462, `dangerousEnvVarNames`) was an **exact-name denylist** covering 7 names (`LD_PRELOAD`, `BASH_ENV`, `NODE_OPTIONS`, `PATH`, `PERL5OPT`, `RUBYOPT`, `GIT_SSH_COMMAND`) — those 7 are correctly blocked. But `DYLD_INSERT_LIBRARIES` (macOS's `LD_PRELOAD` equivalent, named in the *original* finding's own exploit scenario) was never added, along with ten other siblings from the same mechanism families (`LD_LIBRARY_PATH`, `LD_AUDIT`, `NODE_PATH`, `PYTHONPATH`, `PYTHONSTARTUP`, `PYTHONHOME`, `PERL5LIB`, `GCONV_PATH`, `MALLOC_CONF`, `IFS`, `ENV`, `HOME`, `SHELL`).

This is fixed by shape, not by list extension: `dangerousEnvPrefixes` (`LD_`, `DYLD_`, `NODE_`, `PYTHON`, `PERL5`, `BASH_`, `GCONV_`, `MALLOC_`) covers whole families, plus a short `dangerousEnvExact` set (`IFS`, `ENV`, `HOME`, `SHELL`, `PATH`, `RUBYOPT`, `GIT_SSH_COMMAND`) for names with no natural family. An exact list in a code-execution path fails open on every entry it doesn't happen to enumerate — extending it to 18 names just reproduces the same gap for name #19.

## Shipped-version exposure

**`v0.91.0` (the current latest release) has *zero* env-var filtering** — it predates the original `dangerousEnvVarNames` fix entirely. Confirmed: `git merge-base --is-ancestor v0.91.0 e9f74976` (the commit that introduced the first denylist) exits 0, and `git show v0.91.0:internal/cli/run/run.go` contains no `dangerous`/`DYLD`/`LD_PRELOAD` references at all. Operators on the latest shipped release are exposed today. Per `SECURITY.md`'s remediation table, this is a candidate for a GHSA with a requested CVE published same-day as the fix — **flagging for the security-advisory decision, not publishing one as part of this PR.**

## Threat-model framing

No `SECURITY.md` sentence is falsified literally, but "RBAC is enforced at the API level" carries an implicit model where secret-*write* permission does not imply *code execution* in the process running `keyorix run` — which typically holds more privilege than the secret's own scope. This is privilege escalation across the RBAC boundary via `keyorix run`, not an isolated CLI bug.

## Testing

- Full `internal/cli/run` package suite passes, including a new permanent test (`TestDropDangerousEnvKeys_CoversFamiliesNotJustPriorInstances`) asserting both the 7 previously-covered names AND the 14 previously-missing siblings are now dropped.
- `TestIsDangerousEnvKey_LegitimateNamesSurvive` confirms ordinary secret names (`DATABASE_URL`, `STRIPE_API_KEY`, etc.) still pass through — the fix is a filter, not a blanket block.
- **Red-then-green with the real PoC** (manual, not committed — macOS-only, CI is ubuntu-latest exclusively): reused the exact dylib-injection reproduction from the verification pass (compiles a real attacker `.dylib` with a load-time constructor, launches a victim binary with `DYLD_INSERT_LIBRARIES` set from a filtered secret map).
  - Against the pre-fix shape (temporarily reverted to the old exact-only check): attacker constructor **executed**, marker file created — reproduces LIVE.
  - Against this fix: `DYLD_INSERT_LIBRARIES` dropped before `execChild`, PoC never launched — confirms FIXED.
- Deliberate tradeoff documented in code: the `NODE_` prefix also blocks the legitimate `NODE_ENV` when secret-derived — accepted since `keyorix run` still inherits the parent environment unchanged, so operators can set `NODE_ENV` as an ordinary env var; only secret-derived keys are filtered.

## Not in this PR

- The coverage ledger / CI guard work (separate PR).
- Pinning tests for the other 8 verified findings (separate PR).
- Two follow-up items filed separately: `keyorix run` env-name provenance (an explicit `--env NAME=secret-ref` mapping would collapse this attack surface rather than filter it), and `REMEDIATION-STATUS.md` credibility (8 of 9 re-verified findings were uncited there).