### PR TITLE
test: lower bcrypt cost in server/http and internal/core TestMain

### DIFF
--- a/internal/core/sharing_test.go
+++ b/internal/core/sharing_test.go
@@ -12,12 +12,21 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestMain(m *testing.M) {
 	if err := i18n.InitializeForTesting(); err != nil {
 		panic("failed to initialize i18n for tests: " + err.Error())
 	}
+	// bcrypt_cost.go's own doc comment asks for exactly this: "Production
+	// default is 12. Tests should call SetBcryptCostForTesting(bcrypt.MinCost)
+	// in TestMain to avoid slowing down the test suite." Until now only
+	// server/http/handlers did. Cost 12 is 2^8 = 256x the work of MinCost, and
+	// this package hashes on every user create, password change and SCIM
+	// provision -- plus once per failed-login test, because auth.go hashes
+	// dummyBcryptHash as a timing equaliser on the user-not-found path.
+	SetBcryptCostForTesting(bcrypt.MinCost)
 	os.Exit(m.Run())
 }
 

--- a/server/http/main_test.go
+++ b/server/http/main_test.go
@@ -1,0 +1,32 @@
+package http
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+)
+
+// TestMain exists solely to lower the bcrypt work factor for this package's
+// tests. internal/core/bcrypt_cost.go asks for it directly: "Production
+// default is 12. Tests should call SetBcryptCostForTesting(bcrypt.MinCost) in
+// TestMain to avoid slowing down the test suite." server/http/handlers/
+// main_test.go already did; this package had no TestMain at all.
+//
+// It matters more here than anywhere else. Cost 12 is 2^8 = 256x the work of
+// MinCost, and server/http carries 182 Password: fields across its tests
+// (against 55 in handlers) plus 137 auth call sites -- and every FAILED-login
+// test also pays a full hash, because auth.go hashes dummyBcryptHash as a
+// timing equaliser on the user-not-found path so /auth/login cannot be used
+// as a username-existence oracle.
+//
+// The mechanism is race-safe by construction: bcryptCost is an atomic.Int32
+// specifically because SetBcryptCostForTesting is exported and nothing
+// enforces its "call before any test runs" contract (#G63). Calling it here,
+// before m.Run(), is the contract being honoured rather than relied upon.
+func TestMain(m *testing.M) {
+	core.SetBcryptCostForTesting(bcrypt.MinCost)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
`internal/core/bcrypt_cost.go` has asked for this since it was written — *"Production default is 12. Tests should call `SetBcryptCostForTesting(bcrypt.MinCost)` in TestMain to avoid slowing down the test suite."* Only `server/http/handlers` ever did.

## Measured, back-to-back, same machine and flags

`go test -covermode=set -coverprofile`, no `-race`:

| package | before | after | delta |
|---|---|---|---|
| **`server/http`** | **392.580s** | **69.327s** | **−82.3%** |
| `internal/core` | 45.884s | 47.320s | none (noise) |
| total | 6m42.6s | **1m20.5s** | |

**A 5.7x speedup on `server/http` from two lines.** Cost 12 is 2⁸ = 256x the work of `MinCost`, and this package carries 182 `Password:` fields across its tests (against 55 in handlers) plus 137 auth call sites — and every *failed*-login test pays a full hash too, because `auth.go` hashes `dummyBcryptHash` as a timing equaliser so `/auth/login` can't be used as a username-existence oracle.

## Honest about the half that did nothing

`internal/core` measured **no change** — its tests overwhelmingly use `MockStorage` rather than hashing for real. The line is kept because it's what `bcrypt_cost.go` instructs, costs nothing measurable, and without it a future core test that hashes for real silently reintroduces cost 12. Stated plainly so the zero isn't mistaken for a win — happy to drop it if you'd rather keep the diff minimal.

`internal/storage/store` was in the original plan and is **not** included: it doesn't import `internal/core` (verified via `go list -deps`) and has no bcrypt calls at all.

## Risk checked

No test in either package asserts the production cost is 12, and none measures login timing in a way this affects. Two tests generate hashes at `bcrypt.DefaultCost` directly (`webauthn_spec_vectors_test.go`, `mfa_test.go`) — independent of `bcryptCost`, unchanged. Race-safe by construction: `bcryptCost` is an `atomic.Int32` precisely because `SetBcryptCostForTesting` is exported with an unenforced "call before any test runs" contract (#G63); calling it in `TestMain` before `m.Run()` honours that contract.

## Follow-on

This collapses `server/http`'s variable work almost to nothing, which changes the sharding maths. Run 34345617638 put the http group at ~8.2m fixed cost per leg against ~41.5m of test work across 8 legs. With the work cut ~82%, those 8 legs would spend **~65 minutes of fixed cost to run ~7.5 minutes of tests**. Sharding `server/http` 8 ways stops making sense once this lands — and compile-once-run-many becomes the only lever left that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAULgwpMpdNJbHUg8q5RfN