### PR TITLE
docs(remote): label CLI-against-server work-in-progress, with a freshness guard

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -105,7 +105,7 @@ storage:
 ```
 
 `type: remote` points the CLI at a Keyorix server over the API; see the remote
-section of the client config. **It is work in progress:** 197 of 426
+section of the client config. **It is work in progress:** 199 of 427
 `RemoteStorage` methods (46%) return `ErrRemoteUnsupported`, and audit retrieval
 in particular is 3-of-28 implemented. Use `type: local` for anything that
 matters — see `docs/REMOTE_CLI_SETUP.md` for the per-area status. Remote TLS verification is **on by default** —

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -105,7 +105,10 @@ storage:
 ```
 
 `type: remote` points the CLI at a Keyorix server over the API; see the remote
-section of the client config. Remote TLS verification is **on by default** —
+section of the client config. **It is work in progress:** 197 of 426
+`RemoteStorage` methods (46%) return `ErrRemoteUnsupported`, and audit retrieval
+in particular is 3-of-28 implemented. Use `type: local` for anything that
+matters — see `docs/REMOTE_CLI_SETUP.md` for the per-area status. Remote TLS verification is **on by default** —
 an omitted `tls_verify` does not disable certificate checks.
 
 **`type: remote` is a CLI/client mode only.** It cannot back a running Keyorix

--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -1,6 +1,45 @@
 # Remote CLI Setup Guide
 
-This guide explains how to configure the Keyorix CLI to work with remote servers, enabling team collaboration and enterprise deployment.
+> ## ⚠️ Remote mode is WORK IN PROGRESS — not yet a supported deployment
+>
+> **Roughly half of the CLI's storage operations are not implemented over remote
+> mode.** Derived by counting, not estimated: of **426** `RemoteStorage` methods,
+> **197 (46%)** return `ErrRemoteUnsupported`. Local mode
+> (`storage.type: local`) is the complete, supported path today.
+>
+> Unsupported operations fail **loudly**, with an explicit error rather than a
+> silent wrong answer. There are known exceptions to that — a set of wire-format
+> defects that currently return empty or zero-valued results with `err=nil`,
+> found by a conformance-test campaign and being fixed. **Until those land, do
+> not treat a successful-looking empty result from remote mode as authoritative.**
+> The affected calls include role and permission listings, share listings, secret
+> version listings, rotation-policy writes, and audit-log retrieval.
+>
+> **The audit examples further down this document do not work yet.**
+> `remote_audit.go` implements 3 of 28 methods, and `GetAuditLogs` is one of the
+> known-broken calls — it returns a correct-looking total with an empty event
+> list. Do not build a nightly tamper check or a SIEM pull on remote mode yet.
+>
+> ### What works today, by area
+>
+> | | area |
+> |---|---|
+> | **Complete** | invitations, project memberships, legal hold, login attempts, risk exceptions, segregation of duties, access activity |
+> | **Mostly complete** | machine identities (26/27), RBAC (47/63), users (25/38), access-review campaigns (10/11) |
+> | **Substantially incomplete** | secrets (13/31), MFA (7/17), sharing (8/12), dynamic secrets (7/12), stats (2/7), secret ACLs (1/7), **audit (3/28)** |
+> | **Not implemented at all** | compliance, notification channels, secret templates, bulk access, alert escalation, anomaly config, hygiene counts, version comments, secret schedules, retention override, read quota, billing, usage |
+>
+> The authoritative, machine-checked status is the conformance suite in
+> `internal/storage/store/` — that is derived from the code and cannot go stale;
+> this table is a summary of it and can. If the two disagree, believe the tests.
+>
+> **Use local mode for anything that matters.** Remote mode is safe to
+> evaluate — it cannot corrupt a server, and it fails closed on permission
+> checks — but it is not ready to run a team on.
+
+This guide explains how to configure the Keyorix CLI to work with remote servers.
+Remote mode is the intended path for team collaboration and enterprise
+deployment; see the status notice above for how far along it is.
 
 ## Overview
 

--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -3,8 +3,8 @@
 > ## ⚠️ Remote mode is WORK IN PROGRESS — not yet a supported deployment
 >
 > **Roughly half of the CLI's storage operations are not implemented over remote
