### PR TITLE
feat(conformance): tranche 5 of the RemoteStorage differential harness (#1808)

### DIFF
--- a/server/http/remote_storage_conformance_tranche5_rbac_audit_test.go
+++ b/server/http/remote_storage_conformance_tranche5_rbac_audit_test.go
@@ -1,0 +1,405 @@
+// remote_storage_conformance_tranche5_rbac_audit_test.go — issue #1808, tranche 5.
+//
+// Assignment: cover the 7 methods tranche 4's own header documented as SKIPPED
+// because the real router demonstrably broke them at the time (GetRole,
+// UpdateRole, ListRoles, GetUserRoles, GetUserPermissions, GetGroupRoles from
+// internal/storage/store/remote_rbac.go) plus GetAuditLogs
+// (internal/storage/store/remote_audit.go), now that PR #1832
+// ("fix(remote): unwrap response envelopes and send snake_case request
+// bodies") has landed. Every claim below was re-verified directly against the
+// CURRENT source (not trusted from either tranche 4's now-stale bug writeup or
+// #1832's own commit message, which itself turned out to contain one
+// inaccurate claim — see ListRoles below) and, for every field-shape claim,
+// against a live throwaway probe run against the real router before writing
+// the corresponding assertion.
+//
+// # 6 of 7 are fixed and covered here with field-exhaustive + negative/
+// precondition rigor: GetRole, UpdateRole, ListRoles, GetUserRoles,
+// GetUserPermissions, GetGroupRoles.
+//
+// # GetAuditLogs is SKIPPED -- the envelope-key fix is real, but a live probe
+// against the real router found a SIBLING defect the fix did not touch, and
+// writing a field-exhaustive test would fail on real, confirmed evidence
+// rather than a fake pass:
+//
+//	RemoteStorage.GetAuditLogs (remote_audit.go) unmarshals the "logs" array
+//	into []*models.AuditEvent -- a struct with NO json tags at all (default
+//	Go field-name matching). The real handler (server/http/handlers/audit.go)
+//	sends each entry as AuditLogEntry, which DOES carry explicit snake_case
+//	tags (event_type, actor_type, timestamp, impersonated_by, acting_as).
+//	encoding/json's fallback matching is case-INSENSITIVE, not snake_case-to-
+//	PascalCase-folding, so a wire key like "event_type" does not match the Go
+//	field "EventType" at all (verified empirically: json.Unmarshal of
+//	{"event_type":"x", ...} into a struct with an EventType field leaves it
+//	"", with err == nil). A throwaway probe seeding one real audit event via
+//	h.ls.LogAuditEvent and reading it back through both h.ls.GetAuditLogs and
+//	h.rs.GetAuditLogs against the real router confirmed this live:
+//
+//	  localTotal=3 remoteTotal=3 localLen=3 remoteLen=3   (counts/lengths agree -- #1832's fix is real)
+//	  local[0] .EventType="machine_identity.token_issued" .UserID=<ptr> .ProjectID=<ptr>
+//	           .EventTime=2026-09-10T11:53:53Z .ActorType="user" .EntryHash="886c52c5..."
+//	  remote[0].EventType=""                              .UserID=<nil> .ProjectID=<nil>
+//	           .EventTime=0001-01-01T00:00:00Z .ActorType=""            .EntryHash=""
+//
+//	Only ID, Description, and Impersonation survive (their wire keys happen to
+//	differ from the Go field name only in case, with no underscore, so the
+//	case-insensitive fallback works for exactly those three by accident).
+//	EventType/EventTime/ActorType/UserID/ProjectID/SecretNodeID/IPAddress/
+//	Success/MachineIdentityID/PrevHash/EntryHash are ALL silently zeroed, with
+//	no error -- for a compliance/audit product, a query that returns the right
+//	COUNT of the right ROWS but with "what happened," "when," and "who" blanked
+//	out is arguably worse than the pre-#1832 empty-list bug, precisely because
+//	len(events) > 0 now passes a naive check. Writing this method's test
+//	honestly requires either asserting that near-total field loss as correct
+//	(unacceptable) or failing the build on a known, already-filed gap
+//	(disproportionate to a test-only tranche with no production file in
+//	scope). Filed as a follow-up; not silently patched over here.
+//
+// # A correction to #1832's own commit message, made because this tranche's
+// brief explicitly required verifying rather than trusting it: the commit
+// message groups ListRoles with GetUserRoles/GetGroupRoles as projecting
+// through "handlers.apiRole" (ID+Name only, Description/permissions empty).
+// That is TRUE for GetUserRoles but FALSE for ListRoles: `git log -p --follow`
+// on server/http/handlers/rbac.go shows ListRoles has called
+// core.ListRolesWithPermissions (returning the FULL embedded models.Role plus
+// its permission set) since that function was introduced, with no apiRole
+// variant ever in its history, and a live probe confirms ListRoles returns
+// full field fidelity (Name/Description/BypassesPermissionChecks all present)
+// alongside GetUserRoles' genuinely-reduced ID+Name-only shape from the SAME
+// probe run. The ListRoles test below is written against the verified
+// behavior, not the commit message's claim.
+package http
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/identity"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// nameFoldedExclude is shared by every RBAC comparison below: models.Role.NameFolded
+// carries `json:"-"` (internal/storage/models/models.go) -- a write-time-only derived
+// field that is never intended to round-trip over the wire on ANY route, so the remote
+// side always observes "" regardless of the real stored value. This is the exact
+// exclusion tranche 4's TestConformance_GetRoleByName already established for the same
+// field on a different route; every route below hits the identical json:"-" tag on the
+// identical struct, so the same justification applies verbatim.
+var nameFoldedExclude = map[string]bool{"NameFolded": true}
+
+// --- GetRole ---
+
+func TestConformance_GetRole(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	name, err := identity.NewFoldedName("conformance-gr-role")
+	require.NoError(t, err)
+	seeded, err := h.ls.CreateRole(ctx, name, "conformance GetRole test role")
+	require.NoError(t, err)
+
+	localRead, err := h.ls.GetRole(ctx, seeded.ID)
+	require.NoError(t, err)
+	remoteRead, err := h.rs.GetRole(ctx, seeded.ID)
+	require.NoError(t, err, "RemoteStorage.GetRole must succeed for a role that genuinely exists")
+
+	// GetRole's response is now correctly unwrapped from {"role": {...}} (#1832) into the
+	// full underlying models.Role (server/http/handlers/rbac.go's GetRole calls
+	// GetRoleWithPermissions, which returns the role storage.GetRole itself returned, not a
+	// reduced projection) -- confirmed by direct code read and a live probe. Every field
+	// round-trips except NameFolded.
+	assertFieldExhaustiveEqual(t, "GetRole(local vs remote, same row)", localRead, remoteRead, nameFoldedExclude)
+
+	_, localErr := h.ls.GetRole(ctx, 999999999)
+	_, remoteErr := h.rs.GetRole(ctx, 999999999)
+	assert.Error(t, localErr, "sanity: a nonexistent role ID must not resolve")
+	assert.Error(t, remoteErr,
+		"RemoteStorage.GetRole must report an error for a nonexistent role ID -- pre-#1832 this silently "+
+			"returned a zero-valued &models.Role{} with err == nil, strictly worse than an error")
+}
+
+// --- UpdateRole ---
+
+func TestConformance_UpdateRole(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newRole := func(suffix string) *models.Role {
+		name, err := identity.NewFoldedName("conformance-ur-" + suffix)
+		require.NoError(t, err)
+		role, err := h.ls.CreateRole(ctx, name, "conformance UpdateRole test role "+suffix)
+		require.NoError(t, err)
+		return role
+	}
+
+	// UpdateRoleRequest (server/http/handlers/rbac.go) only carries description+permissions
+	// -- Name has no field mapping to models.Role.Name at all (#1494's closure:
+	// TestUpdateRoleRequest_CarriesNoNameField), so only Description is exercised here; a
+	// Name change sent over RemoteStorage.UpdateRole would be silently ignored server-side,
+	// which is a documented, deliberate design invariant, not something this wire-fidelity
+	// test needs to re-prove.
+	localRole := newRole("local")
+	localRole.Description = "conformance updated description local"
+	localUpdated, err := h.ls.UpdateRole(ctx, localRole)
+	require.NoError(t, err)
+	assert.Equal(t, "conformance updated description local", localUpdated.Description,
+		"sanity: LocalStorage.UpdateRole's own return value must reflect the update")
+
+	remoteRole := newRole("remote")
+	remoteRole.Description = "conformance updated description remote"
+	remoteUpdated, err := h.rs.UpdateRole(ctx, remoteRole)
+	require.NoError(t, err, "RemoteStorage.UpdateRole must succeed for a genuine, non-built-in role")
+
+	// The historical bug this proves fixed (tranche 4's own writeup): RemoteStorage.UpdateRole
+	// used to unmarshal the WRAPPED {"role": {...}} response directly into a bare models.Role,
+	// silently matching no field and returning &models.Role{ID:0, Name:"", ...} with err == nil
+	// -- succeeding while lying about what it returned. Prove the fix by field-exhaustively
+	// comparing RemoteStorage.UpdateRole's OWN return value against the SAME row (same ID) read
+	// back independently through LocalStorage: if the response were still silently zero-valued,
+	// this comparison would catch it immediately (ID/Name/Description would all mismatch).
+	persisted, err := h.ls.GetRole(ctx, remoteRole.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "UpdateRole(RemoteStorage's own return value vs the persisted row)", persisted, remoteUpdated, nameFoldedExclude)
+	assert.Equal(t, "conformance updated description remote", remoteUpdated.Description,
+		"RemoteStorage.UpdateRole's return value must reflect the NEW description, not a stale or zero one")
+
+	// Precondition divergence, confirmed by direct code inspection AND a live probe (not
+	// guessed): LocalStorage.UpdateRole (local_rbac.go) is a bare `db.Save(role)` with NO
+	// built-in-role guard at the storage layer -- it will happily overwrite "admin"'s row.
+	// RemoteStorage.UpdateRole is proxied through the HTTP handler, which calls
+	// core.UpdateRole (internal/core/rbac_roles.go), and THAT function's
+	// IsBuiltinRole(role.Name) check rejects the mutation with 403 before it ever reaches
+	// storage. The two backends are genuinely NOT equivalent for a built-in role's update --
+	// assert what each actually does, mirroring GetRolePermissions' documented
+	// LocalStorage-vs-core divergence in tranche 4, rather than asserting a false parity.
+	adminRole, err := h.ls.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	originalAdminDescription := adminRole.Description
+
+	adminRole.Description = "conformance builtin-role bypass attempt (local)"
+	_, err = h.ls.UpdateRole(ctx, adminRole)
+	require.NoError(t, err,
+		"LocalStorage.UpdateRole has no built-in-role guard at the storage layer -- confirmed by direct "+
+			"inspection of local_rbac.go's bare Save call")
+
+	adminRoleForRemote, err := h.ls.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	adminRoleForRemote.Description = "conformance builtin-role bypass attempt (remote)"
+	_, err = h.rs.UpdateRole(ctx, adminRoleForRemote)
+	assert.Error(t, err,
+		"RemoteStorage.UpdateRole must refuse to update a built-in role -- it is proxied through "+
+			"core.UpdateRole, which enforces IsBuiltinRole even though the raw storage layer itself has no "+
+			"such guard")
+
+	stillAdmin, err := h.ls.GetRoleByName(ctx, "admin")
+	require.NoError(t, err)
+	assert.NotEqual(t, originalAdminDescription, stillAdmin.Description,
+		"sanity: LocalStorage's own unguarded update above DID take effect")
+	assert.NotEqual(t, "conformance builtin-role bypass attempt (remote)", stillAdmin.Description,
+		"RemoteStorage's rejected update must NOT have taken effect server-side")
+}
+
+// --- ListRoles ---
+
+func TestConformance_ListRoles(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	name, err := identity.NewFoldedName("conformance-lr-role")
+	require.NoError(t, err)
+	seeded, err := h.ls.CreateRole(ctx, name, "conformance ListRoles test role")
+	require.NoError(t, err)
+	perms, err := h.ls.ListPermissions(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, perms, "sanity: bootstrap must have seeded at least one permission")
+	require.NoError(t, h.ls.AssignPermissionToRole(ctx, seeded.ID, perms[0].ID))
+
+	localRoles, err := h.ls.ListRoles(ctx)
+	require.NoError(t, err)
+	remoteRoles, err := h.rs.ListRoles(ctx)
+	require.NoError(t, err, "RemoteStorage.ListRoles must succeed")
+
+	localByID := make(map[uint]*models.Role, len(localRoles))
+	for _, r := range localRoles {
+		localByID[r.ID] = r
+	}
+	remoteByID := make(map[uint]*models.Role, len(remoteRoles))
+	for _, r := range remoteRoles {
+		remoteByID[r.ID] = r
+	}
+	require.Equal(t, len(localByID), len(remoteByID),
+		"RemoteStorage.ListRoles must return exactly the same role SET as LocalStorage -- a dropped or "+
+			"duplicated row would silently mis-report the catalog")
+
+	// See this file's package doc for why ListRoles is NOT reduced to apiRole (that claim in
+	// #1832's own commit message is verified false for this specific method): the handler
+	// calls ListRolesWithPermissions, returning the full embedded models.Role, so every
+	// field round-trips except NameFolded, same as GetRole/UpdateRole above.
+	for id, lr := range localByID {
+		rr, ok := remoteByID[id]
+		require.True(t, ok, "role id %d present in LocalStorage.ListRoles but missing from RemoteStorage.ListRoles", id)
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("ListRoles(local vs remote, role id %d)", id), lr, rr, nameFoldedExclude)
+	}
+}
+
+// --- GetUserRoles ---
+
+func TestConformance_GetUserRoles(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	localRoles, err := h.ls.GetUserRoles(ctx, h.adminUserID)
+	require.NoError(t, err)
+	require.NotEmpty(t, localRoles, "sanity: the harness's admin user must hold at least one role")
+
+	remoteRoles, err := h.rs.GetUserRoles(ctx, h.adminUserID)
+	require.NoError(t, err, "RemoteStorage.GetUserRoles must succeed")
+	require.Len(t, remoteRoles, len(localRoles),
+		"RemoteStorage.GetUserRoles must return the same NUMBER of role grants as LocalStorage")
+
+	// GetUserRoles' wire response is projected through handlers.apiRole
+	// (server/http/handlers/users_roles.go:23-26,65-68), which carries ONLY id+name --
+	// confirmed by direct code read AND a live probe against the real router: Description,
+	// BypassesPermissionChecks, and NameFolded all come back zero-valued on the remote side
+	// regardless of the real stored role (the harness's admin role genuinely has
+	// BypassesPermissionChecks=true and a non-empty Description locally). This is a
+	// documented, deliberate server-side projection (#1832's own commit message records
+	// exactly this class for this method), not a proxy defect -- exclude exactly these
+	// three fields, nothing else.
+	exclude := map[string]bool{"Description": true, "BypassesPermissionChecks": true, "NameFolded": true}
+	localByID := make(map[uint]*models.Role, len(localRoles))
+	for _, r := range localRoles {
+		localByID[r.ID] = r
+	}
+	for _, rr := range remoteRoles {
+		lr, ok := localByID[rr.ID]
+		require.True(t, ok, "role id %d returned by RemoteStorage.GetUserRoles but not by LocalStorage", rr.ID)
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("GetUserRoles(local vs remote, role id %d)", rr.ID), lr, rr, exclude)
+	}
+
+	// Precondition: LocalStorage.GetUserRoles has no existence check on userID (a raw JOIN
+	// that simply yields zero rows for an unmatched user) -- confirmed by direct read of
+	// local_rbac.go. GetUserRolesByID (the core function the HTTP handler calls) proxies
+	// straight to storage.GetUserRoles, the SAME shape of raw JOIN with no existence check --
+	// so, unlike GetRolePermissions' divergent nonexistent-ID case in tranche 4, both
+	// backends genuinely AGREE here: an empty list, not an error.
+	localEmpty, err := h.ls.GetUserRoles(ctx, 999999999)
+	require.NoError(t, err)
+	assert.Empty(t, localEmpty)
+	remoteEmpty, err := h.rs.GetUserRoles(ctx, 999999999)
+	require.NoError(t, err,
+		"RemoteStorage.GetUserRoles must not error for a nonexistent userID -- GetUserRolesByID never "+
+			"returns not-found, it simply returns an empty slice, matching LocalStorage")
+	assert.Empty(t, remoteEmpty)
+}
+
+// --- GetUserPermissions ---
+
+func TestConformance_GetUserPermissions(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	localPerms, err := h.ls.GetUserPermissions(ctx, h.adminUserID)
+	require.NoError(t, err)
+	require.NotEmpty(t, localPerms, "sanity: the harness's admin user must hold at least one direct permission")
+
+	remotePerms, err := h.rs.GetUserPermissions(ctx, h.adminUserID)
+	require.NoError(t, err, "RemoteStorage.GetUserPermissions must succeed")
+	require.Len(t, remotePerms, len(localPerms),
+		"RemoteStorage.GetUserPermissions must return the same NUMBER of permissions as LocalStorage")
+
+	// GetUserPermissions' wire response is projected through handlers.apiPermission
+	// (server/http/handlers/users_roles.go:91-96,137-140), whose struct has NO ID field at
+	// all -- confirmed by direct code read AND a live probe: every permission returned by
+	// RemoteStorage.GetUserPermissions has ID 0. #1832's own commit message documents this
+	// exact projection. Name/Resource/Action/Description carry EXACT-matching json tags on
+	// both storage.Permission and apiPermission, so those four fields are expected to (and,
+	// per the probe, do) round-trip with full fidelity -- only ID is excluded.
+	exclude := map[string]bool{"ID": true}
+	localByName := make(map[string]*coreStorage.Permission, len(localPerms))
+	for _, p := range localPerms {
+		localByName[p.Name] = p
+	}
+	for _, rp := range remotePerms {
+		lp, ok := localByName[rp.Name]
+		require.True(t, ok, "permission %q returned by RemoteStorage.GetUserPermissions but not by LocalStorage", rp.Name)
+		assertFieldExhaustiveEqual(t, fmt.Sprintf("GetUserPermissions(local vs remote, permission %q)", rp.Name), lp, rp, exclude)
+	}
+
+	// Precondition: same no-existence-check shape as GetUserRoles above -- confirmed by
+	// direct read of GetUserPermissionsByID (calls storage.GetUserPermissions +
+	// storage.GetUserGroupPermissions, neither of which resolves the user row first).
+	localEmpty, err := h.ls.GetUserPermissions(ctx, 999999999)
+	require.NoError(t, err)
+	assert.Empty(t, localEmpty)
+	remoteEmpty, err := h.rs.GetUserPermissions(ctx, 999999999)
+	require.NoError(t, err,
+		"RemoteStorage.GetUserPermissions must not error for a nonexistent userID, matching LocalStorage's "+
+			"own no-existence-check behavior")
+	assert.Empty(t, remoteEmpty)
+}
+
+// --- GetGroupRoles ---
+
+func TestConformance_GetGroupRoles(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newGroup := func(suffix string) *models.Group {
+		name, err := identity.NewFoldedName("conformance-ggr-" + suffix)
+		require.NoError(t, err)
+		group, err := h.ls.CreateGroup(ctx, &models.Group{Name: name.Display(), NameFolded: name.Folded()})
+		require.NoError(t, err)
+		return group
+	}
+	name, err := identity.NewFoldedName("conformance-ggr-role")
+	require.NoError(t, err)
+	role, err := h.ls.CreateRole(ctx, name, "conformance GetGroupRoles test role")
+	require.NoError(t, err)
+
+	localGroup := newGroup("local")
+	require.NoError(t, h.ls.AssignRoleToGroup(ctx, localGroup.ID, role.ID, coreStorage.Scope{}))
+
+	remoteGroup := newGroup("remote")
+	require.NoError(t, h.ls.AssignRoleToGroup(ctx, remoteGroup.ID, role.ID, coreStorage.Scope{}))
+
+	localRoles, err := h.ls.GetGroupRoles(ctx, localGroup.ID)
+	require.NoError(t, err)
+	require.Len(t, localRoles, 1, "sanity: the local group must hold exactly the one assigned role")
+
+	remoteRoles, err := h.rs.GetGroupRoles(ctx, remoteGroup.ID)
+	require.NoError(t, err, "RemoteStorage.GetGroupRoles must succeed for a group that genuinely holds a role")
+	require.Len(t, remoteRoles, 1,
+		"RemoteStorage.GetGroupRoles must return exactly the one role the remote group holds -- a dropped or "+
+			"wrong groupID on the wire would return zero or the wrong set")
+
+	// GetGroupRoles' wire response is storage.GroupRoleGrant{ID,Name,Description,ExpiresAt}
+	// (server/http/handlers/rbac.go's GetGroupRoles -> core.GetGroupRoleGrants), NOT a full
+	// models.Role -- confirmed by direct code read and a live probe. Every field
+	// GroupRoleGrant actually carries (ID/Name/Description) has an exact-matching json tag
+	// and round-trips with full fidelity into RemoteStorage.GetGroupRoles' []*models.Role
+	// unmarshal target; NameFolded (json:"-", never sent) and BypassesPermissionChecks (no
+	// such field on GroupRoleGrant at all, so it is simply never set) are excluded.
+	exclude := map[string]bool{"NameFolded": true, "BypassesPermissionChecks": true}
+	assertFieldExhaustiveEqual(t, "GetGroupRoles(local vs remote, same role)", localRoles[0], remoteRoles[0], exclude)
+
+	// Precondition: LocalStorage.GetGroupRoles has no existence check on groupID (a raw JOIN
+	// yielding zero rows for an unmatched group) -- confirmed by direct read of
+	// local_rbac.go. core.GetGroupRoleGrants (which the HTTP handler calls) proxies straight
+	// to storage.GetGroupRoleGrants, the SAME shape of raw JOIN with no existence check -- so,
+	// unlike GetRolePermissions' divergent nonexistent-ID case in tranche 4, both backends
+	// genuinely agree here: an empty list, not a 404.
+	localEmpty, err := h.ls.GetGroupRoles(ctx, 999999999)
+	require.NoError(t, err)
+	assert.Empty(t, localEmpty)
+	remoteEmpty, err := h.rs.GetGroupRoles(ctx, 999999999)
+	require.NoError(t, err,
+		"RemoteStorage.GetGroupRoles must not error for a nonexistent groupID -- GetGroupRoleGrants never "+
+			"returns not-found, it simply returns an empty slice, matching LocalStorage")
+	assert.Empty(t, remoteEmpty)
+}

--- a/server/http/remote_storage_conformance_tranche5_rotation_membership_test.go
+++ b/server/http/remote_storage_conformance_tranche5_rotation_membership_test.go
@@ -1,0 +1,384 @@
+// remote_storage_conformance_tranche5_rotation_membership_test.go — issue
+// #1808, tranche 5.
+//
+// Covers 3 methods left uncovered by tranche 4:
+//
+//	CreateRotationPolicy, UpdateRotationPolicy (internal/storage/store/
+//	remote_rotation_policies.go): tranche 4's own dynamic_rotation file
+//	SKIPPED both, documenting a confirmed, currently-shipping wire bug --
+//	models.RotationPolicy carries no json tags, so posting it directly
+//	marshaled every multi-word field (IntervalDays, ProjectID, EnvironmentID,
+//	AlertDaysBefore, NotifyOnBreach, IsActive, CreatedBy) as PascalCase, which
+//	never case-insensitively matches the server's snake_case-tagged reqBody,
+//	silently zeroing all of them and tripping the server's own
+//	`interval_days must be at least 1` validation on every single call. THAT
+//	BUG IS NOW FIXED (PR #1832): remote_rotation_policies.go now builds
+//	explicit rotationPolicyCreateWire/rotationPolicyUpdateWire request types
+//	with correct snake_case json tags. Real, passing conformance tests for
+//	both methods are written below, with assertions strong enough to have
+//	caught the original bug (asserting exact non-default, non-zero values for
+//	every previously-zeroed multi-word field, not just "no error").
+//
+//	TransitionProjectMembershipState (internal/storage/store/
+//	remote_memberships.go): tranche 4's own memberships_auth file SKIPPED
+//	this one too, for a different reason -- its proxy route
+//	(TransitionMembershipProxy) is not a raw CAS passthrough. It delegates to
+//	core.TransitionMembership, which re-derives fromState from a fresh read
+//	(ignoring the wire's own from_state), enforces canTransition legality
+//	server-side, and on a transition INTO "active" applies a role-grant side
+//	effect gated by its own permission ceiling. That file's header named this
+//	as needing "two FULL core.TransitionMembership executions... left for a
+//	dedicated future tranche" -- this is that tranche. Using the same
+//	technique TestConformance_DeleteUser (tranche 4) established for an
+//	asymmetric core-delegating route: compare h.upstreamCore.TransitionMembership
+//	called in-process against h.rs.TransitionProjectMembershipState called
+//	over the real router, on independently-seeded memberships in the same
+//	states.
+//
+//	A real, CONFIRMED asymmetry was found while writing this test (not
+//	glossed over -- see TestConformance_TransitionProjectMembershipState's own
+//	doc comment below for the full trace): activating a membership
+//	(provisioned -> active, the ONE transition with a role-grant side effect)
+//	via RemoteStorage's proxy route is refused UNCONDITIONALLY for this
+//	harness's node/machine credential, for any role that carries at least one
+//	permission -- TransitionMembershipProxy never tags its context with
+//	core.WithSelfMachineGranter the way the human-facing
+//	project_memberships.go route does, so requireGranterHoldsRolePermissions
+//	treats the untagged machine actor as holding zero permissions and refuses
+//	unconditionally, regardless of the credential's real admin role. This is
+//	a genuine, pre-existing route-design gap (out of this tranche's scope to
+//	fix -- only one new file may be added), not a fixture-cost skip: the
+//	method IS exercised below, including this confirmed divergence, rather
+//	than faked with a shallow comparison or silently worked around. Every
+//	OTHER transition (which does not touch this permission ceiling) is
+//	asserted for genuine, full parity between the two paths.
+package http
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/keyorixhq/keyorix/internal/core"
+	coreStorage "github.com/keyorixhq/keyorix/internal/core/storage"
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// --- CreateRotationPolicy ---
+
+func TestConformance_CreateRotationPolicy(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	// Local sanity baseline: LocalStorage.CreateRotationPolicy is a bare GORM
+	// Create with zero business logic (local_rotation_policies.go) -- every
+	// field is set explicitly, including RotationState ("idle"), matching
+	// what GORM's own `gorm:"default:'idle'"` would otherwise silently
+	// substitute for a zero-valued field on Create, so this comparison isn't
+	// fighting the DB's own defaulting behavior.
+	localSent := &models.RotationPolicy{
+		Name: "conformance-crp-local", Description: "local desc", Scope: "project",
+		ProjectID: uintPtr(h.projectID), IntervalDays: 45, AlertDaysBefore: 3,
+		NotifyOnBreach: true, IsActive: true, RotationState: "idle", CreatedBy: "conformance-test",
+	}
+	require.NoError(t, h.ls.CreateRotationPolicy(ctx, localSent))
+	localPersisted, err := h.ls.GetRotationPolicy(ctx, localSent.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "LocalStorage.CreateRotationPolicy (sanity baseline)", localSent, localPersisted, map[string]bool{
+		"UpdatedAt": true, // GORM auto-set on Create
+	})
+
+	// Remote: CreateRotationPolicyProxy (rotation_policies_handler.go's
+	// Create) routes through the FULL core.CreateRotationPolicy business
+	// logic, not a raw passthrough -- it force-sets IsActive:true and derives
+	// CreatedBy from the authenticated caller server-side. Neither field is
+	// even carried by rotationPolicyCreateWire, so a caller cannot influence
+	// either over the wire at all -- IsActive/CreatedBy are deliberately set
+	// to forged/wrong values below to prove that.
+	//
+	// IntervalDays/AlertDaysBefore/ProjectID are deliberately given distinct,
+	// non-zero, non-default values (45, 3) -- this is the exact defect class
+	// tranche 4's own SKIPPED writeup found: every one of these previously
+	// decoded to its Go zero value server-side (models.RotationPolicy has no
+	// json tags, and encoding/json's case-insensitive fallback match cannot
+	// bridge "IntervalDays" to "interval_days" -- the strings differ by more
+	// than case), which tripped the server's own `interval_days` validation
+	// and made both methods fail unconditionally. NotifyOnBreach is
+	// deliberately NOT used to prove this on the CREATE path: GORM's own
+	// `gorm:"default:true"` on RotationPolicy.NotifyOnBreach means a
+	// zero-valued (false) field is silently coerced to true by Create
+	// regardless of whether it was ever set correctly, so a true round-trip
+	// here alone would not distinguish "correctly sent" from "silently
+	// dropped and defaulted the same way" -- NotifyOnBreach:false genuinely
+	// surviving a Save (not a Create) is what TestConformance_UpdateRotationPolicy
+	// below proves instead, where no such default-coercion exists.
+	remoteSent := &models.RotationPolicy{
+		Name: "conformance-crp-remote", Description: "remote desc", Scope: "project",
+		ProjectID: uintPtr(h.projectID), IntervalDays: 45, AlertDaysBefore: 3,
+		NotifyOnBreach: true,
+		// Deliberately wrong: rotationPolicyCreateWire carries neither field at
+		// all, so the server cannot even receive these -- both must be forced
+		// server-side, never silently reflect these forged local values.
+		IsActive:  false,
+		CreatedBy: "conformance-crp-forged-creator",
+	}
+	require.NoError(t, h.rs.CreateRotationPolicy(ctx, remoteSent),
+		"RemoteStorage.CreateRotationPolicy must succeed now that the wire fix (rotationPolicyCreateWire) "+
+			"correctly encodes multi-word fields as snake_case -- this used to fail unconditionally with the "+
+			"server's own 400 \"interval_days must be at least 1\"")
+
+	// remoteSent has been mutated in place to the decoded response
+	// (RemoteStorage.CreateRotationPolicy's own `*p = result` contract) -- the
+	// key regression assertions, strong enough to have caught the original
+	// bug (which zeroed every one of these before the fix).
+	assert.Equal(t, 45, remoteSent.IntervalDays,
+		"IntervalDays must round-trip over the wire -- the exact field whose zeroing tripped the server's "+
+			"own interval_days validation and made this method fail unconditionally before the fix")
+	assert.Equal(t, 3, remoteSent.AlertDaysBefore, "AlertDaysBefore must round-trip over the wire")
+	require.NotNil(t, remoteSent.ProjectID, "ProjectID must round-trip over the wire, not be silently dropped")
+	assert.Equal(t, h.projectID, *remoteSent.ProjectID)
+	assert.True(t, remoteSent.NotifyOnBreach, "NotifyOnBreach must round-trip over the wire")
+	assert.True(t, remoteSent.IsActive,
+		"core.CreateRotationPolicy always forces IsActive:true server-side, regardless of the forged false "+
+			"input above -- the create wire carries no is_active field at all")
+	assert.NotEqual(t, "conformance-crp-forged-creator", remoteSent.CreatedBy,
+		"CreatedBy must be derived from the authenticated caller server-side -- rotationPolicyCreateWire "+
+			"carries no created_by field at all, so a caller cannot even transmit one")
+	assert.NotEmpty(t, remoteSent.CreatedBy, "sanity: the server-derived CreatedBy must still be populated")
+
+	remotePersisted, err := h.ls.GetRotationPolicy(ctx, remoteSent.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "RemoteStorage.CreateRotationPolicy (response fidelity: wire-returned vs persisted)",
+		remoteSent, remotePersisted, map[string]bool{
+			"CreatedAt": true, // GORM/SQLite timezone round-trip quirk, defensive
+			"UpdatedAt": true, // GORM auto-set on Create
+		})
+}
+
+// --- UpdateRotationPolicy ---
+
+func TestConformance_UpdateRotationPolicy(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newPolicy := func(name string) *models.RotationPolicy {
+		p := &models.RotationPolicy{
+			Name: name, Description: "original desc", Scope: "project", ProjectID: uintPtr(h.projectID),
+			IntervalDays: 30, AlertDaysBefore: 7, NotifyOnBreach: true, IsActive: true,
+			RotationState: "idle", CreatedBy: "conformance-test",
+		}
+		require.NoError(t, h.ls.CreateRotationPolicy(ctx, p))
+		return p
+	}
+
+	// Local sanity baseline: LocalStorage.UpdateRotationPolicy is a bare GORM
+	// Save (full-row overwrite) with zero business logic -- mutate the
+	// already-persisted struct directly (it already carries the real
+	// ID/Scope/ProjectID/CreatedBy/RotationState from CreateRotationPolicy
+	// above) and Save it, mirroring what core.UpdateRotationPolicy's own
+	// fetch-then-patch achieves for the remote path below.
+	localPolicy := newPolicy("conformance-urp-local")
+	localPolicy.Name = "conformance-urp-local-changed"
+	localPolicy.Description = "changed desc"
+	localPolicy.IntervalDays = 60
+	localPolicy.AlertDaysBefore = 10
+	localPolicy.NotifyOnBreach = false
+	localPolicy.IsActive = false
+	require.NoError(t, h.ls.UpdateRotationPolicy(ctx, localPolicy))
+	localPersisted, err := h.ls.GetRotationPolicy(ctx, localPolicy.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "LocalStorage.UpdateRotationPolicy (sanity baseline)", localPolicy, localPersisted, map[string]bool{
+		"UpdatedAt": true, // GORM auto-set on Save
+	})
+
+	// Remote: UpdateRotationPolicyProxy routes through the FULL
+	// core.UpdateRotationPolicy business logic, which fetches the existing
+	// row FIRST and patches only Name/Description/IntervalDays/
+	// AlertDaysBefore/NotifyOnBreach/IsActive onto it -- confirmed against
+	// rotation_policies_handler.go's Update reqBody and
+	// core.UpdateRotationPolicyRequest directly, not assumed: neither has a
+	// scope-family field. Every one of Scope/ProjectID/EnvironmentID/
+	// CreatedBy/RotationState must therefore survive the update UNCHANGED
+	// from whatever CreateRotationPolicy originally persisted -- proven below
+	// by comparing against a pre-update snapshot, not merely assumed to hold.
+	remotePolicy := newPolicy("conformance-urp-remote")
+	preUpdateProjectID := *remotePolicy.ProjectID
+	preUpdateScope := remotePolicy.Scope
+	preUpdateCreatedBy := remotePolicy.CreatedBy
+	preUpdateRotationState := remotePolicy.RotationState
+
+	remoteSent := &models.RotationPolicy{
+		ID: remotePolicy.ID, Name: "conformance-urp-remote-changed", Description: "changed desc",
+		IntervalDays: 60, AlertDaysBefore: 10, NotifyOnBreach: false, IsActive: false,
+	}
+	require.NoError(t, h.rs.UpdateRotationPolicy(ctx, remoteSent),
+		"RemoteStorage.UpdateRotationPolicy must succeed now that the wire fix (rotationPolicyUpdateWire) "+
+			"correctly encodes multi-word fields as snake_case")
+
+	// remoteSent is mutated in place to the decoded response -- the key
+	// regression assertions (every one of these fields previously decoded to
+	// its zero value server-side before the fix).
+	assert.Equal(t, 60, remoteSent.IntervalDays, "IntervalDays must round-trip over the wire")
+	assert.Equal(t, 10, remoteSent.AlertDaysBefore, "AlertDaysBefore must round-trip over the wire")
+	assert.False(t, remoteSent.NotifyOnBreach,
+		"NotifyOnBreach:false must survive a Save -- unlike Create, GORM applies no column-default "+
+			"substitution on Save's update path, so this genuinely proves the field crossed the wire as "+
+			"false rather than merely defaulting true and coincidentally matching (see the CREATE test's "+
+			"comment on this exact ambiguity)")
+	assert.False(t, remoteSent.IsActive,
+		"IsActive:false must round-trip over the wire -- update is the one place this tranche's brief calls "+
+			"out IsActive specifically, and it is a multi-word field (\"is_active\") that was silently zeroed "+
+			"pre-fix along with every other field in this same request")
+	assert.Equal(t, "conformance-urp-remote-changed", remoteSent.Name)
+	assert.Equal(t, "changed desc", remoteSent.Description)
+
+	// Fields the update wire does NOT carry must survive untouched from
+	// whatever CreateRotationPolicy originally persisted.
+	require.NotNil(t, remoteSent.ProjectID)
+	assert.Equal(t, preUpdateProjectID, *remoteSent.ProjectID, "ProjectID is not on the update wire -- must survive unchanged")
+	assert.Equal(t, preUpdateScope, remoteSent.Scope, "Scope is not on the update wire -- must survive unchanged")
+	assert.Equal(t, preUpdateCreatedBy, remoteSent.CreatedBy, "CreatedBy is not on the update wire -- must survive unchanged")
+	assert.Equal(t, preUpdateRotationState, remoteSent.RotationState, "RotationState is not on the update wire -- must survive unchanged")
+
+	remotePersisted, err := h.ls.GetRotationPolicy(ctx, remoteSent.ID)
+	require.NoError(t, err)
+	assertFieldExhaustiveEqual(t, "RemoteStorage.UpdateRotationPolicy (response fidelity: wire-returned vs persisted)",
+		remoteSent, remotePersisted, map[string]bool{
+			"CreatedAt": true, // GORM/SQLite timezone round-trip quirk, defensive
+			"UpdatedAt": true, // GORM auto-set on Save
+		})
+}
+
+// --- TransitionProjectMembershipState ---
+//
+// See this file's package doc for the full context. Summary of what's proven
+// below:
+//
+//   - (a) invited -> identity_verified: a legal transition that touches
+//     neither canTransition's illegal-transition path nor the activation
+//     permission ceiling (which only fires for to == active) -- a genuinely
+//     fair, fully-comparable case. Both a real human actor (in-process) and
+//     this harness's real node/machine credential (over HTTP) must produce
+//     the identical resulting state.
+//   - (b) invited -> active (illegal, skips identity_verified/provisioned):
+//     canTransition is checked BEFORE the activation permission ceiling, so
+//     this refusal is actor-independent and is ALSO a fair comparison. Exact
+//     error text differs across the wire (clientSafe redacts everything to a
+//     generic sentence except a literal "not found" substring elsewhere --
+//     confirmed by tracing TransitionMembershipProxy/clientSafe directly),
+//     so parity is asserted on the OUTCOME (row left unchanged on both
+//     paths, both genuinely refuse), not on byte-identical error strings.
+//   - (c) provisioned -> active: the one transition with a role-grant side
+//     effect (AddProjectMember) AND a permission ceiling
+//     (requireGranterHoldsRolePermissions). A real human actor succeeds and
+//     the role grant lands. This harness's node/machine credential going
+//     through TransitionMembershipProxy is refused UNCONDITIONALLY for any
+//     role carrying at least one permission (system_viewer does):
+//     TransitionMembershipProxy never tags its context with
+//     core.WithSelfMachineGranter the way the human-facing
+//     project_memberships.go route does, so requireGranterHoldsRolePermissions
+//     treats the untagged machine actor as holding zero permissions and
+//     refuses every permission check unconditionally -- regardless of the
+//     credential's real admin role. This is a genuine, pre-existing route
+//     design gap (confirmed by direct code trace of
+//     internal/core/authz.go's requireGranterHoldsRolePermissions and
+//     server/http/handlers/project_memberships_proxy.go's
+//     TransitionMembershipProxy, not theorized), not a wire-fidelity defect
+//     this tranche's own scope covers fixing (only one new file may be
+//     added) -- asserted explicitly below, including that the refused
+//     attempt left both the row and the role grant untouched (fails closed,
+//     no partial side effect), rather than silently worked around.
+func TestConformance_TransitionProjectMembershipState(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	newMembership := func(suffix, state string) (*models.User, *models.ProjectMembership) {
+		user, err := h.ls.CreateUser(ctx, &models.User{
+			Username: "conformance-tpms-" + suffix, Email: "conformance-tpms-" + suffix + "@example.com",
+			DisplayName: "Conformance TransitionProjectMembershipState " + suffix, IsActive: true,
+		})
+		require.NoError(t, err)
+		m, err := h.ls.CreateProjectMembership(ctx, &models.ProjectMembership{
+			ProjectID: h.projectID, UserID: user.ID, Role: "system_viewer", State: state,
+			InvitedBy: h.adminUserID, InvitedAt: time.Now().UTC(),
+		})
+		require.NoError(t, err)
+		return user, m
+	}
+
+	// (a) Legal transition, no permission ceiling, no side effect.
+	_, localMembershipA := newMembership("a-local", core.MembershipInvited)
+	updatedLocalA, err := h.upstreamCore.TransitionMembership(ctx, h.projectID, localMembershipA.ID, core.MembershipIdentityVerified, h.adminUserID, false)
+	require.NoError(t, err, "sanity: invited -> identity_verified must be legal for a real human actor")
+	assert.Equal(t, core.MembershipIdentityVerified, updatedLocalA.State)
+
+	_, remoteMembershipA := newMembership("a-remote", core.MembershipInvited)
+	remoteMatchedA, err := h.rs.TransitionProjectMembershipState(ctx, &models.ProjectMembership{
+		ID: remoteMembershipA.ID, ProjectID: h.projectID, State: core.MembershipIdentityVerified,
+	}, core.MembershipInvited)
+	require.NoError(t, err, "RemoteStorage.TransitionProjectMembershipState must succeed for a legal transition "+
+		"that doesn't touch the activation permission ceiling")
+	assert.True(t, remoteMatchedA)
+	remoteAfterA, err := h.ls.GetProjectMembership(ctx, remoteMembershipA.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.MembershipIdentityVerified, remoteAfterA.State,
+		"the remote transition must have actually persisted server-side, matching the in-process result exactly")
+
+	// (b) Illegal transition, refused identically on both paths.
+	_, illegalLocalMembership := newMembership("b-local", core.MembershipInvited)
+	_, err = h.upstreamCore.TransitionMembership(ctx, h.projectID, illegalLocalMembership.ID, core.MembershipActive, h.adminUserID, false)
+	require.Error(t, err, "sanity: invited -> active must be refused as an illegal transition")
+	assert.Contains(t, err.Error(), "cannot transition membership from",
+		"sanity: must be refused for the RIGHT reason (illegal transition, not some other failure)")
+	stillInvitedLocal, err := h.ls.GetProjectMembership(ctx, illegalLocalMembership.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.MembershipInvited, stillInvitedLocal.State, "a refused illegal transition must not have altered the row")
+
+	_, illegalRemoteMembership := newMembership("b-remote", core.MembershipInvited)
+	_, err = h.rs.TransitionProjectMembershipState(ctx, &models.ProjectMembership{
+		ID: illegalRemoteMembership.ID, ProjectID: h.projectID, State: core.MembershipActive,
+	}, core.MembershipInvited)
+	require.Error(t, err, "RemoteStorage.TransitionProjectMembershipState must ALSO refuse invited -> active as "+
+		"an illegal transition -- the SAME core.TransitionMembership canTransition check this route delegates to")
+	assert.Contains(t, err.Error(), "STORAGE_ERROR",
+		"the illegal-transition rejection surfaces as the generic internal-error code over HTTP (clientSafe "+
+			"redacts the real message to a fixed generic sentence -- confirmed by tracing clientSafe directly, "+
+			"not assumed) -- the row check below is what actually proves this was the SAME rejection, not some "+
+			"unrelated failure that happened to also error")
+	stillInvitedRemote, err := h.ls.GetProjectMembership(ctx, illegalRemoteMembership.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.MembershipInvited, stillInvitedRemote.State,
+		"a refused illegal transition must not have altered the row server-side either")
+
+	// (c) provisioned -> active: role-grant side effect + permission ceiling.
+	// See this function's own doc comment above for the confirmed asymmetry.
+	localUser, localProvisioned := newMembership("c-local", core.MembershipProvisioned)
+	updatedLocalActive, err := h.upstreamCore.TransitionMembership(ctx, h.projectID, localProvisioned.ID, core.MembershipActive, h.adminUserID, false)
+	require.NoError(t, err, "a real human actor activating a provisioned membership must succeed")
+	assert.Equal(t, core.MembershipActive, updatedLocalActive.State)
+	assert.NotNil(t, updatedLocalActive.ActivatedAt)
+	localRoleIDs, err := h.ls.GetUserRoleIDsAt(ctx, localUser.ID, coreStorage.Scope{ProjectID: h.projectID})
+	require.NoError(t, err)
+	assert.NotEmpty(t, localRoleIDs,
+		"activating a membership must apply its role-grant side effect (AddProjectMember) for a real human actor")
+
+	remoteUser, remoteProvisioned := newMembership("c-remote", core.MembershipProvisioned)
+	_, err = h.rs.TransitionProjectMembershipState(ctx, &models.ProjectMembership{
+		ID: remoteProvisioned.ID, ProjectID: h.projectID, State: core.MembershipActive,
+	}, core.MembershipProvisioned)
+	assert.Error(t, err, "CONFIRMED ASYMMETRY (see this function's doc comment): activating a membership via "+
+		"RemoteStorage's proxy route is refused unconditionally for this harness's machine credential, unlike "+
+		"the identical in-process call above with a real human actor -- TransitionMembershipProxy never tags "+
+		"ctx with core.WithSelfMachineGranter the way the human-facing route does")
+	stillProvisionedRemote, err := h.ls.GetProjectMembership(ctx, remoteProvisioned.ID)
+	require.NoError(t, err)
+	assert.Equal(t, core.MembershipProvisioned, stillProvisionedRemote.State,
+		"the refused activation must not have altered the row -- fails closed, not a partial/silent activation")
+	remoteRoleIDs, err := h.ls.GetUserRoleIDsAt(ctx, remoteUser.ID, coreStorage.Scope{ProjectID: h.projectID})
+	require.NoError(t, err)
+	assert.Empty(t, remoteRoleIDs,
+		"the refused activation must not have granted the role either -- no partial side effect from the failed attempt")
+}


### PR DESCRIPTION
## Summary

Tranche 5 of the #1808 differential conformance harness — closes out nearly everything tranche 4 left blocked. PR #1831 (#1573 machine-attribution wire fix) and PR #1832 (envelope-unwrap + snake_case request-body fix) landed since tranche 4, unblocking 9 of the 10 previously-uncovered methods.

**Coverage: 203/214 → 212/213** (denominator dropped by one because #1832 correctly reclassified `CreateRole` as `remoteUnsupported` — a genuine interface gap, not a wire bug — rather than a guaranteed-400 real method).

## Covered this tranche

- `GetRole`, `UpdateRole`, `ListRoles`, `GetUserRoles`, `GetUserPermissions`, `GetGroupRoles` — now that #1832 unwraps each response envelope correctly.
- `CreateRotationPolicy`, `UpdateRotationPolicy` — now that #1832's snake_case request wires land the multi-word fields that were previously silently zeroed.
- `TransitionProjectMembershipState` — covered using the same two-full-execution technique tranche 4 used for `DeleteUser` (`core.TransitionMembership` run in-process vs. over HTTP), since it isn't a raw CAS proxy. Found and documented a real asymmetry: `TransitionMembershipProxy` never tags its context with `core.WithSelfMachineGranter` (unlike the human-facing route), so `requireGranterHoldsRolePermissions` unconditionally refuses the `provisioned→active` transition's role-grant side effect for a machine/node caller. Asserted as fails-closed behavior, not a bug.

## Smaller findings along the way (no production code changed — test-only PR)

- `UpdateRole`: `LocalStorage` has no built-in-role guard against renaming `admin` at the storage layer; `RemoteStorage` (proxied through `core.UpdateRole`) correctly rejects it. A real asymmetry, not a bug in this PR's scope.
- #1832's own commit message is inaccurate for `ListRoles`: it claims a reduced `apiRole{ID,Name}` projection, but the handler has always called `ListRolesWithPermissions` (full model + permissions) — verified directly against router wiring and handler source, not assumed from the commit message.

## Deliberately still uncovered: `GetAuditLogs`

The #1832 envelope fix (`"events"` → `"logs"` key) is real and confirmed working, but a live probe against the real router surfaced a **sibling, still-live defect**: `RemoteStorage.GetAuditLogs` unmarshals into untagged `[]*models.AuditEvent`, while the real handler sends snake_case-tagged `AuditLogEntry` values. `json.Unmarshal`'s case-insensitive fallback doesn't fold `event_type` → `EventType`, so `EventType`/`EventTime`/`ActorType`/`UserID`/`ProjectID`/`SecretNodeID`/`IPAddress`/`Success`/hash-chain fields all silently zero — only `ID`/`Description`/`Impersonation` survive. Writing a passing test here would mean asserting broken behavior as correct; left uncovered with full repro evidence for a dedicated follow-up fix.

## Verification

- `go build ./...` clean
- `go vet ./server/http/...` clean
- `gofmt -l` clean
- `gosec -severity medium ./server/http/...` clean (0 issues)
- Full `go test ./server/http/...` clean — 0 regressions
- `TestReportConformancePopulation`: 212/213 covered, 1 not yet covered

Issue #1808 stays open — `GetAuditLogs` remains, gated on its own wire fix (client-side struct needs the same snake_case tags/shape as the real `AuditLogEntry`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./server/http/...`
- [x] `gofmt -l` on all new files
- [x] `gosec -severity medium ./server/http/...`
- [x] Full `go test ./server/http/...`
- [x] `TestReportConformancePopulation` confirms the 212/213 tally