### PR TITLE
fix(storage): remove dead storage.GetRBACAuditLogs path

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -108,9 +108,9 @@ storage:
 ```
 
 `type: remote` points the CLI at a Keyorix server over the API; see the remote
-section of the client config. **It is work in progress:** 200 of 427
+section of the client config. **It is work in progress:** 200 of 426
 `RemoteStorage` methods (46%) return `ErrRemoteUnsupported`, and audit retrieval
-in particular is 3-of-28 implemented. Use `type: local` for anything that
+in particular is 2-of-27 implemented. Use `type: local` for anything that
 matters — see `docs/REMOTE_CLI_SETUP.md` for the per-area status. Remote TLS verification is **on by default** —
 an omitted `tls_verify` does not disable certificate checks.
 

--- a/docs/REMOTE_CLI_SETUP.md
+++ b/docs/REMOTE_CLI_SETUP.md
@@ -3,7 +3,7 @@
 > ## ⚠️ Remote mode is WORK IN PROGRESS — not yet a supported deployment
 >
 > **Roughly half of the CLI's storage operations are not implemented over remote
-> mode.** Derived by counting, not estimated: of **427** `RemoteStorage` methods,
+> mode.** Derived by counting, not estimated: of **426** `RemoteStorage` methods,
 > **200 (46%)** return `ErrRemoteUnsupported`. Local mode
 > (`storage.type: local`) is the complete, supported path today.
 >
@@ -16,11 +16,11 @@
 > matching every other supported operation.
 >
 > **The audit examples further down this document are limited, not broken.**
-> `remote_audit.go` implements 3 of 28 methods — `GetAuditLogs` is one of
+> `remote_audit.go` implements 2 of 27 methods — `GetAuditLogs` is one of
 > them, and now returns its actual event list rather than a correct-looking
 > total with an empty one. The other 25 audit methods remain unsupported. Do
 > not build a nightly tamper check or a SIEM pull on remote mode's audit
-> surface until more of that 28 is implemented.
+> surface until more of that 27 is implemented.
 >
 > ### What works today, by area
 >
@@ -28,7 +28,7 @@
 > |---|---|
 > | **Complete** | invitations, project memberships, legal hold, login attempts, risk exceptions, segregation of duties, access activity |
 > | **Mostly complete** | machine identities (26/27), RBAC (46/63), users (25/38), access-review campaigns (10/11) |
-> | **Substantially incomplete** | secrets (13/31), MFA (7/17), sharing (8/12), dynamic secrets (7/12), stats (2/7), secret ACLs (1/7), **audit (3/28)** |
+> | **Substantially incomplete** | secrets (13/31), MFA (7/17), sharing (8/12), dynamic secrets (7/12), stats (2/7), secret ACLs (1/7), **audit (2/27)** |
 > | **Not implemented at all** | compliance, notification channels, secret templates, bulk access, alert escalation, anomaly config, hygiene counts, version comments, secret schedules, retention override, read quota, billing, usage |
 >
 > The authoritative, machine-checked status is the conformance suite in

--- a/internal/core/mock_storage_test.go
+++ b/internal/core/mock_storage_test.go
@@ -1462,14 +1462,6 @@ func (m *MockStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditFil
 	return args.Get(0).([]*models.AuditEvent), args.Get(1).(int64), args.Error(2)
 }
 
-func (m *MockStorage) GetRBACAuditLogs(ctx context.Context, filter *storage.RBACAuditFilter) ([]*storage.RBACAuditLog, int64, error) {
-	args := m.Called(ctx, filter)
-	if args.Get(0) == nil {
-		return nil, args.Get(1).(int64), args.Error(2)
-	}
-	return args.Get(0).([]*storage.RBACAuditLog), args.Get(1).(int64), args.Error(2)
-}
-
 // Session Management
 
 func (m *MockStorage) CreateSession(ctx context.Context, session *models.Session) (*models.Session, error) {

--- a/internal/core/storage/interface.go
+++ b/internal/core/storage/interface.go
@@ -1288,7 +1288,6 @@ type Storage interface {
 	ListUnalertedAnomalyAlerts(ctx context.Context) ([]models.AnomalyAlert, error)
 	MarkAnomalyAlertAlerted(ctx context.Context, id uint) error
 	GetAuditLogs(ctx context.Context, filter *AuditFilter) ([]*models.AuditEvent, int64, error)
-	GetRBACAuditLogs(ctx context.Context, filter *RBACAuditFilter) ([]*RBACAuditLog, int64, error)
 	// AuditRetentionStats returns the total audit event count and the oldest /
 	// newest event timestamps. Keyorix never purges audit events, so these raw
 	// aggregates let an operator demonstrate how far back the trail reaches
@@ -1862,18 +1861,6 @@ type AuditFilter struct {
 	ResourceType *string
 }
 
-// RBACAuditFilter defines filtering options for RBAC audit log queries
-type RBACAuditFilter struct {
-	UserID     *uint
-	Action     *string
-	TargetType *string
-	TargetID   *uint
-	StartTime  *time.Time
-	EndTime    *time.Time
-	Page       int
-	PageSize   int
-}
-
 // Scope identifies the project/environment a role assignment or an
 // authorization check applies to. It uses a 0 = global/unspecified sentinel,
 // matching the stored user_roles/group_roles columns:
@@ -1903,21 +1890,6 @@ type Permission struct {
 	Description string `json:"description"`
 	Resource    string `json:"resource"`
 	Action      string `json:"action"`
-}
-
-// RBACAuditLog represents an RBAC audit log entry
-type RBACAuditLog struct {
-	ID         uint      `json:"id"`
-	UserID     *uint     `json:"user_id"`
-	Username   string    `json:"username"`
-	Action     string    `json:"action"`
-	TargetType string    `json:"target_type"`
-	TargetID   *uint     `json:"target_id"`
-	TargetName string    `json:"target_name"`
-	Details    string    `json:"details"`
-	IPAddress  string    `json:"ip_address"`
-	Success    bool      `json:"success"`
-	Timestamp  time.Time `json:"timestamp"`
 }
 
 // ProjectUsageStat is one row in a usage report, aggregating all metrics for

--- a/internal/storage/store/constants.go
+++ b/internal/storage/store/constants.go
@@ -3,8 +3,6 @@ package store
 const (
 	// apiAuditLogsPath is the server's GET /api/v1/audit/logs route (GetAuditLogs).
 	apiAuditLogsPath = "/api/v1/audit/logs"
-	// apiAuditRBACLogsPath is the server's GET /api/v1/audit/rbac-logs route (GetRBACAuditLogs).
-	apiAuditRBACLogsPath = "/api/v1/audit/rbac-logs"
 	// apiAuditIngestPath is the system-write proxy route that persists a
 	// single AuditEvent from a remote-storage follower (#r122-A).
 	apiAuditIngestPath       = "/api/v1/system/audit/event"

--- a/internal/storage/store/local_audit.go
+++ b/internal/storage/store/local_audit.go
@@ -2,7 +2,7 @@
 //
 // Covers: LogAuditEvent, CreateSecretAccessLog, ListSecretAccessLogs,
 //
-//	GetAuditLogs, GetRBACAuditLogs,
+//	GetAuditLogs,
 //	CreateAnomalyAlert, ListAnomalyAlerts, AcknowledgeAnomalyAlert.
 //
 // All operations use direct GORM queries.
@@ -497,11 +497,6 @@ func (ls *LocalStorage) GetAuditLogs(ctx context.Context, filter *storage.AuditF
 		return nil, 0, fmt.Errorf("failed to get audit logs: %w", err)
 	}
 	return events, total, nil
-}
-
-// GetRBACAuditLogs is not yet implemented; returns empty results.
-func (ls *LocalStorage) GetRBACAuditLogs(_ context.Context, _ *storage.RBACAuditFilter) ([]*storage.RBACAuditLog, int64, error) {
-	return nil, 0, nil
 }
 
 // GetSecretReadCounts aggregates "secret.read" audit events for the given secret

--- a/internal/storage/store/local_failopen_stub_test.go
+++ b/internal/storage/store/local_failopen_stub_test.go
@@ -1,0 +1,144 @@
+// local_failopen_stub_test.go — guards against LocalStorage methods that
+// silently return a zero-shaped ("empty", not-an-error) result with no real
+// implementation behind them: a fail-open stub masquerading as a working
+// query.
+//
+// remote_unsupported_completeness_test.go and remote_reachability_registry_
+// test.go classify every structurally-stub RemoteStorage method — but
+// LocalStorage has no equivalent population or guard. That asymmetry let
+// storage.Storage.GetRBACAuditLogs's LocalStorage implementation
+// (`return nil, 0, nil`, unconditionally, regardless of filter — see this
+// repo's fix/remove-dead-rbac-audit-storage-path, which removed the method
+// outright as dead code) go unclassified and unguarded for its entire
+// lifetime. It had zero production callers throughout, so nothing was ever
+// shown the false result — but had a caller appeared, it would have read
+// "no RBAC changes" as the true state of the audit trail: an affirmative
+// false statement, worse than an error, because it looks like an answer
+// instead of a visible gap.
+//
+// This scans every non-test local_*.go file for *LocalStorage methods whose
+// ENTIRE body is a single return statement, all of whose result expressions
+// are zero-value literals (nil / 0 / "" / false) — the exact "trivially
+// fail-open" shape. No call-graph reachability analysis is needed here,
+// unlike the RemoteStorage guards above: a LocalStorage method that never
+// touches the DB is visible directly in its own one-line body, not hidden
+// behind same-package delegation. The population is asserted to be zero.
+package store
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// localStorageSourceFiles mirrors remoteStorageStubSourceFiles's file-list
+// convention (remote_unsupported_completeness_test.go) for the local_*.go
+// side: every non-test .go file starting with "local_".
+func localStorageSourceFiles(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading .: %v", err)
+	}
+	var files []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		if strings.HasPrefix(name, "local_") {
+			files = append(files, name)
+		}
+	}
+	sort.Strings(files)
+	return files
+}
+
+// isZeroValueLiteral reports whether expr is a trivial zero-value literal:
+// the bare identifiers nil/false, an integer literal "0", or an empty string
+// literal `""`. Deliberately narrow — a real computed value (even one that
+// happens to equal zero at runtime, e.g. `return count, nil`) is not a
+// literal and does not match.
+func isZeroValueLiteral(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name == "nil" || e.Name == "false"
+	case *ast.BasicLit:
+		switch e.Kind {
+		case token.INT:
+			return e.Value == "0"
+		case token.STRING:
+			return e.Value == `""`
+		}
+	}
+	return false
+}
+
+// failOpenLocalStorageStubs returns the name of every *LocalStorage method
+// whose entire body is exactly one return statement, all of whose result
+// expressions are zero-value literals — a method that silently claims
+// success/no-data with no real implementation behind it.
+func failOpenLocalStorageStubs(t *testing.T) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	var hits []string
+
+	for _, name := range localStorageSourceFiles(t) {
+		file, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || len(fn.Recv.List) == 0 {
+				continue
+			}
+			if exprString(fn.Recv.List[0].Type) != "*LocalStorage" {
+				continue
+			}
+			if fn.Body == nil || len(fn.Body.List) != 1 {
+				continue
+			}
+			ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+			if !ok || len(ret.Results) == 0 {
+				continue
+			}
+			allZero := true
+			for _, r := range ret.Results {
+				if !isZeroValueLiteral(r) {
+					allZero = false
+					break
+				}
+			}
+			if allZero {
+				hits = append(hits, fmt.Sprintf("%s (%s)", fn.Name.Name, name))
+			}
+		}
+	}
+	sort.Strings(hits)
+	return hits
+}
+
+// TestNoFailOpenLocalStorageStubs asserts the population above is empty. See
+// this file's package doc for why: a hit here is either a forgotten TODO
+// shipped as if it were a real implementation, or a genuine design choice
+// (an intentionally-empty result) that deserves an explicit comment and,
+// where a caller could be misled, a real error instead of a silent zero
+// value — not an unremarked one-line stub indistinguishable from either.
+func TestNoFailOpenLocalStorageStubs(t *testing.T) {
+	hits := failOpenLocalStorageStubs(t)
+	t.Logf("fail-open LocalStorage stub scan: %d hit(s) across local_*.go", len(hits))
+	if len(hits) > 0 {
+		t.Errorf("found %d LocalStorage method(s) that silently return a zero-value result with no real "+
+			"implementation and no error — indistinguishable from a genuine empty result to any caller. "+
+			"Each one must EITHER return a real error (or a documented sentinel) OR carry an inline comment "+
+			"justifying why a trivial zero-value return is actually correct here:\n  %s",
+			len(hits), strings.Join(hits, "\n  "))
+	}
+}

--- a/internal/storage/store/remote_audit.go
+++ b/internal/storage/store/remote_audit.go
@@ -2,7 +2,7 @@
 //
 // Covers: LogAuditEvent, CreateSecretAccessLog (no-op), GetAuditLogs,
 //
-//	GetRBACAuditLogs, ListSecretAccessLogs (unsupported),
+//	ListSecretAccessLogs (unsupported),
 //	CreateAnomalyAlert, ListAnomalyAlerts, AcknowledgeAnomalyAlert.
 //
 // Access logging and anomaly detection are handled server-side in remote mode;
@@ -159,42 +159,6 @@ func buildAuditFilterPath(filter *storage.AuditFilter) string {
 	params.addString("resource_type", filter.ResourceType)
 	params.addPage(filter.Page, filter.PageSize)
 	return apiAuditLogsPath + params.String()
-}
-
-// GetRBACAuditLogs retrieves RBAC audit logs with optional filtering via remote API.
-func (rs *RemoteStorage) GetRBACAuditLogs(ctx context.Context, filter *storage.RBACAuditFilter) ([]*storage.RBACAuditLog, int64, error) {
-	path := buildRBACAuditFilterPath(filter)
-	resp, err := rs.client.Get(ctx, path)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get RBAC audit logs: %w", err)
-	}
-	if !resp.Success {
-		return nil, 0, fmt.Errorf("get RBAC audit logs failed: %s", resp.Error.Error())
-	}
-	var result struct {
-		Logs  []*storage.RBACAuditLog `json:"logs"`
-		Total int64                   `json:"total"`
-	}
-	if err := json.Unmarshal(resp.Data, &result); err != nil {
-		return nil, 0, fmt.Errorf("failed to parse response: %w", err)
-	}
-	return result.Logs, result.Total, nil
-}
-
-// buildRBACAuditFilterPath constructs the GET /api/v1/audit/rbac-logs query string.
-func buildRBACAuditFilterPath(filter *storage.RBACAuditFilter) string {
-	if filter == nil {
-		return apiAuditRBACLogsPath
-	}
-	params := newQueryBuilder()
-	params.addUint("user_id", filter.UserID)
-	params.addString("action", filter.Action)
-	params.addString("target_type", filter.TargetType)
-	params.addUint("target_id", filter.TargetID)
-	params.addTime("start_time", filter.StartTime)
-	params.addTime("end_time", filter.EndTime)
-	params.addPage(filter.Page, filter.PageSize)
-	return apiAuditRBACLogsPath + params.String()
 }
 
 // ListSecretAccessLogs is not available in remote mode; server handles access logs.

--- a/internal/storage/store/remote_audit_test.go
+++ b/internal/storage/store/remote_audit_test.go
@@ -115,63 +115,6 @@ func TestRemoteStorage_GetAuditLogs_WithFilter(t *testing.T) {
 	assert.Len(t, events, 1)
 }
 
-// --- GetRBACAuditLogs ---
-
-func TestRemoteStorage_GetRBACAuditLogs_NilFilter(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/audit/rbac-logs", r.URL.Path)
-		_, _ = w.Write(apiOK(map[string]interface{}{
-			"logs": []map[string]interface{}{
-				{
-					"id":      1,
-					"action":  "role.assign",
-					"success": true,
-				},
-			},
-			"total": 1,
-		}))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	logs, total, err := rs.GetRBACAuditLogs(context.Background(), nil)
-	require.NoError(t, err)
-	assert.Equal(t, int64(1), total)
-	assert.Len(t, logs, 1)
-	assert.Equal(t, "role.assign", logs[0].Action)
-}
-
-func TestRemoteStorage_GetRBACAuditLogs_WithFilter(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/audit/rbac-logs", r.URL.Path)
-		_, _ = w.Write(apiOK(map[string]interface{}{
-			"logs":  []map[string]interface{}{},
-			"total": int64(0),
-		}))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	action := "role.assign"
-	targetType := "project"
-	filter := &corestorage.RBACAuditFilter{
-		Action:     &action,
-		TargetType: &targetType,
-		Page:       1,
-		PageSize:   10,
-	}
-	logs, total, err := rs.GetRBACAuditLogs(context.Background(), filter)
-	require.NoError(t, err)
-	assert.Equal(t, int64(0), total)
-	assert.Len(t, logs, 0)
-}
-
 // --- ListSecretAccessLogs (unsupported) ---
 
 func TestRemoteStorage_ListSecretAccessLogs_Unsupported(t *testing.T) {

--- a/internal/storage/store/remote_coverage_test.go
+++ b/internal/storage/store/remote_coverage_test.go
@@ -8,7 +8,7 @@
 //   - remote_webauthn.go:AdvanceWebAuthnCredentialCounter (66.7%)
 //   - remote_sharing.go:CheckSharePermission/DeleteExpiredShareRecords (70.0%)
 //   - remote_sso.go:CreateSSOLoginState/ConsumeSSOLoginState (70.0%)
-//   - remote_audit.go:GetAuditLogs/GetRBACAuditLogs (70.0%)
+//   - remote_audit.go:GetAuditLogs (70.0%)
 //   - remote_webauthn.go:CreateWebAuthnCredential/CreateWebAuthnSession (70.0%)
 //   - remote_users.go:toModel/decodeUserResponse (75.0%) via DeletedAt branch
 //
@@ -318,26 +318,6 @@ func TestRemoteCov_GetAuditLogs_Error(t *testing.T) {
 	_, _, err = rs.GetAuditLogs(context.Background(), filter)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "get audit logs failed")
-}
-
-func TestRemoteCov_GetRBACAuditLogs_Error(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(apiNotOK("INTERNAL", "db error"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	action := "role.assign"
-	filter := &corestorage.RBACAuditFilter{
-		Action:   &action,
-		Page:     1,
-		PageSize: 10,
-	}
-	_, _, err = rs.GetRBACAuditLogs(context.Background(), filter)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "get RBAC audit logs failed")
 }
 
 // ─── remote_webauthn.go ─────────────────────────────────────────────────────

--- a/internal/storage/store/remote_group_a_error_sweep_test.go
+++ b/internal/storage/store/remote_group_a_error_sweep_test.go
@@ -350,32 +350,6 @@ func TestRemoteStorage_GetAuditLogs_DecodeError_S1(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to parse response")
 }
 
-func TestRemoteStorage_GetRBACAuditLogs_TransportError_S1(t *testing.T) {
-	srv := httptest.NewServer(errHandler(http.StatusBadRequest, "INTERNAL", "boom"))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	_, _, err = rs.GetRBACAuditLogs(context.Background(), nil)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to get RBAC audit logs")
-}
-
-func TestRemoteStorage_GetRBACAuditLogs_DecodeError_S1(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(apiOK("not-an-object"))
-	}))
-	defer srv.Close()
-
-	rs, err := store.NewRemoteStorage(testConfig(srv.URL))
-	require.NoError(t, err)
-
-	_, _, err = rs.GetRBACAuditLogs(context.Background(), nil)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to parse response")
-}
-
 // ============================================================================
 // remote_auth.go
 // ============================================================================

--- a/internal/storage/store/remote_wire_route_coverage_test.go
+++ b/internal/storage/store/remote_wire_route_coverage_test.go
@@ -960,7 +960,6 @@ var knownUnresolvedWireCalls = map[string]wireCallExclusion{
 	// above, which is exactly why this campaign's own past attempts stopped at
 	// literal/Sprintf/local-var and never reached this category.
 	"remote_audit.go:117":   helperReturnEntry("buildAuditFilterPath(filter)"),
-	"remote_audit.go:167":   helperReturnEntry("buildRBACAuditFilterPath(filter)"),
 	"remote_secrets.go:436": helperReturnEntry("buildSecretFilterPath(filter)"),
 	"remote_users.go:514":   helperReturnEntry("buildUserFilterPath(filter)"),
 

--- a/internal/storage/store/store_s3_test.go
+++ b/internal/storage/store/store_s3_test.go
@@ -735,17 +735,6 @@ func TestCountUnusedSecretsByProject(t *testing.T) {
 	assert.Equal(t, 0, counts[2])
 }
 
-func TestGetRBACAuditLogs(t *testing.T) {
-	ctx := context.Background()
-	ls := newAuditStore(t)
-
-	// GetRBACAuditLogs is a stub; must return empty results, not an error.
-	logs, total, err := ls.GetRBACAuditLogs(ctx, nil)
-	require.NoError(t, err)
-	assert.Zero(t, total)
-	assert.Nil(t, logs)
-}
-
 func TestListUnalertedAnomalyAlerts(t *testing.T) {
 	ctx := context.Background()
 	ls := newStoreS3(t, "unalerted_alerts", &models.AnomalyAlert{})

--- a/server/http/remote_storage_conformance_tranche4_misc_test.go
+++ b/server/http/remote_storage_conformance_tranche4_misc_test.go
@@ -1,14 +1,16 @@
 // remote_storage_conformance_tranche4_misc_test.go — issue #1808, tranche 4.
 //
-// Covers 26 of the 27 assigned methods, spanning eight source files:
-// remote_risk_exceptions.go, remote_notifications.go,
+// Covers 25 of the 26 assigned methods (storage.Storage.GetRBACAuditLogs, the
+// 27th, was removed outright as dead code — see fix/remove-dead-rbac-audit-
+// storage-path — rather than covered or left uncovered), spanning seven
+// source files: remote_risk_exceptions.go, remote_notifications.go,
 // remote_access_activity.go, remote_sod.go, remote_legal_hold.go,
 // remote_break_glass.go (the two read-only survivors,
-// GetBreakGlassActivation/ListBreakGlassActivations), remote_audit.go
-// (GetRBACAuditLogs only), and remote_stats.go (HealthCheck).
+// GetBreakGlassActivation/ListBreakGlassActivations), and remote_stats.go
+// (HealthCheck).
 //
 // GetAuditLogs is deliberately NOT covered — see the comment where its test
-// would otherwise sit (just above TestConformance_GetRBACAuditLogs) for why:
+// would otherwise sit for why:
 // building it surfaced a genuine, live wire-shape defect (RemoteStorage.
 // GetAuditLogs silently returns an empty event list with a correct-looking
 // total, against its own real, currently-registered route) that this file's
@@ -1108,47 +1110,14 @@ func TestConformance_ListBreakGlassActivations(t *testing.T) {
 // probably a dedicated non-human-facing wire DTO/route) before a
 // TestConformance_GetAuditLogs can be added truthfully.
 //
-// GetRBACAuditLogs below has the SAME class of route (it also resolves to a
-// human-facing DashboardHandler.GetRBACAuditLogs, whose per-entry shape --
-// "actor_user_id" instead of "user_id", "created_at" instead of "timestamp",
-// no username/target_name/ip_address/success at all -- doesn't match
-// storage.RBACAuditLog's json tags either), but its top-level envelope key
-// ("logs") DOES happen to match what remote_audit.go's GetRBACAuditLogs
-// decodes for, and LocalStorage.GetRBACAuditLogs is itself an unimplemented
-// stub that always returns empty regardless of filter -- so unlike
-// GetAuditLogs, there is no nonzero local baseline available to make this
-// harness's own comparison actually notice the per-entry field-name
-// mismatch. See that test's own comment for what it can and cannot prove.
-
-// --- GetRBACAuditLogs ---
-
-func TestConformance_GetRBACAuditLogs(t *testing.T) {
-	h := newConformanceHarness(t)
-	ctx := context.Background()
-	now := time.Now().UTC()
-	uid := h.adminUserID
-	action := "role.assigned"
-	targetType := "role"
-	var targetID uint = 1
-	// A realistic filter+pagination payload, not a bare empty-params call --
-	// same #1808 rationale as GetAuditLogs above.
-	filter := &coreStorage.RBACAuditFilter{
-		UserID: &uid, Action: &action, TargetType: &targetType, TargetID: &targetID,
-		StartTime: timePtr(now.Add(-time.Hour)), EndTime: timePtr(now.Add(time.Hour)), Page: 1, PageSize: 10,
-	}
-	// LocalStorage.GetRBACAuditLogs is explicitly "not yet implemented" (its
-	// own doc comment) -- it always returns (nil, 0, nil) regardless of
-	// filter, on both backends (the server proxies onto the SAME LocalStorage
-	// method). The point of this test is #1808's own callout: prove the real
-	// route exists and accepts a realistic filter without 404ing, not to
-	// exercise filtering logic that doesn't exist yet.
-	localLogs, localTotal, err := h.ls.GetRBACAuditLogs(ctx, filter)
-	require.NoError(t, err)
-	remoteLogs, remoteTotal, err := h.rs.GetRBACAuditLogs(ctx, filter)
-	require.NoError(t, err, "GetRBACAuditLogs must succeed against the real router with a realistic filter")
-	assert.Equal(t, localTotal, remoteTotal)
-	assert.Equal(t, len(localLogs), len(remoteLogs))
-}
+// storage.Storage.GetRBACAuditLogs (and its LocalStorage/RemoteStorage
+// implementations) used to sit here — removed outright as dead code (no
+// production caller; see fix/remove-dead-rbac-audit-storage-path) rather than
+// covered by a conformance test. The LIVE RBAC audit trail is
+// core.KeyorixCore.ListRBACAuditLogs, reached via the real
+// GET /api/v1/audit/rbac-logs route (AuditHandler.GetRBACAuditLogs) and the
+// gRPC AuditService.GetRBACAuditLogs — both already exercised by their own
+// handler/service test suites, unaffected by this removal.
 
 // ============================================================================
 // remote_stats.go


### PR DESCRIPTION
## Denominator (as required)

`git --no-pager grep -n 'GetRBACAuditLogs' origin/main -- '*.go'`: **130 total hits**.

| Category | Count | Disposition |
|---|---|---|
| The dead surface itself (interface declaration, `LocalStorage` stub, `RemoteStorage` proxy, `MockStorage` double, orphaned `apiAuditRBACLogsPath` constant) | 9 | **Removed** |
| Tests that existed solely to exercise that dead surface (`remote_audit_test.go`, `remote_coverage_test.go`, `remote_group_a_error_sweep_test.go`, `store_s3_test.go`, `TestConformance_GetRBACAuditLogs`) | 28 | **Removed alongside it** |
| Confirmed-live, unrelated code sharing the method name on a *different* receiver (`AuditHandler.GetRBACAuditLogs`, `AuditGRPCService.GetRBACAuditLogs`, generated protobuf/gRPC, their tests) | 93 | **Untouched** |

No production caller of `storage.Storage.GetRBACAuditLogs` found — selection criterion was "does any hit reference this specific interface method/its two implementations," verified by reading each hit's receiver type, not just its name.

**Also checked** (Go-only sweep wasn't sufficient, per task): `web/src` — 0 references. `keyorix-sdks` (public repo) — GitHub code search for `GetRBACAuditLogs` and `rbac-logs`, 0 hits each.

## What was removed

- `storage.Storage.GetRBACAuditLogs` interface method
- `LocalStorage.GetRBACAuditLogs` (`return nil, 0, nil`, unconditionally — the fail-open stub)
- `RemoteStorage.GetRBACAuditLogs` + its `buildRBACAuditFilterPath` helper (a real HTTP call nothing needed it to make)
- `MockStorage.GetRBACAuditLogs` (test double, no test set expectations on it)
- `storage.RBACAuditFilter` / `storage.RBACAuditLog` types — confirmed unused anywhere else
- `apiAuditRBACLogsPath` constant — confirmed used only by the now-removed proxy

## What stays, confirmed

**The `/api/v1/audit/rbac-logs` route and its handler are untouched and still fully live** — `AuditHandler.GetRBACAuditLogs` calls `core.ListRBACAuditLogs` (never the removed storage method), and `router.go`'s registration is unchanged. Found while confirming this: `internal/cli/rbac/audit_logs.go`'s remote-mode path calls this exact route **directly** via a raw `common.RemoteClient`, completely bypassing `storage.Storage` — a real, independent client of the route that this PR does not affect and that confirms the route must stay exactly as-is.

## Classification gap (recorded per task)

`remote_reachability_registry_test.go` / `remote_unsupported_completeness_test.go` classify every structurally-stub `RemoteStorage` method — `LocalStorage` has no equivalent guard. A `LocalStorage` method returning a zero-shaped result with no error is **fail-open**: indistinguishable from a genuine empty result to any caller. `GetRBACAuditLogs` was the one instance of this shape.

Added `internal/storage/store/local_failopen_stub_test.go` (`TestNoFailOpenLocalStorageStubs`): an AST scan asserting zero `*LocalStorage` methods have a body that is a single return statement whose every result is a zero-value literal (`nil`/`0`/`""`/`false`). Verified both directions, not just asserted green: temporarily reintroduced the exact removed stub shape, confirmed the guard goes red, removed it, confirmed green again at population zero.

One correction to the task's own framing: my mechanical scan of "single-statement-return `*LocalStorage` methods" (same structural definition, pre-restriction to the zero-value-literal subset) found **54**, not the estimated 37 — likely a different counting method or snapshot in time. Doesn't affect the guard's correctness (independently verified via the positive/negative control above), only that one secondary sanity figure.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `gofmt -l` clean on every changed file
- `gosec -severity medium` (`internal/core`, `internal/storage/store`, `server/http`) clean (0 issues)
- `go test ./internal/core/...` clean (0 regressions)
- `go test ./server/http/...` clean (0 regressions)
- All run synchronously in the foreground

**One local finding worth flagging directly:** `go test ./internal/storage/store/... -timeout 25m` **failed on this branch** with a cascading `SQL logic error: no such table: X` pattern across many unrelated tables, traced to `local_secrets_cascade_sweep_test.go` dropping a shared table (`share_records`) without restoring it before other tests run against the same SQLite fixture. The identical failure *signature* (different specific tables) also appeared independently in PR #1835's CI, on a completely unrelated diff. I isolated this by running the identical suite against unmodified `origin/main` in a separate worktree — it passed clean. This points to a pre-existing, latent test-isolation defect in the shared store test suite (unrelated to `GetRBACAuditLogs`) that this branch's changed test-file set appears to reorder/retime into triggering, not a regression this change's logic introduces. Fixing that root cause is out of this change's scope — flagging for separate follow-up, not fixing here. Per this task's own standing constraint ("CI is the authority"), letting real CI render the verdict rather than deciding unilaterally from one local run.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` on all changed files
- [x] `gosec -severity medium` on affected packages
- [x] `go test ./internal/core/...`
- [x] `go test ./server/http/...`
- [x] `TestNoFailOpenLocalStorageStubs` positive+negative control verified manually
- [ ] `go test ./internal/storage/store/...` — failed locally with a likely-pre-existing, unrelated flake (see above); awaiting real CI signal