-> mode.** Derived by counting, not estimated: of **426** `RemoteStorage` methods,
-> **197 (46%)** return `ErrRemoteUnsupported`. Local mode
+> mode.** Derived by counting, not estimated: of **427** `RemoteStorage` methods,
+> **199 (46%)** return `ErrRemoteUnsupported`. Local mode
 > (`storage.type: local`) is the complete, supported path today.
 >
 > Unsupported operations fail **loudly**, with an explicit error rather than a

--- a/internal/storage/store/remote_support_doc_freshness_test.go
+++ b/internal/storage/store/remote_support_doc_freshness_test.go
@@ -1,0 +1,155 @@
+// remote_support_doc_freshness_test.go — docs/REMOTE_CLI_SETUP.md and
+// docs/CONFIGURATION.md both state, in prose, how much of remote mode is
+// actually implemented ("197 of 426 RemoteStorage methods return
+// ErrRemoteUnsupported"). A number written into a document is a claim, and
+// this repository has three separate hand-maintained trackers -- BUGS.md,
+// REMEDIATION-STATUS.md and adversarial-review/QUEUE.md -- that each went
+// stale and each would have sent a reader to re-do already-finished work.
+// The one status source that never went stale is the CI-enforced closure
+// ledger, for exactly one reason: a build failure is not optional.
+//
+// So this test derives the two numbers from the source and fails when the
+// documents stop matching. It fires in both directions, which is the point:
+// implementing a stubbed method is GOOD and will fail this test, because
+// the customer-facing statement about how complete remote mode is has just
+// become wrong in the flattering direction. Update the docs; do not relax
+// the test.
+//
+// See CLAUDE.md, "Core principle: prefer the machine-checked over the
+// asserted."
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// remoteMethodRe matches a method declared on RemoteStorage (pointer or value
+// receiver). Anchored at line start so it cannot match inside a comment body
+// or a nested closure.
+var remoteMethodRe = regexp.MustCompile(`(?m)^func \(.*RemoteStorage\) `)
+
+// countRemoteSupport walks the remote_*.go files in this package's own
+// directory (go test runs with cwd = the package dir) and returns the total
+// number of RemoteStorage methods and how many of them are unimplemented
+// stubs. Derived from source every run -- never from a stored constant, which
+// would just be the same stale-claim problem one level down.
+func countRemoteSupport(t *testing.T) (total, unsupported int) {
+	t.Helper()
+	matches, err := filepath.Glob("remote_*.go")
+	if err != nil {
+		t.Fatalf("globbing remote_*.go: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("no remote_*.go files found -- this test's premise is broken, not satisfied")
+	}
+	for _, f := range matches {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(f) // #nosec G304 -- fixed glob within the package dir
+		if err != nil {
+			t.Fatalf("reading %s: %v", f, err)
+		}
+		src := string(b)
+		total += len(remoteMethodRe.FindAllString(src, -1))
+		unsupported += strings.Count(src, "remoteUnsupported(")
+	}
+	return total, unsupported
+}
+
+// docClaim is one prose statement of the support numbers that must stay true.
+type docClaim struct {
+	path string
+	re   *regexp.Regexp // must capture total and unsupported, in the order given by totalFirst
+	// totalFirst reports whether capture group 1 is the total (else it is the
+	// unsupported count) -- the two documents phrase the sentence in opposite
+	// orders, and pinning the order here is cheaper than normalising the prose.
+	totalFirst bool
+	pct        bool // the sentence also states a percentage that must agree
+}
+
+var docClaims = []docClaim{
+	{
+		path:       filepath.Join("..", "..", "..", "docs", "REMOTE_CLI_SETUP.md"),
+		re:         regexp.MustCompile(`of \*\*(\d+)\*\*\s*` + "`" + `RemoteStorage` + "`" + ` methods,\s*\n?> ?\*\*(\d+) \((\d+)%\)\*\*`),
+		totalFirst: true,
+		pct:        true,
+	},
+	{
+		path:       filepath.Join("..", "..", "..", "docs", "CONFIGURATION.md"),
+		re:         regexp.MustCompile(`(\d+) of (\d+)\s*` + "`" + `RemoteStorage` + "`" + `\s*\n?methods \((\d+)%\)`),
+		totalFirst: false,
+		pct:        true,
+	},
+}
+
+// TestRemoteSupportDocsMatchCode is the guard described in this file's header.
+func TestRemoteSupportDocsMatchCode(t *testing.T) {
+	t.Parallel()
+
+	total, unsupported := countRemoteSupport(t)
+	if total == 0 {
+		t.Fatal("derived 0 RemoteStorage methods -- the counting regex has stopped matching, " +
+			"which would make this guard silently vacuous; fix remoteMethodRe rather than the docs")
+	}
+	wantPct := int(float64(unsupported) / float64(total) * 100.0)
+
+	for _, c := range docClaims {
+		b, err := os.ReadFile(c.path) // #nosec G304 -- fixed repo-relative doc paths
+		if err != nil {
+			t.Errorf("reading %s: %v", c.path, err)
+			continue
+		}
+		m := c.re.FindStringSubmatch(string(b))
+		if m == nil {
+			t.Errorf("%s: could not find the remote-support sentence this guard exists to check.\n"+
+				"Either the sentence was reworded (update the regex in %s) or it was deleted "+
+				"(do not delete it -- it is the statement customers and auditors read). "+
+				"Current derived numbers: %d of %d methods unsupported (%d%%).",
+				c.path, "remote_support_doc_freshness_test.go", unsupported, total, wantPct)
+			continue
+		}
+
+		var gotTotal, gotUnsupported int
+		if c.totalFirst {
+			gotTotal, gotUnsupported = atoi(t, m[1]), atoi(t, m[2])
+		} else {
+			gotUnsupported, gotTotal = atoi(t, m[1]), atoi(t, m[2])
+		}
+
+		if gotTotal != total || gotUnsupported != unsupported {
+			t.Errorf("%s is out of date.\n  document says: %d of %d RemoteStorage methods unsupported\n"+
+				"  code says:     %d of %d\n%s",
+				c.path, gotUnsupported, gotTotal, unsupported, total, updateHint(total, unsupported, wantPct))
+		}
+		if c.pct {
+			if gotPct := atoi(t, m[3]); gotPct != wantPct {
+				t.Errorf("%s states %d%% unsupported; derived value is %d%%.\n%s",
+					c.path, gotPct, wantPct, updateHint(total, unsupported, wantPct))
+			}
+		}
+	}
+}
+
+func updateHint(total, unsupported, pct int) string {
+	return fmt.Sprintf(
+		"\nUpdate the prose to: %d of %d (%d%%). If a stub was just implemented, also check whether\n"+
+			"REMOTE_CLI_SETUP.md's per-area table still describes that area correctly -- the table is\n"+
+			"a summary this guard does NOT verify, and it is the part a customer actually reads.",
+		unsupported, total, pct)
+}
+
+func atoi(t *testing.T, s string) int {
+	t.Helper()
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		t.Fatalf("parsing %q from a doc claim: %v", s, err)
+	}
+	return n
+}


### PR DESCRIPTION
`REMOTE_CLI_SETUP.md` sold remote mode as "enabling team collaboration and enterprise deployment", then documented it as if it worked. Counted, not estimated: **197 of 426 `RemoteStorage` methods (46%) return `ErrRemoteUnsupported`.**

Adds a per-area table — complete for invitations, memberships, legal hold, login attempts, risk exceptions, SoD; substantially incomplete for secrets (13/31), MFA (7/17), sharing (8/12), secret ACLs (1/7) and **audit (3/28)**; entirely absent for compliance, notification channels, secret templates, bulk access and nine more.

Two specifics the document previously implied otherwise:
- **Its own audit examples do not work.** It tells readers to build a nightly tamper check and a SIEM pull on `GetAuditLogs`, which returns a correct-looking total with an empty event list.
- Unsupported operations otherwise fail *loudly*, which is right and worth saying — but a set of wire-format defects return empty results with `err == nil`. Until those land, a successful-looking empty result from remote mode is not authoritative.

**The guard.** `remote_support_doc_freshness_test.go` derives both numbers from source every run and fails when either document drifts — **including when a stub is implemented**, since the completeness claim has then become wrong in the flattering direction. It also fails if it cannot find the sentence, so rewording cannot silently make it vacuous. Both regexes were validated against the real files, and confirmed to reject a drifted number, before commit.

Deliberately **not** claimed: that the per-area table is machine-checked. It is a summary the guard does not verify, and the failure message says so.

Not compiled locally — no Go toolchain on the authoring machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAULgwpMpdNJbHUg8q5RfN