### PR TITLE
fix(encryption): make absolute dek_path/salt_path bootable

### DIFF
--- a/internal/encryption/absolute_key_paths_test.go
+++ b/internal/encryption/absolute_key_paths_test.go
@@ -1,0 +1,99 @@
+// absolute_key_paths_test.go — regression tests for the absolute dek_path /
+// salt_path boot failure fixed in normalizeKeyPaths.
+//
+// Before the fix, server/main.go set baseDir="" whenever DEKPath was absolute,
+// intending "self-contained path, no base-dir restriction". No internal/
+// securefiles primitive implements that convention, so first-boot key
+// generation failed on every start with
+//
+//	failed to write wrapped DEK: access denied: file %q is outside of ""
+//
+// meaning no deployment configuring an absolute key path could ever boot. It
+// went unnoticed because nothing in the test suite used an absolute key path;
+// the DAST workflow (/tmp/keyorix-dast.dek) was the only caller that did, and
+// it is push-triggered on main rather than a PR-blocking check.
+package encryption
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The case that was broken: absolute paths in a shared directory must boot.
+func TestNewKeyManager_AbsolutePaths_FirstBootSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager("", filepath.Join(dir, "keyorix.dek"), filepath.Join(dir, "keyorix.salt"))
+
+	require.NoError(t, km.configErr, "absolute key paths in one directory must be accepted")
+	require.NoError(t, km.Initialize("correct horse battery staple"),
+		"first-boot key generation must succeed with absolute key paths")
+
+	assert.Equal(t, dir, km.baseDir, "base dir should become the keys' directory")
+	assert.Equal(t, "keyorix.dek", km.dekPath, "dek path should be reduced to its base name")
+	assert.Equal(t, "keyorix.salt", km.saltPath, "salt path should be reduced to its base name")
+	assert.FileExists(t, filepath.Join(dir, "keyorix.dek"))
+	assert.FileExists(t, filepath.Join(dir, "keyorix.salt"))
+}
+
+// Guards the trap in the obvious fix. Splitting a RELATIVE path into Dir/Base
+// would convert a traversal rejection into an accepted escape: "../../etc/x" is
+// refused today because safeRelComponents rejects the ".." component, but as
+// (base="../../etc", name="x") both containment checks pass. Only absolute
+// paths may be rewritten — this test fails if that ever changes.
+func TestNewKeyManager_RelativePaths_LeftUnchangedAndStillContained(t *testing.T) {
+	km := NewKeyManager(t.TempDir(), "../../etc/evil.dek", "../../etc/evil.salt")
+	require.NoError(t, km.configErr, "relative paths are not a construction-time error")
+
+	assert.Equal(t, "../../etc/evil.dek", km.dekPath, "a relative path must not be rewritten")
+	assert.Equal(t, "../../etc/evil.salt", km.saltPath, "a relative path must not be rewritten")
+
+	err := km.Initialize("correct horse battery staple")
+	require.Error(t, err, "a relative key path escaping the base dir must still be refused")
+	assert.Contains(t, err.Error(), "access denied")
+}
+
+// An ordinary relative configuration keeps working exactly as before.
+func TestNewKeyManager_RelativePaths_UnderBaseDirStillBoot(t *testing.T) {
+	dir := t.TempDir()
+	km := NewKeyManager(dir, "dek.key", "kek.salt")
+	require.NoError(t, km.configErr)
+	require.NoError(t, km.Initialize("correct horse battery staple"))
+	assert.Equal(t, dir, km.baseDir)
+	assert.FileExists(t, filepath.Join(dir, "dek.key"))
+}
+
+// baseDir is the join root for the DEK lock, the server lock and the .pending
+// rotation siblings as well as the two key files, so two absolute paths in
+// different directories have no single correct base. Refused loudly rather than
+// guessed at.
+func TestNewKeyManager_AbsolutePathsInDifferentDirs_Refused(t *testing.T) {
+	km := NewKeyManager("", filepath.Join(t.TempDir(), "a.dek"), filepath.Join(t.TempDir(), "b.salt"))
+
+	require.Error(t, km.configErr)
+	assert.Contains(t, km.configErr.Error(), "same directory")
+	assert.Error(t, km.Initialize("correct horse battery staple"),
+		"Initialize must surface the construction error rather than proceed")
+}
+
+func TestNewKeyManager_MixedAbsoluteAndRelative_Refused(t *testing.T) {
+	for _, tc := range []struct{ name, dek, salt string }{
+		{"abs dek, rel salt", filepath.Join(t.TempDir(), "a.dek"), "kek.salt"},
+		{"rel dek, abs salt", "dek.key", filepath.Join(t.TempDir(), "b.salt")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			km := NewKeyManager(t.TempDir(), tc.dek, tc.salt)
+			require.Error(t, km.configErr)
+			assert.Contains(t, km.configErr.Error(), "both be absolute or both be relative")
+		})
+	}
+}
+
+// An unset path means "not configured" (keyfiles.Registry skips empty entries),
+// so it must not be mistaken for the relative half of a mixed pair.
+func TestNewKeyManager_EmptyPath_NotTreatedAsMixed(t *testing.T) {
+	km := NewKeyManager(t.TempDir(), filepath.Join(t.TempDir(), "a.dek"), "")
+	assert.NoError(t, km.configErr)
+}

