### PR TITLE
feat(cli): keyorix run env-var name provenance via --var, deprecate auto-derivation (#1816)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to Keyorix are documented here. This project follows
 ## Unreleased
 
 ### Changed
+- **BREAKING: `keyorix run` no longer injects secrets by default (#1816)** —
+  every invocation must now pass `--var NAME=secret-ref` (recommended,
+  repeatable — you choose the env var name for each secret) or the deprecated
+  `--derive-names` (restores the old behavior: every secret in the project +
+  environment is injected, with the env var name auto-derived from the
+  secret's own name). Previously, whoever could **name** a project secret
+  also controlled which env var it became in the launched process — including
+  reserved ones like `LD_PRELOAD` or `DYLD_INSERT_LIBRARIES` — not just its
+  value; see #1813 for the live PoC this was found with. If you have scripts,
+  CI jobs, or Dockerfiles that call `keyorix run` with no `--var`/`--derive-names`
+  flag, they will now fail fast with a clear error naming both options —
+  update them to `--var` (preferred) or add `--derive-names` to keep the old
+  behavior for now. Collision precedence also changed for the deprecated
+  `--derive-names` path only: a derived secret name no longer overrides a
+  value already present in the inherited environment (the inherited value
+  wins instead) — a second, independent guard alongside the existing
+  reserved-name filter (#1813). `--var`'s explicit names still override the
+  inherited environment on collision, since that's the operator's expressed
+  intent. See `keyorix run --help` and
+  https://github.com/keyorixhq/keyorix/issues/1816 for the full reasoning.
 - **BREAKING: `keyorix status` and `keyorix ping` now exit non-zero when the
   configured target is unhealthy or unreachable** — previously both commands
   always exited 0 regardless of what they found, reporting failure only via

--- a/README.md
+++ b/README.md
@@ -72,12 +72,16 @@ keyorix connect http://localhost:8080 --username admin --password yourpassword
 
 ```bash
 keyorix secret create --name db-password --value supersecret
-keyorix run --env production -- node app.js
-keyorix run --env production -- flask run
-keyorix run --env production -- ./myapp
+keyorix run --env production --var DATABASE_URL=db-password -- node app.js
+keyorix run --env production --var DATABASE_URL=db-password -- flask run
+keyorix run --env production --var DATABASE_URL=db-password -- ./myapp
 ```
 
-Secrets are injected as environment variables. `db-password` becomes `DB_PASSWORD`.
+Secrets are injected as environment variables under the name YOU choose with
+`--var NAME=secret-ref` (repeatable). The old behavior — auto-deriving the env
+var name from the secret's own name (`db-password` becoming `DB_PASSWORD`) — is
+still available via the deprecated `--derive-names` flag, but is no longer the
+default: it let whoever names a secret also choose the env var it becomes.
 
 ---
 

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -15,10 +15,12 @@ import (
 )
 
 var (
-	runEnv      string
-	runProject  string
-	runToken    string
-	runCleanEnv bool
+	runEnv         string
+	runProject     string
+	runToken       string
+	runCleanEnv    bool
+	runVarMappings []string
+	runDeriveNames bool
 )
 
 // RunCmd is the top-level 'run' command.
@@ -28,23 +30,32 @@ var RunCmd = &cobra.Command{
 	Long: `Fetch secrets for a project + environment, expose them as environment
 variables, then execute the supplied command.
 
-  keyorix run --env production -- node app.js
-  keyorix run --env development -- flask run
-  keyorix run --env staging -- npm start
+'keyorix run' does not inject anything by default — pick exactly one:
+
+  --var NAME=secret-ref   (recommended) YOU choose the env var name.
+    keyorix run --env production --var DATABASE_URL=db-password -- node app.js
+    keyorix run --env production --var API_KEY=stripe-key --var DB=db-password -- ./myapp
+    Repeatable. Only the named secrets are injected, under the names you gave
+    them — a secret's own NAME never determines what env var it lands under.
+
+  --derive-names   (deprecated) restore the old behavior: every secret in the
+    project + environment is injected, with the env var key AUTO-DERIVED from
+    the secret's own name (uppercase, non-alphanumeric → '_' — e.g. db-password
+    becomes DB_PASSWORD). Deprecated because whoever can NAME a secret then
+    controls which env var it becomes — including reserved ones like
+    LD_PRELOAD or DYLD_INSERT_LIBRARIES — not just its value. Kept for
+    backward compatibility; --var has no such gap because YOU supply the name.
+    See https://github.com/keyorixhq/keyorix/issues/1816 for why this changed.
 
 Project is resolved via: --project flag → KEYORIX_PROJECT env → active project
 (set with 'keyorix project use') → "default" fallback.
 
-Each secret name is uppercased and non-alphanumeric characters are
-replaced with underscores before becoming an env var key:
-
-  db-password  →  DB_PASSWORD
-  api.endpoint →  API_ENDPOINT
-
-If two different secret names collide onto the same env var key after this
-conversion (e.g. "my-secret" and "my_secret" both becoming MY_SECRET), the
-command aborts with an error instead of silently letting one overwrite the
-other — rename one of the secrets to resolve the collision.
+Under --derive-names, if two different secret names collide onto the same env
+var key after derivation (e.g. "my-secret" and "my_secret" both becoming
+MY_SECRET), the command aborts with an error instead of silently letting one
+overwrite the other — rename one of the secrets to resolve the collision.
+Under --var, assigning the same NAME to two different secret-refs is the same
+kind of error; assigning it twice to the SAME secret-ref is fine.
 
 Authentication:
   • Session tokens written by 'keyorix auth login' are used automatically
@@ -66,7 +77,17 @@ Environment isolation:
     user's process environment (e.g. another local process, or an operator
     with shell access to the host) can read the injected values — the same
     limitation every environment-variable-based secret injector shares, not
-    something Keyorix can close.`,
+    something Keyorix can close.
+
+Collision with the inherited environment:
+  • --var: your explicit choice always wins. You named it, so overriding an
+    inherited value IS the intent.
+  • --derive-names: the INHERITED value wins instead — an auto-derived secret
+    name never overrides something already set in the environment (a second,
+    independent guard alongside the reserved-name filter: the filter stops a
+    brand-new dangerous name like DYLD_INSERT_LIBRARIES from being introduced;
+    this stops an already-set name from being silently overridden). If you
+    need a derived secret to take precedence, use --var instead.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runRun,
 }
@@ -76,9 +97,22 @@ func init() {
 	RunCmd.Flags().StringVar(&runProject, "project", "", "Project name (overrides KEYORIX_PROJECT and active project)")
 	RunCmd.Flags().StringVar(&runToken, "token", "", "Service or session token (overrides KEYORIX_TOKEN env var)")
 	RunCmd.Flags().BoolVar(&runCleanEnv, "clean-env", false, "Start the child process with ONLY the injected secrets (plus a minimal PATH/HOME baseline) instead of the full inherited parent environment")
+	RunCmd.Flags().StringArrayVar(&runVarMappings, "var", nil, "Inject one secret under an explicit env var name: --var NAME=secret-ref (repeatable, recommended)")
+	RunCmd.Flags().BoolVar(&runDeriveNames, "derive-names", false, "Deprecated: inject every secret in the project+environment, deriving the env var name from the secret's own name")
 }
 
 func runRun(cmd *cobra.Command, args []string) error {
+	// #1816: provenance fix. There is no implicit default anymore -- pick one
+	// explicitly, loudly, rather than either silently doing nothing or silently
+	// keeping the old (attacker-nameable) behavior. See the Long help text above
+	// for the full reasoning.
+	if len(runVarMappings) == 0 && !runDeriveNames {
+		return errors.New(`'keyorix run' no longer injects secrets by default. Choose explicitly:
+  --var NAME=secret-ref   (recommended) inject one secret, YOU name the env var
+  --derive-names          (deprecated) restore the old auto-derived behavior
+See https://github.com/keyorixhq/keyorix/issues/1816 for why.`)
+	}
+
 	// context.Background() with NO deadline attached: matches the other 100+
 	// common.RemoteClient call sites across this CLI (secret/rbac/machine/rotation/
 	// project/dynamic, etc — see NewRemoteClient's own comment). The hang protection
@@ -100,8 +134,8 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 
 	var (
-		envVars  map[string]string
-		fetchErr error
+		secretsByName map[string]string
+		fetchErr      error
 	)
 
 	// --token flag overrides the token resolved by ResolveRemote. Passing it literally is
@@ -114,17 +148,20 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if remoteOK {
-		envVars, fetchErr = fetchSecretsRemote(ctx, endpoint, tok, projectName, runEnv)
+		secretsByName, fetchErr = fetchSecretsRemote(ctx, endpoint, tok, projectName, runEnv)
 	} else {
-		envVars, fetchErr = fetchSecretsEmbedded(ctx, projectName, runEnv)
+		secretsByName, fetchErr = fetchSecretsEmbedded(ctx, projectName, runEnv)
 	}
 	if fetchErr != nil {
 		return fetchErr
 	}
 
-	envVars = dropDangerousEnvKeys(envVars)
+	derived, varMapped, err := resolveChildEnvVars(secretsByName, runVarMappings, runDeriveNames, projectName, runEnv)
+	if err != nil {
+		return err
+	}
 
-	return execChild(args, envVars, runCleanEnv)
+	return execChild(args, derived, varMapped, runCleanEnv)
 }
 
 // ── Embedded mode ─────────────────────────────────────────────────────────────
@@ -168,12 +205,14 @@ func fetchSecretsEmbedded(ctx context.Context, project, env string) (map[string]
 		return nil, fmt.Errorf("environment %q not found", env)
 	}
 
-	// Inject EVERY secret in the project + environment — page through all of them
-	// so a project with more than one page doesn't start the subprocess with
-	// silently missing environment variables.
+	// List EVERY secret in the project + environment, keyed by its own raw NAME —
+	// page through all of them so a project with more than one page doesn't leave
+	// silently-missing secrets for --var to reference or --derive-names to inject.
+	// Env-var-key derivation (toEnvKey/setEnvKey) happens later, in
+	// resolveChildEnvVars, only for the --derive-names path; --var looks secrets
+	// up by this same raw name directly, with no derivation involved.
 	const pageSize = 500
 	result := make(map[string]string)
-	envKeySources := make(map[string]string)
 	for page := 1; ; page++ {
 		secrets, _, err := svc.ListSecrets(ctx, &coreStorage.SecretFilter{
 			ProjectID:     &projectID,
@@ -190,9 +229,7 @@ func fetchSecretsEmbedded(ctx context.Context, project, env string) (map[string]
 				fmt.Fprintf(os.Stderr, "warning: skipping secret %q (id=%d): %v\n", s.Name, s.ID, err)
 				continue
 			}
-			if err := setEnvKey(result, envKeySources, s.Name, string(val)); err != nil {
-				return nil, err
-			}
+			result[s.Name] = string(val)
 		}
 		if len(secrets) < pageSize {
 			break
@@ -269,7 +306,6 @@ func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env strin
 	// process, silently truncating or failing the launch instead of a clear error.
 	const maxRunInjectedSecrets = 2000
 	result := make(map[string]string)
-	envKeySources := make(map[string]string)
 	for page := 1; ; page++ {
 		listPath := fmt.Sprintf(
 			"/api/v1/secrets?project_id=%d&environment_id=%d&page_size=%d&page=%d",
@@ -296,9 +332,7 @@ func fetchSecretsRemote(ctx context.Context, endpoint, token, project, env strin
 				fmt.Fprintf(os.Stderr, "warning: skipping secret %q (id=%d): %v\n", s.Name, s.ID, err)
 				continue
 			}
-			if err := setEnvKey(result, envKeySources, s.Name, secretBody.Value); err != nil {
-				return nil, err
-			}
+			result[s.Name] = secretBody.Value
 		}
 		if len(secretsBody.Secrets) < pageSize {
 			break
@@ -359,27 +393,27 @@ func setEnvKey(result map[string]string, envKeySources map[string]string, name, 
 //
 // dangerousEnvPrefixes: any env key starting with one of these is dropped.
 //   - LD_      the ELF/Mach-O dynamic linker's whole tunable surface (LD_PRELOAD,
-//              LD_LIBRARY_PATH, LD_AUDIT, ...) — linker behavior, not app config.
+//     LD_LIBRARY_PATH, LD_AUDIT, ...) — linker behavior, not app config.
 //   - DYLD_    macOS dyld's equivalent of LD_ (DYLD_INSERT_LIBRARIES,
-//              DYLD_LIBRARY_PATH, ...) — the exact family the live PoC used.
+//     DYLD_LIBRARY_PATH, ...) — the exact family the live PoC used.
 //   - NODE_    Node.js process-wide behavior flags (NODE_OPTIONS, NODE_PATH, ...).
-//              Deliberate tradeoff: this also blocks the legitimate NODE_ENV: a
-//              project secret writer controlling arbitrary NODE_OPTIONS content
-//              outweighs a launched Node app not getting NODE_ENV from a secret
-//              (operators can still set NODE_ENV as an ordinary shell/CI env var —
-//              `keyorix run` inherits the parent environment unchanged; only
-//              secret-derived keys are filtered here).
+//     Deliberate tradeoff: this also blocks the legitimate NODE_ENV: a
+//     project secret writer controlling arbitrary NODE_OPTIONS content
+//     outweighs a launched Node app not getting NODE_ENV from a secret
+//     (operators can still set NODE_ENV as an ordinary shell/CI env var —
+//     `keyorix run` inherits the parent environment unchanged; only
+//     secret-derived keys are filtered here).
 //   - PYTHON   CPython interpreter startup/path control (PYTHONPATH,
-//              PYTHONSTARTUP, PYTHONHOME, ...). No trailing '_': some real names
-//              (PYTHONDONTWRITEBYTECODE) don't have one after PYTHON.
+//     PYTHONSTARTUP, PYTHONHOME, ...). No trailing '_': some real names
+//     (PYTHONDONTWRITEBYTECODE) don't have one after PYTHON.
 //   - PERL5    Perl 5's interpreter option/library-path family (PERL5OPT,
-//              PERL5LIB). No trailing '_', matching Perl's own naming.
+//     PERL5LIB). No trailing '_', matching Perl's own naming.
 //   - BASH_    bash's own startup-file control (BASH_ENV and siblings).
 //   - GCONV_   glibc's character-conversion module loader (GCONV_PATH) — a
-//              second, less-known arbitrary-code-loading primitive alongside
-//              LD_PRELOAD.
+//     second, less-known arbitrary-code-loading primitive alongside
+//     LD_PRELOAD.
 //   - MALLOC_  glibc/macOS malloc tunables (MALLOC_CHECK_, MALLOC_CONF, ...),
-//              usable for heap-exploitation primitives.
+//     usable for heap-exploitation primitives.
 var dangerousEnvPrefixes = []string{
 	"LD_", "DYLD_", "NODE_", "PYTHON", "PERL5", "BASH_", "GCONV_", "MALLOC_",
 }
@@ -387,12 +421,12 @@ var dangerousEnvPrefixes = []string{
 // dangerousEnvExact names variables that control shell/process behavior directly
 // but don't belong to any linker/interpreter prefix family above:
 //   - IFS    shell field-splitting; corrupting it can turn plain arguments into
-//            separate words/code.
+//     separate words/code.
 //   - ENV    sh's (non-bash) startup-file equivalent of BASH_ENV.
 //   - HOME   many tools (git, ssh, npm, ...) resolve config/credentials relative
-//            to HOME; redirecting it can hijack that resolution.
+//     to HOME; redirecting it can hijack that resolution.
 //   - SHELL  some tools shell out via `$SHELL -c ...` rather than a fixed
-//            interpreter.
+//     interpreter.
 //   - PATH   executable resolution order for the whole child process tree.
 //
 // RUBYOPT and GIT_SSH_COMMAND (in the old exact list) are still covered: neither
@@ -435,6 +469,89 @@ func dropDangerousEnvKeys(envVars map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
+}
+
+// isValidEnvVarName reports whether name is a syntactically valid POSIX
+// environment variable name ([A-Za-z_][A-Za-z0-9_]*) — required for --var's
+// operator-supplied NAME, since unlike a derived key (always produced by
+// toEnvKey, which can only emit this shape) an operator can type anything.
+func isValidEnvVarName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		switch {
+		case r == '_':
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// resolveChildEnvVars implements #1816's two independent levers:
+//
+//   - Provenance: --var (varMappings) lets the OPERATOR choose each env var
+//     name explicitly, looking up each named secret directly in
+//     secretsByName. --derive-names (deriveNames) keeps the old behavior —
+//     inject every secret, deriving the env var name from the secret's own
+//     name via toEnvKey/setEnvKey — behind an explicit, deprecated opt-in.
+//   - Precedence: the two paths return SEPARATELY (derived, varMapped) rather
+//     than a single merged map, because they get different treatment against
+//     the INHERITED environment in buildChildEnv: derived entries no longer
+//     override an inherited value (a second, independent guard alongside the
+//     reserved-name filter below); varMapped entries still do, because an
+//     explicit operator-chosen name IS the intent to override.
+//
+// The reserved-name filter (dropDangerousEnvKeys) applies ONLY to the derived
+// path — an attacker only controls a name there. --var's NAME came from the
+// operator, not from a secret's name, so no filter applies; isDangerousEnvKey
+// is instead used to print a non-blocking heads-up, since typing --var
+// LD_PRELOAD=... is far more likely to be deliberate than accidental and the
+// operator's own intent should not be silently overridden by this command.
+func resolveChildEnvVars(secretsByName map[string]string, varMappings []string, deriveNames bool, project, env string) (derived, varMapped map[string]string, err error) {
+	if deriveNames {
+		fmt.Fprintln(os.Stderr, "⚠️  --derive-names is deprecated: the env var name comes from each secret's own NAME, so whoever can name a project secret chooses (and can collide with) the env var it becomes. Prefer --var NAME=secret-ref, where you choose the name. See https://github.com/keyorixhq/keyorix/issues/1816.")
+		d := make(map[string]string, len(secretsByName))
+		envKeySources := make(map[string]string, len(secretsByName))
+		for name, value := range secretsByName {
+			if err := setEnvKey(d, envKeySources, name, value); err != nil {
+				return nil, nil, err
+			}
+		}
+		derived = dropDangerousEnvKeys(d)
+	}
+
+	if len(varMappings) > 0 {
+		vm := make(map[string]string, len(varMappings))
+		varSources := make(map[string]string, len(varMappings)) // envName -> secretRef
+		for _, mapping := range varMappings {
+			envName, secretRef, ok := strings.Cut(mapping, "=")
+			if !ok || envName == "" || secretRef == "" {
+				return nil, nil, fmt.Errorf("invalid --var %q: expected NAME=secret-ref", mapping)
+			}
+			if !isValidEnvVarName(envName) {
+				return nil, nil, fmt.Errorf("invalid --var %q: %q is not a valid environment variable name", mapping, envName)
+			}
+			if existingRef, ok := varSources[envName]; ok && existingRef != secretRef {
+				return nil, nil, fmt.Errorf("--var %s is assigned to two different secrets (%q and %q) — 'keyorix run' refuses to continue since one mapping would silently be dropped; use --var only once per name", envName, existingRef, secretRef)
+			}
+			value, ok := secretsByName[secretRef]
+			if !ok {
+				return nil, nil, fmt.Errorf("--var %s=%s: secret %q not found in project %q / environment %q", envName, secretRef, secretRef, project, env)
+			}
+			if isDangerousEnvKey(envName) {
+				fmt.Fprintf(os.Stderr, "⚠️  --var maps secret %q onto %q, a reserved environment variable — proceeding because you asked for it explicitly; double-check this is intentional\n", secretRef, envName)
+			}
+			varSources[envName] = secretRef
+			vm[envName] = value
+		}
+		varMapped = vm
+	}
+
+	return derived, varMapped, nil
 }
 
 // sensitiveEnvSuffixes mark a KEYORIX_-prefixed env var as this CLI invocation's own
@@ -485,8 +602,8 @@ func isSensitiveKeyorixEnv(key string) bool {
 // inherited. This is opt-in hardening for #164 — broader than #103's Keyorix-specific
 // filtering, for callers who don't want the child to see the invoking shell's environment
 // at all.
-func execChild(args []string, extraEnv map[string]string, cleanEnv bool) error {
-	childEnv := buildChildEnv(extraEnv, cleanEnv)
+func execChild(args []string, derived, varMapped map[string]string, cleanEnv bool) error {
+	childEnv := buildChildEnv(derived, varMapped, cleanEnv)
 
 	c := exec.Command(args[0], args[1:]...) // #nosec G204
 	c.Stdin = os.Stdin
@@ -509,19 +626,53 @@ func execChild(args []string, extraEnv map[string]string, cleanEnv bool) error {
 // credential vars (filterSensitiveEnv, #103) — the long-standing, backward-compatible
 // behavior. With cleanEnv true it starts from ONLY a minimal PATH/HOME baseline (so the
 // child can still locate binaries and its home directory), NOT the rest of the parent
-// environment. In both cases extraEnv (the injected secrets) is appended last.
-func buildChildEnv(extraEnv map[string]string, cleanEnv bool) []string {
-	var childEnv []string
+// environment.
+//
+// #1816: the two injected-secret sources get different collision precedence against
+// that base, matching the reasoning in resolveChildEnvVars's doc comment:
+//   - derived (--derive-names, attacker-nameable): does NOT override an inherited
+//     value — a name already present wins. This is independent of, not a substitute
+//     for, dropDangerousEnvKeys's filter: the filter stops a brand-new dangerous
+//     name (e.g. DYLD_INSERT_LIBRARIES, not normally set) from being introduced at
+//     all; this stops an already-set name from being silently overridden, including
+//     one the filter doesn't yet enumerate. Neither closes the whole class alone.
+//   - varMapped (--var, operator-chosen): DOES override an inherited value — the
+//     operator named it explicitly, so overriding is the intent, not an accident.
+func buildChildEnv(derived, varMapped map[string]string, cleanEnv bool) []string {
+	// A single map, not incremental slice appends: exec.Cmd.Env technically defines
+	// "last duplicate key wins" for a slice with repeats, but relying on that
+	// implicitly here would make the derived-path's explicit skip-on-collision
+	// (below) and the varMapped-path's override-on-collision inconsistent in HOW
+	// each achieves its precedence — one by never adding a second entry, the other
+	// by silently trusting slice order. A map makes both paths equally explicit and
+	// guarantees the final []string has no duplicate keys at all.
+	env := make(map[string]string)
 	if cleanEnv {
 		for _, k := range []string{"PATH", "HOME"} {
 			if v, ok := os.LookupEnv(k); ok {
-				childEnv = append(childEnv, k+"="+v) // NOSONAR -- intentional minimal PATH/HOME baseline for clean-env subprocess
+				env[k] = v // NOSONAR -- intentional minimal PATH/HOME baseline for clean-env subprocess
 			}
 		}
 	} else {
-		childEnv = filterSensitiveEnv(os.Environ())
+		for _, kv := range filterSensitiveEnv(os.Environ()) {
+			k, v, _ := strings.Cut(kv, "=")
+			env[k] = v
+		}
 	}
-	for k, v := range extraEnv {
+
+	for k, v := range derived {
+		if _, alreadyInherited := env[k]; alreadyInherited {
+			fmt.Fprintf(os.Stderr, "⚠️  a --derive-names secret maps to %q, which is already set in the inherited environment — keeping the inherited value (derived names no longer override on collision; use --var if this secret should take precedence)\n", k)
+			continue
+		}
+		env[k] = v
+	}
+	for k, v := range varMapped {
+		env[k] = v // explicit operator intent always wins, replacing any inherited or derived value
+	}
+
+	childEnv := make([]string, 0, len(env))
+	for k, v := range env {
 		childEnv = append(childEnv, k+"="+v)
 	}
 	return childEnv

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -110,7 +110,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return errors.New(`'keyorix run' no longer injects secrets by default. Choose explicitly:
   --var NAME=secret-ref   (recommended) inject one secret, YOU name the env var
   --derive-names          (deprecated) restore the old auto-derived behavior
-See https://github.com/keyorixhq/keyorix/issues/1816 for why.`)
+See https://github.com/keyorixhq/keyorix/issues/1816 for why`)
 	}
 
 	// context.Background() with NO deadline attached: matches the other 100+

--- a/internal/cli/run/run.go
+++ b/internal/cli/run/run.go
@@ -343,28 +343,83 @@ func setEnvKey(result map[string]string, envKeySources map[string]string, name, 
 	return nil
 }
 
-// dangerousEnvVarNames names environment variables that affect dynamic-linker,
-// interpreter, or shell behavior for the CHILD PROCESS `keyorix run` launches — not
-// Keyorix's own credentials (see sensitiveEnvSuffixes below, a separate concern).
-// #G39: toEnvKey derives the child's env var keys directly from a project secret's
-// NAME (uppercased, non-alphanumeric → '_'), with no filtering at all — a secret
-// named "path" or "ld_preload" becomes an env key that collides with (and, since
-// buildChildEnv appends the injected secrets LAST, overrides) one of these,
-// letting a project-level secret WRITER hijack or control code execution in
-// whatever `keyorix run` launches, without ever needing direct system access
-// themselves. Matches the detection_idea's own required-coverage list exactly.
-var dangerousEnvVarNames = map[string]bool{
-	"LD_PRELOAD":      true,
-	"BASH_ENV":        true,
-	"NODE_OPTIONS":    true,
-	"PATH":            true,
-	"PERL5OPT":        true,
-	"RUBYOPT":         true,
-	"GIT_SSH_COMMAND": true,
+// dangerousEnvPrefixes and dangerousEnvExact together replace what used to be a
+// single exact-name map (dangerousEnvVarNames). That map was itself the #G39 fix
+// for toEnvKey deriving child env keys straight from an untrusted secret NAME with
+// no filtering at all — but an exact-name list in a code-execution path is the
+// same defect shape one layer down: it fails open on every name it doesn't happen
+// to enumerate. Verification against a real dylib-injection PoC (2026-09-09,
+// CLI-RUN-001 release-gate re-check) confirmed this: DYLD_INSERT_LIBRARIES —
+// macOS's LD_PRELOAD equivalent, named in the ORIGINAL finding's own exploit
+// scenario — was never in the list, and a secret literally named
+// "dyld_insert_libraries" reached the child process and ran an attacker
+// constructor. The fix is not "add DYLD_INSERT_LIBRARIES" (that just reproduces
+// the same gap for the next sibling — LD_LIBRARY_PATH, GCONV_PATH, ... — one CVE
+// at a time); it's covering the FAMILY each dangerous name belongs to.
+//
+// dangerousEnvPrefixes: any env key starting with one of these is dropped.
+//   - LD_      the ELF/Mach-O dynamic linker's whole tunable surface (LD_PRELOAD,
+//              LD_LIBRARY_PATH, LD_AUDIT, ...) — linker behavior, not app config.
+//   - DYLD_    macOS dyld's equivalent of LD_ (DYLD_INSERT_LIBRARIES,
+//              DYLD_LIBRARY_PATH, ...) — the exact family the live PoC used.
+//   - NODE_    Node.js process-wide behavior flags (NODE_OPTIONS, NODE_PATH, ...).
+//              Deliberate tradeoff: this also blocks the legitimate NODE_ENV: a
+//              project secret writer controlling arbitrary NODE_OPTIONS content
+//              outweighs a launched Node app not getting NODE_ENV from a secret
+//              (operators can still set NODE_ENV as an ordinary shell/CI env var —
+//              `keyorix run` inherits the parent environment unchanged; only
+//              secret-derived keys are filtered here).
+//   - PYTHON   CPython interpreter startup/path control (PYTHONPATH,
+//              PYTHONSTARTUP, PYTHONHOME, ...). No trailing '_': some real names
+//              (PYTHONDONTWRITEBYTECODE) don't have one after PYTHON.
+//   - PERL5    Perl 5's interpreter option/library-path family (PERL5OPT,
+//              PERL5LIB). No trailing '_', matching Perl's own naming.
+//   - BASH_    bash's own startup-file control (BASH_ENV and siblings).
+//   - GCONV_   glibc's character-conversion module loader (GCONV_PATH) — a
+//              second, less-known arbitrary-code-loading primitive alongside
+//              LD_PRELOAD.
+//   - MALLOC_  glibc/macOS malloc tunables (MALLOC_CHECK_, MALLOC_CONF, ...),
+//              usable for heap-exploitation primitives.
+var dangerousEnvPrefixes = []string{
+	"LD_", "DYLD_", "NODE_", "PYTHON", "PERL5", "BASH_", "GCONV_", "MALLOC_",
+}
+
+// dangerousEnvExact names variables that control shell/process behavior directly
+// but don't belong to any linker/interpreter prefix family above:
+//   - IFS    shell field-splitting; corrupting it can turn plain arguments into
+//            separate words/code.
+//   - ENV    sh's (non-bash) startup-file equivalent of BASH_ENV.
+//   - HOME   many tools (git, ssh, npm, ...) resolve config/credentials relative
+//            to HOME; redirecting it can hijack that resolution.
+//   - SHELL  some tools shell out via `$SHELL -c ...` rather than a fixed
+//            interpreter.
+//   - PATH   executable resolution order for the whole child process tree.
+//
+// RUBYOPT and GIT_SSH_COMMAND (in the old exact list) are still covered: neither
+// has siblings that would justify a prefix family of their own, so they stay
+// exact entries rather than being dropped.
+var dangerousEnvExact = map[string]bool{
+	"IFS": true, "ENV": true, "HOME": true, "SHELL": true, "PATH": true,
+	"RUBYOPT": true, "GIT_SSH_COMMAND": true,
+}
+
+// isDangerousEnvKey reports whether key is a reserved dynamic-linker/
+// interpreter/shell control variable — see dangerousEnvPrefixes and
+// dangerousEnvExact above for the two ways a key can match.
+func isDangerousEnvKey(key string) bool {
+	if dangerousEnvExact[key] {
+		return true
+	}
+	for _, prefix := range dangerousEnvPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // dropDangerousEnvKeys removes any entry keyed on a dynamic-linker/interpreter/
-// shell control variable name (dangerousEnvVarNames) — envVars is already keyed by
+// shell control variable name (isDangerousEnvKey) — envVars is already keyed by
 // the DERIVED env var key (toEnvKey(secret.Name)), not the raw secret name; see
 // fetchSecretsEmbedded/fetchSecretsRemote. Warns on stderr for each one dropped so
 // the operator can see why a secret they expected didn't reach the child process
@@ -373,7 +428,7 @@ var dangerousEnvVarNames = map[string]bool{
 func dropDangerousEnvKeys(envVars map[string]string) map[string]string {
 	out := make(map[string]string, len(envVars))
 	for key, value := range envVars {
-		if dangerousEnvVarNames[key] {
+		if isDangerousEnvKey(key) {
 			fmt.Fprintf(os.Stderr, "⚠️  a secret maps to the reserved environment variable %q — refusing to inject it (would override %s in the launched process)\n", key, key)
 			continue
 		}

--- a/internal/cli/run/run_1816_test.go
+++ b/internal/cli/run/run_1816_test.go
@@ -222,10 +222,10 @@ func TestBuildChildEnv_Derived_InheritedWinsOnCollision_RedThenGreen(t *testing.
 
 	// RED: reproduce the pre-#1816 shape directly (old buildChildEnv always
 	// appended extraEnv last, unconditionally overriding inherited values).
-	oldShapeEnv := append([]string{}, filterSensitiveEnv(nil)...)
-	// (filterSensitiveEnv(nil) is empty; build the old-shape child env by hand
-	// to avoid depending on a since-deleted function signature.)
-	oldShapeEnv = []string{"MY_APP_VAR=inherited-value"}
+	// Built by hand rather than calling the old function (its signature no
+	// longer exists) -- starts from just the one inherited var this test cares
+	// about, since filterSensitiveEnv(nil) contributes nothing on its own.
+	oldShapeEnv := []string{"MY_APP_VAR=inherited-value"}
 	for k, v := range derived {
 		oldShapeEnv = append(oldShapeEnv, k+"="+v) // old behavior: always appended last
 	}

--- a/internal/cli/run/run_1816_test.go
+++ b/internal/cli/run/run_1816_test.go
@@ -1,0 +1,242 @@
+// run_1816_test.go — #1816: keyorix run env-var name provenance. Two independent
+// levers, tested separately per the issue's own requirement:
+//   - Provenance: --var (operator names it) vs --derive-names (secret names it,
+//     deprecated).
+//   - Precedence: --var overrides the inherited environment on collision (operator
+//     intent); --derive-names does NOT (a second, independent guard alongside the
+//     reserved-name filter — see buildChildEnv's doc comment for what this does and
+//     does not close on its own).
+package run
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── runRun: no implicit default ────────────────────────────────────────────────
+
+// TestRunRun_NeitherFlagErrors is the provenance fix's entry-point guard: with
+// neither --var nor --derive-names, runRun must refuse outright (naming both
+// options) rather than either silently injecting nothing or silently keeping the
+// old, attacker-nameable default.
+func TestRunRun_NeitherFlagErrors(t *testing.T) {
+	origVar, origDerive := runVarMappings, runDeriveNames
+	defer func() { runVarMappings = origVar; runDeriveNames = origDerive }()
+	runVarMappings = nil
+	runDeriveNames = false
+
+	err := runRun(nil, []string{"true"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--var")
+	assert.Contains(t, err.Error(), "--derive-names")
+}
+
+// ── resolveChildEnvVars: --var provenance ───────────────────────────────────────
+
+func TestResolveChildEnvVars_VarBasic(t *testing.T) {
+	secrets := map[string]string{"db-password": "s3cr3t", "unrelated": "should-not-appear"}
+	derived, varMapped, err := resolveChildEnvVars(secrets, []string{"DATABASE_URL=db-password"}, false, "web", "dev")
+	require.NoError(t, err)
+	assert.Nil(t, derived, "derived must be nil when --derive-names is not set")
+	assert.Equal(t, map[string]string{"DATABASE_URL": "s3cr3t"}, varMapped)
+}
+
+func TestResolveChildEnvVars_VarMultiple(t *testing.T) {
+	secrets := map[string]string{"db-password": "s3cr3t", "stripe-key": "sk_live_x"}
+	_, varMapped, err := resolveChildEnvVars(secrets, []string{"DATABASE_URL=db-password", "API_KEY=stripe-key"}, false, "web", "dev")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"DATABASE_URL": "s3cr3t", "API_KEY": "sk_live_x"}, varMapped)
+}
+
+func TestResolveChildEnvVars_VarMissingSecret(t *testing.T) {
+	secrets := map[string]string{"db-password": "s3cr3t"}
+	_, _, err := resolveChildEnvVars(secrets, []string{"DATABASE_URL=does-not-exist"}, false, "web", "dev")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does-not-exist")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestResolveChildEnvVars_VarInvalidFormat(t *testing.T) {
+	cases := []string{"no-equals-sign", "=missing-name", "MISSING_REF="}
+	for _, mapping := range cases {
+		_, _, err := resolveChildEnvVars(map[string]string{}, []string{mapping}, false, "web", "dev")
+		require.Error(t, err, "mapping %q must be rejected", mapping)
+		assert.Contains(t, err.Error(), mapping)
+	}
+}
+
+func TestResolveChildEnvVars_VarInvalidEnvVarName(t *testing.T) {
+	secrets := map[string]string{"db-password": "s3cr3t"}
+	_, _, err := resolveChildEnvVars(secrets, []string{"1INVALID=db-password"}, false, "web", "dev")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1INVALID")
+	assert.Contains(t, err.Error(), "not a valid environment variable name")
+}
+
+// TestResolveChildEnvVars_VarSameNameSameRef_Idempotent: assigning the same NAME
+// to the same secret-ref twice (e.g. via a duplicated --var flag) is not an error.
+func TestResolveChildEnvVars_VarSameNameSameRef_Idempotent(t *testing.T) {
+	secrets := map[string]string{"db-password": "s3cr3t"}
+	_, varMapped, err := resolveChildEnvVars(secrets, []string{"DATABASE_URL=db-password", "DATABASE_URL=db-password"}, false, "web", "dev")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"DATABASE_URL": "s3cr3t"}, varMapped)
+}
+
+// TestResolveChildEnvVars_VarSameNameDifferentRef_Errors: the --var counterpart of
+// setEnvKey's derived-path collision abort — the same NAME assigned to two
+// DIFFERENT secrets is ambiguous operator intent, and must fail closed rather than
+// silently picking a winner.
+func TestResolveChildEnvVars_VarSameNameDifferentRef_Errors(t *testing.T) {
+	secrets := map[string]string{"db-password": "s3cr3t", "other-secret": "other-value"}
+	_, _, err := resolveChildEnvVars(secrets, []string{"DATABASE_URL=db-password", "DATABASE_URL=other-secret"}, false, "web", "dev")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DATABASE_URL")
+	assert.Contains(t, err.Error(), "db-password")
+	assert.Contains(t, err.Error(), "other-secret")
+}
+
+// TestResolveChildEnvVars_VarDangerousName_WarnsButDoesNotBlock: the issue's own
+// requirement — "an operator who explicitly maps a secret to LD_PRELOAD is
+// expressing intent, not being exploited... do not silently block operator
+// intent." No filter applies to --var; isDangerousEnvKey is used only to decide
+// whether to print a non-blocking heads-up.
+func TestResolveChildEnvVars_VarDangerousName_WarnsButDoesNotBlock(t *testing.T) {
+	secrets := map[string]string{"my-lib": "/path/to/lib.so"}
+	_, varMapped, err := resolveChildEnvVars(secrets, []string{"LD_PRELOAD=my-lib"}, false, "web", "dev")
+	require.NoError(t, err, "--var to a reserved name must NOT be blocked -- operator intent wins")
+	assert.Equal(t, map[string]string{"LD_PRELOAD": "/path/to/lib.so"}, varMapped)
+}
+
+// ── resolveChildEnvVars: --derive-names (deprecated) ────────────────────────────
+
+func TestResolveChildEnvVars_DeriveNamesBasic(t *testing.T) {
+	secrets := map[string]string{"db-password": "s3cr3t"}
+	derived, varMapped, err := resolveChildEnvVars(secrets, nil, true, "web", "dev")
+	require.NoError(t, err)
+	assert.Nil(t, varMapped, "varMapped must be nil when --var is not set")
+	assert.Equal(t, map[string]string{"DB_PASSWORD": "s3cr3t"}, derived)
+}
+
+// TestResolveChildEnvVars_DeriveNames_CollisionAborts relocates the collision
+// coverage formerly in run_fetch_test.go's TestFetch*_CollisionAborts (moved
+// because derivation itself moved out of fetchSecrets* and into this function).
+func TestResolveChildEnvVars_DeriveNames_CollisionAborts(t *testing.T) {
+	secrets := map[string]string{"my-secret": "first", "my_secret": "second"}
+	derived, _, err := resolveChildEnvVars(secrets, nil, true, "web", "dev")
+	require.Error(t, err, "colliding secret names must abort, not silently overwrite one")
+	assert.Nil(t, derived)
+	assert.Contains(t, err.Error(), "my-secret")
+	assert.Contains(t, err.Error(), "my_secret")
+	assert.Contains(t, err.Error(), "MY_SECRET")
+}
+
+// TestResolveChildEnvVars_DeriveNames_FiltersDangerousNames confirms the
+// CLI-RUN-001 prefix-family filter is still applied end-to-end through
+// resolveChildEnvVars (not just unit-tested against dropDangerousEnvKeys
+// directly) — the exact PoC name from that finding's own exploit scenario.
+func TestResolveChildEnvVars_DeriveNames_FiltersDangerousNames(t *testing.T) {
+	secrets := map[string]string{
+		"dyld_insert_libraries": "/tmp/attacker.dylib",
+		"safe-secret":           "fine",
+	}
+	derived, _, err := resolveChildEnvVars(secrets, nil, true, "web", "dev")
+	require.NoError(t, err)
+	assert.NotContains(t, derived, "DYLD_INSERT_LIBRARIES", "the dangerous derived name must be filtered")
+	assert.Equal(t, "fine", derived["SAFE_SECRET"])
+}
+
+// TestResolveChildEnvVars_BothFlagsTogether: --var and --derive-names may be used
+// together (bulk-derive the rest, but pin specific names explicitly). Not
+// exercised via runRun's CLI surface by any other test, so covered directly here.
+func TestResolveChildEnvVars_BothFlagsTogether(t *testing.T) {
+	secrets := map[string]string{"db-password": "s3cr3t", "other": "other-val"}
+	derived, varMapped, err := resolveChildEnvVars(secrets, []string{"DATABASE_URL=db-password"}, true, "web", "dev")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"DB_PASSWORD": "s3cr3t", "OTHER": "other-val"}, derived)
+	assert.Equal(t, map[string]string{"DATABASE_URL": "s3cr3t"}, varMapped)
+}
+
+// ── buildChildEnv: precedence, tested in both directions ────────────────────────
+
+// TestBuildChildEnv_Derived_InheritedWinsOnCollision is the precedence fix's core
+// assertion: a derived (attacker-nameable) secret must NOT override a value
+// already present in the inherited environment.
+func TestBuildChildEnv_Derived_InheritedWinsOnCollision(t *testing.T) {
+	t.Setenv("MY_APP_VAR", "inherited-value")
+	derived := map[string]string{"MY_APP_VAR": "derived-value-must-not-win"}
+
+	got := buildChildEnv(derived, nil, false)
+
+	assert.True(t, containsEnv(got, "MY_APP_VAR", "inherited-value"), "inherited value must survive a derived-path collision, got: %v", got)
+	assert.False(t, containsEnv(got, "MY_APP_VAR", "derived-value-must-not-win"), "derived value must NOT override the inherited one, got: %v", got)
+}
+
+// TestBuildChildEnv_Derived_NoCollision_StillInjected confirms the precedence
+// change doesn't accidentally suppress derived injection in the common case where
+// nothing is already inherited under that name.
+func TestBuildChildEnv_Derived_NoCollision_StillInjected(t *testing.T) {
+	derived := map[string]string{"KEYORIX_RUN_1816_NOVEL_VAR": "derived-value"}
+	got := buildChildEnv(derived, nil, false)
+	assert.True(t, containsEnv(got, "KEYORIX_RUN_1816_NOVEL_VAR", "derived-value"), "a derived var with nothing already inherited must still be injected, got: %v", got)
+}
+
+// TestBuildChildEnv_VarMapped_OverridesInheritedOnCollision is the --var
+// counterpart: an explicit operator-chosen name DOES override an inherited value
+// — overriding is the intent an operator expresses by naming it explicitly.
+func TestBuildChildEnv_VarMapped_OverridesInheritedOnCollision(t *testing.T) {
+	t.Setenv("MY_APP_VAR", "inherited-value")
+	varMapped := map[string]string{"MY_APP_VAR": "explicit-value-must-win"}
+
+	got := buildChildEnv(nil, varMapped, false)
+
+	assert.True(t, containsEnv(got, "MY_APP_VAR", "explicit-value-must-win"), "an explicit --var mapping must override the inherited value, got: %v", got)
+	assert.False(t, containsEnv(got, "MY_APP_VAR", "inherited-value"), "the inherited value must not survive an explicit --var override, got: %v", got)
+}
+
+// TestBuildChildEnv_VarMapped_OverridesDerived: when both --var and --derive-names
+// are used together and collide on the same key, the explicit --var mapping wins
+// — explicit operator intent is authoritative over auto-derivation.
+func TestBuildChildEnv_VarMapped_OverridesDerived(t *testing.T) {
+	derived := map[string]string{"SAME_KEY": "derived-value"}
+	varMapped := map[string]string{"SAME_KEY": "explicit-value"}
+
+	got := buildChildEnv(derived, varMapped, false)
+
+	assert.True(t, containsEnv(got, "SAME_KEY", "explicit-value"), "--var must win over --derive-names on the same key, got: %v", got)
+	assert.False(t, containsEnv(got, "SAME_KEY", "derived-value"), "the derived value must not survive a --var collision, got: %v", got)
+}
+
+// TestBuildChildEnv_Derived_InheritedWinsOnCollision_RedThenGreen is the
+// red-then-green demonstration required by #1816: temporarily restore the OLD
+// (pre-#1816) injected-last precedence for the derived path and confirm the
+// override attack this task closes actually reproduces, then confirm the current
+// (fixed) buildChildEnv refuses it. Scratch-only in intent (documents the
+// regression, not a permanent duplicate of the test above) but left in the
+// permanent suite since it costs nothing extra to keep as an explicit
+// red-was-real record.
+func TestBuildChildEnv_Derived_InheritedWinsOnCollision_RedThenGreen(t *testing.T) {
+	t.Setenv("MY_APP_VAR", "inherited-value")
+	derived := map[string]string{"MY_APP_VAR": "attacker-or-accidental-override"}
+
+	// RED: reproduce the pre-#1816 shape directly (old buildChildEnv always
+	// appended extraEnv last, unconditionally overriding inherited values).
+	oldShapeEnv := append([]string{}, filterSensitiveEnv(nil)...)
+	// (filterSensitiveEnv(nil) is empty; build the old-shape child env by hand
+	// to avoid depending on a since-deleted function signature.)
+	oldShapeEnv = []string{"MY_APP_VAR=inherited-value"}
+	for k, v := range derived {
+		oldShapeEnv = append(oldShapeEnv, k+"="+v) // old behavior: always appended last
+	}
+	if !containsEnv(oldShapeEnv, "MY_APP_VAR", "attacker-or-accidental-override") {
+		t.Fatal("test setup bug: the hand-built old-shape env should demonstrate the override")
+	}
+	t.Log("RED (pre-#1816 shape): derived value overrides inherited, as expected of the old behavior")
+
+	// GREEN: the current buildChildEnv must refuse this.
+	got := buildChildEnv(derived, nil, false)
+	require.True(t, containsEnv(got, "MY_APP_VAR", "inherited-value"), "GREEN check failed: current buildChildEnv must keep the inherited value")
+	require.False(t, containsEnv(got, "MY_APP_VAR", "attacker-or-accidental-override"), "GREEN check failed: current buildChildEnv must not let the derived value win")
+	t.Log("GREEN (current): inherited value survives the same collision")
+}

--- a/internal/cli/run/run_dangerous_env_test.go
+++ b/internal/cli/run/run_dangerous_env_test.go
@@ -33,6 +33,53 @@ func TestDropDangerousEnvKeys_DropsEveryReservedName(t *testing.T) {
 	}
 }
 
+// TestDropDangerousEnvKeys_CoversFamiliesNotJustPriorInstances is the CLI-RUN-001
+// release-gate re-verification (2026-09-09) regression test: the original
+// dangerousEnvVarNames exact list missed DYLD_INSERT_LIBRARIES (named in the
+// finding's own exploit scenario, confirmed live via a real dylib-injection PoC)
+// and every other sibling of an already-covered mechanism family. This asserts
+// the FAMILY is covered, not just the one instance that happened to get reported.
+func TestDropDangerousEnvKeys_CoversFamiliesNotJustPriorInstances(t *testing.T) {
+	reserved := []string{
+		// Already covered by the pre-2026-09-09 exact list:
+		"LD_PRELOAD", "BASH_ENV", "NODE_OPTIONS", "PATH", "PERL5OPT", "RUBYOPT", "GIT_SSH_COMMAND",
+		// Missing siblings the prefix-family fix must now catch:
+		"DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "LD_LIBRARY_PATH", "LD_AUDIT",
+		"NODE_PATH", "PYTHONPATH", "PYTHONSTARTUP", "PYTHONHOME", "PERL5LIB",
+		"GCONV_PATH", "MALLOC_CONF", "IFS", "ENV", "HOME", "SHELL",
+	}
+	envVars := map[string]string{"DATABASE_URL": "postgres://x"}
+	for _, name := range reserved {
+		envVars[name] = "attacker-controlled-value"
+	}
+
+	got := dropDangerousEnvKeys(envVars)
+
+	if _, ok := got["DATABASE_URL"]; !ok {
+		t.Error("an unrelated, legitimate secret must survive the filter")
+	}
+	for _, name := range reserved {
+		if _, ok := got[name]; ok {
+			t.Errorf("reserved name %q must be dropped, not passed through to the child process", name)
+		}
+	}
+	if len(got) != 1 {
+		t.Errorf("expected exactly 1 surviving entry, got %d: %v", len(got), got)
+	}
+}
+
+// TestIsDangerousEnvKey_LegitimateNamesSurvive confirms the fix is a filter, not
+// a denylist so broad it blocks everything — a handful of ordinary, unrelated
+// secret-derived env keys must still pass through untouched.
+func TestIsDangerousEnvKey_LegitimateNamesSurvive(t *testing.T) {
+	legit := []string{"DATABASE_URL", "STRIPE_API_KEY", "REDIS_URL", "APP_PORT", "LOG_LEVEL"}
+	for _, name := range legit {
+		if isDangerousEnvKey(name) {
+			t.Errorf("isDangerousEnvKey(%q) = true, want false — a legitimate secret name must not be blocked", name)
+		}
+	}
+}
+
 func TestDropDangerousEnvKeys_EmptyMapNoop(t *testing.T) {
 	got := dropDangerousEnvKeys(map[string]string{})
 	if len(got) != 0 {
@@ -55,8 +102,8 @@ func TestToEnvKey_SecretNameCollidesWithReservedVar(t *testing.T) {
 		if got := toEnvKey(secretName); got != wantKey {
 			t.Errorf("toEnvKey(%q) = %q, want %q", secretName, got, wantKey)
 		}
-		if !dangerousEnvVarNames[wantKey] {
-			t.Errorf("dangerousEnvVarNames must cover %q (derived from secret name %q)", wantKey, secretName)
+		if !isDangerousEnvKey(wantKey) {
+			t.Errorf("isDangerousEnvKey must cover %q (derived from secret name %q)", wantKey, secretName)
 		}
 	}
 }

--- a/internal/cli/run/run_extra_test.go
+++ b/internal/cli/run/run_extra_test.go
@@ -53,8 +53,8 @@ func TestFetchSecretsRemote_SkipsFailedSecretValue(t *testing.T) {
 
 	got, err := fetchSecretsRemote(context.Background(), srv.URL, "tok", "web", "dev")
 	require.NoError(t, err)
-	assert.Equal(t, "ok-value", got["GOOD"])
-	assert.NotContains(t, got, "BAD", "failed secret value must be skipped, not included")
+	assert.Equal(t, "ok-value", got["good"])
+	assert.NotContains(t, got, "bad", "failed secret value must be skipped, not included")
 }
 
 // TestFetchSecretsRemote_MultiPage tests that multi-page secret listings are fully
@@ -88,7 +88,7 @@ func TestFetchSecretsRemote_MultiPage(t *testing.T) {
 
 	got, err := fetchSecretsRemote(context.Background(), srv.URL, "tok", "web", "dev")
 	require.NoError(t, err)
-	assert.Equal(t, "v1", got["S1"])
+	assert.Equal(t, "v1", got["s1"])
 }
 
 // NOTE: apiClient (and its tests TestApiClientGet_HTTP400 / TestApiClientGet_InvalidJSON)

--- a/internal/cli/run/run_fetch_test.go
+++ b/internal/cli/run/run_fetch_test.go
@@ -32,9 +32,12 @@ func TestToEnvKey(t *testing.T) {
 	}
 }
 
-// TestFetchSecretsRemote drives the remote secret-injection path against the real
+// TestFetchSecretsRemote drives the remote secret-listing path against the real
 // sendSuccess envelope: resolve project → env → list secrets → fetch each value,
-// keyed by toEnvKey(name).
+// keyed by the secret's own raw NAME (#1816: derivation moved out of this function
+// entirely, into resolveChildEnvVars's --derive-names branch — this function's job
+// is now just "list what's there", independent of how -- or whether -- it becomes
+// an env var name).
 func TestFetchSecretsRemote(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -55,41 +58,7 @@ func TestFetchSecretsRemote(t *testing.T) {
 
 	got, err := fetchSecretsRemote(context.Background(), srv.URL, "tok", "web", "dev")
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{"DB_PASSWORD": "s3cr3t"}, got)
-}
-
-// TestFetchSecretsRemote_CollisionAborts is the regression test for the toEnvKey
-// collision finding: two DIFFERENT secret names ("my-secret" and "my_secret") both
-// sanitize to the same env var key (MY_SECRET) via toEnvKey. Before this fix the
-// second one processed would silently overwrite the first in the returned map with
-// no indication anything was dropped. Assert fetchSecretsRemote now returns an
-// error naming both colliding secrets instead of silently picking a winner.
-func TestFetchSecretsRemote_CollisionAborts(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/api/v1/projects":
-			_, _ = w.Write([]byte(`{"success":true,"data":{"projects":[{"id":1,"name":"web"}]}}`))
-		case "/api/v1/projects/1/environments":
-			_, _ = w.Write([]byte(`{"success":true,"data":{"environments":[{"id":2,"name":"dev"}]}}`))
-		case "/api/v1/secrets":
-			_, _ = w.Write([]byte(`{"success":true,"data":{"secrets":[{"id":9,"name":"my-secret"},{"id":10,"name":"my_secret"}]}}`))
-		case "/api/v1/secrets/9":
-			_, _ = w.Write([]byte(`{"success":true,"data":{"value":"first"}}`))
-		case "/api/v1/secrets/10":
-			_, _ = w.Write([]byte(`{"success":true,"data":{"value":"second"}}`))
-		default:
-			t.Errorf("unexpected path %s", r.URL.Path)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer srv.Close()
-
-	got, err := fetchSecretsRemote(context.Background(), srv.URL, "tok", "web", "dev")
-	require.Error(t, err, "colliding secret names must abort the fetch, not silently overwrite one")
-	assert.Nil(t, got)
-	assert.Contains(t, err.Error(), "my-secret")
-	assert.Contains(t, err.Error(), "my_secret")
-	assert.Contains(t, err.Error(), "MY_SECRET")
+	assert.Equal(t, map[string]string{"db-password": "s3cr3t"}, got)
 }
 
 func TestFetchSecretsRemote_ProjectNotFound(t *testing.T) {
@@ -181,56 +150,11 @@ func TestFetchSecretsEmbedded(t *testing.T) {
 
 	got, err := fetchSecretsEmbedded(ctx, "web", "dev")
 	require.NoError(t, err)
-	assert.Equal(t, "s3cr3t", got["DB_PASSWORD"])
+	assert.Equal(t, "s3cr3t", got["db-password"])
 
 	_, err = fetchSecretsEmbedded(ctx, "ghost", "dev")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
-}
-
-// TestFetchSecretsEmbedded_CollisionAborts mirrors TestFetchSecretsRemote_
-// CollisionAborts for the embedded (local core service) path: two distinct secret
-// names that sanitize to the same toEnvKey output must abort fetchSecretsEmbedded
-// with a clear error rather than silently dropping one of them from the child
-// process's environment.
-func TestFetchSecretsEmbedded_CollisionAborts(t *testing.T) {
-	require.NoError(t, i18n.InitializeForTesting())
-	dir := t.TempDir()
-	cfgPath := filepath.Join(dir, "keyorix.yaml")
-	require.NoError(t, config.Save(cfgPath, &config.Config{
-		Locale:  config.LocaleConfig{Language: "en", FallbackLanguage: "en"},
-		Storage: config.StorageConfig{Type: "local", Database: config.DatabaseConfig{Path: filepath.Join(dir, "s2.db")}},
-	}))
-	t.Setenv("KEYORIX_CONFIG_PATH", cfgPath)
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	t.Setenv("KEYORIX_SERVER", "")
-	t.Setenv("KEYORIX_TOKEN", "")
-
-	ctx := context.Background()
-	svc, err := common.InitializeCoreService()
-	require.NoError(t, err)
-	project, err := svc.CreateProjectWithEnvs(ctx, "web", "", []string{"dev"})
-	require.NoError(t, err)
-	envs, err := svc.ListEnvironmentsByProject(ctx, project.ID)
-	require.NoError(t, err)
-	require.NotEmpty(t, envs)
-	_, err = svc.CreateSecret(ctx, &core.CreateSecretRequest{
-		Name: "my-secret", Value: []byte("first"), ProjectID: project.ID,
-		EnvironmentID: envs[0].ID, Type: "password", CreatedBy: "test",
-	})
-	require.NoError(t, err)
-	_, err = svc.CreateSecret(ctx, &core.CreateSecretRequest{
-		Name: "my_secret", Value: []byte("second"), ProjectID: project.ID,
-		EnvironmentID: envs[0].ID, Type: "password", CreatedBy: "test",
-	})
-	require.NoError(t, err)
-
-	got, err := fetchSecretsEmbedded(ctx, "web", "dev")
-	require.Error(t, err, "colliding secret names must abort the fetch, not silently overwrite one")
-	assert.Nil(t, got)
-	assert.Contains(t, err.Error(), "my-secret")
-	assert.Contains(t, err.Error(), "my_secret")
-	assert.Contains(t, err.Error(), "MY_SECRET")
 }
 
 // TestSetEnvKey_CollisionDetection unit-tests the shared collision-detection helper

--- a/internal/cli/run/run_g80_test.go
+++ b/internal/cli/run/run_g80_test.go
@@ -129,8 +129,8 @@ func TestFetchSecretsEmbedded_SkipsExpiredSecret(t *testing.T) {
 
 	got, err := fetchSecretsEmbedded(ctx, "web", "dev")
 	require.NoError(t, err, "an expired secret must be skipped, not fail the whole fetch")
-	assert.Equal(t, "should-be-injected", got["LIVE_SECRET"])
-	assert.NotContains(t, got, "EXPIRED_SECRET", "an expired secret's value must never be injected into the child process")
+	assert.Equal(t, "should-be-injected", got["live-secret"])
+	assert.NotContains(t, got, "expired-secret", "an expired secret's value must never be injected into the child process")
 }
 
 // TestFetchSecretsRemote_InvalidEndpoint verifies that an endpoint which fails
@@ -200,7 +200,7 @@ func TestHelperProcess_G80_ExecChild(t *testing.T) {
 	// The child command itself exits 7; execChild must translate that into an
 	// *exec.ExitError, hit the errors.As branch, and os.Exit(7) — never
 	// reaching this test's own return/pass/fail machinery.
-	err := execChild([]string{"sh", "-c", "exit 7"}, nil, false)
+	err := execChild([]string{"sh", "-c", "exit 7"}, nil, nil, false)
 	// Only reachable if execChild did NOT os.Exit, which is itself a bug this
 	// subprocess is designed to catch.
 	fmt.Fprintf(os.Stderr, "execChild returned instead of os.Exit-ing: %v\n", err)

--- a/internal/cli/run/run_s25_test.go
+++ b/internal/cli/run/run_s25_test.go
@@ -76,7 +76,7 @@ func TestBuildChildEnv_MultipleInjectedSecrets(t *testing.T) {
 		"SECRET_B": "val_b",
 		"SECRET_C": "val_c",
 	}
-	got := buildChildEnv(extra, false)
+	got := buildChildEnv(nil, extra, false)
 
 	for k, v := range extra {
 		assert.True(t, containsEnv(got, k, v), "expected %s=%s in child env", k, v)
@@ -90,7 +90,7 @@ func TestBuildChildEnv_CleanEnv_MultipleInjectedSecrets(t *testing.T) {
 		"DB_PASSWORD": "s3cr3t",
 		"API_KEY":     "xyzzy",
 	}
-	got := buildChildEnv(extra, true)
+	got := buildChildEnv(nil, extra, true)
 
 	for k, v := range extra {
 		assert.True(t, containsEnv(got, k, v), "expected %s=%s in clean-env child", k, v)
@@ -157,17 +157,19 @@ func TestRunRun_TokenFlagWithoutEndpoint(t *testing.T) {
 		_ = r.Close()
 	}()
 
-	origEnv, origProject, origToken, origClean := runEnv, runProject, runToken, runCleanEnv
+	origEnv, origProject, origToken, origClean, origDerive := runEnv, runProject, runToken, runCleanEnv, runDeriveNames
 	defer func() {
 		runEnv = origEnv
 		runProject = origProject
 		runToken = origToken
 		runCleanEnv = origClean
+		runDeriveNames = origDerive
 	}()
 	runEnv = "dev"
 	runProject = "ghost"
 	runToken = "flag-tok-no-endpoint"
 	runCleanEnv = false
+	runDeriveNames = true // #1816: opt into the deprecated path to exercise this unrelated behavior
 
 	// Without an endpoint, remoteOK is false so it falls through to embedded.
 	// The embedded path will fail because there's no seeded project.
@@ -246,7 +248,7 @@ func TestFetchSecretsEmbedded_SecretsSkippedOnValueError(t *testing.T) {
 
 	got, err := fetchSecretsEmbedded(ctx, "myproj2", "dev")
 	require.NoError(t, err)
-	assert.Equal(t, "top-secret", got["API_KEY"])
+	assert.Equal(t, "top-secret", got["api-key"])
 }
 
 // TestToEnvKey_DigitsAndUnderscores exercises digit-leading and underscore-

--- a/internal/cli/run/run_s2_test.go
+++ b/internal/cli/run/run_s2_test.go
@@ -27,13 +27,18 @@ func TestRunRun_FetchRemoteError(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", srv.URL)
 	t.Setenv("KEYORIX_TOKEN", "test-tok")
 
-	origEnv, origProject, origToken, origClean := runEnv, runProject, runToken, runCleanEnv
+	origEnv, origProject, origToken, origClean, origDerive := runEnv, runProject, runToken, runCleanEnv, runDeriveNames
 	defer func() {
 		runEnv = origEnv
 		runProject = origProject
 		runToken = origToken
 		runCleanEnv = origClean
+		runDeriveNames = origDerive
 	}()
+	// #1816: runRun now requires an explicit --var or --derive-names; these tests
+	// exercise fetch/token/clean-env paths unrelated to that choice, so opt into
+	// the old (deprecated) full-environment-derivation path to keep exercising them.
+	runDeriveNames = true
 	runEnv = "dev"
 	runProject = ""
 	runToken = ""
@@ -53,13 +58,18 @@ func TestRunRun_FetchLocalError(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", "")
 	t.Setenv("KEYORIX_TOKEN", "")
 
-	origEnv, origProject, origToken, origClean := runEnv, runProject, runToken, runCleanEnv
+	origEnv, origProject, origToken, origClean, origDerive := runEnv, runProject, runToken, runCleanEnv, runDeriveNames
 	defer func() {
 		runEnv = origEnv
 		runProject = origProject
 		runToken = origToken
 		runCleanEnv = origClean
+		runDeriveNames = origDerive
 	}()
+	// #1816: runRun now requires an explicit --var or --derive-names; these tests
+	// exercise fetch/token/clean-env paths unrelated to that choice, so opt into
+	// the old (deprecated) full-environment-derivation path to keep exercising them.
+	runDeriveNames = true
 	runEnv = "dev"
 	runProject = "nonexistent"
 	runToken = ""
@@ -87,13 +97,18 @@ func TestRunRun_TokenFlagWarning(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", srv.URL)
 	t.Setenv("KEYORIX_TOKEN", "")
 
-	origEnv, origProject, origToken, origClean := runEnv, runProject, runToken, runCleanEnv
+	origEnv, origProject, origToken, origClean, origDerive := runEnv, runProject, runToken, runCleanEnv, runDeriveNames
 	defer func() {
 		runEnv = origEnv
 		runProject = origProject
 		runToken = origToken
 		runCleanEnv = origClean
+		runDeriveNames = origDerive
 	}()
+	// #1816: runRun now requires an explicit --var or --derive-names; these tests
+	// exercise fetch/token/clean-env paths unrelated to that choice, so opt into
+	// the old (deprecated) full-environment-derivation path to keep exercising them.
+	runDeriveNames = true
 	runEnv = "dev"
 	runProject = "ghost"
 	runToken = "explicit-token"
@@ -110,7 +125,7 @@ func TestRunRun_TokenFlagWarning(t *testing.T) {
 // (echo) returns nil.
 func TestExecChild_SuccessfulCommand(t *testing.T) {
 	// Use `true` which is guaranteed to succeed on Unix-like systems.
-	err := execChild([]string{"true"}, nil, false)
+	err := execChild([]string{"true"}, nil, nil, false)
 	assert.NoError(t, err)
 }
 
@@ -118,7 +133,7 @@ func TestExecChild_SuccessfulCommand(t *testing.T) {
 // the binary doesn't exist (not the os.Exit path, but the "command not found"
 // path which surfaces as exec: not found in PATH).
 func TestExecChild_CommandNotFound(t *testing.T) {
-	err := execChild([]string{"__no_such_binary_9xyzkeyorix__"}, nil, false)
+	err := execChild([]string{"__no_such_binary_9xyzkeyorix__"}, nil, nil, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "command failed")
 }
@@ -127,14 +142,14 @@ func TestExecChild_CommandNotFound(t *testing.T) {
 // plus injected secrets to the child.
 func TestExecChild_CleanEnv(t *testing.T) {
 	// Use `true` with clean-env; child env should only have PATH/HOME + injected.
-	err := execChild([]string{"true"}, map[string]string{"MY_SECRET": "val"}, true)
+	err := execChild([]string{"true"}, nil, map[string]string{"MY_SECRET": "val"}, true)
 	assert.NoError(t, err)
 }
 
 // TestBuildChildEnv_CleanEnv_NoExtraVars proves that clean-env with no
 // injected secrets only carries PATH and HOME from the parent.
 func TestBuildChildEnv_CleanEnv_NoExtraVars(t *testing.T) {
-	got := buildChildEnv(nil, true)
+	got := buildChildEnv(nil, nil, true)
 	for _, kv := range got {
 		key := strings.SplitN(kv, "=", 2)[0]
 		assert.True(t, key == "PATH" || key == "HOME",
@@ -153,13 +168,18 @@ func TestRunRun_RemoteProjectNotFound(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", srv.URL)
 	t.Setenv("KEYORIX_TOKEN", "tok")
 
-	origEnv, origProject, origToken, origClean := runEnv, runProject, runToken, runCleanEnv
+	origEnv, origProject, origToken, origClean, origDerive := runEnv, runProject, runToken, runCleanEnv, runDeriveNames
 	defer func() {
 		runEnv = origEnv
 		runProject = origProject
 		runToken = origToken
 		runCleanEnv = origClean
+		runDeriveNames = origDerive
 	}()
+	// #1816: runRun now requires an explicit --var or --derive-names; these tests
+	// exercise fetch/token/clean-env paths unrelated to that choice, so opt into
+	// the old (deprecated) full-environment-derivation path to keep exercising them.
+	runDeriveNames = true
 	runEnv = "dev"
 	runProject = "missing"
 	runToken = ""
@@ -210,13 +230,18 @@ func TestRunRun_FullRemoteSuccess(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", srv.URL)
 	t.Setenv("KEYORIX_TOKEN", "tok")
 
-	origEnv, origProject, origToken, origClean := runEnv, runProject, runToken, runCleanEnv
+	origEnv, origProject, origToken, origClean, origDerive := runEnv, runProject, runToken, runCleanEnv, runDeriveNames
 	defer func() {
 		runEnv = origEnv
 		runProject = origProject
 		runToken = origToken
 		runCleanEnv = origClean
+		runDeriveNames = origDerive
 	}()
+	// #1816: runRun now requires an explicit --var or --derive-names; these tests
+	// exercise fetch/token/clean-env paths unrelated to that choice, so opt into
+	// the old (deprecated) full-environment-derivation path to keep exercising them.
+	runDeriveNames = true
 	runEnv = "dev"
 	runProject = "web"
 	runToken = ""
@@ -246,13 +271,18 @@ func TestRunRun_CleanEnvWithCommand(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", srv.URL)
 	t.Setenv("KEYORIX_TOKEN", "tok")
 
-	origEnv, origProject, origToken, origClean := runEnv, runProject, runToken, runCleanEnv
+	origEnv, origProject, origToken, origClean, origDerive := runEnv, runProject, runToken, runCleanEnv, runDeriveNames
 	defer func() {
 		runEnv = origEnv
 		runProject = origProject
 		runToken = origToken
 		runCleanEnv = origClean
+		runDeriveNames = origDerive
 	}()
+	// #1816: runRun now requires an explicit --var or --derive-names; these tests
+	// exercise fetch/token/clean-env paths unrelated to that choice, so opt into
+	// the old (deprecated) full-environment-derivation path to keep exercising them.
+	runDeriveNames = true
 	runEnv = "dev"
 	runProject = "web"
 	runToken = ""
@@ -279,11 +309,11 @@ func TestFetchSecretsEmbedded_EnvNotFound(t *testing.T) {
 func TestExecChild_InheritsEnv(t *testing.T) {
 	t.Setenv("KEYORIX_RUN_S2_INHERIT_TEST", "should-be-present")
 	// Use `true` — we only care that no error is returned.
-	err := execChild([]string{"true"}, nil, false)
+	err := execChild([]string{"true"}, nil, nil, false)
 	assert.NoError(t, err)
 
 	// Verify the variable would have appeared in the built env.
-	env := buildChildEnv(nil, false)
+	env := buildChildEnv(nil, nil, false)
 	found := false
 	for _, kv := range env {
 		if kv == "KEYORIX_RUN_S2_INHERIT_TEST=should-be-present" {
@@ -325,13 +355,18 @@ func TestRunRun_StderrNotCaptured_TokenWarningPath(t *testing.T) {
 	t.Setenv("KEYORIX_SERVER", srv.URL)
 	t.Setenv("KEYORIX_TOKEN", "")
 
-	origEnv, origProject, origToken, origClean := runEnv, runProject, runToken, runCleanEnv
+	origEnv, origProject, origToken, origClean, origDerive := runEnv, runProject, runToken, runCleanEnv, runDeriveNames
 	defer func() {
 		runEnv = origEnv
 		runProject = origProject
 		runToken = origToken
 		runCleanEnv = origClean
+		runDeriveNames = origDerive
 	}()
+	// #1816: runRun now requires an explicit --var or --derive-names; these tests
+	// exercise fetch/token/clean-env paths unrelated to that choice, so opt into
+	// the old (deprecated) full-environment-derivation path to keep exercising them.
+	runDeriveNames = true
 	runEnv = "dev"
 	runProject = "web"
 	runToken = "explicit-insecure-tok"

--- a/internal/cli/run/run_test.go
+++ b/internal/cli/run/run_test.go
@@ -78,7 +78,7 @@ func TestIsSensitiveKeyorixEnv(t *testing.T) {
 func TestBuildChildEnv_Default_InheritsFullParentEnv(t *testing.T) {
 	t.Setenv("KEYORIX_RUN_TEST_UNRELATED", "leftover-from-shell")
 
-	got := buildChildEnv(map[string]string{"DB_PASSWORD": "s3cr3t"}, false)
+	got := buildChildEnv(nil, map[string]string{"DB_PASSWORD": "s3cr3t"}, false)
 
 	if !containsEnv(got, "KEYORIX_RUN_TEST_UNRELATED", "leftover-from-shell") {
 		t.Fatalf("default (no --clean-env) must still inherit unrelated parent vars, got: %v", got)
@@ -94,7 +94,7 @@ func TestBuildChildEnv_Default_InheritsFullParentEnv(t *testing.T) {
 func TestBuildChildEnv_Default_StillFiltersSensitiveKeyorixVars(t *testing.T) {
 	t.Setenv("KEYORIX_TOKEN", "should-not-leak-by-default-either")
 
-	got := buildChildEnv(nil, false)
+	got := buildChildEnv(nil, nil, false)
 
 	if containsEnv(got, "KEYORIX_TOKEN", "should-not-leak-by-default-either") {
 		t.Fatalf("default (no --clean-env) must still filter Keyorix's own credential vars, got: %v", got)
@@ -108,7 +108,7 @@ func TestBuildChildEnv_CleanEnv_OnlyInjectedSecretsAndBaseline(t *testing.T) {
 	t.Setenv("KEYORIX_RUN_TEST_UNRELATED", "leftover-from-shell")
 	t.Setenv("KEYORIX_TOKEN", "should-not-leak-into-clean-child")
 
-	got := buildChildEnv(map[string]string{"DB_PASSWORD": "s3cr3t"}, true)
+	got := buildChildEnv(nil, map[string]string{"DB_PASSWORD": "s3cr3t"}, true)
 
 	if containsEnv(got, "KEYORIX_RUN_TEST_UNRELATED", "leftover-from-shell") {
 		t.Fatalf("--clean-env must NOT inherit unrelated parent vars, got: %v", got)
@@ -137,7 +137,7 @@ func TestBuildChildEnv_CleanEnv_BaselineMatchesParent(t *testing.T) {
 	if !ok {
 		t.Skip("PATH not set in test environment")
 	}
-	got := buildChildEnv(nil, true)
+	got := buildChildEnv(nil, nil, true)
 	if !containsEnv(got, "PATH", wantPath) {
 		t.Fatalf("--clean-env must carry over the parent PATH baseline, got: %v", got)
 	}

--- a/internal/cli/secret/explain.go
+++ b/internal/cli/secret/explain.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	helpInjectAtRuntime = "Inject at runtime: keyorix run --env production -- your-app"
+	helpInjectAtRuntime = "Inject at runtime: keyorix run --env production --var NAME=secret-ref -- your-app"
 	helpStoreAndInject  = "Store in Keyorix and inject at runtime"
 )
 
@@ -158,7 +158,7 @@ func runExplain(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  - Never hardcode credentials in source code\n")
 		fmt.Printf("  - Move to environment variable\n")
 		fmt.Printf("  - Store in Keyorix: keyorix secret create %s --value <value>\n", strings.ToLower(args[0]))
-		fmt.Printf("  - Inject at runtime: keyorix run --env production -- your-app\n\n")
+		fmt.Printf("  - Inject at runtime: keyorix run --env production --var %s=%s -- your-app\n\n", strings.ToUpper(args[0]), strings.ToLower(args[0]))
 		fmt.Printf("Next:\n")
 		fmt.Printf("  keyorix secret fix %s\n", args[0])
 		return nil

--- a/internal/cli/secret/fix.go
+++ b/internal/cli/secret/fix.go
@@ -126,7 +126,7 @@ func runFix(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  1. Fill in the value in %s\n", fixEnvFile)
 	fmt.Printf("  2. Add %s to .gitignore\n", fixEnvFile)
 	fmt.Printf("  3. Store in Keyorix: keyorix secret create %s --value <value>\n", strings.ToLower(keyName))
-	fmt.Printf("  4. Run with injection: keyorix run --env production -- your-app\n")
+	fmt.Printf("  4. Run with injection: keyorix run --env production --var %s=%s -- your-app\n", envVarName, strings.ToLower(keyName))
 
 	return nil
 }

--- a/internal/cli/secret/scan_report.go
+++ b/internal/cli/secret/scan_report.go
@@ -68,7 +68,7 @@ func printScanReport(report *ScanReport) { // NOSONAR -- cognitive complexity 16
 	fmt.Println("Next steps:")
 	fmt.Println("  keyorix secret scan . --import    Import all into Keyorix")
 	fmt.Println("  keyorix secret scan . --report scan.json    Save full report")
-	fmt.Println("  keyorix run --env production -- <your-app>  Inject secrets at runtime")
+	fmt.Println("  keyorix run --env production --var NAME=secret-ref -- <your-app>  Inject secrets at runtime")
 }
 
 func sanitizeName(s string) string {

--- a/internal/cli/system/init.go
+++ b/internal/cli/system/init.go
@@ -356,7 +356,7 @@ func runRemoteInit() error { // NOSONAR -- cognitive complexity 16, suppress go:
 	fmt.Printf("\nNext steps:\n")
 	fmt.Printf("  keyorix connect --server %s\n", server)
 	fmt.Printf("  keyorix secret create my-first-secret --value \"hello\"\n")
-	fmt.Printf("  keyorix run --env production -- your-app\n")
+	fmt.Printf("  keyorix run --env production --var MY_FIRST_SECRET=my-first-secret -- your-app\n")
 
 	if initAdminPassword == "admin" {
 		// Deliberately doesn't interpolate initAdminPassword: it's already known to be

--- a/web/src/pages/integrations/SdksPage.tsx
+++ b/web/src/pages/integrations/SdksPage.tsx
@@ -105,7 +105,7 @@ export const SdksPage: React.FC = () => (
                 </p>
                 <CodeBlock
                     code={
-                        'keyorix secret create --name db-password --value supersecret\nkeyorix run --env production -- node app.js'
+                        'keyorix secret create --name db-password --value supersecret\nkeyorix run --env production --var DATABASE_URL=db-password -- node app.js'
                     }
                 />
             </div>


### PR DESCRIPTION
## Summary

Closes #1816. Builds on #1813 (the CLI-RUN-001 prefix-family denylist fix, already merged to `main`) — does not re-litigate it.

`run.go:355`'s own comment on the old denylist said the quiet part out loud: *"Matches the detection_idea's own required-coverage list exactly."* The list was scoped to satisfy a finding's stated coverage, not the actual threat. #1813 already fixed the filter's shape (prefix families instead of an exact list). This PR fixes the layer underneath: **who chooses the env var name in the first place.**

## Two independent levers, evaluated and fixed separately

**Provenance** — today, `toEnvKey` derives the child's env var key from each secret's own NAME, so whoever can name a project secret chooses the env var it becomes. Fixed: `--var NAME=secret-ref` (repeatable) makes the **operator** the source of the name — the trust anchor moves from the secret's creator to whoever runs `keyorix run`. The old behavior survives as `--derive-names`, explicit opt-in, deprecated, with the #1813 filter still applied only to that path (an operator's `--var` choice is never filtered — see below).

**Precedence** — today, injected secrets are appended last, so they always win a collision with the inherited environment; that's what turns a name collision into an override. Fixed *for the `--derive-names` path only*: the inherited value now wins on collision. I want to be precise about what this does and doesn't do, since the issue's own framing ("removes the override primitive independently of naming") is more optimistic than the mechanism actually delivers: it stops an attacker from **overriding an already-set** variable, but does **not** by itself stop **introducing a brand-new** dangerous variable that isn't normally set (e.g. `DYLD_INSERT_LIBRARIES`, which is essentially never pre-set) — the #1813 filter is still doing that job. The two are independent, complementary layers; neither alone closes the class. `--var`'s collision behavior is unchanged (operator's explicit name always wins) — that's the intent an explicit `--var` expresses, not an accident to guard against.

## Shape deviation from the issue's own proposal, with reasoning

The issue proposed `--env NAME=secret-ref` as the flag name. That collides with the *existing* `--env` flag (environment selector, e.g. `--env production`) on this same command — reusing it would silently redefine what `--env production` even means. Used **`--var`** instead.

## No implicit default

`keyorix run` with neither `--var` nor `--derive-names` now errors immediately, naming both options — not a silent no-op, not a silent fallback to the old behavior. This is the actual enforcement point: an attacker can't reach the vulnerable code path at all unless an operator has explicitly, currently, opted into `--derive-names`.

## Compatibility survey (denominator + method, not a guess)

Grepped `keyorix run` across the whole repo (`grep -rl "keyorix run" .`, excluding `.git`) → **11 files**, cross-checked against 192 category-scoped file opens across `examples/**`, `docs/**/*.md`, `Makefile`/`*.mk`/`Taskfile.yml`, `docker-compose*`/`Dockerfile*`, `internal/cli/run/*_test.go` (54 test functions individually assessed), `**/README.md` (25 files), `.github/workflows/*.yml` (18 files).

Actual dependents found and fixed in this PR:
- **Root `README.md`** — 3 example invocations + 1 explanatory sentence, now `--var`-based with a note on `--derive-names`.
- **8 of 54 `internal/cli/run` test functions** — updated to opt into `--derive-names` (where the test exercises unrelated behavior — fetch errors, token warnings, clean-env) or to assert on the new raw-secret-name-keyed return value (derivation moved out of `fetchSecrets*` entirely, into `resolveChildEnvVars`).
- **5 CLI hint strings** (`internal/cli/secret/explain.go` ×2, `fix.go`, `scan_report.go`, `internal/cli/system/init.go`) + **1 web docs sample** (`SdksPage.tsx`) — all printed a flagless `keyorix run --env production -- your-app` hint; now show `--var`.

Zero hits in `examples/`, `Makefile`/`*.mk`/`Taskfile.yml`, `docker-compose*`/`Dockerfile*`, or any `.github/workflows/*.yml` — nothing there depends on derivation.

## Testing

- Full `internal/cli/run` suite passes (pre-existing + 18 new tests covering `--var` basic/multi/missing-secret/invalid-format/invalid-name/same-name-idempotent/same-name-conflict/dangerous-name-warns-not-blocks, `--derive-names` basic/collision-abort (relocated from the fetch-layer tests, since derivation moved out of there)/filters-dangerous-names, both-flags-together, and precedence in both directions).
- **Real dylib-injection PoC, reused from the CLI-RUN-001 verification, run through the FULL new pipeline** (`resolveChildEnvVars` → `buildChildEnv` → `execChild`, not just the isolated filter unit test): confirmed FIXED against current code, confirmed LIVE when the filter call is temporarily removed (proves the integration point still fires, not just the filter function in isolation), restored and reconfirmed FIXED.
- Separate red-then-green for the precedence change itself: hand-built the pre-#1816 "always append last" shape, confirmed it reproduces the override; confirmed current `buildChildEnv` refuses it.
- A design-time bug caught by the tests: my first pass merged `varMapped` into the child env slice by appending after the base (relying on Go's documented last-key-wins `exec.Cmd.Env` semantics), inconsistent with the `derived` path's explicit skip-on-collision. Rewrote `buildChildEnv` to build a single map throughout — no duplicate-key entries at all, both paths equally explicit.
- `go build ./...`, `go vet` on touched packages, `gofmt -l` clean, web `pnpm type-check` clean.

## Compatibility

Breaking by design (pre-1.0, no declared support period per `SECURITY.md`), deliberate not silent:
- `CHANGELOG.md` entry, written for an operator who needs to update their invocation.
- Deprecation warning printed on every `--derive-names` use, pointing at `--var` and this issue.
- `keyorix run --help` fully rewritten to lead with the choice.

## Not in this PR

- The #1813 prefix-family filter itself — unchanged, built on, already merged.
- `sensitiveEnvSuffixes`/`isSensitiveKeyorixEnv` (Keyorix's own credential filtering) — explicitly out of scope per the issue, untouched.