### PR TITLE
test(remote): add #1808 conformance coverage gate

### DIFF
--- a/internal/cli/cli_remote_check_guard_test.go
+++ b/internal/cli/cli_remote_check_guard_test.go
@@ -79,6 +79,11 @@ func TestCLICommandsCheckRemoteBeforeLocalStorage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("walking %s: %v", root, err)
 	}
+	if len(seen) == 0 {
+		t.Fatal("found 0 internal/cli files calling InitializeCoreService/InitializeStorage — " +
+			"this guard is now vacuous and is no longer checking anything; fix the scan, not " +
+			"this assertion")
+	}
 
 	sort.Strings(flagged)
 	if len(flagged) > 0 {

--- a/internal/cli/writeguard/write_guard_test.go
+++ b/internal/cli/writeguard/write_guard_test.go
@@ -184,6 +184,11 @@ func findAllSites(t *testing.T, repo string) map[string]site {
 // second scan root; GREEN after each was fixed.
 func TestNoUnprotectedSensitiveFileWrites(t *testing.T) {
 	found := findAllSites(t, repoRoot(t))
+	if len(found) == 0 {
+		t.Fatal("found 0 os.Create/os.OpenFile/os.WriteFile call sites across scanRoots — " +
+			"this guard is now vacuous and is no longer checking anything; fix the scan, not " +
+			"this assertion")
+	}
 
 	var unallowed []string
 	for key, s := range found {

--- a/internal/storage/account_state_fatal_migration_guard_test.go
+++ b/internal/storage/account_state_fatal_migration_guard_test.go
@@ -49,13 +49,49 @@ func TestMigrateDatabase_AccountStateCallsAbortOnError(t *testing.T) {
 		t.Fatal("could not find migrateDatabase's declaration in factory.go")
 	}
 
-	for _, target := range []string{"backfillBlankAccountState", "guardAccountStateValid"} {
+	targets := []string{"backfillBlankAccountState", "guardAccountStateValid"}
+	var calledAtAll int
+	for _, target := range targets {
+		if bodyCallsFunction(migrateDatabaseDecl.Body, target) {
+			calledAtAll++
+		}
 		if !callAbortsOnError(migrateDatabaseDecl, target) {
 			t.Errorf("migrateDatabase's call to %s(...) must be wired as "+
 				"`if err := %s(db); err != nil { return ... }` -- a failure here must abort "+
 				"migrateDatabase, not be logged/ignored and continued past", target, target)
 		}
 	}
+	// Distinct from the per-target abort-shape check above: if NEITHER target is
+	// even called anywhere in migrateDatabase's body, the two t.Errorf calls above
+	// would still fire (so this specific scenario isn't actually silent) -- but this
+	// makes the "both were found at all" signal explicit and independently
+	// verifiable, rather than inferred from the abort-shape check's own failure
+	// message, which is worded for "wrong shape," not "absent entirely."
+	if calledAtAll == 0 {
+		t.Fatal("neither backfillBlankAccountState nor guardAccountStateValid is called " +
+			"anywhere in migrateDatabase's body — this guard is now vacuous and is no longer " +
+			"checking anything; fix the scan, not this assertion")
+	}
+}
+
+// bodyCallsFunction reports whether body contains a call expression to a
+// bare (unqualified) function named target, anywhere -- regardless of
+// whether that call is wired to abort on error. Weaker than
+// callAbortsOnError on purpose: it answers "is this even still called,"
+// independent of "is it called correctly."
+func bodyCallsFunction(body *ast.BlockStmt, target string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == target {
+			found = true
+		}
+		return true
+	})
+	return found
 }
 
 // callAbortsOnError reports whether fd's body contains an if-statement of the

--- a/internal/storage/store/g81_guard_test.go
+++ b/internal/storage/store/g81_guard_test.go
@@ -224,11 +224,13 @@ func TestG81_NoUntrackedRangeQueriedTimeColumns(t *testing.T) {
 	}
 
 	fset := token.NewFileSet()
+	var scanned int
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
+		scanned++
 		path := filepath.Join(".", name)
 		src, err := os.ReadFile(path)
 		if err != nil {
@@ -265,5 +267,9 @@ func TestG81_NoUntrackedRangeQueriedTimeColumns(t *testing.T) {
 			}
 			return true
 		})
+	}
+	if scanned == 0 {
+		t.Fatal("scanned 0 non-test .go files in the package directory — this guard is now " +
+			"vacuous and is no longer checking anything; fix the scan, not this assertion")
 	}
 }

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -108,6 +108,11 @@ func remoteStorageStubSourceFiles(t *testing.T) []string {
 			files = append(files, name)
 		}
 	}