--- a/internal/encryption/keymanager_lifecycle.go
+++ b/internal/encryption/keymanager_lifecycle.go
@@ -39,9 +39,15 @@ import (
 
 // KeyManager handles key lifecycle and storage.
 type KeyManager struct {
-	dekPath    string
-	saltPath   string
-	baseDir    string
+	dekPath  string
+	saltPath string
+	baseDir  string
+	// configErr records a key-path configuration that cannot be honoured,
+	// detected at construction. NewKeyManager cannot return an error (it is
+	// called from NewService, which cannot either, from seven call sites), so
+	// the error is held here and returned by Initialize -- the first method
+	// that touches a key file, and the one whose failure stops a boot.
+	configErr  error
 	currentDEK []byte
 	// dekSnapshot is the raw wrapped-DEK bytes read from disk at the moment
 	// currentDEK was last set (Initialize/RotateDEKWithSweep). It
@@ -189,12 +195,104 @@ type KeyInfo struct {
 
 // NewKeyManager creates a new KeyManager.
 func NewKeyManager(baseDir, dekPath, saltPath string) *KeyManager {
+	base, dek, salt, err := normalizeKeyPaths(baseDir, dekPath, saltPath)
 	return &KeyManager{
-		dekPath:    dekPath,
-		saltPath:   saltPath,
-		baseDir:    baseDir,
+		dekPath:    dek,
+		saltPath:   salt,
+		baseDir:    base,
 		keyVersion: "v1",
+		configErr:  err,
 	}
+}
+
+// normalizeKeyPaths reconciles a configured (baseDir, dekPath, saltPath) with
+// what internal/securefiles actually accepts: a base directory plus a path
+// RELATIVE to it. securefiles.safeRelComponents rejects any absolute path
+// outright ("must be relative"), and isPathInsideBase resolves an empty base
+// via filepath.Abs("") -- the process working directory -- so an absolute key
+// path was refused as "outside" it.
+//
+// That made an absolute dek_path/salt_path impossible to boot with: server/
+// main.go set baseDir="" for absolute paths intending "self-contained, no
+// base-dir restriction", but no securefiles primitive implements that
+// convention. First-boot key generation failed with
+//
+//	failed to write wrapped DEK: access denied: file %q is outside of ""
+//
+// on every start. (Found via the DAST workflow, which configures
+// /tmp/keyorix-dast.dek and had failed on every run for ~19 hours.)
+//
+// The convention applied here -- absolute wins, relative resolves under
+// baseDir -- is the one this codebase already uses in two other places:
+// internal/keyfiles/registry.go's resolve() and internal/startup's
+// resolveKeyPath(). internal/encryption is the component that never got it.
+//
+// Three rules, and the reasoning for each:
+//
+//   - Both paths relative: returned UNCHANGED. This is deliberate and load
+//     bearing. Splitting a relative path into Dir/Base would turn a rejection
+//     into an escape: dek_path "../../etc/x" is refused today because
+//     safeRelComponents rejects the ".." component, but as
+//     (base="../../etc", name="x") both checks would pass. Only absolute
+//     paths are rewritten.
+//
+//   - Both absolute and sharing a directory: reduced to that directory plus
+//     the two base names. baseDir is the join root for more than these two
+//     files -- the DEK lock (keymanager_filelock.go), the ".pending" siblings
+//     (keymanager_kek_rotation.go, keymanager_rewrap.go, keymanager_rotation.go)
+//     and the server lock (exclusive_lock.go) all hang off it -- so keeping a
+//     single base directory leaves every one of those join sites working
+//     unchanged, with locks and pending files landing beside the keys where an
+//     operator expects them.
+//
+//   - Anything else (one absolute and one relative, or two absolute paths in
+//     different directories): refused with a clear error rather than guessed
+//     at. Supporting split directories would mean inventing a placement rule
+//     for the lock and .pending files that no caller has asked for; a loud
+//     refusal is the honest answer until one does.
+//
+// Containment is not weakened by the rewrite. The property that actually
+// defends key material is SecureOpenBeneath's per-component O_NOFOLLOW walk,
+// which still refuses a symlink planted anywhere in the key directory. The
+// base-directory check only ever guarded against traversal inside a RELATIVE
+// configured value, and that path is untouched. An operator who writes an
+// absolute dek_path has chosen that directory explicitly.
+//
+// An empty path is left alone: it means "not configured", and
+// keyfiles.Registry already skips empty entries.
+func normalizeKeyPaths(baseDir, dekPath, saltPath string) (string, string, string, error) {
+	dekAbs := filepath.IsAbs(dekPath)
+	saltAbs := filepath.IsAbs(saltPath)
+
+	if dekPath == "" || saltPath == "" || (!dekAbs && !saltAbs) {
+		return baseDir, dekPath, saltPath, nil
+	}
+
+	if dekAbs != saltAbs {
+		return baseDir, dekPath, saltPath, fmt.Errorf(
+			"encryption key paths must both be absolute or both be relative: "+
+				"dek_path %q is %s but salt_path %q is %s",
+			dekPath, absOrRel(dekAbs), saltPath, absOrRel(saltAbs))
+	}
+
+	dekDir := filepath.Dir(filepath.Clean(dekPath))
+	saltDir := filepath.Dir(filepath.Clean(saltPath))
+	if dekDir != saltDir {
+		return baseDir, dekPath, saltPath, fmt.Errorf(
+			"absolute encryption key paths must live in the same directory "+
+				"(the DEK lock, the server lock and the .pending rotation files are all "+
+				"placed alongside them): dek_path is in %q but salt_path is in %q",
+			dekDir, saltDir)
+	}
+
+	return dekDir, filepath.Base(dekPath), filepath.Base(saltPath), nil
+}
+
+func absOrRel(abs bool) string {
+	if abs {
+		return "absolute"
+	}
+	return "relative"
 }
 
 // Initialize sets up the key manager.
@@ -203,6 +301,13 @@ func NewKeyManager(baseDir, dekPath, saltPath string) *KeyManager {
 func (km *KeyManager) Initialize(passphrase string) error {
 	km.mu.Lock()
 	defer km.mu.Unlock()
+
+	// A key-path configuration NewKeyManager could not honour. Reported here
+	// because this is the first method to touch a key file, so a bad config
+	// stops the boot rather than surfacing later as a confusing I/O error.
+	if km.configErr != nil {
+		return km.configErr
+	}
 
 	kek, err := km.deriveKEK(passphrase)
 	if err != nil {

--- a/server/main.go
+++ b/server/main.go
@@ -315,10 +315,19 @@ func initializeEncryption(cfg *config.Config, auditSink encryption.AuditSink) (*
 		passphrase = string(passphraseBytes)
 	}
 
-	baseDir := ""
-	if !filepath.IsAbs(cfg.Storage.Encryption.DEKPath) {
-		baseDir = "."
-	}
+	// Always ".". An absolute dek_path/salt_path is reconciled by
+	// NewKeyManager (normalizeKeyPaths), which is where every other
+	// encryption.NewService caller benefits from it too -- the six CLI call
+	// sites included, so `keyorix encryption ...` can operate on the same key
+	// files this server just created.
+	//
+	// This previously set baseDir="" for an absolute DEKPath, meaning "the
+	// path is self-contained, no base-dir restriction". No securefiles
+	// primitive implements that convention: isPathInsideBase resolves "" to
+	// the working directory and rejected the key file as outside it, so a
+	// deployment configuring an absolute key path could never complete
+	// first-boot key generation.
+	baseDir := "."
 	svc := encryption.NewService(&cfg.Storage.Encryption, baseDir)
 	if auditSink != nil {
 		svc.SetAuditSink(auditSink)


### PR DESCRIPTION
An absolute `dek_path` or `salt_path` could never complete first-boot key generation. The DAST workflow has failed on **every run for ~19 hours** (15 consecutive; first bad run 2026-09-08 21:03, predating today's merges):

```
failed to initialize core service: failed to initialize encryption:
failed to write wrapped DEK: access denied: file "/tmp/keyorix-dast.dek" is outside of ""
```

## Root cause

`server/main.go` set `baseDir=""` whenever `DEKPath` was absolute, intending *"the path is self-contained, no base-dir restriction"*. **No `internal/securefiles` primitive implements that convention:**

- `isPathInsideBase` resolves `""` through `filepath.Abs("")` — the process working directory — then rejects any absolute path outside it. Hence the literal `outside of ""`.
- `safeRelComponents`, reached by every actual open via `SecureOpenBeneath`, rejects absolute paths unconditionally (`"must be relative"`) — so it would have failed one layer down even if containment passed.

It was never going to work, so no deployment can be relying on it.

**The convention already exists in this codebase, twice** — `internal/keyfiles/registry.go`'s `resolve()` and `internal/startup`'s `resolveKeyPath()` both do "absolute wins, relative resolves under baseDir". `internal/encryption` is the one component that never got it; its own registry comment even warns `filepath.Join` isn't equivalent for absolute paths, and `keymanager_io.go` joins anyway.

## Where it's fixed, and why not in server/main.go

In `NewKeyManager`. There are **seven** `encryption.NewService` call sites, six of them CLI — fixing only the server would let it create keys at an absolute path that `keyorix encryption ...` then could not read.

## Three rules

- **Both relative → returned UNCHANGED.** Load bearing, not laziness. Splitting a relative path into `Dir`/`Base` converts a rejection into an escape: `../../etc/x` is refused today because `safeRelComponents` rejects `..`, but as `(base="../../etc", name="x")` both checks pass. Only absolute paths are rewritten, and a test asserts it.
- **Both absolute, same directory → reduced to that dir + two base names.** `baseDir` is the join root for more than the key files: the DEK lock, the `.pending` rotation siblings, and the server lock all hang off it. One base directory keeps every join site working, with locks and pending files beside the keys.
- **Anything else → refused with a clear error.** Split directories would mean inventing a placement rule for the lock and `.pending` files that no caller has asked for.

`NewKeyManager` can't return an error (nor can `NewService`), so the config error is held on the struct and returned by `Initialize` — the first method that touches a key file, and the one whose failure stops a boot.

## Security

**Containment is not weakened.** What actually defends key material is `SecureOpenBeneath`'s per-component `O_NOFOLLOW` walk, which still refuses a symlink planted anywhere in the key directory. The base-directory check only ever guarded traversal inside a *relative* configured value, and that path is untouched. An operator writing an absolute `dek_path` chose that directory explicitly.

## Verification

Six regression tests — **verified to fail without the fix.** Neutering `normalizeKeyPaths` to a passthrough reproduces the production error exactly:

```
failed to write salt: access denied: file ".../keyorix.salt" is outside of ""
```

(salt first, because `ensureSaltExists` runs before `ensureWrappedDEKExists`.)

`go test -race`, all green: `internal/encryption` 194.3s · `internal/keyfiles` 1.9s · `internal/startup` 1.5s · `internal/cli/encryption` 133.4s · `internal/cli/common` 13.7s.

## Why it survived

Nothing in the test suite used an absolute key path. DAST was the only caller that did, and it's push-triggered on main rather than a PR-blocking check — so it failed unattended for 19 hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAULgwpMpdNJbHUg8q5RfN
