### PR TITLE
feat(conformance): tranche 4 of the RemoteStorage differential harness (#1808)

### DIFF
--- a/server/http/remote_storage_conformance_tranche4_auth_security_test.go
+++ b/server/http/remote_storage_conformance_tranche4_auth_security_test.go
@@ -1,0 +1,1175 @@
+// remote_storage_conformance_tranche4_auth_security_test.go — issue #1808,
+// tranche 4: the authentication/second-factor cluster tranche 3 explicitly
+// flagged as HIGH priority and deliberately deferred (WebAuthn, TOTP MFA, MFA
+// step-up grants, SSO login state, the password/MFA login-verification proxy,
+// and the cluster-wide login-attempt rate limiter).
+//
+// Two methods here have NO LocalStorage equivalent to compare against:
+// VerifyLoginCredentials (remote_login_verify.go) and VerifyMFALoginCredentials
+// (remote_mfa.go) both implement a core.RemoteLoginVerifier/RemoteMFAVerifier
+// interface that LocalStorage never needs to satisfy — a LocalStorage-backed
+// core does the ENTIRE check in-process (core.Login/core.VerifyPasswordCredentials,
+// core.VerifyMFACredentials) and never proxies anything. For these two, the
+// "local" side of the differential is the core-level function the upstream
+// server's OWN handler calls for the real HTTP request (confirmed against
+// server/http/handlers/users_crud.go's VerifyCredentials/VerifyMFACredentials
+// doc comments), exercised directly against h.upstreamCore — not h.ls. Every
+// other method in this file has a real LocalStorage primitive and follows the
+// established h.ls vs h.rs shape.
+//
+// MFA enrolment fixtures use the SAME real path internal/core/mfa_test.go's own
+// TestMFA_FullFlow uses: h.upstreamCore.BeginMFAEnrollment + ActivateMFA against
+// a real bcrypt password and a real (encryption-enabled) TOTP secret, with
+// codes generated via github.com/pquerna/otp/totp against the wall clock
+// (validateTOTPStep tolerates the adjacent +-1 step, i.e. a ~90s window, so
+// generating a code immediately before use is not flaky in practice) — not a
+// shortcut, per the task brief's explicit instruction to use the codebase's own
+// enrollment patterns rather than inventing one.
+//
+// GetMFASecret's comparison deliberately does NOT run SecretEnc/SecretMeta
+// through assertFieldExhaustiveEqual (whose failure path prints %#v of both
+// structs): even though this is ciphertext, not the raw TOTP secret, targeted
+// bytes.Equal/len comparisons prove the same wire fidelity without ever
+// printing the ciphertext bytes into a test failure message.
+package http
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/config"
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/encryption"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// conformanceSHA256Hex mirrors core's own (unexported) sha256Hex — MFA/WebAuthn
+// challenge and session tokens are stored only as a hash, and this file needs
+// to resolve a plaintext token it minted back to its stored row via LocalStorage
+// read primitives that key on the hash, exactly like the real callers do.
+func conformanceSHA256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// enableMFAEncryption wires a real, enabled encryption.Service onto
+// h.upstreamCore — BeginMFAEnrollment refuses outright ("requires at-rest
+// encryption to be enabled") without one, and newConformanceHarness's own
+// newTestCore never wires one (no test up to this tranche has needed MFA
+// enrolment). Mirrors internal/core/mfa_test.go's newMFATestCore setup exactly.
+func enableMFAEncryption(t *testing.T, h *conformanceHarness) {
+	t.Helper()
+	enc := encryption.NewService(&config.EncryptionConfig{
+		Enabled: true, DEKPath: "conformance-dek.key", SaltPath: "conformance-kek.salt",
+	}, t.TempDir())
+	require.NoError(t, enc.Initialize("conformance-test-passphrase"))
+	h.upstreamCore.SetAuthEncryptor(enc)
+}
+
+// Deliberately unrelated to any username/email/display-name word used by this
+// file's fixtures: internal/core/password_policy.go's containsPersonalInfo
+// rejects a password containing ANY 3+ char word of the display name
+// case-insensitively, and every fixture in this file names its user
+// "Conformance <Method> <suffix>" -- a password built from those same words
+// (e.g. containing "conformance") fails CreateUser with a validation error.
+// ensureMFAStepUpGrantTable AutoMigrates models.MFAStepUpGrant onto the
+// harness's underlying DB. models.AllTestModels() (internal/storage/models/all_models.go,
+// the single source of truth newConformanceHarness's newTestCore AutoMigrates)
+// does not include MFAStepUpGrant -- no test up to this tranche has needed the
+// table, so the omission was never exercised. Fixed here, scoped to this file's
+// own tests only, rather than editing that shared list (out of scope for this
+// task's "one new file" constraint); the real fix belongs in all_models.go.
+func ensureMFAStepUpGrantTable(t *testing.T, h *conformanceHarness) {
+	t.Helper()
+	require.NoError(t, h.ls.DB().AutoMigrate(&models.MFAStepUpGrant{}))
+}
+
+const conformanceMFAPassword = "Xk9#Tq2Lm7@Wp4Rb!"
+
+// enrollMFA creates a real user and fully enrolls + activates real TOTP MFA for
+// them via h.upstreamCore (in-process, real bcrypt password, real encrypted
+// secret) — the exact BeginMFAEnrollment/ActivateMFA sequence
+// internal/core/mfa_test.go's TestMFA_FullFlow uses. Returns the user and the
+// base32 TOTP secret (needed to generate valid codes in tests).
+func enrollMFA(t *testing.T, h *conformanceHarness, ctx context.Context, username string) (*models.User, string) {
+	t.Helper()
+	user, err := h.upstreamCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: username, Email: username + "@example.com", DisplayName: "Conformance MFA " + username,
+		Password: conformanceMFAPassword,
+	})
+	require.NoError(t, err)
+	_, secret, err := h.upstreamCore.BeginMFAEnrollment(ctx, user.ID)
+	require.NoError(t, err)
+	// Activate using the PREVIOUS time-step (mirrors internal/core/mfa_test.go's
+	// TestMFA_FullFlow exactly): validateTOTPStep's anti-replay (MarkTOTPStepUsed)
+	// burns whichever step the activation code resolves to, so activating with the
+	// CURRENT step would leave a caller-generated login code for "now" looking like
+	// a replay of the very code that just activated MFA, a few milliseconds later
+	// in the same 30s window.
+	code, err := totp.GenerateCode(secret, time.Now().Add(-30*time.Second))
+	require.NoError(t, err)
+	_, err = h.upstreamCore.ActivateMFA(ctx, user.ID, code, conformanceMFAPassword)
+	require.NoError(t, err)
+	return user, secret
+}
+
+// --- CreateWebAuthnSession ---
+
+func TestConformance_CreateWebAuthnSession(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-cwas-" + suffix, Email: "conformance-cwas-" + suffix + "@example.com",
+			DisplayName: "Conformance CreateWebAuthnSession " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	expiresAt := time.Now().Add(5 * time.Minute).UTC().Truncate(time.Second)
+
+	localUser := newUser("local")
+	localSession := &models.WebAuthnSession{
+		UserID: localUser.ID, TokenHash: "conformance-cwas-hash-local", Purpose: "login",
+		Data: []byte(`{"challenge":"local"}`), ExpiresAt: expiresAt, CreatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, h.ls.CreateWebAuthnSession(ctx, localSession))
+	require.NotZero(t, localSession.ID, "sanity: LocalStorage.CreateWebAuthnSession must assign an ID")
+
+	remoteUser := newUser("remote")
+	remoteSession := &models.WebAuthnSession{
+		UserID: remoteUser.ID, TokenHash: "conformance-cwas-hash-remote", Purpose: "login",
+		Data: []byte(`{"challenge":"remote"}`), ExpiresAt: expiresAt, CreatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, h.rs.CreateWebAuthnSession(ctx, remoteSession), "RemoteStorage.CreateWebAuthnSession must succeed")
+	require.NotZero(t, remoteSession.ID, "the server-assigned ID must be copied back onto the caller's struct, not left zero")
+
+	// Read back through the SAME LocalStorage instance the router wraps -- proves the
+	// session actually landed server-side, not just that the client-side struct was
+	// echoed back unmodified. ConsumeWebAuthnSession is the only read primitive
+	// available (there is no non-consuming getter), so this necessarily also
+	// exercises the single-use consume -- fine, since this fixture is dedicated to it.
+	now := time.Now().UTC()
+	localConsumed, err := h.ls.ConsumeWebAuthnSession(ctx, "conformance-cwas-hash-local", now)
+	require.NoError(t, err, "sanity: the local session must be consumable")
+	remoteConsumed, err := h.ls.ConsumeWebAuthnSession(ctx, "conformance-cwas-hash-remote", now)
+	require.NoError(t, err,
+		"the session created via RemoteStorage must actually exist server-side with a valid, unexpired, unused "+
+			"row -- not just report success")
+
+	exclude := map[string]bool{"UsedAt": true} // stamped by the consume READ itself, not by Create
+	assertFieldExhaustiveEqual(t, "LocalStorage.CreateWebAuthnSession (sanity baseline)", localSession, localConsumed, exclude)
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateWebAuthnSession (wire round trip)", remoteSession, remoteConsumed, exclude)
+}
+
+// --- ConsumeWebAuthnSession ---
+
+func TestConformance_ConsumeWebAuthnSession(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-cws-" + suffix, Email: "conformance-cws-" + suffix + "@example.com",
+			DisplayName: "Conformance ConsumeWebAuthnSession " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+	newSession := func(userID uint, suffix string, expiresAt time.Time) string {
+		tokenHash := "conformance-cws-hash-" + suffix
+		require.NoError(t, h.ls.CreateWebAuthnSession(ctx, &models.WebAuthnSession{
+			UserID: userID, TokenHash: tokenHash, Purpose: "login",
+			Data: []byte(`{"challenge":"x"}`), ExpiresAt: expiresAt, CreatedAt: time.Now().UTC(),
+		}))
+		return tokenHash
+	}
+
+	now := time.Now().UTC()
+
+	localUser := newUser("local")
+	localHash := newSession(localUser.ID, "local", now.Add(5*time.Minute))
+	localConsumed, err := h.ls.ConsumeWebAuthnSession(ctx, localHash, now)
+	require.NoError(t, err)
+	assert.Equal(t, localUser.ID, localConsumed.UserID)
+	assert.NotNil(t, localConsumed.UsedAt)
+	_, err = h.ls.ConsumeWebAuthnSession(ctx, localHash, now)
+	assert.Error(t, err, "sanity: a consumed session must not be consumable twice")
+
+	remoteUser := newUser("remote")
+	remoteHash := newSession(remoteUser.ID, "remote", now.Add(5*time.Minute))
+	remoteConsumed, err := h.rs.ConsumeWebAuthnSession(ctx, remoteHash, now)
+	require.NoError(t, err, "RemoteStorage.ConsumeWebAuthnSession must succeed for a valid, unexpired, unused session")
+	assert.Equal(t, remoteUser.ID, remoteConsumed.UserID)
+	assert.NotNil(t, remoteConsumed.UsedAt, "the session must actually be marked used server-side")
+	_, err = h.rs.ConsumeWebAuthnSession(ctx, remoteHash, now)
+	assert.Error(t, err, "RemoteStorage.ConsumeWebAuthnSession must refuse a second consume of an already-used "+
+		"session -- single-use must hold across the wire too")
+
+	expiredUser := newUser("expired")
+	expiredHash := newSession(expiredUser.ID, "expired", now.Add(-time.Minute))
+	_, err = h.rs.ConsumeWebAuthnSession(ctx, expiredHash, now)
+	assert.Error(t, err, "RemoteStorage.ConsumeWebAuthnSession must refuse an expired session, even though it was never consumed")
+}
+
+// --- ListWebAuthnCredentials ---
+
+func TestConformance_ListWebAuthnCredentials(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-lwac-" + suffix, Email: "conformance-lwac-" + suffix + "@example.com",
+			DisplayName: "Conformance ListWebAuthnCredentials " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+	newCred := func(userID uint, suffix string) *models.WebAuthnCredential {
+		cred := &models.WebAuthnCredential{
+			UserID: userID, CredentialID: []byte("conformance-lwac-credid-" + suffix),
+			Name: "cred-" + suffix, CredentialBlob: []byte(`{"id":"` + suffix + `"}`), CreatedAt: time.Now().UTC(),
+		}
+		require.NoError(t, h.ls.CreateWebAuthnCredential(ctx, cred))
+		return cred
+	}
+
+	localUser := newUser("local")
+	newCred(localUser.ID, "local-1")
+	newCred(localUser.ID, "local-2")
+	localList, err := h.ls.ListWebAuthnCredentials(ctx, localUser.ID)
+	require.NoError(t, err)
+	assert.Len(t, localList, 2, "sanity: both of the local user's credentials must be listed")
+
+	remoteUser := newUser("remote")
+	newCred(remoteUser.ID, "remote-1")
+	newCred(remoteUser.ID, "remote-2")
+	bystander := newUser("bystander")
+	newCred(bystander.ID, "bystander")
+
+	remoteList, err := h.rs.ListWebAuthnCredentials(ctx, remoteUser.ID)
+	require.NoError(t, err, "RemoteStorage.ListWebAuthnCredentials must succeed")
+	require.Len(t, remoteList, 2, "must return exactly the caller's own two credentials -- a bystander's credential "+
+		"leaking in (or the caller's own being dropped) would both be scope-drop defects")
+
+	for _, got := range remoteList {
+		want, err := h.ls.GetWebAuthnCredentialByCredID(ctx, got.CredentialID, remoteUser.ID)
+		require.NoError(t, err)
+		assertFieldExhaustiveEqual(t, "RemoteStorage.ListWebAuthnCredentials (wire fidelity)", want, got, nil)
+	}
+}
+
+// --- GetWebAuthnCredentialByCredID ---
+
+func TestConformance_GetWebAuthnCredentialByCredID(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-gwaci-" + suffix, Email: "conformance-gwaci-" + suffix + "@example.com",
+			DisplayName: "Conformance GetWebAuthnCredentialByCredID " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+	newCred := func(userID uint, suffix string) *models.WebAuthnCredential {
+		cred := &models.WebAuthnCredential{
+			UserID: userID, CredentialID: []byte("conformance-gwaci-credid-" + suffix),
+			Name: "cred-" + suffix, CredentialBlob: []byte(`{"id":"` + suffix + `"}`), CreatedAt: time.Now().UTC(),
+		}
+		require.NoError(t, h.ls.CreateWebAuthnCredential(ctx, cred))
+		return cred
+	}
+
+	localUser := newUser("local")
+	localCred := newCred(localUser.ID, "local")
+	localGot, err := h.ls.GetWebAuthnCredentialByCredID(ctx, localCred.CredentialID, localUser.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "LocalStorage.GetWebAuthnCredentialByCredID (sanity baseline)", localCred, localGot, nil)
+
+	remoteUser := newUser("remote")
+	remoteCred := newCred(remoteUser.ID, "remote")
+	remoteGot, err := h.rs.GetWebAuthnCredentialByCredID(ctx, remoteCred.CredentialID, remoteUser.ID)
+	require.NoError(t, err, "RemoteStorage.GetWebAuthnCredentialByCredID must find a genuinely owned credential")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.GetWebAuthnCredentialByCredID (wire round trip)", remoteCred, remoteGot, nil)
+
+	// #307 ownership scoping: a DIFFERENT user's userID must not resolve this credential.
+	otherUser := newUser("other")
+	_, err = h.rs.GetWebAuthnCredentialByCredID(ctx, remoteCred.CredentialID, otherUser.ID)
+	assert.Error(t, err, "RemoteStorage.GetWebAuthnCredentialByCredID must not let a caller fetch another user's "+
+		"credential blob by supplying a different user_id")
+}
+
+// --- LockWebAuthnCredentialForUpdate ---
+
+func TestConformance_LockWebAuthnCredentialForUpdate(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-lwcfu-" + suffix, Email: "conformance-lwcfu-" + suffix + "@example.com",
+			DisplayName: "Conformance LockWebAuthnCredentialForUpdate " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+	newCred := func(userID uint, suffix string) *models.WebAuthnCredential {
+		cred := &models.WebAuthnCredential{
+			UserID: userID, CredentialID: []byte("conformance-lwcfu-credid-" + suffix),
+			Name: "cred-" + suffix, CredentialBlob: []byte(`{"id":"` + suffix + `"}`), CreatedAt: time.Now().UTC(),
+		}
+		require.NoError(t, h.ls.CreateWebAuthnCredential(ctx, cred))
+		return cred
+	}
+
+	localUser := newUser("local")
+	localCred := newCred(localUser.ID, "local")
+	localLocked, err := h.ls.LockWebAuthnCredentialForUpdate(ctx, localCred.CredentialID, localUser.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "LocalStorage.LockWebAuthnCredentialForUpdate (sanity baseline)", localCred, localLocked, nil)
+
+	remoteUser := newUser("remote")
+	remoteCred := newCred(remoteUser.ID, "remote")
+	remoteLocked, err := h.rs.LockWebAuthnCredentialForUpdate(ctx, remoteCred.CredentialID, remoteUser.ID)
+	require.NoError(t, err, "RemoteStorage.LockWebAuthnCredentialForUpdate must find a genuinely owned credential")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.LockWebAuthnCredentialForUpdate (wire round trip)", remoteCred, remoteLocked, nil)
+
+	otherUser := newUser("other")
+	_, err = h.rs.LockWebAuthnCredentialForUpdate(ctx, remoteCred.CredentialID, otherUser.ID)
+	assert.Error(t, err, "RemoteStorage.LockWebAuthnCredentialForUpdate must preserve the same ownership scoping as "+
+		"GetWebAuthnCredentialByCredID -- a different user_id must not resolve the row")
+}
+
+// --- UpdateWebAuthnCredential ---
+
+func TestConformance_UpdateWebAuthnCredential(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-uwac-" + suffix, Email: "conformance-uwac-" + suffix + "@example.com",
+			DisplayName: "Conformance UpdateWebAuthnCredential " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+	newCred := func(userID uint, suffix string) *models.WebAuthnCredential {
+		cred := &models.WebAuthnCredential{
+			UserID: userID, CredentialID: []byte("conformance-uwac-credid-" + suffix),
+			Name: "cred-" + suffix, CredentialBlob: []byte(`{"id":"` + suffix + `"}`), CreatedAt: time.Now().UTC(),
+		}
+		require.NoError(t, h.ls.CreateWebAuthnCredential(ctx, cred))
+		return cred
+	}
+
+	// LocalStorage's own primitive (local_webauthn.go) is an unconditional full-row
+	// Save with no restriction -- the ceiling exercised below is a server/handler-
+	// level narrowing (#1714), not a storage-layer one, so the LOCAL sanity
+	// baseline exercises a full mutation exactly like tranche2/3's other
+	// full-row-Save conformance tests (e.g. TransitionMachineIdentityState).
+	localCred := newCred(newUser("local").ID, "local")
+	localCred.Name = "updated-local"
+	localCred.Disabled = true
+	now := time.Now().UTC().Truncate(time.Second)
+	localCred.LastUsedAt = &now
+	require.NoError(t, h.ls.UpdateWebAuthnCredential(ctx, localCred))
+	localAfter, err := h.ls.GetWebAuthnCredentialByCredID(ctx, localCred.CredentialID, localCred.UserID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "LocalStorage.UpdateWebAuthnCredential (sanity baseline)", localCred, localAfter, nil)
+
+	// RemoteStorage.UpdateWebAuthnCredential's OWN doc comment (remote_webauthn.go)
+	// still describes this as "an unconditional full-row Save, matching
+	// LocalStorage's own semantics exactly" -- but #1714
+	// (server/http/handlers/webauthn_proxy.go's UpdateWebAuthnCredentialProxy doc)
+	// narrowed the SERVER-SIDE handler to exactly rejectIfCloned's disable-on-clone
+	// write: identify the row by (credential_id, user_id) -- which scopes ownership
+	// by construction -- require disabled == true, and ignore every other field.
+	// The prior unconditional Save let a system.write holder reassign a
+	// credential's ownership or silently re-enable a clone-disabled credential
+	// (contradicting the model's own "never auto-re-enabled" invariant), neither
+	// requiring any real WebAuthn ceremony. That RemoteStorage-side doc comment is
+	// now stale relative to the real wire contract -- this test's fair comparison
+	// is against what the route actually does, not what its client-side comment
+	// claims (found while writing this conformance test; not a pre-existing
+	// finding this task set out to look for).
+	remoteCred := newCred(newUser("remote").ID, "remote")
+	remoteCred.Name = "updated-remote"
+	remoteCred.Disabled = true
+	remoteCred.LastUsedAt = &now
+	require.NoError(t, h.rs.UpdateWebAuthnCredential(ctx, remoteCred),
+		"RemoteStorage.UpdateWebAuthnCredential must succeed for the disable-on-clone write rejectIfCloned performs")
+	remoteAfter, err := h.ls.GetWebAuthnCredentialByCredID(ctx, remoteCred.CredentialID, remoteCred.UserID)
+	require.NoError(t, err)
+	assert.True(t, remoteAfter.Disabled, "the credential must actually be disabled server-side")
+	assert.NotEqual(t, "updated-remote", remoteAfter.Name,
+		"#1714: every field besides the disable flag must be IGNORED by this narrowed route, not silently "+
+			"applied -- confirms the server-side ceiling is real, not merely documented as a full-row Save")
+	assert.Nil(t, remoteAfter.LastUsedAt, "LastUsedAt must also be ignored by this route")
+
+	// Re-enabling (disabled: false) must be rejected outright, never silently
+	// applied nor silently ignored-but-reported-success.
+	remoteCred.Disabled = false
+	err = h.rs.UpdateWebAuthnCredential(ctx, remoteCred)
+	assert.Error(t, err, "RemoteStorage.UpdateWebAuthnCredential must reject an attempt to re-enable a credential "+
+		"-- #1714 narrowed this route to disable-on-clone only, never re-enable")
+	stillDisabled, err := h.ls.GetWebAuthnCredentialByCredID(ctx, remoteCred.CredentialID, remoteCred.UserID)
+	require.NoError(t, err)
+	assert.True(t, stillDisabled.Disabled, "a rejected re-enable attempt must not have actually re-enabled the credential")
+}
+
+// --- CountWebAuthnCredentials ---
+
+func TestConformance_CountWebAuthnCredentials(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-cwac-" + suffix, Email: "conformance-cwac-" + suffix + "@example.com",
+			DisplayName: "Conformance CountWebAuthnCredentials " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+	newCred := func(userID uint, suffix string) {
+		require.NoError(t, h.ls.CreateWebAuthnCredential(ctx, &models.WebAuthnCredential{
+			UserID: userID, CredentialID: []byte("conformance-cwac-credid-" + suffix),
+			Name: "cred-" + suffix, CredentialBlob: []byte(`{}`), CreatedAt: time.Now().UTC(),
+		}))
+	}
+
+	localUser := newUser("local")
+	newCred(localUser.ID, "local-1")
+	newCred(localUser.ID, "local-2")
+	localCount, err := h.ls.CountWebAuthnCredentials(ctx, localUser.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), localCount)
+
+	remoteUser := newUser("remote")
+	newCred(remoteUser.ID, "remote-1")
+	remoteCount, err := h.rs.CountWebAuthnCredentials(ctx, remoteUser.ID)
+	require.NoError(t, err, "RemoteStorage.CountWebAuthnCredentials must succeed")
+	assert.Equal(t, int64(1), remoteCount, "must count exactly this user's own credentials")
+}
+
+// --- AdvanceWebAuthnCredentialCounter ---
+
+func TestConformance_AdvanceWebAuthnCredentialCounter(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-awcc-" + suffix, Email: "conformance-awcc-" + suffix + "@example.com",
+			DisplayName: "Conformance AdvanceWebAuthnCredentialCounter " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+	newCredWithCounter := func(userID uint, suffix string, signCount uint32) *models.WebAuthnCredential {
+		cred := &models.WebAuthnCredential{
+			UserID: userID, CredentialID: []byte("conformance-awcc-credid-" + suffix), Name: "cred",
+			CredentialBlob: []byte(fmt.Sprintf(`{"authenticator":{"signCount":%d}}`, signCount)), CreatedAt: time.Now().UTC(),
+		}
+		require.NoError(t, h.ls.CreateWebAuthnCredential(ctx, cred))
+		return cred
+	}
+	lastUsed := time.Now().UTC().Truncate(time.Second)
+
+	localUser := newUser("local")
+	localCred := newCredWithCounter(localUser.ID, "local", 5)
+	newBlobLocal := []byte(`{"authenticator":{"signCount":10}}`)
+	advancedLocal, err := h.ls.AdvanceWebAuthnCredentialCounter(ctx, localCred.CredentialID, localUser.ID, newBlobLocal, 10, lastUsed)
+	require.NoError(t, err)
+	assert.True(t, advancedLocal, "sanity: a strictly greater counter must advance")
+	afterLocal, err := h.ls.GetWebAuthnCredentialByCredID(ctx, localCred.CredentialID, localUser.ID)
+	require.NoError(t, err)
+	assert.Equal(t, newBlobLocal, []byte(afterLocal.CredentialBlob))
+
+	remoteUser := newUser("remote")
+	remoteCred := newCredWithCounter(remoteUser.ID, "remote", 5)
+	newBlobRemote := []byte(`{"authenticator":{"signCount":10}}`)
+	advancedRemote, err := h.rs.AdvanceWebAuthnCredentialCounter(ctx, remoteCred.CredentialID, remoteUser.ID, newBlobRemote, 10, lastUsed)
+	require.NoError(t, err, "RemoteStorage.AdvanceWebAuthnCredentialCounter must succeed")
+	assert.True(t, advancedRemote, "must report Advanced=true for a strictly greater counter")
+	afterRemote, err := h.ls.GetWebAuthnCredentialByCredID(ctx, remoteCred.CredentialID, remoteUser.ID)
+	require.NoError(t, err)
+	assert.Equal(t, newBlobRemote, []byte(afterRemote.CredentialBlob), "the new blob must actually be persisted server-side")
+	assert.NotNil(t, afterRemote.LastUsedAt)
+
+	// Stale counter must be a no-op on both -- the #306/#517 CAS guarantee this
+	// method exists to preserve across the wire.
+	staleBlob := []byte(`{"authenticator":{"signCount":3}}`)
+	staleLocal, err := h.ls.AdvanceWebAuthnCredentialCounter(ctx, localCred.CredentialID, localUser.ID, staleBlob, 3, time.Now().UTC())
+	require.NoError(t, err)
+	assert.False(t, staleLocal, "sanity: a stale counter must not advance")
+
+	staleRemote, err := h.rs.AdvanceWebAuthnCredentialCounter(ctx, remoteCred.CredentialID, remoteUser.ID, staleBlob, 3, time.Now().UTC())
+	require.NoError(t, err)
+	assert.False(t, staleRemote, "RemoteStorage.AdvanceWebAuthnCredentialCounter must report Advanced=false for a "+
+		"stale counter, not silently apply it and regress the persisted counter (defeats clone detection)")
+	stillFreshRemote, err := h.ls.GetWebAuthnCredentialByCredID(ctx, remoteCred.CredentialID, remoteUser.ID)
+	require.NoError(t, err)
+	assert.Equal(t, newBlobRemote, []byte(stillFreshRemote.CredentialBlob),
+		"a stale-counter attempt must not have overwritten the already-persisted newer blob")
+}
+
+// --- GetMFASecret ---
+
+func TestConformance_GetMFASecret(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	enableMFAEncryption(t, h)
+
+	localUser, _ := enrollMFA(t, h, ctx, "conformance-gms-local")
+	localSecret, err := h.ls.GetMFASecret(ctx, localUser.ID)
+	require.NoError(t, err)
+	assert.True(t, localSecret.Activated)
+
+	remoteUser, _ := enrollMFA(t, h, ctx, "conformance-gms-remote")
+	remoteSecret, err := h.rs.GetMFASecret(ctx, remoteUser.ID)
+	require.NoError(t, err, "RemoteStorage.GetMFASecret must find a genuinely enrolled user's secret row")
+
+	wantRemote, err := h.ls.GetMFASecret(ctx, remoteUser.ID)
+	require.NoError(t, err)
+	assert.Equal(t, wantRemote.ID, remoteSecret.ID)
+	assert.Equal(t, wantRemote.UserID, remoteSecret.UserID)
+	assert.Equal(t, wantRemote.Activated, remoteSecret.Activated)
+	assert.Equal(t, wantRemote.LastUsedStep, remoteSecret.LastUsedStep)
+	assert.True(t, wantRemote.CreatedAt.Equal(remoteSecret.CreatedAt))
+	// Deliberately targeted, non-printing assertions for the ciphertext fields
+	// (see this file's package doc) -- bytes.Equal never prints the actual bytes
+	// into a testify failure message, unlike assertFieldExhaustiveEqual's %#v dump.
+	assert.True(t, bytes.Equal(wantRemote.SecretEnc, remoteSecret.SecretEnc),
+		"SecretEnc ciphertext must round-trip over the wire unchanged")
+	assert.True(t, bytes.Equal(wantRemote.SecretMeta, remoteSecret.SecretMeta),
+		"SecretMeta must round-trip over the wire unchanged")
+
+	bystander, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gms-none", Email: "conformance-gms-none@example.com", DisplayName: "no mfa", IsActive: true,
+	})
+	require.NoError(t, err)
+	_, err = h.ls.GetMFASecret(ctx, bystander.ID)
+	assert.Error(t, err, "sanity: no MFA secret row exists yet")
+	_, err = h.rs.GetMFASecret(ctx, bystander.ID)
+	assert.Error(t, err, "RemoteStorage.GetMFASecret must also fail for a user with no MFA secret row, not silently succeed")
+}
+
+// --- MarkTOTPStepUsed ---
+
+func TestConformance_MarkTOTPStepUsed(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	enableMFAEncryption(t, h)
+
+	// ActivateMFA (inside enrollMFA) already calls MarkTOTPStepUsed once, for the
+	// REAL current wall-clock TOTP step (unix-time/30, tens of millions today) --
+	// an arbitrary small constant like 12345 would be "older" than that already-
+	// persisted step and get rejected as stale, not accepted as fresh. Derive the
+	// baseline from the row enrollMFA actually left behind instead of guessing.
+	localUser, _ := enrollMFA(t, h, ctx, "conformance-mtsu-local")
+	localSecretRow, err := h.ls.GetMFASecret(ctx, localUser.ID)
+	require.NoError(t, err)
+	require.NotNil(t, localSecretRow.LastUsedStep, "sanity: ActivateMFA must have already recorded a last-used step")
+	localFreshStep := *localSecretRow.LastUsedStep + 100
+	freshLocal, err := h.ls.MarkTOTPStepUsed(ctx, localUser.ID, localFreshStep)
+	require.NoError(t, err)
+	assert.True(t, freshLocal, "sanity: a strictly greater step must be accepted as fresh")
+	replayLocal, err := h.ls.MarkTOTPStepUsed(ctx, localUser.ID, localFreshStep)
+	require.NoError(t, err)
+	assert.False(t, replayLocal, "sanity: the SAME step replayed must be rejected")
+
+	remoteUser, _ := enrollMFA(t, h, ctx, "conformance-mtsu-remote")
+	remoteSecretRow, err := h.ls.GetMFASecret(ctx, remoteUser.ID)
+	require.NoError(t, err)
+	require.NotNil(t, remoteSecretRow.LastUsedStep)
+	remoteFreshStep := *remoteSecretRow.LastUsedStep + 100
+	freshRemote, err := h.rs.MarkTOTPStepUsed(ctx, remoteUser.ID, remoteFreshStep)
+	require.NoError(t, err)
+	assert.True(t, freshRemote, "RemoteStorage.MarkTOTPStepUsed must report fresh=true for a strictly greater step")
+	replayRemote, err := h.rs.MarkTOTPStepUsed(ctx, remoteUser.ID, remoteFreshStep)
+	require.NoError(t, err)
+	assert.False(t, replayRemote, "RemoteStorage.MarkTOTPStepUsed must reject a replayed step server-side, not "+
+		"silently accept it twice")
+
+	// An older step than what's now persisted must also be rejected -- confirms the
+	// advance really landed server-side, not merely that a duplicate call happened
+	// to also return false.
+	olderRemote, err := h.rs.MarkTOTPStepUsed(ctx, remoteUser.ID, remoteFreshStep-1)
+	require.NoError(t, err)
+	assert.False(t, olderRemote, "an older step than the persisted last-used-step must be rejected")
+}
+
+// --- CountUnusedMFARecoveryCodes ---
+
+func TestConformance_CountUnusedMFARecoveryCodes(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-cumrc-" + suffix, Email: "conformance-cumrc-" + suffix + "@example.com",
+			DisplayName: "Conformance CountUnusedMFARecoveryCodes " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	localUser := newUser("local")
+	require.NoError(t, h.ls.CreateMFARecoveryCodes(ctx, localUser.ID, []string{"h1", "h2", "h3"}))
+	consumedLocal, err := h.ls.ConsumeMFARecoveryCode(ctx, localUser.ID, "h1", time.Now().UTC())
+	require.NoError(t, err)
+	require.True(t, consumedLocal)
+	localCount, err := h.ls.CountUnusedMFARecoveryCodes(ctx, localUser.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, localCount)
+
+	remoteUser := newUser("remote")
+	require.NoError(t, h.ls.CreateMFARecoveryCodes(ctx, remoteUser.ID, []string{"r1", "r2", "r3", "r4"}))
+	consumedRemote, err := h.ls.ConsumeMFARecoveryCode(ctx, remoteUser.ID, "r1", time.Now().UTC())
+	require.NoError(t, err)
+	require.True(t, consumedRemote)
+	remoteCount, err := h.rs.CountUnusedMFARecoveryCodes(ctx, remoteUser.ID)
+	require.NoError(t, err, "RemoteStorage.CountUnusedMFARecoveryCodes must succeed")
+	assert.Equal(t, 3, remoteCount, "must count only the still-unused codes server-side")
+}
+
+// --- IssueMFAChallenge ---
+
+func TestConformance_IssueMFAChallenge(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-imc-" + suffix, Email: "conformance-imc-" + suffix + "@example.com",
+			DisplayName: "Conformance IssueMFAChallenge " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	// "Local" baseline: h.upstreamCore.CreateMFAChallenge is what IssueMFAChallenge's
+	// wire handler itself calls server-side (see remote_mfa.go's doc and
+	// users_crud.go's IssueMFAChallenge) -- IssueMFAChallenge has no separate
+	// LocalStorage primitive of its own to compare against (LocalStorage.CreateMFAChallenge
+	// takes a full pre-built *models.MFAChallenge, not a bare userID).
+	localUser := newUser("local")
+	localToken, err := h.upstreamCore.CreateMFAChallenge(ctx, localUser.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, localToken)
+	localCh, err := h.ls.GetActiveMFAChallenge(ctx, conformanceSHA256Hex(localToken), time.Now())
+	require.NoError(t, err, "sanity: the locally issued challenge token must resolve back to an active challenge row")
+	assert.Equal(t, localUser.ID, localCh.UserID)
+
+	remoteUser := newUser("remote")
+	remoteToken, err := h.rs.IssueMFAChallenge(ctx, remoteUser.ID)
+	require.NoError(t, err, "RemoteStorage.IssueMFAChallenge must succeed")
+	assert.NotEmpty(t, remoteToken)
+	remoteCh, err := h.ls.GetActiveMFAChallenge(ctx, conformanceSHA256Hex(remoteToken), time.Now())
+	require.NoError(t, err, "the challenge minted via RemoteStorage.IssueMFAChallenge must actually be persisted "+
+		"server-side, resolvable through the SAME LocalStorage instance the router wraps -- not just an opaque "+
+		"token that goes nowhere")
+	assert.Equal(t, remoteUser.ID, remoteCh.UserID, "the challenge must be bound to the caller-supplied user_id")
+}
+
+// --- GetActiveMFAChallenge ---
+
+func TestConformance_GetActiveMFAChallenge(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-gamc-" + suffix, Email: "conformance-gamc-" + suffix + "@example.com",
+			DisplayName: "Conformance GetActiveMFAChallenge " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	localUser := newUser("local")
+	localToken, err := h.upstreamCore.CreateMFAChallenge(ctx, localUser.ID)
+	require.NoError(t, err)
+	localCh, err := h.ls.GetActiveMFAChallenge(ctx, conformanceSHA256Hex(localToken), time.Now())
+	require.NoError(t, err)
+	assert.Nil(t, localCh.UsedAt, "sanity: a fresh challenge is not yet consumed")
+
+	remoteUser := newUser("remote")
+	remoteToken, err := h.upstreamCore.CreateMFAChallenge(ctx, remoteUser.ID)
+	require.NoError(t, err)
+	remoteCh, err := h.rs.GetActiveMFAChallenge(ctx, conformanceSHA256Hex(remoteToken), time.Now())
+	require.NoError(t, err, "RemoteStorage.GetActiveMFAChallenge must find a genuinely active challenge")
+	assert.Nil(t, remoteCh.UsedAt, "a not-yet-consumed challenge must not appear used")
+	assert.Equal(t, remoteUser.ID, remoteCh.UserID)
+
+	// Consuming it must make it no longer "active".
+	_, err = h.ls.ConsumeMFAChallenge(ctx, conformanceSHA256Hex(remoteToken), time.Now())
+	require.NoError(t, err)
+	_, err = h.rs.GetActiveMFAChallenge(ctx, conformanceSHA256Hex(remoteToken), time.Now())
+	assert.Error(t, err, "RemoteStorage.GetActiveMFAChallenge must refuse an already-consumed challenge, not report "+
+		"it as still active")
+}
+
+// --- ConsumeMFAChallenge ---
+
+func TestConformance_ConsumeMFAChallenge(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-cmc-" + suffix, Email: "conformance-cmc-" + suffix + "@example.com",
+			DisplayName: "Conformance ConsumeMFAChallenge " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	localUser := newUser("local")
+	localToken, err := h.upstreamCore.CreateMFAChallenge(ctx, localUser.ID)
+	require.NoError(t, err)
+	localConsumed, err := h.ls.ConsumeMFAChallenge(ctx, conformanceSHA256Hex(localToken), time.Now())
+	require.NoError(t, err)
+	assert.NotNil(t, localConsumed.UsedAt)
+	_, err = h.ls.ConsumeMFAChallenge(ctx, conformanceSHA256Hex(localToken), time.Now())
+	assert.Error(t, err, "sanity: a challenge is single-use")
+
+	remoteUser := newUser("remote")
+	remoteToken, err := h.upstreamCore.CreateMFAChallenge(ctx, remoteUser.ID)
+	require.NoError(t, err)
+	remoteConsumed, err := h.rs.ConsumeMFAChallenge(ctx, conformanceSHA256Hex(remoteToken), time.Now())
+	require.NoError(t, err, "RemoteStorage.ConsumeMFAChallenge must succeed for a valid, active challenge")
+	assert.NotNil(t, remoteConsumed.UsedAt, "the challenge must actually be marked used server-side")
+	_, err = h.rs.ConsumeMFAChallenge(ctx, conformanceSHA256Hex(remoteToken), time.Now())
+	assert.Error(t, err, "RemoteStorage.ConsumeMFAChallenge must refuse a second consume -- single-use must hold "+
+		"across the wire")
+}
+
+// --- VerifyMFALoginCredentials ---
+
+func TestConformance_VerifyMFALoginCredentials(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	enableMFAEncryption(t, h)
+
+	// "Local" baseline: core.VerifyMFACredentials is the SAME function the
+	// upstream's own POST /api/v1/users/verify-mfa handler calls
+	// (server/http/handlers/users_crud.go's VerifyMFACredentials doc comment) --
+	// VerifyMFALoginCredentials has no LocalStorage equivalent of its own to
+	// proxy to (it implements core.RemoteMFAVerifier, an interface only
+	// RemoteStorage needs to satisfy).
+	localUser, localSecret := enrollMFA(t, h, ctx, "conformance-vmlc-local")
+	localChallenge, err := h.upstreamCore.CreateMFAChallenge(ctx, localUser.ID)
+	require.NoError(t, err)
+	localCode, err := totp.GenerateCode(localSecret, time.Now())
+	require.NoError(t, err)
+	verifiedLocal, localUsedRecovery, err := h.upstreamCore.VerifyMFACredentials(ctx, localChallenge, localCode)
+	require.NoError(t, err, "sanity: a correct TOTP code against a fresh challenge must verify")
+	assert.False(t, localUsedRecovery)
+	assert.Equal(t, localUser.ID, verifiedLocal.ID)
+
+	// Remote: the identical shape, through RemoteStorage.VerifyMFALoginCredentials.
+	remoteUser, remoteSecret := enrollMFA(t, h, ctx, "conformance-vmlc-remote")
+	remoteChallenge, err := h.upstreamCore.CreateMFAChallenge(ctx, remoteUser.ID)
+	require.NoError(t, err)
+	remoteCode, err := totp.GenerateCode(remoteSecret, time.Now())
+	require.NoError(t, err)
+	remoteVerified, remoteUsedRecovery, err := h.rs.VerifyMFALoginCredentials(ctx, remoteChallenge, remoteCode)
+	require.NoError(t, err, "RemoteStorage.VerifyMFALoginCredentials must succeed for a correct TOTP code against a fresh challenge")
+	assert.False(t, remoteUsedRecovery)
+
+	// Field fidelity: verifyMFAWireResponse deliberately narrows the returned User to
+	// ID/Username/PasswordChangedAt/CreatedAt (remote_mfa.go's doc) specifically
+	// because enforcePasswordExpiryGate (ADR-025) reads PasswordChangedAt -- a
+	// dropped field here would silently defeat that gate under storage.type: remote.
+	wantUser, err := h.ls.GetUser(ctx, remoteUser.ID)
+	require.NoError(t, err)
+	assert.Equal(t, wantUser.ID, remoteVerified.ID)
+	assert.Equal(t, wantUser.Username, remoteVerified.Username)
+	require.NotNil(t, remoteVerified.PasswordChangedAt,
+		"PasswordChangedAt must not be dropped on the wire -- ADR-025's password-expiry gate silently no-ops without it")
+	assert.True(t, wantUser.PasswordChangedAt.Equal(*remoteVerified.PasswordChangedAt))
+	assert.True(t, wantUser.CreatedAt.Equal(remoteVerified.CreatedAt), "CreatedAt must not be dropped either")
+
+	// Negative: a wrong code must fail, AND the challenge must be burned by that
+	// FIRST attempt regardless of correctness (core.VerifyMFACredentials consumes
+	// the challenge before ever checking the code) -- a subsequent, CORRECT code
+	// against the same challenge must also fail.
+	wrongUser, wrongSecret := enrollMFA(t, h, ctx, "conformance-vmlc-wrongcode")
+	wrongChallenge, err := h.upstreamCore.CreateMFAChallenge(ctx, wrongUser.ID)
+	require.NoError(t, err)
+	_, _, err = h.rs.VerifyMFALoginCredentials(ctx, wrongChallenge, "000000")
+	assert.Error(t, err, "RemoteStorage.VerifyMFALoginCredentials must reject an incorrect TOTP code")
+	rightCode, err := totp.GenerateCode(wrongSecret, time.Now())
+	require.NoError(t, err)
+	_, _, err = h.rs.VerifyMFALoginCredentials(ctx, wrongChallenge, rightCode)
+	assert.Error(t, err, "a challenge must be single-use regardless of whether the first attempt's code was "+
+		"correct -- a wrong-code attempt still burns it")
+
+	// Unknown/garbage challenge must be rejected too.
+	_, _, err = h.rs.VerifyMFALoginCredentials(ctx, "not-a-real-challenge-token", "123456")
+	assert.Error(t, err, "an unknown challenge token must be rejected")
+}
+
+// --- GetActiveMFAStepUpGrant ---
+
+func TestConformance_GetActiveMFAStepUpGrant(t *testing.T) {
+	h := newConformanceHarness(t)
+	ensureMFAStepUpGrantTable(t, h)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-gamsug-" + suffix, Email: "conformance-gamsug-" + suffix + "@example.com",
+			DisplayName: "Conformance GetActiveMFAStepUpGrant " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	localUser := newUser("local")
+	localSeed := &models.MFAStepUpGrant{
+		UserID: localUser.ID, Purpose: models.MFAStepUpPurposeReauth,
+		ExpiresAt: time.Now().Add(15 * time.Minute).UTC().Truncate(time.Second), CreatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, h.ls.CreateMFAStepUpGrant(ctx, localSeed))
+	localGrant, err := h.ls.GetActiveMFAStepUpGrant(ctx, localUser.ID, models.MFAStepUpPurposeReauth, time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, localGrant)
+	assertFieldExhaustiveEqual(t, "LocalStorage.GetActiveMFAStepUpGrant (sanity baseline)", localSeed, localGrant, nil)
+
+	remoteUser := newUser("remote")
+	remoteSeed := &models.MFAStepUpGrant{
+		UserID: remoteUser.ID, Purpose: models.MFAStepUpPurposeReauth,
+		ExpiresAt: time.Now().Add(15 * time.Minute).UTC().Truncate(time.Second), CreatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, h.ls.CreateMFAStepUpGrant(ctx, remoteSeed))
+	remoteGrant, err := h.rs.GetActiveMFAStepUpGrant(ctx, remoteUser.ID, models.MFAStepUpPurposeReauth, time.Now())
+	require.NoError(t, err, "RemoteStorage.GetActiveMFAStepUpGrant must find a genuinely active grant")
+	require.NotNil(t, remoteGrant)
+	// mfaStepUpGrantWire never carries ConsumedAt (remote_mfa_stepup_grant.go) -- both
+	// sides are nil here anyway (the grant was never consumed), so no exclusion needed.
+	assertFieldExhaustiveEqual(t, "RemoteStorage.GetActiveMFAStepUpGrant (wire round trip)", remoteSeed, remoteGrant, nil)
+
+	noGrantUser := newUser("nogrant")
+	gotNil, err := h.rs.GetActiveMFAStepUpGrant(ctx, noGrantUser.ID, models.MFAStepUpPurposeReauth, time.Now())
+	require.NoError(t, err, "RemoteStorage.GetActiveMFAStepUpGrant must return (nil, nil) for no active grant, not an error")
+	assert.Nil(t, gotNil)
+
+	expiredUser := newUser("expired")
+	require.NoError(t, h.ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
+		UserID: expiredUser.ID, Purpose: models.MFAStepUpPurposeReauth,
+		ExpiresAt: time.Now().Add(-time.Minute).UTC(), CreatedAt: time.Now().UTC(),
+	}))
+	gotExpired, err := h.rs.GetActiveMFAStepUpGrant(ctx, expiredUser.ID, models.MFAStepUpPurposeReauth, time.Now())
+	require.NoError(t, err)
+	assert.Nil(t, gotExpired, "an expired grant must not be reported as active")
+}
+
+// --- PruneMFAStepUpGrants ---
+
+func TestConformance_PruneMFAStepUpGrants(t *testing.T) {
+	h := newConformanceHarness(t)
+	ensureMFAStepUpGrantTable(t, h)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-pmsug-" + suffix, Email: "conformance-pmsug-" + suffix + "@example.com",
+			DisplayName: "Conformance PruneMFAStepUpGrants " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	// PruneMFAStepUpGrantsProxy (CORE-RATE-003, mirroring PruneLoginAttemptsProxy)
+	// deliberately does NOT trust the wire `before` verbatim: it routes through
+	// core.KeyorixCore.PruneMFAStepUpGrants, which clamps the effective cutoff to
+	// max(30 days ago, before) -- a caller can only NARROW the deletion window,
+	// never widen it past the 30-day floor. A `before` of "1 hour ago" (fine for
+	// LocalStorage's own unclamped primitive) would silently clamp to "30 days
+	// ago" over the wire, and a grant merely 1 hour past its expiry would survive
+	// the remote call even though it wouldn't survive the local one -- so `past`
+	// here must be older than that 30-day floor for the remote and local
+	// comparisons to agree on what gets purged.
+	past := time.Now().Add(-31 * 24 * time.Hour).UTC()
+	future := time.Now().Add(time.Hour).UTC()
+	cutoff := time.Now().UTC()
+
+	localExpired := newUser("local-expired")
+	require.NoError(t, h.ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
+		UserID: localExpired.ID, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: past, CreatedAt: time.Now().UTC(),
+	}))
+	localFuture := newUser("local-future")
+	require.NoError(t, h.ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
+		UserID: localFuture.ID, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: future, CreatedAt: time.Now().UTC(),
+	}))
+	localRemoved, err := h.ls.PruneMFAStepUpGrants(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), localRemoved, "sanity: exactly the expired grant must be purged")
+
+	remoteExpired := newUser("remote-expired")
+	require.NoError(t, h.ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
+		UserID: remoteExpired.ID, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: past, CreatedAt: time.Now().UTC(),
+	}))
+	remoteFuture := newUser("remote-future")
+	require.NoError(t, h.ls.CreateMFAStepUpGrant(ctx, &models.MFAStepUpGrant{
+		UserID: remoteFuture.ID, Purpose: models.MFAStepUpPurposeReauth, ExpiresAt: future, CreatedAt: time.Now().UTC(),
+	}))
+	remoteRemoved, err := h.rs.PruneMFAStepUpGrants(ctx, cutoff)
+	require.NoError(t, err, "RemoteStorage.PruneMFAStepUpGrants must succeed")
+	assert.Equal(t, int64(1), remoteRemoved, "RemoteStorage.PruneMFAStepUpGrants must report exactly the one "+
+		"expired grant it purged this call, not the earlier local one too and not zero (silent no-op)")
+
+	stillActive, err := h.ls.GetActiveMFAStepUpGrant(ctx, remoteFuture.ID, models.MFAStepUpPurposeReauth, time.Now())
+	require.NoError(t, err)
+	assert.NotNil(t, stillActive, "PruneMFAStepUpGrants must not touch a grant that has not yet expired")
+}
+
+// --- CreateSSOLoginState ---
+
+func TestConformance_CreateSSOLoginState(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	localState := &models.SSOLoginState{
+		State: "conformance-csls-state-local", Nonce: "nonce-local", Provider: "oidc", ReturnTo: "/dashboard",
+		ExpiresAt: time.Now().Add(10 * time.Minute).UTC().Truncate(time.Second), CreatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, h.ls.CreateSSOLoginState(ctx, localState))
+	require.NotZero(t, localState.ID)
+
+	remoteState := &models.SSOLoginState{
+		State: "conformance-csls-state-remote", Nonce: "nonce-remote", Provider: "saml", ReturnTo: "/settings",
+		ExpiresAt: time.Now().Add(10 * time.Minute).UTC().Truncate(time.Second), CreatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, h.rs.CreateSSOLoginState(ctx, remoteState), "RemoteStorage.CreateSSOLoginState must succeed")
+	require.NotZero(t, remoteState.ID, "the server-assigned ID must be copied back onto the caller's struct")
+
+	// ConsumeSSOLoginState is the only read primitive (no non-consuming getter),
+	// so reading back necessarily also exercises the single-use consume --
+	// acceptable, this fixture is dedicated to this one read.
+	localConsumed, err := h.ls.ConsumeSSOLoginState(ctx, "conformance-csls-state-local")
+	require.NoError(t, err)
+	remoteConsumed, err := h.ls.ConsumeSSOLoginState(ctx, "conformance-csls-state-remote")
+	require.NoError(t, err, "the state created via RemoteStorage must actually exist server-side")
+
+	assertFieldExhaustiveEqual(t, "LocalStorage.CreateSSOLoginState (sanity baseline)", localState, localConsumed, nil)
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateSSOLoginState (wire round trip)", remoteState, remoteConsumed, nil)
+}
+
+// --- ConsumeSSOLoginState ---
+
+func TestConformance_ConsumeSSOLoginState(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newState := func(suffix string) string {
+		state := "conformance-cssls-" + suffix
+		require.NoError(t, h.ls.CreateSSOLoginState(ctx, &models.SSOLoginState{
+			State: state, Nonce: "nonce-" + suffix, Provider: "oidc",
+			ExpiresAt: time.Now().Add(10 * time.Minute).UTC(), CreatedAt: time.Now().UTC(),
+		}))
+		return state
+	}
+
+	localState := newState("local")
+	localConsumed, err := h.ls.ConsumeSSOLoginState(ctx, localState)
+	require.NoError(t, err)
+	assert.Equal(t, localState, localConsumed.State)
+	_, err = h.ls.ConsumeSSOLoginState(ctx, localState)
+	assert.Error(t, err, "sanity: a state is single-use")
+
+	remoteState := newState("remote")
+	remoteConsumed, err := h.rs.ConsumeSSOLoginState(ctx, remoteState)
+	require.NoError(t, err, "RemoteStorage.ConsumeSSOLoginState must succeed for a genuinely pending state")
+	assert.Equal(t, remoteState, remoteConsumed.State)
+	_, err = h.rs.ConsumeSSOLoginState(ctx, remoteState)
+	assert.Error(t, err, "RemoteStorage.ConsumeSSOLoginState must refuse a REPLAYED state/RelayState -- single-use "+
+		"must hold across the wire, closing exactly the TOCTOU the atomic read-then-conditional-delete exists to prevent")
+
+	_, err = h.rs.ConsumeSSOLoginState(ctx, "conformance-cssls-never-existed")
+	assert.Error(t, err, "an unknown state must be rejected")
+}
+
+// --- VerifyLoginCredentials ---
+
+func TestConformance_VerifyLoginCredentials(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// See conformanceMFAPassword's doc for why this must not overlap with any
+	// word this file's usernames/display names use.
+	const password = "Zp4Rn8Ky3@Tw6Hf!"
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.upstreamCore.CreateUser(ctx, &core.CreateUserRequest{
+			Username: "conformance-vlc-" + suffix, Email: "conformance-vlc-" + suffix + "@example.com",
+			DisplayName: "Conformance VerifyLoginCredentials " + suffix, Password: password,
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	// "Local" baseline: core.Login exercised in-process -- the same function the
+	// upstream's own VerifyCredentials handler calls server-side for the remote
+	// path below (server/http/handlers/users_crud.go's doc comment). RemoteStorage
+	// has no local equivalent (VerifyLoginCredentials implements
+	// core.RemoteLoginVerifier, an interface only RemoteStorage needs).
+	localUser := newUser("local")
+	localSession, loggedInLocal, err := h.upstreamCore.Login(ctx, &core.LoginRequest{
+		Username: localUser.Username, Password: password, UserAgent: "conformance-ua", IPAddress: "10.0.0.1",
+	})
+	require.NoError(t, err, "sanity: a correct password must log in")
+	require.NotNil(t, localSession)
+	assert.Equal(t, localUser.ID, loggedInLocal.ID)
+
+	remoteUser := newUser("remote")
+	remoteModelUser, remoteSession, err := h.rs.VerifyLoginCredentials(ctx, remoteUser.Username, password, "conformance-ua", "10.0.0.2")
+	require.NoError(t, err, "RemoteStorage.VerifyLoginCredentials must succeed for the correct password")
+	require.NotNil(t, remoteSession, "a session must be minted atomically with verification (#508) when no second factor is required")
+	assert.Equal(t, remoteUser.ID, remoteModelUser.ID)
+	assert.Equal(t, remoteUser.Username, remoteModelUser.Username)
+	assert.Equal(t, remoteUser.Email, remoteModelUser.Email)
+	assert.Equal(t, remoteUser.DisplayName, remoteModelUser.DisplayName)
+	assert.True(t, remoteModelUser.IsActive)
+	assert.False(t, remoteModelUser.MFAEnabled)
+	assert.False(t, remoteModelUser.WebAuthnEnabled)
+
+	// The session minted server-side must actually be usable -- read it back through
+	// the SAME LocalStorage instance the router wraps, not just trust the wire response.
+	persistedSession, err := h.ls.GetSession(ctx, remoteSession.SessionToken)
+	require.NoError(t, err, "the session minted via RemoteStorage.VerifyLoginCredentials must actually exist server-side")
+	assert.Equal(t, remoteUser.ID, persistedSession.UserID)
+
+	// Wrong password must fail identically on both paths, without minting a session.
+	_, _, err = h.upstreamCore.Login(ctx, &core.LoginRequest{Username: localUser.Username, Password: "wrong-password", UserAgent: "ua", IPAddress: "10.0.0.1"})
+	assert.Error(t, err, "sanity: a wrong password must be rejected")
+	_, wrongSession, err := h.rs.VerifyLoginCredentials(ctx, remoteUser.Username, "wrong-password", "conformance-ua", "10.0.0.2")
+	assert.Error(t, err, "RemoteStorage.VerifyLoginCredentials must reject an incorrect password")
+	assert.Nil(t, wrongSession)
+
+	// Unknown username must fail the same generic way (no user-enumeration oracle).
+	_, _, err = h.rs.VerifyLoginCredentials(ctx, "conformance-vlc-does-not-exist", password, "ua", "1.2.3.4")
+	assert.Error(t, err)
+}
+
+// --- RecordLoginAttempt ---
+
+func TestConformance_RecordLoginAttempt(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	before := time.Now().UTC().Add(-time.Minute)
+
+	localIP := "203.0.113.10"
+	require.NoError(t, h.ls.RecordLoginAttempt(ctx, localIP, time.Now().UTC()))
+	localCount, err := h.ls.CountRecentLoginAttempts(ctx, localIP, before)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), localCount, "sanity: the local attempt must be counted")
+
+	// The exact defect class CLAUDE.md documents this codebase having hit before: a
+	// RemoteStorage login-attempt no-op that reported success but never actually
+	// recorded the row server-side. A success return value alone would not
+	// distinguish "it happened" from "it silently didn't" -- observe the effect via
+	// BOTH RemoteStorage's own count AND LocalStorage's count against the SAME
+	// backing store, independently of each other.
+	remoteIP := "203.0.113.20"
+	require.NoError(t, h.rs.RecordLoginAttempt(ctx, remoteIP, time.Now().UTC()), "RemoteStorage.RecordLoginAttempt must succeed")
+
+	remoteCountViaRemote, err := h.rs.CountRecentLoginAttempts(ctx, remoteIP, before)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), remoteCountViaRemote,
+		"RemoteStorage.CountRecentLoginAttempts must see the attempt RecordLoginAttempt just recorded")
+
+	remoteCountViaLocal, err := h.ls.CountRecentLoginAttempts(ctx, remoteIP, before)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), remoteCountViaLocal,
+		"the attempt recorded via RemoteStorage.RecordLoginAttempt must exist as a REAL row in the SAME "+
+			"LocalStorage-backed table the router wraps -- read back through LocalStorage directly, independent of "+
+			"RemoteStorage's own count call, to rule out a client-side-only echo masquerading as a real write "+
+			"(the historical no-op defect this method's own doc comment names)")
+
+	bystanderCount, err := h.ls.CountRecentLoginAttempts(ctx, "203.0.113.30", before)
+	require.NoError(t, err)
+	assert.Zero(t, bystanderCount, "a bystander IP's count must be unaffected")
+}
+
+// --- CountRecentLoginAttempts ---
+
+func TestConformance_CountRecentLoginAttempts(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	since := now.Add(-time.Hour)
+
+	localIP := "198.51.100.10"
+	require.NoError(t, h.ls.RecordLoginAttempt(ctx, localIP, now.Add(-30*time.Minute)))
+	require.NoError(t, h.ls.RecordLoginAttempt(ctx, localIP, now.Add(-2*time.Hour))) // outside the window
+	localCount, err := h.ls.CountRecentLoginAttempts(ctx, localIP, since)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), localCount, "sanity: only the in-window attempt counts")
+
+	remoteIP := "198.51.100.20"
+	require.NoError(t, h.ls.RecordLoginAttempt(ctx, remoteIP, now.Add(-30*time.Minute)))
+	require.NoError(t, h.ls.RecordLoginAttempt(ctx, remoteIP, now.Add(-2*time.Hour)))
+	remoteCount, err := h.rs.CountRecentLoginAttempts(ctx, remoteIP, since)
+	require.NoError(t, err, "RemoteStorage.CountRecentLoginAttempts must succeed")
+	assert.Equal(t, int64(1), remoteCount, "must count only attempts strictly after `since`, matching "+
+		"LocalStorage's own windowing exactly -- a dropped/widened since-bound on the wire would over- or under-count")
+
+	otherIPCount, err := h.rs.CountRecentLoginAttempts(ctx, "198.51.100.30", since)
+	require.NoError(t, err)
+	assert.Zero(t, otherIPCount, "a different IP must not be conflated into this count")
+}
+
+// --- PruneLoginAttempts ---
+
+func TestConformance_PruneLoginAttempts(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	past := now.Add(-24 * time.Hour)
+	recent := now.Add(-time.Minute)
+	cutoff := now.Add(-time.Hour)
+
+	localIP := "192.0.2.10"
+	require.NoError(t, h.ls.RecordLoginAttempt(ctx, localIP, past))
+	require.NoError(t, h.ls.RecordLoginAttempt(ctx, localIP, recent))
+	localRemoved, err := h.ls.PruneLoginAttempts(ctx, cutoff)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), localRemoved, "sanity: only the stale attempt must be purged")
+	localAfter, err := h.ls.CountRecentLoginAttempts(ctx, localIP, now.Add(-25*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), localAfter, "the recent attempt must survive")
+
+	remoteIP := "192.0.2.20"
+	require.NoError(t, h.ls.RecordLoginAttempt(ctx, remoteIP, past))
+	require.NoError(t, h.ls.RecordLoginAttempt(ctx, remoteIP, recent))
+	remoteRemoved, err := h.rs.PruneLoginAttempts(ctx, cutoff)
+	require.NoError(t, err, "RemoteStorage.PruneLoginAttempts must succeed")
+	assert.Equal(t, int64(1), remoteRemoved, "RemoteStorage.PruneLoginAttempts must report exactly the one stale "+
+		"attempt it purged this call -- not the earlier local IP's row too (cross-IP leakage) and not zero (silent no-op)")
+	remoteAfter, err := h.ls.CountRecentLoginAttempts(ctx, remoteIP, now.Add(-25*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), remoteAfter, "the recent attempt must survive the prune, verified by reading back "+
+		"through LocalStorage directly, not just trusting the reported delete count")
+}

--- a/server/http/remote_storage_conformance_tranche4_dynamic_rotation_test.go
+++ b/server/http/remote_storage_conformance_tranche4_dynamic_rotation_test.go
@@ -1,0 +1,551 @@
+// remote_storage_conformance_tranche4_dynamic_rotation_test.go — issue #1808,
+// tranche 4.
+//
+// Covers 10 of the assigned 12 methods spanning two source files:
+//
+//	remote_dynamic.go: CountActiveLeases, CountDynamicSecretConfigsByClassification,
+//	GetDynamicSecretConfig, GetDynamicSecretLease, ListDynamicSecretConfigs,
+//	ListDynamicSecretLeases, ListExpiredActiveLeases
+//
+//	remote_rotation_policies.go: DeleteRotationPolicy, GetRotationPolicy,
+//	ListRotationPolicies
+//
+// (CreateDynamicSecretConfig/UpdateDynamicSecretConfig/
+// TransitionDynamicSecretConfigDisabled/CreateDynamicSecretLease/
+// UpdateDynamicSecretLease are NOT in this tranche's method list -- they are
+// also hard `remoteUnsupported` stubs on RemoteStorage per the G80 liveness
+// sweep, so every dynamic-secrets fixture below is seeded exclusively through
+// h.ls, matching how those stubs already force every OTHER dynamic-secrets
+// test in this repo to seed.)
+//
+// SKIPPED (not a fixture-cost skip -- a genuine, confirmed, currently-shipping
+// wire bug found while writing this tranche, exactly the class of defect this
+// harness exists to catch):
+//
+//   - CreateRotationPolicy, UpdateRotationPolicy: RemoteStorage.CreateRotationPolicy/
+//     UpdateRotationPolicy (remote_rotation_policies.go) POST/PUT the caller's
+//     *models.RotationPolicy directly via `rs.client.Post/Put(ctx, path, p)`,
+//     which json.Marshal's it verbatim -- and models.RotationPolicy carries NO
+//     json tags on Name/Scope/ProjectID/EnvironmentID/IntervalDays/
+//     AlertDaysBefore/NotifyOnBreach/IsActive/CreatedBy (only RotationState/
+//     LastRotationError/LastStateAt do), so it marshals as PascalCase keys
+//     ("IntervalDays", "ProjectID", ...). The server-side handler
+//     (rotation_policies_handler.go's Create/Update) decodes into a reqBody
+//     struct tagged with snake_case keys ("interval_days", "project_id", ...).
+//     encoding/json's fallback case-insensitive field match (bytes.EqualFold)
+//     cannot bridge "IntervalDays" to "interval_days" -- the strings differ by
+//     more than case (an inserted underscore), so EqualFold never matches for
+//     any multi-word field. The result: reqBody.IntervalDays/ProjectID/
+//     EnvironmentID/AlertDaysBefore/NotifyOnBreach ALL silently decode to their
+//     zero values regardless of what the caller actually set, and
+//     reqBody.IntervalDays == 0 then trips `validate:"required,min=1,max=365"`
+//     -- confirmed empirically (not theorized): every real attempt below
+//     failed with the server's own 400 `{"field":"interval_days","message":
+//     "must be at least 1"}`, for a caller that set IntervalDays: 30. This
+//     means CreateRotationPolicy/UpdateRotationPolicy are BROKEN over
+//     RemoteStorage unconditionally -- every storage.type: remote deployment's
+//     downstream server fails every rotation-policy create/update a real user
+//     performs through it, not an edge case. Filed as a critical, human-reachable
+//     finding for immediate follow-up rather than fixed here: fixing it means
+//     editing remote_rotation_policies.go and/or rotation_policies_handler.go,
+//     both existing files this tranche's own scope forbids touching (only ONE
+//     new file may be added). A real passing conformance test for either method
+//     cannot be written until that fix lands -- writing one now would either be
+//     a tautological test of the ALREADY-KNOWN-BROKEN 400 response (not what
+//     this harness is for) or would require modifying the very files this task
+//     says not to touch.
+//
+// Fixture pattern: the 7 remote_dynamic.go methods and GetRotationPolicy/
+// ListRotationPolicies are pure reads (or install-wide aggregates) with no
+// server-side business logic that could legitimately mutate a result -- for
+// these, a SINGLE shared fixture set is seeded via h.ls and then read through
+// BOTH h.ls.M(x) and h.rs.M(x), exactly like remote_storage_conformance_test.go's
+// GetSecretByName/LockUserForUpdate. This is a strictly stronger check than
+// two independent "local scenario"/"remote scenario" fixtures would be: it
+// directly tests the harness's own stated property (RemoteStorage.M(x) against
+// the SAME backing store LocalStorage.M(x) sees), rather than two isolated
+// scenarios that could each pass without ever proving the two facades agree.
+//
+// CreateRotationPolicy/UpdateRotationPolicy/DeleteRotationPolicy are the
+// mutating exception, and use the dual local-scenario/remote-scenario fixture
+// pattern established in tranches 2 and 3 (independent rows per facade, so one
+// path's write can never contaminate the other's comparison).
+//
+// CreateRotationPolicy and UpdateRotationPolicy both route through the
+// human-facing REST handlers (rotation_policies_handler.go), which run the
+// FULL core.CreateRotationPolicy/UpdateRotationPolicy business logic -- NOT a
+// raw storage passthrough like the dynamic-secrets /system proxy routes above.
+// CreatedBy in particular is always derived server-side from the authenticated
+// caller's own session (userCtx.Username), discarding whatever CreatedBy the
+// wire model carries -- see CreateRotationPolicy's own comment below for the
+// confirmed call site.
+package http
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// uintPtr is a small local helper for the *uint-typed scope fields
+// (RotationPolicy.ProjectID/EnvironmentID, ListRotationPolicies' parameters)
+// used repeatedly below.
+func uintPtr(v uint) *uint { return &v }
+
+// --- GetDynamicSecretConfig ---
+
+func TestConformance_GetDynamicSecretConfig(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	cfg, err := h.ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+		Name: "conformance-gdsc-config", ProjectID: h.projectID, EnvironmentID: h.environmentID,
+		BackendType: "postgres",
+		// AdminDSNEnc/AdminDSNMeta: opaque test ciphertext bytes -- the whole point
+		// of this proxy tree (dynamic_secrets_proxy.go's package doc) is that this
+		// crosses the wire byte-for-byte. models.DynamicSecretConfig tags these
+		// `json:"-"`, but that tag is irrelevant to assertFieldExhaustiveEqual (a
+		// reflection-based comparator over the Go struct, not a JSON marshal of the
+		// model) -- the actual wire DTO (dynamicSecretConfigWire /
+		// dynamicSecretConfigProxyWire) carries its own explicit
+		// `json:"admin_dsn_enc,omitempty"` tag that puts these bytes on the wire.
+		AdminDSNEnc:       []byte("conformance-ciphertext-admin-dsn"),
+		AdminDSNMeta:      []byte("conformance-admin-dsn-meta-v1"),
+		CreationTemplate:  "GRANT SELECT ON ALL TABLES IN SCHEMA public TO {{name}};",
+		DefaultTTLSeconds: 3600,
+		MaxTTLSeconds:     86400,
+		MaxActiveLeases:   5,
+		Classification:    "confidential",
+		CreatedBy:         "conformance-test",
+	})
+	require.NoError(t, err)
+
+	// Both reads fetch the identical DB row (same backing store) -- no server-side
+	// business logic can legitimately mutate a read, so a clean field-exhaustive
+	// comparison, same reasoning as GetSecretByName
+	// (remote_storage_conformance_test.go).
+	localOut, err := h.ls.GetDynamicSecretConfig(ctx, cfg.ID)
+	require.NoError(t, err)
+	remoteOut, err := h.rs.GetDynamicSecretConfig(ctx, cfg.ID)
+	require.NoError(t, err, "RemoteStorage.GetDynamicSecretConfig must succeed for a config that genuinely exists")
+	assertFieldExhaustiveEqual(t, "GetDynamicSecretConfig (RemoteStorage vs LocalStorage, same row)",
+		localOut, remoteOut, map[string]bool{})
+
+	_, err = h.rs.GetDynamicSecretConfig(ctx, cfg.ID+987654)
+	assert.Error(t, err, "RemoteStorage.GetDynamicSecretConfig must fail for a config that does not exist")
+}
+
+// --- GetDynamicSecretLease ---
+
+func TestConformance_GetDynamicSecretLease(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	cfg, err := h.ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+		Name: "conformance-gdsl-config", ProjectID: h.projectID, EnvironmentID: h.environmentID,
+		BackendType: "postgres", CreationTemplate: "-- noop", DefaultTTLSeconds: 3600,
+		MaxTTLSeconds: 86400, MaxActiveLeases: 5, CreatedBy: "conformance-test",
+	})
+	require.NoError(t, err)
+
+	revokedAt := time.Now().Add(-30 * time.Minute).UTC().Truncate(time.Second)
+	lease, err := h.ls.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
+		ConfigID: cfg.ID, LeaseID: "conformance-gdsl-lease-id", ProjectID: h.projectID,
+		EnvironmentID: h.environmentID, RoleName: "conformance-gdsl-role",
+		// CredentialEnc/CredentialMeta: same reasoning as AdminDSNEnc/AdminDSNMeta
+		// above -- opaque ciphertext test bytes, deliberately exercised because
+		// dynamicSecretLeaseWire/dynamicSecretLeaseProxyWire carry them explicitly.
+		CredentialEnc:  []byte("conformance-cred-ciphertext"),
+		CredentialMeta: []byte("conformance-cred-meta-v1"),
+		Status:         "revoked",
+		RevokeReason:   "conformance test revoke",
+		IssuedAt:       time.Now().Add(-time.Hour).UTC().Truncate(time.Second),
+		ExpiresAt:      time.Now().Add(time.Hour).UTC().Truncate(time.Second),
+		RevokedAt:      &revokedAt,
+	})
+	require.NoError(t, err)
+
+	localOut, err := h.ls.GetDynamicSecretLease(ctx, lease.LeaseID)
+	require.NoError(t, err)
+	remoteOut, err := h.rs.GetDynamicSecretLease(ctx, lease.LeaseID)
+	require.NoError(t, err, "RemoteStorage.GetDynamicSecretLease must succeed for a lease that genuinely exists")
+	assertFieldExhaustiveEqual(t, "GetDynamicSecretLease (RemoteStorage vs LocalStorage, same row)",
+		localOut, remoteOut, map[string]bool{})
+
+	_, err = h.rs.GetDynamicSecretLease(ctx, "conformance-gdsl-does-not-exist")
+	assert.Error(t, err, "RemoteStorage.GetDynamicSecretLease must fail for a lease ID that does not exist")
+}
+
+// --- ListDynamicSecretConfigs ---
+
+func TestConformance_ListDynamicSecretConfigs(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-ldsc-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+	otherEnvs, err := h.ls.ListEnvironmentsByProject(ctx, otherProject.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, otherEnvs)
+
+	newConfig := func(projectID, environmentID uint, name string) *models.DynamicSecretConfig {
+		cfg, err := h.ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+			Name: name, ProjectID: projectID, EnvironmentID: environmentID, BackendType: "postgres",
+			CreationTemplate: "-- noop", DefaultTTLSeconds: 3600, MaxTTLSeconds: 86400, MaxActiveLeases: 5,
+			CreatedBy: "conformance-test",
+		})
+		require.NoError(t, err)
+		return cfg
+	}
+
+	target := newConfig(h.projectID, h.environmentID, "conformance-ldsc-target")
+	// A config in a DIFFERENT project must not appear when filtering by
+	// h.projectID -- the scope-drop risk this method exists to guard against.
+	_ = newConfig(otherProject.ID, otherEnvs[0].ID, "conformance-ldsc-other")
+
+	localList, err := h.ls.ListDynamicSecretConfigs(ctx, h.projectID, h.environmentID)
+	require.NoError(t, err)
+	remoteList, err := h.rs.ListDynamicSecretConfigs(ctx, h.projectID, h.environmentID)
+	require.NoError(t, err, "RemoteStorage.ListDynamicSecretConfigs must succeed for the caller's own project")
+
+	require.Len(t, localList, 1, "sanity: LocalStorage must return only the target project's config")
+	require.Len(t, remoteList, 1,
+		"RemoteStorage.ListDynamicSecretConfigs must return only the config genuinely scoped to the "+
+			"caller-supplied project -- a dropped/ignored project_id on the wire would leak the other "+
+			"project's config too")
+	assertFieldExhaustiveEqual(t, "ListDynamicSecretConfigs[0] (RemoteStorage vs LocalStorage)",
+		localList[0], remoteList[0], map[string]bool{})
+	assert.Equal(t, target.ID, remoteList[0].ID)
+}
+
+// --- ListDynamicSecretLeases ---
+
+func TestConformance_ListDynamicSecretLeases(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newConfig := func(name string) *models.DynamicSecretConfig {
+		cfg, err := h.ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+			Name: name, ProjectID: h.projectID, EnvironmentID: h.environmentID, BackendType: "postgres",
+			CreationTemplate: "-- noop", DefaultTTLSeconds: 3600, MaxTTLSeconds: 86400, MaxActiveLeases: 5,
+			CreatedBy: "conformance-test",
+		})
+		require.NoError(t, err)
+		return cfg
+	}
+	newLease := func(configID uint, leaseID string) *models.DynamicSecretLease {
+		l, err := h.ls.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
+			ConfigID: configID, LeaseID: leaseID, ProjectID: h.projectID, EnvironmentID: h.environmentID,
+			RoleName: "conformance-role-" + leaseID, Status: "active",
+			IssuedAt: time.Now().UTC().Truncate(time.Second), ExpiresAt: time.Now().Add(time.Hour).UTC().Truncate(time.Second),
+		})
+		require.NoError(t, err)
+		return l
+	}
+
+	targetConfig := newConfig("conformance-ldsl-target-config")
+	otherConfig := newConfig("conformance-ldsl-other-config")
+	targetLease := newLease(targetConfig.ID, "conformance-ldsl-target-lease")
+	// A lease belonging to a DIFFERENT config must not appear -- the scope-drop
+	// risk this method exists to guard against.
+	_ = newLease(otherConfig.ID, "conformance-ldsl-other-lease")
+
+	localList, err := h.ls.ListDynamicSecretLeases(ctx, targetConfig.ID)
+	require.NoError(t, err)
+	remoteList, err := h.rs.ListDynamicSecretLeases(ctx, targetConfig.ID)
+	require.NoError(t, err, "RemoteStorage.ListDynamicSecretLeases must succeed for a config that genuinely exists")
+
+	require.Len(t, localList, 1, "sanity: LocalStorage must return only the target config's lease")
+	require.Len(t, remoteList, 1,
+		"RemoteStorage.ListDynamicSecretLeases must return only the lease genuinely scoped to the "+
+			"caller-supplied config -- a dropped/ignored config_id on the wire would leak the other "+
+			"config's lease too")
+	assertFieldExhaustiveEqual(t, "ListDynamicSecretLeases[0] (RemoteStorage vs LocalStorage)",
+		localList[0], remoteList[0], map[string]bool{})
+	assert.Equal(t, targetLease.ID, remoteList[0].ID)
+}
+
+// --- CountActiveLeases ---
+
+func TestConformance_CountActiveLeases(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newConfig := func(name string) *models.DynamicSecretConfig {
+		cfg, err := h.ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+			Name: name, ProjectID: h.projectID, EnvironmentID: h.environmentID,
+			BackendType: "postgres", CreationTemplate: "-- noop", DefaultTTLSeconds: 3600,
+			MaxTTLSeconds: 86400, MaxActiveLeases: 10, CreatedBy: "conformance-test",
+		})
+		require.NoError(t, err)
+		return cfg
+	}
+
+	// Negative case (brief's suggested example): a config with zero leases must
+	// count zero on both facades. A SEPARATE, never-queried-before config is
+	// used for this (rather than re-querying the populated config below) --
+	// RemoteStorage.HTTPClient caches a GET response for 5 minutes keyed by its
+	// exact URL (client.go's Get, the same mechanism LockUserForUpdate's class-6
+	// conformance test exercises deliberately); querying the SAME config_id
+	// twice before/after seeding leases would silently replay the first (zero)
+	// response instead of genuinely re-querying, certifying nothing.
+	zeroCfg := newConfig("conformance-cal-zero-config")
+	localZero, err := h.ls.CountActiveLeases(ctx, zeroCfg.ID)
+	require.NoError(t, err)
+	remoteZero, err := h.rs.CountActiveLeases(ctx, zeroCfg.ID)
+	require.NoError(t, err, "RemoteStorage.CountActiveLeases must succeed for a config that genuinely exists")
+	assert.Equal(t, int64(0), localZero, "sanity: a config with zero leases must count zero")
+	assert.Equal(t, int64(0), remoteZero, "RemoteStorage.CountActiveLeases must also count zero for a config with zero leases")
+
+	populatedCfg := newConfig("conformance-cal-populated-config")
+	newLease := func(leaseID, status string) {
+		_, err := h.ls.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
+			ConfigID: populatedCfg.ID, LeaseID: leaseID, ProjectID: h.projectID, EnvironmentID: h.environmentID,
+			RoleName: "conformance-role-" + leaseID, Status: status,
+			IssuedAt: time.Now().UTC().Truncate(time.Second), ExpiresAt: time.Now().Add(time.Hour).UTC().Truncate(time.Second),
+		})
+		require.NoError(t, err)
+	}
+	// local_dynamic.go's own #411 doc: "active" AND "revoke_failed" both still
+	// hold a live credential upstream and must count; "revoked" and "expired" do
+	// not -- exercising the exclusion side of the filter is the point, not just
+	// the inclusion side (an over-broad filter would silently inflate this count
+	// and let a caller exceed MaxActiveLeases; an over-narrow one would let a
+	// revoke_failed lease's still-live credential go uncounted forever).
+	newLease("conformance-cal-active", "active")
+	newLease("conformance-cal-revoke-failed", "revoke_failed")
+	newLease("conformance-cal-revoked", "revoked")
+	newLease("conformance-cal-expired", "expired")
+
+	localCount, err := h.ls.CountActiveLeases(ctx, populatedCfg.ID)
+	require.NoError(t, err)
+	remoteCount, err := h.rs.CountActiveLeases(ctx, populatedCfg.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), localCount, "sanity: only active + revoke_failed leases count")
+	assert.Equal(t, int64(2), remoteCount,
+		"RemoteStorage.CountActiveLeases must count exactly the still-live leases (active + revoke_failed), "+
+			"matching LocalStorage against the same backing store -- a widened or narrowed status filter on "+
+			"the wire would over- or under-count")
+}
+
+// --- CountDynamicSecretConfigsByClassification ---
+
+func TestConformance_CountDynamicSecretConfigsByClassification(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newConfig := func(name, classification string) {
+		_, err := h.ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+			Name: name, ProjectID: h.projectID, EnvironmentID: h.environmentID, BackendType: "postgres",
+			CreationTemplate: "-- noop", DefaultTTLSeconds: 3600, MaxTTLSeconds: 86400, MaxActiveLeases: 5,
+			Classification: classification, CreatedBy: "conformance-test",
+		})
+		require.NoError(t, err)
+	}
+	newConfig("conformance-cdscbc-confidential-1", "confidential")
+	newConfig("conformance-cdscbc-confidential-2", "confidential")
+	newConfig("conformance-cdscbc-internal", "internal")
+	newConfig("conformance-cdscbc-unclassified", "")
+
+	// Install-wide (no project scope): LocalStorage and RemoteStorage are
+	// necessarily reading the identical aggregate over the SAME rows here, so
+	// there is no local-scenario/remote-scenario split to make -- just a direct
+	// same-store comparison, like GetSecretByName.
+	localCounts, err := h.ls.CountDynamicSecretConfigsByClassification(ctx)
+	require.NoError(t, err)
+	remoteCounts, err := h.rs.CountDynamicSecretConfigsByClassification(ctx)
+	require.NoError(t, err, "RemoteStorage.CountDynamicSecretConfigsByClassification must succeed")
+
+	assert.Equal(t, 2, localCounts["confidential"], "sanity: two confidential configs seeded")
+	assert.Equal(t, 1, localCounts["internal"], "sanity: one internal config seeded")
+	assert.Equal(t, 1, localCounts[""], "sanity: one unclassified config seeded")
+	assert.Equal(t, localCounts, remoteCounts,
+		"RemoteStorage.CountDynamicSecretConfigsByClassification must return the identical per-classification "+
+			"counts as LocalStorage against the same backing store")
+}
+
+// --- ListExpiredActiveLeases ---
+
+func TestConformance_ListExpiredActiveLeases(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	cfg, err := h.ls.CreateDynamicSecretConfig(ctx, &models.DynamicSecretConfig{
+		Name: "conformance-leal-config", ProjectID: h.projectID, EnvironmentID: h.environmentID,
+		BackendType: "postgres", CreationTemplate: "-- noop", DefaultTTLSeconds: 3600,
+		MaxTTLSeconds: 86400, MaxActiveLeases: 10, CreatedBy: "conformance-test",
+	})
+	require.NoError(t, err)
+
+	cutoff := time.Now().UTC()
+	past := cutoff.Add(-1 * time.Hour)
+	future := cutoff.Add(1 * time.Hour)
+
+	newLease := func(leaseID, status string, expiresAt time.Time) {
+		_, err := h.ls.CreateDynamicSecretLease(ctx, &models.DynamicSecretLease{
+			ConfigID: cfg.ID, LeaseID: leaseID, ProjectID: h.projectID, EnvironmentID: h.environmentID,
+			RoleName: "conformance-role-" + leaseID, Status: status,
+			IssuedAt: past.Add(-time.Hour), ExpiresAt: expiresAt,
+		})
+		require.NoError(t, err)
+	}
+
+	// Must be INCLUDED: past expiry, still-live status.
+	newLease("conformance-leal-active-expired", "active", past)
+	newLease("conformance-leal-revokefailed-expired", "revoke_failed", past)
+	// Must be EXCLUDED: past expiry but already revoked -- no live credential
+	// left to drop, so re-including it would make the sweep re-attempt a revoke
+	// against a credential that's already gone.
+	newLease("conformance-leal-revoked-expired", "revoked", past)
+	// Must be EXCLUDED -- the brief's explicit off-by-scope risk: a genuinely
+	// still-live, still-active lease that has NOT expired yet must not be swept.
+	newLease("conformance-leal-active-future", "active", future)
+
+	localList, err := h.ls.ListExpiredActiveLeases(ctx, cutoff)
+	require.NoError(t, err)
+	remoteList, err := h.rs.ListExpiredActiveLeases(ctx, cutoff)
+	require.NoError(t, err, "RemoteStorage.ListExpiredActiveLeases must succeed")
+
+	idsOf := func(leases []*models.DynamicSecretLease) []string {
+		ids := make([]string, len(leases))
+		for i, l := range leases {
+			ids[i] = l.LeaseID
+		}
+		return ids
+	}
+	wantIDs := []string{"conformance-leal-active-expired", "conformance-leal-revokefailed-expired"}
+	assert.ElementsMatch(t, wantIDs, idsOf(localList),
+		"sanity: LocalStorage must return exactly the two still-live, past-expiry leases")
+	assert.ElementsMatch(t, wantIDs, idsOf(remoteList),
+		"RemoteStorage.ListExpiredActiveLeases must return exactly the two still-live, past-expiry leases -- "+
+			"neither a not-yet-expired lease nor an already-revoked one, matching LocalStorage against the "+
+			"same backing store (a widened/narrowed status or expiry filter on the wire would leak or drop rows)")
+}
+
+// --- GetRotationPolicy ---
+
+func TestConformance_GetRotationPolicy(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	policy := &models.RotationPolicy{
+		Name: "conformance-grp-policy", Description: "conformance test policy", Scope: "project",
+		ProjectID: uintPtr(h.projectID), IntervalDays: 30, AlertDaysBefore: 7, NotifyOnBreach: true,
+		IsActive: true, RotationState: "idle", CreatedBy: "conformance-test",
+	}
+	require.NoError(t, h.ls.CreateRotationPolicy(ctx, policy))
+
+	// Same row, two facades -- no server-side business logic runs on a plain
+	// Get, so a clean field-exhaustive comparison, same reasoning as
+	// GetSecretByName.
+	localOut, err := h.ls.GetRotationPolicy(ctx, policy.ID)
+	require.NoError(t, err)
+	remoteOut, err := h.rs.GetRotationPolicy(ctx, policy.ID)
+	require.NoError(t, err, "RemoteStorage.GetRotationPolicy must succeed for a policy that genuinely exists")
+	assertFieldExhaustiveEqual(t, "GetRotationPolicy (RemoteStorage vs LocalStorage, same row)",
+		localOut, remoteOut, map[string]bool{})
+
+	_, err = h.rs.GetRotationPolicy(ctx, policy.ID+987654)
+	assert.Error(t, err, "RemoteStorage.GetRotationPolicy must fail for a policy that does not exist")
+}
+
+// --- ListRotationPolicies ---
+
+func TestConformance_ListRotationPolicies(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lrp-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+
+	newPolicy := func(projectID uint, name string) *models.RotationPolicy {
+		p := &models.RotationPolicy{
+			Name: name, Scope: "project", ProjectID: uintPtr(projectID), IntervalDays: 30,
+			AlertDaysBefore: 7, NotifyOnBreach: true, IsActive: true, RotationState: "idle",
+			CreatedBy: "conformance-test",
+		}
+		require.NoError(t, h.ls.CreateRotationPolicy(ctx, p))
+		return p
+	}
+
+	target := newPolicy(h.projectID, "conformance-lrp-target")
+	// A policy scoped to a DIFFERENT project must not appear -- the scope-drop
+	// risk this method exists to guard against.
+	_ = newPolicy(otherProject.ID, "conformance-lrp-other")
+
+	localList, err := h.ls.ListRotationPolicies(ctx, uintPtr(h.projectID), nil)
+	require.NoError(t, err)
+	remoteList, err := h.rs.ListRotationPolicies(ctx, uintPtr(h.projectID), nil)
+	require.NoError(t, err, "RemoteStorage.ListRotationPolicies must succeed for the caller's own project")
+
+	require.Len(t, localList, 1, "sanity: LocalStorage must return only the target project's policy")
+	require.Len(t, remoteList, 1,
+		"RemoteStorage.ListRotationPolicies must return only the policy genuinely scoped to the "+
+			"caller-supplied project -- a dropped/ignored project_id on the wire would leak the other "+
+			"project's policy too")
+	assertFieldExhaustiveEqual(t, "ListRotationPolicies[0] (RemoteStorage vs LocalStorage)",
+		localList[0], remoteList[0], map[string]bool{})
+	assert.Equal(t, target.ID, remoteList[0].ID)
+}
+
+// --- CreateRotationPolicy, UpdateRotationPolicy: SKIPPED ---
+//
+// See this file's package doc above for the confirmed wire-format bug that
+// makes both methods fail unconditionally over RemoteStorage (every real
+// attempt during this tranche's own development failed with the server's
+// 400 "interval_days must be at least 1", for callers that set IntervalDays
+// to a valid value) -- not a fixture-cost skip, a discovered defect that
+// needs a fix to remote_rotation_policies.go/rotation_policies_handler.go
+// before a real conformance test can be written for either method.
+
+// --- DeleteRotationPolicy ---
+
+func TestConformance_DeleteRotationPolicy(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newPolicy := func(suffix string) *models.RotationPolicy {
+		p := &models.RotationPolicy{
+			Name: "conformance-drp-" + suffix, Scope: "project", ProjectID: uintPtr(h.projectID),
+			IntervalDays: 30, AlertDaysBefore: 7, NotifyOnBreach: true, IsActive: true,
+			RotationState: "idle", CreatedBy: "conformance-test",
+		}
+		require.NoError(t, h.ls.CreateRotationPolicy(ctx, p))
+		return p
+	}
+
+	localPolicy := newPolicy("local")
+	require.NoError(t, h.ls.DeleteRotationPolicy(ctx, localPolicy.ID))
+
+	remotePolicy := newPolicy("remote")
+	require.NoError(t, h.rs.DeleteRotationPolicy(ctx, remotePolicy.ID),
+		"RemoteStorage.DeleteRotationPolicy must succeed for a policy that genuinely exists")
+
+	_, localErr := h.ls.GetRotationPolicy(ctx, localPolicy.ID)
+	_, remoteErr := h.ls.GetRotationPolicy(ctx, remotePolicy.ID)
+	assert.Error(t, localErr, "sanity: the local policy must no longer be retrievable")
+	assert.Error(t, remoteErr,
+		"the policy deleted via RemoteStorage must actually be gone server-side, not just report success")
+
+	// Deleting an already-deleted policy: the RAW LocalStorage primitive is an
+	// idempotent no-op (GORM's default soft-delete scope excludes the
+	// already-deleted row from the second DELETE's WHERE clause, so
+	// RowsAffected=0 with no error) -- but RemoteStorage's proxy runs
+	// core.DeleteRotationPolicy, which re-fetches the policy via
+	// GetRotationPolicy FIRST (to build the audit-log message) and that fetch
+	// now 404s, surfacing as a genuine error through the wire. This asymmetry
+	// is a real, pre-existing core-vs-raw-storage semantic difference (not a
+	// proxy-layer wire bug): the raw primitive was always silently idempotent;
+	// the core layer was always fetch-first. Both are asserted here so a future
+	// regression in either direction is caught.
+	assert.NoError(t, h.ls.DeleteRotationPolicy(ctx, localPolicy.ID),
+		"sanity: LocalStorage's raw DeleteRotationPolicy primitive is an idempotent no-op on an already-deleted row")
+	assert.Error(t, h.rs.DeleteRotationPolicy(ctx, remotePolicy.ID),
+		"RemoteStorage.DeleteRotationPolicy must fail for an already-deleted policy -- core.DeleteRotationPolicy "+
+			"re-fetches the row first and that fetch now 404s, not silently no-op a second time")
+}

--- a/server/http/remote_storage_conformance_tranche4_invitations_access_review_test.go
+++ b/server/http/remote_storage_conformance_tranche4_invitations_access_review_test.go
@@ -1,0 +1,1129 @@
+// remote_storage_conformance_tranche4_invitations_access_review_test.go —
+// issue #1808, tranche 4.
+//
+// Scope: all 20 real *RemoteStorage methods backed by
+// internal/storage/store/remote_invitations.go (project invitations + access
+// requests, ADR-024/#523) and internal/storage/store/remote_access_review_campaigns.go
+// (access-review campaigns, ISO 27001 A.5.18, #519) — every method named in
+// this tranche's assignment is covered; none skipped.
+//
+//	remote_invitations.go: CreateAccessRequest, CreateAccessRequestApproval,
+//	CreateProjectInvitation, GetAccessRequest, GetProjectInvitation,
+//	ListAccessRequestApprovals, ListAccessRequests, ListProjectInvitations,
+//	UpdateAccessRequest, UpdateProjectInvitation
+//
+//	remote_access_review_campaigns.go: CountPendingAccessReviewItems,
+//	CreateAccessReviewCampaign, CreateAccessReviewItems,
+//	GetAccessReviewCampaign, GetAccessReviewItem,
+//	GetLatestClosedAccessReviewCampaign, GetOpenAccessReviewCampaign,
+//	ListAccessReviewCampaigns, ListAccessReviewItems, UpdateAccessReviewItem
+//
+// (UpdateAccessReviewCampaign, also in that file, is deliberately excluded —
+// it was deleted in the G80 liveness sweep and now always returns
+// errUnsupportedRemote; it is not in this tranche's method list.)
+//
+// # Actor-identity gating discovered while writing this tranche
+//
+// Several of these routes gate on the AUTHENTICATED caller's actor kind, not
+// just a permission bit, which shapes which harness credential can drive each
+// test:
+//
+//   - actorID(r) (server/http/handlers/catalog.go) always returns 0 for a
+//     machine/node caller (UserContext.UserID is never set for one) — so
+//     CreateInvitationProxy's InvitedBy and CreateAccessReviewCampaignProxy's
+//     CreatedBy always land as 0 when created via h.rs (the harness's
+//     node/machine credential), never the caller's real identity.
+//   - requestActorKindAndID(r), used by the access-request routes, DOES carry
+//     a machine caller's real PrincipalID (unlike actorID) — AccessRequest's
+//     ResolvedByMachineIdentityID / AccessRequestApproval's
+//     ApproverMachineIdentityID correctly capture it (the #1573/#1622 fix).
+//   - RequireGranterHoldsRolePermissions unconditionally refuses ANY
+//     permission-carrying role grant for a machine actor relayed through a
+//     /system proxy route with no WithSelfMachineGranter tag (no such tag is
+//     ever set on this tree) — confirmed in tranche 3's AssignRoleWithExpiry/
+//     AssignMachineRole comment; every role created below for a
+//     CreateInvitationProxy/UpdateAccessRequestProxy/
+//     CreateAccessRequestApprovalProxy call is a zero-permission role for the
+//     same reason (the loop that does the refusing has nothing to iterate).
+//   - RequireAdminAuthorityAt is a USER-scoped check only (scopedRoleIDs never
+//     consults machine role grants) — a secret-scoped access-request approval
+//     is therefore only reachable by a real user session, not h.rs; this
+//     tranche exercises the project/role-scoped approve branch instead (which
+//     RequireGranterHoldsRolePermissions gates, satisfiable by a
+//     zero-permission role) rather than adding a second minted user session
+//     for a branch that would exercise the same wire-fidelity contract twice.
+//   - AuthorizePrincipal for a machine actor has NO admin-name bypass
+//     (internal/core/authz.go's own doc comment) — h.rs's "roles.assign" pass
+//     for UpdateAccessRequestProxy's reject/expire branch works because the
+//     admin role's own permission bundle genuinely includes "roles.assign" at
+//     global scope (which GetMachineRoleIDsAt's project_id=0 OR project_id=?
+//     clause matches against any project), not because of a bypass.
+//   - UpdateAccessReviewItemProxy hard-refuses any non-human caller outright
+//     (ARC-005: "an independent reviewer concept has no meaning for a machine
+//     caller") — h.rs cannot drive this route at all, so
+//     TestConformance_UpdateAccessReviewItem mints a second RemoteStorage
+//     client on a real user session, mirroring tranche 3's
+//     RevokeBreakGlassActivation.
+//
+// # Two known wire-fidelity gaps found while writing this tranche
+//
+// Neither is fixed here ("Do NOT modify any existing file" — this tranche's
+// assignment) — both are flagged as follow-up findings, asserted as the
+// CURRENT (unfortunate) behavior rather than silently excluded from
+// comparison, so a future fix has a red test to turn green:
+//
+//  1. models.ProjectInvitation.InvitedByMachineIdentityID (#1573) exists
+//     specifically so a machine caller's real identity survives when
+//     InvitedBy is 0 for that reason — the same fix already applied to
+//     AccessRequest.ResolvedByMachineIdentityID / AccessRequestApproval.
+//     ApproverMachineIdentityID. Neither invitationWire
+//     (remote_invitations.go) nor invitationProxyWire (invitations_proxy.go)
+//     carries this field, and CreateInvitationProxy never independently sets
+//     it — an invitation genuinely created by a machine/node credential (the
+//     realistic production caller for this storage-layer method, per this
+//     file's own package doc) silently loses its inviter's identity
+//     entirely. See TestConformance_CreateProjectInvitation.
+//  2. models.AccessReviewCampaign.CreatedByMachineIdentityID/
+//     ClosedByMachineIdentityID (#1573) have the identical gap: absent from
+//     accessReviewCampaignWire/accessReviewCampaignProxyWire, never
+//     independently set by CreateAccessReviewCampaignProxy. See
+//     TestConformance_CreateAccessReviewCampaign.
+package http
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// --- CreateProjectInvitation ---
+
+func TestConformance_CreateProjectInvitation(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// A zero-permission role for the invitation's Role field -- see this
+	// file's package doc on RequireGranterHoldsRolePermissions.
+	roleName, err := identity.NewFoldedName("conformance-cpi-role")
+	require.NoError(t, err)
+	role, err := h.ls.CreateRole(ctx, roleName, "conformance test role")
+	require.NoError(t, err)
+
+	expiresAt := time.Now().Add(72 * time.Hour).UTC()
+
+	// Local sanity baseline: LocalStorage.CreateProjectInvitation is a raw
+	// create -- every field, including InvitedBy, round-trips verbatim.
+	localInput := &models.ProjectInvitation{
+		ProjectID: h.projectID, Email: "conformance-cpi-local@example.com", Role: role.Name,
+		State: "pending", InvitedBy: h.adminUserID, ValidationModeAtInvite: "strict", ExpiresAt: &expiresAt,
+	}
+	localCreated, err := h.ls.CreateProjectInvitation(ctx, localInput)
+	require.NoError(t, err)
+	localPersisted, err := h.ls.GetProjectInvitation(ctx, localCreated.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "LocalStorage.CreateProjectInvitation (sanity baseline)", localInput, localPersisted,
+		map[string]bool{"ID": true, "CreatedAt": true})
+
+	// Remote: CreateInvitationProxy forces InvitedBy to the AUTHENTICATED
+	// caller, never the wire value (2026-08-25 finding, invitations_proxy.go's
+	// own package doc) -- the harness's machine/node credential's actorID(r)
+	// is always 0, so InvitedBy lands as 0, not the forged admin ID below.
+	const forgedInvitedBy = 999999
+	remoteInput := &models.ProjectInvitation{
+		ProjectID: h.projectID, Email: "conformance-cpi-remote@example.com", Role: role.Name,
+		State: "pending", InvitedBy: forgedInvitedBy, ValidationModeAtInvite: "strict", ExpiresAt: &expiresAt,
+	}
+	remoteCreated, err := h.rs.CreateProjectInvitation(ctx, remoteInput)
+	require.NoError(t, err, "RemoteStorage.CreateProjectInvitation must succeed for a zero-permission role")
+	remotePersisted, err := h.ls.GetProjectInvitation(ctx, remoteCreated.ID)
+	require.NoError(t, err)
+	assert.NotEqual(t, uint(forgedInvitedBy), remotePersisted.InvitedBy,
+		"InvitedBy must be derived from the authenticated caller, never trusted from the wire")
+	assert.Equal(t, uint(0), remotePersisted.InvitedBy,
+		"the harness's machine/node credential's actorID(r) is always 0 (no UserID) -- InvitedBy lands as 0")
+
+	// KNOWN WIRE-FIDELITY GAP -- see this file's package doc, item 1. Asserting
+	// the CURRENT (unfortunate) behavior rather than excluding the field
+	// silently.
+	assert.Equal(t, uint(0), remotePersisted.InvitedByMachineIdentityID,
+		"KNOWN GAP: the machine caller's real identity is silently lost -- InvitedByMachineIdentityID is not "+
+			"carried on this wire at all today (see this file's package doc)")
+
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateProjectInvitation (wire round trip, InvitedBy* excluded -- see comments)",
+		remoteInput, remotePersisted,
+		map[string]bool{"ID": true, "CreatedAt": true, "InvitedBy": true, "InvitedByMachineIdentityID": true})
+}
+
+// --- GetProjectInvitation ---
+
+func TestConformance_GetProjectInvitation(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	expiresAt := time.Now().Add(48 * time.Hour).UTC()
+
+	inv, err := h.ls.CreateProjectInvitation(ctx, &models.ProjectInvitation{
+		ProjectID: h.projectID, Email: "conformance-gpi@example.com", Role: "irrelevant-role-name",
+		State: "pending", InvitedBy: h.adminUserID, ValidationModeAtInvite: "strict", ExpiresAt: &expiresAt,
+	})
+	require.NoError(t, err)
+
+	localFound, err := h.ls.GetProjectInvitation(ctx, inv.ID)
+	require.NoError(t, err)
+	remoteFound, err := h.rs.GetProjectInvitation(ctx, inv.ID)
+	require.NoError(t, err, "RemoteStorage.GetProjectInvitation must find an invitation that genuinely exists")
+	assertFieldExhaustiveEqual(t, "GetProjectInvitation", localFound, remoteFound, nil)
+
+	_, localErr := h.ls.GetProjectInvitation(ctx, inv.ID+999999)
+	_, remoteErr := h.rs.GetProjectInvitation(ctx, inv.ID+999999)
+	assert.Error(t, localErr, "sanity: a nonexistent invitation ID must error locally")
+	assert.Error(t, remoteErr, "RemoteStorage.GetProjectInvitation must error for a nonexistent invitation ID")
+}
+
+// --- UpdateProjectInvitation ---
+
+func TestConformance_UpdateProjectInvitation(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newPendingInvitation := func(suffix string) *models.ProjectInvitation {
+		inv, err := h.ls.CreateProjectInvitation(ctx, &models.ProjectInvitation{
+			ProjectID: h.projectID, Email: "conformance-upi-" + suffix + "@example.com",
+			Role: "conformance-upi-role-" + suffix, State: "pending", InvitedBy: h.adminUserID,
+			SystemRole: "conformance-upi-sysrole-" + suffix,
+		})
+		require.NoError(t, err)
+		return inv
+	}
+
+	acceptedAt := time.Now().UTC()
+	revokedAt := time.Now().UTC()
+
+	// Wrong-fromState precondition + sanity baseline: LocalStorage.UpdateProjectInvitation
+	// is a raw Select("*") full-row update with no re-fetch/narrowing of its
+	// own (unlike the proxy handler below) -- a real caller mutates the FULL
+	// row it already fetched, which is exactly what this does.
+	localInv := newPendingInvitation("local")
+	localInv.State = "accepted"
+	localInv.AcceptedAt = &acceptedAt
+	localMatched, err := h.ls.UpdateProjectInvitation(ctx, localInv)
+	require.NoError(t, err)
+	require.True(t, localMatched, "sanity: the first transition off pending must match")
+	localInv.State = "revoked"
+	localInv.RevokedAt = &revokedAt
+	localMatchedAgain, err := h.ls.UpdateProjectInvitation(ctx, localInv)
+	require.NoError(t, err)
+	assert.False(t, localMatchedAgain, "sanity: a second transition off an already-resolved invitation must not match")
+
+	// Remote: UpdateInvitationProxy re-fetches the authoritative row
+	// server-side and applies ONLY State/AcceptedAt/RevokedAt from the wire
+	// onto it -- a forged Role/SystemRole/Email/InvitedBy in the wire body
+	// must NOT overwrite the original row's identity, even though the
+	// underlying storage call is a Select("*") full-row update (the
+	// AR-001-shape guard, invitations_proxy.go's own package doc).
+	remoteInv := newPendingInvitation("remote")
+	remoteMatched, err := h.rs.UpdateProjectInvitation(ctx, &models.ProjectInvitation{
+		ID: remoteInv.ID, State: "accepted", AcceptedAt: &acceptedAt,
+		Role: "forged-role", SystemRole: "forged-sysrole", Email: "forged@evil.example", InvitedBy: 999999,
+	})
+	require.NoError(t, err, "RemoteStorage.UpdateProjectInvitation must match a genuinely pending invitation")
+	require.True(t, remoteMatched)
+	afterFirst, err := h.ls.GetProjectInvitation(ctx, remoteInv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "accepted", afterFirst.State)
+	require.NotNil(t, afterFirst.AcceptedAt)
+	assert.True(t, afterFirst.AcceptedAt.Equal(acceptedAt))
+	assert.Equal(t, remoteInv.Role, afterFirst.Role, "a forged Role on the wire must not overwrite the original")
+	assert.Equal(t, remoteInv.SystemRole, afterFirst.SystemRole, "a forged SystemRole on the wire must not overwrite the original")
+	assert.Equal(t, remoteInv.Email, afterFirst.Email, "a forged Email on the wire must not overwrite the original")
+	assert.Equal(t, remoteInv.InvitedBy, afterFirst.InvitedBy, "a forged InvitedBy on the wire must not overwrite the original")
+
+	remoteMatchedAgain, err := h.rs.UpdateProjectInvitation(ctx, &models.ProjectInvitation{ID: remoteInv.ID, State: "revoked", RevokedAt: &revokedAt})
+	require.NoError(t, err)
+	assert.False(t, remoteMatchedAgain,
+		"RemoteStorage.UpdateProjectInvitation must report no match for a second transition attempt off an "+
+			"already-resolved invitation, not silently re-apply it")
+	afterSecond, err := h.ls.GetProjectInvitation(ctx, remoteInv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "accepted", afterSecond.State, "the failed second transition attempt must not have altered the row's state")
+}
+
+// --- ListProjectInvitations ---
+
+func TestConformance_ListProjectInvitations(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	inv1, err := h.ls.CreateProjectInvitation(ctx, &models.ProjectInvitation{
+		ProjectID: h.projectID, Email: "conformance-lpi-1@example.com", Role: "irrelevant-role-name",
+		State: "pending", InvitedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+	inv2, err := h.ls.CreateProjectInvitation(ctx, &models.ProjectInvitation{
+		ProjectID: h.projectID, Email: "conformance-lpi-2@example.com", Role: "irrelevant-role-name",
+		State: "revoked", InvitedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+	_, _ = inv1, inv2
+
+	localRows, err := h.ls.ListProjectInvitations(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteRows, err := h.rs.ListProjectInvitations(ctx, h.projectID)
+	require.NoError(t, err, "RemoteStorage.ListProjectInvitations must list the SAME invitations server-side")
+	require.Len(t, remoteRows, len(localRows))
+	require.GreaterOrEqual(t, len(localRows), 2)
+	localByID := map[uint]*models.ProjectInvitation{}
+	for _, inv := range localRows {
+		localByID[inv.ID] = inv
+	}
+	for _, rinv := range remoteRows {
+		linv, ok := localByID[rinv.ID]
+		require.True(t, ok, "remote row %d has no matching local row", rinv.ID)
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("ListProjectInvitations invitation %d", rinv.ID), linv, rinv, nil)
+	}
+
+	// Negative: a fresh project with zero invitations must return an empty list.
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lpi-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+	emptyLocal, err := h.ls.ListProjectInvitations(ctx, otherProject.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	emptyRemote, err := h.rs.ListProjectInvitations(ctx, otherProject.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyRemote, "RemoteStorage.ListProjectInvitations must return an empty list for a project with no invitations")
+}
+
+// --- CreateAccessRequest ---
+
+func TestConformance_CreateAccessRequest(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	requester, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-car-requester", Email: "conformance-car-requester@example.com",
+		DisplayName: "Conformance CreateAccessRequest Requester", IsActive: true,
+	})
+	require.NoError(t, err)
+	expiresAt := time.Now().Add(24 * time.Hour).UTC()
+
+	// Local sanity baseline: LocalStorage.CreateAccessRequest is a raw create
+	// -- every field, including ResolvedBy, round-trips verbatim.
+	localInput := &models.AccessRequest{
+		ProjectID: h.projectID, UserID: requester.ID, SuggestedRole: "conformance-role",
+		State: core.AccessRequestPending, Reason: "conformance local", ExpiresAt: &expiresAt, ResolvedBy: h.adminUserID,
+	}
+	localCreated, err := h.ls.CreateAccessRequest(ctx, localInput)
+	require.NoError(t, err)
+	localPersisted, err := h.ls.GetAccessRequest(ctx, localCreated.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "LocalStorage.CreateAccessRequest (sanity baseline)", localInput, localPersisted,
+		map[string]bool{"ID": true, "CreatedAt": true})
+
+	// Remote: CreateAccessRequestProxy always forces ResolvedBy to 0 on create
+	// (#1529-shape guard, access_request_proxy.go's own package doc) -- a
+	// newly created request is never pre-resolved, regardless of the wire.
+	const forgedResolvedBy = 999999
+	remoteInput := &models.AccessRequest{
+		ProjectID: h.projectID, UserID: requester.ID, SuggestedRole: "conformance-role",
+		State: core.AccessRequestPending, Reason: "conformance remote", ExpiresAt: &expiresAt, ResolvedBy: forgedResolvedBy,
+	}
+	remoteCreated, err := h.rs.CreateAccessRequest(ctx, remoteInput)
+	require.NoError(t, err, "RemoteStorage.CreateAccessRequest must succeed for a well-formed pending request")
+	remotePersisted, err := h.ls.GetAccessRequest(ctx, remoteCreated.ID)
+	require.NoError(t, err)
+	assert.Equal(t, uint(0), remotePersisted.ResolvedBy, "ResolvedBy must be forced to 0 on create regardless of the wire value")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateAccessRequest (wire round trip)", remoteInput, remotePersisted,
+		map[string]bool{"ID": true, "CreatedAt": true, "ResolvedBy": true})
+
+	// Negative: CreateAccessRequestProxy's own #1529-shape guard rejects any
+	// State other than "pending" outright -- a caller cannot mint a
+	// pre-resolved request via this route.
+	_, err = h.rs.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: h.projectID, UserID: requester.ID, SuggestedRole: "conformance-role", State: core.AccessRequestApproved,
+	})
+	assert.Error(t, err, "RemoteStorage.CreateAccessRequest must refuse a request created in a non-pending state")
+}
+
+// --- GetAccessRequest ---
+
+func TestConformance_GetAccessRequest(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	requester, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gar-requester", Email: "conformance-gar-requester@example.com",
+		DisplayName: "Conformance GetAccessRequest Requester", IsActive: true,
+	})
+	require.NoError(t, err)
+	req, err := h.ls.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: h.projectID, UserID: requester.ID, SuggestedRole: "conformance-role", State: core.AccessRequestPending,
+	})
+	require.NoError(t, err)
+
+	localFound, err := h.ls.GetAccessRequest(ctx, req.ID)
+	require.NoError(t, err)
+	remoteFound, err := h.rs.GetAccessRequest(ctx, req.ID)
+	require.NoError(t, err, "RemoteStorage.GetAccessRequest must find a request that genuinely exists")
+	assertFieldExhaustiveEqual(t, "GetAccessRequest", localFound, remoteFound, nil)
+
+	_, localErr := h.ls.GetAccessRequest(ctx, req.ID+999999)
+	_, remoteErr := h.rs.GetAccessRequest(ctx, req.ID+999999)
+	assert.Error(t, localErr, "sanity: a nonexistent access-request ID must error locally")
+	assert.Error(t, remoteErr, "RemoteStorage.GetAccessRequest must error for a nonexistent request ID")
+}
+
+// --- UpdateAccessRequest ---
+
+func TestConformance_UpdateAccessRequest(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	roleName, err := identity.NewFoldedName("conformance-uar-role")
+	require.NoError(t, err)
+	role, err := h.ls.CreateRole(ctx, roleName, "conformance test role")
+	require.NoError(t, err)
+
+	requester, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-uar-requester", Email: "conformance-uar-requester@example.com",
+		DisplayName: "Conformance UpdateAccessRequest Requester", IsActive: true,
+	})
+	require.NoError(t, err)
+
+	newPendingRequest := func(suffix string) *models.AccessRequest {
+		req, err := h.ls.CreateAccessRequest(ctx, &models.AccessRequest{
+			ProjectID: h.projectID, UserID: requester.ID, SuggestedRole: role.Name,
+			State: core.AccessRequestPending, Reason: "conformance test " + suffix,
+		})
+		require.NoError(t, err)
+		return req
+	}
+
+	// Wrong-fromState precondition + sanity baseline: LocalStorage.UpdateAccessRequest
+	// is a raw Select("*") full-row update -- a real caller mutates the full
+	// row it already fetched, which is exactly what this does.
+	localReq := newPendingRequest("local")
+	localReq.State = core.AccessRequestRejected
+	localReq.GrantedRole = role.Name
+	localMatched, err := h.ls.UpdateAccessRequest(ctx, localReq)
+	require.NoError(t, err)
+	require.True(t, localMatched, "sanity: the first transition off pending must match")
+	localReq.State = core.AccessRequestApproved
+	localMatchedAgain, err := h.ls.UpdateAccessRequest(ctx, localReq)
+	require.NoError(t, err)
+	assert.False(t, localMatchedAgain, "sanity: a second transition off an already-resolved request must not match")
+
+	// Remote, reject branch: AuthorizePrincipal(machine, "roles.assign", scope)
+	// -- see this file's package doc for why this passes for h.rs (a real held
+	// permission via the admin role's own bundle, not a bypass).
+	rejectReq := newPendingRequest("reject")
+	rejectMatched, err := h.rs.UpdateAccessRequest(ctx, &models.AccessRequest{
+		ID: rejectReq.ID, ProjectID: rejectReq.ProjectID, UserID: rejectReq.UserID,
+		SuggestedRole: rejectReq.SuggestedRole, State: core.AccessRequestRejected, Reason: "conformance reject",
+	})
+	require.NoError(t, err, "RemoteStorage.UpdateAccessRequest must match a genuinely pending request for a roles.assign holder")
+	require.True(t, rejectMatched)
+	afterReject, err := h.ls.GetAccessRequest(ctx, rejectReq.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.AccessRequestRejected, afterReject.State)
+	assert.Equal(t, "conformance reject", afterReject.Reason, "Reason must round-trip correctly")
+
+	rejectMatchedAgain, err := h.rs.UpdateAccessRequest(ctx, &models.AccessRequest{
+		ID: rejectReq.ID, ProjectID: rejectReq.ProjectID, UserID: rejectReq.UserID,
+		SuggestedRole: rejectReq.SuggestedRole, State: core.AccessRequestApproved,
+	})
+	require.NoError(t, err)
+	assert.False(t, rejectMatchedAgain,
+		"RemoteStorage.UpdateAccessRequest must report no match for a second transition attempt off an "+
+			"already-resolved request, not silently re-apply it")
+	afterSecond, err := h.ls.GetAccessRequest(ctx, rejectReq.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.AccessRequestRejected, afterSecond.State, "the failed second transition attempt must not have altered the row's state")
+
+	// Remote, approve branch (project/role-scoped, zero-permission role) --
+	// forged resolved_by on the wire must be discarded: UpdateAccessRequestProxy
+	// always derives attribution from the AUTHENTICATED caller. For a machine
+	// actor, the real attribution lands in ResolvedByMachineIdentityID (the
+	// #1573/#1622-fixed sibling field for THIS model -- unlike
+	// ProjectInvitation/AccessReviewCampaign's still-missing sibling, flagged
+	// in this file's package doc), never in ResolvedBy and never trusting the
+	// wire value for either.
+	const forgedResolvedBy = 999999
+	now := time.Now().UTC()
+	approveReq := newPendingRequest("approve")
+	approveMatched, err := h.rs.UpdateAccessRequest(ctx, &models.AccessRequest{
+		ID: approveReq.ID, ProjectID: approveReq.ProjectID, UserID: approveReq.UserID,
+		SuggestedRole: approveReq.SuggestedRole, GrantedRole: role.Name,
+		State: core.AccessRequestApproved, ResolvedBy: forgedResolvedBy, ResolvedAt: &now,
+	})
+	require.NoError(t, err, "RemoteStorage.UpdateAccessRequest must match a genuinely pending request for a zero-permission role grant")
+	require.True(t, approveMatched)
+	persisted, err := h.ls.GetAccessRequest(ctx, approveReq.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.AccessRequestApproved, persisted.State)
+	assert.Equal(t, role.Name, persisted.GrantedRole, "GrantedRole must round-trip correctly")
+	assert.NotEqual(t, uint(forgedResolvedBy), persisted.ResolvedBy, "ResolvedBy must never be trusted verbatim from the wire")
+	assert.Equal(t, uint(0), persisted.ResolvedBy, "a machine actor's attribution belongs in ResolvedByMachineIdentityID, not ResolvedBy")
+	assert.NotEqual(t, uint(0), persisted.ResolvedByMachineIdentityID, "the machine caller's real identity must be recorded")
+	require.NotNil(t, persisted.ResolvedAt)
+	assert.True(t, persisted.ResolvedAt.Equal(now))
+}
+
+// --- ListAccessRequests ---
+
+func TestConformance_ListAccessRequests(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	requester, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-lar-requester", Email: "conformance-lar-requester@example.com",
+		DisplayName: "Conformance ListAccessRequests Requester", IsActive: true,
+	})
+	require.NoError(t, err)
+	req1, err := h.ls.CreateAccessRequest(ctx, &models.AccessRequest{ProjectID: h.projectID, UserID: requester.ID, SuggestedRole: "role-1", State: core.AccessRequestPending})
+	require.NoError(t, err)
+	req2, err := h.ls.CreateAccessRequest(ctx, &models.AccessRequest{ProjectID: h.projectID, UserID: requester.ID, SuggestedRole: "role-2", State: core.AccessRequestRejected})
+	require.NoError(t, err)
+	_, _ = req1, req2
+
+	localRows, err := h.ls.ListAccessRequests(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteRows, err := h.rs.ListAccessRequests(ctx, h.projectID)
+	require.NoError(t, err, "RemoteStorage.ListAccessRequests must list the SAME requests server-side")
+	require.Len(t, remoteRows, len(localRows))
+	require.GreaterOrEqual(t, len(localRows), 2)
+	localByID := map[uint]*models.AccessRequest{}
+	for _, r := range localRows {
+		localByID[r.ID] = r
+	}
+	for _, rr := range remoteRows {
+		lr, ok := localByID[rr.ID]
+		require.True(t, ok, "remote row %d has no matching local row", rr.ID)
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("ListAccessRequests request %d", rr.ID), lr, rr, nil)
+	}
+
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lar-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+	emptyLocal, err := h.ls.ListAccessRequests(ctx, otherProject.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	emptyRemote, err := h.rs.ListAccessRequests(ctx, otherProject.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyRemote, "RemoteStorage.ListAccessRequests must return an empty list for a project with no requests")
+}
+
+// --- CreateAccessRequestApproval ---
+
+func TestConformance_CreateAccessRequestApproval(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	roleName, err := identity.NewFoldedName("conformance-cara-role")
+	require.NoError(t, err)
+	role, err := h.ls.CreateRole(ctx, roleName, "conformance test role")
+	require.NoError(t, err)
+
+	requester, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-cara-requester", Email: "conformance-cara-requester@example.com",
+		DisplayName: "Conformance CreateAccessRequestApproval Requester", IsActive: true,
+	})
+	require.NoError(t, err)
+
+	newPendingRequest := func() *models.AccessRequest {
+		req, err := h.ls.CreateAccessRequest(ctx, &models.AccessRequest{
+			ProjectID: h.projectID, UserID: requester.ID, SuggestedRole: role.Name, State: core.AccessRequestPending,
+		})
+		require.NoError(t, err)
+		return req
+	}
+
+	// Local sanity baseline: LocalStorage.CreateAccessRequestApproval is a raw
+	// INSERT ... ON CONFLICT DO NOTHING -- every field round-trips verbatim.
+	localReq := newPendingRequest()
+	require.NoError(t, h.ls.CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{RequestID: localReq.ID, ApproverID: h.adminUserID}))
+	localRows, err := h.ls.ListAccessRequestApprovals(ctx, localReq.ID)
+	require.NoError(t, err)
+	require.Len(t, localRows, 1)
+	assert.Equal(t, h.adminUserID, localRows[0].ApproverID)
+
+	// Remote: CreateAccessRequestApprovalProxy always derives the approver
+	// from the AUTHENTICATED caller, never the wire-supplied approver_id/
+	// approver_machine_identity_id (the #1642-shape ceiling fix,
+	// access_request_proxy.go's own package doc) -- a machine actor's real
+	// identity lands in ApproverMachineIdentityID, never ApproverID, and
+	// never the forged values below.
+	remoteReq := newPendingRequest()
+	const forgedApproverID = 999999
+	const forgedApproverMachineID = 888888
+	err = h.rs.CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{
+		RequestID: remoteReq.ID, ApproverID: forgedApproverID, ApproverMachineIdentityID: forgedApproverMachineID,
+	})
+	require.NoError(t, err, "RemoteStorage.CreateAccessRequestApproval must succeed for a genuine, non-self, zero-permission-role approver")
+	remoteRows, err := h.ls.ListAccessRequestApprovals(ctx, remoteReq.ID)
+	require.NoError(t, err)
+	require.Len(t, remoteRows, 1)
+	assert.NotEqual(t, uint(forgedApproverID), remoteRows[0].ApproverID)
+	assert.Equal(t, uint(0), remoteRows[0].ApproverID, "a machine approver's ApproverID (the USER discriminator) must stay 0")
+	assert.NotEqual(t, uint(forgedApproverMachineID), remoteRows[0].ApproverMachineIdentityID)
+	assert.NotEqual(t, uint(0), remoteRows[0].ApproverMachineIdentityID, "the machine approver's real identity must be recorded")
+
+	// Negative: a duplicate sign-off from the SAME approver (the harness's own
+	// machine/node credential, twice) must be a benign no-op (ON CONFLICT DO
+	// NOTHING, local_invitations.go), not a second row and not an error --
+	// the M-of-K dual-control count's own race backstop, unchanged by this
+	// HTTP hop.
+	err = h.rs.CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{RequestID: remoteReq.ID})
+	require.NoError(t, err, "a duplicate approval from the same approver must not error")
+	afterDuplicate, err := h.ls.ListAccessRequestApprovals(ctx, remoteReq.ID)
+	require.NoError(t, err)
+	assert.Len(t, afterDuplicate, 1, "a duplicate approval from the same approver must not create a second row")
+}
+
+// --- ListAccessRequestApprovals ---
+
+func TestConformance_ListAccessRequestApprovals(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	requester, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-lara-requester", Email: "conformance-lara-requester@example.com",
+		DisplayName: "Conformance ListAccessRequestApprovals Requester", IsActive: true,
+	})
+	require.NoError(t, err)
+	req, err := h.ls.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: h.projectID, UserID: requester.ID, SuggestedRole: "irrelevant", State: core.AccessRequestPending,
+	})
+	require.NoError(t, err)
+
+	approver1, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-lara-approver1", Email: "conformance-lara-approver1@example.com",
+		DisplayName: "Conformance Approver 1", IsActive: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{RequestID: req.ID, ApproverID: approver1.ID}))
+	require.NoError(t, h.ls.CreateAccessRequestApproval(ctx, &models.AccessRequestApproval{RequestID: req.ID, ApproverMachineIdentityID: 777}))
+
+	localRows, err := h.ls.ListAccessRequestApprovals(ctx, req.ID)
+	require.NoError(t, err)
+	remoteRows, err := h.rs.ListAccessRequestApprovals(ctx, req.ID)
+	require.NoError(t, err, "RemoteStorage.ListAccessRequestApprovals must list the SAME approvals server-side")
+	require.Len(t, remoteRows, len(localRows))
+	require.Len(t, localRows, 2)
+	for i := range localRows {
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("ListAccessRequestApprovals approval index %d", i), localRows[i], remoteRows[i], nil)
+	}
+
+	// Negative: a request with no approvals yet must return an empty list.
+	freshReq, err := h.ls.CreateAccessRequest(ctx, &models.AccessRequest{
+		ProjectID: h.projectID, UserID: requester.ID, SuggestedRole: "irrelevant", State: core.AccessRequestPending,
+	})
+	require.NoError(t, err)
+	emptyLocal, err := h.ls.ListAccessRequestApprovals(ctx, freshReq.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	emptyRemote, err := h.rs.ListAccessRequestApprovals(ctx, freshReq.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyRemote, "RemoteStorage.ListAccessRequestApprovals must return an empty list for a request with no approvals")
+}
+
+// --- CreateAccessReviewCampaign ---
+
+func TestConformance_CreateAccessReviewCampaign(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// Local sanity baseline: LocalStorage.CreateAccessReviewCampaign is a raw
+	// create with no forcing -- every field we send round-trips verbatim.
+	localInput := &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-carc-local", State: core.CampaignStateOpen,
+		CreatedBy: h.adminUserID, Degraded: true, DegradedReasons: []string{"conformance-reason-local"},
+	}
+	localCreated, err := h.ls.CreateAccessReviewCampaign(ctx, localInput)
+	require.NoError(t, err)
+	localPersisted, err := h.ls.GetAccessReviewCampaign(ctx, localCreated.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "LocalStorage.CreateAccessReviewCampaign (sanity baseline)", localInput, localPersisted,
+		map[string]bool{"ID": true, "CreatedAt": true})
+
+	// Remote: CreateAccessReviewCampaignProxy (ARC-003) unconditionally
+	// normalizes every lifecycle field to a freshly-opened campaign's values
+	// regardless of what the caller sends, and forces CreatedBy to the
+	// AUTHENTICATED caller -- never the wire. The harness's machine/node
+	// credential's actorID(r) is always 0, so CreatedBy lands as 0, not the
+	// forged value below.
+	const forgedCreatedBy = 999999
+	forgedClosedAt := time.Now().UTC()
+	remoteInput := &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-carc-remote", State: "closed", /* forged: must normalize to open */
+		CreatedBy: forgedCreatedBy, ClosedBy: 424242, ClosedAt: &forgedClosedAt, ForcedIncomplete: true, /* forged */
+		Degraded: true, DegradedReasons: []string{"conformance-reason-remote"},
+	}
+	remoteCreated, err := h.rs.CreateAccessReviewCampaign(ctx, remoteInput)
+	require.NoError(t, err, "RemoteStorage.CreateAccessReviewCampaign must succeed for a valid project_id+name")
+	remotePersisted, err := h.ls.GetAccessReviewCampaign(ctx, remoteCreated.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, core.CampaignStateOpen, remotePersisted.State, "a caller-supplied lifecycle state must be normalized to open (ARC-003)")
+	assert.Equal(t, uint(0), remotePersisted.ClosedBy, "a caller-supplied closed_by must be stripped on create (ARC-003)")
+	assert.Nil(t, remotePersisted.ClosedAt, "a caller-supplied closed_at must be stripped on create (ARC-003)")
+	assert.False(t, remotePersisted.ForcedIncomplete, "a caller-supplied forced_incomplete must be stripped on create (ARC-003)")
+	assert.NotEqual(t, uint(forgedCreatedBy), remotePersisted.CreatedBy,
+		"CreatedBy must be derived from the authenticated caller, never trusted from the wire")
+	assert.Equal(t, uint(0), remotePersisted.CreatedBy,
+		"the harness's machine/node credential's actorID(r) is always 0 (no UserID) -- CreatedBy lands as 0")
+
+	// KNOWN WIRE-FIDELITY GAP -- see this file's package doc, item 2. Asserting
+	// the CURRENT (unfortunate) behavior rather than excluding the field
+	// silently.
+	assert.Equal(t, uint(0), remotePersisted.CreatedByMachineIdentityID,
+		"KNOWN GAP: the machine caller's real identity is silently lost -- CreatedByMachineIdentityID is not "+
+			"carried on this wire at all today (see this file's package doc)")
+
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateAccessReviewCampaign (wire round trip, ARC-003 fields excluded -- see comments)",
+		remoteInput, remotePersisted,
+		map[string]bool{
+			"ID": true, "CreatedAt": true, "State": true, "CreatedBy": true, "ClosedBy": true, "ClosedAt": true,
+			"ForcedIncomplete": true, "CreatedByMachineIdentityID": true, "ClosedByMachineIdentityID": true,
+		})
+}
+
+// --- GetAccessReviewCampaign ---
+
+func TestConformance_GetAccessReviewCampaign(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	c, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-garc-campaign", State: core.CampaignStateOpen,
+		CreatedBy: h.adminUserID, Degraded: true, DegradedReasons: []string{"conformance-reason"},
+	})
+	require.NoError(t, err)
+
+	localFound, err := h.ls.GetAccessReviewCampaign(ctx, c.ID)
+	require.NoError(t, err)
+	remoteFound, err := h.rs.GetAccessReviewCampaign(ctx, c.ID)
+	require.NoError(t, err, "RemoteStorage.GetAccessReviewCampaign must find a campaign that genuinely exists")
+	assertFieldExhaustiveEqual(t, "GetAccessReviewCampaign", localFound, remoteFound, nil)
+
+	_, localErr := h.ls.GetAccessReviewCampaign(ctx, c.ID+999999)
+	_, remoteErr := h.rs.GetAccessReviewCampaign(ctx, c.ID+999999)
+	assert.Error(t, localErr, "sanity: a nonexistent campaign ID must error locally")
+	assert.Error(t, remoteErr, "RemoteStorage.GetAccessReviewCampaign must error for a nonexistent campaign ID")
+}
+
+// --- ListAccessReviewCampaigns ---
+
+func TestConformance_ListAccessReviewCampaigns(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	c1, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-larc-1", State: core.CampaignStateOpen, CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+	c2, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-larc-2", State: core.CampaignStateClosed, CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+	_, _ = c1, c2
+
+	localRows, err := h.ls.ListAccessReviewCampaigns(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteRows, err := h.rs.ListAccessReviewCampaigns(ctx, h.projectID)
+	require.NoError(t, err, "RemoteStorage.ListAccessReviewCampaigns must list the SAME campaigns server-side")
+	require.Len(t, remoteRows, len(localRows))
+	require.GreaterOrEqual(t, len(localRows), 2)
+	localByID := map[uint]*models.AccessReviewCampaign{}
+	for _, c := range localRows {
+		localByID[c.ID] = c
+	}
+	for _, rc := range remoteRows {
+		lc, ok := localByID[rc.ID]
+		require.True(t, ok, "remote row %d has no matching local row", rc.ID)
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("ListAccessReviewCampaigns campaign %d", rc.ID), lc, rc, nil)
+	}
+
+	// Negative: a fresh project with zero campaigns must return an empty list.
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-larc-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+	emptyLocal, err := h.ls.ListAccessReviewCampaigns(ctx, otherProject.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	emptyRemote, err := h.rs.ListAccessReviewCampaigns(ctx, otherProject.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyRemote, "RemoteStorage.ListAccessReviewCampaigns must return an empty list for a project with no campaigns")
+}
+
+// --- GetOpenAccessReviewCampaign ---
+
+func TestConformance_GetOpenAccessReviewCampaign(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	campaign, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-goarc-campaign", State: core.CampaignStateOpen, CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+
+	localFound, err := h.ls.GetOpenAccessReviewCampaign(ctx, h.projectID)
+	require.NoError(t, err)
+	require.NotNil(t, localFound, "sanity: LocalStorage must find the open campaign")
+	remoteFound, err := h.rs.GetOpenAccessReviewCampaign(ctx, h.projectID)
+	require.NoError(t, err)
+	require.NotNil(t, remoteFound, "RemoteStorage.GetOpenAccessReviewCampaign must find the SAME open campaign server-side")
+	assertFieldExhaustiveEqual(t, "GetOpenAccessReviewCampaign (found)", localFound, remoteFound, nil)
+	assert.Equal(t, campaign.ID, remoteFound.ID)
+
+	// Negative: a project with no open campaign at all must return (nil, nil)
+	// -- not an error, not a 404 -- on both paths (a fresh project with zero
+	// campaign history).
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-goarc-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+	localNone, err := h.ls.GetOpenAccessReviewCampaign(ctx, otherProject.ID)
+	require.NoError(t, err)
+	assert.Nil(t, localNone, "sanity: no campaign at all means no open campaign")
+	remoteNone, err := h.rs.GetOpenAccessReviewCampaign(ctx, otherProject.ID)
+	require.NoError(t, err)
+	assert.Nil(t, remoteNone, "RemoteStorage.GetOpenAccessReviewCampaign must also report no open campaign as (nil, nil), not an error")
+}
+
+// --- GetLatestClosedAccessReviewCampaign ---
+
+func TestConformance_GetLatestClosedAccessReviewCampaign(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	older, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-glcarc-older", State: core.CampaignStateClosed,
+		CreatedBy: h.adminUserID, CreatedAt: time.Now().Add(-2 * time.Hour).UTC(),
+	})
+	require.NoError(t, err)
+	newer, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-glcarc-newer", State: core.CampaignStateClosed,
+		CreatedBy: h.adminUserID, CreatedAt: time.Now().Add(-1 * time.Hour).UTC(),
+	})
+	require.NoError(t, err)
+	_ = older
+
+	localFound, err := h.ls.GetLatestClosedAccessReviewCampaign(ctx, h.projectID)
+	require.NoError(t, err)
+	require.NotNil(t, localFound)
+	assert.Equal(t, newer.ID, localFound.ID, "sanity: LocalStorage must pick the most recently created closed campaign")
+
+	remoteFound, err := h.rs.GetLatestClosedAccessReviewCampaign(ctx, h.projectID)
+	require.NoError(t, err)
+	require.NotNil(t, remoteFound, "RemoteStorage.GetLatestClosedAccessReviewCampaign must find the SAME latest-closed campaign server-side")
+	assert.Equal(t, newer.ID, remoteFound.ID,
+		"RemoteStorage.GetLatestClosedAccessReviewCampaign must pick the most recently created closed campaign, not an arbitrary or oldest one")
+	assertFieldExhaustiveEqual(t, "GetLatestClosedAccessReviewCampaign (found)", localFound, remoteFound, nil)
+
+	// Negative: a project that has never had a campaign must return (nil, nil).
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-glcarc-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+	localNone, err := h.ls.GetLatestClosedAccessReviewCampaign(ctx, otherProject.ID)
+	require.NoError(t, err)
+	assert.Nil(t, localNone)
+	remoteNone, err := h.rs.GetLatestClosedAccessReviewCampaign(ctx, otherProject.ID)
+	require.NoError(t, err)
+	assert.Nil(t, remoteNone, "RemoteStorage.GetLatestClosedAccessReviewCampaign must report (nil, nil) for a project with no campaign history")
+}
+
+// --- CreateAccessReviewItems ---
+
+func TestConformance_CreateAccessReviewItems(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newOpenCampaign := func(suffix string) *models.AccessReviewCampaign {
+		c, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+			ProjectID: h.projectID, Name: "conformance-cari-campaign-" + suffix, State: core.CampaignStateOpen, CreatedBy: h.adminUserID,
+		})
+		require.NoError(t, err)
+		return c
+	}
+
+	// Local sanity baseline: LocalStorage.CreateAccessReviewItems is a raw
+	// bulk create -- every field, including Decision/DecidedBy/DecidedAt,
+	// round-trips verbatim (no ARC-004 normalization at the storage layer).
+	localCampaign := newOpenCampaign("local")
+	localItem := &models.AccessReviewItem{
+		CampaignID: localCampaign.ID, PrincipalType: "role", PrincipalID: 42, PrincipalName: "conformance-principal-local",
+		Source: "role", RoleID: 7, RoleName: "conformance-role-local", AccessLevel: "read",
+		EnvironmentID: h.environmentID, SecretID: 99, SecretName: "conformance-secret-local",
+		Decision: core.ReviewItemAttested, DecidedBy: h.adminUserID,
+	}
+	require.NoError(t, h.ls.CreateAccessReviewItems(ctx, []*models.AccessReviewItem{localItem}))
+	localPersistedRows, err := h.ls.ListAccessReviewItems(ctx, localCampaign.ID)
+	require.NoError(t, err)
+	require.Len(t, localPersistedRows, 1)
+	assertFieldExhaustiveEqual(t, "LocalStorage.CreateAccessReviewItems (sanity baseline)", localItem, localPersistedRows[0],
+		map[string]bool{"ID": true})
+
+	// Remote: CreateAccessReviewItemsProxy (ARC-004) unconditionally strips
+	// any pre-supplied decision state -- every newly created item must start
+	// pending with no decider, regardless of what the caller sends.
+	remoteCampaign := newOpenCampaign("remote")
+	forgedDecidedAt := time.Now().UTC()
+	remoteItem := &models.AccessReviewItem{
+		CampaignID: remoteCampaign.ID, PrincipalType: "role", PrincipalID: 42, PrincipalName: "conformance-principal-remote",
+		Source: "role", RoleID: 7, RoleName: "conformance-role-remote", AccessLevel: "read",
+		EnvironmentID: h.environmentID, SecretID: 99, SecretName: "conformance-secret-remote",
+		Decision: core.ReviewItemAttested, DecidedBy: 999999, DecidedAt: &forgedDecidedAt, // forged: must be stripped
+	}
+	require.NoError(t, h.rs.CreateAccessReviewItems(ctx, []*models.AccessReviewItem{remoteItem}),
+		"RemoteStorage.CreateAccessReviewItems must succeed for a valid campaign")
+	remotePersistedRows, err := h.ls.ListAccessReviewItems(ctx, remoteCampaign.ID)
+	require.NoError(t, err)
+	require.Len(t, remotePersistedRows, 1)
+	assert.Equal(t, core.ReviewItemPending, remotePersistedRows[0].Decision, "a caller-supplied decision must be stripped to pending (ARC-004)")
+	assert.Equal(t, uint(0), remotePersistedRows[0].DecidedBy, "a caller-supplied decided_by must be stripped on create (ARC-004)")
+	assert.Nil(t, remotePersistedRows[0].DecidedAt, "a caller-supplied decided_at must be stripped on create (ARC-004)")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateAccessReviewItems (wire round trip, ARC-004 fields excluded)",
+		remoteItem, remotePersistedRows[0],
+		map[string]bool{"ID": true, "Decision": true, "DecidedBy": true, "DecidedAt": true})
+
+	// Negative: an empty item slice is a documented no-op on both paths --
+	// RemoteStorage.CreateAccessReviewItems returns early client-side (it
+	// derives the campaign ID from items[0] and would otherwise panic on an
+	// empty slice), making no HTTP call at all.
+	assert.NoError(t, h.ls.CreateAccessReviewItems(ctx, nil))
+	assert.NoError(t, h.rs.CreateAccessReviewItems(ctx, nil))
+}
+
+// --- ListAccessReviewItems ---
+
+func TestConformance_ListAccessReviewItems(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	campaign, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-lari-campaign", State: core.CampaignStateOpen, CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+	item1 := &models.AccessReviewItem{CampaignID: campaign.ID, PrincipalType: "role", PrincipalID: 1, Source: "role", AccessLevel: "read", EnvironmentID: h.environmentID, Decision: core.ReviewItemPending}
+	item2 := &models.AccessReviewItem{CampaignID: campaign.ID, PrincipalType: "user", PrincipalID: 2, Source: "owner", AccessLevel: "write", EnvironmentID: h.environmentID, Decision: core.ReviewItemPending}
+	require.NoError(t, h.ls.CreateAccessReviewItems(ctx, []*models.AccessReviewItem{item1, item2}))
+
+	localRows, err := h.ls.ListAccessReviewItems(ctx, campaign.ID)
+	require.NoError(t, err)
+	remoteRows, err := h.rs.ListAccessReviewItems(ctx, campaign.ID)
+	require.NoError(t, err, "RemoteStorage.ListAccessReviewItems must list the SAME items server-side")
+	require.Len(t, remoteRows, len(localRows))
+	require.Len(t, localRows, 2)
+	for i := range localRows {
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("ListAccessReviewItems item index %d", i), localRows[i], remoteRows[i], nil)
+	}
+
+	otherCampaign, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-lari-empty-campaign", State: core.CampaignStateOpen, CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+	emptyLocal, err := h.ls.ListAccessReviewItems(ctx, otherCampaign.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	emptyRemote, err := h.rs.ListAccessReviewItems(ctx, otherCampaign.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyRemote, "RemoteStorage.ListAccessReviewItems must return an empty list for a campaign with no items")
+}
+
+// --- CountPendingAccessReviewItems ---
+
+func TestConformance_CountPendingAccessReviewItems(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newCampaignWithItems := func(suffix string, pending, decided int) *models.AccessReviewCampaign {
+		c, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+			ProjectID: h.projectID, Name: "conformance-cpari-campaign-" + suffix, State: core.CampaignStateOpen, CreatedBy: h.adminUserID,
+		})
+		require.NoError(t, err)
+		var items []*models.AccessReviewItem
+		for i := 0; i < pending; i++ {
+			items = append(items, &models.AccessReviewItem{
+				CampaignID: c.ID, PrincipalType: "role", PrincipalID: uint(i + 1), Source: "role",
+				AccessLevel: "read", EnvironmentID: h.environmentID, Decision: core.ReviewItemPending,
+			})
+		}
+		for i := 0; i < decided; i++ {
+			items = append(items, &models.AccessReviewItem{
+				CampaignID: c.ID, PrincipalType: "role", PrincipalID: uint(100 + i), Source: "role",
+				AccessLevel: "read", EnvironmentID: h.environmentID, Decision: core.ReviewItemAttested, DecidedBy: h.adminUserID,
+			})
+		}
+		require.NoError(t, h.ls.CreateAccessReviewItems(ctx, items))
+		return c
+	}
+
+	localCampaign := newCampaignWithItems("local", 2, 1)
+	localCount, err := h.ls.CountPendingAccessReviewItems(ctx, localCampaign.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, localCount, "sanity: LocalStorage must count only the pending items")
+
+	remoteCampaign := newCampaignWithItems("remote", 2, 1)
+	remoteCount, err := h.rs.CountPendingAccessReviewItems(ctx, remoteCampaign.ID)
+	require.NoError(t, err, "RemoteStorage.CountPendingAccessReviewItems must succeed")
+	assert.Equal(t, 2, remoteCount, "RemoteStorage.CountPendingAccessReviewItems must count only the pending items, not every item")
+
+	// Negative: a campaign with zero pending items (every item already decided) must count 0.
+	allDecided := newCampaignWithItems("all-decided", 0, 3)
+	zeroCount, err := h.rs.CountPendingAccessReviewItems(ctx, allDecided.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, zeroCount, "RemoteStorage.CountPendingAccessReviewItems must report 0 when every item is already decided")
+}
+
+// --- GetAccessReviewItem ---
+
+func TestConformance_GetAccessReviewItem(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	campaign, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-gari-campaign", State: core.CampaignStateOpen, CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+	item := &models.AccessReviewItem{
+		CampaignID: campaign.ID, PrincipalType: "role", PrincipalID: 5, PrincipalName: "conformance-principal",
+		Source: "role", RoleID: 3, RoleName: "conformance-role", AccessLevel: "read", EnvironmentID: h.environmentID,
+		SecretID: 9, SecretName: "conformance-secret", Decision: core.ReviewItemPending,
+	}
+	require.NoError(t, h.ls.CreateAccessReviewItems(ctx, []*models.AccessReviewItem{item}))
+
+	localFound, err := h.ls.GetAccessReviewItem(ctx, item.ID)
+	require.NoError(t, err)
+	remoteFound, err := h.rs.GetAccessReviewItem(ctx, item.ID)
+	require.NoError(t, err, "RemoteStorage.GetAccessReviewItem must find an item that genuinely exists")
+	assertFieldExhaustiveEqual(t, "GetAccessReviewItem", localFound, remoteFound, nil)
+
+	_, localErr := h.ls.GetAccessReviewItem(ctx, item.ID+999999)
+	_, remoteErr := h.rs.GetAccessReviewItem(ctx, item.ID+999999)
+	assert.Error(t, localErr, "sanity: a nonexistent item ID must error locally")
+	assert.Error(t, remoteErr, "RemoteStorage.GetAccessReviewItem must error for a nonexistent item ID")
+}
+
+// --- UpdateAccessReviewItem ---
+
+func TestConformance_UpdateAccessReviewItem(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// UpdateAccessReviewItemProxy hard-refuses any caller that is not an
+	// attributable, authenticated HUMAN (ARC-005: "an independent reviewer
+	// concept has no meaning for a machine caller") -- h.rs cannot drive this
+	// route at all. Mint a second RemoteStorage client authenticated with a
+	// real user session against the SAME server, mirroring tranche 3's
+	// RevokeBreakGlassActivation.
+	userToken := createTestToken(t, h.upstreamCore)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: userToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	newOpenCampaign := func(suffix string) *models.AccessReviewCampaign {
+		c, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+			ProjectID: h.projectID, Name: "conformance-uari-campaign-" + suffix, State: core.CampaignStateOpen, CreatedBy: h.adminUserID,
+		})
+		require.NoError(t, err)
+		return c
+	}
+	newPendingItem := func(campaignID, principalID uint) *models.AccessReviewItem {
+		item := &models.AccessReviewItem{
+			CampaignID: campaignID, PrincipalType: "role", PrincipalID: principalID, PrincipalName: "conformance-principal",
+			Source: "role", AccessLevel: "read", EnvironmentID: h.environmentID, Decision: core.ReviewItemPending,
+		}
+		require.NoError(t, h.ls.CreateAccessReviewItems(ctx, []*models.AccessReviewItem{item}))
+		return item
+	}
+
+	// A machine/node caller must be refused outright, regardless of the item's state.
+	machineRefusedCampaign := newOpenCampaign("machine-refused")
+	machineRefusedItem := newPendingItem(machineRefusedCampaign.ID, 1)
+	_, err = h.rs.UpdateAccessReviewItem(ctx, &models.AccessReviewItem{ID: machineRefusedItem.ID, Decision: core.ReviewItemAttested})
+	assert.Error(t, err, "RemoteStorage.UpdateAccessReviewItem must refuse a machine/node caller outright -- an "+
+		"independent reviewer must be an attributable, authenticated human")
+
+	// Self-certification precondition: a reviewer may not decide their OWN
+	// access-review item -- checked against the item's REAL, server-fetched
+	// principal (the 2026-09-04 finding fixed in this exact handler; see its
+	// package doc), not a client-asserted PrincipalType/PrincipalID.
+	admin, err := h.upstreamCore.GetUserByEmail(ctx, "testadmin@example.com")
+	require.NoError(t, err)
+	selfCertCampaign := newOpenCampaign("self-cert")
+	selfCertItem := &models.AccessReviewItem{
+		CampaignID: selfCertCampaign.ID, PrincipalType: "user", PrincipalID: admin.ID, PrincipalName: "testadmin",
+		Source: "role", AccessLevel: "read", EnvironmentID: h.environmentID, Decision: core.ReviewItemPending,
+	}
+	require.NoError(t, h.ls.CreateAccessReviewItems(ctx, []*models.AccessReviewItem{selfCertItem}))
+	_, err = rsAsUser.UpdateAccessReviewItem(ctx, &models.AccessReviewItem{
+		ID: selfCertItem.ID, Decision: core.ReviewItemAttested,
+		PrincipalType: "role", PrincipalID: 999999, // lying about the principal must not bypass the check
+	})
+	assert.Error(t, err, "a reviewer must not be able to self-certify their own item by lying about "+
+		"PrincipalType/PrincipalID on the wire -- the check is anchored to the server-fetched real principal")
+	stillPending, err := h.ls.GetAccessReviewItem(ctx, selfCertItem.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.ReviewItemPending, stillPending.Decision, "a rejected self-certification attempt must not have altered the item")
+
+	// Wrong-precondition: a campaign that is CLOSED must refuse a decision
+	// (Matched=false) even though the item itself is still pending -- #343's
+	// atomic (item-pending AND campaign-open) conditional UPDATE.
+	closedCampaign, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-uari-closed-campaign", State: core.CampaignStateClosed, CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+	closedItem := newPendingItem(closedCampaign.ID, 2)
+	closedMatched, err := rsAsUser.UpdateAccessReviewItem(ctx, &models.AccessReviewItem{ID: closedItem.ID, Decision: core.ReviewItemAttested})
+	require.NoError(t, err)
+	assert.False(t, closedMatched, "RemoteStorage.UpdateAccessReviewItem must report no match for an item whose campaign is closed, not silently decide it")
+	stillPendingClosed, err := h.ls.GetAccessReviewItem(ctx, closedItem.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.ReviewItemPending, stillPendingClosed.Decision, "a decision against a closed campaign must not have altered the item")
+
+	// Same wrong-precondition, local sanity baseline: LocalStorage.UpdateAccessReviewItem
+	// applies the identical atomic conditional.
+	localClosedCampaign, err := h.ls.CreateAccessReviewCampaign(ctx, &models.AccessReviewCampaign{
+		ProjectID: h.projectID, Name: "conformance-uari-local-closed-campaign", State: core.CampaignStateClosed, CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+	localClosedItem := newPendingItem(localClosedCampaign.ID, 3)
+	localClosedItem.Decision = core.ReviewItemAttested
+	localMatched, err := h.ls.UpdateAccessReviewItem(ctx, localClosedItem)
+	require.NoError(t, err)
+	assert.False(t, localMatched, "sanity: LocalStorage must also refuse a decision against a closed campaign")
+
+	// Correct path: an open campaign, a pending item, a non-self reviewer --
+	// forged decided_by on the wire must be discarded, replaced with the
+	// AUTHENTICATED reviewer's real user ID (ARC-005), and a forged
+	// PrincipalType/PrincipalID/CampaignID must not overwrite the item's
+	// frozen evidence snapshot (the handler re-fetches and applies only
+	// Decision/Reason/DecidedBy/DecidedAt onto the real row).
+	openCampaign := newOpenCampaign("correct")
+	correctItem := newPendingItem(openCampaign.ID, 4)
+	const forgedDecidedBy = 999999
+	decidedAt := time.Now().UTC()
+	matched, err := rsAsUser.UpdateAccessReviewItem(ctx, &models.AccessReviewItem{
+		ID: correctItem.ID, Decision: core.ReviewItemRevoked, Reason: "conformance revoke reason",
+		DecidedBy: forgedDecidedBy, DecidedAt: &decidedAt,
+		PrincipalType: "forged-type", PrincipalID: 424242, CampaignID: 424242,
+	})
+	require.NoError(t, err, "RemoteStorage.UpdateAccessReviewItem must match a genuinely pending item in a genuinely open campaign")
+	assert.True(t, matched)
+	persisted, err := h.ls.GetAccessReviewItem(ctx, correctItem.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.ReviewItemRevoked, persisted.Decision)
+	assert.Equal(t, "conformance revoke reason", persisted.Reason)
+	assert.NotEqual(t, uint(forgedDecidedBy), persisted.DecidedBy, "DecidedBy must never be trusted verbatim from the wire")
+	assert.Equal(t, admin.ID, persisted.DecidedBy, "DecidedBy must be the AUTHENTICATED reviewer's real user ID")
+	require.NotNil(t, persisted.DecidedAt)
+	assert.True(t, persisted.DecidedAt.Equal(decidedAt))
+	assert.Equal(t, correctItem.PrincipalType, persisted.PrincipalType, "the item's frozen PrincipalType must survive unchanged")
+	assert.Equal(t, correctItem.PrincipalID, persisted.PrincipalID, "the item's frozen PrincipalID must survive unchanged")
+	assert.Equal(t, correctItem.CampaignID, persisted.CampaignID, "the item's CampaignID must survive unchanged")
+}

--- a/server/http/remote_storage_conformance_tranche4_machine_identities_test.go
+++ b/server/http/remote_storage_conformance_tranche4_machine_identities_test.go
@@ -1,0 +1,932 @@
+// remote_storage_conformance_tranche4_machine_identities_test.go — issue #1808,
+// tranche 4.
+//
+// Selection: this tranche was assigned directly (not mechanically derived from
+// TestReportConformancePopulation like tranches 2/3) — all 21 remaining methods
+// declared on *RemoteStorage in internal/storage/store/remote_machine_identities.go
+// that had no TestConformance_ test yet:
+//
+//	CountMachineIdentitiesByClassification, CountMachineIdentityCredentialsByClassification,
+//	CreateMachineIdentity, CreateOIDCBinding, DeleteOIDCBinding, GetMachineByOIDCSubject,
+//	GetMachineIdentity, GetMachineIdentityCredentialByHash, GetMachineIdentityCredentialByID,
+//	GetMachineRoleIDsAt, GetMachineRoles, GetOIDCBindingByID, ListActiveMachineIdentityCredentials,
+//	ListAllMachineIdentities, ListMachineIdentities, ListMachineIdentityCredentials,
+//	ListOIDCBindings, LockMachineIdentityForUpdate, RemoveMachineRole,
+//	TouchMachineIdentityCredential, UpdateMachineIdentityCredential
+//
+// (CreateMachineIdentityCredential and AssignMachineRole are used throughout as
+// raw fixture-seeding helpers — mirroring tranche 2/3's own convention — but are
+// NOT in this tranche's assigned list: AssignMachineRole already has a
+// TestConformance_ test (tranche 3), and CreateMachineIdentityCredential was not
+// assigned to this tranche.)
+//
+// Two genuine, confirmed asymmetries surfaced while reading
+// server/http/handlers/machine_identities_proxy.go before writing these tests —
+// both handled the way tranche 3's TransitionSecretStatus/RemoveGlobalAdminRoleGuarded
+// handled their own narrowings: proven and documented, not silently assumed away.
+//
+//  1. CreateMachineIdentity's proxy (CreateMachineIdentityProxy) is NOT a raw
+//     passthrough, unlike every other method in this file — it routes through
+//     core.CreateMachineIdentity, which unconditionally forces State=MachineActive
+//     and derives CreatedBy/CreatedByMachineIdentityID from the AUTHENTICATED actor
+//     behind the request (never from the caller-supplied model), per that handler's
+//     own G80 doc comment. TestConformance_CreateMachineIdentity proves this
+//     explicitly with a deliberately-wrong State/CreatedBy/CreatedByMachineIdentityID
+//     on the wire model and asserts the actor-derived values win.
+//
+//  2. UpdateMachineIdentityCredential's proxy (UpdateMachineIdentityCredentialProxy)
+//     is likewise not a raw full-row Save — it routes through
+//     core.ClassifyMachineTokenByID, which re-fetches the row SERVER-SIDE and
+//     applies ONLY Classification, discarding TokenHash/Revoked/ExpiresAt/etc from
+//     the wire body entirely (that handler's own #1542-shape-fix doc comment).
+//     TestConformance_UpdateMachineIdentityCredential proves the narrowing directly:
+//     it sends a forged TokenHash and Revoked=true alongside a genuine
+//     Classification change and asserts only Classification lands.
+//
+// Also confirmed, THIS time by a failing assertion while writing this tranche
+// (not just by reading code): the CreatedByMachineIdentityID field (#1573,
+// present on models.MachineIdentity) is absent from BOTH
+// remote_machine_identities.go's machineIdentityWire (client) and
+// machine_identities_proxy.go's machineIdentityProxyWire (server) — dropped on
+// every machine-identity response over RemoteStorage, including the CREATE
+// response itself, not just later GET/List reads. TestConformance_CreateMachineIdentity
+// originally asserted the CREATE response's own CreatedByMachineIdentityID was
+// non-zero (since the actor behind h.rs's request IS a real machine identity,
+// so core.CreateMachineIdentity's server-side derivation should have set it) —
+// that assertion failed with "was 0" even though a direct LocalStorage read of
+// the SAME persisted row confirms the server-side derivation genuinely ran and
+// set the correct nonzero value. The test now verifies the server's actual
+// derived value via a direct LocalStorage read (which bypasses the dropped
+// wire field), and documents the response-wire gap inline rather than
+// asserting around it silently. Every OTHER fixture in this file uses
+// CreatedByMachineIdentityID=0 (a human-created identity, the overwhelmingly
+// common case), so this gap does not surface elsewhere as a
+// field-exhaustive-comparison failure. Flagged for a future tranche/fix; not
+// remediated here since doing so would require editing existing non-test
+// files, out of this tranche's scope.
+//
+// requireGranterHoldsRolePermissions / privilege-ceiling notes carried over from
+// tranche 3, applied here too:
+//
+//   - RemoveMachineRole (and the AssignMachineRole calls used to seed its
+//     fixture) use a zero-permission role, matching tranche 3's own
+//     AssignMachineRole test — h.rs's admin-role node/machine credential
+//     cannot be trusted to exercise a permission-carrying grant/removal
+//     through a /system proxy route.
+//   - CreateOIDCBinding is gated by core.CreateOIDCBinding's
+//     requireAdminAuthorityAt, which resolves authority from the AUTHENTICATED
+//     USER actor's own role grants (scopedRoleIDs keyed on a User ID) — a
+//     machine-authenticated caller always resolves actorID(r)==0 for this
+//     check (ADR-085 removed the former node-relay exemption for this route
+//     family), so h.rs's node/machine credential can NEVER satisfy it,
+//     regardless of what role the node itself holds. Mints a second
+//     RemoteStorage client authenticated as a real admin USER session instead,
+//     mirroring RevokeBreakGlassActivation's rsAsUser pattern (tranche 3).
+//     DeleteOIDCBinding has no equivalent admin-authority gate of its own
+//     (core.DeleteOIDCBinding only re-checks machineInProject), so h.rs works
+//     fine there.
+package http
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// --- CreateMachineIdentity ---
+
+func TestConformance_CreateMachineIdentity(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// LocalStorage.CreateMachineIdentity is a raw, unconditional GORM Create --
+	// every field on the caller-supplied model lands exactly as sent.
+	localModel := &models.MachineIdentity{
+		ProjectID: h.projectID, Name: "conformance-cmi-local", IdentityType: "service",
+		State: "active", Description: "conformance test", CreatedBy: h.adminUserID,
+	}
+	localCreated, err := h.ls.CreateMachineIdentity(ctx, localModel)
+	require.NoError(t, err)
+	assert.Equal(t, "active", localCreated.State, "sanity: local create preserves the caller-supplied State")
+	assert.Equal(t, h.adminUserID, localCreated.CreatedBy, "sanity: local create preserves the caller-supplied CreatedBy")
+
+	// RemoteStorage.CreateMachineIdentity's proxy handler does NOT perform a raw
+	// passthrough Create (see this file's package doc, asymmetry #1): it forces
+	// State=active and derives CreatedBy/CreatedByMachineIdentityID from the
+	// AUTHENTICATED actor, never the wire model. h.rs authenticates as a
+	// MACHINE credential (the harness's own node token), so CreatedBy must come
+	// back 0 (no UserID for a machine actor) and CreatedByMachineIdentityID
+	// must be that node's own machine ID -- neither the deliberately-wrong
+	// values sent below.
+	remoteModel := &models.MachineIdentity{
+		ProjectID: h.projectID, Name: "conformance-cmi-remote", IdentityType: "service",
+		State:                      "revoked", // deliberately wrong -- must be ignored, not persisted
+		Description:                "conformance test",
+		CreatedBy:                  999999, // deliberately forged
+		CreatedByMachineIdentityID: 888888, // deliberately forged
+	}
+	remoteCreated, err := h.rs.CreateMachineIdentity(ctx, remoteModel)
+	require.NoError(t, err, "RemoteStorage.CreateMachineIdentity must succeed for an actor holding roles.assign at the target project")
+
+	assert.Equal(t, "conformance-cmi-remote", remoteCreated.Name)
+	assert.Equal(t, h.projectID, remoteCreated.ProjectID)
+	assert.Equal(t, "service", remoteCreated.IdentityType)
+	assert.Equal(t, "conformance test", remoteCreated.Description)
+	assert.Equal(t, "active", remoteCreated.State,
+		"RemoteStorage.CreateMachineIdentity must force State=active regardless of what the caller sent -- "+
+			"a machine identity is never born in any other state (core.CreateMachineIdentity's own contract)")
+	assert.Equal(t, uint(0), remoteCreated.CreatedBy,
+		"CreatedBy must be derived from the authenticated actor (a machine actor has no UserID), never trusted from the wire")
+	// remoteCreated.CreatedByMachineIdentityID itself is NOT a usable signal
+	// here: machineIdentityProxyWire/machineIdentityWire (both sides of this
+	// route) omit the CreatedByMachineIdentityID field entirely, so the
+	// CREATE response's decoded value is unconditionally 0 -- confirmed by
+	// running this exact assertion against a nonzero expectation and seeing
+	// it fail even though the server-side derivation genuinely ran (see the
+	// package doc's confirmed-gap note). Verify the SERVER's actual derived
+	// value by reading the persisted row directly via LocalStorage instead,
+	// which bypasses that wire entirely.
+	persisted, err := h.ls.GetMachineIdentity(ctx, remoteCreated.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "active", persisted.State, "the created identity must actually be persisted server-side with the forced state")
+	assert.NotEqual(t, uint(888888), persisted.CreatedByMachineIdentityID,
+		"the persisted CreatedByMachineIdentityID must be derived from the authenticated actor, never the caller-supplied value")
+	assert.NotZero(t, persisted.CreatedByMachineIdentityID,
+		"the harness's own node credential IS a real machine identity, so the server-derived, persisted value must be non-zero "+
+			"(even though RemoteStorage's own CREATE response cannot show it -- see above)")
+
+	// Negative: missing required fields must be rejected.
+	_, remoteErr := h.rs.CreateMachineIdentity(ctx, &models.MachineIdentity{})
+	assert.Error(t, remoteErr, "RemoteStorage.CreateMachineIdentity must reject a request missing name/project_id")
+}
+
+// --- GetMachineIdentity ---
+
+func TestConformance_GetMachineIdentity(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-gmi", core.MachineTypeService, "conformance test machine", "confidential", h.adminUserID, 0)
+	require.NoError(t, err)
+
+	localRead, err := h.ls.GetMachineIdentity(ctx, mi.ID)
+	require.NoError(t, err)
+	remoteRead, err := h.rs.GetMachineIdentity(ctx, mi.ID)
+	require.NoError(t, err, "RemoteStorage.GetMachineIdentity must retrieve a genuinely existing machine identity")
+	// A pure dual-read of the SAME already-persisted row -- no write timing
+	// skew of any kind, so no exclusions are needed (see this file's package
+	// doc for the one confirmed field this comparison cannot expose, given
+	// this fixture's CreatedByMachineIdentityID=0).
+	assertFieldExhaustiveEqual(t, "RemoteStorage.GetMachineIdentity (wire round trip)", localRead, remoteRead, nil)
+
+	// Negative: a nonexistent ID must fail identically on both paths.
+	_, localErr := h.ls.GetMachineIdentity(ctx, mi.ID+1000000)
+	_, remoteErr := h.rs.GetMachineIdentity(ctx, mi.ID+1000000)
+	assert.Error(t, localErr, "sanity: a nonexistent machine identity must not be retrievable locally")
+	assert.Error(t, remoteErr, "RemoteStorage.GetMachineIdentity must report an error for a nonexistent machine identity, not a zero-value success")
+}
+
+// --- LockMachineIdentityForUpdate ---
+
+func TestConformance_LockMachineIdentityForUpdate(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-lmifu", core.MachineTypeService, "conformance test machine", "internal", h.adminUserID, 0)
+	require.NoError(t, err)
+
+	// LockMachineIdentityForUpdate has no row lock to take over HTTP (see
+	// remote_machine_identities.go's own doc) -- it is a plain read on both
+	// sides, so a fair conformance check is exactly the same dual-read shape
+	// as GetMachineIdentity, not a locking/concurrency test (that guarantee now
+	// lives entirely in TransitionMachineIdentityState, already covered in
+	// tranche 2).
+	localRead, err := h.ls.LockMachineIdentityForUpdate(ctx, mi.ID)
+	require.NoError(t, err)
+	remoteRead, err := h.rs.LockMachineIdentityForUpdate(ctx, mi.ID)
+	require.NoError(t, err, "RemoteStorage.LockMachineIdentityForUpdate must retrieve a genuinely existing machine identity")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.LockMachineIdentityForUpdate (wire round trip)", localRead, remoteRead, nil)
+
+	_, localErr := h.ls.LockMachineIdentityForUpdate(ctx, mi.ID+1000000)
+	_, remoteErr := h.rs.LockMachineIdentityForUpdate(ctx, mi.ID+1000000)
+	assert.Error(t, localErr, "sanity: a nonexistent machine identity must not be retrievable locally")
+	assert.Error(t, remoteErr, "RemoteStorage.LockMachineIdentityForUpdate must report an error for a nonexistent machine identity")
+}
+
+// --- ListMachineIdentities ---
+
+func TestConformance_ListMachineIdentities(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lmi-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+
+	byName := func(rows []*models.MachineIdentity, name string) *models.MachineIdentity {
+		for _, m := range rows {
+			if m.Name == name {
+				return m
+			}
+		}
+		return nil
+	}
+
+	inScope, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-lmi-in-scope", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	outOfScope, err := h.upstreamCore.CreateMachineIdentity(ctx, otherProject.ID, "conformance-lmi-out-of-scope", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+
+	localList, err := h.ls.ListMachineIdentities(ctx, h.projectID)
+	require.NoError(t, err)
+	assert.NotNil(t, byName(localList, inScope.Name), "sanity: an in-project identity must be listed")
+	assert.Nil(t, byName(localList, outOfScope.Name), "sanity: an identity in a different project must not be listed")
+
+	remoteList, err := h.rs.ListMachineIdentities(ctx, h.projectID)
+	require.NoError(t, err)
+	found := byName(remoteList, inScope.Name)
+	require.NotNil(t, found, "RemoteStorage.ListMachineIdentities must return the in-project identity")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.ListMachineIdentities item", inScope, found, nil)
+	assert.Nil(t, byName(remoteList, outOfScope.Name),
+		"RemoteStorage.ListMachineIdentities must NOT include an identity from a different project -- a dropped/ignored project_id on the wire would leak it")
+}
+
+// --- ListAllMachineIdentities ---
+
+func TestConformance_ListAllMachineIdentities(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lami-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+
+	byName := func(rows []*models.MachineIdentity, name string) *models.MachineIdentity {
+		for _, m := range rows {
+			if m.Name == name {
+				return m
+			}
+		}
+		return nil
+	}
+
+	remoteName := "conformance-lami-remote"
+	remoteMI, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, remoteName, core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	remoteOtherMI, err := h.upstreamCore.CreateMachineIdentity(ctx, otherProject.ID, "conformance-lami-remote-other", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+
+	// Sanity via LocalStorage first: ListAllMachineIdentities spans every
+	// project, not just h.projectID.
+	localList, err := h.ls.ListAllMachineIdentities(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, byName(localList, remoteName), "sanity: local identity must be listed")
+	assert.NotNil(t, byName(localList, remoteOtherMI.Name), "sanity: ListAllMachineIdentities spans every project")
+
+	remoteList, err := h.rs.ListAllMachineIdentities(ctx)
+	require.NoError(t, err)
+	found := byName(remoteList, remoteName)
+	require.NotNil(t, found, "RemoteStorage.ListAllMachineIdentities must include a genuine identity")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.ListAllMachineIdentities item", remoteMI, found, nil)
+	assert.NotNil(t, byName(remoteList, remoteOtherMI.Name),
+		"RemoteStorage.ListAllMachineIdentities must span every project, not just the caller's own -- a "+
+			"dropped/scoped-down query would hide identities in other projects")
+}
+
+// --- CountMachineIdentitiesByClassification ---
+
+func TestConformance_CountMachineIdentitiesByClassification(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		_, err := h.ls.CreateMachineIdentity(ctx, &models.MachineIdentity{
+			ProjectID: h.projectID, Name: fmt.Sprintf("conformance-cmibc-local-%d", i), IdentityType: "service",
+			State: "active", Classification: "confidential",
+		})
+		require.NoError(t, err)
+	}
+	localCounts, err := h.ls.CountMachineIdentitiesByClassification(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, localCounts["confidential"], "sanity: local count must reflect the seeded classification")
+
+	for i := 0; i < 3; i++ {
+		_, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, fmt.Sprintf("conformance-cmibc-remote-%d", i), core.MachineTypeService, "d", "restricted", h.adminUserID, 0)
+		require.NoError(t, err)
+	}
+	remoteCounts, err := h.rs.CountMachineIdentitiesByClassification(ctx)
+	require.NoError(t, err, "RemoteStorage.CountMachineIdentitiesByClassification must succeed")
+	assert.Equal(t, 3, remoteCounts["restricted"],
+		"RemoteStorage.CountMachineIdentitiesByClassification must reflect exactly the identities actually created, grouped correctly by classification")
+	assert.Equal(t, 2, remoteCounts["confidential"],
+		"RemoteStorage's install-wide count must also include identities created directly via LocalStorage (same backing store)")
+}
+
+// --- CountMachineIdentityCredentialsByClassification ---
+
+func TestConformance_CountMachineIdentityCredentialsByClassification(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newCred := func(suffix, classification string) {
+		mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-cmicbc-mi-"+suffix, core.MachineTypeService, "d", "", h.adminUserID, 0)
+		require.NoError(t, err)
+		_, err = h.ls.CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{
+			MachineIdentityID: mi.ID, Name: "conformance-cmicbc-cred-" + suffix, TokenHash: "conformance-cmicbc-hash-" + suffix,
+			TokenPrefix: "kxm_" + suffix, Classification: classification,
+		})
+		require.NoError(t, err)
+	}
+
+	newCred("local-1", "confidential")
+	newCred("local-2", "confidential")
+	localCounts, err := h.ls.CountMachineIdentityCredentialsByClassification(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, localCounts["confidential"], "sanity: local count must reflect the seeded classification")
+
+	newCred("remote-1", "restricted")
+	newCred("remote-2", "restricted")
+	newCred("remote-3", "restricted")
+	remoteCounts, err := h.rs.CountMachineIdentityCredentialsByClassification(ctx)
+	require.NoError(t, err, "RemoteStorage.CountMachineIdentityCredentialsByClassification must succeed")
+	assert.Equal(t, 3, remoteCounts["restricted"], "RemoteStorage's count must reflect exactly what was seeded")
+	assert.Equal(t, 2, remoteCounts["confidential"],
+		"RemoteStorage's install-wide count must also include credentials created directly via LocalStorage")
+}
+
+// --- GetMachineIdentityCredentialByHash ---
+
+func TestConformance_GetMachineIdentityCredentialByHash(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-gmicbh-mi", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	_, err = h.ls.CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{
+		MachineIdentityID: mi.ID, Name: "conformance-gmicbh-cred", TokenHash: "conformance-gmicbh-hash", TokenPrefix: "kxm_gmicbh",
+	})
+	require.NoError(t, err)
+
+	localRead, err := h.ls.GetMachineIdentityCredentialByHash(ctx, "conformance-gmicbh-hash")
+	require.NoError(t, err)
+	remoteRead, err := h.rs.GetMachineIdentityCredentialByHash(ctx, "conformance-gmicbh-hash")
+	require.NoError(t, err,
+		"RemoteStorage.GetMachineIdentityCredentialByHash must resolve a genuinely existing hash -- backs core.ValidateMachineToken's authentication lookup")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.GetMachineIdentityCredentialByHash (wire round trip)", localRead, remoteRead, nil)
+
+	_, localErr := h.ls.GetMachineIdentityCredentialByHash(ctx, "no-such-hash")
+	_, remoteErr := h.rs.GetMachineIdentityCredentialByHash(ctx, "no-such-hash")
+	assert.Error(t, localErr, "sanity: an unknown hash must not resolve locally")
+	assert.Error(t, remoteErr, "RemoteStorage.GetMachineIdentityCredentialByHash must report an error for an unknown hash, not a zero-value success")
+}
+
+// --- GetMachineIdentityCredentialByID ---
+
+func TestConformance_GetMachineIdentityCredentialByID(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-gmicbid-mi", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	cred, err := h.ls.CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{
+		MachineIdentityID: mi.ID, Name: "conformance-gmicbid-cred", TokenHash: "conformance-gmicbid-hash", TokenPrefix: "kxm_gmicbid",
+	})
+	require.NoError(t, err)
+
+	localRead, err := h.ls.GetMachineIdentityCredentialByID(ctx, cred.ID)
+	require.NoError(t, err)
+	remoteRead, err := h.rs.GetMachineIdentityCredentialByID(ctx, cred.ID)
+	require.NoError(t, err, "RemoteStorage.GetMachineIdentityCredentialByID must retrieve a genuinely existing credential")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.GetMachineIdentityCredentialByID (wire round trip)", localRead, remoteRead, nil)
+
+	_, localErr := h.ls.GetMachineIdentityCredentialByID(ctx, cred.ID+1000000)
+	_, remoteErr := h.rs.GetMachineIdentityCredentialByID(ctx, cred.ID+1000000)
+	assert.Error(t, localErr, "sanity: a nonexistent credential must not be retrievable locally")
+	assert.Error(t, remoteErr, "RemoteStorage.GetMachineIdentityCredentialByID must report an error for a nonexistent credential")
+}
+
+// --- ListMachineIdentityCredentials ---
+
+func TestConformance_ListMachineIdentityCredentials(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-lmic-mi", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	otherMI, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-lmic-other-mi", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+
+	cred, err := h.ls.CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{
+		MachineIdentityID: mi.ID, Name: "conformance-lmic-cred", TokenHash: "conformance-lmic-hash", TokenPrefix: "kxm_lmic",
+	})
+	require.NoError(t, err)
+	_, err = h.ls.CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{
+		MachineIdentityID: otherMI.ID, Name: "conformance-lmic-other-cred", TokenHash: "conformance-lmic-other-hash", TokenPrefix: "kxm_lmico",
+	})
+	require.NoError(t, err)
+
+	localList, err := h.ls.ListMachineIdentityCredentials(ctx, mi.ID)
+	require.NoError(t, err)
+	require.Len(t, localList, 1, "sanity: only the target machine's own credential must be listed")
+
+	remoteList, err := h.rs.ListMachineIdentityCredentials(ctx, mi.ID)
+	require.NoError(t, err)
+	require.Len(t, remoteList, 1,
+		"RemoteStorage.ListMachineIdentityCredentials must return only the target machine's own credential, not "+
+			"another machine's -- a dropped/ignored machine_identity_id on the wire would leak or hide credentials")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.ListMachineIdentityCredentials item", cred, remoteList[0], nil)
+
+	bystander, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-lmic-bystander", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	emptyList, err := h.rs.ListMachineIdentityCredentials(ctx, bystander.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyList, "a machine with no credentials must return an empty list, not error")
+}
+
+// --- ListActiveMachineIdentityCredentials ---
+
+func TestConformance_ListActiveMachineIdentityCredentials(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newMachineWithCred := func(suffix string, revoked bool) *models.MachineIdentityCredential {
+		mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-lamic-mi-"+suffix, core.MachineTypeService, "d", "", h.adminUserID, 0)
+		require.NoError(t, err)
+		cred, err := h.ls.CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{
+			MachineIdentityID: mi.ID, Name: "conformance-lamic-cred-" + suffix,
+			TokenHash: "conformance-lamic-hash-" + suffix, TokenPrefix: "kxm_" + suffix, Revoked: revoked,
+		})
+		require.NoError(t, err)
+		return cred
+	}
+
+	byHash := func(creds []*models.MachineIdentityCredential, hash string) *models.MachineIdentityCredential {
+		for _, c := range creds {
+			if c.TokenHash == hash {
+				return c
+			}
+		}
+		return nil
+	}
+
+	activeLocal := newMachineWithCred("local-active", false)
+	revokedLocal := newMachineWithCred("local-revoked", true)
+	localList, err := h.ls.ListActiveMachineIdentityCredentials(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, byHash(localList, activeLocal.TokenHash), "sanity: an active local credential must be listed")
+	assert.Nil(t, byHash(localList, revokedLocal.TokenHash), "sanity: a revoked local credential must NOT be listed")
+
+	activeRemote := newMachineWithCred("remote-active", false)
+	revokedRemote := newMachineWithCred("remote-revoked", true)
+	remoteList, err := h.rs.ListActiveMachineIdentityCredentials(ctx)
+	require.NoError(t, err)
+	found := byHash(remoteList, activeRemote.TokenHash)
+	require.NotNil(t, found, "RemoteStorage.ListActiveMachineIdentityCredentials must include a genuinely active credential")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.ListActiveMachineIdentityCredentials item", activeRemote, found, nil)
+	assert.Nil(t, byHash(remoteList, revokedRemote.TokenHash),
+		"a revoked credential must not appear in RemoteStorage's active list either -- a dropped/ignored revoked filter on the wire would leak it")
+}
+
+// --- UpdateMachineIdentityCredential ---
+
+func TestConformance_UpdateMachineIdentityCredential(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newCredential := func(suffix string) *models.MachineIdentityCredential {
+		mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-umic-mi-"+suffix, core.MachineTypeService, "d", "", h.adminUserID, 0)
+		require.NoError(t, err)
+		cred, err := h.ls.CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{
+			MachineIdentityID: mi.ID, Name: "conformance-umic-cred-" + suffix, TokenHash: "conformance-umic-hash-" + suffix, TokenPrefix: "kxm_" + suffix,
+		})
+		require.NoError(t, err)
+		return cred
+	}
+
+	// LocalStorage.UpdateMachineIdentityCredential is a raw, unconditional
+	// full-row Save -- every field the caller mutated lands.
+	localCred := newCredential("local")
+	localCred.Classification = "confidential"
+	require.NoError(t, h.ls.UpdateMachineIdentityCredential(ctx, localCred))
+	localAfter, err := h.ls.GetMachineIdentityCredentialByID(ctx, localCred.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "confidential", localAfter.Classification, "sanity: local update must land")
+
+	// RemoteStorage.UpdateMachineIdentityCredential's proxy handler deliberately
+	// does NOT perform a raw full-row Save -- see this file's package doc,
+	// asymmetry #2: it routes through core.ClassifyMachineTokenByID, which
+	// re-fetches the row server-side and applies ONLY Classification,
+	// discarding every other field the client's in-memory struct carries. A
+	// fair comparison mutates ONLY Classification (matching the real caller,
+	// ClassifyMachineToken) AND separately proves the narrowing by ALSO
+	// sending a forged TokenHash/Revoked and confirming they do NOT land.
+	remoteCred := newCredential("remote")
+	originalTokenHash := remoteCred.TokenHash
+	remoteCred.Classification = "confidential"
+	remoteCred.TokenHash = "conformance-umic-FORGED-hash"
+	remoteCred.Revoked = true
+	require.NoError(t, h.rs.UpdateMachineIdentityCredential(ctx, remoteCred),
+		"RemoteStorage.UpdateMachineIdentityCredential must succeed for a genuine, existing credential")
+
+	remotePersisted, err := h.ls.GetMachineIdentityCredentialByID(ctx, remoteCred.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "confidential", remotePersisted.Classification,
+		"the classification change must actually be persisted server-side, not just report success")
+	assert.Equal(t, originalTokenHash, remotePersisted.TokenHash,
+		"TokenHash must NOT be overwritten by a client-supplied value under cover of a classification update -- "+
+			"the server narrows the write to Classification only (core.ClassifyMachineTokenByID)")
+	assert.False(t, remotePersisted.Revoked, "Revoked must NOT be flippable via this route either -- same narrowing")
+
+	// Negative: an invalid classification value must be rejected.
+	remoteCred.Classification = "not-a-real-classification"
+	assert.Error(t, h.rs.UpdateMachineIdentityCredential(ctx, remoteCred),
+		"RemoteStorage.UpdateMachineIdentityCredential must reject an invalid classification value")
+}
+
+// --- TouchMachineIdentityCredential ---
+
+func TestConformance_TouchMachineIdentityCredential(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newCredential := func(suffix string) *models.MachineIdentityCredential {
+		mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-tmic-mi-"+suffix, core.MachineTypeService, "d", "", h.adminUserID, 0)
+		require.NoError(t, err)
+		cred, err := h.ls.CreateMachineIdentityCredential(ctx, &models.MachineIdentityCredential{
+			MachineIdentityID: mi.ID, Name: "conformance-tmic-cred-" + suffix, TokenHash: "conformance-tmic-hash-" + suffix, TokenPrefix: "kxm_" + suffix,
+		})
+		require.NoError(t, err)
+		return cred
+	}
+
+	staleness := time.Hour
+	usedAt := time.Now().UTC().Truncate(time.Second)
+
+	localCred := newCredential("local")
+	require.NoError(t, h.ls.TouchMachineIdentityCredential(ctx, localCred.ID, usedAt, staleness))
+	localAfter, err := h.ls.GetMachineIdentityCredentialByID(ctx, localCred.ID)
+	require.NoError(t, err)
+	require.NotNil(t, localAfter.LastUsedAt)
+	assert.True(t, localAfter.LastUsedAt.Equal(usedAt), "sanity: LocalStorage must record the used-at timestamp")
+
+	remoteCred := newCredential("remote")
+	require.NoError(t, h.rs.TouchMachineIdentityCredential(ctx, remoteCred.ID, usedAt, staleness),
+		"RemoteStorage.TouchMachineIdentityCredential must succeed")
+	remoteAfter, err := h.ls.GetMachineIdentityCredentialByID(ctx, remoteCred.ID)
+	require.NoError(t, err)
+	require.NotNil(t, remoteAfter.LastUsedAt)
+	assert.True(t, remoteAfter.LastUsedAt.Equal(usedAt),
+		"RemoteStorage.TouchMachineIdentityCredential must actually persist the used-at timestamp server-side")
+
+	// Throttling: a second touch with an EARLIER usedAt, still within the
+	// staleness window, must be a no-op -- proves the wire call preserves the
+	// conditional "only update if stale" write (local_machine_credentials.go's
+	// `WHERE id = ? AND (last_used_at IS NULL OR last_used_at < cutoff)`), not
+	// an unconditional overwrite that would defeat the throttle.
+	earlierUsedAt := usedAt.Add(-time.Minute)
+	require.NoError(t, h.rs.TouchMachineIdentityCredential(ctx, remoteCred.ID, earlierUsedAt, staleness))
+	stillAfter, err := h.ls.GetMachineIdentityCredentialByID(ctx, remoteCred.ID)
+	require.NoError(t, err)
+	assert.True(t, stillAfter.LastUsedAt.Equal(usedAt),
+		"a second touch within the staleness window must NOT overwrite the existing last_used_at over RemoteStorage")
+}
+
+// --- GetMachineRoleIDsAt ---
+
+func TestConformance_GetMachineRoleIDsAt(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	roleName, err := identity.NewFoldedName("conformance-gmria-role")
+	require.NoError(t, err)
+	role, err := h.ls.CreateRole(ctx, roleName, "conformance test role")
+	require.NoError(t, err)
+
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-gmria-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+
+	scope := coreStorage.Scope{ProjectID: h.projectID}
+
+	newGrantedMachine := func(suffix string) *models.MachineIdentity {
+		mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-gmria-mi-"+suffix, core.MachineTypeService, "d", "", h.adminUserID, 0)
+		require.NoError(t, err)
+		require.NoError(t, h.ls.AssignMachineRole(ctx, mi.ID, role.ID, scope))
+		return mi
+	}
+
+	localMachine := newGrantedMachine("local")
+	localIDs, err := h.ls.GetMachineRoleIDsAt(ctx, localMachine.ID, scope)
+	require.NoError(t, err)
+	assert.Contains(t, localIDs, role.ID, "sanity: local grant visible at the target scope")
+
+	remoteMachine := newGrantedMachine("remote")
+	remoteIDs, err := h.rs.GetMachineRoleIDsAt(ctx, remoteMachine.ID, scope)
+	require.NoError(t, err)
+	assert.Contains(t, remoteIDs, role.ID, "RemoteStorage.GetMachineRoleIDsAt must see the role grant server-side")
+
+	// Negative: a grant scoped to one project must not leak into a query for a
+	// genuinely different project -- the project-drop/widen risk this method
+	// exists to catch.
+	otherScope := coreStorage.Scope{ProjectID: otherProject.ID}
+	emptyIDs, err := h.rs.GetMachineRoleIDsAt(ctx, remoteMachine.ID, otherScope)
+	require.NoError(t, err)
+	assert.NotContains(t, emptyIDs, role.ID,
+		"a grant scoped to one project must not leak into a query for a different project")
+}
+
+// --- GetMachineRoles ---
+
+func TestConformance_GetMachineRoles(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	roleName, err := identity.NewFoldedName("conformance-gmr-role")
+	require.NoError(t, err)
+	role, err := h.ls.CreateRole(ctx, roleName, "conformance test role")
+	require.NoError(t, err)
+	scope := coreStorage.Scope{ProjectID: h.projectID}
+
+	newGrantedMachine := func(suffix string) *models.MachineIdentity {
+		mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-gmr-mi-"+suffix, core.MachineTypeService, "d", "", h.adminUserID, 0)
+		require.NoError(t, err)
+		require.NoError(t, h.ls.AssignMachineRole(ctx, mi.ID, role.ID, scope))
+		return mi
+	}
+
+	byID := func(roles []*models.Role, id uint) *models.Role {
+		for _, r := range roles {
+			if r.ID == id {
+				return r
+			}
+		}
+		return nil
+	}
+
+	localMachine := newGrantedMachine("local")
+	localRoles, err := h.ls.GetMachineRoles(ctx, localMachine.ID)
+	require.NoError(t, err)
+	require.NotNil(t, byID(localRoles, role.ID), "sanity: local role visible")
+
+	remoteMachine := newGrantedMachine("remote")
+	remoteRoles, err := h.rs.GetMachineRoles(ctx, remoteMachine.ID)
+	require.NoError(t, err)
+	found := byID(remoteRoles, role.ID)
+	require.NotNil(t, found, "RemoteStorage.GetMachineRoles must return the granted role")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.GetMachineRoles role fields", role, found, map[string]bool{
+		// NameFolded carries json:"-" on models.Role itself (never sent to ANY
+		// API surface, including the human-facing one) -- roleProxyWire/roleWire
+		// (ID/Name/Description only) both omit it on purpose, confirmed by that
+		// tag, not assumed.
+		"NameFolded": true,
+	})
+
+	// Negative: a machine with no grants must return an empty list, not error.
+	bystander, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-gmr-bystander", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	bystanderRoles, err := h.rs.GetMachineRoles(ctx, bystander.ID)
+	require.NoError(t, err)
+	assert.Empty(t, bystanderRoles, "a machine with no role grants must return an empty list")
+}
+
+// --- RemoveMachineRole ---
+
+func TestConformance_RemoveMachineRole(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// Zero-permission role -- mirrors tranche 3's AssignMachineRole/
+	// AssignRoleWithExpiry reasoning: h.rs's admin-role node/machine
+	// credential relayed through a /system proxy route cannot be trusted to
+	// exercise a permission-carrying grant/removal.
+	roleName, err := identity.NewFoldedName("conformance-rmr-role")
+	require.NoError(t, err)
+	role, err := h.ls.CreateRole(ctx, roleName, "conformance test role")
+	require.NoError(t, err)
+	scope := coreStorage.Scope{ProjectID: h.projectID}
+
+	newGrantedMachine := func(suffix string) *models.MachineIdentity {
+		mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-rmr-mi-"+suffix, core.MachineTypeService, "d", "", h.adminUserID, 0)
+		require.NoError(t, err)
+		require.NoError(t, h.ls.AssignMachineRole(ctx, mi.ID, role.ID, scope))
+		return mi
+	}
+
+	localMachine := newGrantedMachine("local")
+	require.NoError(t, h.ls.RemoveMachineRole(ctx, localMachine.ID, role.ID, scope))
+
+	remoteMachine := newGrantedMachine("remote")
+	require.NoError(t, h.rs.RemoveMachineRole(ctx, remoteMachine.ID, role.ID, scope),
+		"RemoteStorage.RemoveMachineRole must succeed for a genuine, existing grant on a machine in the caller-supplied project")
+
+	localIDsAfter, err := h.ls.GetMachineRoleIDsAt(ctx, localMachine.ID, scope)
+	require.NoError(t, err)
+	remoteIDsAfter, err := h.ls.GetMachineRoleIDsAt(ctx, remoteMachine.ID, scope)
+	require.NoError(t, err)
+	assert.NotContains(t, localIDsAfter, role.ID, "sanity: local grant must be gone")
+	assert.NotContains(t, remoteIDsAfter, role.ID, "the remote grant must actually be gone server-side, not just report success")
+
+	// Negative: removing a grant that doesn't exist (already removed) must
+	// fail identically on both paths, not silently no-op succeed.
+	assert.Error(t, h.ls.RemoveMachineRole(ctx, localMachine.ID, role.ID, scope))
+	assert.Error(t, h.rs.RemoveMachineRole(ctx, remoteMachine.ID, role.ID, scope))
+}
+
+// --- CreateOIDCBinding ---
+
+func TestConformance_CreateOIDCBinding(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// core.CreateOIDCBinding requires GLOBAL admin authority resolved from the
+	// AUTHENTICATED USER actor's own role grants (requireAdminAuthorityAt ->
+	// scopedRoleIDs keyed on a User ID) -- h.rs's node/machine credential
+	// always resolves actorID(r)==0 for this check (ADR-085 removed the
+	// former node-relay exemption), so it can never satisfy this route no
+	// matter what role the node itself holds. Mint a second RemoteStorage
+	// client authenticated as a real admin USER session instead, mirroring
+	// RevokeBreakGlassActivation's rsAsUser pattern (tranche 3).
+	userToken := createTestToken(t, h.upstreamCore)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: userToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	newMachine := func(suffix string) *models.MachineIdentity {
+		mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-cob-mi-"+suffix, core.MachineTypeService, "d", "", h.adminUserID, 0)
+		require.NoError(t, err)
+		return mi
+	}
+
+	localMachine := newMachine("local")
+	localBinding, err := h.ls.CreateOIDCBinding(ctx, &models.MachineIdentityOIDCBinding{
+		MachineIdentityID: localMachine.ID, Issuer: "https://issuer.example/cob-local", Subject: "sub-cob-local", CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, h.adminUserID, localBinding.CreatedBy, "sanity: local create preserves the caller-supplied CreatedBy")
+
+	remoteMachine := newMachine("remote")
+	remoteBinding, err := rsAsUser.CreateOIDCBinding(ctx, &models.MachineIdentityOIDCBinding{
+		MachineIdentityID: remoteMachine.ID, Issuer: "https://issuer.example/cob-remote", Subject: "sub-cob-remote",
+		CreatedBy: 999999, // deliberately wrong -- must be ignored, see below
+	})
+	require.NoError(t, err,
+		"RemoteStorage.CreateOIDCBinding must succeed for an admin USER actor creating a binding for a machine in a project it belongs to")
+
+	assert.Equal(t, remoteMachine.ID, remoteBinding.MachineIdentityID)
+	assert.Equal(t, "https://issuer.example/cob-remote", remoteBinding.Issuer)
+	assert.Equal(t, "sub-cob-remote", remoteBinding.Subject)
+	// CreatedBy must be derived from the authenticated session, never trusted
+	// from the wire -- same never-trust-client-asserted-attribution discipline
+	// as RevokeBreakGlassActivation's RevokedBy (tranche 3).
+	assert.NotEqual(t, uint(999999), remoteBinding.CreatedBy,
+		"CreatedBy must be derived from the authenticated session server-side, not trusted from the wire")
+	assert.Equal(t, h.adminUserID, remoteBinding.CreatedBy)
+
+	persisted, err := h.ls.GetOIDCBindingByID(ctx, remoteBinding.ID)
+	require.NoError(t, err)
+	assert.Equal(t, remoteMachine.ID, persisted.MachineIdentityID, "the binding must actually be persisted server-side, not just report success")
+
+	// Negative: a duplicate (issuer, subject) pair must be rejected identically
+	// on both paths, not silently succeed a second time.
+	_, dupLocalErr := h.ls.CreateOIDCBinding(ctx, &models.MachineIdentityOIDCBinding{
+		MachineIdentityID: localMachine.ID, Issuer: "https://issuer.example/cob-local", Subject: "sub-cob-local", CreatedBy: h.adminUserID,
+	})
+	assert.Error(t, dupLocalErr, "sanity: a duplicate (issuer, subject) pair must be rejected locally")
+	_, dupRemoteErr := rsAsUser.CreateOIDCBinding(ctx, &models.MachineIdentityOIDCBinding{
+		MachineIdentityID: remoteMachine.ID, Issuer: "https://issuer.example/cob-remote", Subject: "sub-cob-remote",
+	})
+	assert.Error(t, dupRemoteErr, "RemoteStorage.CreateOIDCBinding must reject a duplicate (issuer, subject) pair too, not silently succeed")
+}
+
+// --- GetMachineByOIDCSubject ---
+
+func TestConformance_GetMachineByOIDCSubject(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-gmbos-mi", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	_, err = h.ls.CreateOIDCBinding(ctx, &models.MachineIdentityOIDCBinding{
+		MachineIdentityID: mi.ID, Issuer: "https://issuer.example/gmbos", Subject: "sub-gmbos", CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+
+	localRead, err := h.ls.GetMachineByOIDCSubject(ctx, "https://issuer.example/gmbos", "sub-gmbos")
+	require.NoError(t, err)
+	remoteRead, err := h.rs.GetMachineByOIDCSubject(ctx, "https://issuer.example/gmbos", "sub-gmbos")
+	require.NoError(t, err, "RemoteStorage.GetMachineByOIDCSubject must resolve a genuinely bound (issuer, subject)")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.GetMachineByOIDCSubject (wire round trip)", localRead, remoteRead, nil)
+
+	_, localErr := h.ls.GetMachineByOIDCSubject(ctx, "https://issuer.example/gmbos", "no-such-subject")
+	_, remoteErr := h.rs.GetMachineByOIDCSubject(ctx, "https://issuer.example/gmbos", "no-such-subject")
+	assert.Error(t, localErr, "sanity: an unbound subject must not resolve locally")
+	assert.Error(t, remoteErr, "RemoteStorage.GetMachineByOIDCSubject must report an error for an unbound (issuer, subject), not a zero-value success")
+}
+
+// --- ListOIDCBindings ---
+
+func TestConformance_ListOIDCBindings(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-lob-mi", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	otherMI, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-lob-other-mi", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+
+	binding, err := h.ls.CreateOIDCBinding(ctx, &models.MachineIdentityOIDCBinding{
+		MachineIdentityID: mi.ID, Issuer: "https://issuer.example/lob", Subject: "sub-lob", CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+	_, err = h.ls.CreateOIDCBinding(ctx, &models.MachineIdentityOIDCBinding{
+		MachineIdentityID: otherMI.ID, Issuer: "https://issuer.example/lob-other", Subject: "sub-lob-other", CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+
+	localList, err := h.ls.ListOIDCBindings(ctx, mi.ID)
+	require.NoError(t, err)
+	require.Len(t, localList, 1, "sanity: only the target machine's own binding must be listed")
+
+	remoteList, err := h.rs.ListOIDCBindings(ctx, mi.ID)
+	require.NoError(t, err)
+	require.Len(t, remoteList, 1, "RemoteStorage.ListOIDCBindings must return only the target machine's own binding, not another machine's")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.ListOIDCBindings item", binding, remoteList[0], nil)
+
+	bystander, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-lob-bystander", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	emptyList, err := h.rs.ListOIDCBindings(ctx, bystander.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyList, "a machine with no bindings must return an empty list, not error")
+}
+
+// --- GetOIDCBindingByID ---
+
+func TestConformance_GetOIDCBindingByID(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-gobbi-mi", core.MachineTypeService, "d", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	binding, err := h.ls.CreateOIDCBinding(ctx, &models.MachineIdentityOIDCBinding{
+		MachineIdentityID: mi.ID, Issuer: "https://issuer.example/gobbi", Subject: "sub-gobbi", CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+
+	localRead, err := h.ls.GetOIDCBindingByID(ctx, binding.ID)
+	require.NoError(t, err)
+	remoteRead, err := h.rs.GetOIDCBindingByID(ctx, binding.ID)
+	require.NoError(t, err, "RemoteStorage.GetOIDCBindingByID must retrieve a genuinely existing binding")
+	assertFieldExhaustiveEqual(t, "RemoteStorage.GetOIDCBindingByID (wire round trip)", localRead, remoteRead, nil)
+
+	_, localErr := h.ls.GetOIDCBindingByID(ctx, binding.ID+1000000)
+	_, remoteErr := h.rs.GetOIDCBindingByID(ctx, binding.ID+1000000)
+	assert.Error(t, localErr, "sanity: a nonexistent binding must not be retrievable locally")
+	assert.Error(t, remoteErr, "RemoteStorage.GetOIDCBindingByID must report an error for a nonexistent binding")
+}
+
+// --- DeleteOIDCBinding ---
+
+func TestConformance_DeleteOIDCBinding(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// Unlike CreateOIDCBinding, core.DeleteOIDCBinding has no separate
+	// admin-authority gate of its own (only a machineInProject re-check
+	// against the SERVER-resolved project) -- h.rs's node/machine credential
+	// works fine here, no rsAsUser needed.
+	newBoundMachine := func(suffix string) *models.MachineIdentityOIDCBinding {
+		mi, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-dob-mi-"+suffix, core.MachineTypeService, "d", "", h.adminUserID, 0)
+		require.NoError(t, err)
+		b, err := h.ls.CreateOIDCBinding(ctx, &models.MachineIdentityOIDCBinding{
+			MachineIdentityID: mi.ID, Issuer: "https://issuer.example/dob-" + suffix, Subject: "sub-dob-" + suffix, CreatedBy: h.adminUserID,
+		})
+		require.NoError(t, err)
+		return b
+	}
+
+	localBinding := newBoundMachine("local")
+	require.NoError(t, h.ls.DeleteOIDCBinding(ctx, localBinding.ID))
+
+	remoteBinding := newBoundMachine("remote")
+	require.NoError(t, h.rs.DeleteOIDCBinding(ctx, remoteBinding.ID),
+		"RemoteStorage.DeleteOIDCBinding must succeed for a binding that genuinely exists")
+
+	_, localErr := h.ls.GetOIDCBindingByID(ctx, localBinding.ID)
+	_, remoteErr := h.ls.GetOIDCBindingByID(ctx, remoteBinding.ID)
+	assert.Error(t, localErr, "sanity: the local binding must be gone")
+	assert.Error(t, remoteErr, "the binding deleted via RemoteStorage must actually be gone server-side, not just report success")
+
+	// Deleting an already-deleted (or never-existent) binding must fail
+	// identically on both paths.
+	assert.Error(t, h.ls.DeleteOIDCBinding(ctx, localBinding.ID))
+	assert.Error(t, h.rs.DeleteOIDCBinding(ctx, remoteBinding.ID))
+}

--- a/server/http/remote_storage_conformance_tranche4_memberships_auth_test.go
+++ b/server/http/remote_storage_conformance_tranche4_memberships_auth_test.go
@@ -1,0 +1,919 @@
+// remote_storage_conformance_tranche4_memberships_auth_test.go — issue #1808,
+// tranche 4.
+//
+// Assignment: cover the 8 methods in internal/storage/store/remote_memberships.go
+// and the 8 methods in internal/storage/store/remote_auth.go named in the tranche
+// brief:
+//
+//	remote_memberships.go: CountProjectMembershipsByUsers, CreateProjectMembership,
+//	GetActiveProjectMembership, GetProjectMembership, ListProjectMemberships,
+//	ListStaleInvitedMemberships, ListUserProjectMemberships,
+//	TransitionProjectMembershipState
+//
+//	remote_auth.go: CountSetupTokensSince, CreateSetupToken, DeleteSession,
+//	DeleteSessionsForUserExcept, GetSession, GetSetupTokenByHash,
+//	MarkSetupTokenExpired, SupersedeActiveSetupTokens
+//
+// 15 of the 16 are covered below. One is deliberately skipped:
+//
+//   - TransitionProjectMembershipState: unlike every other "Transition*"/"CAS"
+//     method already covered by this harness (TransitionMachineIdentityState,
+//     TransitionSecretStatus — tranche 2/3), the server-side route backing
+//     this one (TransitionMembershipProxy, project_memberships_proxy.go) is
+//     NOT a raw passthrough onto storage.TransitionProjectMembershipState's
+//     CAS primitive. It fully delegates to core.TransitionMembership, which
+//     re-reads the row itself, derives fromState from that fresh read (the
+//     wire's own from_state is accepted but explicitly documented as unused),
+//     enforces canTransition legality service-side, and applies a role-grant
+//     side effect (AddProjectMember) the raw primitive never does. A caller
+//     cannot even PRODUCE the raw CAS's "wrong fromState -> no match" outcome
+//     through this route: within one synchronous request there is no window
+//     for the server's own fresh read to already be stale, so matched=false
+//     is unreachable without genuine concurrency, and an illegal target state
+//     surfaces as a different error shape (a generic STORAGE_ERROR, not the
+//     matched=false wire contract every other CAS method here shares). A fair
+//     conformance test would need to compare two FULL core.TransitionMembership
+//     executions (one in-process, one over HTTP through a second, RemoteStorage
+//     -backed core.KeyorixCore) rather than RemoteStorage against the raw
+//     LocalStorage primitive — this is the exact same shape of problem tranche
+//     2's own header names for excluding DeleteUser ("real, separate design
+//     work, not a checkbox this tranche had room for"), and is left for a
+//     dedicated future tranche for the identical reason, not faked here with a
+//     shallow/tautological comparison.
+//
+// # Two wire-fidelity gaps found while building this tranche, NOT fixed here
+//
+// This tranche's own instructions are to add exactly one new test file and
+// touch nothing else, so both of the following are documented and worked
+// around (excluded from the relevant field-exhaustive comparison, with the
+// gap spelled out inline at the exclusion) rather than repaired. Both match
+// the #1573 "which machine identity performed this action" attribution
+// pattern this codebase already carries for several other models.
+//
+//  1. SetupToken.CreatedByMachineIdentityID (remote_auth.go's CreateSetupToken):
+//     remote_auth.go's own client-side setupTokenWire has no field for it at
+//     all, while server/http/handlers/setup_tokens_proxy.go's
+//     setupTokenProxyWire — the wire struct for the exact same JSON key,
+//     "created_by_machine_identity_id" — does. CreateSetupTokenProxy derives
+//     and PERSISTS the correct value from the authenticated caller
+//     (machineID(r)) server-side, so the DATABASE row is correct; only the
+//     HTTP response decoded back into the client's *models.SetupToken loses
+//     it, because there is nowhere on that struct for the field to land. See
+//     TestConformance_CreateSetupToken below, where this is demonstrated by
+//     reading the persisted row directly (nonzero) alongside the wire-decoded
+//     response (always zero). Fix: add a CreatedByMachineIdentityID field to
+//     remote_auth.go's setupTokenWire (mirroring setupTokenProxyWire exactly)
+//     and thread it through newSetupTokenWire/toModel.
+//
+//  2. ProjectMembership.InvitedByMachineIdentityID (remote_memberships.go's
+//     CreateProjectMembership): worse than (1) — this one is missing from
+//     BOTH sides of the wire. remote_memberships.go's membershipWire AND
+//     server/http/handlers/project_memberships_proxy.go's membershipProxyWire
+//     both lack the field entirely, so it never even reaches the JSON
+//     envelope in either direction. CreateMembershipProxy also never derives
+//     it from the authenticated caller the way CreateSetupTokenProxy does for
+//     CreatedByMachineIdentityID (it only forces InvitedBy = actorID(r), not
+//     an analogous InvitedByMachineIdentityID = machineID(r)) — so a
+//     machine-authenticated node relay creating a membership over
+//     storage.type: remote silently persists InvitedByMachineIdentityID as 0
+//     no matter which machine identity actually performed the invite,
+//     server-side DB row included, not just the HTTP response. This tranche's
+//     TestConformance_CreateProjectMembership does not attempt to demonstrate
+//     it (setting the field on the request wouldn't even round-trip to
+//     compare against, since neither wire struct carries it) — flagged here
+//     instead so it isn't lost. Fix needs three changes: add the field to
+//     BOTH membershipWire and membershipProxyWire, and add
+//     model.InvitedByMachineIdentityID = machineID(r) to CreateMembershipProxy
+//     alongside its existing InvitedBy = actorID(r) line.
+package http
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// --- CreateProjectMembership ---
+
+func TestConformance_CreateProjectMembership(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// A zero-permission role: CreateMembershipProxy routes the grant through
+	// RequireGranterHoldsRolePermissions (#1578), which for a machine actor
+	// relayed through a /system proxy route fails closed on ANY bundled
+	// permission (isSelfMachineGrant is only ever set by non-proxy handlers) —
+	// same reasoning tranche 3 documents for AssignRoleWithExpiry/
+	// AssignMachineRole. A role with no permissions makes that loop a no-op.
+	roleName, err := identity.NewFoldedName("conformance-cpm-role")
+	require.NoError(t, err)
+	role, err := h.ls.CreateRole(ctx, roleName, "conformance test role")
+	require.NoError(t, err)
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-cpm-" + suffix, Email: "conformance-cpm-" + suffix + "@example.com",
+			DisplayName: "Conformance CreateProjectMembership " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	invitedAt := time.Now().UTC().Truncate(time.Second)
+
+	localUser := newUser("local")
+	localSent := &models.ProjectMembership{
+		ProjectID: h.projectID, UserID: localUser.ID, Role: role.Name, State: "invited",
+		InvitedBy: h.adminUserID, InvitedAt: invitedAt,
+	}
+	_, err = h.ls.CreateProjectMembership(ctx, localSent)
+	require.NoError(t, err)
+	localPersisted, err := h.ls.GetProjectMembership(ctx, localSent.ID)
+	require.NoError(t, err)
+	localExclude := map[string]bool{
+		"UpdatedAt": true, // GORM auto-sets this on Create -- confirmed the sole diff by running this test
+	}
+	assertFieldExhaustiveEqual(t, "LocalStorage.CreateProjectMembership (sanity baseline)", localSent, localPersisted, localExclude)
+
+	remoteUser := newUser("remote")
+	const forgedInvitedBy = 999999
+	remoteSent := &models.ProjectMembership{
+		ProjectID: h.projectID, UserID: remoteUser.ID, Role: role.Name, State: "invited",
+		InvitedBy: forgedInvitedBy, InvitedAt: invitedAt,
+	}
+	remoteCreated, err := h.rs.CreateProjectMembership(ctx, remoteSent)
+	require.NoError(t, err, "RemoteStorage.CreateProjectMembership must succeed for a zero-permission role and a genuine project/user")
+
+	// G80-style forced-attribution check (#1578): InvitedBy must come from the
+	// authenticated caller server-side, never the wire-supplied value.
+	assert.NotEqual(t, uint(forgedInvitedBy), remoteCreated.InvitedBy,
+		"InvitedBy must be derived from the authenticated caller server-side, never trusted from the wire")
+
+	remotePersisted, err := h.ls.GetProjectMembership(ctx, remoteCreated.ID)
+	require.NoError(t, err)
+
+	requestExclude := map[string]bool{
+		"ID":        true, // not yet assigned on the pre-create wire struct; response fidelity is checked separately below via remoteCreated
+		"InvitedBy": true, // forged input, forced server-side -- asserted explicitly above
+		"UpdatedAt": true, // GORM auto-set on Create
+	}
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateProjectMembership (request fidelity: sent vs persisted)", remoteSent, remotePersisted, requestExclude)
+
+	responseExclude := map[string]bool{
+		"UpdatedAt": true, // GORM auto-set on Create; defensive, same class as every other Create test in this harness
+	}
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateProjectMembership (response fidelity: wire-returned vs persisted)", remoteCreated, remotePersisted, responseExclude)
+
+	// Duplicate-active-membership conflict (#309): a second create for the SAME
+	// (project, user) while a non-revoked membership already exists must be
+	// rejected identically on both paths, translating to the SAME sentinel --
+	// remote_memberships.go's own CreateProjectMembership doc names this as
+	// the exact wire-error-code translation this proxy exists to preserve.
+	_, dupLocalErr := h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: h.projectID, UserID: localUser.ID, Role: role.Name, State: "invited",
+		InvitedBy: h.adminUserID, InvitedAt: invitedAt,
+	})
+	assert.ErrorIs(t, dupLocalErr, coreStorage.ErrDuplicateActiveMembership,
+		"sanity: a second active membership for the same (project, user) must be rejected")
+
+	_, dupRemoteErr := h.rs.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: h.projectID, UserID: remoteUser.ID, Role: role.Name, State: "invited",
+		InvitedBy: forgedInvitedBy, InvitedAt: invitedAt,
+	})
+	assert.ErrorIs(t, dupRemoteErr, coreStorage.ErrDuplicateActiveMembership,
+		"RemoteStorage.CreateProjectMembership must translate the upstream's DB-level duplicate-active-membership "+
+			"rejection into the SAME sentinel across the HTTP hop, not an opaque failure")
+}
+
+// --- GetProjectMembership ---
+
+func TestConformance_GetProjectMembership(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	user, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gpm", Email: "conformance-gpm@example.com",
+		DisplayName: "Conformance GetProjectMembership", IsActive: true,
+	})
+	require.NoError(t, err)
+	invitedAt := time.Now().UTC().Truncate(time.Second)
+	membership, err := h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: h.projectID, UserID: user.ID, Role: "system_viewer", State: "invited",
+		InvitedBy: h.adminUserID, InvitedAt: invitedAt,
+	})
+	require.NoError(t, err)
+
+	// ls and rs read the SAME row through the SAME backing store here -- no
+	// separate "local"/"remote" fixture needed for a pure read (see the DeleteUser
+	// -adjacent skip note above for why that split matters for MUTATING methods).
+	viaLocal, err := h.ls.GetProjectMembership(ctx, membership.ID)
+	require.NoError(t, err)
+	viaRemote, err := h.rs.GetProjectMembership(ctx, membership.ID)
+	require.NoError(t, err, "RemoteStorage.GetProjectMembership must find a genuinely existing membership")
+	assertFieldExhaustiveEqual(t, "GetProjectMembership (LocalStorage vs RemoteStorage over the SAME row)", viaLocal, viaRemote, nil)
+
+	_, localErr := h.ls.GetProjectMembership(ctx, 999999999)
+	_, remoteErr := h.rs.GetProjectMembership(ctx, 999999999)
+	assert.Error(t, localErr, "sanity: an unknown membership ID must not resolve")
+	assert.Error(t, remoteErr, "RemoteStorage.GetProjectMembership must also refuse an unknown ID, not silently return something")
+}
+
+// --- ListProjectMemberships ---
+
+func TestConformance_ListProjectMemberships(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	project, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lpm-project", "", []string{"dev"})
+	require.NoError(t, err)
+
+	newMember := func(suffix, state string) uint {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-lpm-" + suffix, Email: "conformance-lpm-" + suffix + "@example.com",
+			DisplayName: "Conformance ListProjectMemberships " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		m, err := h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+			ProjectID: project.ID, UserID: user.ID, Role: "system_viewer", State: state,
+			InvitedBy: h.adminUserID, InvitedAt: time.Now().UTC(),
+		})
+		require.NoError(t, err)
+		return m.ID
+	}
+	id1 := newMember("a", "invited")
+	id2 := newMember("b", "active")
+
+	// A DIFFERENT project's membership must not leak into this project's list
+	// -- the scope-drop risk this method exists to catch.
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lpm-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+	otherUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-lpm-other", Email: "conformance-lpm-other@example.com",
+		DisplayName: "Conformance ListProjectMemberships other", IsActive: true,
+	})
+	require.NoError(t, err)
+	_, err = h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: otherProject.ID, UserID: otherUser.ID, Role: "system_viewer", State: "invited",
+		InvitedBy: h.adminUserID, InvitedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	viaLocal, err := h.ls.ListProjectMemberships(ctx, project.ID)
+	require.NoError(t, err)
+	viaRemote, err := h.rs.ListProjectMemberships(ctx, project.ID)
+	require.NoError(t, err, "RemoteStorage.ListProjectMemberships must succeed")
+
+	idsOf := func(rows []*models.ProjectMembership) []uint {
+		ids := make([]uint, len(rows))
+		for i, r := range rows {
+			ids[i] = r.ID
+		}
+		return ids
+	}
+	assert.ElementsMatch(t, []uint{id1, id2}, idsOf(viaLocal), "sanity: LocalStorage must list exactly this project's memberships")
+	assert.ElementsMatch(t, []uint{id1, id2}, idsOf(viaRemote),
+		"RemoteStorage.ListProjectMemberships must return exactly the SAME set -- a dropped/wrong project_id on "+
+			"the wire would return the wrong project's memberships, or none")
+}
+
+// --- GetActiveProjectMembership ---
+
+func TestConformance_GetActiveProjectMembership(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	project, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-gapm-project", "", []string{"dev"})
+	require.NoError(t, err)
+
+	activeUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gapm-active", Email: "conformance-gapm-active@example.com",
+		DisplayName: "Conformance GetActiveProjectMembership active", IsActive: true,
+	})
+	require.NoError(t, err)
+	active, err := h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: project.ID, UserID: activeUser.ID, Role: "system_viewer", State: "active",
+		InvitedBy: h.adminUserID, InvitedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	revokedUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gapm-revoked", Email: "conformance-gapm-revoked@example.com",
+		DisplayName: "Conformance GetActiveProjectMembership revoked", IsActive: true,
+	})
+	require.NoError(t, err)
+	_, err = h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: project.ID, UserID: revokedUser.ID, Role: "system_viewer", State: "revoked",
+		InvitedBy: h.adminUserID, InvitedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	viaLocal, err := h.ls.GetActiveProjectMembership(ctx, project.ID, activeUser.ID)
+	require.NoError(t, err)
+	viaRemote, err := h.rs.GetActiveProjectMembership(ctx, project.ID, activeUser.ID)
+	require.NoError(t, err, "RemoteStorage.GetActiveProjectMembership must find the genuinely active membership")
+	assertFieldExhaustiveEqual(t, "GetActiveProjectMembership (LocalStorage vs RemoteStorage over the SAME row)", viaLocal, viaRemote, nil)
+	assert.Equal(t, active.ID, viaRemote.ID)
+
+	// A user whose ONLY membership is revoked must not resolve as active --
+	// the state-filter risk this method exists to catch.
+	_, localErr := h.ls.GetActiveProjectMembership(ctx, project.ID, revokedUser.ID)
+	_, remoteErr := h.rs.GetActiveProjectMembership(ctx, project.ID, revokedUser.ID)
+	assert.Error(t, localErr, "sanity: a revoked-only membership must not resolve as active")
+	assert.Error(t, remoteErr, "RemoteStorage.GetActiveProjectMembership must also refuse a revoked-only membership, not silently return it")
+}
+
+// --- ListStaleInvitedMemberships ---
+
+func TestConformance_ListStaleInvitedMemberships(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	project, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lsim-project", "", []string{"dev"})
+	require.NoError(t, err)
+
+	cutoff := time.Now().UTC()
+	stalePast := cutoff.Add(-48 * time.Hour)
+	recentFuture := cutoff.Add(48 * time.Hour)
+
+	newMembership := func(suffix, state string, invitedAt time.Time) uint {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-lsim-" + suffix, Email: "conformance-lsim-" + suffix + "@example.com",
+			DisplayName: "Conformance ListStaleInvitedMemberships " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		m, err := h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+			ProjectID: project.ID, UserID: user.ID, Role: "system_viewer", State: state, InvitedBy: h.adminUserID, InvitedAt: invitedAt,
+		})
+		require.NoError(t, err)
+		return m.ID
+	}
+
+	staleID := newMembership("stale", "invited", stalePast)
+	recentID := newMembership("recent", "invited", recentFuture)
+	// Old but NOT invited (already active) -- must be excluded despite the
+	// stale invited_at, proving the state filter isn't dropped/widened on the wire.
+	activeOldID := newMembership("active-old", "active", stalePast)
+
+	viaLocal, err := h.ls.ListStaleInvitedMemberships(ctx, cutoff)
+	require.NoError(t, err)
+	viaRemote, err := h.rs.ListStaleInvitedMemberships(ctx, cutoff)
+	require.NoError(t, err, "RemoteStorage.ListStaleInvitedMemberships must succeed")
+
+	idsOf := func(rows []*models.ProjectMembership) []uint {
+		ids := make([]uint, len(rows))
+		for i, r := range rows {
+			ids[i] = r.ID
+		}
+		return ids
+	}
+	localIDs := idsOf(viaLocal)
+	remoteIDs := idsOf(viaRemote)
+
+	assert.Contains(t, localIDs, staleID, "sanity: LocalStorage must list the stale invited membership")
+	assert.NotContains(t, localIDs, recentID, "sanity: a recently-invited membership must not be listed as stale")
+	assert.NotContains(t, localIDs, activeOldID, "sanity: an old but non-invited membership must not be listed")
+
+	assert.Contains(t, remoteIDs, staleID,
+		"RemoteStorage.ListStaleInvitedMemberships must list the stale invited membership -- a dropped/wrong "+
+			"'before' cutoff on the wire would omit it")
+	assert.NotContains(t, remoteIDs, recentID,
+		"RemoteStorage.ListStaleInvitedMemberships must NOT list a recently-invited membership -- a dropped or "+
+			"widened cutoff would include it")
+	assert.NotContains(t, remoteIDs, activeOldID,
+		"RemoteStorage.ListStaleInvitedMemberships must NOT list an old but non-invited membership -- a dropped "+
+			"state filter on the wire would include it")
+}
+
+// --- ListUserProjectMemberships ---
+
+func TestConformance_ListUserProjectMemberships(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	user, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-lupm", Email: "conformance-lupm@example.com",
+		DisplayName: "Conformance ListUserProjectMemberships", IsActive: true,
+	})
+	require.NoError(t, err)
+
+	projectB, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lupm-project-b", "", []string{"dev"})
+	require.NoError(t, err)
+
+	m1, err := h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: h.projectID, UserID: user.ID, Role: "system_viewer", State: "active",
+		InvitedBy: h.adminUserID, InvitedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	m2, err := h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: projectB.ID, UserID: user.ID, Role: "system_viewer", State: "invited",
+		InvitedBy: h.adminUserID, InvitedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	// A bystander user's own membership must never appear -- the scope-drop
+	// risk this method exists to catch.
+	bystander, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-lupm-bystander", Email: "conformance-lupm-bystander@example.com",
+		DisplayName: "Conformance ListUserProjectMemberships bystander", IsActive: true,
+	})
+	require.NoError(t, err)
+	_, err = h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: h.projectID, UserID: bystander.ID, Role: "system_viewer", State: "active",
+		InvitedBy: h.adminUserID, InvitedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	viaLocal, err := h.ls.ListUserProjectMemberships(ctx, user.ID)
+	require.NoError(t, err)
+	viaRemote, err := h.rs.ListUserProjectMemberships(ctx, user.ID)
+	require.NoError(t, err, "RemoteStorage.ListUserProjectMemberships must succeed")
+
+	idsOf := func(rows []*models.ProjectMembership) []uint {
+		ids := make([]uint, len(rows))
+		for i, r := range rows {
+			ids[i] = r.ID
+		}
+		return ids
+	}
+	assert.ElementsMatch(t, []uint{m1.ID, m2.ID}, idsOf(viaLocal), "sanity: LocalStorage must list exactly this user's memberships, across both projects")
+	assert.ElementsMatch(t, []uint{m1.ID, m2.ID}, idsOf(viaRemote),
+		"RemoteStorage.ListUserProjectMemberships must return exactly the SAME set -- a dropped/wrong user_id on "+
+			"the wire would return another user's memberships, or none")
+}
+
+// --- CountProjectMembershipsByUsers ---
+
+func TestConformance_CountProjectMembershipsByUsers(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// uniq_project_memberships_active (#309) allows at most ONE non-revoked
+	// membership per (project, user) -- to get a user with Active:1/Total:2,
+	// spread the non-revoked memberships across different projects, plus one
+	// revoked row (excluded from Total) in a third.
+	projectB, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-cpmbu-project-b", "", []string{"dev"})
+	require.NoError(t, err)
+	projectC, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-cpmbu-project-c", "", []string{"dev"})
+	require.NoError(t, err)
+
+	user, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-cpmbu", Email: "conformance-cpmbu@example.com",
+		DisplayName: "Conformance CountProjectMembershipsByUsers", IsActive: true,
+	})
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		projectID uint
+		state     string
+	}{
+		{h.projectID, "active"},
+		{projectB.ID, "invited"},
+		{projectC.ID, "revoked"},
+	} {
+		_, err := h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+			ProjectID: tc.projectID, UserID: user.ID, Role: "system_viewer", State: tc.state,
+			InvitedBy: h.adminUserID, InvitedAt: time.Now().UTC(),
+		})
+		require.NoError(t, err)
+	}
+
+	// A user NOT in the requested ID list must not appear in the result --
+	// the scope-drop risk this method exists to catch.
+	bystander, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-cpmbu-bystander", Email: "conformance-cpmbu-bystander@example.com",
+		DisplayName: "Conformance CountProjectMembershipsByUsers bystander", IsActive: true,
+	})
+	require.NoError(t, err)
+	_, err = h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+		ProjectID: h.projectID, UserID: bystander.ID, Role: "system_viewer", State: "active",
+		InvitedBy: h.adminUserID, InvitedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	localCounts, err := h.ls.CountProjectMembershipsByUsers(ctx, []uint{user.ID})
+	require.NoError(t, err)
+	remoteCounts, err := h.rs.CountProjectMembershipsByUsers(ctx, []uint{user.ID})
+	require.NoError(t, err, "RemoteStorage.CountProjectMembershipsByUsers must succeed")
+
+	assert.Equal(t, coreStorage.MembershipCounts{Active: 1, Total: 2}, localCounts[user.ID],
+		"sanity: one active + one invited (both non-revoked) = active:1 total:2; the revoked row must not count toward total")
+	assert.Equal(t, localCounts[user.ID], remoteCounts[user.ID],
+		"RemoteStorage.CountProjectMembershipsByUsers must return the identical counts LocalStorage computes over the SAME rows")
+	_, bystanderRequested := remoteCounts[bystander.ID]
+	assert.False(t, bystanderRequested, "a user ID not in the request must not appear in the result")
+
+	emptyCounts, err := h.rs.CountProjectMembershipsByUsers(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, emptyCounts, "an empty user-ID list must short-circuit to an empty map (RemoteStorage's own shortcut skips the HTTP round trip entirely)")
+}
+
+// --- GetSession ---
+
+func TestConformance_GetSession(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	user, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gs", Email: "conformance-gs@example.com",
+		DisplayName: "Conformance GetSession", IsActive: true,
+	})
+	require.NoError(t, err)
+
+	expiresAt := time.Now().Add(time.Hour).UTC()
+	_, err = h.ls.CreateSession(ctx, &models.Session{
+		UserID: user.ID, SessionToken: "conformance-gs-token", UserAgent: "conformance-test-agent",
+		IPAddress: "127.0.0.1", ExpiresAt: &expiresAt,
+	})
+	require.NoError(t, err)
+
+	// ls and rs read the SAME session row here -- see GetProjectMembership's
+	// comment above for why a pure read doesn't need a separate local/remote fixture.
+	viaLocal, err := h.ls.GetSession(ctx, "conformance-gs-token")
+	require.NoError(t, err)
+	viaRemote, err := h.rs.GetSession(ctx, "conformance-gs-token")
+	require.NoError(t, err, "RemoteStorage.GetSession must find a genuinely live session by its token")
+
+	exclude := map[string]bool{
+		// models.Session.SessionToken is tagged `json:"-"` BY DESIGN (see
+		// remote_auth.go's CreateSession doc comment) -- the at-rest hash must
+		// never cross the wire generically, so viaRemote.SessionToken is
+		// always "" regardless of viaLocal's real (hashed) value. Analogous to
+		// SecretNode.ValueStored's exclusion in tranche 3.
+		"SessionToken": true,
+	}
+	assertFieldExhaustiveEqual(t, "GetSession (LocalStorage vs RemoteStorage over the SAME session)", viaLocal, viaRemote, exclude)
+	assert.Empty(t, viaRemote.SessionToken, "sanity: the session hash must never actually cross the wire")
+
+	_, localErr := h.ls.GetSession(ctx, "conformance-gs-nonexistent-token")
+	_, remoteErr := h.rs.GetSession(ctx, "conformance-gs-nonexistent-token")
+	assert.Error(t, localErr, "sanity: an unknown token must not resolve to a session")
+	assert.Error(t, remoteErr, "RemoteStorage.GetSession must also refuse an unknown token, not silently return something")
+}
+
+// --- DeleteSession ---
+
+func TestConformance_DeleteSession(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	expiresAt := time.Now().Add(time.Hour).UTC()
+
+	newSession := func(suffix string) *models.Session {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-ds-" + suffix, Email: "conformance-ds-" + suffix + "@example.com",
+			DisplayName: "Conformance DeleteSession " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		session, err := h.ls.CreateSession(ctx, &models.Session{
+			UserID: user.ID, SessionToken: "conformance-ds-token-" + suffix, ExpiresAt: &expiresAt,
+		})
+		require.NoError(t, err)
+		return session
+	}
+
+	localTarget := newSession("local-target")
+	localBystander := newSession("local-bystander")
+	require.NoError(t, h.ls.DeleteSession(ctx, localTarget.ID))
+
+	remoteTarget := newSession("remote-target")
+	remoteBystander := newSession("remote-bystander")
+	require.NoError(t, h.rs.DeleteSession(ctx, remoteTarget.ID), "RemoteStorage.DeleteSession must succeed for a genuinely existing session")
+
+	_, localErr := h.ls.GetSessionByID(ctx, localTarget.ID)
+	_, remoteErr := h.ls.GetSessionByID(ctx, remoteTarget.ID)
+	assert.Error(t, localErr, "sanity: the local target session must be gone")
+	assert.Error(t, remoteErr, "the remote target session must actually be gone server-side, not just report success")
+
+	_, bystanderLocalErr := h.ls.GetSessionByID(ctx, localBystander.ID)
+	_, bystanderRemoteErr := h.ls.GetSessionByID(ctx, remoteBystander.ID)
+	assert.NoError(t, bystanderLocalErr, "sanity: a bystander session must survive")
+	assert.NoError(t, bystanderRemoteErr, "a bystander session must survive the remote delete too -- a dropped/wrong ID on the wire would delete the wrong row")
+
+	// Deleting an already-deleted (or never-existent) session ID is a silent
+	// no-op on both paths -- GORM's plain Delete-by-ID does not error on zero
+	// rows affected. Confirm the wire preserves that exact idempotent
+	// semantics rather than turning a harmless double-delete into a surprise error.
+	assert.NoError(t, h.ls.DeleteSession(ctx, localTarget.ID))
+	assert.NoError(t, h.rs.DeleteSession(ctx, remoteTarget.ID))
+}
+
+// --- DeleteSessionsForUserExcept ---
+
+func TestConformance_DeleteSessionsForUserExcept(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	expiresAt := time.Now().Add(time.Hour).UTC()
+
+	newUserWithSessions := func(suffix string, n int) (*models.User, []*models.Session) {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-dsfue-" + suffix, Email: "conformance-dsfue-" + suffix + "@example.com",
+			DisplayName: "Conformance DeleteSessionsForUserExcept " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		sessions := make([]*models.Session, 0, n)
+		for i := 0; i < n; i++ {
+			s, err := h.ls.CreateSession(ctx, &models.Session{
+				UserID: user.ID, SessionToken: suffixedToken(suffix, i), ExpiresAt: &expiresAt,
+			})
+			require.NoError(t, err)
+			sessions = append(sessions, s)
+		}
+		return user, sessions
+	}
+
+	// A bystander user's sessions must never be touched -- the scope-drop risk
+	// this method exists to catch.
+	bystander, bystanderSessions := newUserWithSessions("bystander", 1)
+
+	localUser, localSessions := newUserWithSessions("local", 3)
+	exceptID := localSessions[0].ID
+	require.NoError(t, h.ls.DeleteSessionsForUserExcept(ctx, localUser.ID, exceptID))
+	localRemaining, err := h.ls.ListSessionsByUser(ctx, localUser.ID)
+	require.NoError(t, err)
+	require.Len(t, localRemaining, 1, "sanity: exactly the excepted session must remain")
+	assert.Equal(t, exceptID, localRemaining[0].ID)
+
+	remoteUser, remoteSessions := newUserWithSessions("remote", 3)
+	remoteExceptID := remoteSessions[1].ID
+	require.NoError(t, h.rs.DeleteSessionsForUserExcept(ctx, remoteUser.ID, remoteExceptID),
+		"RemoteStorage.DeleteSessionsForUserExcept must succeed for a genuine target user")
+	remoteRemaining, err := h.ls.ListSessionsByUser(ctx, remoteUser.ID)
+	require.NoError(t, err)
+	// Not zero (over-deleted) and not all (no-op) -- mirroring tranche 3's
+	// RemoveAllProjectRoleGrants scoping discipline.
+	require.Len(t, remoteRemaining, 1,
+		"exactly the excepted session must survive server-side -- not zero and not all")
+	assert.Equal(t, remoteExceptID, remoteRemaining[0].ID,
+		"the SPECIFIC excepted session ID must be the one that survives, not merely any one session")
+
+	bystanderRemaining, err := h.ls.ListSessionsByUser(ctx, bystander.ID)
+	require.NoError(t, err)
+	assert.Len(t, bystanderRemaining, len(bystanderSessions), "a bystander user's sessions must survive both calls untouched")
+}
+
+// suffixedToken builds a unique session token for DeleteSessionsForUserExcept's
+// multi-session fixtures (session_token has a unique index).
+func suffixedToken(suffix string, i int) string {
+	return "conformance-dsfue-token-" + suffix + "-" + string(rune('a'+i))
+}
+
+// --- CreateSetupToken ---
+
+func TestConformance_CreateSetupToken(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-cst-" + suffix, Email: "conformance-cst-" + suffix + "@example.com",
+			DisplayName: "Conformance CreateSetupToken " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	expiresAt := time.Now().Add(24 * time.Hour).UTC()
+
+	localUser := newUser("local")
+	localSent := &models.SetupToken{
+		TokenHash: "conformance-cst-hash-local", Purpose: "account_setup", SubjectUserID: &localUser.ID,
+		SubjectEmail: localUser.Email, State: "active", ExpiresAt: expiresAt, CreatedBy: h.adminUserID,
+		CreatedAt: time.Now().UTC(),
+	}
+	_, err := h.ls.CreateSetupToken(ctx, localSent)
+	require.NoError(t, err)
+	localPersisted, err := h.ls.GetSetupTokenByHash(ctx, "conformance-cst-hash-local")
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "LocalStorage.CreateSetupToken (sanity baseline)", localSent, localPersisted, nil)
+
+	remoteUser := newUser("remote")
+	const forgedCreatedBy = 999999
+	remoteSent := &models.SetupToken{
+		TokenHash: "conformance-cst-hash-remote", Purpose: "account_setup", SubjectUserID: &remoteUser.ID,
+		SubjectEmail: remoteUser.Email, State: "active", ExpiresAt: expiresAt, CreatedBy: forgedCreatedBy,
+		CreatedAt: time.Now().UTC(),
+	}
+	remoteCreated, err := h.rs.CreateSetupToken(ctx, remoteSent)
+	require.NoError(t, err, "RemoteStorage.CreateSetupToken must succeed for a genuine, matching subject_user_id/subject_email")
+
+	// G80-style forced-attribution check: CreatedBy must come from the
+	// authenticated caller server-side, never the wire-supplied value.
+	assert.NotEqual(t, uint(forgedCreatedBy), remoteCreated.CreatedBy,
+		"CreatedBy must be derived from the authenticated caller server-side, never trusted from the wire")
+
+	remotePersisted, err := h.ls.GetSetupTokenByHash(ctx, "conformance-cst-hash-remote")
+	require.NoError(t, err)
+
+	requestExclude := map[string]bool{
+		"ID":        true, // not yet assigned on the pre-create wire struct; response fidelity checked separately below
+		"CreatedBy": true, // forged input, forced server-side -- asserted explicitly above
+		// CONFIRMED WIRE-DROP BUG, not a design choice, NOT fixed in this
+		// tranche (see this file's package doc for the full write-up):
+		// remote_auth.go's setupTokenWire (RemoteStorage's own client struct)
+		// has no CreatedByMachineIdentityID field at all, so it can't even be
+		// SENT, let alone round-tripped.
+		"CreatedByMachineIdentityID": true,
+	}
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateSetupToken (request fidelity: sent vs persisted)", remoteSent, remotePersisted, requestExclude)
+
+	responseExclude := map[string]bool{
+		// Same confirmed bug, RESPONSE side: setup_tokens_proxy.go's
+		// setupTokenProxyWire DOES send "created_by_machine_identity_id" (and
+		// the server DID correctly derive+persist it from this harness's real
+		// machine credential -- see the assert.NotZero below), but
+		// remote_auth.go's client-side setupTokenWire has no field to decode
+		// it into, so remoteCreated.CreatedByMachineIdentityID always comes
+		// back 0 regardless of the true persisted value.
+		"CreatedByMachineIdentityID": true,
+	}
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateSetupToken (response fidelity: wire-returned vs persisted)", remoteCreated, remotePersisted, responseExclude)
+
+	assert.NotZero(t, remotePersisted.CreatedByMachineIdentityID,
+		"sanity: the server-side create really did derive and persist real machine attribution from the "+
+			"authenticated node credential -- confirms the gap documented above is a client-side wire-decode "+
+			"drop only, not a full server-side loss of attribution too")
+
+	// Cross-reference guard: CreateSetupTokenProxy rejects a subject_user_id/
+	// subject_email pair that doesn't reference the same real user -- a
+	// wire-fidelity guard unreachable on the raw LocalStorage primitive (which
+	// performs no such check), so there is no local-side equivalent to assert here.
+	_, err = h.rs.CreateSetupToken(ctx, &models.SetupToken{
+		TokenHash: "conformance-cst-hash-mismatch", Purpose: "account_setup", SubjectUserID: &remoteUser.ID,
+		SubjectEmail: "conformance-cst-mismatched-email@example.com", State: "active", ExpiresAt: expiresAt,
+	})
+	assert.Error(t, err, "RemoteStorage.CreateSetupToken must refuse a subject_user_id/subject_email pair that "+
+		"does not cross-reference the same real user")
+}
+
+// --- GetSetupTokenByHash ---
+
+func TestConformance_GetSetupTokenByHash(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	user, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gsth", Email: "conformance-gsth@example.com",
+		DisplayName: "Conformance GetSetupTokenByHash", IsActive: true,
+	})
+	require.NoError(t, err)
+
+	_, err = h.ls.CreateSetupToken(ctx, &models.SetupToken{
+		TokenHash: "conformance-gsth-hash", Purpose: "account_setup", SubjectUserID: &user.ID,
+		SubjectEmail: user.Email, State: "active", ExpiresAt: time.Now().Add(24 * time.Hour).UTC(),
+		CreatedBy: h.adminUserID, CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	viaLocal, err := h.ls.GetSetupTokenByHash(ctx, "conformance-gsth-hash")
+	require.NoError(t, err)
+	viaRemote, err := h.rs.GetSetupTokenByHash(ctx, "conformance-gsth-hash")
+	require.NoError(t, err, "RemoteStorage.GetSetupTokenByHash must find a genuinely active token by hash")
+	assertFieldExhaustiveEqual(t, "GetSetupTokenByHash (LocalStorage vs RemoteStorage over the SAME row)", viaLocal, viaRemote, nil)
+
+	_, localErr := h.ls.GetSetupTokenByHash(ctx, "conformance-gsth-nonexistent")
+	_, remoteErr := h.rs.GetSetupTokenByHash(ctx, "conformance-gsth-nonexistent")
+	assert.Error(t, localErr, "sanity: an unknown hash must not resolve")
+	assert.Error(t, remoteErr, "RemoteStorage.GetSetupTokenByHash must also refuse an unknown hash, not silently return something")
+}
+
+// --- MarkSetupTokenExpired ---
+
+func TestConformance_MarkSetupTokenExpired(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newActiveToken := func(hash string) *models.SetupToken {
+		tok, err := h.ls.CreateSetupToken(ctx, &models.SetupToken{
+			TokenHash: hash, Purpose: "account_setup", SubjectEmail: "conformance-mste@example.com",
+			State: "active", ExpiresAt: time.Now().Add(24 * time.Hour).UTC(), CreatedAt: time.Now().UTC(),
+		})
+		require.NoError(t, err)
+		return tok
+	}
+
+	localTok := newActiveToken("conformance-mste-local")
+	require.NoError(t, h.ls.MarkSetupTokenExpired(ctx, localTok.ID))
+	localAfter, err := h.ls.GetSetupTokenByHash(ctx, "conformance-mste-local")
+	require.NoError(t, err)
+	assert.Equal(t, "expired", localAfter.State, "sanity: local expire must flip active -> expired")
+
+	remoteTok := newActiveToken("conformance-mste-remote")
+	require.NoError(t, h.rs.MarkSetupTokenExpired(ctx, remoteTok.ID),
+		"RemoteStorage.MarkSetupTokenExpired must succeed for a genuinely active token")
+	remoteAfter, err := h.ls.GetSetupTokenByHash(ctx, "conformance-mste-remote")
+	require.NoError(t, err)
+	assert.Equal(t, "expired", remoteAfter.State, "the remote token must actually be expired server-side, not just report success")
+
+	// Expiring an ALREADY-expired token is a silent no-op on both paths (the
+	// underlying `WHERE state = 'active'` UPDATE matches zero rows, and
+	// local_auth.go's MarkSetupTokenExpired does not check RowsAffected) --
+	// confirm the wire preserves that exact idempotent semantics rather than
+	// turning a harmless re-expire into a surprise error.
+	require.NoError(t, h.ls.MarkSetupTokenExpired(ctx, localTok.ID))
+	require.NoError(t, h.rs.MarkSetupTokenExpired(ctx, remoteTok.ID))
+	localStill, err := h.ls.GetSetupTokenByHash(ctx, "conformance-mste-local")
+	require.NoError(t, err)
+	remoteStill, err := h.ls.GetSetupTokenByHash(ctx, "conformance-mste-remote")
+	require.NoError(t, err)
+	assert.Equal(t, "expired", localStill.State)
+	assert.Equal(t, "expired", remoteStill.State)
+}
+
+// --- SupersedeActiveSetupTokens ---
+
+func TestConformance_SupersedeActiveSetupTokens(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newActiveToken := func(email, hash string) {
+		_, err := h.ls.CreateSetupToken(ctx, &models.SetupToken{
+			TokenHash: hash, Purpose: "password_reset_link", SubjectEmail: email,
+			State: "active", ExpiresAt: time.Now().Add(24 * time.Hour).UTC(), CreatedAt: time.Now().UTC(),
+		})
+		require.NoError(t, err)
+	}
+
+	const localEmail = "conformance-sast-local@example.com"
+	const localBystanderEmail = "conformance-sast-local-bystander@example.com"
+	newActiveToken(localEmail, "conformance-sast-local-1")
+	newActiveToken(localEmail, "conformance-sast-local-2")
+	newActiveToken(localBystanderEmail, "conformance-sast-local-bystander")
+	require.NoError(t, h.ls.SupersedeActiveSetupTokens(ctx, "password_reset_link", localEmail, nil))
+
+	tok1, err := h.ls.GetSetupTokenByHash(ctx, "conformance-sast-local-1")
+	require.NoError(t, err)
+	tok2, err := h.ls.GetSetupTokenByHash(ctx, "conformance-sast-local-2")
+	require.NoError(t, err)
+	localBystanderTok, err := h.ls.GetSetupTokenByHash(ctx, "conformance-sast-local-bystander")
+	require.NoError(t, err)
+	assert.Equal(t, "superseded", tok1.State, "sanity: both same-email active tokens must be superseded")
+	assert.Equal(t, "superseded", tok2.State)
+	assert.Equal(t, "active", localBystanderTok.State, "sanity: a different email's active token must survive")
+
+	const remoteEmail = "conformance-sast-remote@example.com"
+	const remoteBystanderEmail = "conformance-sast-remote-bystander@example.com"
+	newActiveToken(remoteEmail, "conformance-sast-remote-1")
+	newActiveToken(remoteEmail, "conformance-sast-remote-2")
+	newActiveToken(remoteBystanderEmail, "conformance-sast-remote-bystander")
+	require.NoError(t, h.rs.SupersedeActiveSetupTokens(ctx, "password_reset_link", remoteEmail, nil),
+		"RemoteStorage.SupersedeActiveSetupTokens must succeed")
+
+	rtok1, err := h.ls.GetSetupTokenByHash(ctx, "conformance-sast-remote-1")
+	require.NoError(t, err)
+	rtok2, err := h.ls.GetSetupTokenByHash(ctx, "conformance-sast-remote-2")
+	require.NoError(t, err)
+	remoteBystanderTok, err := h.ls.GetSetupTokenByHash(ctx, "conformance-sast-remote-bystander")
+	require.NoError(t, err)
+	assert.Equal(t, "superseded", rtok1.State, "both of the remote email's active tokens must actually be superseded server-side")
+	assert.Equal(t, "superseded", rtok2.State)
+	assert.Equal(t, "active", remoteBystanderTok.State,
+		"a different email's active token must survive the remote call too -- a dropped/widened email filter on "+
+			"the wire would supersede it too")
+
+	// Already-superseded: calling again for the same (purpose, email) matches
+	// zero rows (no more active tokens left) and is a silent no-op, not an
+	// error, on both paths.
+	require.NoError(t, h.ls.SupersedeActiveSetupTokens(ctx, "password_reset_link", localEmail, nil))
+	require.NoError(t, h.rs.SupersedeActiveSetupTokens(ctx, "password_reset_link", remoteEmail, nil))
+}
+
+// --- CountSetupTokensSince ---
+
+func TestConformance_CountSetupTokensSince(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	const purpose = "account_setup"
+	const email = "conformance-csts@example.com"
+	cutoff := time.Now().UTC()
+	before := cutoff.Add(-time.Hour)
+	after1 := cutoff.Add(time.Hour)
+	after2 := cutoff.Add(2 * time.Hour)
+
+	newToken := func(hash string, createdAt time.Time, tokenEmail string) {
+		_, err := h.ls.CreateSetupToken(ctx, &models.SetupToken{
+			TokenHash: hash, Purpose: purpose, SubjectEmail: tokenEmail, State: "active",
+			ExpiresAt: createdAt.Add(24 * time.Hour), CreatedAt: createdAt,
+		})
+		require.NoError(t, err)
+	}
+	newToken("conformance-csts-before", before, email)
+	newToken("conformance-csts-after-1", after1, email)
+	newToken("conformance-csts-after-2", after2, email)
+	// A different email must not be counted -- scope check.
+	newToken("conformance-csts-other-email", after1, "conformance-csts-other@example.com")
+
+	localCount, err := h.ls.CountSetupTokensSince(ctx, purpose, email, cutoff)
+	require.NoError(t, err)
+	remoteCount, err := h.rs.CountSetupTokensSince(ctx, purpose, email, cutoff)
+	require.NoError(t, err, "RemoteStorage.CountSetupTokensSince must succeed")
+
+	assert.Equal(t, int64(2), localCount, "sanity: only the two after-cutoff, same-email tokens must count")
+	assert.Equal(t, localCount, remoteCount,
+		"RemoteStorage.CountSetupTokensSince must return the identical count LocalStorage computes over the SAME rows")
+}

--- a/server/http/remote_storage_conformance_tranche4_misc_test.go
+++ b/server/http/remote_storage_conformance_tranche4_misc_test.go
@@ -1,0 +1,1169 @@
+// remote_storage_conformance_tranche4_misc_test.go — issue #1808, tranche 4.
+//
+// Covers 26 of the 27 assigned methods, spanning eight source files:
+// remote_risk_exceptions.go, remote_notifications.go,
+// remote_access_activity.go, remote_sod.go, remote_legal_hold.go,
+// remote_break_glass.go (the two read-only survivors,
+// GetBreakGlassActivation/ListBreakGlassActivations), remote_audit.go
+// (GetRBACAuditLogs only), and remote_stats.go (HealthCheck).
+//
+// GetAuditLogs is deliberately NOT covered — see the comment where its test
+// would otherwise sit (just above TestConformance_GetRBACAuditLogs) for why:
+// building it surfaced a genuine, live wire-shape defect (RemoteStorage.
+// GetAuditLogs silently returns an empty event list with a correct-looking
+// total, against its own real, currently-registered route) that this file's
+// "one new file, no other edits" scope cannot fix without touching
+// remote_audit.go/audit.go, and CLAUDE.md is explicit that a found defect
+// must never be papered over by weakening the assertion to match it.
+//
+// # A different shape than tranche 2/3, and why
+//
+// Tranche 2/3 compared RemoteStorage.M(x) against LocalStorage.M(x) run with
+// the SAME scenario on both sides, because their methods are raw storage
+// primitives on both ends — the proxy handler forwards straight to
+// storage.Storage with no extra business logic in between.
+//
+// Several methods in this tranche are not that shape. Risk exceptions, SoD
+// policies, and legal hold are governance controls whose CREATE/APPROVE/
+// REVOKE/DELETE/LIFT routes deliberately route through core.KeyorixCore
+// SERVER-SIDE (confirmed by reading risk_exceptions_proxy.go, sod_proxy.go,
+// legal_hold_proxy.go directly) — re-deriving the acting principal from the
+// AUTHENTICATED HTTP SESSION and re-running admin-tier/dual-control/human-only
+// checks, rather than trusting anything the wire body carries for actor
+// attribution. LocalStorage's own primitives (local_risk_exceptions.go,
+// local_sod.go, local_legal_hold.go), by contrast, are raw GORM calls that
+// trust the caller's struct completely — the authority check is the CALLING
+// core's job, not storage's, on both backends; this tranche calls the raw
+// storage primitives directly on the LocalStorage side, without a calling
+// core in front of them.
+//
+// So for that subset, a "same scenario on both sides" comparison would prove
+// nothing (LocalStorage would trivially trust whatever we hand it). Instead
+// each such test compares LocalStorage's raw, fully-caller-trusting contract
+// against RemoteStorage's ACTUAL server-enforced contract, using a
+// deliberately FORGED wire attribution field (CreatedBy/ApprovedBy/RevokedBy/
+// PlacedBy/ReleasedBy) as the differential probe: does the real router+handler
+// ignore it and derive the true actor from the session, the way tranche 3's
+// TestConformance_RevokeBreakGlassActivation already proved for break-glass
+// revocation? This generalizes that discipline to every method in this file
+// carrying a similar actor-identity field, per the task brief's own callout.
+//
+// HealthCheck (remote_stats.go) has no LocalStorage analog at all — see its
+// own test for the documented deviation.
+package http
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// timePtr returns a *time.Time pointing at a copy of t -- a small helper so
+// call sites can inline a pointer to a computed time.Time value.
+func timePtr(t time.Time) *time.Time { return &t }
+
+// newAdminSession creates a brand-new user, grants it the global "admin" role
+// directly at the storage layer (the same globalScope := coreStorage.Scope{}
+// pattern TestConformance_RemoveGlobalAdminRoleGuarded uses), logs it in for a
+// REAL session token, and returns both the user (for its ID, when a test only
+// needs to assert on an actor identity) and a RemoteStorage client
+// authenticated as them.
+//
+// Needed throughout this file wherever a core-layer function requires a
+// human, admin-tier actor: h.rs's shared node/machine credential can never
+// satisfy this (isMachineActor(r) is unconditionally true for it, and
+// actorID(r) always resolves to 0 for a machine caller, which holds no role
+// grant of its own — see catalog.go's actorID/isMachineActor doc comments).
+func newAdminSession(t *testing.T, h *conformanceHarness, suffix string) (*models.User, *store.RemoteStorage) {
+	t.Helper()
+	ctx := context.Background()
+	username := "conformance-t4-" + suffix
+	password := "Conformance-T4-Pw-1!"
+	user, err := h.upstreamCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: username, Email: username + "@example.com", Password: password,
+	})
+	require.NoError(t, err)
+	adminRole, err := h.ls.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	require.NoError(t, h.ls.AssignRole(ctx, user.ID, adminRole.ID, coreStorage.Scope{}))
+	session, _, err := h.upstreamCore.Login(ctx, &core.LoginRequest{Username: username, Password: password})
+	require.NoError(t, err)
+	rs, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: session.SessionToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+	return user, rs
+}
+
+// ============================================================================
+// remote_risk_exceptions.go
+// ============================================================================
+
+// --- CreateRiskException ---
+
+func TestConformance_CreateRiskException(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	userToken := createTestToken(t, h.upstreamCore) // session for h.adminUserID (global admin)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: userToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	expiresAt := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+	const forgedCreatedBy = 999999
+
+	// LocalStorage's own primitive: a raw insert that fully trusts whatever
+	// CreatedBy the caller sets -- no actor derivation, no human/machine
+	// check, no admin-tier check. This is the raw contract the proxy's own
+	// additional server-side hardening (below) deliberately narrows.
+	localException, err := h.ls.CreateRiskException(ctx, &models.RiskException{
+		Title: "conformance-cre-local", Category: "other", Justification: "conformance test",
+		CreatedBy: forgedCreatedBy, ExpiresAt: expiresAt,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(forgedCreatedBy), localException.CreatedBy,
+		"sanity: LocalStorage.CreateRiskException trusts the caller-supplied CreatedBy verbatim")
+
+	// RemoteStorage.CreateRiskException, authenticated as a real human
+	// admin-tier user, sending the SAME forged CreatedBy on the wire.
+	// CreateRiskExceptionProxy decodes only Title/Category/Reference/
+	// Justification/ExpiresAt off the wire body and passes actorID(r) to
+	// core.CreateRiskException -- body.CreatedBy is never read.
+	remoteException, err := rsAsUser.CreateRiskException(ctx, &models.RiskException{
+		Title: "conformance-cre-remote", Category: "other", Justification: "conformance test",
+		CreatedBy: forgedCreatedBy, ExpiresAt: expiresAt,
+	})
+	require.NoError(t, err, "RemoteStorage.CreateRiskException must succeed for a genuine human admin-tier actor")
+	assert.Equal(t, h.adminUserID, remoteException.CreatedBy,
+		"CreatedBy must be derived from the authenticated session server-side, not trusted from the wire -- "+
+			"the forged value above must never land")
+	assert.Equal(t, "conformance-cre-remote", remoteException.Title)
+	assert.Equal(t, "other", remoteException.Category)
+	assert.True(t, expiresAt.Equal(remoteException.ExpiresAt), "ExpiresAt must round-trip")
+	assert.False(t, remoteException.Revoked)
+	assert.False(t, remoteException.Approved)
+
+	persisted, err := h.ls.GetRiskException(ctx, remoteException.ID)
+	require.NoError(t, err)
+	assert.Equal(t, h.adminUserID, persisted.CreatedBy,
+		"the real CreatedBy must actually be persisted server-side, not just reported so in the response")
+
+	// Negative: a machine-authenticated caller (h.rs's node/machine
+	// credential) must be refused entirely -- dual control's own "creator"
+	// must always be attributable to a real human.
+	_, err = h.rs.CreateRiskException(ctx, &models.RiskException{
+		Title: "conformance-cre-machine", Category: "other", Justification: "conformance test", ExpiresAt: expiresAt,
+	})
+	assert.Error(t, err, "RemoteStorage.CreateRiskException must refuse a machine-authenticated caller")
+}
+
+// --- GetRiskException ---
+
+func TestConformance_GetRiskException(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	expiresAt := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+
+	// GetRiskExceptionProxy is a raw storage passthrough (no core call, no
+	// actor check) -- confirmed by reading risk_exceptions_proxy.go -- so
+	// h.rs's shared node/machine credential can read it directly.
+	seeded, err := h.ls.CreateRiskException(ctx, &models.RiskException{
+		Title: "conformance-gre", Category: "other", Justification: "conformance test",
+		CreatedBy: h.adminUserID, ExpiresAt: expiresAt,
+	})
+	require.NoError(t, err)
+
+	localGot, err := h.ls.GetRiskException(ctx, seeded.ID)
+	require.NoError(t, err)
+	remoteGot, err := h.rs.GetRiskException(ctx, seeded.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "GetRiskException", localGot, remoteGot, nil)
+
+	_, err = h.rs.GetRiskException(ctx, seeded.ID+999999)
+	assert.Error(t, err, "a nonexistent risk exception id must error, not silently return a zero value")
+}
+
+// --- ListRiskExceptions ---
+
+func TestConformance_ListRiskExceptions(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	expiresAt := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+
+	active, err := h.ls.CreateRiskException(ctx, &models.RiskException{
+		Title: "conformance-lre-active", Category: "other", Justification: "j", CreatedBy: h.adminUserID, ExpiresAt: expiresAt,
+	})
+	require.NoError(t, err)
+	revoked, err := h.ls.CreateRiskException(ctx, &models.RiskException{
+		Title: "conformance-lre-revoked", Category: "other", Justification: "j", CreatedBy: h.adminUserID, ExpiresAt: expiresAt,
+	})
+	require.NoError(t, err)
+	revokedAt := time.Now().UTC()
+	revoked.Revoked = true
+	revoked.RevokedBy = h.adminUserID
+	revoked.RevokedAt = &revokedAt
+	matched, err := h.ls.RevokeRiskExceptionIfNotRevoked(ctx, revoked)
+	require.NoError(t, err)
+	require.True(t, matched)
+
+	localAll, err := h.ls.ListRiskExceptions(ctx, false)
+	require.NoError(t, err)
+	remoteAll, err := h.rs.ListRiskExceptions(ctx, false)
+	require.NoError(t, err)
+	require.Equal(t, len(localAll), len(remoteAll), "active_only=false must return the same row count on both paths")
+
+	localActiveOnly, err := h.ls.ListRiskExceptions(ctx, true)
+	require.NoError(t, err)
+	remoteActiveOnly, err := h.rs.ListRiskExceptions(ctx, true)
+	require.NoError(t, err)
+	require.Equal(t, len(localActiveOnly), len(remoteActiveOnly))
+	foundActive := false
+	for _, e := range remoteActiveOnly {
+		assert.NotEqual(t, revoked.ID, e.ID, "active_only=true must exclude the revoked exception")
+		if e.ID == active.ID {
+			foundActive = true
+		}
+	}
+	assert.True(t, foundActive, "active_only=true must still include the non-revoked exception")
+}
+
+// --- ApproveRiskExceptionIfPending ---
+
+func TestConformance_ApproveRiskExceptionIfPending(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	expiresAt := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+	const forgedApprovedBy = 888888
+
+	// LocalStorage's raw CAS primitive: no actor/dual-control check at all --
+	// it trusts whatever ApprovedBy the caller sets.
+	localException, err := h.ls.CreateRiskException(ctx, &models.RiskException{
+		Title: "conformance-arei-local", Category: "other", Justification: "j",
+		CreatedBy: h.adminUserID, ExpiresAt: expiresAt,
+	})
+	require.NoError(t, err)
+	approvedAt := time.Now().UTC()
+	localException.Approved = true
+	localException.ApprovedBy = forgedApprovedBy
+	localException.ApprovedAt = &approvedAt
+	localMatched, err := h.ls.ApproveRiskExceptionIfPending(ctx, localException)
+	require.NoError(t, err)
+	assert.True(t, localMatched, "sanity: the raw CAS primitive must match a genuinely pending exception")
+	localPersisted, err := h.ls.GetRiskException(ctx, localException.ID)
+	require.NoError(t, err)
+	assert.Equal(t, uint(forgedApprovedBy), localPersisted.ApprovedBy,
+		"sanity: LocalStorage.ApproveRiskExceptionIfPending trusts the caller-supplied ApprovedBy verbatim")
+
+	// RemoteStorage: real dual control -- the creator and approver must be
+	// two DIFFERENT human, admin-tier actors, and ApproveRiskExceptionProxy
+	// doesn't even decode a request body (it only reads the URL id) -- the
+	// approver identity comes entirely from the authenticated session.
+	creatorToken := createTestToken(t, h.upstreamCore)
+	rsCreator, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: creatorToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+	approver, rsApprover := newAdminSession(t, h, "arei-approver")
+
+	remoteException, err := rsCreator.CreateRiskException(ctx, &models.RiskException{
+		Title: "conformance-arei-remote", Category: "other", Justification: "j", ExpiresAt: expiresAt,
+	})
+	require.NoError(t, err)
+	require.Equal(t, h.adminUserID, remoteException.CreatedBy)
+
+	// Self-approval must be refused -- dual control (#170): the creator can
+	// never approve their own exception.
+	_, err = rsCreator.ApproveRiskExceptionIfPending(ctx, remoteException)
+	assert.Error(t, err, "the exception's own creator must not be able to approve it (dual control)")
+
+	remoteException.Approved = true
+	remoteException.ApprovedBy = forgedApprovedBy
+	remoteMatched, err := rsApprover.ApproveRiskExceptionIfPending(ctx, remoteException)
+	require.NoError(t, err)
+	assert.True(t, remoteMatched,
+		"RemoteStorage.ApproveRiskExceptionIfPending must match a genuinely pending exception approved by a "+
+			"different admin-tier human")
+
+	remotePersisted, err := h.ls.GetRiskException(ctx, remoteException.ID)
+	require.NoError(t, err)
+	assert.True(t, remotePersisted.Approved)
+	assert.Equal(t, approver.ID, remotePersisted.ApprovedBy,
+		"ApprovedBy must be derived from the authenticated session server-side, not trusted from the wire -- "+
+			"the forged value above must never land")
+
+	// Wrong-state: an already-approved exception must not match a second
+	// time -- a normal matched=false outcome, not an error.
+	secondMatched, err := rsApprover.ApproveRiskExceptionIfPending(ctx, remoteException)
+	require.NoError(t, err)
+	assert.False(t, secondMatched)
+}
+
+// --- RevokeRiskExceptionIfNotRevoked ---
+
+func TestConformance_RevokeRiskExceptionIfNotRevoked(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	expiresAt := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+	const forgedRevokedBy = 777777
+
+	localException, err := h.ls.CreateRiskException(ctx, &models.RiskException{
+		Title: "conformance-rrei-local", Category: "other", Justification: "j",
+		CreatedBy: h.adminUserID, ExpiresAt: expiresAt,
+	})
+	require.NoError(t, err)
+	revokedAt := time.Now().UTC()
+	localException.Revoked = true
+	localException.RevokedBy = forgedRevokedBy
+	localException.RevokedAt = &revokedAt
+	localMatched, err := h.ls.RevokeRiskExceptionIfNotRevoked(ctx, localException)
+	require.NoError(t, err)
+	assert.True(t, localMatched)
+	localPersisted, err := h.ls.GetRiskException(ctx, localException.ID)
+	require.NoError(t, err)
+	assert.Equal(t, uint(forgedRevokedBy), localPersisted.RevokedBy,
+		"sanity: LocalStorage.RevokeRiskExceptionIfNotRevoked trusts the caller-supplied RevokedBy verbatim")
+
+	userToken := createTestToken(t, h.upstreamCore)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: userToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	remoteException, err := rsAsUser.CreateRiskException(ctx, &models.RiskException{
+		Title: "conformance-rrei-remote", Category: "other", Justification: "j", ExpiresAt: expiresAt,
+	})
+	require.NoError(t, err)
+
+	remoteException.Revoked = true
+	remoteException.RevokedBy = forgedRevokedBy
+	remoteMatched, err := rsAsUser.RevokeRiskExceptionIfNotRevoked(ctx, remoteException)
+	require.NoError(t, err, "RemoteStorage.RevokeRiskExceptionIfNotRevoked must succeed for the exception's own creator")
+	assert.True(t, remoteMatched)
+
+	remotePersisted, err := h.ls.GetRiskException(ctx, remoteException.ID)
+	require.NoError(t, err)
+	assert.True(t, remotePersisted.Revoked)
+	assert.Equal(t, h.adminUserID, remotePersisted.RevokedBy,
+		"RevokedBy must be derived from the authenticated session server-side, not trusted from the wire -- "+
+			"the forged value above must never land")
+
+	secondMatched, err := rsAsUser.RevokeRiskExceptionIfNotRevoked(ctx, remoteException)
+	require.NoError(t, err, "an already-revoked exception is a normal matched=false outcome, not an error")
+	assert.False(t, secondMatched)
+}
+
+// ============================================================================
+// remote_notifications.go
+// ============================================================================
+
+// --- CreateNotification ---
+
+func TestConformance_CreateNotification(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	localUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-cn-local", Email: "conformance-cn-local@example.com", DisplayName: "Conformance CN Local", IsActive: true,
+	})
+	require.NoError(t, err)
+	localNotif, err := h.ls.CreateNotification(ctx, &models.Notification{
+		UserID: localUser.ID, Type: "conformance.local", Title: "Local Title", Message: "Local Message",
+		Link: "/local", Severity: models.NotificationSeverityWarning, CreatedAt: time.Now().UTC().Truncate(time.Second),
+	})
+	require.NoError(t, err)
+	assert.False(t, localNotif.IsRead)
+
+	remoteUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-cn-remote", Email: "conformance-cn-remote@example.com", DisplayName: "Conformance CN Remote", IsActive: true,
+	})
+	require.NoError(t, err)
+	sentCreatedAt := time.Now().UTC().Truncate(time.Second)
+	remoteNotif, err := h.rs.CreateNotification(ctx, &models.Notification{
+		UserID: remoteUser.ID, Type: "conformance.remote", Title: "Remote Title", Message: "Remote Message",
+		Link: "/remote", Severity: models.NotificationSeverityWarning, CreatedAt: sentCreatedAt,
+	})
+	require.NoError(t, err, "RemoteStorage.CreateNotification must succeed for a genuine, non-zero recipient")
+	assert.Equal(t, remoteUser.ID, remoteNotif.UserID)
+	assert.Equal(t, "conformance.remote", remoteNotif.Type)
+	assert.Equal(t, "Remote Title", remoteNotif.Title)
+	assert.Equal(t, "Remote Message", remoteNotif.Message)
+	assert.Equal(t, "/remote", remoteNotif.Link)
+	assert.Equal(t, models.NotificationSeverityWarning, remoteNotif.Severity)
+	assert.False(t, remoteNotif.IsRead, "CreateNotificationProxy always creates with IsRead=false")
+	assert.True(t, sentCreatedAt.Equal(remoteNotif.CreatedAt))
+
+	persisted, err := h.ls.ListNotifications(ctx, remoteUser.ID, false, 10)
+	require.NoError(t, err)
+	require.Len(t, persisted, 1, "the notification must actually be persisted server-side, not just reported so")
+	assertFieldExhaustiveEqual(t, "CreateNotification (wire round trip)", remoteNotif, persisted[0], nil)
+
+	// Negative: a zero recipient must be refused, not silently create an
+	// unaddressed notification.
+	_, err = h.rs.CreateNotification(ctx, &models.Notification{
+		Type: "conformance.norecipient", Title: "x", Message: "y", CreatedAt: time.Now().UTC(),
+	})
+	assert.Error(t, err, "CreateNotificationProxy must refuse a zero UserID")
+}
+
+// --- ListNotifications ---
+
+func TestConformance_ListNotifications(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// ListNotifications/CountUnreadNotifications/MarkNotificationRead/
+	// MarkAllNotificationsRead are all self-scoped: the server derives the
+	// caller from the authenticated session (ADR-024), never from a wire
+	// userID (notifications_handler.go's List/MarkRead/MarkAllRead all read
+	// middleware.GetUserFromContext, which is nil for h.rs's shared
+	// node/machine credential -- exactly why tranche 3's
+	// RevokeBreakGlassActivation needed a second, human-authenticated client
+	// instead of h.rs).
+	userToken := createTestToken(t, h.upstreamCore)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: userToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		_, err := h.ls.CreateNotification(ctx, &models.Notification{
+			UserID: h.adminUserID, Type: fmt.Sprintf("conformance.ln.unread.%d", i),
+			Title: fmt.Sprintf("Unread %d", i), Message: "m", CreatedAt: time.Now().UTC().Add(time.Duration(i) * time.Second),
+		})
+		require.NoError(t, err)
+	}
+	readOne, err := h.ls.CreateNotification(ctx, &models.Notification{
+		UserID: h.adminUserID, Type: "conformance.ln.read", Title: "Read", Message: "m",
+		CreatedAt: time.Now().UTC().Add(2 * time.Second),
+	})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.MarkNotificationRead(ctx, readOne.ID, h.adminUserID))
+
+	localAll, err := h.ls.ListNotifications(ctx, h.adminUserID, false, 10)
+	require.NoError(t, err)
+	require.Len(t, localAll, 3, "sanity: all three notifications must be visible via LocalStorage")
+
+	remoteAll, err := rsAsUser.ListNotifications(ctx, 0 /* ignored -- self-scoped */, false, 10)
+	require.NoError(t, err, "RemoteStorage.ListNotifications must succeed for a genuine authenticated human session")
+	require.Len(t, remoteAll, len(localAll),
+		"the self-scoped GET /notifications route must return the SAME rows LocalStorage sees for this user")
+	for i := range localAll {
+		assert.Equal(t, localAll[i].ID, remoteAll[i].ID, "same order, same rows -- both read the identical underlying data")
+		assert.Equal(t, localAll[i].Type, remoteAll[i].Type)
+		assert.Equal(t, localAll[i].IsRead, remoteAll[i].IsRead)
+	}
+
+	localUnreadOnly, err := h.ls.ListNotifications(ctx, h.adminUserID, true, 10)
+	require.NoError(t, err)
+	remoteUnreadOnly, err := rsAsUser.ListNotifications(ctx, 0, true, 10)
+	require.NoError(t, err)
+	assert.Equal(t, len(localUnreadOnly), len(remoteUnreadOnly), "unread=true must filter identically on both paths")
+	for _, n := range remoteUnreadOnly {
+		assert.NotEqual(t, readOne.ID, n.ID, "the already-read notification must be excluded from unread=true")
+	}
+}
+
+// --- CountUnreadNotifications ---
+
+func TestConformance_CountUnreadNotifications(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	userToken := createTestToken(t, h.upstreamCore)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: userToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		_, err := h.ls.CreateNotification(ctx, &models.Notification{
+			UserID: h.adminUserID, Type: fmt.Sprintf("conformance.cun.%d", i), Title: "t", Message: "m", CreatedAt: time.Now().UTC(),
+		})
+		require.NoError(t, err)
+	}
+
+	localCount, err := h.ls.CountUnreadNotifications(ctx, h.adminUserID)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, localCount, "sanity")
+
+	remoteCount, err := rsAsUser.CountUnreadNotifications(ctx, 0 /* ignored -- self-scoped */)
+	require.NoError(t, err, "RemoteStorage.CountUnreadNotifications must succeed for a genuine authenticated human session")
+	assert.Equal(t, localCount, remoteCount,
+		"the unread count must reflect the SAME underlying rows LocalStorage sees for this user, not a stale or "+
+			"differently-scoped count")
+}
+
+// --- MarkNotificationRead ---
+
+func TestConformance_MarkNotificationRead(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	userToken := createTestToken(t, h.upstreamCore)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: userToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	localNotif, err := h.ls.CreateNotification(ctx, &models.Notification{
+		UserID: h.adminUserID, Type: "conformance.mnr.local", Title: "t", Message: "m", CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.MarkNotificationRead(ctx, localNotif.ID, h.adminUserID))
+	localAfter, err := h.ls.ListNotifications(ctx, h.adminUserID, false, 10)
+	require.NoError(t, err)
+	require.True(t, findNotificationRead(localAfter, localNotif.ID), "sanity: LocalStorage.MarkNotificationRead must mark the row read")
+
+	remoteNotif, err := h.ls.CreateNotification(ctx, &models.Notification{
+		UserID: h.adminUserID, Type: "conformance.mnr.remote", Title: "t", Message: "m", CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, rsAsUser.MarkNotificationRead(ctx, remoteNotif.ID, 0 /* ignored -- self-scoped */),
+		"RemoteStorage.MarkNotificationRead must succeed for the authenticated caller's own notification")
+	remoteAfter, err := h.ls.ListNotifications(ctx, h.adminUserID, false, 10)
+	require.NoError(t, err)
+	assert.True(t, findNotificationRead(remoteAfter, remoteNotif.ID),
+		"the notification marked read via RemoteStorage must actually be read server-side, not just report success")
+
+	// Negative: marking a nonexistent notification read must error, not
+	// silently succeed, on both paths.
+	assert.Error(t, h.ls.MarkNotificationRead(ctx, remoteNotif.ID+999999, h.adminUserID))
+	assert.Error(t, rsAsUser.MarkNotificationRead(ctx, remoteNotif.ID+999999, 0))
+}
+
+func findNotificationRead(notifs []*models.Notification, id uint) bool {
+	for _, n := range notifs {
+		if n.ID == id {
+			return n.IsRead
+		}
+	}
+	return false
+}
+
+// --- MarkAllNotificationsRead ---
+
+func TestConformance_MarkAllNotificationsRead(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	userToken := createTestToken(t, h.upstreamCore)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: userToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	// A bystander user whose unrelated notification must NOT be touched --
+	// the self-scoped route must only ever act on the AUTHENTICATED caller's
+	// own rows, matching tranche 2's bystander-scope-drop discipline.
+	bystander, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-marn-bystander", Email: "conformance-marn-bystander@example.com", DisplayName: "Bystander", IsActive: true,
+	})
+	require.NoError(t, err)
+	bystanderNotif, err := h.ls.CreateNotification(ctx, &models.Notification{
+		UserID: bystander.ID, Type: "conformance.marn.bystander", Title: "t", Message: "m", CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		_, err := h.ls.CreateNotification(ctx, &models.Notification{
+			UserID: h.adminUserID, Type: fmt.Sprintf("conformance.marn.%d", i), Title: "t", Message: "m", CreatedAt: time.Now().UTC(),
+		})
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, rsAsUser.MarkAllNotificationsRead(ctx, 0 /* ignored -- self-scoped */),
+		"RemoteStorage.MarkAllNotificationsRead must succeed for the authenticated caller")
+
+	callerAfter, err := h.ls.ListNotifications(ctx, h.adminUserID, true, 10)
+	require.NoError(t, err)
+	assert.Empty(t, callerAfter, "every one of the caller's own notifications must actually be marked read server-side")
+
+	bystanderAfter, err := h.ls.ListNotifications(ctx, bystander.ID, true, 10)
+	require.NoError(t, err)
+	require.Len(t, bystanderAfter, 1,
+		"a bystander user's unrelated notification must survive -- the self-scoped route must only touch the "+
+			"authenticated caller's own rows")
+	assert.Equal(t, bystanderNotif.ID, bystanderAfter[0].ID)
+}
+
+// ============================================================================
+// remote_access_activity.go
+// ============================================================================
+
+// seedAccessActivityEvent writes one audit_events row directly via
+// h.ls.LogAuditEvent, scoped to projectID/userID/eventType -- the fixture
+// shape LastUser*Activity's shared lastUserActivityByEventTypes query reads
+// (local_access_activity.go).
+func seedAccessActivityEvent(t *testing.T, h *conformanceHarness, projectID, userID uint, eventType string, at time.Time) {
+	t.Helper()
+	uid, pid, success := userID, projectID, true
+	require.NoError(t, h.ls.LogAuditEvent(context.Background(), &models.AuditEvent{
+		EventType: eventType, UserID: &uid, ProjectID: &pid, Success: &success, EventTime: at,
+	}))
+}
+
+// assertAccessActivityMatches compares two map[uint]time.Time results the way
+// assertFieldExhaustiveEqual would for a struct field: time.Time needs
+// .Equal(), not ==/DeepEqual (see fieldDiffs' own doc for why), and the two
+// key sets must match exactly -- a dropped/wrong project_id on the wire would
+// either drop users or pull in ones that don't belong.
+func assertAccessActivityMatches(t *testing.T, label string, local, remote map[uint]time.Time) {
+	t.Helper()
+	require.Len(t, remote, len(local), "%s: user-count mismatch", label)
+	for uid, lt := range local {
+		rt, ok := remote[uid]
+		require.True(t, ok, "%s: remote result missing user %d", label, uid)
+		assert.True(t, lt.Equal(rt), "%s: user %d: want %v got %v", label, uid, lt, rt)
+	}
+}
+
+func TestConformance_LastUserSecretActivity(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	activeUser, err := h.ls.CreateUser(ctx, &models.User{Username: "conformance-lusa-active", Email: "conformance-lusa-active@example.com", DisplayName: "Active", IsActive: true})
+	require.NoError(t, err)
+	dormantUser, err := h.ls.CreateUser(ctx, &models.User{Username: "conformance-lusa-dormant", Email: "conformance-lusa-dormant@example.com", DisplayName: "Dormant", IsActive: true})
+	require.NoError(t, err)
+	seedAccessActivityEvent(t, h, h.projectID, activeUser.ID, "secret.read", time.Now().UTC().Truncate(time.Second))
+
+	localActivity, err := h.ls.LastUserSecretActivity(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteActivity, err := h.rs.LastUserSecretActivity(ctx, h.projectID)
+	require.NoError(t, err)
+	assertAccessActivityMatches(t, "LastUserSecretActivity", localActivity, remoteActivity)
+	assert.Contains(t, remoteActivity, activeUser.ID)
+	assert.NotContains(t, remoteActivity, dormantUser.ID, "a user with no matching event must be absent, not zero-valued")
+}
+
+func TestConformance_LastUserRoleManagementActivity(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	activeUser, err := h.ls.CreateUser(ctx, &models.User{Username: "conformance-lurma-active", Email: "conformance-lurma-active@example.com", DisplayName: "Active", IsActive: true})
+	require.NoError(t, err)
+	dormantUser, err := h.ls.CreateUser(ctx, &models.User{Username: "conformance-lurma-dormant", Email: "conformance-lurma-dormant@example.com", DisplayName: "Dormant", IsActive: true})
+	require.NoError(t, err)
+	seedAccessActivityEvent(t, h, h.projectID, activeUser.ID, "role.assigned", time.Now().UTC().Truncate(time.Second))
+
+	localActivity, err := h.ls.LastUserRoleManagementActivity(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteActivity, err := h.rs.LastUserRoleManagementActivity(ctx, h.projectID)
+	require.NoError(t, err)
+	assertAccessActivityMatches(t, "LastUserRoleManagementActivity", localActivity, remoteActivity)
+	assert.Contains(t, remoteActivity, activeUser.ID)
+	assert.NotContains(t, remoteActivity, dormantUser.ID)
+}
+
+func TestConformance_LastUserSecretDeletionActivity(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	activeUser, err := h.ls.CreateUser(ctx, &models.User{Username: "conformance-lusda-active", Email: "conformance-lusda-active@example.com", DisplayName: "Active", IsActive: true})
+	require.NoError(t, err)
+	dormantUser, err := h.ls.CreateUser(ctx, &models.User{Username: "conformance-lusda-dormant", Email: "conformance-lusda-dormant@example.com", DisplayName: "Dormant", IsActive: true})
+	require.NoError(t, err)
+	seedAccessActivityEvent(t, h, h.projectID, activeUser.ID, "secret.deleted", time.Now().UTC().Truncate(time.Second))
+
+	localActivity, err := h.ls.LastUserSecretDeletionActivity(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteActivity, err := h.rs.LastUserSecretDeletionActivity(ctx, h.projectID)
+	require.NoError(t, err)
+	assertAccessActivityMatches(t, "LastUserSecretDeletionActivity", localActivity, remoteActivity)
+	assert.Contains(t, remoteActivity, activeUser.ID)
+	assert.NotContains(t, remoteActivity, dormantUser.ID)
+}
+
+func TestConformance_LastUserSecretReadActivity(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	activeUser, err := h.ls.CreateUser(ctx, &models.User{Username: "conformance-lusra-active", Email: "conformance-lusra-active@example.com", DisplayName: "Active", IsActive: true})
+	require.NoError(t, err)
+	writeOnlyUser, err := h.ls.CreateUser(ctx, &models.User{Username: "conformance-lusra-write", Email: "conformance-lusra-write@example.com", DisplayName: "WriteOnly", IsActive: true})
+	require.NoError(t, err)
+	seedAccessActivityEvent(t, h, h.projectID, activeUser.ID, "secret.read", time.Now().UTC().Truncate(time.Second))
+	// writeOnlyUser only ever writes, never reads -- the read-only bucket
+	// must not credit their write activity (the plain-tier read/write split,
+	// #487 round 112).
+	seedAccessActivityEvent(t, h, h.projectID, writeOnlyUser.ID, "secret.created", time.Now().UTC().Truncate(time.Second))
+
+	localActivity, err := h.ls.LastUserSecretReadActivity(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteActivity, err := h.rs.LastUserSecretReadActivity(ctx, h.projectID)
+	require.NoError(t, err)
+	assertAccessActivityMatches(t, "LastUserSecretReadActivity", localActivity, remoteActivity)
+	assert.Contains(t, remoteActivity, activeUser.ID)
+	assert.NotContains(t, remoteActivity, writeOnlyUser.ID, "a write-only event must not satisfy the read-activity bucket")
+}
+
+func TestConformance_LastUserSecretWriteActivity(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	activeUser, err := h.ls.CreateUser(ctx, &models.User{Username: "conformance-luswa-active", Email: "conformance-luswa-active@example.com", DisplayName: "Active", IsActive: true})
+	require.NoError(t, err)
+	readOnlyUser, err := h.ls.CreateUser(ctx, &models.User{Username: "conformance-luswa-read", Email: "conformance-luswa-read@example.com", DisplayName: "ReadOnly", IsActive: true})
+	require.NoError(t, err)
+	seedAccessActivityEvent(t, h, h.projectID, activeUser.ID, "secret.updated", time.Now().UTC().Truncate(time.Second))
+	seedAccessActivityEvent(t, h, h.projectID, readOnlyUser.ID, "secret.read", time.Now().UTC().Truncate(time.Second))
+
+	localActivity, err := h.ls.LastUserSecretWriteActivity(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteActivity, err := h.rs.LastUserSecretWriteActivity(ctx, h.projectID)
+	require.NoError(t, err)
+	assertAccessActivityMatches(t, "LastUserSecretWriteActivity", localActivity, remoteActivity)
+	assert.Contains(t, remoteActivity, activeUser.ID)
+	assert.NotContains(t, remoteActivity, readOnlyUser.ID, "a read-only event must not satisfy the write-activity bucket")
+}
+
+// ============================================================================
+// remote_sod.go
+// ============================================================================
+
+// --- CreateSoDPolicy ---
+
+func TestConformance_CreateSoDPolicy(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	userToken := createTestToken(t, h.upstreamCore)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: userToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+	const forgedCreatedBy = 555555
+
+	localPolicy, err := h.ls.CreateSoDPolicy(ctx, &models.SoDPolicy{
+		Name: "conformance-csp-local", PermissionA: "roles.assign", PermissionB: "secrets.delete",
+		CreatedBy: forgedCreatedBy, CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(forgedCreatedBy), localPolicy.CreatedBy,
+		"sanity: LocalStorage.CreateSoDPolicy trusts the caller-supplied CreatedBy verbatim")
+
+	remotePolicy, err := rsAsUser.CreateSoDPolicy(ctx, &models.SoDPolicy{
+		Name: "conformance-csp-remote", PermissionA: "roles.assign", PermissionB: "secrets.delete", CreatedBy: forgedCreatedBy,
+	})
+	require.NoError(t, err, "RemoteStorage.CreateSoDPolicy must succeed for a genuine human admin-tier actor")
+	assert.Equal(t, h.adminUserID, remotePolicy.CreatedBy,
+		"CreatedBy must be derived from the authenticated session server-side, not trusted from the wire")
+
+	persisted, err := h.ls.GetSoDPolicy(ctx, remotePolicy.ID)
+	require.NoError(t, err)
+	assert.Equal(t, h.adminUserID, persisted.CreatedBy)
+
+	// Negative: a machine-authenticated caller must be refused -- creating a
+	// policy requires an admin-tier HUMAN actor, and a machine credential's
+	// actorID(r) resolves to 0, which holds no role grant.
+	_, err = h.rs.CreateSoDPolicy(ctx, &models.SoDPolicy{Name: "conformance-csp-machine", PermissionA: "a", PermissionB: "b"})
+	assert.Error(t, err, "RemoteStorage.CreateSoDPolicy must refuse a machine-authenticated caller")
+}
+
+// --- DeleteSoDPolicy ---
+
+func TestConformance_DeleteSoDPolicy(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	userToken := createTestToken(t, h.upstreamCore)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: userToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	localPolicy, err := h.ls.CreateSoDPolicy(ctx, &models.SoDPolicy{
+		Name: "conformance-dsp-local", PermissionA: "a1", PermissionB: "b1", CreatedBy: h.adminUserID, CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.DeleteSoDPolicy(ctx, localPolicy.ID), "sanity: LocalStorage.DeleteSoDPolicy has no actor check at all")
+
+	remotePolicy, err := h.ls.CreateSoDPolicy(ctx, &models.SoDPolicy{
+		Name: "conformance-dsp-remote", PermissionA: "a2", PermissionB: "b2", CreatedBy: h.adminUserID, CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, rsAsUser.DeleteSoDPolicy(ctx, remotePolicy.ID),
+		"RemoteStorage.DeleteSoDPolicy must succeed for the policy's own creator")
+	_, err = h.ls.GetSoDPolicy(ctx, remotePolicy.ID)
+	assert.Error(t, err, "the policy deleted via RemoteStorage must actually be gone server-side")
+
+	// Negative: deleting a nonexistent policy must error identically on both paths.
+	assert.Error(t, h.ls.DeleteSoDPolicy(ctx, remotePolicy.ID+999999))
+	assert.Error(t, rsAsUser.DeleteSoDPolicy(ctx, remotePolicy.ID+999999))
+}
+
+// --- GetSoDPolicy ---
+
+func TestConformance_GetSoDPolicy(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	seeded, err := h.ls.CreateSoDPolicy(ctx, &models.SoDPolicy{
+		Name: "conformance-gsp", Description: "d", PermissionA: "a", PermissionB: "b", CreatedBy: h.adminUserID, CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	localGot, err := h.ls.GetSoDPolicy(ctx, seeded.ID)
+	require.NoError(t, err)
+	remoteGot, err := h.rs.GetSoDPolicy(ctx, seeded.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "GetSoDPolicy", localGot, remoteGot, nil)
+
+	_, err = h.rs.GetSoDPolicy(ctx, seeded.ID+999999)
+	assert.Error(t, err)
+}
+
+// --- ListSoDPolicies ---
+
+func TestConformance_ListSoDPolicies(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	_, err := h.ls.CreateSoDPolicy(ctx, &models.SoDPolicy{Name: "conformance-lsp-1", PermissionA: "a1", PermissionB: "b1", CreatedBy: h.adminUserID, CreatedAt: time.Now().UTC()})
+	require.NoError(t, err)
+	_, err = h.ls.CreateSoDPolicy(ctx, &models.SoDPolicy{Name: "conformance-lsp-2", PermissionA: "a2", PermissionB: "b2", CreatedBy: h.adminUserID, CreatedAt: time.Now().UTC()})
+	require.NoError(t, err)
+
+	localList, err := h.ls.ListSoDPolicies(ctx)
+	require.NoError(t, err)
+	remoteList, err := h.rs.ListSoDPolicies(ctx)
+	require.NoError(t, err)
+	require.Equal(t, len(localList), len(remoteList))
+	for i := range localList {
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("ListSoDPolicies[%d]", i), localList[i], remoteList[i], nil)
+	}
+}
+
+// ============================================================================
+// remote_legal_hold.go
+// ============================================================================
+
+// --- GetActiveLegalHold ---
+
+func TestConformance_GetActiveLegalHold(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// Precondition: no legal hold is active yet.
+	localNone, err := h.ls.GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	remoteNone, err := h.rs.GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, localNone, "sanity: no hold is active yet")
+	assert.Nil(t, remoteNone, "RemoteStorage.GetActiveLegalHold must also report no active hold")
+
+	seeded, err := h.ls.CreateLegalHold(ctx, &models.LegalHold{Reason: "conformance-galh", PlacedBy: h.adminUserID, PlacedAt: time.Now().UTC(), Released: false})
+	require.NoError(t, err)
+
+	// internal/storage/remote.HTTPClient caches successful GET responses for
+	// 5 minutes, keyed by path, invalidated only by a MUTATION performed
+	// through that SAME client instance (client.go's cache/cacheMux) -- h.rs
+	// already served (and cached) "no active hold" for this exact path
+	// (/api/v1/system/legal-hold/active, no query string) via remoteNone
+	// above, and the mutation just above went through h.ls, not h.rs, so
+	// h.rs's cache is never invalidated. Reusing h.rs here would silently
+	// replay the stale cached response instead of exercising the real
+	// round trip -- mint a fresh client (empty cache) for the post-mutation
+	// read instead, matching this file's own createNodeToken-based node
+	// credential exactly.
+	rsFresh, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: h.nodeToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	localGot, err := h.ls.GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	remoteGot, err := rsFresh.GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, remoteGot)
+	assertFieldExhaustiveEqual(t, "GetActiveLegalHold", localGot, remoteGot, nil)
+	assert.Equal(t, seeded.ID, remoteGot.ID)
+}
+
+// --- CreateLegalHold ---
+
+func TestConformance_CreateLegalHold(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	userToken := createTestToken(t, h.upstreamCore)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: userToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+	const forgedPlacedBy = 444444
+
+	// Legal hold is a deployment-wide SINGLETON (a partial unique index
+	// allows at most one un-released row) -- unlike every other method in
+	// this file, the local and remote scenarios below cannot coexist as two
+	// simultaneously "active" rows, so they run sequentially against the
+	// same slot instead of against two independently seeded rows.
+	remoteHold, err := rsAsUser.CreateLegalHold(ctx, &models.LegalHold{Reason: "conformance-clh-remote", PlacedBy: forgedPlacedBy})
+	require.NoError(t, err, "RemoteStorage.CreateLegalHold must succeed for a genuine human admin-tier actor")
+	assert.Equal(t, h.adminUserID, remoteHold.PlacedBy,
+		"PlacedBy must be derived from the authenticated session server-side, not trusted from the wire")
+	assert.Equal(t, "conformance-clh-remote", remoteHold.Reason)
+	assert.False(t, remoteHold.Released)
+
+	persisted, err := h.ls.GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, h.adminUserID, persisted.PlacedBy)
+
+	// Negative: a second placement while one is already active must be
+	// refused, reconstructing the SAME sentinel a local caller's own
+	// pre-check/DB-race branch would produce -- proving the DB-level partial
+	// unique index's rejection survives the HTTP hop.
+	_, err = rsAsUser.CreateLegalHold(ctx, &models.LegalHold{Reason: "conformance-clh-second"})
+	assert.ErrorIs(t, err, coreStorage.ErrLegalHoldAlreadyActive,
+		"a second concurrent placement must be refused, reconstructing the same sentinel a local caller would see")
+
+	// Free the slot, then exercise LocalStorage's own raw contract: unlike
+	// the proxy above, it trusts whatever PlacedBy the caller sets.
+	require.NoError(t, h.ls.UpdateLegalHold(ctx, &models.LegalHold{
+		ID: persisted.ID, Reason: persisted.Reason, PlacedBy: persisted.PlacedBy, PlacedAt: persisted.PlacedAt,
+		Released: true, ReleasedBy: h.adminUserID, ReleasedAt: timePtr(time.Now().UTC()), ReleaseReason: "freeing the slot for the local-contract check",
+	}))
+	localHold, err := h.ls.CreateLegalHold(ctx, &models.LegalHold{
+		Reason: "conformance-clh-local", PlacedBy: forgedPlacedBy, PlacedAt: time.Now().UTC(), Released: false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint(forgedPlacedBy), localHold.PlacedBy,
+		"sanity: LocalStorage.CreateLegalHold trusts the caller-supplied PlacedBy verbatim")
+}
+
+// --- UpdateLegalHold ---
+
+func TestConformance_UpdateLegalHold(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	userToken := createTestToken(t, h.upstreamCore)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: userToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+	const forgedReleasedBy = 333333
+
+	// LocalStorage's own raw contract first: an unconditional Save that
+	// trusts whatever ReleasedBy the caller sets.
+	localHold, err := h.ls.CreateLegalHold(ctx, &models.LegalHold{Reason: "conformance-ulh-local", PlacedBy: h.adminUserID, PlacedAt: time.Now().UTC(), Released: false})
+	require.NoError(t, err)
+	localHold.Released = true
+	localHold.ReleasedBy = forgedReleasedBy
+	localHold.ReleasedAt = timePtr(time.Now().UTC())
+	localHold.ReleaseReason = "conformance local release"
+	require.NoError(t, h.ls.UpdateLegalHold(ctx, localHold))
+	assert.Equal(t, uint(forgedReleasedBy), localHold.ReleasedBy,
+		"sanity: LocalStorage.UpdateLegalHold trusts the caller-supplied ReleasedBy verbatim")
+	// storage.Storage exposes no GetLegalHold-by-ID -- GetActiveLegalHold is
+	// the only read primitive, and it now (correctly) reports no active hold.
+	afterLocalRelease, err := h.ls.GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, afterLocalRelease, "sanity: the just-released hold must no longer be the active one")
+
+	// Remote: place fresh (the slot is free again), then lift via
+	// RemoteStorage with a forged ReleasedBy. UpdateLegalHoldProxy routes
+	// through core.LiftLegalHold, which re-resolves the active hold and
+	// every field itself except ReleaseReason -- there is no
+	// GetLegalHold-by-ID to read the released row's ReleasedBy back
+	// directly, so the derivation check instead reads core.LiftLegalHold's
+	// own audit trail (writeAuditEvent's userID parameter is the actor core
+	// resolved, EventLegalHoldLifted) -- an equally direct signal of which
+	// actor the server actually attributed the lift to.
+	remoteHold, err := h.ls.CreateLegalHold(ctx, &models.LegalHold{Reason: "conformance-ulh-remote", PlacedBy: h.adminUserID, PlacedAt: time.Now().UTC(), Released: false})
+	require.NoError(t, err)
+	require.NoError(t, rsAsUser.UpdateLegalHold(ctx, &models.LegalHold{
+		ID: remoteHold.ID, ReleaseReason: "conformance remote release", ReleasedBy: forgedReleasedBy,
+	}), "RemoteStorage.UpdateLegalHold must succeed for the placing admin lifting the currently-active hold")
+
+	afterRemoteRelease, err := h.ls.GetActiveLegalHold(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, afterRemoteRelease, "the hold lifted via RemoteStorage must actually no longer be active server-side")
+
+	liftEventType := "data.legal_hold_lifted"
+	events, total, err := h.ls.GetAuditLogs(ctx, &coreStorage.AuditFilter{Action: &liftEventType})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total, "exactly one lift event must have been recorded (the local scenario above used the raw primitive, which writes no audit event)")
+	require.Len(t, events, 1)
+	require.NotNil(t, events[0].UserID)
+	assert.Equal(t, h.adminUserID, *events[0].UserID,
+		"the lift's own actor attribution must be derived from the authenticated session server-side, not trusted "+
+			"from the wire -- the forged ReleasedBy above must never land")
+
+	// Negative: lifting again when nothing is active must be refused.
+	err = rsAsUser.UpdateLegalHold(ctx, &models.LegalHold{ID: remoteHold.ID, ReleaseReason: "conformance second release"})
+	assert.Error(t, err, "RemoteStorage.UpdateLegalHold must refuse to lift when no legal hold is active")
+}
+
+// ============================================================================
+// remote_break_glass.go (GetBreakGlassActivation / ListBreakGlassActivations
+// only -- the other three break-glass methods were already covered by
+// tranche 3's TestConformance_RevokeBreakGlassActivation, and
+// CreateBreakGlassActivation/UpdateBreakGlassActivation are permanently
+// remoteUnsupported per the G80 liveness sweep, not live methods this
+// harness could exercise)
+// ============================================================================
+
+// --- GetBreakGlassActivation ---
+
+func TestConformance_GetBreakGlassActivation(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	user, err := h.ls.CreateUser(ctx, &models.User{Username: "conformance-gbga", Email: "conformance-gbga@example.com", DisplayName: "GBGA", IsActive: true})
+	require.NoError(t, err)
+	role, err := h.ls.GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err)
+	seeded, err := h.ls.CreateBreakGlassActivation(ctx, &models.BreakGlassActivation{
+		ProjectID: h.projectID, UserID: user.ID, RoleID: role.ID, RoleName: role.Name, Justification: "conformance test", State: "active",
+	})
+	require.NoError(t, err)
+
+	localGot, err := h.ls.GetBreakGlassActivation(ctx, seeded.ID)
+	require.NoError(t, err)
+	remoteGot, err := h.rs.GetBreakGlassActivation(ctx, seeded.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "GetBreakGlassActivation", localGot, remoteGot, nil)
+
+	_, err = h.rs.GetBreakGlassActivation(ctx, seeded.ID+999999)
+	assert.Error(t, err, "a nonexistent activation id must error, not silently return a zero value")
+}
+
+// --- ListBreakGlassActivations ---
+
+func TestConformance_ListBreakGlassActivations(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lbga-other", "", []string{"dev"})
+	require.NoError(t, err)
+	role, err := h.ls.GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err)
+	newActivation := func(projectID uint, suffix string) *models.BreakGlassActivation {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-lbga-" + suffix, Email: "conformance-lbga-" + suffix + "@example.com", DisplayName: suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		a, err := h.ls.CreateBreakGlassActivation(ctx, &models.BreakGlassActivation{
+			ProjectID: projectID, UserID: user.ID, RoleID: role.ID, RoleName: role.Name, Justification: "j", State: "active",
+		})
+		require.NoError(t, err)
+		return a
+	}
+	inScope := newActivation(h.projectID, "in-scope")
+	_ = newActivation(otherProject.ID, "other-project") // must NOT appear in a project_id-scoped list
+
+	localList, err := h.ls.ListBreakGlassActivations(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteList, err := h.rs.ListBreakGlassActivations(ctx, h.projectID)
+	require.NoError(t, err)
+	require.Equal(t, len(localList), len(remoteList))
+	require.Len(t, remoteList, 1,
+		"a dropped/ignored project_id on the wire would return every project's activations, not just this one's")
+	assertFieldExhaustiveEqual(t, "ListBreakGlassActivations[0]", localList[0], remoteList[0], nil)
+	assert.Equal(t, inScope.ID, remoteList[0].ID)
+}
+
+// ============================================================================
+// remote_audit.go
+// ============================================================================
+
+// --- GetAuditLogs: SKIPPED, not a fixture-cost skip -- a confirmed live defect ---
+//
+// GetAuditLogs is deliberately NOT covered by a TestConformance_GetAuditLogs
+// in this file. Building the test surfaced a genuine, live wire-shape defect
+// that this task's "one new file, no other edits" scope cannot fix, and
+// CLAUDE.md is explicit that a found defect must never be papered over by
+// weakening the assertion to match broken behavior -- so the honest options
+// were "skip and report" or "fix production code," and only the former is in
+// scope here.
+//
+// The defect: apiAuditLogsPath ("/api/v1/audit/logs", internal/storage/store/
+// constants.go) resolves to the HUMAN-facing AuditHandler.GetAuditLogs
+// (server/http/handlers/audit.go) -- the only handler registered on that
+// route (router.go: r.Get("/logs", auditHandler.GetAuditLogs) under the
+// permAuditRead-gated /audit group). That handler's response envelope is
+// {"logs": [...AuditLogEntry...], "total":..., "page":..., ...} -- key
+// "logs", and each entry is a UI-oriented AuditLogEntry DTO (Actor as a
+// resolved username STRING, Timestamp instead of EventTime, no UserID/
+// SecretNodeID/ProjectID/IPAddress/Success/PrevHash/EntryHash at all).
+// RemoteStorage.GetAuditLogs (internal/storage/store/remote_audit.go),
+// however, decodes the response as:
+//
+//	var result struct {
+//	    Events []*models.AuditEvent `json:"events"`
+//	    Total  int64                `json:"total"`
+//	}
+//
+// "total" happens to decode correctly (the key name matches), which is what
+// makes this defect insidious rather than loudly broken: RemoteStorage.
+// GetAuditLogs returns a NONZERO, seemingly-correct total count alongside an
+// ALWAYS-EMPTY event list, for every real deployment, unconditionally --
+// json key "events" never appears in the actual response body, so
+// result.Events stays at its zero value regardless of how many matching
+// events exist server-side. Verified directly: a fixture of 3 real, matching
+// audit_events rows plus a correct filter (project_id/user_id/action/time
+// range/pagination) round-tripped through the real router produced
+// total=3, events=[] on the RemoteStorage side, against total=3, len(events)=3
+// on the LocalStorage side. This is exactly the defect class #1808 exists to
+// catch -- confirmed live via the real router, not a fake-handler artifact --
+// and needs a follow-up fix to remote_audit.go's response struct (and
+// probably a dedicated non-human-facing wire DTO/route) before a
+// TestConformance_GetAuditLogs can be added truthfully.
+//
+// GetRBACAuditLogs below has the SAME class of route (it also resolves to a
+// human-facing DashboardHandler.GetRBACAuditLogs, whose per-entry shape --
+// "actor_user_id" instead of "user_id", "created_at" instead of "timestamp",
+// no username/target_name/ip_address/success at all -- doesn't match
+// storage.RBACAuditLog's json tags either), but its top-level envelope key
+// ("logs") DOES happen to match what remote_audit.go's GetRBACAuditLogs
+// decodes for, and LocalStorage.GetRBACAuditLogs is itself an unimplemented
+// stub that always returns empty regardless of filter -- so unlike
+// GetAuditLogs, there is no nonzero local baseline available to make this
+// harness's own comparison actually notice the per-entry field-name
+// mismatch. See that test's own comment for what it can and cannot prove.
+
+// --- GetRBACAuditLogs ---
+
+func TestConformance_GetRBACAuditLogs(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	uid := h.adminUserID
+	action := "role.assigned"
+	targetType := "role"
+	var targetID uint = 1
+	// A realistic filter+pagination payload, not a bare empty-params call --
+	// same #1808 rationale as GetAuditLogs above.
+	filter := &coreStorage.RBACAuditFilter{
+		UserID: &uid, Action: &action, TargetType: &targetType, TargetID: &targetID,
+		StartTime: timePtr(now.Add(-time.Hour)), EndTime: timePtr(now.Add(time.Hour)), Page: 1, PageSize: 10,
+	}
+	// LocalStorage.GetRBACAuditLogs is explicitly "not yet implemented" (its
+	// own doc comment) -- it always returns (nil, 0, nil) regardless of
+	// filter, on both backends (the server proxies onto the SAME LocalStorage
+	// method). The point of this test is #1808's own callout: prove the real
+	// route exists and accepts a realistic filter without 404ing, not to
+	// exercise filtering logic that doesn't exist yet.
+	localLogs, localTotal, err := h.ls.GetRBACAuditLogs(ctx, filter)
+	require.NoError(t, err)
+	remoteLogs, remoteTotal, err := h.rs.GetRBACAuditLogs(ctx, filter)
+	require.NoError(t, err, "GetRBACAuditLogs must succeed against the real router with a realistic filter")
+	assert.Equal(t, localTotal, remoteTotal)
+	assert.Equal(t, len(localLogs), len(remoteLogs))
+}
+
+// ============================================================================
+// remote_stats.go
+// ============================================================================
+
+// --- HealthCheck ---
+
+func TestConformance_HealthCheck(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	// HealthCheck has no LocalStorage-comparable "same backing store"
+	// scenario to differentially compare against: it's a RemoteStorage-only
+	// liveness probe against /health, an unauthenticated, non-enveloped
+	// k8s-probe-style endpoint (see remote_stats.go's own doc comment on
+	// Health/HealthCheck). Deviating from this file's usual local-vs-remote
+	// shape: just verify it succeeds against the live harness server.
+	require.NoError(t, h.rs.HealthCheck(ctx), "RemoteStorage.HealthCheck must succeed against a live, healthy server")
+}

--- a/server/http/remote_storage_conformance_tranche4_rbac_projects_test.go
+++ b/server/http/remote_storage_conformance_tranche4_rbac_projects_test.go
@@ -1,0 +1,864 @@
+// remote_storage_conformance_tranche4_rbac_projects_test.go — issue #1808, tranche 4.
+//
+// Covers 18 methods from internal/storage/store/remote_rbac.go's Project/
+// Environment catalog and group/machine RBAC-listing surface (#528/#525/#527):
+//
+//	DeleteEnvironment, DeleteProjectIfEmpty, GetEnvironment, GetProject,
+//	ListEnvironments, ListEnvironmentsByProject,
+//	ListEnvironmentsByProjectIncludingDeleted, ListProjectMachineRoleAssignments,
+//	ListProjectMembers, ListProjectRoleAssignments, ListProjects,
+//	ListProjectsWithCounts, AssignRoleToGroup, AssignRoleToGroupWithExpiry,
+//	GetGroupRoleGrants, ListGroupRoleAssignments, ListConnectRefGrants,
+//	ListConnectRefGrantsByConnector
+//
+// Every one of these is a thin server/http proxy handler (project_catalog_proxy.go,
+// environment_catalog_proxy.go, rbac_role_grants_proxy.go, connect_grants_proxy.go)
+// onto the SAME storage.Storage primitive LocalStorage itself implements — no
+// intervening core business logic decides what the wire carries, so the field-
+// exhaustive comparator is used wherever a full struct/list of structs comes back,
+// per the shared harness's own stated purpose.
+//
+// Most of these read/list global or shared-scope state (h.ls and h.rs are two
+// handles on the SAME backing database, per newConformanceHarness's own doc
+// comment) — for that shape, seeding fixtures once (via h.ls or h.upstreamCore) and
+// then comparing h.ls.M(x) against h.rs.M(x) directly on the SAME fixtures IS the
+// correct, and simpler, comparison: there is no meaningful "local scenario" vs
+// "remote scenario" split for a pure read of shared state, unlike a destructive or
+// creating call where two independent target rows are needed to attribute an
+// observed difference to one specific path. Each test's own comment says which
+// shape it uses. newConformanceHarness's own bootstrapping (newTestCore) opens a
+// brand-new isolated in-memory SQLite DB per test (server/http/integration_test.go's
+// newTestCore, via uniqueMemDSN) — confirmed by reading that helper — so full-list
+// equality (not just set-membership of this test's own fixtures) is safe throughout.
+//
+// Known gotcha applied below (AssignRoleToGroup / AssignRoleToGroupWithExpiry):
+// h.rs's credential is a machine/node identity. AssignRoleToGroupWithExpiry proxies
+// through POST /api/v1/system/rbac/assign-role-to-group-with-expiry
+// (rbac_role_grants_proxy.go), which calls core.AssignGroupRoleWithExpiry with
+// actorID()==0 (a machine caller has no UserID) and no core.WithSelfMachineGranter
+// tag (that tag is only set by the human-facing, non-/system route) — so
+// requireGranterHoldsRolePermissions (internal/core/authz.go) takes its
+// "actorIsMachine but ctx carries no WithSelfMachineGranter tag: fail closed" branch
+// for every permission the target role holds. A role with ZERO permissions makes
+// that loop a no-op (nothing to iterate), so the call succeeds regardless — this is
+// why both group-assignment tests below create a plain, zero-permission role rather
+// than reusing "admin", exactly like tranche 3's AssignRoleWithExpiry/
+// AssignMachineRole tests.
+package http
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// --- small unexported matchers (list-membership helpers for this tranche only) ---
+
+func findProjectByID(projects []*models.Project, id uint) *models.Project {
+	for _, p := range projects {
+		if p.ID == id {
+			return p
+		}
+	}
+	return nil
+}
+
+func findEnvironmentByID(envs []*models.Environment, id uint) *models.Environment {
+	for _, e := range envs {
+		if e.ID == id {
+			return e
+		}
+	}
+	return nil
+}
+
+func findProjectWithCountsByID(projects []coreStorage.ProjectWithCounts, id uint) *coreStorage.ProjectWithCounts {
+	for i := range projects {
+		if projects[i].ID == id {
+			return &projects[i]
+		}
+	}
+	return nil
+}
+
+func findGroupRoleGrantByRoleID(grants []*coreStorage.GroupRoleGrant, roleID uint) *coreStorage.GroupRoleGrant {
+	for _, g := range grants {
+		if g.ID == roleID {
+			return g
+		}
+	}
+	return nil
+}
+
+func findProjectMember(members []coreStorage.ProjectMember, userID, roleID uint) *coreStorage.ProjectMember {
+	for i := range members {
+		if members[i].UserID == userID && members[i].RoleID == roleID {
+			return &members[i]
+		}
+	}
+	return nil
+}
+
+func findConnectRefGrantByID(grants []*models.ConnectRefGrant, id uint) *models.ConnectRefGrant {
+	for _, g := range grants {
+		if g.ID == id {
+			return g
+		}
+	}
+	return nil
+}
+
+// --- GetProject ---
+
+func TestConformance_GetProject(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	project, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-gp-project", "conformance test project", []string{"dev"})
+	require.NoError(t, err)
+	// Mutate two fields the wire struct carries (Description, RequireMFA) away from
+	// their zero/default values -- a field silently dropped on the read side would
+	// come back false/empty instead of the real persisted value.
+	project.RequireMFA = true
+	project.Description = "conformance get-project description"
+	_, err = h.ls.UpdateProject(ctx, project)
+	require.NoError(t, err)
+
+	localOut, err := h.ls.GetProject(ctx, project.ID)
+	require.NoError(t, err)
+	remoteOut, err := h.rs.GetProject(ctx, project.ID)
+	require.NoError(t, err, "RemoteStorage.GetProject must succeed for a project that genuinely exists")
+	assertFieldExhaustiveEqual(t, "GetProject (RemoteStorage vs LocalStorage, same row)", localOut, remoteOut, map[string]bool{})
+
+	// Not-found precondition: both paths must fail, not silently return a zero-value project.
+	_, localErr := h.ls.GetProject(ctx, 999999999)
+	_, remoteErr := h.rs.GetProject(ctx, 999999999)
+	assert.Error(t, localErr, "sanity: LocalStorage.GetProject must fail for a nonexistent id")
+	assert.Error(t, remoteErr, "RemoteStorage.GetProject must fail for a nonexistent id, not report false success")
+}
+
+// --- ListProjects ---
+
+func TestConformance_ListProjects(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// Global listing over shared state (see package doc): seed once, compare both
+	// handles against the SAME resulting rows.
+	projectA, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lp-a", "project A", []string{"dev"})
+	require.NoError(t, err)
+	projectB, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lp-b", "project B", []string{"dev"})
+	require.NoError(t, err)
+	// A soft-deleted project must not appear in the list -- exercised as this
+	// method's natural negative/precondition case (GORM's default deleted_at IS
+	// NULL scope on Project applies to a plain Find with no explicit filter).
+	deletedProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lp-deleted", "", []string{"dev"})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.DeleteProject(ctx, deletedProject.ID))
+
+	localList, err := h.ls.ListProjects(ctx)
+	require.NoError(t, err)
+	remoteList, err := h.rs.ListProjects(ctx)
+	require.NoError(t, err, "RemoteStorage.ListProjects must succeed")
+
+	require.Len(t, remoteList, len(localList), "RemoteStorage.ListProjects must return exactly the same number of "+
+		"rows as LocalStorage against the same backing store")
+	assert.Nil(t, findProjectByID(localList, deletedProject.ID), "sanity: the soft-deleted project must be excluded locally")
+	assert.Nil(t, findProjectByID(remoteList, deletedProject.ID),
+		"the soft-deleted project must also be excluded from RemoteStorage's list")
+
+	for _, want := range []*models.Project{projectA, projectB} {
+		localEntry := findProjectByID(localList, want.ID)
+		require.NotNil(t, localEntry, "sanity: %s must appear in LocalStorage's list", want.Name)
+		remoteEntry := findProjectByID(remoteList, want.ID)
+		require.NotNil(t, remoteEntry, "%s must appear in RemoteStorage's list", want.Name)
+		assertFieldExhaustiveEqual(t, "ListProjects entry "+want.Name, localEntry, remoteEntry, map[string]bool{})
+	}
+}
+
+// --- ListProjectsWithCounts ---
+
+func TestConformance_ListProjectsWithCounts(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	live, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lpwc-live", "", []string{"dev"})
+	require.NoError(t, err)
+	liveEnvs, err := h.ls.ListEnvironmentsByProject(ctx, live.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, liveEnvs)
+	for i := 0; i < 2; i++ {
+		_, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+			Name: "conformance-lpwc-secret", ProjectID: live.ID, EnvironmentID: liveEnvs[0].ID, Type: "password",
+		})
+		require.NoError(t, err)
+		// Names need not be unique across environments/projects in this schema, but
+		// give each a distinct name anyway for clarity in failures.
+	}
+
+	deleted, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lpwc-deleted", "", []string{"dev"})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.DeleteProject(ctx, deleted.ID))
+
+	// include_deleted=false: the deleted project must be excluded on both paths,
+	// and the live project's counts must round-trip exactly.
+	localVisible, err := h.ls.ListProjectsWithCounts(ctx, false)
+	require.NoError(t, err)
+	remoteVisible, err := h.rs.ListProjectsWithCounts(ctx, false)
+	require.NoError(t, err, "RemoteStorage.ListProjectsWithCounts(false) must succeed")
+
+	assert.Nil(t, findProjectWithCountsByID(localVisible, deleted.ID), "sanity: deleted project excluded locally")
+	assert.Nil(t, findProjectWithCountsByID(remoteVisible, deleted.ID),
+		"the soft-deleted project must also be excluded from RemoteStorage's include_deleted=false list")
+
+	localLiveEntry := findProjectWithCountsByID(localVisible, live.ID)
+	require.NotNil(t, localLiveEntry, "sanity: the live project must appear locally")
+	require.EqualValues(t, 2, localLiveEntry.SecretCount, "sanity: local secret count")
+	remoteLiveEntry := findProjectWithCountsByID(remoteVisible, live.ID)
+	require.NotNil(t, remoteLiveEntry, "the live project must appear in RemoteStorage's list")
+	assertFieldExhaustiveEqual(t, "ListProjectsWithCounts(false) live project", localLiveEntry, remoteLiveEntry, map[string]bool{})
+
+	// include_deleted=true: the deleted project must now appear on both paths,
+	// Deleted=true with a populated DeletedAt.
+	localAll, err := h.ls.ListProjectsWithCounts(ctx, true)
+	require.NoError(t, err)
+	remoteAll, err := h.rs.ListProjectsWithCounts(ctx, true)
+	require.NoError(t, err, "RemoteStorage.ListProjectsWithCounts(true) must succeed")
+
+	localDeletedEntry := findProjectWithCountsByID(localAll, deleted.ID)
+	require.NotNil(t, localDeletedEntry, "sanity: the deleted project must appear locally with include_deleted=true")
+	assert.True(t, localDeletedEntry.Deleted, "sanity: local Deleted flag")
+	remoteDeletedEntry := findProjectWithCountsByID(remoteAll, deleted.ID)
+	require.NotNil(t, remoteDeletedEntry,
+		"the deleted project must appear in RemoteStorage's include_deleted=true list, not stay hidden")
+	assertFieldExhaustiveEqual(t, "ListProjectsWithCounts(true) deleted project", localDeletedEntry, remoteDeletedEntry, map[string]bool{})
+}
+
+// --- DeleteProjectIfEmpty ---
+
+func TestConformance_DeleteProjectIfEmpty(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newEmptyProject := func(suffix string) *models.Project {
+		p, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-dpie-empty-"+suffix, "", []string{"dev"})
+		require.NoError(t, err)
+		return p
+	}
+	newNonEmptyProject := func(suffix string) *models.Project {
+		p, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-dpie-nonempty-"+suffix, "", []string{"dev"})
+		require.NoError(t, err)
+		envs, err := h.ls.ListEnvironmentsByProject(ctx, p.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, envs)
+		_, err = h.ls.CreateSecret(ctx, &models.SecretNode{
+			Name: "conformance-dpie-secret-" + suffix, ProjectID: p.ID, EnvironmentID: envs[0].ID, Type: "password",
+		})
+		require.NoError(t, err)
+		return p
+	}
+
+	// Positive: an empty project is actually deleted, blockingSecretCount == 0.
+	localEmpty := newEmptyProject("local")
+	localBlocking, err := h.ls.DeleteProjectIfEmpty(ctx, localEmpty.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, localBlocking, "sanity: LocalStorage reports zero blocking secrets for a genuinely empty project")
+	_, err = h.ls.GetProject(ctx, localEmpty.ID)
+	assert.Error(t, err, "sanity: the local empty project must actually be gone")
+
+	remoteEmpty := newEmptyProject("remote")
+	remoteBlocking, err := h.rs.DeleteProjectIfEmpty(ctx, remoteEmpty.ID)
+	require.NoError(t, err, "RemoteStorage.DeleteProjectIfEmpty must succeed for a genuinely empty project")
+	assert.Equal(t, 0, remoteBlocking, "RemoteStorage must report zero blocking secrets for a genuinely empty project")
+	_, err = h.ls.GetProject(ctx, remoteEmpty.ID)
+	assert.Error(t, err, "the remote empty project must actually be gone server-side, not just report success")
+
+	// Negative/precondition: a non-empty project must be REFUSED (blockingSecretCount
+	// > 0, err == nil, project survives) -- not silently deleted anyway.
+	localNonEmpty := newNonEmptyProject("local")
+	localBlocking2, err := h.ls.DeleteProjectIfEmpty(ctx, localNonEmpty.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, localBlocking2, "sanity: LocalStorage reports the blocking secret count, not an error")
+	_, err = h.ls.GetProject(ctx, localNonEmpty.ID)
+	assert.NoError(t, err, "sanity: the local non-empty project must survive a refused delete-if-empty")
+
+	remoteNonEmpty := newNonEmptyProject("remote")
+	remoteBlocking2, err := h.rs.DeleteProjectIfEmpty(ctx, remoteNonEmpty.ID)
+	require.NoError(t, err, "RemoteStorage.DeleteProjectIfEmpty must report the guard refusal via the return value, not an error")
+	assert.Equal(t, 1, remoteBlocking2,
+		"RemoteStorage must report the SAME blocking secret count the guard on the server actually computed")
+	_, err = h.ls.GetProject(ctx, remoteNonEmpty.ID)
+	assert.NoError(t, err, "the remote non-empty project must survive server-side -- a dropped guard would have deleted it anyway")
+}
+
+// --- GetEnvironment ---
+
+func TestConformance_GetEnvironment(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	env, err := h.ls.CreateEnvironment(ctx, &models.Environment{ProjectID: h.projectID, Name: "conformance-ge-env"})
+	require.NoError(t, err)
+
+	localOut, err := h.ls.GetEnvironment(ctx, env.ID)
+	require.NoError(t, err)
+	remoteOut, err := h.rs.GetEnvironment(ctx, env.ID)
+	require.NoError(t, err, "RemoteStorage.GetEnvironment must succeed for an environment that genuinely exists")
+	assertFieldExhaustiveEqual(t, "GetEnvironment (RemoteStorage vs LocalStorage, same row)", localOut, remoteOut, map[string]bool{})
+
+	_, localErr := h.ls.GetEnvironment(ctx, 999999999)
+	_, remoteErr := h.rs.GetEnvironment(ctx, 999999999)
+	assert.Error(t, localErr, "sanity: LocalStorage.GetEnvironment must fail for a nonexistent id")
+	assert.Error(t, remoteErr, "RemoteStorage.GetEnvironment must fail for a nonexistent id, not report false success")
+}
+
+// --- DeleteEnvironment ---
+
+func TestConformance_DeleteEnvironment(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newEmptyEnv := func(suffix string) *models.Environment {
+		e, err := h.ls.CreateEnvironment(ctx, &models.Environment{ProjectID: h.projectID, Name: "conformance-de-empty-" + suffix})
+		require.NoError(t, err)
+		return e
+	}
+
+	localEnv := newEmptyEnv("local")
+	require.NoError(t, h.ls.DeleteEnvironment(ctx, localEnv.ID))
+	_, err := h.ls.GetEnvironment(ctx, localEnv.ID)
+	assert.Error(t, err, "sanity: the local environment must actually be gone")
+
+	remoteEnv := newEmptyEnv("remote")
+	require.NoError(t, h.rs.DeleteEnvironment(ctx, remoteEnv.ID),
+		"RemoteStorage.DeleteEnvironment must succeed for an environment with no active secrets")
+	_, err = h.ls.GetEnvironment(ctx, remoteEnv.ID)
+	assert.Error(t, err, "the remote environment must actually be gone server-side, not just report success")
+
+	// Negative/precondition: an environment with a live (active) secret must be
+	// REFUSED on both paths, and must survive the refused attempt.
+	newActiveEnv := func(suffix string) *models.Environment {
+		e, err := h.ls.CreateEnvironment(ctx, &models.Environment{ProjectID: h.projectID, Name: "conformance-de-active-" + suffix})
+		require.NoError(t, err)
+		_, err = h.ls.CreateSecret(ctx, &models.SecretNode{
+			Name: "conformance-de-secret-" + suffix, ProjectID: h.projectID, EnvironmentID: e.ID, Type: "password", Status: "active",
+		})
+		require.NoError(t, err)
+		return e
+	}
+
+	localActiveEnv := newActiveEnv("local")
+	assert.Error(t, h.ls.DeleteEnvironment(ctx, localActiveEnv.ID), "sanity: an environment with an active secret must refuse deletion")
+	_, err = h.ls.GetEnvironment(ctx, localActiveEnv.ID)
+	assert.NoError(t, err, "sanity: the local environment must survive a refused delete")
+
+	remoteActiveEnv := newActiveEnv("remote")
+	assert.Error(t, h.rs.DeleteEnvironment(ctx, remoteActiveEnv.ID),
+		"RemoteStorage.DeleteEnvironment must refuse an environment with an active secret, not delete it anyway")
+	_, err = h.ls.GetEnvironment(ctx, remoteActiveEnv.ID)
+	assert.NoError(t, err, "the remote environment must survive server-side after a refused delete")
+}
+
+// --- ListEnvironments (global) ---
+
+func TestConformance_ListEnvironments(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-le-other-project", "", nil)
+	require.NoError(t, err)
+	envA, err := h.ls.CreateEnvironment(ctx, &models.Environment{ProjectID: h.projectID, Name: "conformance-le-a"})
+	require.NoError(t, err)
+	envB, err := h.ls.CreateEnvironment(ctx, &models.Environment{ProjectID: otherProject.ID, Name: "conformance-le-b"})
+	require.NoError(t, err)
+
+	// Negative/precondition: a soft-deleted environment must be excluded from the
+	// global list on both paths.
+	deletedEnv, err := h.ls.CreateEnvironment(ctx, &models.Environment{ProjectID: h.projectID, Name: "conformance-le-deleted"})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.DeleteEnvironment(ctx, deletedEnv.ID))
+
+	localList, err := h.ls.ListEnvironments(ctx)
+	require.NoError(t, err)
+	remoteList, err := h.rs.ListEnvironments(ctx)
+	require.NoError(t, err, "RemoteStorage.ListEnvironments must succeed")
+
+	require.Len(t, remoteList, len(localList),
+		"RemoteStorage.ListEnvironments must return exactly the same number of rows as LocalStorage")
+	assert.Nil(t, findEnvironmentByID(localList, deletedEnv.ID), "sanity: the soft-deleted environment is excluded locally")
+	assert.Nil(t, findEnvironmentByID(remoteList, deletedEnv.ID),
+		"the soft-deleted environment must also be excluded from RemoteStorage's global list")
+
+	for _, want := range []*models.Environment{envA, envB} {
+		localEntry := findEnvironmentByID(localList, want.ID)
+		require.NotNil(t, localEntry, "sanity: %s must appear locally", want.Name)
+		remoteEntry := findEnvironmentByID(remoteList, want.ID)
+		require.NotNil(t, remoteEntry, "%s must appear in RemoteStorage's global list", want.Name)
+		assertFieldExhaustiveEqual(t, "ListEnvironments entry "+want.Name, localEntry, remoteEntry, map[string]bool{})
+	}
+}
+
+// --- ListEnvironmentsByProject ---
+
+func TestConformance_ListEnvironmentsByProject(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	extraEnv, err := h.ls.CreateEnvironment(ctx, &models.Environment{ProjectID: h.projectID, Name: "conformance-lebp-extra"})
+	require.NoError(t, err)
+
+	// Negative/precondition: an environment belonging to a DIFFERENT project must
+	// not appear when listing h.projectID's environments -- the scope-drop risk
+	// this method exists to catch.
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lebp-other-project", "", []string{"other"})
+	require.NoError(t, err)
+
+	localList, err := h.ls.ListEnvironmentsByProject(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteList, err := h.rs.ListEnvironmentsByProject(ctx, h.projectID)
+	require.NoError(t, err, "RemoteStorage.ListEnvironmentsByProject must succeed")
+
+	require.Len(t, remoteList, len(localList),
+		"RemoteStorage.ListEnvironmentsByProject must return exactly the same number of rows as LocalStorage")
+	assert.NotNil(t, findEnvironmentByID(localList, h.environmentID), "sanity: the harness's default env is included locally")
+	assert.NotNil(t, findEnvironmentByID(remoteList, h.environmentID), "the harness's default env must be included remotely")
+	assert.NotNil(t, findEnvironmentByID(localList, extraEnv.ID), "sanity: the extra env is included locally")
+	remoteExtra := findEnvironmentByID(remoteList, extraEnv.ID)
+	require.NotNil(t, remoteExtra, "the extra env must be included in RemoteStorage's project-scoped list")
+	assertFieldExhaustiveEqual(t, "ListEnvironmentsByProject extra env", extraEnv, remoteExtra, map[string]bool{})
+
+	otherEnvs, err := h.ls.ListEnvironmentsByProject(ctx, otherProject.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, otherEnvs)
+	assert.Nil(t, findEnvironmentByID(localList, otherEnvs[0].ID),
+		"sanity: the other project's environment must not leak into h.projectID's local listing")
+	assert.Nil(t, findEnvironmentByID(remoteList, otherEnvs[0].ID),
+		"the other project's environment must not leak into h.projectID's REMOTE listing either -- a "+
+			"dropped/ignored project_id filter on the wire would return every environment instead of "+
+			"scoping to the named project")
+}
+
+// --- ListEnvironmentsByProjectIncludingDeleted ---
+
+func TestConformance_ListEnvironmentsByProjectIncludingDeleted(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	project, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lebpid-project", "", nil)
+	require.NoError(t, err)
+	liveEnv, err := h.ls.CreateEnvironment(ctx, &models.Environment{ProjectID: project.ID, Name: "conformance-lebpid-live"})
+	require.NoError(t, err)
+	deletedEnv, err := h.ls.CreateEnvironment(ctx, &models.Environment{ProjectID: project.ID, Name: "conformance-lebpid-deleted"})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.DeleteEnvironment(ctx, deletedEnv.ID))
+
+	// Negative/precondition: the default (non-including-deleted) listing excludes
+	// the soft-deleted environment on both paths -- the contrast this test exists
+	// to establish against the "including deleted" variant below.
+	localDefault, err := h.ls.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	remoteDefault, err := h.rs.ListEnvironmentsByProject(ctx, project.ID)
+	require.NoError(t, err)
+	assert.Nil(t, findEnvironmentByID(localDefault, deletedEnv.ID), "sanity: default listing excludes the deleted env locally")
+	assert.Nil(t, findEnvironmentByID(remoteDefault, deletedEnv.ID), "default listing must also exclude the deleted env remotely")
+
+	localAll, err := h.ls.ListEnvironmentsByProjectIncludingDeleted(ctx, project.ID)
+	require.NoError(t, err)
+	remoteAll, err := h.rs.ListEnvironmentsByProjectIncludingDeleted(ctx, project.ID)
+	require.NoError(t, err, "RemoteStorage.ListEnvironmentsByProjectIncludingDeleted must succeed")
+
+	require.Len(t, remoteAll, len(localAll), "RemoteStorage must return exactly the same rows as LocalStorage, deleted included")
+	require.NotNil(t, findEnvironmentByID(localAll, liveEnv.ID), "sanity: the live env is present locally")
+	require.NotNil(t, findEnvironmentByID(remoteAll, liveEnv.ID), "the live env must be present remotely")
+
+	localDeletedEntry := findEnvironmentByID(localAll, deletedEnv.ID)
+	require.NotNil(t, localDeletedEntry, "sanity: the soft-deleted env appears locally when including deleted")
+	remoteDeletedEntry := findEnvironmentByID(remoteAll, deletedEnv.ID)
+	require.NotNil(t, remoteDeletedEntry,
+		"the soft-deleted env must appear in RemoteStorage's IncludingDeleted listing, not stay hidden")
+	assert.True(t, remoteDeletedEntry.DeletedAt.Valid, "the wire round trip must preserve the DeletedAt timestamp, not just the row's existence")
+	assertFieldExhaustiveEqual(t, "ListEnvironmentsByProjectIncludingDeleted deleted env", localDeletedEntry, remoteDeletedEntry, map[string]bool{})
+}
+
+// --- ListProjectMembers ---
+
+func TestConformance_ListProjectMembers(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	role, err := h.ls.GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err)
+
+	member, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-lpm-member", Email: "conformance-lpm-member@example.com",
+		DisplayName: "Conformance Project Member", IsActive: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.AssignRole(ctx, member.ID, role.ID, coreStorage.Scope{ProjectID: h.projectID}))
+
+	// Negative/precondition: a user with only an ENVIRONMENT-scoped grant (not
+	// project-scope, environment_id=0) must NOT be reported as a project member --
+	// ListProjectMembers.'s own doc comment restricts to environment_id = 0.
+	envScopedUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-lpm-envscoped", Email: "conformance-lpm-envscoped@example.com",
+		DisplayName: "Conformance Env-Scoped User", IsActive: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.AssignRole(ctx, envScopedUser.ID, role.ID, coreStorage.Scope{ProjectID: h.projectID, EnvironmentID: h.environmentID}))
+
+	localMembers, err := h.ls.ListProjectMembers(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteMembers, err := h.rs.ListProjectMembers(ctx, h.projectID)
+	require.NoError(t, err, "RemoteStorage.ListProjectMembers must succeed")
+
+	require.Len(t, remoteMembers, len(localMembers), "RemoteStorage.ListProjectMembers must return the same row count as LocalStorage")
+	assert.Nil(t, findProjectMember(localMembers, envScopedUser.ID, role.ID), "sanity: the env-scoped user is not a project member locally")
+	assert.Nil(t, findProjectMember(remoteMembers, envScopedUser.ID, role.ID),
+		"the env-scoped user must also not be reported as a project member remotely -- a dropped "+
+			"environment_id=0 filter on the wire would over-report project membership")
+
+	localEntry := findProjectMember(localMembers, member.ID, role.ID)
+	require.NotNil(t, localEntry, "sanity: the genuine project member appears locally")
+	remoteEntry := findProjectMember(remoteMembers, member.ID, role.ID)
+	require.NotNil(t, remoteEntry, "the genuine project member must appear in RemoteStorage's list")
+	assertFieldExhaustiveEqual(t, "ListProjectMembers entry", localEntry, remoteEntry, map[string]bool{})
+}
+
+// --- ListProjectRoleAssignments ---
+
+func TestConformance_ListProjectRoleAssignments(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	projectRole, err := h.ls.GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err)
+	globalRole, err := h.ls.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+
+	user, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-lpra-user", Email: "conformance-lpra-user@example.com",
+		DisplayName: "Conformance LPRA User", IsActive: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.AssignRole(ctx, user.ID, projectRole.ID, coreStorage.Scope{ProjectID: h.projectID}))
+	require.NoError(t, h.ls.AssignRole(ctx, user.ID, projectRole.ID, coreStorage.Scope{ProjectID: h.projectID, EnvironmentID: h.environmentID}))
+
+	group, err := h.upstreamCore.CreateGroup(ctx, h.adminUserID, &core.CreateGroupRequest{Name: "conformance-lpra-group"})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.AssignRoleToGroup(ctx, group.ID, projectRole.ID, coreStorage.Scope{ProjectID: h.projectID}))
+
+	// Negative/precondition: a GLOBAL (project_id=0) grant for the SAME user must
+	// be excluded -- ListProjectRoleAssignments's own doc comment says global
+	// assignments are deliberately excluded (reviewed separately). Uses a
+	// different role so it cannot be confused with the project-scope grant above.
+	require.NoError(t, h.ls.AssignRole(ctx, user.ID, globalRole.ID, coreStorage.Scope{}))
+
+	localAssignments, err := h.ls.ListProjectRoleAssignments(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteAssignments, err := h.rs.ListProjectRoleAssignments(ctx, h.projectID)
+	require.NoError(t, err, "RemoteStorage.ListProjectRoleAssignments must succeed")
+
+	assert.ElementsMatch(t, localAssignments, remoteAssignments,
+		"RemoteStorage.ListProjectRoleAssignments must return exactly the same set of user+group grants as "+
+			"LocalStorage against the same backing store")
+	assert.False(t, containsRoleGrant(remoteAssignments, globalRole.ID, coreStorage.Scope{}),
+		"a GLOBAL-scope grant must never appear in a project-scoped assignment listing -- a dropped project_id "+
+			"filter on the wire would leak install-wide grants into a project's own access review")
+	assert.True(t, containsRoleGrant(remoteAssignments, projectRole.ID, coreStorage.Scope{ProjectID: h.projectID}),
+		"the project-scope user grant must be present remotely")
+	assert.True(t, containsRoleGrant(remoteAssignments, projectRole.ID, coreStorage.Scope{ProjectID: h.projectID, EnvironmentID: h.environmentID}),
+		"the environment-scope user grant must also be present remotely")
+}
+
+// --- ListProjectMachineRoleAssignments ---
+
+func TestConformance_ListProjectMachineRoleAssignments(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	role, err := h.ls.GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err)
+
+	machine, err := h.upstreamCore.CreateMachineIdentity(ctx, h.projectID, "conformance-lpmra-machine", core.MachineTypeService, "conformance test machine", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	require.NoError(t, h.ls.AssignMachineRole(ctx, machine.ID, role.ID, coreStorage.Scope{ProjectID: h.projectID}))
+
+	// Negative/precondition: a machine role grant scoped to a DIFFERENT project
+	// must not leak into this project's listing -- the scope-drop risk this
+	// method exists to catch.
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lpmra-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+	otherMachine, err := h.upstreamCore.CreateMachineIdentity(ctx, otherProject.ID, "conformance-lpmra-other-machine", core.MachineTypeService, "conformance test machine", "", h.adminUserID, 0)
+	require.NoError(t, err)
+	require.NoError(t, h.ls.AssignMachineRole(ctx, otherMachine.ID, role.ID, coreStorage.Scope{ProjectID: otherProject.ID}))
+
+	localAssignments, err := h.ls.ListProjectMachineRoleAssignments(ctx, h.projectID)
+	require.NoError(t, err)
+	remoteAssignments, err := h.rs.ListProjectMachineRoleAssignments(ctx, h.projectID)
+	require.NoError(t, err, "RemoteStorage.ListProjectMachineRoleAssignments must succeed")
+
+	assert.ElementsMatch(t, localAssignments, remoteAssignments,
+		"RemoteStorage.ListProjectMachineRoleAssignments must return exactly the same set as LocalStorage")
+	assert.True(t, containsRoleGrant(remoteAssignments, role.ID, coreStorage.Scope{ProjectID: h.projectID}),
+		"the genuine machine grant in h.projectID must be present remotely")
+	assert.False(t, containsRoleGrant(remoteAssignments, role.ID, coreStorage.Scope{ProjectID: otherProject.ID}),
+		"the other project's machine grant must not leak into h.projectID's remote listing")
+}
+
+// --- AssignRoleToGroup ---
+
+func TestConformance_AssignRoleToGroup(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// Zero-permission role -- see package doc comment for why.
+	roleName, err := identity.NewFoldedName("conformance-artg-role")
+	require.NoError(t, err)
+	role, err := h.ls.CreateRole(ctx, roleName, "conformance test role")
+	require.NoError(t, err)
+
+	scope := coreStorage.Scope{ProjectID: h.projectID, EnvironmentID: h.environmentID}
+
+	localGroup, err := h.upstreamCore.CreateGroup(ctx, h.adminUserID, &core.CreateGroupRequest{Name: "conformance-artg-local"})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.AssignRoleToGroup(ctx, localGroup.ID, role.ID, scope))
+
+	remoteGroup, err := h.upstreamCore.CreateGroup(ctx, h.adminUserID, &core.CreateGroupRequest{Name: "conformance-artg-remote"})
+	require.NoError(t, err)
+	require.NoError(t, h.rs.AssignRoleToGroup(ctx, remoteGroup.ID, role.ID, scope),
+		"RemoteStorage.AssignRoleToGroup must succeed for a zero-permission role grant")
+
+	localAfter, err := h.ls.ListGroupRoleAssignments(ctx, localGroup.ID)
+	require.NoError(t, err)
+	remoteAfter, err := h.ls.ListGroupRoleAssignments(ctx, remoteGroup.ID)
+	require.NoError(t, err)
+	assert.True(t, containsRoleGrant(localAfter, role.ID, scope), "sanity: the local group grant is visible")
+	assert.True(t, containsRoleGrant(remoteAfter, role.ID, scope),
+		"the remote group grant must actually be visible server-side, not just report success")
+
+	// Negative/precondition: assigning the SAME (group, role, scope) a second time
+	// must fail on both paths ("already assigned"), not silently succeed a second
+	// time and mask a dropped-scope defect as false idempotent success.
+	assert.Error(t, h.ls.AssignRoleToGroup(ctx, localGroup.ID, role.ID, scope))
+	assert.Error(t, h.rs.AssignRoleToGroup(ctx, remoteGroup.ID, role.ID, scope),
+		"RemoteStorage.AssignRoleToGroup must refuse a duplicate assignment at the exact same scope")
+}
+
+// --- AssignRoleToGroupWithExpiry ---
+
+func TestConformance_AssignRoleToGroupWithExpiry(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// Zero-permission role -- see package doc comment for why: this method
+	// proxies through the /system route, where requireGranterHoldsRolePermissions
+	// fails closed for a machine actor with no WithSelfMachineGranter tag, UNLESS
+	// the target role carries zero permissions (nothing to check).
+	roleName, err := identity.NewFoldedName("conformance-artge-role")
+	require.NoError(t, err)
+	role, err := h.ls.CreateRole(ctx, roleName, "conformance test role")
+	require.NoError(t, err)
+
+	scope := coreStorage.Scope{ProjectID: h.projectID}
+	expiresAt := time.Now().Add(time.Hour).UTC()
+
+	localGroup, err := h.upstreamCore.CreateGroup(ctx, h.adminUserID, &core.CreateGroupRequest{Name: "conformance-artge-local"})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.AssignRoleToGroupWithExpiry(ctx, localGroup.ID, role.ID, scope, expiresAt))
+
+	remoteGroup, err := h.upstreamCore.CreateGroup(ctx, h.adminUserID, &core.CreateGroupRequest{Name: "conformance-artge-remote"})
+	require.NoError(t, err)
+	require.NoError(t, h.rs.AssignRoleToGroupWithExpiry(ctx, remoteGroup.ID, role.ID, scope, expiresAt),
+		"RemoteStorage.AssignRoleToGroupWithExpiry must succeed for a zero-permission role grant")
+
+	localAfter, err := h.ls.ListGroupRoleAssignments(ctx, localGroup.ID)
+	require.NoError(t, err)
+	remoteAfter, err := h.ls.ListGroupRoleAssignments(ctx, remoteGroup.ID)
+	require.NoError(t, err)
+	assert.True(t, containsRoleGrant(localAfter, role.ID, scope), "sanity: the local time-bound grant is visible pre-expiry")
+	assert.True(t, containsRoleGrant(remoteAfter, role.ID, scope),
+		"the remote time-bound grant must actually be visible server-side pre-expiry, not just report success")
+
+	// Negative/precondition: a second assignment at the same (group, role, scope)
+	// while the first is still live (not expired) must be refused on both paths.
+	assert.Error(t, h.ls.AssignRoleToGroupWithExpiry(ctx, localGroup.ID, role.ID, scope, expiresAt))
+	// AssignRoleToGroupWithExpiryProxy (unlike the human-facing AssignRoleToGroup
+	// handler) has no "already assigned" -> 409 special-case, so this genuinely
+	// surfaces as a 500 on the real server -- and the shared harness's h.rs (like
+	// every conformance test's) defaults RetryAttempts to 3 with quadratic backoff
+	// for any 5xx (internal/storage/remote/client.go's isRetryableError), which
+	// would otherwise burn a real 1+4+9=14s here for no additional signal beyond
+	// "an error occurred". A short per-call timeout lets the FIRST attempt (which
+	// already reaches the real server and gets the real refusal) complete
+	// normally, then cuts the retry loop's backoff sleep short via ctx.Done()
+	// instead of waiting it out -- the assertion only needs SOME error, not the
+	// specific one from a particular attempt.
+	shortCtx, cancel := context.WithTimeout(ctx, 300*time.Millisecond)
+	defer cancel()
+	assert.Error(t, h.rs.AssignRoleToGroupWithExpiry(shortCtx, remoteGroup.ID, role.ID, scope, expiresAt),
+		"RemoteStorage.AssignRoleToGroupWithExpiry must refuse a duplicate assignment while the existing grant is still live")
+}
+
+// --- GetGroupRoleGrants ---
+
+func TestConformance_GetGroupRoleGrants(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	permanentRole, err := h.ls.GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err)
+	expiringRole, err := h.ls.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+
+	group, err := h.upstreamCore.CreateGroup(ctx, h.adminUserID, &core.CreateGroupRequest{Name: "conformance-ggrg-group"})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.AssignRoleToGroup(ctx, group.ID, permanentRole.ID, coreStorage.Scope{ProjectID: h.projectID}))
+	// An EXPIRED grant: GetGroupRoleGrants (unlike ListGroupRoleAssignments) applies
+	// no expiry filter at all -- it must still be reported, on both paths, so this
+	// doubles as the precondition/negative case relative to that sibling method's
+	// filtering behavior.
+	pastExpiry := time.Now().Add(-time.Hour).UTC()
+	require.NoError(t, h.ls.AssignRoleToGroupWithExpiry(ctx, group.ID, expiringRole.ID, coreStorage.Scope{ProjectID: h.projectID}, pastExpiry))
+
+	localGrants, err := h.ls.GetGroupRoleGrants(ctx, group.ID)
+	require.NoError(t, err)
+	remoteGrants, err := h.rs.GetGroupRoleGrants(ctx, group.ID)
+	require.NoError(t, err, "RemoteStorage.GetGroupRoleGrants must succeed")
+
+	require.Len(t, remoteGrants, len(localGrants), "RemoteStorage.GetGroupRoleGrants must return the same row count as LocalStorage")
+	localPermanent := findGroupRoleGrantByRoleID(localGrants, permanentRole.ID)
+	require.NotNil(t, localPermanent, "sanity: the permanent grant appears locally")
+	remotePermanent := findGroupRoleGrantByRoleID(remoteGrants, permanentRole.ID)
+	require.NotNil(t, remotePermanent, "the permanent grant must appear in RemoteStorage's list")
+	assertFieldExhaustiveEqual(t, "GetGroupRoleGrants permanent grant", localPermanent, remotePermanent, map[string]bool{})
+
+	localExpired := findGroupRoleGrantByRoleID(localGrants, expiringRole.ID)
+	require.NotNil(t, localExpired, "sanity: the EXPIRED grant still appears locally (no expiry filter on this method)")
+	remoteExpired := findGroupRoleGrantByRoleID(remoteGrants, expiringRole.ID)
+	require.NotNil(t, remoteExpired,
+		"the EXPIRED grant must also still appear via RemoteStorage -- an over-eager expiry filter accidentally "+
+			"added on the wire path would silently hide it")
+	assertFieldExhaustiveEqual(t, "GetGroupRoleGrants expired grant", localExpired, remoteExpired, map[string]bool{})
+
+	// Negative/precondition: a group with zero grants returns an empty list, not
+	// an error.
+	emptyGroup, err := h.upstreamCore.CreateGroup(ctx, h.adminUserID, &core.CreateGroupRequest{Name: "conformance-ggrg-empty"})
+	require.NoError(t, err)
+	remoteEmpty, err := h.rs.GetGroupRoleGrants(ctx, emptyGroup.ID)
+	require.NoError(t, err, "RemoteStorage.GetGroupRoleGrants must succeed (empty) for a group with no grants")
+	assert.Empty(t, remoteEmpty)
+}
+
+// --- ListGroupRoleAssignments ---
+
+func TestConformance_ListGroupRoleAssignments(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	liveRole, err := h.ls.GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err)
+	expiredRole, err := h.ls.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+
+	group, err := h.upstreamCore.CreateGroup(ctx, h.adminUserID, &core.CreateGroupRequest{Name: "conformance-lgra-group"})
+	require.NoError(t, err)
+	scope := coreStorage.Scope{ProjectID: h.projectID, EnvironmentID: h.environmentID}
+	require.NoError(t, h.ls.AssignRoleToGroup(ctx, group.ID, liveRole.ID, scope))
+
+	// Negative/precondition: an EXPIRED grant must be excluded here (contrast
+	// with GetGroupRoleGrants above, which does not filter by expiry) --
+	// ListGroupRoleAssignments's own doc comment says it excludes expired grants.
+	pastExpiry := time.Now().Add(-time.Hour).UTC()
+	require.NoError(t, h.ls.AssignRoleToGroupWithExpiry(ctx, group.ID, expiredRole.ID, scope, pastExpiry))
+
+	localAssignments, err := h.ls.ListGroupRoleAssignments(ctx, group.ID)
+	require.NoError(t, err)
+	remoteAssignments, err := h.rs.ListGroupRoleAssignments(ctx, group.ID)
+	require.NoError(t, err, "RemoteStorage.ListGroupRoleAssignments must succeed")
+
+	assert.ElementsMatch(t, localAssignments, remoteAssignments,
+		"RemoteStorage.ListGroupRoleAssignments must return exactly the same LIVE grant set as LocalStorage")
+	assert.True(t, containsRoleGrant(remoteAssignments, liveRole.ID, scope), "the live grant must be present remotely")
+	assert.False(t, containsRoleGrant(remoteAssignments, expiredRole.ID, scope),
+		"the EXPIRED grant must be excluded from RemoteStorage's list -- a dropped expiry filter on the wire "+
+			"would report a lapsed grant as still-live")
+
+	// A group with zero grants returns an empty list, not an error.
+	emptyGroup, err := h.upstreamCore.CreateGroup(ctx, h.adminUserID, &core.CreateGroupRequest{Name: "conformance-lgra-empty"})
+	require.NoError(t, err)
+	remoteEmpty, err := h.rs.ListGroupRoleAssignments(ctx, emptyGroup.ID)
+	require.NoError(t, err, "RemoteStorage.ListGroupRoleAssignments must succeed (empty) for a group with no grants")
+	assert.Empty(t, remoteEmpty)
+}
+
+// --- ListConnectRefGrants ---
+
+func TestConformance_ListConnectRefGrants(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	role, err := h.ls.GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err)
+
+	grantA, err := h.ls.CreateConnectRefGrant(ctx, &models.ConnectRefGrant{RoleID: role.ID, Connector: "conformance-lcrg-connA", RefPrefix: "prod/"})
+	require.NoError(t, err)
+	expiry := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+	grantB, err := h.ls.CreateConnectRefGrant(ctx, &models.ConnectRefGrant{
+		RoleID: role.ID, Connector: "conformance-lcrg-connB", RefPrefix: "staging/", ExpiresAt: &expiry,
+	})
+	require.NoError(t, err)
+
+	localList, err := h.ls.ListConnectRefGrants(ctx)
+	require.NoError(t, err)
+	remoteList, err := h.rs.ListConnectRefGrants(ctx)
+	require.NoError(t, err, "RemoteStorage.ListConnectRefGrants must succeed")
+
+	require.Len(t, remoteList, len(localList), "RemoteStorage.ListConnectRefGrants must return the same row count as LocalStorage")
+	for _, want := range []*models.ConnectRefGrant{grantA, grantB} {
+		localEntry := findConnectRefGrantByID(localList, want.ID)
+		require.NotNil(t, localEntry, "sanity: grant for connector %s appears locally", want.Connector)
+		remoteEntry := findConnectRefGrantByID(remoteList, want.ID)
+		require.NotNil(t, remoteEntry, "grant for connector %s must appear in RemoteStorage's list", want.Connector)
+		assertFieldExhaustiveEqual(t, "ListConnectRefGrants entry "+want.Connector, localEntry, remoteEntry, map[string]bool{})
+	}
+}
+
+// --- ListConnectRefGrantsByConnector ---
+
+func TestConformance_ListConnectRefGrantsByConnector(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	role, err := h.ls.GetRoleByName(ctx, "system_viewer")
+	require.NoError(t, err)
+
+	target, err := h.ls.CreateConnectRefGrant(ctx, &models.ConnectRefGrant{RoleID: role.ID, Connector: "conformance-lcrgbc-target", RefPrefix: "prod/"})
+	require.NoError(t, err)
+	// Negative/precondition risk: a grant for a DIFFERENT connector must not leak
+	// into a by-connector query for "target" -- the exact filter
+	// connectRefAllowed's hot path depends on for deny-by-default correctness.
+	_, err = h.ls.CreateConnectRefGrant(ctx, &models.ConnectRefGrant{RoleID: role.ID, Connector: "conformance-lcrgbc-other", RefPrefix: "prod/"})
+	require.NoError(t, err)
+
+	localList, err := h.ls.ListConnectRefGrantsByConnector(ctx, "conformance-lcrgbc-target")
+	require.NoError(t, err)
+	remoteList, err := h.rs.ListConnectRefGrantsByConnector(ctx, "conformance-lcrgbc-target")
+	require.NoError(t, err, "RemoteStorage.ListConnectRefGrantsByConnector must succeed")
+
+	require.Len(t, remoteList, 1, "RemoteStorage.ListConnectRefGrantsByConnector must return exactly the one grant scoped to this connector")
+	require.Len(t, localList, 1, "sanity: LocalStorage returns exactly the one grant scoped to this connector")
+	assertFieldExhaustiveEqual(t, "ListConnectRefGrantsByConnector target grant", target, remoteList[0], map[string]bool{})
+
+	// Negative/precondition: a connector with zero grants returns an empty list.
+	emptyList, err := h.rs.ListConnectRefGrantsByConnector(ctx, "conformance-lcrgbc-nonexistent")
+	require.NoError(t, err, "RemoteStorage.ListConnectRefGrantsByConnector must succeed (empty) for a connector with no grants")
+	assert.Empty(t, emptyList)
+}

--- a/server/http/remote_storage_conformance_tranche4_rbac_roles_test.go
+++ b/server/http/remote_storage_conformance_tranche4_rbac_roles_test.go
@@ -1,0 +1,304 @@
+// remote_storage_conformance_tranche4_rbac_roles_test.go — issue #1808, tranche 4.
+//
+// Assignment: cover CreateRole, DeleteRole, UpdateRole, RemovePermissionFromRole,
+// GetRole, GetRoleByName, GetRolePermissions, GetPermission, ListPermissions,
+// ListRoles, GetUserPermissions, GetUserRoles, GetGroupRoles (all declared on
+// *RemoteStorage in internal/storage/store/remote_rbac.go).
+//
+// # 7 of the 13 methods are SKIPPED — not for fixture-cost reasons, but because
+// running each one against the REAL router (via a throwaway probe using this
+// file's own harness, since deleted) surfaced a genuine, live, currently-shipping
+// defect. This is exactly the defect class this harness exists to catch (see
+// remote_storage_conformance_helpers_test.go's package doc and #1812's
+// CreateSecret finding) — writing a passing test for any of these 7 would mean
+// either asserting the WRONG (buggy) behavior as correct, or quietly hand-waving
+// past a real bug. Neither is acceptable, so each is left uncovered here with the
+// exact reproduction evidence below for whoever picks up the fix. All 7 need a
+// PRODUCTION code change (handler response shape and/or RemoteStorage request/
+// response wiring), which is out of scope for a test-only tranche.
+//
+//   - CreateRole: RemoteStorage.CreateRole (remote_rbac.go) POSTs {name, description}
+//     to POST /api/v1/roles, but the handler's CreateRoleRequest DTO
+//     (server/http/handlers/rbac.go) requires `permissions` with
+//     `validate:"required,min=1"`. RemoteStorage never sends a permissions field
+//     at all, so EVERY call 400s: confirmed live —
+//     `ValidationError: Invalid request data ({"errors":[{"field":"permissions",
+//     "message":"must have at least 1 items"}]})`. RemoteStorage.CreateRole can
+//     never succeed against a real server.
+//   - GetRole: the handler wraps its response as
+//     `{"role": {...}, "permissions": [...]}` (GetRoleWithPermissions), but
+//     RemoteStorage.GetRole unmarshals resp.Data directly into a bare
+//     `models.Role`. Since no field in that JSON object is named after any
+//     models.Role field, json.Unmarshal silently sets nothing and returns NO
+//     ERROR — confirmed live: a real, existing role read back as
+//     `&models.Role{ID:0, Name:"", ...}` with `err=<nil>`. This is a silent
+//     wrong-data bug, strictly worse than an error.
+//   - UpdateRole: identical wrapping mismatch and identical silent-zero-value
+//     symptom as GetRole (same handler response shape). Confirmed live: the
+//     WRITE itself succeeds and is correctly persisted (verified by reading the
+//     row back through LocalStorage afterward), but RemoteStorage.UpdateRole's
+//     own return value is silently `&models.Role{ID:0, Name:"", ...}` with
+//     `err=<nil>` — any caller that uses the returned struct (logging, chaining)
+//     gets garbage while believing the call fully succeeded.
+//   - ListRoles: the handler wraps as `{"roles":[...], "total": N}`, but
+//     RemoteStorage.ListRoles unmarshals resp.Data directly into `[]*models.Role`
+//     (a bare array). Unlike the object-into-struct cases above, object-into-
+//     slice IS a hard type error: confirmed live —
+//     `failed to parse response: json: cannot unmarshal object into Go value of
+//     type []*models.Role`. Every call fails.
+//   - GetUserRoles: RemoteStorage.GetUserRoles calls
+//     `GET /api/v1/users/{userId}/roles`, which routes to
+//     UsersRolesHandler.GetUserRolesForUser (NOT rbacHandler.GetUserRoles, which
+//     is wired at the unrelated path `/api/v1/user-roles/user/{userId}`).
+//     GetUserRolesForUser wraps its response as `{"roles": [...]}` (also using a
+//     reduced `apiRole{ID, Name}` shape, dropping Description/BypassesPermission-
+//     Checks/NameFolded), but RemoteStorage.GetUserRoles unmarshals into a bare
+//     `[]*models.Role`. Confirmed live: `failed to parse response: json: cannot
+//     unmarshal object into Go value of type []*models.Role`. Every call fails.
+//   - GetUserPermissions: same class as GetUserRoles. The wired handler
+//     (UsersRolesHandler.GetUserPermissionsForUser) wraps as
+//     `{"permissions": [...]}` using a reduced `apiPermission` shape (no ID
+//     field), but RemoteStorage.GetUserPermissions unmarshals into a bare
+//     `[]*storage.Permission`. Confirmed live: `failed to parse response: json:
+//     cannot unmarshal object into Go value of type []*storage.Permission`.
+//   - GetGroupRoles: the wired handler (rbacHandler.GetGroupRoles) wraps as
+//     `{"group_id": N, "roles": [...]}`, where `roles` are
+//     `[]*storage.GroupRoleGrant` (ID/Name/Description/ExpiresAt — NOT a full
+//     models.Role), but RemoteStorage.GetGroupRoles unmarshals into a bare
+//     `[]*models.Role`. Confirmed live: `failed to parse response: json: cannot
+//     unmarshal object into Go value of type []*models.Role`. Two independent
+//     defects stacked (wrapping AND shape), either one alone would already break
+//     this call.
+//
+// This is a HIGH-severity, previously-undiscovered finding: under ADR-049's
+// storage.type: remote deployment shape (a downstream Keyorix node whose
+// core.KeyorixCore is backed by RemoteStorage), role management is effectively
+// non-functional end-to-end — creating, reading, listing, or updating a role, and
+// reading a user's or group's roles/permissions, either hard-fails or silently
+// returns zero-value data. Filed for a dedicated follow-up fix; NOT patched here
+// per this tranche's test-only scope (no production file may be touched by this
+// change).
+//
+// The remaining 6 methods below are confirmed working correctly against the real
+// router and are covered with full field-exhaustive + negative-case rigor:
+// DeleteRole, RemovePermissionFromRole, GetRoleByName, GetRolePermissions,
+// GetPermission, ListPermissions.
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// --- DeleteRole ---
+
+func TestConformance_DeleteRole(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newRole := func(suffix string) *models.Role {
+		name, err := identity.NewFoldedName("conformance-dr-" + suffix)
+		require.NoError(t, err)
+		role, err := h.ls.CreateRole(ctx, name, "conformance DeleteRole test role "+suffix)
+		require.NoError(t, err)
+		return role
+	}
+
+	localRole := newRole("local")
+	require.NoError(t, h.ls.DeleteRole(ctx, localRole.ID))
+
+	remoteRole := newRole("remote")
+	require.NoError(t, h.rs.DeleteRole(ctx, remoteRole.ID),
+		"RemoteStorage.DeleteRole must succeed for a role that genuinely exists")
+
+	_, localErr := h.ls.GetRole(ctx, localRole.ID)
+	_, remoteErr := h.ls.GetRole(ctx, remoteRole.ID)
+	assert.Error(t, localErr, "sanity: a deleted role must not be readable")
+	assert.Error(t, remoteErr,
+		"the role deleted via RemoteStorage must actually be gone server-side, not just report success -- "+
+			"read back through the SAME LocalStorage instance the router wraps, not just trusting the HTTP response")
+
+	// Deleting an already-deleted (or never-existent) role must fail identically on
+	// both paths -- not silently succeed a second time, which would mask a
+	// dropped-ID / wrong-route defect as false "idempotent" success.
+	assert.Error(t, h.ls.DeleteRole(ctx, localRole.ID))
+	assert.Error(t, h.rs.DeleteRole(ctx, remoteRole.ID))
+}
+
+// --- RemovePermissionFromRole ---
+
+func TestConformance_RemovePermissionFromRole(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	perms, err := h.ls.ListPermissions(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, perms, "sanity: bootstrap must have seeded at least one permission")
+	permID := perms[0].ID
+
+	newRoleWithPermission := func(suffix string) *models.Role {
+		name, err := identity.NewFoldedName("conformance-rpfr-" + suffix)
+		require.NoError(t, err)
+		role, err := h.ls.CreateRole(ctx, name, "conformance RemovePermissionFromRole test role "+suffix)
+		require.NoError(t, err)
+		require.NoError(t, h.ls.AssignPermissionToRole(ctx, role.ID, permID))
+		return role
+	}
+
+	localRole := newRoleWithPermission("local")
+	require.NoError(t, h.ls.RemovePermissionFromRole(ctx, localRole.ID, permID))
+
+	remoteRole := newRoleWithPermission("remote")
+	require.NoError(t, h.rs.RemovePermissionFromRole(ctx, remoteRole.ID, permID),
+		"RemoteStorage.RemovePermissionFromRole must succeed for a permission genuinely assigned to the role")
+
+	localPermsAfter, err := h.ls.GetRolePermissions(ctx, localRole.ID)
+	require.NoError(t, err)
+	remotePermsAfter, err := h.ls.GetRolePermissions(ctx, remoteRole.ID)
+	require.NoError(t, err)
+	assert.Empty(t, localPermsAfter, "sanity: the local role's permission must be gone")
+	assert.Empty(t, remotePermsAfter,
+		"the remote role's permission must actually be gone server-side, not just report success -- read back "+
+			"through the SAME LocalStorage instance the router wraps")
+
+	// Removing a permission the role no longer holds (already removed above) must
+	// fail identically on both paths -- not silently no-op success, which would
+	// mask a dropped-roleID/permissionID defect as false "idempotent" success.
+	assert.Error(t, h.ls.RemovePermissionFromRole(ctx, localRole.ID, permID))
+	assert.Error(t, h.rs.RemovePermissionFromRole(ctx, remoteRole.ID, permID),
+		"RemoteStorage.RemovePermissionFromRole must report an error for a permission the role does not hold, "+
+			"not silently succeed")
+}
+
+// --- GetRoleByName ---
+
+func TestConformance_GetRoleByName(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	name, err := identity.NewFoldedName("conformance-grbn-role")
+	require.NoError(t, err)
+	seeded, err := h.ls.CreateRole(ctx, name, "conformance GetRoleByName test role")
+	require.NoError(t, err)
+
+	localRead, err := h.ls.GetRoleByName(ctx, seeded.Name)
+	require.NoError(t, err)
+	remoteRead, err := h.rs.GetRoleByName(ctx, seeded.Name)
+	require.NoError(t, err, "RemoteStorage.GetRoleByName must succeed for a role that genuinely exists")
+
+	exclude := map[string]bool{
+		// models.Role.NameFolded carries `json:"-"` -- a write-time-only derived
+		// field (identity.NewFoldedName run at CreateRole time) that is never
+		// intended to round-trip over the wire; the server independently
+		// re-derives it from Name on writes, and no read handler serializes it.
+		// Confirmed empirically: RemoteStorage.GetRoleByName always returns
+		// NameFolded="" regardless of the real stored value, while LocalStorage's
+		// direct DB read returns the real folded string -- a wire-format
+		// omission by design (the json tag), not a proxy defect.
+		"NameFolded": true,
+	}
+	assertFieldExhaustiveEqual(t, "GetRoleByName(local vs remote, same row)", localRead, remoteRead, exclude)
+
+	_, localErr := h.ls.GetRoleByName(ctx, "conformance-grbn-does-not-exist")
+	_, remoteErr := h.rs.GetRoleByName(ctx, "conformance-grbn-does-not-exist")
+	assert.Error(t, localErr, "sanity: a nonexistent role name must not resolve")
+	assert.Error(t, remoteErr,
+		"RemoteStorage.GetRoleByName must report an error for a nonexistent role name, not a false match")
+}
+
+// --- GetRolePermissions ---
+
+func TestConformance_GetRolePermissions(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	allPerms, err := h.ls.ListPermissions(ctx)
+	require.NoError(t, err)
+	require.True(t, len(allPerms) >= 2, "sanity: bootstrap must have seeded at least 2 permissions")
+
+	name, err := identity.NewFoldedName("conformance-grp-role")
+	require.NoError(t, err)
+	role, err := h.ls.CreateRole(ctx, name, "conformance GetRolePermissions test role")
+	require.NoError(t, err)
+	require.NoError(t, h.ls.AssignPermissionToRole(ctx, role.ID, allPerms[0].ID))
+	require.NoError(t, h.ls.AssignPermissionToRole(ctx, role.ID, allPerms[1].ID))
+
+	localPerms, err := h.ls.GetRolePermissions(ctx, role.ID)
+	require.NoError(t, err)
+	remotePerms, err := h.rs.GetRolePermissions(ctx, role.ID)
+	require.NoError(t, err, "RemoteStorage.GetRolePermissions must succeed for a role that genuinely exists")
+	assert.ElementsMatch(t, localPerms, remotePerms,
+		"RemoteStorage.GetRolePermissions must return exactly the same permission set as LocalStorage for the "+
+			"SAME role -- a dropped join or wrong roleID on the wire would return the wrong set")
+
+	// Precondition divergence, confirmed by direct code inspection (not guessed):
+	// LocalStorage.GetRolePermissions is a raw JOIN with no existence check on
+	// the role row (an unmatched roleID simply yields zero join rows), while
+	// RemoteStorage.GetRolePermissions is proxied through the server's
+	// GetRolePermissions handler, which calls core.GetRoleWithPermissions --
+	// that function calls storage.GetRole FIRST and returns ITS NotFound error
+	// before ever reaching GetRolePermissions. The two backends are genuinely
+	// NOT equivalent for a nonexistent roleID; assert what each actually does
+	// rather than asserting a false parity between them.
+	localEmpty, err := h.ls.GetRolePermissions(ctx, 999999998)
+	require.NoError(t, err,
+		"LocalStorage.GetRolePermissions has no existence check on the role row -- an unmatched roleID is "+
+			"simply zero rows, not an error")
+	assert.Empty(t, localEmpty)
+	_, remoteNotFoundErr := h.rs.GetRolePermissions(ctx, 999999999)
+	assert.Error(t, remoteNotFoundErr,
+		"RemoteStorage.GetRolePermissions is proxied through a handler that resolves the role first "+
+			"(core.GetRoleWithPermissions), so a nonexistent roleID must surface as an error, not an empty list")
+}
+
+// --- GetPermission ---
+
+func TestConformance_GetPermission(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	allPerms, err := h.ls.ListPermissions(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, allPerms, "sanity: bootstrap must have seeded at least one permission")
+	target := allPerms[0]
+
+	localRead, err := h.ls.GetPermission(ctx, target.ID)
+	require.NoError(t, err)
+	remoteRead, err := h.rs.GetPermission(ctx, target.ID)
+	require.NoError(t, err, "RemoteStorage.GetPermission must succeed for a permission that genuinely exists")
+	assertFieldExhaustiveEqual(t, "GetPermission(local vs remote, same row)", localRead, remoteRead, map[string]bool{})
+
+	_, localErr := h.ls.GetPermission(ctx, 999999999)
+	_, remoteErr := h.rs.GetPermission(ctx, 999999999)
+	assert.Error(t, localErr, "sanity: a nonexistent permission ID must not resolve")
+	assert.Error(t, remoteErr,
+		"RemoteStorage.GetPermission must report an error for a nonexistent permission ID, not a false match")
+}
+
+// --- ListPermissions ---
+
+// No natural negative/precondition case exists for this method: the permission
+// catalog is seeded at bootstrap and RemoteStorage.ListPermissions takes no
+// filter argument to exercise an edge case against (the handler's own optional
+// ?resource= query param is never sent by this client method) -- the meaningful
+// assertion is that the two backends agree on the full catalog content.
+func TestConformance_ListPermissions(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	localPerms, err := h.ls.ListPermissions(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, localPerms, "sanity: bootstrap must have seeded the permission catalog")
+
+	remotePerms, err := h.rs.ListPermissions(ctx)
+	require.NoError(t, err, "RemoteStorage.ListPermissions must succeed")
+	assert.ElementsMatch(t, localPerms, remotePerms,
+		"RemoteStorage.ListPermissions must return exactly the same permission catalog as LocalStorage -- a "+
+			"dropped row or field on the wire would silently under-report the catalog")
+}

--- a/server/http/remote_storage_conformance_tranche4_sharing_secrets_test.go
+++ b/server/http/remote_storage_conformance_tranche4_sharing_secrets_test.go
@@ -1,0 +1,1179 @@
+// remote_storage_conformance_tranche4_sharing_secrets_test.go — issue #1808, tranche 4.
+//
+// Covers 19 methods spanning three source files, per the task brief:
+//
+//	remote_sharing.go (8): DeleteExpiredShareRecords, DeleteShareRecord,
+//	  ListSharesByGroup, ListSharesByOwner, ListSharesBySecret,
+//	  ListSharesBySecretIDs, ListSharesByUser, UpdateShareRecord
+//	remote_secrets.go (8): GetSecret, GetSecretIncludingDeleted, GetSecretVersions,
+//	  GetSecretsByIDs, ListSecretVersions, ListSecrets, RestoreSecret, UpdateSecret
+//	remote_secret_dependencies.go (3): CreateSecretDependencyExclusive,
+//	  GetSecretDependency, ListSecretDependenciesForProject
+//
+// All 19 are covered; none skipped.
+//
+// # A recurring theme: the harness's own admin credential often can't drive these
+//
+// newConformanceHarness's h.rs is a MACHINE/NODE credential holding "admin" at
+// GLOBAL scope (project_id=0). That is sufficient for every /api/v1/system/*
+// proxy route (gated on the same broad system.read/system.write tier), and for
+// any human-facing route whose OWN authorization is a plain RBAC permission
+// check (AuthorizePrincipal/Authorize: a project_id=0 role grant satisfies ANY
+// specific project scope, per GetUserRoleIDsAt's "project_id = 0 OR ..."
+// convention). It is NOT sufficient for two other, narrower gates several of
+// these 19 methods sit behind, both confirmed by direct code reading before
+// writing a single test:
+//
+//   - requireLiveOwnerAuthority (internal/core/permissions.go): requires the
+//     acting user to be the resource's OwnerID AND a LIVE, PROJECT-SCOPED member
+//     (IsProjectMember explicitly excludes project_id=0 grants — its own doc
+//     comment: "a global/install-wide role does NOT count"). UpdateShareRecord,
+//     DeleteShareRecord, and (transitively, since RemoteStorage.ListSharesBySecretIDs
+//     loops ListSharesBySecret) ListSharesBySecret all proxy onto human-facing
+//     /api/v1/shares* routes gated this way — h.rs can never pass this, no matter
+//     how much RBAC it holds. newSharingOwnerSession below mints a real user
+//     session that both owns the fixture secret and holds a genuine project-scoped
+//     role grant (IsProjectMember only checks a grant EXISTS at that scope, not
+//     what it permits, so a zero-permission role suffices).
+//   - An explicit `if userID == 0 { return err }` guard some core functions run
+//     BEFORE any permission check at all (UpdateSecretWithPermissionCheck,
+//     GetSecretVersionsWithPermissionCheck) — a machine credential's UserContext
+//     never has UserID set (only MachineIdentityID), so these hard-fail
+//     regardless of admin bypass. UpdateSecret/GetSecretVersions/
+//     ListSecretVersions need a real user session for this reason (confirmed by
+//     the pre-existing remote_storage_g80_secret_update_test.go, which already
+//     uses createTestToken rather than a node credential for exactly this route).
+//
+// GetSecret/GetSecretIncludingDeleted/GetSecretsByIDs/ListSecrets/RestoreSecret,
+// and every /system/secret-dependencies and /system/shares/by-owner|by-user
+// route, have neither gate (confirmed by reading each handler) and are driven
+// directly by h.rs.
+//
+// # A found (not fixed) wire-fidelity defect: UpdateShareRecord can never change ExpiresAt
+//
+// models.ShareRecord carries no json tags at all, so RemoteStorage.UpdateShareRecord
+// marshals it with bare Go field names ("Permission", "ExpiresAt", ...). The server's
+// UpdateSharePermission handler (shares_crud.go) decodes into a DTO tagged
+// `json:"permission"` / `json:"expires_at"`. encoding/json's case-insensitive
+// decode fallback only saves single-word fields (Permission/permission, verified
+// empirically to round-trip) — "ExpiresAt" is not a case-insensitive match for
+// "expires_at" (they differ by more than case: one has an underscore), so a
+// caller's ExpiresAt change is silently dropped on every call, landing at
+// whatever the row's current value already was. TestConformance_UpdateShareRecord
+// pins this AS a found defect (a failing-if-fixed assertion, with a comment
+// explaining exactly why) rather than papering over it — this file only adds
+// tests, per the task brief, so it is reported here rather than patched.
+//
+// # More found (not fixed) defects: bare-slice vs enveloped-object responses
+//
+// RemoteStorage.ListSharesByGroup, ListSharesBySecret (and its batch caller
+// ListSharesBySecretIDs, which loops it), and ListSecretVersions (and its alias
+// GetSecretVersions) each decode their HTTP response body directly into a bare
+// Go slice (`var result []*models.ShareRecord` / `[]*models.SecretVersion`), but
+// the real server wraps every one of those responses in an envelope object
+// (`{"shares": [...]}` / `{"versions": [...]}`) — confirmed by reading both the
+// RemoteStorage decode call and the exact handler `sendSuccess` call on the
+// other end of each route. json.Unmarshal of a JSON object into a Go slice
+// always errors, so these FIVE RemoteStorage entry points (four distinct
+// methods, one of them doubly-named) are unconditionally broken against a real
+// server: every call fails, success or not, non-empty or empty result alike —
+// not an edge case this harness had to construct, the ONLY case. All are
+// cross-checked against sibling methods that DO unwrap the same kind of
+// envelope correctly (ListSharesByOwner/ListSharesByUser use
+// `struct{ Shares []*models.ShareRecord }`), so each is a genuine one-off
+// omission, not a repo-wide convention gap. TestConformance_ListSharesByGroup /
+// TestConformance_ListSharesBySecret / TestConformance_ListSharesBySecretIDs /
+// TestConformance_GetSecretVersions / TestConformance_ListSecretVersions each
+// pin the CURRENT (broken) behavior with a require.Error assertion and a comment
+// explaining exactly why, rather than silently working around it — this file
+// only adds tests, per the task brief, so these are reported here rather than
+// patched.
+package http
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/remote"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
+)
+
+// --- Shared helpers (unexported to this file, per the task brief) ---
+
+// newSharingOwnerSession creates a human user, grants them the built-in
+// "editor" role (secrets.read/write/delete) at a genuine PROJECT scope, logs
+// them in for a real session token, and returns both the user and a
+// *store.RemoteStorage authenticated as that session. Two distinct gates make
+// this necessary, not just IsProjectMember:
+//
+//  1. The ROUTE middleware for PUT/DELETE /api/v1/shares/{id} and GET
+//     /api/v1/secrets/{id}/shares requires a real secrets.write/secrets.read
+//     RBAC grant at the resource's scope (RequireScopedPermission/
+//     RequireScopedSecretPermission) -- a zero-permission role clears
+//     IsProjectMember but still 403s at this layer (confirmed: an earlier
+//     draft using a zero-permission role, matching tranche3's
+//     AssignRoleWithExpiry/AssignMachineRole convention, failed here with
+//     "Forbidden: Insufficient permissions" on every call).
+//  2. The HANDLER-internal requireLiveOwnerAuthority additionally requires
+//     IsProjectMember specifically (a grant scoped to project_id=0 does NOT
+//     count, per that function's own doc comment) -- so the grant must be
+//     project-scoped, not global, regardless of (1).
+//
+// "editor" (RBAC Phase 2's canonical project-scoped role) satisfies both at once.
+func newSharingOwnerSession(t *testing.T, h *conformanceHarness, suffix string) (*models.User, *store.RemoteStorage) {
+	t.Helper()
+	ctx := context.Background()
+
+	const password = "Qr7#Kp2$Lm5@Vn9!"
+	user, err := h.upstreamCore.CreateUser(ctx, &core.CreateUserRequest{
+		Username: "conformance-share-owner-" + suffix,
+		Email:    "conformance-share-owner-" + suffix + "@example.com",
+		Password: password,
+	})
+	require.NoError(t, err)
+
+	editorRole, err := h.ls.GetRoleByName(ctx, "editor")
+	require.NoError(t, err)
+	require.NoError(t, h.ls.AssignRole(ctx, user.ID, editorRole.ID, coreStorage.Scope{ProjectID: h.projectID}))
+
+	session, _, err := h.upstreamCore.Login(ctx, &core.LoginRequest{Username: user.Username, Password: password})
+	require.NoError(t, err)
+
+	rsAsOwner, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: session.SessionToken, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+	return user, rsAsOwner
+}
+
+// newSecretsHumanSession mints a *store.RemoteStorage authenticated as the
+// harness's own bootstrap admin (testadmin — the SAME user h.adminUserID
+// names), via a real login session rather than the harness's machine/node
+// credential. testadmin's admin role is GLOBAL (project_id=0), which — unlike
+// IsProjectMember above — DOES satisfy AuthorizePrincipal/Authorize's RBAC
+// checks at any specific project scope (GetUserRoleIDsAt's own
+// "project_id = 0 OR ..." resolution), so this is sufficient for
+// UpdateSecret/GetSecretVersions/ListSecretVersions's plain secrets.write/
+// secrets.read gates. It is NOT a live-owner/project-member session (no
+// project-scoped grant is created here) — don't reuse this for
+// requireLiveOwnerAuthority-gated calls; use newSharingOwnerSession there.
+func newSecretsHumanSession(t *testing.T, h *conformanceHarness) *store.RemoteStorage {
+	t.Helper()
+	token := createTestToken(t, h.upstreamCore)
+	rsAsUser, err := store.NewRemoteStorage(&remote.Config{
+		BaseURL: h.server.URL, APIKey: token, TimeoutSeconds: 5, RetryAttempts: 0, TLSVerify: true,
+	})
+	require.NoError(t, err)
+	return rsAsUser
+}
+
+func newConformanceTestUser(t *testing.T, h *conformanceHarness, suffix string) *models.User {
+	t.Helper()
+	user, err := h.ls.CreateUser(context.Background(), &models.User{
+		Username: "conformance-" + suffix, Email: "conformance-" + suffix + "@example.com",
+		DisplayName: "Conformance " + suffix, IsActive: true,
+	})
+	require.NoError(t, err)
+	return user
+}
+
+func containsShareID(shares []*models.ShareRecord, id uint) bool {
+	for _, s := range shares {
+		if s.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func secretByID(t *testing.T, secrets []*models.SecretNode, id uint) *models.SecretNode {
+	t.Helper()
+	for _, s := range secrets {
+		if s.ID == id {
+			return s
+		}
+	}
+	t.Fatalf("secret %d not found in result set", id)
+	return nil
+}
+
+func mustGetSecretDependency(t *testing.T, h *conformanceHarness, id uint) *models.SecretDependency {
+	t.Helper()
+	d, err := h.ls.GetSecretDependency(context.Background(), id)
+	require.NoError(t, err)
+	return d
+}
+
+// ============================================================================
+// Group A — remote_sharing.go
+// ============================================================================
+
+// --- ListSharesBySecret ---
+
+func TestConformance_ListSharesBySecret(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	recipient := newConformanceTestUser(t, h, "lss-recipient")
+
+	// local: raw storage, no authz needed.
+	localOwner := newConformanceTestUser(t, h, "lss-owner-local")
+	localSecret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-lss-secret-local", ProjectID: h.projectID, EnvironmentID: h.environmentID,
+		Type: "password", OwnerID: localOwner.ID,
+	})
+	require.NoError(t, err)
+	localShare, err := h.ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: localSecret.ID, OwnerID: localOwner.ID, RecipientID: recipient.ID, Permission: "read",
+	})
+	require.NoError(t, err)
+
+	localShares, err := h.ls.ListSharesBySecret(ctx, localSecret.ID)
+	require.NoError(t, err)
+	require.Len(t, localShares, 1, "sanity: exactly one active share for the local secret")
+	assertFieldExhaustiveEqual(t, "LocalStorage.ListSharesBySecret (sanity baseline)", localShare, localShares[0], map[string]bool{})
+
+	// remote: ListSharesBySecret proxies onto the human-facing, owner-gated
+	// GET /api/v1/secrets/{id}/shares route (ListSecretSharesWithPermissionCheck) --
+	// see the package doc for why h.rs itself cannot drive this even setting the
+	// envelope defect below aside.
+	remoteOwner, rsAsOwner := newSharingOwnerSession(t, h, "lss-remote")
+	remoteSecret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-lss-secret-remote", ProjectID: h.projectID, EnvironmentID: h.environmentID,
+		Type: "password", OwnerID: remoteOwner.ID,
+	})
+	require.NoError(t, err)
+	_, err = h.ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: remoteSecret.ID, OwnerID: remoteOwner.ID, RecipientID: recipient.ID, Permission: "read",
+	})
+	require.NoError(t, err)
+
+	// FOUND DEFECT (same class as ListSharesByGroup/GetSecretVersions -- see the
+	// package doc): GET /api/v1/secrets/{id}/shares (ListSecretShares) also wraps
+	// its response as {"shares": [...]}, but RemoteStorage.ListSharesBySecret
+	// decodes straight into a bare `[]*models.ShareRecord`. Unconditionally
+	// broken against a real server for every call, confirmed here with a genuine
+	// live owner (the authorization gate passes -- the 200 response body itself
+	// is what fails to parse). Not fixed here, per the task brief -- pinned.
+	_, err = rsAsOwner.ListSharesBySecret(ctx, remoteSecret.ID)
+	require.Error(t, err,
+		"FOUND DEFECT: RemoteStorage.ListSharesBySecret must currently fail on ANY call, even for a genuine "+
+			"live owner -- it decodes the server's {\"shares\": [...]} envelope directly into a bare slice, "+
+			"which json.Unmarshal always rejects")
+	assert.Contains(t, err.Error(), "failed to parse response")
+
+	// Negative (still pinning the same defect): a secret with no shares gets the
+	// identical envelope shape server-side, so it fails to parse too, not a
+	// clean empty list.
+	emptySecret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-lss-empty", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password", OwnerID: remoteOwner.ID,
+	})
+	require.NoError(t, err)
+	emptyLocal, err := h.ls.ListSharesBySecret(ctx, emptySecret.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	_, err = rsAsOwner.ListSharesBySecret(ctx, emptySecret.ID)
+	assert.Error(t, err, "the same envelope-vs-bare-slice mismatch fails an empty-result call too")
+}
+
+// --- ListSharesBySecretIDs ---
+
+func TestConformance_ListSharesBySecretIDs(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	recipient := newConformanceTestUser(t, h, "lsbi-recipient")
+	owner, rsAsOwner := newSharingOwnerSession(t, h, "lsbi")
+
+	secretA, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-lsbi-a", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password", OwnerID: owner.ID,
+	})
+	require.NoError(t, err)
+	// secretB deliberately has NO shares -- exercises the "some IDs contribute
+	// zero shares" branch without failing the batch.
+	secretB, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-lsbi-b", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password", OwnerID: owner.ID,
+	})
+	require.NoError(t, err)
+	_, err = h.ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secretA.ID, OwnerID: owner.ID, RecipientID: recipient.ID, Permission: "read",
+	})
+	require.NoError(t, err)
+
+	ids := []uint{secretA.ID, secretB.ID}
+	localResult, err := h.ls.ListSharesBySecretIDs(ctx, ids)
+	require.NoError(t, err)
+	require.Len(t, localResult, 1)
+
+	// FOUND DEFECT (transitively, from ListSharesBySecret's own bug -- see the
+	// package doc and TestConformance_ListSharesBySecret): RemoteStorage.
+	// ListSharesBySecretIDs loops rs.ListSharesBySecret once per ID, so it
+	// inherits the identical bare-slice-vs-{"shares":[...]}-envelope mismatch
+	// and fails on the FIRST id in any non-empty batch, regardless of ownership
+	// -- confirmed here with a genuine live owner of every secret in the batch,
+	// so the failure is the parse bug, not an authorization gate. This also
+	// means the #407 "fail the whole batch on an unauthorized id" contract
+	// documented in remote_sharing.go cannot currently be distinguished from
+	// this parse bug by an external caller -- both surface as the same opaque
+	// error today. Not fixed here, per the task brief -- pinned.
+	_, err = rsAsOwner.ListSharesBySecretIDs(ctx, ids)
+	require.Error(t, err,
+		"FOUND DEFECT: RemoteStorage.ListSharesBySecretIDs must currently fail for ANY non-empty batch, even "+
+			"one the caller owns entirely -- it inherits ListSharesBySecret's bare-slice-vs-envelope parse bug")
+	assert.Contains(t, err.Error(), "failed to parse response")
+
+	// Negative: empty input is a genuine no-op on both paths -- RemoteStorage's
+	// loop makes zero HTTP calls for an empty id list, so it never reaches the
+	// broken parse path at all.
+	emptyLocal, err := h.ls.ListSharesBySecretIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	emptyRemote, err := rsAsOwner.ListSharesBySecretIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, emptyRemote)
+}
+
+// --- ListSharesByGroup ---
+
+func TestConformance_ListSharesByGroup(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	owner := newConformanceTestUser(t, h, "lsbg-owner")
+	group, err := h.upstreamCore.CreateGroup(ctx, h.adminUserID, &core.CreateGroupRequest{Name: "conformance-lsbg-group"})
+	require.NoError(t, err)
+	secret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-lsbg-secret", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password", OwnerID: owner.ID,
+	})
+	require.NoError(t, err)
+	share, err := h.ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secret.ID, OwnerID: owner.ID, RecipientID: group.ID, IsGroup: true, Permission: "write",
+	})
+	require.NoError(t, err)
+
+	localOut, err := h.ls.ListSharesByGroup(ctx, group.ID)
+	require.NoError(t, err)
+	require.Len(t, localOut, 1)
+	_ = share
+
+	// FOUND DEFECT: RemoteStorage.ListSharesByGroup is unconditionally broken
+	// against a real server, for every call, success or not. GET
+	// /api/v1/groups/{id}/shares (shares_query.go's ListGroupShares) wraps its
+	// response as {"shares": [...]} --
+	//
+	//	h.sendSuccess(w, map[string]interface{}{"shares": shares}, "")
+	//
+	// -- but RemoteStorage.ListSharesByGroup (remote_sharing.go) decodes
+	// resp.Data straight into a bare `var result []*models.ShareRecord`, never
+	// unwrapping the "shares" envelope key. json.Unmarshal of a JSON OBJECT into
+	// a Go SLICE always fails, regardless of content, so this method 100% fails
+	// every real call, non-empty or empty alike -- not an edge case, the ONLY
+	// case. Confirmed directly against the real router below (not a mock), and
+	// cross-checked against every sibling in this file: ListSharesByOwner/
+	// ListSharesByUser correctly decode into `struct{ Shares []*models.ShareRecord
+	// }`, so this is a genuine one-off omission in ListSharesByGroup specifically,
+	// not a wrapping convention this repo lacks. Not fixed here (this file adds
+	// tests only, no production changes) -- pinned so a future fix flips this
+	// from red to green rather than a silent regression going unnoticed.
+	_, err = h.rs.ListSharesByGroup(ctx, group.ID)
+	require.Error(t, err,
+		"FOUND DEFECT: RemoteStorage.ListSharesByGroup must currently fail on ANY call -- it decodes the server's "+
+			"{\"shares\": [...]} envelope directly into a bare slice, which json.Unmarshal always rejects")
+	assert.Contains(t, err.Error(), "failed to parse response")
+
+	// Negative (still pinning the same defect): even a group with zero shares
+	// gets the identical envelope shape server-side, so it 500s/fails to parse
+	// too, not a clean empty list.
+	emptyGroup, err := h.upstreamCore.CreateGroup(ctx, h.adminUserID, &core.CreateGroupRequest{Name: "conformance-lsbg-empty"})
+	require.NoError(t, err)
+	emptyLocal, err := h.ls.ListSharesByGroup(ctx, emptyGroup.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	_, err = h.rs.ListSharesByGroup(ctx, emptyGroup.ID)
+	assert.Error(t, err, "the same envelope-vs-bare-slice mismatch fails an empty-result call too")
+}
+
+// --- ListSharesByOwner ---
+
+func TestConformance_ListSharesByOwner(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	owner := newConformanceTestUser(t, h, "lsbo-owner")
+	recipient := newConformanceTestUser(t, h, "lsbo-recipient")
+	secret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-lsbo-secret", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password", OwnerID: owner.ID,
+	})
+	require.NoError(t, err)
+	share, err := h.ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secret.ID, OwnerID: owner.ID, RecipientID: recipient.ID, Permission: "write",
+	})
+	require.NoError(t, err)
+
+	localOut, err := h.ls.ListSharesByOwner(ctx, owner.ID)
+	require.NoError(t, err)
+	require.Len(t, localOut, 1)
+
+	// A raw /api/v1/system/shares/by-owner/{ownerID} proxy (system.read tier) --
+	// h.rs's admin machine credential drives this directly.
+	remoteOut, err := h.rs.ListSharesByOwner(ctx, owner.ID)
+	require.NoError(t, err, "RemoteStorage.ListSharesByOwner must succeed via the /system proxy route")
+	require.Len(t, remoteOut, 1)
+	assertFieldExhaustiveEqual(t, "ListSharesByOwner (RemoteStorage vs LocalStorage, same row)", share, remoteOut[0], map[string]bool{})
+
+	// Negative: an owner with no shares gets an empty list.
+	bystander := newConformanceTestUser(t, h, "lsbo-bystander")
+	emptyLocal, err := h.ls.ListSharesByOwner(ctx, bystander.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	emptyRemote, err := h.rs.ListSharesByOwner(ctx, bystander.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyRemote)
+}
+
+// --- ListSharesByUser ---
+
+func TestConformance_ListSharesByUser(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	owner := newConformanceTestUser(t, h, "lsbu-owner")
+	recipient := newConformanceTestUser(t, h, "lsbu-recipient")
+	secret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-lsbu-secret", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password", OwnerID: owner.ID,
+	})
+	require.NoError(t, err)
+	share, err := h.ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: secret.ID, OwnerID: owner.ID, RecipientID: recipient.ID, Permission: "read",
+	})
+	require.NoError(t, err)
+
+	localOut, err := h.ls.ListSharesByUser(ctx, recipient.ID)
+	require.NoError(t, err)
+	require.Len(t, localOut, 1)
+
+	// A raw /api/v1/system/shares/by-user/{userID} proxy (system.read tier) --
+	// h.rs's admin machine credential drives this directly.
+	remoteOut, err := h.rs.ListSharesByUser(ctx, recipient.ID)
+	require.NoError(t, err, "RemoteStorage.ListSharesByUser must succeed via the /system proxy route")
+	require.Len(t, remoteOut, 1)
+	assertFieldExhaustiveEqual(t, "ListSharesByUser (RemoteStorage vs LocalStorage, same row)", share, remoteOut[0], map[string]bool{})
+
+	// Negative: a user with no shares received gets an empty list.
+	bystander := newConformanceTestUser(t, h, "lsbu-bystander")
+	emptyLocal, err := h.ls.ListSharesByUser(ctx, bystander.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	emptyRemote, err := h.rs.ListSharesByUser(ctx, bystander.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyRemote)
+}
+
+// --- UpdateShareRecord ---
+
+func TestConformance_UpdateShareRecord(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	recipient := newConformanceTestUser(t, h, "usr-recipient")
+	newExpiry := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+
+	// local: raw storage round trip, sanity baseline -- both Permission and
+	// ExpiresAt changes must apply.
+	localOwner := newConformanceTestUser(t, h, "usr-owner-local")
+	localSecret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-usr-secret-local", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password", OwnerID: localOwner.ID,
+	})
+	require.NoError(t, err)
+	localShare, err := h.ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: localSecret.ID, OwnerID: localOwner.ID, RecipientID: recipient.ID, Permission: "read",
+	})
+	require.NoError(t, err)
+	localShare.Permission = "write"
+	localShare.ExpiresAt = &newExpiry
+	localUpdated, err := h.ls.UpdateShareRecord(ctx, localShare)
+	require.NoError(t, err)
+	assert.Equal(t, "write", localUpdated.Permission, "sanity: local Permission change must apply")
+	require.NotNil(t, localUpdated.ExpiresAt, "sanity: local ExpiresAt change must apply")
+	assert.True(t, newExpiry.Equal(*localUpdated.ExpiresAt))
+
+	// remote: UpdateShareRecord proxies onto the human-facing, owner-gated
+	// PUT /api/v1/shares/{id} route -- needs a real live-owner session, see the
+	// package doc.
+	remoteOwner, rsAsOwner := newSharingOwnerSession(t, h, "usr-remote")
+	remoteSecret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-usr-secret-remote", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password", OwnerID: remoteOwner.ID,
+	})
+	require.NoError(t, err)
+	remoteShare, err := h.ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: remoteSecret.ID, OwnerID: remoteOwner.ID, RecipientID: recipient.ID, Permission: "read",
+	})
+	require.NoError(t, err)
+	remoteShare.Permission = "write"
+	remoteShare.ExpiresAt = &newExpiry
+	remoteUpdated, err := rsAsOwner.UpdateShareRecord(ctx, remoteShare)
+	require.NoError(t, err, "RemoteStorage.UpdateShareRecord must succeed for the share's genuine live owner")
+	assert.Equal(t, "write", remoteUpdated.Permission,
+		"the Permission change must land server-side -- ShareRecord.Permission has no json tag, so its bare Go "+
+			"field name round-trips case-insensitively onto the handler's `permission` json tag")
+
+	// FOUND DEFECT (see package doc): ExpiresAt can never change through this
+	// wire path. Pinning the CURRENT (buggy) behavior deliberately -- this
+	// assertion should start failing, not be deleted, the day someone fixes the
+	// key-name mismatch.
+	persisted, err := h.ls.GetShareRecord(ctx, remoteShare.ID)
+	require.NoError(t, err)
+	assert.Nil(t, persisted.ExpiresAt,
+		"FOUND DEFECT: RemoteStorage.UpdateShareRecord cannot change ExpiresAt at all. ShareRecord carries no "+
+			"json tags, so marshaling it sends the bare Go field name \"ExpiresAt\"; the handler's reqBody expects "+
+			"the JSON key \"expires_at\". encoding/json's case-insensitive fallback does not bridge an "+
+			"underscore difference (confirmed empirically), so this field is silently dropped on every call and "+
+			"the share's ExpiresAt never changes from whatever it already was (nil here, since the share was "+
+			"created with none) -- not fixed in this file (tests only, no production changes), just pinned so a "+
+			"future fix flips this from red to green instead of a silent regression going unnoticed.")
+
+	// Negative: updating a nonexistent share ID fails on both paths.
+	_, err = h.ls.UpdateShareRecord(ctx, &models.ShareRecord{ID: 9999999, Permission: "read"})
+	assert.Error(t, err)
+	_, err = rsAsOwner.UpdateShareRecord(ctx, &models.ShareRecord{ID: 9999999, Permission: "read"})
+	assert.Error(t, err)
+}
+
+// --- DeleteShareRecord ---
+
+func TestConformance_DeleteShareRecord(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	recipient := newConformanceTestUser(t, h, "dsr-recipient")
+
+	// local: raw storage, no authz needed.
+	localOwner := newConformanceTestUser(t, h, "dsr-owner-local")
+	localSecret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-dsr-secret-local", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password", OwnerID: localOwner.ID,
+	})
+	require.NoError(t, err)
+	localShare, err := h.ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: localSecret.ID, OwnerID: localOwner.ID, RecipientID: recipient.ID, Permission: "read",
+	})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.DeleteShareRecord(ctx, localShare.ID))
+	_, err = h.ls.GetShareRecord(ctx, localShare.ID)
+	assert.Error(t, err, "sanity: the locally-deleted share must be gone")
+
+	// remote: DeleteShareRecord proxies onto the human-facing, owner-gated
+	// DELETE /api/v1/shares/{id} route (core.RevokeShare's requireLiveOwnerAuthority)
+	// -- needs a real live-owner session, see the package doc.
+	remoteOwner, rsAsOwner := newSharingOwnerSession(t, h, "dsr-remote")
+	remoteSecret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-dsr-secret-remote", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password", OwnerID: remoteOwner.ID,
+	})
+	require.NoError(t, err)
+	remoteShare, err := h.ls.CreateShareRecord(ctx, &models.ShareRecord{
+		SecretID: remoteSecret.ID, OwnerID: remoteOwner.ID, RecipientID: recipient.ID, Permission: "read",
+	})
+	require.NoError(t, err)
+	require.NoError(t, rsAsOwner.DeleteShareRecord(ctx, remoteShare.ID),
+		"RemoteStorage.DeleteShareRecord must succeed for the share's genuine live owner")
+	_, err = h.ls.GetShareRecord(ctx, remoteShare.ID)
+	assert.Error(t, err, "the share revoked via RemoteStorage must actually be gone server-side, not just report success")
+
+	// Negative: revoking an already-revoked/nonexistent share fails identically on both paths.
+	assert.Error(t, h.ls.DeleteShareRecord(ctx, localShare.ID))
+	assert.Error(t, rsAsOwner.DeleteShareRecord(ctx, remoteShare.ID))
+}
+
+// --- DeleteExpiredShareRecords ---
+
+func TestConformance_DeleteExpiredShareRecords(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	recipient := newConformanceTestUser(t, h, "desr-recipient")
+	past := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+	future := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+	cutoff := time.Now().UTC()
+
+	newShare := func(suffix string, expiresAt time.Time) *models.ShareRecord {
+		owner := newConformanceTestUser(t, h, "desr-owner-"+suffix)
+		secret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+			Name: "conformance-desr-secret-" + suffix, ProjectID: h.projectID, EnvironmentID: h.environmentID,
+			Type: "password", OwnerID: owner.ID,
+		})
+		require.NoError(t, err)
+		expiry := expiresAt
+		share, err := h.ls.CreateShareRecord(ctx, &models.ShareRecord{
+			SecretID: secret.ID, OwnerID: owner.ID, RecipientID: recipient.ID, Permission: "read", ExpiresAt: &expiry,
+		})
+		require.NoError(t, err)
+		return share
+	}
+
+	// Local: one already-expired share (must be purged) and one not-yet-expired
+	// share (must survive).
+	localExpired := newShare("local-expired", past)
+	localFuture := newShare("local-future", future)
+	localRemoved, err := h.ls.DeleteExpiredShareRecords(ctx, cutoff)
+	require.NoError(t, err)
+	assert.True(t, containsShareID(localRemoved, localExpired.ID), "sanity: LocalStorage must report the expired share it purged")
+	_, err = h.ls.GetShareRecord(ctx, localExpired.ID)
+	assert.Error(t, err, "sanity: the purged share must no longer be retrievable")
+	_, err = h.ls.GetShareRecord(ctx, localFuture.ID)
+	assert.NoError(t, err, "sanity: the not-yet-expired share must survive")
+
+	// Remote: a raw /api/v1/system/retention/share-records/purge-expired proxy
+	// (system.write tier) -- h.rs's admin machine credential drives this directly,
+	// unlike UpdateShareRecord/DeleteShareRecord/ListSharesBySecret above.
+	remoteExpired := newShare("remote-expired", past)
+	remoteFuture := newShare("remote-future", future)
+	remoteRemoved, err := h.rs.DeleteExpiredShareRecords(ctx, cutoff)
+	require.NoError(t, err, "RemoteStorage.DeleteExpiredShareRecords must succeed and report the purged shares")
+	assert.True(t, containsShareID(remoteRemoved, remoteExpired.ID),
+		"RemoteStorage.DeleteExpiredShareRecords must actually report the expired share it purged server-side, not just an empty/wrong list")
+
+	_, err = h.ls.GetShareRecord(ctx, remoteExpired.ID)
+	assert.Error(t, err, "the expired share purged via RemoteStorage must actually be gone server-side")
+	_, err = h.ls.GetShareRecord(ctx, remoteFuture.ID)
+	assert.NoError(t, err, "RemoteStorage.DeleteExpiredShareRecords must NOT touch a share that has not yet expired")
+
+	var removedShare *models.ShareRecord
+	for _, s := range remoteRemoved {
+		if s.ID == remoteExpired.ID {
+			removedShare = s
+		}
+	}
+	require.NotNil(t, removedShare)
+	assertFieldExhaustiveEqual(t, "DeleteExpiredShareRecords (removed row round trip)", remoteExpired, removedShare, map[string]bool{})
+}
+
+// ============================================================================
+// Group B — remote_secrets.go
+// ============================================================================
+
+// --- GetSecret ---
+
+func TestConformance_GetSecret(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	maxReads := 3
+	expiry := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+	created, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-gs-secret", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password",
+		Description: "conformance test secret", MaxReads: &maxReads, Expiration: &expiry,
+		Classification: "internal", Metadata: models.JSON(`{"k":"v"}`), OwnerID: h.adminUserID,
+	})
+	require.NoError(t, err)
+
+	// GetSecret's handler branches on isMachine and fetches directly with no
+	// permission check at all for a machine principal (already authorized at
+	// the route's scoped-permission gate) -- h.rs drives this fine.
+	localOut, err := h.ls.GetSecret(ctx, created.ID)
+	require.NoError(t, err)
+	remoteOut, err := h.rs.GetSecret(ctx, created.ID)
+	require.NoError(t, err, "RemoteStorage.GetSecret must succeed for a secret that genuinely exists")
+
+	assertFieldExhaustiveEqual(t, "GetSecret (RemoteStorage vs LocalStorage, same row)", localOut, remoteOut, map[string]bool{})
+
+	// Negative: a nonexistent ID fails identically on both paths.
+	_, err = h.ls.GetSecret(ctx, 9999999)
+	assert.Error(t, err)
+	_, err = h.rs.GetSecret(ctx, 9999999)
+	assert.Error(t, err)
+}
+
+// --- GetSecretIncludingDeleted ---
+
+func TestConformance_GetSecretIncludingDeleted(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	created, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-gsid-secret", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password",
+	})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.DeleteSecret(ctx, created.ID))
+
+	localOut, err := h.ls.GetSecretIncludingDeleted(ctx, created.ID)
+	require.NoError(t, err)
+	assert.True(t, localOut.DeletedAt.Valid, "sanity: the secret must be soft-deleted")
+
+	// A raw /api/v1/system/secrets/{id}/including-deleted proxy (system.read
+	// tier, Unscoped lookup) -- h.rs drives this directly.
+	remoteOut, err := h.rs.GetSecretIncludingDeleted(ctx, created.ID)
+	require.NoError(t, err, "RemoteStorage.GetSecretIncludingDeleted must reach a soft-deleted secret via the system proxy route")
+
+	assertFieldExhaustiveEqual(t, "GetSecretIncludingDeleted (RemoteStorage vs LocalStorage, same row)", localOut, remoteOut, map[string]bool{})
+
+	// Negative: an ID that never existed fails on both paths.
+	_, err = h.ls.GetSecretIncludingDeleted(ctx, 9999999)
+	assert.Error(t, err)
+	_, err = h.rs.GetSecretIncludingDeleted(ctx, 9999999)
+	assert.Error(t, err)
+}
+
+// --- GetSecretsByIDs ---
+
+func TestConformance_GetSecretsByIDs(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	secretA, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-gsbi-a", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password"})
+	require.NoError(t, err)
+	secretB, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-gsbi-b", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password"})
+	require.NoError(t, err)
+
+	ids := []uint{secretA.ID, secretB.ID, 9999999} // the third ID does not exist
+
+	localOut, err := h.ls.GetSecretsByIDs(ctx, ids)
+	require.NoError(t, err)
+	assert.Len(t, localOut, 2, "sanity: a nonexistent ID is simply absent from the result, not an error")
+
+	// RemoteStorage.GetSecretsByIDs loops rs.GetSecret per ID, skipping IDs that
+	// fail rather than failing the whole batch (#409's rotation planner already
+	// treats a missing ID this way) -- h.rs drives each underlying GetSecret call
+	// fine (machine-bypass path).
+	remoteOut, err := h.rs.GetSecretsByIDs(ctx, ids)
+	require.NoError(t, err, "RemoteStorage.GetSecretsByIDs must succeed and skip the nonexistent ID rather than failing the whole batch")
+	require.Len(t, remoteOut, 2)
+
+	assertFieldExhaustiveEqual(t, "GetSecretsByIDs[A]", secretByID(t, localOut, secretA.ID), secretByID(t, remoteOut, secretA.ID), map[string]bool{})
+	assertFieldExhaustiveEqual(t, "GetSecretsByIDs[B]", secretByID(t, localOut, secretB.ID), secretByID(t, remoteOut, secretB.ID), map[string]bool{})
+
+	// Negative: an all-nonexistent batch returns an empty (not error) slice on both paths.
+	emptyLocal, err := h.ls.GetSecretsByIDs(ctx, []uint{9999999})
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	emptyRemote, err := h.rs.GetSecretsByIDs(ctx, []uint{9999999})
+	require.NoError(t, err)
+	assert.Empty(t, emptyRemote)
+}
+
+// --- GetSecretVersions / ListSecretVersions ---
+//
+// Both need a real human session: GetSecretVersionsWithPermissionCheck hard-fails
+// with "user ID is required" for ANY userID==0 caller -- a machine credential's
+// UserContext never has UserID set (only MachineIdentityID), so h.rs itself can
+// never drive this route regardless of the RBAC it holds. See the package doc.
+//
+// FOUND DEFECT, same class as ListSharesByGroup above: GET
+// /api/v1/secrets/{id}/versions (secrets_versions.go's GetSecretVersions
+// handler) wraps its response as {"versions": [...]} --
+//
+//	h.sendSuccess(w, map[string]any{"versions": versions}, "")
+//
+// -- but RemoteStorage.ListSecretVersions (remote_secrets.go), and its alias
+// GetSecretVersions, both decode resp.Data straight into a bare
+// `var result []*models.SecretVersion`, never unwrapping the "versions"
+// envelope key. json.Unmarshal of a JSON OBJECT into a Go SLICE always fails,
+// so BOTH RemoteStorage entry points 100% fail on every real call, non-empty
+// or empty alike. Confirmed directly against the real router (not a mock).
+// Not fixed here (this file adds tests only) -- pinned so a future fix flips
+// these from red to green rather than a silent regression going unnoticed.
+
+func seedSecretVersions(t *testing.T, h *conformanceHarness, suffix string) (secretID uint, v1, v2 *models.SecretVersion) {
+	t.Helper()
+	ctx := context.Background()
+	secret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+		Name: "conformance-sv-secret-" + suffix, ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password",
+	})
+	require.NoError(t, err)
+	v1, err = h.ls.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: secret.ID, VersionNumber: 1, EncryptedValue: []byte("ciphertext-v1"), EncryptionMetadata: models.JSON(`{"alg":"aes"}`),
+	})
+	require.NoError(t, err)
+	v2, err = h.ls.CreateSecretVersion(ctx, &models.SecretVersion{
+		SecretNodeID: secret.ID, VersionNumber: 2, EncryptedValue: []byte("ciphertext-v2"), EncryptionMetadata: models.JSON(`{"alg":"aes"}`),
+	})
+	require.NoError(t, err)
+	return secret.ID, v1, v2
+}
+
+func TestConformance_GetSecretVersions(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	rsAsUser := newSecretsHumanSession(t, h)
+
+	secretID, _, _ := seedSecretVersions(t, h, "gsv")
+
+	localOut, err := h.ls.GetSecretVersions(ctx, secretID)
+	require.NoError(t, err)
+	require.Len(t, localOut, 2)
+
+	_, err = rsAsUser.GetSecretVersions(ctx, secretID)
+	require.Error(t, err,
+		"FOUND DEFECT: RemoteStorage.GetSecretVersions must currently fail on ANY call -- it decodes the "+
+			"server's {\"versions\": [...]} envelope directly into a bare slice, which json.Unmarshal always rejects")
+	assert.Contains(t, err.Error(), "failed to parse response")
+
+	// Negative (still pinning the same defect): a secret with no versions gets
+	// the identical envelope shape server-side, so it fails to parse too, not
+	// a clean empty list.
+	emptySecret, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-gsv-empty", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password"})
+	require.NoError(t, err)
+	emptyLocal, err := h.ls.GetSecretVersions(ctx, emptySecret.ID)
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	_, err = rsAsUser.GetSecretVersions(ctx, emptySecret.ID)
+	assert.Error(t, err, "the same envelope-vs-bare-slice mismatch fails an empty-result call too")
+}
+
+func TestConformance_ListSecretVersions(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	rsAsUser := newSecretsHumanSession(t, h)
+
+	secretID, _, _ := seedSecretVersions(t, h, "lsv")
+
+	localOut, err := h.ls.GetSecretVersions(ctx, secretID)
+	require.NoError(t, err)
+	require.Len(t, localOut, 2)
+
+	// ListSecretVersions is RemoteStorage's own additional name for the
+	// identical call GetSecretVersions makes (a literal alias -- see
+	// remote_secrets.go); LocalStorage has no separate ListSecretVersions
+	// method at all. This test exercises that entry point by name, distinct
+	// from TestConformance_GetSecretVersions above, and hits the SAME found
+	// defect since it's a straight passthrough to GetSecretVersions.
+	_, err = rsAsUser.ListSecretVersions(ctx, secretID)
+	require.Error(t, err,
+		"FOUND DEFECT: RemoteStorage.ListSecretVersions must currently fail on ANY call, same envelope mismatch as GetSecretVersions")
+	assert.Contains(t, err.Error(), "failed to parse response")
+}
+
+// --- ListSecrets ---
+
+func TestConformance_ListSecrets(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	secretA, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-lsecrets-a", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password"})
+	require.NoError(t, err)
+	secretB, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-lsecrets-b", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password"})
+	require.NoError(t, err)
+
+	// PageSize must be set explicitly: LocalStorage.ListSecrets's own
+	// clampPageSize passes a caller-supplied 0 straight through as 0 ("several
+	// callers rely on 0 meaning use my own default", per its doc comment) --
+	// but ListSecrets itself applies no such default, so GORM's Limit(0) then
+	// returns ZERO rows. RemoteStorage's path goes through core.ListSecretsInScope,
+	// which DOES default PageSize<1 to 20 before ever reaching the same
+	// LocalStorage.ListSecrets call -- so comparing the two storage backends
+	// fairly requires supplying the same explicit PageSize a real caller (every
+	// core-layer entry point) always would, on both sides.
+	filter := &coreStorage.SecretFilter{ProjectID: &h.projectID, EnvironmentID: &h.environmentID, Page: 1, PageSize: 20}
+
+	localSecrets, localTotal, err := h.ls.ListSecrets(ctx, filter)
+	require.NoError(t, err)
+
+	// RemoteStorage.ListSecrets proxies onto GET /api/v1/secrets, which for a
+	// machine/node credential (ADR-030) requires an explicit project_id
+	// (CWE-862 guard, secrets_list.go) and runs core.ListSecretsInScope rather
+	// than a raw storage.ListSecrets passthrough -- but ListSecretsInScope's own
+	// body calls c.storage.ListSecrets with the SAME filter shape, then just
+	// sorts/paginates in memory, so the ROW SET for this unfiltered scope is
+	// identical; only ordering and the wrapper type differ.
+	remoteSecrets, remoteTotal, err := h.rs.ListSecrets(ctx, filter)
+	require.NoError(t, err, "RemoteStorage.ListSecrets must succeed for a machine credential that supplies project_id")
+
+	assert.Equal(t, localTotal, remoteTotal, "the total count for the same scope must match")
+
+	idSet := func(secrets []*models.SecretNode) map[uint]*models.SecretNode {
+		m := make(map[uint]*models.SecretNode, len(secrets))
+		for _, s := range secrets {
+			m[s.ID] = s
+		}
+		return m
+	}
+	localByID := idSet(localSecrets)
+	remoteByID := idSet(remoteSecrets)
+	require.Len(t, remoteByID, len(localByID), "the same set of secret IDs must come back on both paths")
+	require.Contains(t, localByID, secretA.ID)
+	require.Contains(t, localByID, secretB.ID)
+
+	for id, local := range localByID {
+		remote, ok := remoteByID[id]
+		require.True(t, ok, "secret %d present locally must also be present via RemoteStorage.ListSecrets", id)
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("ListSecrets[%d]", id), local, remote, map[string]bool{
+			// models.SecretWithSharingInfo (the type ListSecretsInScope's response
+			// actually carries) embeds *SecretNode anonymously AND declares its
+			// OWN IsShared field -- the outer field (always false here, since
+			// ListSecretsInScope attaches no sharing info) shadows the embedded
+			// SecretNode's real IsShared for JSON marshaling by Go's own
+			// promoted-field rule, regardless of the raw row's actual value. A
+			// pre-existing model-shape quirk in SecretWithSharingInfo, not a
+			// RemoteStorage wire-fidelity defect this harness's CreateSecret/
+			// UpdateSecret siblings exist to catch -- neither secret here is
+			// ever shared, so this doesn't mask a real divergence in this test.
+			"IsShared": true,
+		})
+	}
+
+	// Negative: a machine/node credential without project_id must be rejected
+	// (CWE-862 guard) -- otherwise it could enumerate secrets across every project.
+	_, _, err = h.rs.ListSecrets(ctx, &coreStorage.SecretFilter{})
+	assert.Error(t, err, "a machine/node credential must be required to supply project_id")
+}
+
+// --- RestoreSecret ---
+
+func TestConformance_RestoreSecret(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newDeletedSecret := func(suffix string) *models.SecretNode {
+		secret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+			Name: "conformance-rs-secret-" + suffix, ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password",
+		})
+		require.NoError(t, err)
+		require.NoError(t, h.ls.DeleteSecret(ctx, secret.ID))
+		return secret
+	}
+
+	localSecret := newDeletedSecret("local")
+	require.NoError(t, h.ls.RestoreSecret(ctx, localSecret.ID))
+	localAfter, err := h.ls.GetSecret(ctx, localSecret.ID)
+	require.NoError(t, err, "sanity: the locally-restored secret must be readable again through the normal getter")
+	assert.False(t, localAfter.DeletedAt.Valid)
+
+	// core.RestoreSecret (behind POST /api/v1/secrets/{id}/restore) calls
+	// storage.RestoreSecret directly with no internal UserID==0 guard -- h.rs's
+	// admin machine credential drives this fine, unlike UpdateSecret below.
+	remoteSecret := newDeletedSecret("remote")
+	require.NoError(t, h.rs.RestoreSecret(ctx, remoteSecret.ID),
+		"RemoteStorage.RestoreSecret must succeed for a secret that is genuinely soft-deleted")
+	remoteAfter, err := h.ls.GetSecret(ctx, remoteSecret.ID)
+	require.NoError(t, err, "the secret restored via RemoteStorage must actually be readable again server-side, not just report success")
+	assert.False(t, remoteAfter.DeletedAt.Valid)
+
+	// Negative: restoring a secret that is NOT deleted must fail identically on both paths.
+	activeLocal, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-rs-active-local", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password"})
+	require.NoError(t, err)
+	assert.Error(t, h.ls.RestoreSecret(ctx, activeLocal.ID), "sanity: restoring an already-active secret must fail")
+
+	activeRemote, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-rs-active-remote", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password"})
+	require.NoError(t, err)
+	assert.Error(t, h.rs.RestoreSecret(ctx, activeRemote.ID),
+		"RemoteStorage.RestoreSecret must refuse to restore a secret that is not deleted, not silently no-op success")
+}
+
+// --- UpdateSecret ---
+
+func TestConformance_UpdateSecret(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+	rsAsUser := newSecretsHumanSession(t, h)
+
+	newActiveSecret := func(suffix string) *models.SecretNode {
+		secret, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+			Name: "conformance-us-secret-" + suffix, ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password",
+		})
+		require.NoError(t, err)
+		fresh, err := h.ls.GetSecret(ctx, secret.ID)
+		require.NoError(t, err)
+		return fresh
+	}
+
+	maxReads := 5
+	expiry := time.Now().Add(72 * time.Hour).UTC().Truncate(time.Second)
+
+	// Sanity baseline: LocalStorage.UpdateSecret is a raw Save with no field narrowing at all.
+	localSecret := newActiveSecret("local")
+	localSecret.Type = "api_key"
+	localSecret.Description = "conformance updated description"
+	localSecret.MaxReads = &maxReads
+	localSecret.Expiration = &expiry
+	localSecret.Metadata = models.JSON(`{"note":"conformance-test"}`)
+	localUpdated, err := h.ls.UpdateSecret(ctx, localSecret)
+	require.NoError(t, err)
+	assert.Equal(t, "api_key", localUpdated.Type)
+
+	// RemoteStorage.UpdateSecret proxies onto PUT /api/v1/secrets/{id}, which
+	// runs a default-deny diff against the hub's own authoritative row
+	// (secret_update_diff.go, #G80 Phase 0): only Type/Description/MaxReads/
+	// Expiration/Metadata may change through this endpoint; every other field
+	// must be byte-identical to the hub's current row or the WHOLE request is
+	// rejected. Matching tranche3's TransitionSecretStatus precedent, a fair
+	// comparison mutates ONLY the fields a real caller (core.UpdateSecret) is
+	// allowed to change.
+	remoteSecret := newActiveSecret("remote")
+	remoteSecret.Type = "api_key"
+	remoteSecret.Description = "conformance updated description"
+	remoteSecret.MaxReads = &maxReads
+	remoteSecret.Expiration = &expiry
+	remoteSecret.Metadata = models.JSON(`{"note":"conformance-test"}`)
+	remoteUpdated, err := rsAsUser.UpdateSecret(ctx, remoteSecret)
+	require.NoError(t, err, "RemoteStorage.UpdateSecret must succeed when only allowlisted fields change")
+
+	persisted, err := h.ls.GetSecret(ctx, remoteSecret.ID)
+	require.NoError(t, err)
+
+	exclude := map[string]bool{
+		// secretFieldIgnored (secret_update_diff.go): the hub always stamps its
+		// own now(), the client-supplied value is never even inspected.
+		"UpdatedAt": true,
+	}
+	assertFieldExhaustiveEqual(t, "LocalStorage.UpdateSecret (sanity baseline)", localSecret, localUpdated, exclude)
+	assertFieldExhaustiveEqual(t, "RemoteStorage.UpdateSecret (wire round trip)", remoteSecret, remoteUpdated, exclude)
+	assertFieldExhaustiveEqual(t, "RemoteStorage.UpdateSecret (persisted server-side)", remoteSecret, persisted, exclude)
+
+	// Negative: a rejected field (Name -- BulkRenameSecrets' own gate, not this
+	// endpoint's) must fail the WHOLE request, by name, rather than silently
+	// applying the allowed fields and ignoring the rest.
+	renamed := newActiveSecret("rejected")
+	renamed.Name = "conformance-us-renamed"
+	_, err = rsAsUser.UpdateSecret(ctx, renamed)
+	require.Error(t, err, "RemoteStorage.UpdateSecret must refuse a request that also changes a non-allowlisted field")
+	assert.Contains(t, err.Error(), "name")
+	stillOriginal, err := h.ls.GetSecret(ctx, renamed.ID)
+	require.NoError(t, err)
+	assert.NotEqual(t, "conformance-us-renamed", stillOriginal.Name, "a rejected update must not partially apply")
+}
+
+// ============================================================================
+// Group C — remote_secret_dependencies.go
+// ============================================================================
+
+// --- CreateSecretDependencyExclusive ---
+
+func TestConformance_CreateSecretDependencyExclusive(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newSecret := func(suffix string) *models.SecretNode {
+		s, err := h.ls.CreateSecret(ctx, &models.SecretNode{
+			Name: "conformance-csde-" + suffix, ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password",
+		})
+		require.NoError(t, err)
+		return s
+	}
+
+	// local: raw storage, sanity baseline.
+	localA, localB := newSecret("local-a"), newSecret("local-b")
+	localDep, err := h.ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: h.projectID, DependentSecretID: localA.ID, DependsOnSecretID: localB.ID,
+		Note: "conformance local dep", CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err)
+
+	// Duplicate must be rejected with the sentinel error.
+	_, err = h.ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: h.projectID, DependentSecretID: localA.ID, DependsOnSecretID: localB.ID,
+	})
+	assert.ErrorIs(t, err, coreStorage.ErrDuplicateSecretDependency, "sanity: a duplicate edge must be rejected")
+
+	// Cycle must be rejected: B cannot then depend on A (A already depends on B).
+	_, err = h.ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: h.projectID, DependentSecretID: localB.ID, DependsOnSecretID: localA.ID,
+	})
+	assert.ErrorIs(t, err, coreStorage.ErrSecretDependencyCycle, "sanity: a reverse edge forming a 2-cycle must be rejected")
+
+	// remote: the SAME duplicate/cycle invariant must be enforced identically
+	// over the wire -- CreateSecretDependencyExclusiveProxy is gated on
+	// system.write, so h.rs's admin machine credential drives this directly.
+	remoteA, remoteB := newSecret("remote-a"), newSecret("remote-b")
+	remoteDep, err := h.rs.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: h.projectID, DependentSecretID: remoteA.ID, DependsOnSecretID: remoteB.ID,
+		Note: "conformance remote dep", CreatedBy: h.adminUserID,
+	})
+	require.NoError(t, err, "RemoteStorage.CreateSecretDependencyExclusive must succeed for a genuinely new, acyclic edge")
+
+	assertFieldExhaustiveEqual(t, "CreateSecretDependencyExclusive (local sanity baseline)",
+		localDep, mustGetSecretDependency(t, h, localDep.ID), map[string]bool{})
+	assertFieldExhaustiveEqual(t, "CreateSecretDependencyExclusive (wire round trip)",
+		remoteDep, mustGetSecretDependency(t, h, remoteDep.ID), map[string]bool{})
+
+	_, err = h.rs.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: h.projectID, DependentSecretID: remoteA.ID, DependsOnSecretID: remoteB.ID,
+	})
+	assert.ErrorIs(t, err, coreStorage.ErrDuplicateSecretDependency,
+		"RemoteStorage.CreateSecretDependencyExclusive must reject a duplicate edge with the SAME sentinel error "+
+			"LocalStorage uses, reconstructed from the wire error code")
+
+	_, err = h.rs.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: h.projectID, DependentSecretID: remoteB.ID, DependsOnSecretID: remoteA.ID,
+	})
+	assert.ErrorIs(t, err, coreStorage.ErrSecretDependencyCycle,
+		"RemoteStorage.CreateSecretDependencyExclusive must reject a cycle-forming edge with the SAME sentinel error LocalStorage uses")
+}
+
+// --- GetSecretDependency ---
+
+func TestConformance_GetSecretDependency(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	secretA, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-gsd-a", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password"})
+	require.NoError(t, err)
+	secretB, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-gsd-b", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password"})
+	require.NoError(t, err)
+	dep, err := h.ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: h.projectID, DependentSecretID: secretA.ID, DependsOnSecretID: secretB.ID, Note: "conformance dep",
+	})
+	require.NoError(t, err)
+
+	localOut, err := h.ls.GetSecretDependency(ctx, dep.ID)
+	require.NoError(t, err)
+	remoteOut, err := h.rs.GetSecretDependency(ctx, dep.ID)
+	require.NoError(t, err, "RemoteStorage.GetSecretDependency must succeed for an edge that genuinely exists")
+
+	assertFieldExhaustiveEqual(t, "GetSecretDependency (RemoteStorage vs LocalStorage, same row)", localOut, remoteOut, map[string]bool{})
+
+	// Negative: a nonexistent ID fails on both paths.
+	_, err = h.ls.GetSecretDependency(ctx, 9999999)
+	assert.Error(t, err)
+	_, err = h.rs.GetSecretDependency(ctx, 9999999)
+	assert.Error(t, err)
+}
+
+// --- ListSecretDependenciesForProject ---
+
+func TestConformance_ListSecretDependenciesForProject(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	otherProject, err := h.upstreamCore.CreateProjectWithEnvs(ctx, "conformance-lsdfp-other-project", "", []string{"dev"})
+	require.NoError(t, err)
+	otherEnvs, err := h.ls.ListEnvironmentsByProject(ctx, otherProject.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, otherEnvs)
+
+	secretA, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-lsdfp-a", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password"})
+	require.NoError(t, err)
+	secretB, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-lsdfp-b", ProjectID: h.projectID, EnvironmentID: h.environmentID, Type: "password"})
+	require.NoError(t, err)
+	dep, err := h.ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: h.projectID, DependentSecretID: secretA.ID, DependsOnSecretID: secretB.ID,
+	})
+	require.NoError(t, err)
+
+	// A dependency edge in a DIFFERENT project must not leak into this project's listing.
+	otherA, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-lsdfp-other-a", ProjectID: otherProject.ID, EnvironmentID: otherEnvs[0].ID, Type: "password"})
+	require.NoError(t, err)
+	otherB, err := h.ls.CreateSecret(ctx, &models.SecretNode{Name: "conformance-lsdfp-other-b", ProjectID: otherProject.ID, EnvironmentID: otherEnvs[0].ID, Type: "password"})
+	require.NoError(t, err)
+	_, err = h.ls.CreateSecretDependencyExclusive(ctx, &models.SecretDependency{
+		ProjectID: otherProject.ID, DependentSecretID: otherA.ID, DependsOnSecretID: otherB.ID,
+	})
+	require.NoError(t, err)
+
+	localOut, err := h.ls.ListSecretDependenciesForProject(ctx, h.projectID)
+	require.NoError(t, err)
+	require.Len(t, localOut, 1)
+
+	remoteOut, err := h.rs.ListSecretDependenciesForProject(ctx, h.projectID)
+	require.NoError(t, err, "RemoteStorage.ListSecretDependenciesForProject must succeed")
+	require.Len(t, remoteOut, 1,
+		"must return exactly this project's edge, not the other project's -- a dropped/ignored project_id filter "+
+			"on the wire would leak cross-project")
+
+	assertFieldExhaustiveEqual(t, "ListSecretDependenciesForProject[0]", dep, remoteOut[0], map[string]bool{})
+}

--- a/server/http/remote_storage_conformance_tranche4_users_test.go
+++ b/server/http/remote_storage_conformance_tranche4_users_test.go
@@ -1,0 +1,1353 @@
+// remote_storage_conformance_tranche4_users_test.go — issue #1808, tranche 4.
+//
+// Selection: this tranche is scoped by the task brief, not the mechanical
+// population sweep tranches 2/3 used — every real (non-stub) method declared
+// on *RemoteStorage in internal/storage/store/remote_users.go, with a
+// matching *LocalStorage implementation in local_users.go: the User/Group
+// surface tranche 2 and tranche 3 both explicitly deferred.
+//
+// DeleteUser: tranche 2's own doc comment excluded it ("core.DeleteUser is a
+// multi-step cascade ... that LocalStorage.DeleteUser's raw storage primitive
+// does not reproduce on its own"); tranche 3 repeated the exclusion
+// verbatim. Investigated here, not skipped: DELETE /api/v1/users/{id}
+// (users_crud.go's DeleteUser handler) runs core.KeyorixCore.DeleteUser's
+// FULL cascade server-side (deactivate, revoke every session, revoke every
+// PAT, THEN soft-delete, THEN audit — internal/core/users.go:629), while
+// LocalStorage.DeleteUser is a bare one-line `ls.db.Delete(&models.User{},
+// id)` with zero cascade. h.ls.DeleteUser(ctx, id) and h.rs.DeleteUser(ctx,
+// id) are therefore NOT "the same storage.Storage primitive over two
+// transports" the way DeleteSecret/DeleteProject are in tranches 2/3 — they
+// are genuinely different operations, because for this one method the wire
+// boundary this harness can observe sits between a raw storage primitive and
+// a route that runs full business logic, not between two implementations of
+// the same primitive. TestConformance_DeleteUser below adapts to that: it
+// compares two FULL executions of core.KeyorixCore.DeleteUser against the
+// SAME upstream core+storage — one driven in-process
+// (h.upstreamCore.DeleteUser), one driven over the real HTTP/router stack via
+// h.rs.DeleteUser (whose server-side handler invokes the IDENTICAL
+// core.DeleteUser method against that SAME upstreamCore instance) — and
+// verifies the cascade's real, observable effects (deactivation, session
+// revocation, PAT revocation, soft-delete, last-admin refusal) land
+// identically on both. This is the same class of question the harness exists
+// to ask (does going over the real router+handler stack change the
+// observable outcome of an operation this codebase considers one thing), just
+// answered at the core-method boundary instead of the storage.Storage
+// boundary for this one method, because that is where the real "same
+// operation, two paths" comparison actually lives here.
+//
+// CreateUser, UpdateUser, and RestoreUser share a lighter version of the same
+// asymmetry: each proxies onto a human-facing route
+// (POST/PUT/POST-restore /api/v1/users...) that runs core business logic
+// (buildUserForCreate's bcrypt hash + folding + PasswordChangedAt stamp;
+// UpdateUser's uniqueness/folding/conditional-write/deactivation-cascade
+// switch; RestoreUser's forced reactivation + AccountState reset), not a raw
+// storage.Storage passthrough — confirmed by tracing each handler
+// (users_crud.go) down to internal/core/users.go before writing these three
+// tests. A field-exhaustive struct comparison against LocalStorage's own bare
+// primitive would fail on fields core computes that the raw path never
+// touches (UsernameFolded/EmailFolded, PasswordHash, PasswordChangedAt,
+// forced IsActive/AccountState on restore) — none of which is a wire-fidelity
+// defect. These three tests instead assert the SPECIFIC fields each route's
+// wire DTO exists to protect (the #496 DisplayName/IsActive-dropped class),
+// and verify the change actually persisted server-side via a LocalStorage
+// readback, matching TransitionSecretStatus's (tranche 3) "compare each
+// side's own sent struct against its own persisted result" discipline for an
+// asymmetric route.
+//
+// Every other method below (GetUser family, UpdateUserIfActiveStateMatches,
+// ListUsers, ListUsersInStateBefore, CreateUserWithRoleGrants) proxies onto
+// either a route with no meaningful extra core logic beyond validation (the
+// four Get* user lookups — confirmed by tracing each to its
+// internal/core/users.go counterpart) or a genuine raw storage.Storage
+// passthrough (CreateUserWithRoleGrants and UpdateUserIfActiveStateMatches's
+// dedicated /api/v1/system/... routes, per their own doc comments) — these
+// get the full field-exhaustive treatment tranche 2/3 established for
+// genuine same-primitive comparisons.
+//
+// Group methods split down the middle, NOT uniformly raw as remote_users.go's
+// own package doc claims ("The new routes below are raw passthroughs onto
+// storage.Storage's own Group primitives instead") — that comment is stale
+// for the mutating routes. Traced directly against
+// server/http/handlers/groups_proxy.go (not inferred from the doc): GetGroup/
+// ListGroups/ListGroupsPage/ListGroupMembers/ListGroupMembersByGroupIDs/
+// GetUserGroups ARE raw storage.Storage passthroughs and get full
+// field-exhaustive treatment; CreateGroup/UpdateGroup/DeleteGroup/
+// RestoreGroup/AddUserToGroup/RemoveUserFromGroup all route through
+// core.KeyorixCore (CreateGroup/UpdateGroup/DeleteGroup/RestoreGroup/
+// AddUserToGroup/RemoveUserFromGroup respectively — each one's own doc
+// comment in groups_proxy.go names the specific ceiling this buys, e.g.
+// guardLastGlobalAdminGroupDelete on DeleteGroupProxy), so those six get a
+// narrower comparison (existence/membership/specific-field checks) rather
+// than a blanket field-exhaustive one, plus a documented field-level
+// exclusion where core computes something the wire response never carries
+// back (UpdateGroup/NameFolded, confirmed by running the test — see below).
+package http
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// userTimestampExclusions excludes CreatedAt/UpdatedAt from a models.User
+// field-exhaustive comparison — the same established GORM/SQLite
+// timezone-and-precision round-trip quirk TestConformance_LockUserForUpdate
+// (tranche 1) already documents and excludes for the identical reason: a
+// value read twice through GORM for the same row (once directly, once via
+// this harness's HTTP/JSON envelope) can surface with different sub-second
+// precision/Location despite representing the same instant, independent of
+// any proxy-layer defect.
+func userTimestampExclusions() map[string]bool {
+	return map[string]bool{"CreatedAt": true, "UpdatedAt": true}
+}
+
+// userWireDecodeExclusions is userTimestampExclusions plus UsernameFolded/
+// EmailFolded — a REAL wire-fidelity gap, confirmed by running these tests,
+// not a GORM timing artifact: remote_users.go's userWireResponse (the type
+// decodeUserResponse uses for every User-returning read — GetUser/
+// GetUserByEmail/GetUserByUsername/GetUserByExternalID all share it) declares
+// no username_folded/email_folded field at all, so a decoded RemoteStorage
+// result always reports these as "" regardless of the real, correctly-folded
+// server-side value (TestConformance_UpdateUserIfActiveStateMatches proves
+// the real value IS correct server-side — it reads back via a direct
+// LocalStorage.GetUser call instead of this lossy decode path, and passes
+// with these fields populated). Same defect SHAPE as the historical #500/
+// #524 dropped-field class this harness exists to catch (MFAEnabled/
+// ExternalID/LoginLockedUntil were once silently dropped from this exact
+// wire type) — flagged here as a genuine, currently-uncovered gap rather
+// than silently masked, but not fixed: this tranche may only add a new test
+// file, not modify remote_users.go.
+func userWireDecodeExclusions() map[string]bool {
+	e := userTimestampExclusions()
+	e["UsernameFolded"] = true
+	e["EmailFolded"] = true
+	return e
+}
+
+// --- CreateUser ---
+
+func TestConformance_CreateUser(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	localUser := &models.User{
+		Username: "conformance-cu-local", Email: "conformance-cu-local@example.com",
+		DisplayName: "Conformance CreateUser Local", IsActive: true,
+	}
+	createdLocal, err := h.ls.CreateUser(ctx, localUser)
+	require.NoError(t, err)
+	assert.Equal(t, localUser.Username, createdLocal.Username)
+
+	remoteUser := &models.User{
+		Username: "conformance-cu-remote", Email: "conformance-cu-remote@example.com",
+		DisplayName: "Conformance CreateUser Remote", IsActive: true,
+	}
+	createdRemote, err := h.rs.CreateUser(ctx, remoteUser, "SomeConf0rmancePassw0rd!")
+	require.NoError(t, err, "RemoteStorage.CreateUser must succeed for a genuinely new user with a valid password")
+	assert.Equal(t, remoteUser.Username, createdRemote.Username,
+		"Username must round-trip over the wire -- #496: a marshal without this file's explicit wire DTOs "+
+			"silently dropped every field whose JSON tag doesn't case-insensitively match the Go field name")
+	assert.Equal(t, remoteUser.Email, createdRemote.Email, "Email must round-trip over the wire")
+	assert.Equal(t, remoteUser.DisplayName, createdRemote.DisplayName,
+		"DisplayName must round-trip over the wire -- the #496 defect class: DisplayName does not "+
+			"case-insensitively match a snake_case JSON tag")
+	assert.True(t, createdRemote.IsActive, "IsActive must round-trip over the wire (also silently dropped by the #496 class)")
+	assert.NotZero(t, createdRemote.ID)
+
+	// Persisted server-side, not just echoed back in the decoded response
+	// envelope -- read back through the SAME LocalStorage instance the router
+	// wraps.
+	persisted, err := h.ls.GetUser(ctx, createdRemote.ID)
+	require.NoError(t, err)
+	assert.Equal(t, remoteUser.Username, persisted.Username)
+	assert.Equal(t, remoteUser.Email, persisted.Email)
+
+	// Negative: a duplicate email must be refused on both paths, not silently
+	// create a second account (#117's partial unique index is the ultimate
+	// enforcement either way; core.CreateUser's own pre-check on the remote
+	// path just surfaces it earlier/cleaner).
+	_, err = h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-cu-local-dup", Email: localUser.Email, DisplayName: "dup", IsActive: true,
+	})
+	assert.Error(t, err, "sanity: a duplicate email must be refused locally")
+
+	_, err = h.rs.CreateUser(ctx, &models.User{
+		Username: "conformance-cu-remote-dup", Email: remoteUser.Email, DisplayName: "dup", IsActive: true,
+	}, "AnotherConf0rmancePassw0rd!")
+	assert.Error(t, err, "RemoteStorage.CreateUser must refuse a duplicate email, not silently create a second account")
+}
+
+// --- CreateUserWithRoleGrants ---
+
+func TestConformance_CreateUserWithRoleGrants(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// Zero-permission role: CreateUserWithRoleGrantsProxy re-validates every
+	// grant via ValidateRoleGrantAuthority, which — like AssignRoleWithExpiry/
+	// AssignMachineRole in tranche 3 — unconditionally refuses ANY
+	// permission-carrying grant relayed through a /system proxy route when the
+	// acting principal is a machine/node credential. A zero-permission role
+	// sidesteps that pre-existing, already-covered ceiling rather than
+	// fighting it, matching tranche 3's established convention.
+	roleName, err := identity.NewFoldedName("conformance-cuwrg-role")
+	require.NoError(t, err)
+	role, err := h.ls.CreateRole(ctx, roleName, "conformance test role")
+	require.NoError(t, err)
+	grants := []coreStorage.RoleGrant{{RoleID: role.ID, Scope: coreStorage.Scope{ProjectID: h.projectID}}}
+
+	// A format-plausible (not cryptographically real) bcrypt hash: this route
+	// is a raw storage-primitive passthrough (unlike CreateUser above, which
+	// runs core.CreateUser's own bcrypt hashing) — the CALLING server's own
+	// core.CreateUserWithAssignments has already computed the real hash
+	// before this method is ever invoked (see remote_users.go's doc), so the
+	// server-side handler only sanity-checks the SHAPE (isPlausibleBcryptHash:
+	// exactly 60 bytes, a real bcrypt prefix), not the content.
+	fakeBcryptHash := "$2b$" + strings.Repeat("a", 56)
+	changedAt := time.Now().UTC().Truncate(time.Second)
+
+	newUserFields := func(suffix string) *models.User {
+		usernameFolded, ferr := identity.NewFoldedName("conformance-cuwrg-" + suffix)
+		require.NoError(t, ferr)
+		emailFolded, ferr := identity.NewFoldedName("conformance-cuwrg-" + suffix + "@example.com")
+		require.NoError(t, ferr)
+		return &models.User{
+			Username: "conformance-cuwrg-" + suffix, UsernameFolded: usernameFolded.Folded(),
+			Email: "conformance-cuwrg-" + suffix + "@example.com", EmailFolded: emailFolded.Folded(),
+			DisplayName:       "Conformance CreateUserWithRoleGrants " + suffix,
+			PasswordHash:      fakeBcryptHash,
+			IsActive:          true,
+			AccountState:      "active",
+			PasswordChangedAt: &changedAt,
+		}
+	}
+
+	localUser := newUserFields("local")
+	createdLocal, err := h.ls.CreateUserWithRoleGrants(ctx, localUser, grants)
+	require.NoError(t, err)
+	localRoleIDs, err := h.ls.GetUserRoleIDsAt(ctx, createdLocal.ID, coreStorage.Scope{ProjectID: h.projectID})
+	require.NoError(t, err)
+	assert.Contains(t, localRoleIDs, role.ID, "sanity: the local grant must be visible at the target scope")
+
+	remoteUser := newUserFields("remote")
+	createdRemote, err := h.rs.CreateUserWithRoleGrants(ctx, remoteUser, grants)
+	require.NoError(t, err, "RemoteStorage.CreateUserWithRoleGrants must succeed for a genuinely new user with a zero-permission role grant")
+	remoteRoleIDs, err := h.ls.GetUserRoleIDsAt(ctx, createdRemote.ID, coreStorage.Scope{ProjectID: h.projectID})
+	require.NoError(t, err)
+	assert.Contains(t, remoteRoleIDs, role.ID,
+		"the remote grant must actually be visible server-side at the target scope -- proving the ATOMIC "+
+			"create-user+grants request (not two separate calls) actually landed the grant, not just the user")
+
+	// Field-exhaustive comparison against the SAME LocalStorage instance's own
+	// read of the created row -- NOT the HTTP response envelope's own decoded
+	// struct, which is lossy for this specific method: RemoteStorage.
+	// CreateUserWithRoleGrants decodes via decodeUserResponse's shared
+	// userWireResponse type, but this handler's OWN response uses the
+	// narrower userRetentionProxyWire shape (it additionally omits
+	// mfa_enabled). A direct LocalStorage readback sidesteps that decode
+	// mismatch and asks the question this harness actually cares about: what
+	// did the server PERSIST, not what did this one response happen to echo.
+	localPersisted, err := h.ls.GetUser(ctx, createdLocal.ID)
+	require.NoError(t, err)
+	remotePersisted, err := h.ls.GetUser(ctx, createdRemote.ID)
+	require.NoError(t, err)
+	exclude := userTimestampExclusions()
+	// ID: LocalStorage.CreateUserWithRoleGrants mutates its *models.User
+	// argument in place via GORM's Create (localUser.ID is populated as a
+	// side effect, matching createdLocal), but RemoteStorage never mutates
+	// its input struct -- it returns a freshly decoded value instead
+	// (createdRemote), leaving remoteUser.ID at its original zero value. A
+	// real Go API-contract difference between the two implementations, not a
+	// wire-fidelity defect (both createdLocal.ID and createdRemote.ID are
+	// asserted equal to the persisted row separately, above, via the
+	// GetUserRoleIDsAt calls' use of createdLocal.ID/createdRemote.ID).
+	exclude["ID"] = true
+	assertFieldExhaustiveEqual(t, "LocalStorage.CreateUserWithRoleGrants (sanity baseline)", localUser, localPersisted, exclude)
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateUserWithRoleGrants (wire round trip)", remoteUser, remotePersisted, exclude)
+
+	// Negative: a duplicate email must be refused on both paths, not
+	// silently create a second account or a half-provisioned one -- ADR-028's
+	// atomicity is exactly what this method exists to preserve over the wire
+	// (see remote_users.go's doc). Asserting only Error (not ErrorIs
+	// storage.ErrDuplicateEmail): this harness's own newTestCore
+	// (server/http/integration_test.go) creates a LEGACY-shaped
+	// `uniq_users_email_active ON users (LOWER(email))` index for the test
+	// schema rather than mirroring production's real
+	// `uniq_users_email_folded_active` (on email_folded) migration path
+	// (internal/storage/factory.go's ensureUserEmailIndex explicitly DROPS
+	// the legacy index in production) -- confirmed by running this test:
+	// the constraint that actually fires is named uniq_users_email_active,
+	// which isDuplicateEmailViolation (local_users.go) does not recognize,
+	// so the sentinel translation never fires under THIS test harness
+	// regardless of proxy correctness. A pre-existing harness/production
+	// migration-path mismatch, not a wire defect, and out of scope for this
+	// tranche (no existing file may be modified) -- both paths refusing the
+	// duplicate at all is still verified.
+	dupLocal := newUserFields("local-dup")
+	dupLocal.Email = localUser.Email
+	_, err = h.ls.CreateUserWithRoleGrants(ctx, dupLocal, grants)
+	assert.Error(t, err, "sanity: a duplicate email must be refused locally")
+
+	dupRemote := newUserFields("remote-dup")
+	dupRemote.Email = remoteUser.Email
+	_, err = h.rs.CreateUserWithRoleGrants(ctx, dupRemote, grants)
+	assert.Error(t, err, "RemoteStorage.CreateUserWithRoleGrants must refuse a duplicate email, not silently create a second account")
+}
+
+// --- GetUser / GetUserByEmail / GetUserByUsername / GetUserByExternalID ---
+
+func TestConformance_GetUser(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	localUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gu-local", Email: "conformance-gu-local@example.com",
+		DisplayName: "Conformance GetUser Local", IsActive: true,
+	})
+	require.NoError(t, err)
+	gotLocal, err := h.ls.GetUser(ctx, localUser.ID)
+	require.NoError(t, err)
+
+	remoteUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gu-remote", Email: "conformance-gu-remote@example.com",
+		DisplayName: "Conformance GetUser Remote", IsActive: true,
+	})
+	require.NoError(t, err)
+	gotRemote, err := h.rs.GetUser(ctx, remoteUser.ID)
+	require.NoError(t, err, "RemoteStorage.GetUser must succeed for a genuinely existing user")
+
+	exclude := userTimestampExclusions()
+	assertFieldExhaustiveEqual(t, "GetUser (sanity baseline)", localUser, gotLocal, exclude)
+	assertFieldExhaustiveEqual(t, "GetUser (wire round trip)", remoteUser, gotRemote, exclude)
+
+	_, err = h.ls.GetUser(ctx, 9_999_999)
+	assert.Error(t, err, "sanity: a nonexistent user must fail locally")
+	_, err = h.rs.GetUser(ctx, 9_999_999)
+	assert.Error(t, err, "RemoteStorage.GetUser must fail for a nonexistent user, not return a zero-value success")
+}
+
+func TestConformance_GetUserByEmail(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// GetUserByEmail looks up by email_folded (identity.NewFoldedName's
+	// output), not the raw email column -- LocalStorage.CreateUser is a bare
+	// insert that never computes this itself (only core.CreateUser's
+	// buildUserForCreate does, on the OTHER route), so a fixture created
+	// without explicitly setting EmailFolded is genuinely unfindable by this
+	// lookup, on EITHER storage implementation -- confirmed by running this
+	// test without it. Fold explicitly here, matching what every real
+	// CreateUser call site in this codebase already does.
+	localEmailFolded, err := identity.NewFoldedName("conformance-gube-local@example.com")
+	require.NoError(t, err)
+	localUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gube-local", Email: "conformance-gube-local@example.com", EmailFolded: localEmailFolded.Folded(),
+		DisplayName: "Conformance GetUserByEmail Local", IsActive: true,
+	})
+	require.NoError(t, err)
+	gotLocal, err := h.ls.GetUserByEmail(ctx, localUser.Email)
+	require.NoError(t, err)
+
+	remoteEmailFolded, err := identity.NewFoldedName("conformance-gube-remote@example.com")
+	require.NoError(t, err)
+	remoteUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gube-remote", Email: "conformance-gube-remote@example.com", EmailFolded: remoteEmailFolded.Folded(),
+		DisplayName: "Conformance GetUserByEmail Remote", IsActive: true,
+	})
+	require.NoError(t, err)
+	gotRemote, err := h.rs.GetUserByEmail(ctx, remoteUser.Email)
+	require.NoError(t, err, "RemoteStorage.GetUserByEmail must succeed for a genuinely existing email")
+
+	exclude := userWireDecodeExclusions()
+	assertFieldExhaustiveEqual(t, "GetUserByEmail (sanity baseline)", localUser, gotLocal, exclude)
+	assertFieldExhaustiveEqual(t, "GetUserByEmail (wire round trip)", remoteUser, gotRemote, exclude)
+
+	// Negative: a nonexistent email must fail identically on both paths --
+	// #503's historical regression was specifically a route mismatch
+	// (/api/v1/users/by-email/{email}, never registered) that 404'd
+	// unconditionally regardless of whether the user existed, so this must
+	// fail for the RIGHT reason (genuinely absent), not coincidentally.
+	_, err = h.ls.GetUserByEmail(ctx, "conformance-gube-does-not-exist@example.com")
+	assert.Error(t, err, "sanity: a nonexistent email must fail locally")
+	_, err = h.rs.GetUserByEmail(ctx, "conformance-gube-does-not-exist@example.com")
+	assert.Error(t, err, "RemoteStorage.GetUserByEmail must fail for a nonexistent email")
+}
+
+func TestConformance_GetUserByUsername(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// GetUserByUsername looks up by username_folded -- same reasoning as
+	// GetUserByEmail's identical fold requirement above; a fixture created
+	// via the raw LocalStorage.CreateUser primitive without it is genuinely
+	// unfindable by this lookup regardless of proxy correctness.
+	localUsernameFolded, err := identity.NewFoldedName("conformance-gubu-local")
+	require.NoError(t, err)
+	localUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gubu-local", UsernameFolded: localUsernameFolded.Folded(),
+		Email: "conformance-gubu-local@example.com", DisplayName: "Conformance GetUserByUsername Local", IsActive: true,
+	})
+	require.NoError(t, err)
+	gotLocal, err := h.ls.GetUserByUsername(ctx, localUser.Username)
+	require.NoError(t, err)
+
+	remoteUsernameFolded, err := identity.NewFoldedName("conformance-gubu-remote")
+	require.NoError(t, err)
+	remoteUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gubu-remote", UsernameFolded: remoteUsernameFolded.Folded(),
+		Email: "conformance-gubu-remote@example.com", DisplayName: "Conformance GetUserByUsername Remote", IsActive: true,
+	})
+	require.NoError(t, err)
+	gotRemote, err := h.rs.GetUserByUsername(ctx, remoteUser.Username)
+	require.NoError(t, err, "RemoteStorage.GetUserByUsername must succeed for a genuinely existing username -- "+
+		"#505: this used to be an unconditional stub that failed every password login under storage.type: remote")
+
+	exclude := userWireDecodeExclusions()
+	assertFieldExhaustiveEqual(t, "GetUserByUsername (sanity baseline)", localUser, gotLocal, exclude)
+	assertFieldExhaustiveEqual(t, "GetUserByUsername (wire round trip)", remoteUser, gotRemote, exclude)
+
+	_, err = h.ls.GetUserByUsername(ctx, "conformance-gubu-does-not-exist")
+	assert.Error(t, err, "sanity: a nonexistent username must fail locally")
+	_, err = h.rs.GetUserByUsername(ctx, "conformance-gubu-does-not-exist")
+	assert.Error(t, err, "RemoteStorage.GetUserByUsername must fail for a nonexistent username")
+}
+
+func TestConformance_GetUserByExternalID(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	localUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gubxid-local", Email: "conformance-gubxid-local@example.com",
+		DisplayName: "Conformance GetUserByExternalID Local", IsActive: true, ExternalID: "conformance-ext-local",
+	})
+	require.NoError(t, err)
+	gotLocal, err := h.ls.GetUserByExternalID(ctx, localUser.ExternalID)
+	require.NoError(t, err)
+
+	remoteUser, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gubxid-remote", Email: "conformance-gubxid-remote@example.com",
+		DisplayName: "Conformance GetUserByExternalID Remote", IsActive: true, ExternalID: "conformance-ext-remote",
+	})
+	require.NoError(t, err)
+	gotRemote, err := h.rs.GetUserByExternalID(ctx, remoteUser.ExternalID)
+	require.NoError(t, err, "RemoteStorage.GetUserByExternalID must succeed for a genuinely existing external ID")
+
+	exclude := userTimestampExclusions()
+	assertFieldExhaustiveEqual(t, "GetUserByExternalID (sanity baseline)", localUser, gotLocal, exclude)
+	assertFieldExhaustiveEqual(t, "GetUserByExternalID (wire round trip)", remoteUser, gotRemote, exclude)
+
+	_, err = h.ls.GetUserByExternalID(ctx, "conformance-ext-does-not-exist")
+	assert.Error(t, err, "sanity: a nonexistent external ID must fail locally")
+	_, err = h.rs.GetUserByExternalID(ctx, "conformance-ext-does-not-exist")
+	assert.Error(t, err, "RemoteStorage.GetUserByExternalID must fail for a nonexistent external ID")
+}
+
+// --- UpdateUser ---
+
+func TestConformance_UpdateUser(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUser := func(suffix string) *models.User {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-uu-" + suffix, Email: "conformance-uu-" + suffix + "@example.com",
+			DisplayName: "Conformance UpdateUser " + suffix + " original", IsActive: true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	// Deliberately change ONLY DisplayName (IsActive unchanged) to exercise
+	// core.UpdateUser's non-deactivating branch -- see the file doc for why a
+	// deactivating update isn't a fair field-exhaustive comparison target
+	// here (it also cascades PAT/session revocation and the last-admin
+	// guard, both already covered elsewhere in this codebase's own tests).
+	localUser := newUser("local")
+	localUser.DisplayName = "Conformance UpdateUser local changed"
+	updatedLocal, err := h.ls.UpdateUser(ctx, localUser)
+	require.NoError(t, err)
+	assert.Equal(t, "Conformance UpdateUser local changed", updatedLocal.DisplayName)
+
+	remoteUser := newUser("remote")
+	remoteUser.DisplayName = "Conformance UpdateUser remote changed"
+	updatedRemote, err := h.rs.UpdateUser(ctx, remoteUser)
+	require.NoError(t, err, "RemoteStorage.UpdateUser must succeed for a genuine active-state-preserving update")
+	assert.Equal(t, "Conformance UpdateUser remote changed", updatedRemote.DisplayName,
+		"DisplayName must round-trip over the wire -- the #496 defect class")
+	assert.Equal(t, remoteUser.Username, updatedRemote.Username, "Username must be preserved when not changed")
+	assert.Equal(t, remoteUser.Email, updatedRemote.Email, "Email must be preserved when not changed")
+	assert.True(t, updatedRemote.IsActive, "IsActive must round-trip / be preserved over the wire")
+
+	persisted, err := h.ls.GetUser(ctx, remoteUser.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Conformance UpdateUser remote changed", persisted.DisplayName,
+		"the change must actually be persisted server-side, not just report success in the response envelope")
+
+	// Negative: updating a nonexistent user must fail on the real (business
+	// logic) route -- LocalStorage.UpdateUser is a bare GORM Save, which for a
+	// non-existent-but-non-zero primary key issues a no-op UPDATE (0 rows
+	// affected, no error), so there is no fair local "sanity" leg for this
+	// negative case; core.UpdateUser's own GetUser pre-check is what actually
+	// 404s, and that is what this proves over the wire.
+	ghost := &models.User{ID: 9_999_999, Username: "ghost", Email: "ghost@example.com", DisplayName: "ghost", IsActive: true}
+	_, err = h.rs.UpdateUser(ctx, ghost)
+	assert.Error(t, err, "RemoteStorage.UpdateUser must fail for a nonexistent user ID, not silently no-op success")
+}
+
+// --- UpdateUserIfActiveStateMatches ---
+
+func TestConformance_UpdateUserIfActiveStateMatches(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newActiveUser := func(suffix string) *models.User {
+		usernameFolded, ferr := identity.NewFoldedName("conformance-uiasm-" + suffix)
+		require.NoError(t, ferr)
+		emailFolded, ferr := identity.NewFoldedName("conformance-uiasm-" + suffix + "@example.com")
+		require.NoError(t, ferr)
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-uiasm-" + suffix, UsernameFolded: usernameFolded.Folded(),
+			Email: "conformance-uiasm-" + suffix + "@example.com", EmailFolded: emailFolded.Folded(),
+			DisplayName:  "Conformance UpdateUserIfActiveStateMatches " + suffix,
+			IsActive:     true,
+			PasswordHash: "conformance-uiasm-hash-" + suffix,
+			AccountState: "pending_first_login",
+			ExternalID:   "conformance-uiasm-ext-" + suffix,
+			MFAEnabled:   true,
+		})
+		require.NoError(t, err)
+		return user
+	}
+
+	// Wrong-fromActive precondition must be a no-op (Matched=false) on both
+	// paths, and must NOT alter the row -- the same CAS guarantee
+	// TransitionMachineIdentityState/TransitionSecretStatus (tranche 2/3)
+	// exist to preserve over the wire.
+	localUser := newActiveUser("local")
+	localMatchedWrong, err := h.ls.UpdateUserIfActiveStateMatches(ctx, localUser, false /* wrong: it's active */)
+	require.NoError(t, err)
+	assert.False(t, localMatchedWrong, "sanity: a wrong fromActive must not match")
+
+	remoteUser := newActiveUser("remote")
+	remoteMatchedWrong, err := h.rs.UpdateUserIfActiveStateMatches(ctx, remoteUser, false)
+	require.NoError(t, err)
+	assert.False(t, remoteMatchedWrong,
+		"RemoteStorage.UpdateUserIfActiveStateMatches must report no match for a wrong fromActive, not silently apply it")
+
+	stillActive, err := h.ls.GetUser(ctx, remoteUser.ID)
+	require.NoError(t, err)
+	assert.True(t, stillActive.IsActive, "a wrong-fromActive attempt must not have altered the row at all")
+
+	// Correct fromActive: the transition must apply, and every field the
+	// server-side route is NOT supposed to touch must survive untouched.
+	// PasswordHash/AccountState are the historically-confirmed regression
+	// (users_active_transition_proxy.go's own doc: this route used to
+	// reconstruct a fresh struct from the wire body alone and Select("*")
+	// that over the real row, silently blanking PasswordHash and
+	// AccountState on every call -- blanking AccountState on a
+	// suspended/deprovisioned account bypassed the login-block check
+	// entirely, a full authentication-bypass chain, not just data loss). The
+	// fix fetches the existing row server-side first and patches only
+	// username/email/display_name/active/updated_at onto it -- this test
+	// re-proves that fix holds over RemoteStorage's actual wire call, not a
+	// hand-rolled httptest body.
+	localUser.IsActive = false
+	localUser.DisplayName = "conformance uiasm changed local"
+	localUser.UpdatedAt = time.Now().UTC()
+	localMatched, err := h.ls.UpdateUserIfActiveStateMatches(ctx, localUser, true)
+	require.NoError(t, err)
+	assert.True(t, localMatched, "sanity: the correct fromActive must match")
+
+	remoteUser.IsActive = false
+	remoteUser.DisplayName = "conformance uiasm changed remote"
+	remoteUser.UpdatedAt = time.Now().UTC()
+	remoteMatched, err := h.rs.UpdateUserIfActiveStateMatches(ctx, remoteUser, true)
+	require.NoError(t, err)
+	assert.True(t, remoteMatched, "RemoteStorage.UpdateUserIfActiveStateMatches must report a match for the correct fromActive")
+
+	localPersisted, err := h.ls.GetUser(ctx, localUser.ID)
+	require.NoError(t, err)
+	remotePersisted, err := h.ls.GetUser(ctx, remoteUser.ID)
+	require.NoError(t, err)
+
+	exclude := userTimestampExclusions()
+	assertFieldExhaustiveEqual(t, "LocalStorage.UpdateUserIfActiveStateMatches (sanity baseline)", localUser, localPersisted, exclude)
+	assertFieldExhaustiveEqual(t, "RemoteStorage.UpdateUserIfActiveStateMatches (wire round trip)", remoteUser, remotePersisted, exclude)
+	assert.Equal(t, "conformance-uiasm-hash-remote", remotePersisted.PasswordHash,
+		"PasswordHash must survive this route untouched -- the historical blank-on-every-call regression")
+	assert.Equal(t, "pending_first_login", remotePersisted.AccountState,
+		"AccountState must survive this route untouched -- blanking it would have bypassed the login-block check")
+}
+
+// --- DeleteUser (dedicated tranche, see file doc) ---
+
+func TestConformance_DeleteUser(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUserWithSessionAndPAT := func(suffix string) (*models.User, string) {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-du-" + suffix, Email: "conformance-du-" + suffix + "@example.com",
+			DisplayName: "Conformance DeleteUser " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		sessionToken := "conformance-du-session-" + suffix
+		_, err = h.ls.CreateSession(ctx, &models.Session{UserID: user.ID, SessionToken: sessionToken})
+		require.NoError(t, err)
+		_, err = h.ls.CreatePersonalAccessToken(ctx, &models.PersonalAccessToken{
+			UserID: user.ID, Name: "conformance-du-pat", TokenHash: "conformance-du-pat-hash-" + suffix, TokenPrefix: "kx_pat_du",
+		})
+		require.NoError(t, err)
+		return user, sessionToken
+	}
+
+	// The fair comparison (see file doc): two FULL executions of
+	// core.KeyorixCore.DeleteUser against the SAME upstream core+storage --
+	// one in-process, one over the real HTTP/router stack.
+	localUser, _ := newUserWithSessionAndPAT("local")
+	require.NoError(t, h.upstreamCore.DeleteUser(ctx, h.adminUserID, localUser.ID),
+		"sanity: a direct in-process core.DeleteUser call must succeed for a genuine, non-last-admin user")
+
+	remoteUser, _ := newUserWithSessionAndPAT("remote")
+	require.NoError(t, h.rs.DeleteUser(ctx, remoteUser.ID),
+		"RemoteStorage.DeleteUser must succeed for a genuine, non-last-admin user, and must trigger the SAME "+
+			"core.DeleteUser cascade server-side as the in-process call above")
+
+	for _, tc := range []struct {
+		label  string
+		userID uint
+	}{
+		{"local (direct core.DeleteUser call)", localUser.ID},
+		{"remote (RemoteStorage.DeleteUser over HTTP)", remoteUser.ID},
+	} {
+		_, err := h.ls.GetUser(ctx, tc.userID)
+		assert.Error(t, err, tc.label+": the user must be soft-deleted (not retrievable via the normal getter)")
+
+		hashes, err := h.ls.ListSessionTokenHashesForUser(ctx, tc.userID)
+		require.NoError(t, err)
+		assert.Empty(t, hashes, tc.label+": every session must have been revoked by the cascade")
+	}
+
+	// Every PAT must be revoked too (RevokeAllPersonalAccessTokensForUser is
+	// part of the same cascade) -- a soft-deleted user's PATs are marked
+	// Revoked, not deleted, so ListPersonalAccessTokensByUser still finds them.
+	localPATs, err := h.ls.ListPersonalAccessTokensByUser(ctx, localUser.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, localPATs)
+	for _, p := range localPATs {
+		assert.True(t, p.Revoked, "sanity: the local user's PAT must be revoked by the cascade")
+	}
+	remotePATs, err := h.ls.ListPersonalAccessTokensByUser(ctx, remoteUser.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, remotePATs)
+	for _, p := range remotePATs {
+		assert.True(t, p.Revoked,
+			"the remote user's PAT must actually be revoked server-side by RemoteStorage.DeleteUser's cascade, not just report success")
+	}
+
+	// Negative: deleting an already-deleted (or never-existent) user must
+	// fail identically on both paths.
+	assert.Error(t, h.upstreamCore.DeleteUser(ctx, h.adminUserID, localUser.ID))
+	assert.Error(t, h.rs.DeleteUser(ctx, remoteUser.ID))
+
+	// Negative: the install's last global administrator must be refused on
+	// both paths (guardLastAdminDeactivation). h.adminUserID is the harness's
+	// sole HUMAN admin -- the node/machine credential h.rs authenticates with
+	// also holds "admin" (createNodeToken), but resolveGlobalAdminHolders
+	// (internal/core/authz.go) only counts "user"/"group" principal types,
+	// never "machine_identity", so it does not count as a fallback admin
+	// (matching tranche 3's TestConformance_RemoveGlobalAdminRoleGuarded's
+	// identical observation). core.DeleteUser has no separate self-delete
+	// guard (that check lives only in the HTTP handler, and only fires when
+	// userCtx.UserID equals the target -- 0 for a node token, so it never
+	// trips here); the last-admin guard is the one being proven.
+	require.Error(t, h.upstreamCore.DeleteUser(ctx, h.adminUserID, h.adminUserID),
+		"sanity: deleting the install's only human admin in-process must be refused by the last-admin guard")
+	stillThere, err := h.ls.GetUser(ctx, h.adminUserID)
+	require.NoError(t, err)
+	assert.True(t, stillThere.IsActive, "the last-admin guard must have blocked the deactivation, not just the final soft-delete")
+
+	err = h.rs.DeleteUser(ctx, h.adminUserID)
+	assert.Error(t, err,
+		"RemoteStorage.DeleteUser must ALSO be refused for the install's only human admin -- the last-admin "+
+			"guard runs server-side inside the same core.DeleteUser this route calls, so it must trip identically over HTTP")
+	stillThereAfterRemote, err := h.ls.GetUser(ctx, h.adminUserID)
+	require.NoError(t, err)
+	assert.True(t, stillThereAfterRemote.IsActive, "a refused remote delete attempt must not have deactivated the admin")
+}
+
+// --- RestoreUser ---
+
+func TestConformance_RestoreUser(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newDeletedUser := func(suffix string) *models.User {
+		// Create active, then explicitly flip to inactive/deprovisioned via a
+		// separate UpdateUser (Save) call -- models.User.IsActive carries
+		// `gorm:"default:true"`, and GORM's Create silently OMITS a
+		// zero-valued (false) column from the INSERT when a `default` tag is
+		// present, letting the DB apply its own default instead (confirmed by
+		// running this test: passing IsActive:false directly to CreateUser
+		// persisted true). Save's full-row UPDATE has no such default-skip
+		// behavior, so this two-step construction reliably persists false.
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-ru-" + suffix, Email: "conformance-ru-" + suffix + "@example.com",
+			DisplayName: "Conformance RestoreUser " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		user.IsActive = false
+		user.AccountState = "deprovisioned"
+		user, err = h.ls.UpdateUser(ctx, user)
+		require.NoError(t, err)
+		require.NoError(t, h.ls.DeleteUser(ctx, user.ID)) // raw soft-delete; no cascade needed to set up this fixture
+		return user
+	}
+
+	// See file doc: core.RestoreUser force-sets IsActive=true and
+	// AccountState=password_reset_required beyond storage.Storage.
+	// RestoreUser's raw "clear deleted_at" primitive, so this test verifies
+	// what IS comparable (the row becomes retrievable again on both paths)
+	// rather than asserting IsActive/AccountState match each other, which
+	// they structurally cannot: the raw primitive intentionally does less
+	// than the business route by design.
+	localUser := newDeletedUser("local")
+	require.NoError(t, h.ls.RestoreUser(ctx, localUser.ID))
+	localAfter, err := h.ls.GetUser(ctx, localUser.ID)
+	require.NoError(t, err, "sanity: the local user must be retrievable again after restore")
+	assert.False(t, localAfter.IsActive, "sanity: LocalStorage.RestoreUser is a raw primitive -- it must NOT reactivate the account on its own")
+
+	remoteUser := newDeletedUser("remote")
+	require.NoError(t, h.rs.RestoreUser(ctx, remoteUser.ID),
+		"RemoteStorage.RestoreUser must succeed for a genuinely soft-deleted user")
+	remoteAfter, err := h.ls.GetUser(ctx, remoteUser.ID)
+	require.NoError(t, err, "the remote user must actually be retrievable again server-side, not just report success")
+	assert.True(t, remoteAfter.IsActive,
+		"RemoteStorage.RestoreUser's real route (core.RestoreUser) deliberately reactivates the account -- "+
+			"confirms the route ran its full business logic, not a bare deleted_at clear")
+	assert.Equal(t, "password_reset_required", remoteAfter.AccountState)
+
+	// Negative: restoring a user that was never deleted must fail identically
+	// on both paths.
+	neverDeletedRemote, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-ru-active-remote", Email: "conformance-ru-active-remote@example.com",
+		DisplayName: "never deleted", IsActive: true,
+	})
+	require.NoError(t, err)
+	assert.Error(t, h.ls.RestoreUser(ctx, neverDeletedRemote.ID), "sanity: restoring a non-deleted user must fail locally")
+	assert.Error(t, h.rs.RestoreUser(ctx, neverDeletedRemote.ID),
+		"RemoteStorage.RestoreUser must refuse a user who is not currently deleted, not silently no-op success")
+}
+
+// --- ListUsers ---
+
+func TestConformance_ListUsers(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	for _, n := range []string{"conformance-lu-alice", "conformance-lu-bob"} {
+		_, err := h.ls.CreateUser(ctx, &models.User{
+			Username: n, Email: n + "@example.com", DisplayName: n, IsActive: true,
+		})
+		require.NoError(t, err)
+	}
+
+	// A read-only listing against a fresh, per-test-isolated harness DB (see
+	// newConformanceHarness) -- ls and rs observe the exact same underlying
+	// rows here, so a single comparison (not a local/remote scenario pair) is
+	// the fair test, scoped by a distinctive Username filter to avoid
+	// coupling to the harness's own pre-seeded admin user. Username (LIKE),
+	// not Search (ILIKE): local_users.go's ListUsers Search branch uses
+	// ILIKE, which is Postgres-only syntax -- SQLite (this test harness's
+	// backend) has no ILIKE at all and errors outright, confirmed by running
+	// this test with Search set. A pre-existing backend gap in the Search
+	// filter, unrelated to RemoteStorage proxy correctness and out of scope
+	// to fix here (no existing file may be modified); Username's plain LIKE
+	// works on both backends and exercises the same filter/wire-fidelity
+	// question this test cares about.
+	username := "conformance-lu-"
+	filter := &coreStorage.UserFilter{Username: &username, PageSize: 50}
+	localUsers, localTotal, err := h.ls.ListUsers(ctx, filter)
+	require.NoError(t, err)
+	remoteUsers, remoteTotal, err := h.rs.ListUsers(ctx, filter)
+	require.NoError(t, err, "RemoteStorage.ListUsers must succeed")
+
+	assert.Equal(t, localTotal, remoteTotal)
+	assert.Equal(t, int64(2), remoteTotal)
+	require.Len(t, remoteUsers, 2)
+
+	byUsername := func(users []*models.User, username string) *models.User {
+		for _, u := range users {
+			if u.Username == username {
+				return u
+			}
+		}
+		t.Fatalf("user %q not found", username)
+		return nil
+	}
+	exclude := userTimestampExclusions()
+	for _, want := range localUsers {
+		got := byUsername(remoteUsers, want.Username)
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("ListUsers %s", want.Username), want, got, exclude)
+	}
+
+	// Negative: a filter matching nothing must return an empty (not error)
+	// result on both paths.
+	noMatch := "conformance-lu-does-not-exist"
+	emptyFilter := &coreStorage.UserFilter{Username: &noMatch, PageSize: 50}
+	_, localEmptyTotal, err := h.ls.ListUsers(ctx, emptyFilter)
+	require.NoError(t, err)
+	assert.Zero(t, localEmptyTotal)
+	_, remoteEmptyTotal, err := h.rs.ListUsers(ctx, emptyFilter)
+	require.NoError(t, err, "RemoteStorage.ListUsers must succeed (not error) for a filter matching nothing")
+	assert.Zero(t, remoteEmptyTotal)
+}
+
+// --- ListUsersInStateBefore ---
+
+func TestConformance_ListUsersInStateBefore(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	past := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+	future := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Second)
+	cutoff := time.Now().UTC()
+	const staleState = "pending_first_login"
+
+	newUserInState := func(username, state string, createdAt time.Time) *models.User {
+		u, err := h.ls.CreateUser(ctx, &models.User{
+			Username: username, Email: username + "@example.com", DisplayName: username, IsActive: true,
+			AccountState: state, CreatedAt: createdAt,
+		})
+		require.NoError(t, err)
+		return u
+	}
+
+	// Three rows exercising both filter dimensions this method must get
+	// right -- mirrors TestConformance_DeleteExpiredRoleGrants's (tranche 2)
+	// "prove both the state filter AND the before filter, not just one"
+	// discipline.
+	staleUser := newUserInState("conformance-luisb-stale", staleState, past)
+	freshUser := newUserInState("conformance-luisb-fresh", staleState, future)
+	wrongStateUser := newUserInState("conformance-luisb-wrongstate", "active", past)
+
+	localResult, err := h.ls.ListUsersInStateBefore(ctx, staleState, cutoff)
+	require.NoError(t, err)
+	remoteResult, err := h.rs.ListUsersInStateBefore(ctx, staleState, cutoff)
+	require.NoError(t, err, "RemoteStorage.ListUsersInStateBefore must succeed")
+
+	usernamesOf := func(users []*models.User) []string {
+		out := make([]string, len(users))
+		for i, u := range users {
+			out[i] = u.Username
+		}
+		return out
+	}
+	localUsernames := usernamesOf(localResult)
+	remoteUsernames := usernamesOf(remoteResult)
+	assert.ElementsMatch(t, localUsernames, remoteUsernames)
+	assert.Contains(t, remoteUsernames, staleUser.Username,
+		"a user in the right state, created before the cutoff, must be reported")
+	assert.NotContains(t, remoteUsernames, freshUser.Username,
+		"RemoteStorage.ListUsersInStateBefore must NOT report a user created AFTER the cutoff -- a dropped or "+
+			"widened 'before' filter on the wire would report this one too")
+	assert.NotContains(t, remoteUsernames, wrongStateUser.Username,
+		"RemoteStorage.ListUsersInStateBefore must NOT report a user in a DIFFERENT state -- a dropped or "+
+			"widened state filter on the wire would report this one too")
+}
+
+// --- GetUserGroups ---
+
+func TestConformance_GetUserGroups(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUserInGroups := func(suffix string, n int) (*models.User, []uint) {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-gug-" + suffix, Email: "conformance-gug-" + suffix + "@example.com",
+			DisplayName: "Conformance GetUserGroups " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		var groupIDs []uint
+		for i := 0; i < n; i++ {
+			g, err := h.ls.CreateGroup(ctx, &models.Group{Name: fmt.Sprintf("conformance-gug-group-%s-%d", suffix, i)})
+			require.NoError(t, err)
+			require.NoError(t, h.ls.AddUserToGroup(ctx, user.ID, g.ID, 0))
+			groupIDs = append(groupIDs, g.ID)
+		}
+		return user, groupIDs
+	}
+
+	_, localGroupIDs := newUserInGroups("local", 2)
+	assert.Len(t, localGroupIDs, 2)
+
+	remoteUser, remoteGroupIDs := newUserInGroups("remote", 2)
+	remoteGroups, err := h.rs.GetUserGroups(ctx, remoteUser.ID)
+	require.NoError(t, err, "RemoteStorage.GetUserGroups must succeed and return every group the user belongs to")
+	require.Len(t, remoteGroups, 2,
+		"RemoteStorage.GetUserGroups must return every membership -- this method used to silently return an "+
+			"empty slice instead of an error, under-granting every group-inherited permission (see remote_users.go's doc)")
+	gotIDs := make([]uint, len(remoteGroups))
+	for i, g := range remoteGroups {
+		gotIDs[i] = g.ID
+	}
+	assert.ElementsMatch(t, remoteGroupIDs, gotIDs)
+
+	// Negative: a user in zero groups must return an empty slice, not an error.
+	lonelyRemote, err := h.ls.CreateUser(ctx, &models.User{
+		Username: "conformance-gug-lonely-remote", Email: "conformance-gug-lonely-remote@example.com",
+		DisplayName: "lonely", IsActive: true,
+	})
+	require.NoError(t, err)
+	emptyRemote, err := h.rs.GetUserGroups(ctx, lonelyRemote.ID)
+	require.NoError(t, err, "RemoteStorage.GetUserGroups must succeed (not error) for a user with zero memberships")
+	assert.Empty(t, emptyRemote)
+}
+
+// --- CreateGroup ---
+
+func TestConformance_CreateGroup(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	createdLocal, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-cg-local", Description: "local desc"})
+	require.NoError(t, err)
+	assert.NotZero(t, createdLocal.ID)
+
+	createdRemote, err := h.rs.CreateGroup(ctx, &models.Group{Name: "conformance-cg-remote", Description: "remote desc"})
+	require.NoError(t, err, "RemoteStorage.CreateGroup must succeed for a genuinely new group")
+
+	localPersisted, err := h.ls.GetGroup(ctx, createdLocal.ID)
+	require.NoError(t, err)
+	remotePersisted, err := h.ls.GetGroup(ctx, createdRemote.ID)
+	require.NoError(t, err)
+
+	// NameFolded: CreateGroupProxy also routes through core.KeyorixCore.
+	// CreateGroup (see the file doc), which computes and persists NameFolded
+	// server-side; groupProxyWire never carries it back to the client --
+	// same confirmed gap as UpdateGroup's identical exclusion below.
+	exclude := userTimestampExclusions()
+	exclude["NameFolded"] = true
+	assertFieldExhaustiveEqual(t, "LocalStorage.CreateGroup (sanity baseline)", createdLocal, localPersisted, exclude)
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateGroup (wire round trip)", createdRemote, remotePersisted, exclude)
+	assert.Equal(t, "remote desc", remotePersisted.Description,
+		"Description must round-trip over the wire, not be silently dropped like the historical AllowedCIDRs/ParentID class")
+}
+
+// --- GetGroup ---
+
+func TestConformance_GetGroup(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	localGroup, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-gg-local", Description: "local"})
+	require.NoError(t, err)
+	remoteGroup, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-gg-remote", Description: "remote"})
+	require.NoError(t, err)
+
+	exclude := userTimestampExclusions()
+	gotLocal, err := h.ls.GetGroup(ctx, localGroup.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "GetGroup (sanity baseline)", localGroup, gotLocal, exclude)
+
+	gotRemote, err := h.rs.GetGroup(ctx, remoteGroup.ID)
+	require.NoError(t, err, "RemoteStorage.GetGroup must succeed for a genuinely existing group")
+	assertFieldExhaustiveEqual(t, "GetGroup (wire round trip)", remoteGroup, gotRemote, exclude)
+
+	// Negative: a nonexistent group must fail identically on both paths.
+	_, err = h.ls.GetGroup(ctx, 9_999_999)
+	assert.Error(t, err, "sanity: a nonexistent group must fail locally")
+	_, err = h.rs.GetGroup(ctx, 9_999_999)
+	assert.Error(t, err, "RemoteStorage.GetGroup must fail for a nonexistent group, not return a zero-value success")
+}
+
+// --- UpdateGroup ---
+
+func TestConformance_UpdateGroup(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	localGroup, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-ug-local", Description: "before"})
+	require.NoError(t, err)
+	localGroup.Description = "after local"
+	_, err = h.ls.UpdateGroup(ctx, localGroup)
+	require.NoError(t, err)
+
+	remoteGroup, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-ug-remote", Description: "before"})
+	require.NoError(t, err)
+	remoteGroup.Description = "after remote"
+	updatedRemote, err := h.rs.UpdateGroup(ctx, remoteGroup)
+	require.NoError(t, err, "RemoteStorage.UpdateGroup must succeed for a genuinely existing group")
+	assert.Equal(t, "after remote", updatedRemote.Description, "Description must round-trip over the wire")
+
+	persistedRemote, err := h.ls.GetGroup(ctx, remoteGroup.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "after remote", persistedRemote.Description, "the change must actually be persisted server-side")
+
+	exclude := map[string]bool{
+		"CreatedAt": true,
+		// GORM auto-regenerates UpdatedAt at save time regardless of the
+		// caller-supplied value -- same note as TransitionSecretStatus (tranche 3).
+		"UpdatedAt": true,
+		// NameFolded: UpdateGroupProxy routes through core.KeyorixCore.UpdateGroup
+		// (NOT a raw storage.UpdateGroup passthrough, despite remote_users.go's
+		// package doc claiming every Group route bypasses core -- that doc is
+		// stale for the mutating Group routes; confirmed directly against
+		// groups_proxy.go: Create/Update/Delete/Restore/AddMember/RemoveMember
+		// all call h.coreService.X, only Get/List stay raw). core.UpdateGroup
+		// computes and persists NameFolded server-side; groupWire/
+		// groupProxyWire never carry that field back to the client (confirmed
+		// by running this test: the persisted remote row's NameFolded is
+		// correctly non-empty, but the in-memory remoteGroup struct this test
+		// sent never had it set, since LocalStorage's own raw primitive relies
+		// entirely on the caller to have already folded it). A real,
+		// route-specific field the wire response type omits -- not a GORM
+		// timing artifact -- documented here rather than silently masked.
+		"NameFolded": true,
+	}
+	localPersisted, err := h.ls.GetGroup(ctx, localGroup.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "LocalStorage.UpdateGroup (sanity baseline)", localGroup, localPersisted, exclude)
+	assertFieldExhaustiveEqual(t, "RemoteStorage.UpdateGroup (wire round trip)", remoteGroup, persistedRemote, exclude)
+}
+
+// --- DeleteGroup ---
+
+func TestConformance_DeleteGroup(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newGroupWithMember := func(suffix string) (*models.Group, *models.User) {
+		g, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-dg-" + suffix})
+		require.NoError(t, err)
+		u, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-dg-" + suffix, Email: "conformance-dg-" + suffix + "@example.com",
+			DisplayName: "Conformance DeleteGroup " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		require.NoError(t, h.ls.AddUserToGroup(ctx, u.ID, g.ID, 0))
+		return g, u
+	}
+
+	localGroup, _ := newGroupWithMember("local")
+	require.NoError(t, h.ls.DeleteGroup(ctx, localGroup.ID))
+
+	remoteGroup, remoteUser := newGroupWithMember("remote")
+	require.NoError(t, h.rs.DeleteGroup(ctx, remoteGroup.ID),
+		"RemoteStorage.DeleteGroup must succeed for a genuinely existing group")
+
+	_, localErr := h.ls.GetGroup(ctx, localGroup.ID)
+	_, remoteErr := h.ls.GetGroup(ctx, remoteGroup.ID)
+	assert.Error(t, localErr, "sanity: the local group must no longer be retrievable")
+	assert.Error(t, remoteErr, "the remote group must actually be gone server-side, not just report success")
+
+	// DeleteGroup is a soft delete that deliberately KEEPS memberships/role
+	// grants intact so a restore brings the group back whole (see
+	// local_users.go's own inline comment on DeleteGroup). Verify the
+	// membership row survives on BOTH paths via ListGroupMembersByGroupIDs,
+	// which (unlike ListGroupMembers) does not itself require the group to
+	// still exist, so it can see past the soft delete.
+	localMembersAfter, err := h.ls.ListGroupMembersByGroupIDs(ctx, []uint{localGroup.ID})
+	require.NoError(t, err)
+	assert.Len(t, localMembersAfter[localGroup.ID], 1, "sanity: the local membership must survive the soft delete")
+
+	remoteMembersAfter, err := h.ls.ListGroupMembersByGroupIDs(ctx, []uint{remoteGroup.ID})
+	require.NoError(t, err)
+	require.Len(t, remoteMembersAfter[remoteGroup.ID], 1,
+		"the remote group's membership must survive RemoteStorage.DeleteGroup's soft delete too -- a wire call "+
+			"that accidentally hard-deleted or cascaded to memberships would break restore")
+	assert.Equal(t, remoteUser.ID, remoteMembersAfter[remoteGroup.ID][0].ID)
+
+	// Negative: deleting an already-deleted group must fail identically on both paths.
+	assert.Error(t, h.ls.DeleteGroup(ctx, localGroup.ID))
+	assert.Error(t, h.rs.DeleteGroup(ctx, remoteGroup.ID))
+}
+
+// --- RestoreGroup ---
+
+func TestConformance_RestoreGroup(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	localGroup, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-rg-local"})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.DeleteGroup(ctx, localGroup.ID))
+	require.NoError(t, h.ls.RestoreGroup(ctx, localGroup.ID))
+	_, err = h.ls.GetGroup(ctx, localGroup.ID)
+	assert.NoError(t, err, "sanity: the local group must be retrievable again after restore")
+
+	remoteGroup, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-rg-remote"})
+	require.NoError(t, err)
+	require.NoError(t, h.ls.DeleteGroup(ctx, remoteGroup.ID))
+	require.NoError(t, h.rs.RestoreGroup(ctx, remoteGroup.ID),
+		"RemoteStorage.RestoreGroup must succeed for a genuinely soft-deleted group")
+	_, err = h.ls.GetGroup(ctx, remoteGroup.ID)
+	assert.NoError(t, err, "the remote group must actually be retrievable again server-side, not just report success")
+
+	// Negative: restoring a group that was never deleted must fail
+	// identically on both paths.
+	neverDeletedLocal, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-rg-active-local"})
+	require.NoError(t, err)
+	assert.Error(t, h.ls.RestoreGroup(ctx, neverDeletedLocal.ID), "sanity: restoring a non-deleted group must fail")
+
+	neverDeletedRemote, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-rg-active-remote"})
+	require.NoError(t, err)
+	assert.Error(t, h.rs.RestoreGroup(ctx, neverDeletedRemote.ID),
+		"RemoteStorage.RestoreGroup must refuse a group that is not currently deleted, not silently no-op success")
+}
+
+// --- ListGroups ---
+
+func TestConformance_ListGroups(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	_, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-lg-alpha", Description: "alpha"})
+	require.NoError(t, err)
+	_, err = h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-lg-beta", Description: "beta"})
+	require.NoError(t, err)
+
+	// A read-only, deployment-wide listing against a fresh, isolated per-test
+	// harness DB -- ls and rs observe the exact same underlying rows here, so
+	// a single comparison (not a local/remote scenario pair) is the fair test.
+	localList, err := h.ls.ListGroups(ctx)
+	require.NoError(t, err)
+	remoteList, err := h.rs.ListGroups(ctx)
+	require.NoError(t, err, "RemoteStorage.ListGroups must succeed")
+
+	require.Len(t, remoteList, len(localList))
+	require.Len(t, remoteList, 2)
+	exclude := userTimestampExclusions()
+	for i := range localList {
+		// ListGroups orders by name (ORDER BY name), so both paths query the
+		// SAME underlying rows in the same deterministic order -- index-wise
+		// comparison is valid.
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("ListGroups[%d]", i), localList[i], remoteList[i], exclude)
+	}
+}
+
+// --- ListGroupsPage ---
+
+func TestConformance_ListGroupsPage(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	for _, n := range []string{"conformance-lgp-a", "conformance-lgp-b", "conformance-lgp-c"} {
+		_, err := h.ls.CreateGroup(ctx, &models.Group{Name: n})
+		require.NoError(t, err)
+	}
+
+	localPage, localTotal, err := h.ls.ListGroupsPage(ctx, 1, 1)
+	require.NoError(t, err)
+	remotePage, remoteTotal, err := h.rs.ListGroupsPage(ctx, 1, 1)
+	require.NoError(t, err, "RemoteStorage.ListGroupsPage must succeed")
+
+	assert.Equal(t, localTotal, remoteTotal)
+	assert.Equal(t, int64(3), remoteTotal)
+	require.Len(t, remotePage, 1)
+	require.Len(t, localPage, 1)
+	assert.Equal(t, localPage[0].Name, remotePage[0].Name,
+		"RemoteStorage.ListGroupsPage must return the SAME name-ordered page as LocalStorage for the same offset/limit")
+	assert.Equal(t, "conformance-lgp-b", remotePage[0].Name, "offset=1,limit=1 of a 3-row name-ordered set must return the middle row")
+}
+
+// --- AddUserToGroup ---
+
+func TestConformance_AddUserToGroup(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newUserAndGroup := func(suffix string) (*models.User, *models.Group) {
+		u, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-autg-" + suffix, Email: "conformance-autg-" + suffix + "@example.com",
+			DisplayName: "Conformance AddUserToGroup " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		g, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-autg-group-" + suffix})
+		require.NoError(t, err)
+		return u, g
+	}
+
+	localUser, localGroup := newUserAndGroup("local")
+	require.NoError(t, h.ls.AddUserToGroup(ctx, localUser.ID, localGroup.ID, h.projectID))
+	require.NoError(t, h.ls.AddUserToGroup(ctx, localUser.ID, localGroup.ID, h.projectID)) // idempotent
+	localMembers, err := h.ls.ListGroupMembers(ctx, localGroup.ID)
+	require.NoError(t, err)
+	require.Len(t, localMembers, 1, "sanity: adding the same membership twice must not create a duplicate row")
+
+	remoteUser, remoteGroup := newUserAndGroup("remote")
+	require.NoError(t, h.rs.AddUserToGroup(ctx, remoteUser.ID, remoteGroup.ID, h.projectID),
+		"RemoteStorage.AddUserToGroup must succeed for a genuine user and group")
+	require.NoError(t, h.rs.AddUserToGroup(ctx, remoteUser.ID, remoteGroup.ID, h.projectID),
+		"a second identical RemoteStorage.AddUserToGroup call must remain idempotent, not error")
+	remoteMembers, err := h.ls.ListGroupMembers(ctx, remoteGroup.ID)
+	require.NoError(t, err)
+	require.Len(t, remoteMembers, 1,
+		"the remote membership must actually exist exactly once server-side, not duplicated by two wire calls")
+	assert.Equal(t, remoteUser.ID, remoteMembers[0].ID)
+
+	// Scope matters: a membership added at projectID=h.projectID must NOT be
+	// visible from an unrelated project scope -- a dropped/ignored
+	// project_id on the wire would silently create a GLOBAL membership
+	// instead of the scoped one requested.
+	otherProjectMembers, err := h.ls.GetUserGroupsAt(ctx, remoteUser.ID, coreStorage.Scope{ProjectID: h.projectID + 999})
+	require.NoError(t, err)
+	assert.Empty(t, otherProjectMembers,
+		"a project-scoped membership must not be visible from an unrelated project scope -- a dropped "+
+			"project_id on the wire would have created a global (project_id=0) membership instead")
+}
+
+// --- RemoveUserFromGroup ---
+
+func TestConformance_RemoveUserFromGroup(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newMember := func(suffix string) (*models.User, *models.Group) {
+		u, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-rufg-" + suffix, Email: "conformance-rufg-" + suffix + "@example.com",
+			DisplayName: "Conformance RemoveUserFromGroup " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		g, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-rufg-group-" + suffix})
+		require.NoError(t, err)
+		require.NoError(t, h.ls.AddUserToGroup(ctx, u.ID, g.ID, h.projectID))
+		return u, g
+	}
+
+	localUser, localGroup := newMember("local")
+	require.NoError(t, h.ls.RemoveUserFromGroup(ctx, localUser.ID, localGroup.ID, h.projectID))
+	localMembers, err := h.ls.ListGroupMembers(ctx, localGroup.ID)
+	require.NoError(t, err)
+	assert.Empty(t, localMembers, "sanity: the local membership must be gone")
+
+	remoteUser, remoteGroup := newMember("remote")
+	require.NoError(t, h.rs.RemoveUserFromGroup(ctx, remoteUser.ID, remoteGroup.ID, h.projectID),
+		"RemoteStorage.RemoveUserFromGroup must succeed for a genuine membership")
+	remoteMembers, err := h.ls.ListGroupMembers(ctx, remoteGroup.ID)
+	require.NoError(t, err)
+	assert.Empty(t, remoteMembers, "the remote membership must actually be gone server-side")
+
+	// Negative: removing a membership that never existed (or was already
+	// removed) must remain a silent no-op success on both paths, matching
+	// LocalStorage.RemoveUserFromGroup's own documented behavior.
+	assert.NoError(t, h.ls.RemoveUserFromGroup(ctx, localUser.ID, localGroup.ID, h.projectID))
+	assert.NoError(t, h.rs.RemoveUserFromGroup(ctx, remoteUser.ID, remoteGroup.ID, h.projectID),
+		"a repeat RemoteStorage.RemoveUserFromGroup call for an already-removed membership must remain a no-op, not error")
+
+	// Scope matters: removing with the WRONG projectID must not affect a
+	// membership held at a DIFFERENT scope.
+	scopedUser, scopedGroup := newMember("scoped")
+	require.NoError(t, h.rs.RemoveUserFromGroup(ctx, scopedUser.ID, scopedGroup.ID, h.projectID+999),
+		"removing with a project_id that doesn't match the real membership's scope must still report success "+
+			"(matching LocalStorage's own no-rows-affected-is-not-an-error behavior)")
+	stillMember, err := h.ls.ListGroupMembers(ctx, scopedGroup.ID)
+	require.NoError(t, err)
+	assert.Len(t, stillMember, 1,
+		"the real, correctly-scoped membership must survive a removal attempt against the WRONG project_id -- a "+
+			"dropped/ignored project_id on the wire would have removed it anyway")
+}
+
+// --- ListGroupMembers ---
+
+func TestConformance_ListGroupMembers(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newGroupWithMembers := func(suffix string, n int) *models.Group {
+		g, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-lgm-" + suffix})
+		require.NoError(t, err)
+		for i := 0; i < n; i++ {
+			u, err := h.ls.CreateUser(ctx, &models.User{
+				Username: fmt.Sprintf("conformance-lgm-%s-%d", suffix, i), Email: fmt.Sprintf("conformance-lgm-%s-%d@example.com", suffix, i),
+				DisplayName: "member", IsActive: true,
+			})
+			require.NoError(t, err)
+			require.NoError(t, h.ls.AddUserToGroup(ctx, u.ID, g.ID, 0))
+		}
+		return g
+	}
+
+	localGroup := newGroupWithMembers("local", 2)
+	localMembers, err := h.ls.ListGroupMembers(ctx, localGroup.ID)
+	require.NoError(t, err)
+	assert.Len(t, localMembers, 2)
+
+	remoteGroup := newGroupWithMembers("remote", 2)
+	remoteMembers, err := h.rs.ListGroupMembers(ctx, remoteGroup.ID)
+	require.NoError(t, err, "RemoteStorage.ListGroupMembers must succeed")
+	require.Len(t, remoteMembers, 2)
+
+	localTruth, err := h.ls.ListGroupMembers(ctx, remoteGroup.ID)
+	require.NoError(t, err)
+	byID := func(users []*models.User, id uint) *models.User {
+		for _, u := range users {
+			if u.ID == id {
+				return u
+			}
+		}
+		t.Fatalf("user %d not found", id)
+		return nil
+	}
+	exclude := userTimestampExclusions()
+	for _, want := range localTruth {
+		got := byID(remoteMembers, want.ID)
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("ListGroupMembers member %d", want.ID), want, got, exclude)
+	}
+
+	// Negative: a nonexistent group must fail identically on both paths.
+	_, err = h.ls.ListGroupMembers(ctx, 9_999_999)
+	assert.Error(t, err, "sanity: listing members of a nonexistent group must fail")
+	_, err = h.rs.ListGroupMembers(ctx, 9_999_999)
+	assert.Error(t, err, "RemoteStorage.ListGroupMembers must fail for a nonexistent group")
+}
+
+// --- ListGroupMembersByGroupIDs ---
+
+func TestConformance_ListGroupMembersByGroupIDs(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newGroupWithMember := func(suffix string) (*models.Group, *models.User) {
+		g, err := h.ls.CreateGroup(ctx, &models.Group{Name: "conformance-lgmbi-" + suffix})
+		require.NoError(t, err)
+		u, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-lgmbi-" + suffix, Email: "conformance-lgmbi-" + suffix + "@example.com",
+			DisplayName: "member", IsActive: true,
+		})
+		require.NoError(t, err)
+		require.NoError(t, h.ls.AddUserToGroup(ctx, u.ID, g.ID, 0))
+		return g, u
+	}
+
+	g1, u1 := newGroupWithMember("one")
+	g2, u2 := newGroupWithMember("two")
+
+	localResult, err := h.ls.ListGroupMembersByGroupIDs(ctx, []uint{g1.ID, g2.ID})
+	require.NoError(t, err)
+	remoteResult, err := h.rs.ListGroupMembersByGroupIDs(ctx, []uint{g1.ID, g2.ID})
+	require.NoError(t, err, "RemoteStorage.ListGroupMembersByGroupIDs must succeed")
+
+	require.Len(t, remoteResult[g1.ID], 1)
+	require.Len(t, remoteResult[g2.ID], 1)
+	assert.Equal(t, u1.ID, remoteResult[g1.ID][0].ID)
+	assert.Equal(t, u2.ID, remoteResult[g2.ID][0].ID)
+	assert.Equal(t, len(localResult), len(remoteResult))
+
+	// Negative: an empty ID list must return an empty (not error) map on both paths.
+	emptyLocal, err := h.ls.ListGroupMembersByGroupIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, emptyLocal)
+	emptyRemote, err := h.rs.ListGroupMembersByGroupIDs(ctx, nil)
+	require.NoError(t, err, "RemoteStorage.ListGroupMembersByGroupIDs must succeed (not error) for an empty ID list")
+	assert.Empty(t, emptyRemote)
+}


### PR DESCRIPTION
## Summary

Tranche 4 of the #1808 differential conformance harness. Adds `TestConformance_*` coverage for 182 of the 193 methods left uncovered after tranche 3, taking coverage from 21/214 to **203/214** real (non-stub) `RemoteStorage` methods.

10 new files, one per domain area, each following the established pattern from `remote_storage_conformance_helpers_test.go`/tranche2/tranche3: seed identical fixtures on `LocalStorage` and `RemoteStorage`, compare with a field-exhaustive reflection-based comparator, cover negative/precondition paths, not just the happy path.

## The 11 methods deliberately still uncovered

Each is pinned with a documented reason, not silently skipped:

- **`TransitionProjectMembershipState`** — not a raw CAS primitive over the wire (delegates to `core.TransitionMembership`, which re-derives state and applies a role-grant side effect); needs dedicated design work, same class as tranche 2's original `DeleteUser` deferral (which tranche 4 *did* now cover).
- **`CreateRotationPolicy` / `UpdateRotationPolicy`** — confirmed broken today: `models.RotationPolicy` has no JSON tags, so it wire-serializes PascalCase against a snake_case handler decode. Every multi-word field (`IntervalDays`, `ProjectID`, ...) silently zeroes, failing server-side validation on every real call.
- **`GetAuditLogs`** — confirmed broken today: decodes under JSON key `"events"` against a real response keyed `"logs"` with a completely different per-entry shape. Returns `total=N, events=[]` for every real deployment — a correct-looking count masking an always-empty result.
- **7 RBAC methods** (`CreateRole`, `GetRole`, `UpdateRole`, `ListRoles`, `GetUserRoles`, `GetUserPermissions`, `GetGroupRoles`) — each confirmed broken by live execution against the real router (wrong envelope shape, wrong route, or a newly-required field the client never sends).
- **`ListSharesByGroup`, `ListSharesBySecret`** (+`ListSharesBySecretIDs`, which loops it), **`ListSecretVersions`/`GetSecretVersions`** — bare-array decode against a real `{"key": [...]}` envelope; fail unconditionally.

## Systemic finding: dropped machine-identity attribution

Several defects trace to one root cause: `*MachineIdentityID` attribution fields (#1573) are missing from `RemoteStorage` wire structs on both client and server-proxy sides. Found independently on:

- `MachineIdentity.CreatedByMachineIdentityID`
- `SetupToken.CreatedByMachineIdentityID`
- `ProjectMembership.InvitedByMachineIdentityID` (also never derived server-side for machine callers)
- `ProjectInvitation.InvitedByMachineIdentityID`
- `AccessReviewCampaign.CreatedByMachineIdentityID` / `ClosedByMachineIdentityID`

None are fixed in this PR (out of scope — test-only) but each is pinned with a test asserting current (buggy) behavior, so a real fix has a red test to turn green.

Also found: `User`/`Group` folded-name fields dropped from the wire (`UsernameFolded`/`EmailFolded`/`NameFolded`), a stale doc comment on `UpdateWebAuthnCredential` (claims full-row save; actual behavior is a narrowed disable-only write per #1714), and `MFAStepUpGrant` missing from the shared SQLite test-schema model list.

## Verification

- `go build ./...` clean
- `go vet ./server/http/...` clean
- `gofmt -l` clean
- `gosec -severity medium ./server/http/...` clean (0 issues)
- Full `go test ./server/http/...` clean — 0 regressions
- `TestReportConformancePopulation`: 203/214 covered, 11 not yet covered

Issue #1808 stays open — 11 methods remain, several gated on the fixes documented above landing first (candidates for a dedicated fix-wave PR).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./server/http/...`
- [x] `gofmt -l` on all new files
- [x] `gosec -severity medium ./server/http/...`
- [x] Full `go test ./server/http/...`
- [x] `TestReportConformancePopulation` confirms the 203/214 tally