+	if len(files) == 0 {
+		t.Fatal("found 0 remote_*.go/entry.go source files in internal/storage/store — this " +
+			"guard is now vacuous and is no longer checking anything; fix the scan, not this " +
+			"assertion")
+	}
 	sort.Strings(files)
 	return files
 }
@@ -170,6 +175,10 @@ func actualRemoteUnsupportedStubs(t *testing.T) map[string]bool {
 				rsMethods[fn.Name.Name] = true
 			}
 		}
+	}
+	if len(rsMethods) == 0 {
+		t.Fatal("found 0 *RemoteStorage methods across the stub-source files — this guard is " +
+			"now vacuous and is no longer checking anything; fix the scan, not this assertion")
 	}
 
 	visiting := map[string]bool{}

--- a/server/http/full_row_overwrite_guard_test.go
+++ b/server/http/full_row_overwrite_guard_test.go
@@ -156,6 +156,7 @@ func TestNoUnfetchedStructIntoFullRowOverwrite(t *testing.T) {
 
 	flaggedFuncs := map[string]bool{}
 	var flagged []string
+	var filesScanned int
 	for _, dir := range dirs {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
@@ -167,6 +168,7 @@ func TestNoUnfetchedStructIntoFullRowOverwrite(t *testing.T) {
 			if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 				continue
 			}
+			filesScanned++
 			f, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
 			if err != nil {
 				t.Fatalf("parsing %s: %v", name, err)
@@ -189,6 +191,11 @@ func TestNoUnfetchedStructIntoFullRowOverwrite(t *testing.T) {
 				}
 			}
 		}
+	}
+	if filesScanned == 0 {
+		t.Fatal("scanned 0 .go files across server/http/handlers, server/grpc/services, and " +
+			"internal/core — this guard is now vacuous and is no longer checking anything; " +
+			"fix the scan, not this assertion")
 	}
 	sort.Strings(flagged)
 	if len(flagged) > 0 {

--- a/server/http/permission_sweep_test.go
+++ b/server/http/permission_sweep_test.go
@@ -181,6 +181,11 @@ func scanRouterForSystemReadOnlyGates(t *testing.T, routerGoPath string) map[str
 func TestNoUnjustifiedSystemReadOnlyGates(t *testing.T) {
 	routerGoPath := filepath.Join(permissionSweepRepoRoot(t), "server", "http", "router.go")
 	found := scanRouterForSystemReadOnlyGates(t, routerGoPath)
+	if len(found) == 0 {
+		t.Fatal("found 0 RequirePermission(permSystemRead)/RequireScopedPermission(permSystemRead, " +
+			"...) call sites in router.go — this guard is now vacuous and is no longer checking " +
+			"anything; fix the scan, not this assertion")
+	}
 
 	var unallowed []string
 	for key, s := range found {
@@ -757,6 +762,10 @@ func scanRouterForUngatedRoutes(t *testing.T, routerGoPath string) map[string]un
 func TestNoUngatedRoutes(t *testing.T) {
 	routerGoPath := filepath.Join(permissionSweepRepoRoot(t), "server", "http", "router.go")
 	found := scanRouterForUngatedRoutes(t, routerGoPath)
+	if len(found) == 0 {
+		t.Fatal("found 0 route-registration call sites in NewRouter — this guard is now " +
+			"vacuous and is no longer checking anything; fix the scan, not this assertion")
+	}
 
 	var unallowed []string
 	for key, u := range found {

--- a/server/http/remote_storage_conformance_population_test.go
+++ b/server/http/remote_storage_conformance_population_test.go
@@ -1,7 +1,17 @@
-// remote_storage_conformance_population_test.go — #1808 tranche selection and
-// reporting: derives (a) every real (non-stub) *RemoteStorage method and
-// (b) which of those already have a TestConformance_ test, both mechanically,
-// so "what's left" is never a hand-maintained list.
+// remote_storage_conformance_population_test.go — #1808 tranche selection,
+// reporting, AND (as of the gate added to close #1808) enforcement: derives
+// (a) every real (non-stub) *RemoteStorage method and (b) which of those
+// already have a TestConformance_ test, both mechanically, so "what's left"
+// is never a hand-maintained list, then fails the build when an uncovered
+// method has no declared exclusion. See TestConformanceCoverageIsCompleteOrDeclared.
+//
+// What this gate does NOT verify: that a TestConformance_ test exists for a
+// method says nothing about whether it is a GOOD test, or which of #1808's
+// seven defect classes it actually exercises. A green run here must not be
+// read as "all seven defect classes are covered for this method" — only that
+// some conformance test naming it exists. Defect-class coverage is a
+// per-method judgment call made when the test is written, not something this
+// mechanical AST scan can check.
 //
 // Why this duplicates internal/storage/store's AST-scan logic instead of
 // importing it: Go test files (_test.go) are never importable across package
@@ -28,6 +38,7 @@
 package http
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -355,5 +366,62 @@ func TestReportConformancePopulation(t *testing.T) {
 	if len(staleNames) > 0 {
 		t.Errorf("%d TestConformance_* test(s) name a method that is not a real (non-stub, exported) "+
 			"*RemoteStorage method — stale test, renamed method, or a typo: %v", len(staleNames), staleNames)
+	}
+}
+
+// conformanceCoverageExclusions: real (non-stub) RemoteStorage methods deliberately
+// without a TestConformance_ test, each with a written reason.
+//
+// EMPTY, and it started empty — #1808 reached 0 uncovered before this gate was added,
+// which is the only moment a registry like this can begin with nothing to argue about.
+// An entry here is a considered exception, not a backlog item: adding one should feel
+// like a decision, and the reason should be something a reviewer can disagree with.
+var conformanceCoverageExclusions = map[string]string{}
+
+// TestConformanceCoverageIsCompleteOrDeclared is #1808's closing gate. Coverage was
+// complete when #1808 closed; this is what keeps it that way. A newly added real proxy
+// method fails here until it either gets a TestConformance_ test or an explicit,
+// reasoned exclusion.
+func TestConformanceCoverageIsCompleteOrDeclared(t *testing.T) {
+	t.Parallel()
+	real := conformancePopRealProxyMethods(t)
+	covered := conformancePopCoveredMethods(t)
+
+	if len(real) == 0 {
+		t.Fatal("derived 0 real RemoteStorage methods — the scan has stopped working and " +
+			"this gate is now vacuous; fix the scan, not this test")
+	}
+
+	var undeclared []string
+	for name := range real {
+		if covered[name] {
+			continue
+		}
+		if _, ok := conformanceCoverageExclusions[name]; !ok {
+			undeclared = append(undeclared,
+				fmt.Sprintf("%s (%s:%d)", name, real[name].File, real[name].Line))
+		}
+	}
+	sort.Strings(undeclared)
+	if len(undeclared) > 0 {
+		t.Errorf("%d real (non-stub) RemoteStorage method(s) have no TestConformance_ test "+
+			"and no declared exclusion:\n  %s\n\n#1808 closed at 0 uncovered. Either write "+
+			"the conformance test, or add an entry to conformanceCoverageExclusions with a "+
+			"reason. Do not delete or skip this check to get green.",
+			len(undeclared), strings.Join(undeclared, "\n  "))
+	}
+
+	// The reverse, so exclusions cannot rot — same shape as ADR-074's CheckPartition.
+	for name, reason := range conformanceCoverageExclusions {
+		if _, isReal := real[name]; !isReal {
+			t.Errorf("conformanceCoverageExclusions names %q, which is not a real "+
+				"(non-stub, exported) RemoteStorage method — it was renamed, deleted, or "+
+				"became a stub. Remove the entry.", name)
+			continue
+		}
+		if covered[name] {
+			t.Errorf("conformanceCoverageExclusions still excludes %s (%q), but it now HAS "+
+				"a TestConformance_ test — remove the entry.", name, reason)
+		}
 	}
 }


### PR DESCRIPTION
## Summary — Part 1: #1808 conformance coverage gate
- Adds `TestConformanceCoverageIsCompleteOrDeclared`, which fails the build when a real (non-stub) `RemoteStorage` method has neither a `TestConformance_` test nor a declared entry in `conformanceCoverageExclusions` — closing the gap where `TestReportConformancePopulation` reports coverage but never gates on it.
- `conformanceCoverageExclusions` starts empty, deliberately: #1808 reached 0 uncovered before this gate existed, which is the only moment such a registry can begin with nothing to argue about.
- The reverse direction is also checked: an exclusion naming a method that's no longer real, or one that's since gained a `TestConformance_` test, fails too — exclusions can't rot silently either way.
- File header now states plainly what the gate does **not** verify: that a `TestConformance_` test exists says nothing about whether it's a *good* test, or which of #1808's seven defect classes it exercises.

## Summary — Part 2: non-vacuity assertions in 8 repo-scanning guards
- 31 tests in this repo derive their subject from the repository itself (AST walks, `os.ReadDir`, `parser.ParseFile`) — the class of test that can silently become vacuous: the scan returns zero files/matches, the loop body never executes, and the test passes having verified nothing.
- 22 of the 31 already asserted non-emptiness or carried a self-test; these 8 did not. Ordinary unit tests (fixed inputs, asserted outputs) were deliberately left alone.
- For each file, found the actual collection whose emptiness would make the guard meaningless (not a generic `len(entries)==0` bolted onto the wrong variable) and added a `t.Fatal` immediately after it's built. One of the 8 (`server/proto/pb/generated_code_test.go`) already had the exact check from #1541 — verified it actually fires rather than just being present, no code change needed.
- Every assertion was watched fail at least once before being trusted: for each file, temporarily pointed the scan at an empty/nonexistent directory or renamed the symbol it looks for, confirmed the new `t.Fatal` fires with the expected message, then restored and confirmed green again.

## Test plan
- [x] `go build ./...` / `go vet ./...` — clean
- [x] `gofmt -l` / `goimports -l` — clean
- [x] `golangci-lint run` on all affected packages — 0 issues
- [x] Part 1 green: `TestConformanceCoverageIsCompleteOrDeclared` passes as-is
- [x] Part 1 red (missing coverage): temporarily renamed `TestConformance_UpdateShareRecord` to `...X` — gate failed and named exactly `UpdateShareRecord (remote_sharing.go:64)`. Reverted.
- [x] Part 1 red (rotten exclusion): temporarily added an exclusion entry for `UpdateShareRecord` (which IS covered) — gate failed with the "remove the entry" message. Reverted.
- [x] `TestReportConformancePopulation` still passes and still prints its report (`NOT yet covered: 0`) unchanged.
- [x] Part 2: all 8 guards individually red-tested (temporarily broke each guard's own scan/symbol) and confirmed the new `t.Fatal` fires with the correct message, then restored to green.
- [x] Full affected-package test runs clean: `internal/cli`, `internal/cli/writeguard`, `internal/storage`, `server/http`, `server/proto/pb` all pass; `internal/storage/store` hits a known pre-existing environmental timeout (needs `-timeout 20m+`) with 0 actual test failures.

Closes #1808.