### PR TITLE
ci: make every required check report on merge_group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
     # directly, until it's that PR's turn to land) — without these, a PR
     # based on a sibling feature branch never triggers CI at all.
     branches: [main, 'adr082/**', 'feat/**', 'fix/**']
+  # Merge queue. Every REQUIRED status check must also report on the
+  # merge_group event or the queue never merges anything -- a check that
+  # simply does not run is indistinguishable from one still pending, and it
+  # blocks the queue forever rather than failing loudly.
+  merge_group:
 
 # Workflow-level default: zero permissions. No job here writes to the repo,
 # comments on PRs, or publishes anything — a compromised dependency/action in

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     # See ci.yml's own comment: also covers stacked-PR review chains.
     branches: [main, 'adr082/**', 'feat/**', 'fix/**']
+  # Merge queue. Every REQUIRED status check must also report on the
+  # merge_group event or the queue never merges anything -- a check that
+  # simply does not run is indistinguishable from one still pending, and it
+  # blocks the queue forever rather than failing loudly.
+  merge_group:
   schedule:
     # Weekly deep scan: catches newly-published CodeQL query packs against
     # unchanged code, not just what a push/PR diff touches.

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     # See ci.yml's own comment: also covers stacked-PR review chains.
     branches: [main, 'adr082/**', 'feat/**', 'fix/**']
+  # Merge queue. Every REQUIRED status check must also report on the
+  # merge_group event or the queue never merges anything -- a check that
+  # simply does not run is indistinguishable from one still pending, and it
+  # blocks the queue forever rather than failing loudly.
+  merge_group:
 
 # Read-only: this job only inspects commit metadata already in the PR, it
 # never needs to write anything.
@@ -46,6 +51,11 @@ jobs:
           # entirely — a skipped/never-run required check blocks merge
           # exactly as much as a failed one ("Expected — waiting for status").
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          # merge_group carries no pull_request payload. The merge group has
+          # its own base/head, and they bracket exactly the commits about to
+          # land, so the same sign-off check applies unchanged.
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: |
           case "$PR_AUTHOR" in
             'dependabot[bot]'|'app/dependabot')
@@ -54,8 +64,8 @@ jobs:
               ;;
           esac
 
-          base="${{ github.event.pull_request.base.sha }}"
-          head="${{ github.event.pull_request.head.sha }}"
+          base="$BASE_SHA"
+          head="$HEAD_SHA"
           fail=0
           for sha in $(git rev-list --no-merges "$base..$head"); do
             author_email="$(git log -1 --format=%ae "$sha")"

--- a/.github/workflows/security-fix-regression-test.yml
+++ b/.github/workflows/security-fix-regression-test.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     # See ci.yml's own comment: also covers stacked-PR review chains.
     branches: [main, 'adr082/**', 'feat/**', 'fix/**']
+  # Merge queue. Every REQUIRED status check must also report on the
+  # merge_group event or the queue never merges anything -- a check that
+  # simply does not run is indistinguishable from one still pending, and it
+  # blocks the queue forever rather than failing loudly.
+  merge_group:
 
 # Read-only: this job only inspects PR metadata and the diff already in the
 # PR, it never needs to write anything.
@@ -43,6 +48,17 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+          # This gate keys off the PR TITLE convention, and merge_group has no
+          # pull_request payload to read one from. Skip explicitly and say so,
+          # rather than letting an empty PR_TITLE fall through the case below
+          # and report a pass that looks like it checked something. The gate
+          # already ran on the pull request itself, and a merge group cannot
+          # change a PR title.
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "merge_group: no PR title to read; this check ran on the PR itself."
+            exit 0
+          fi
+
           case "$PR_TITLE" in
             'fix(security):'*) ;;
             *)


### PR DESCRIPTION
Prerequisite for turning on the merge queue. **No behaviour changes on `pull_request` or `push`.**

A merge queue reuses branch protection's required status checks against the merge group, so every required check must also fire on `merge_group`. `dco.yml` already states the principle: *"a skipped/never-run required check blocks merge exactly as much as a failed one."* In a queue that's worse than a failure — it waits forever instead of reporting.

## The 16 required contexts

| workflow | required checks |
|---|---|
| `ci.yml` | adr-numbers, assert-leg-completeness, base-branch-check, build-and-test, exclusion-freshness, gitleaks, helm-chart, helm-chart-security, licenses, lint, operator, pnpm-workspace-root-guard, workflow-lint |
| `codeql.yml` | Analyze (server), Analyze (operator) |
| `dco.yml`, `security-fix-regression-test.yml` | check |

All four get the trigger. **Three needed nothing else:**

- `ci.yml` and `codeql.yml`'s `changes` jobs already branch on `github.event_name != 'pull_request'` and emit all-false — so a merge group runs the *full* matrix and analysis, not a gated subset. Correct for the commit actually about to land.
- `base-branch-check` already has `if: github.event_name == 'pull_request'`. It skips on merge_group, and a skipped job still reports a check-run branch protection accepts — the same property `ci.yml`'s docs_only gating relies on. Its subject has no meaning in a merge group anyway.

**Two needed real handling:**

- `dco.yml` read `github.event.pull_request.{base,head}.sha`, empty on merge_group. Both now fall back to `github.event.merge_group.{base,head}_sha`, which bracket exactly the commits about to land — so the sign-off check stays *unchanged*, not merely quiet.
- `security-fix-regression-test.yml` keys off the PR **title** convention, and a merge group has none. An empty `PR_TITLE` would have fallen through its `case` and reported a pass that looks like it checked something. It now skips explicitly and says why.

## Enabling it

The queue itself is a branch-protection setting, deliberately left to a separate step so this lands and can be observed first: **Settings → Branches → `main` → Require merge queue.**

**Rollback is instant:** if the queue ever stalls, turn it off in branch protection and normal merges resume. Nothing in this PR has to be reverted.

`actionlint` clean on all four workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAULgwpMpdNJbHUg8q5RfN