### PR TITLE
fix(proto): stop `make proto` deleting its own guard test, and close the descriptor drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,14 @@ proto-lint:
 
 # Regenerate server/proto/pb/*.pb.go from server/proto/keyorix.proto. Runs
 # proto-deps first so a fresh checkout works; needs the Go bin dir on PATH.
+#
+# The rm is what buf.gen.yaml's `clean:` used to do, narrowed to the files
+# this target actually owns. buf's own clean wipes the whole output directory,
+# which meant every `make proto` deleted server/proto/pb/generated_code_test.go
+# -- the hand-written guard asserting this package contains only generated
+# code. See buf.gen.yaml for the full note.
 proto: proto-deps
+	rm -f server/proto/pb/*.pb.go
 	PATH="$$(go env GOPATH)/bin:$$PATH" buf generate
 
 build: build-cli build-server

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,5 +1,22 @@
 version: v2
-clean: true
+
+# clean: false, deliberately. buf's `clean: true` deletes the ENTIRE contents
+# of every plugin `out:` directory before generating, not just the files it is
+# about to write. server/proto/pb holds one hand-written file —
+# generated_code_test.go, #1541's guard that every other .go file in the
+# package really is generated — and `clean: true` silently deleted it on every
+# `make proto`. Found 2026-09-10, when `make proto` was run for the first time
+# since #1541 landed: the guard that protects this package from hand-written
+# code was itself the casualty of regenerating it.
+#
+# The Makefile's `proto` target removes server/proto/pb/*.pb.go explicitly
+# instead, which is the actual property `clean` was wanted for (no stale
+# generated output when an RPC or message is renamed or deleted) without the
+# collateral damage. TestBufGenerateWillNotDeleteHandWrittenFiles in
+# server/proto/pb/generated_code_test.go fails if this is ever set back to
+# true while a hand-written file sits in an output directory.
+clean: false
+
 plugins:
   - local: protoc-gen-go
     out: server/proto/pb

--- a/server/proto/pb/generated_code_test.go
+++ b/server/proto/pb/generated_code_test.go
@@ -28,10 +28,14 @@
 package pb
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // generatedCodeHeaderMarkers are the exact header lines Go's own protoc
@@ -103,4 +107,155 @@ func TestEveryFileIsGenerated(t *testing.T) {
 			"scripts/ci-test-legs.sh and let this package run in CI like any other.",
 			len(missing), headerScanLines, missing)
 	}
+}
+
+// TestBufGenerateWillNotDeleteHandWrittenFiles is the guard for the defect
+// that this file was itself the victim of.
+//
+// buf's `clean: true` deletes the entire contents of every plugin `out:`
+// directory before generating — not only the files the plugins are about to
+// write. server/proto/pb is a plugin output directory that also holds this
+// hand-written file, so from #1541 (which added it) until 2026-09-10 every
+// `make proto` silently deleted TestEveryFileIsGenerated. Nobody noticed
+// because nobody ran `make proto` in that window; the drift that finally
+// prompted a regeneration (the `reserved 11 to 20` block on
+// CreateSecretRequest, ADR-105 phase 0) is what surfaced it.
+//
+// The repair was to set `clean: false` and have the Makefile remove
+// server/proto/pb/*.pb.go explicitly instead. That repair is a line in a YAML
+// file, which is exactly the kind of thing that gets reverted by someone
+// reasonably assuming clean-before-generate is good hygiene. So it is checked
+// here rather than explained in a comment and hoped for: if `clean` is true
+// and any plugin output directory contains a .go file without a generated
+// header, this fails and names the file that would be destroyed.
+func TestBufGenerateWillNotDeleteHandWrittenFiles(t *testing.T) {
+	root, err := repoRootForBufConfig()
+	if err != nil {
+		t.Fatalf("locating buf.gen.yaml: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(root, "buf.gen.yaml"))
+	if err != nil {
+		t.Fatalf("reading buf.gen.yaml: %v", err)
+	}
+
+	var cfg struct {
+		Clean   bool `yaml:"clean"`
+		Plugins []struct {
+			Out string `yaml:"out"`
+		} `yaml:"plugins"`
+	}
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parsing buf.gen.yaml: %v", err)
+	}
+
+	if len(cfg.Plugins) == 0 {
+		t.Fatal("buf.gen.yaml declares no plugins — either the file moved, its schema changed, or the " +
+			"parse silently failed; this guard is now vacuous, so fix the parse, not this assertion")
+	}
+
+	outDirs := map[string]bool{}
+	for _, p := range cfg.Plugins {
+		if p.Out != "" {
+			outDirs[filepath.Clean(p.Out)] = true
+		}
+	}
+	if len(outDirs) == 0 {
+		t.Fatal("buf.gen.yaml declares plugins but none with an `out:` directory — this guard has nothing " +
+			"to check and is vacuous; fix the parse, not this assertion")
+	}
+
+	// This file lives in a plugin output directory; that is the whole reason
+	// the guard exists. If it ever stops being true, the guard has quietly
+	// stopped guarding the thing it was written for.
+	const selfDir = "server/proto/pb"
+	if !outDirs[selfDir] {
+		t.Fatalf("%s is no longer a buf plugin output directory (out dirs: %v) — this guard was written "+
+			"because this package is BOTH generated into and hand-written in. If the layout changed, "+
+			"re-point or retire this test deliberately rather than letting it pass vacuously",
+			selfDir, keysOf(outDirs))
+	}
+
+	if !cfg.Clean {
+		return // the safe configuration; nothing to report
+	}
+
+	var atRisk []string
+	for dir := range outDirs {
+		entries, err := os.ReadDir(filepath.Join(root, dir))
+		if err != nil {
+			t.Fatalf("reading plugin output dir %s: %v", dir, err)
+		}
+		for _, e := range entries {
+			name := e.Name()
+			if e.IsDir() || !strings.HasSuffix(name, ".go") {
+				continue
+			}
+			b, err := os.ReadFile(filepath.Join(root, dir, name))
+			if err != nil {
+				t.Fatalf("reading %s/%s: %v", dir, name, err)
+			}
+			if !hasGeneratedHeader(b) {
+				atRisk = append(atRisk, filepath.ToSlash(filepath.Join(dir, name)))
+			}
+		}
+	}
+
+	if len(atRisk) > 0 {
+		t.Errorf("buf.gen.yaml sets `clean: true`, which deletes the entire contents of every plugin "+
+			"output directory before generating. %d hand-written file(s) sit in those directories and "+
+			"would be destroyed by the next `make proto`: %v\n"+
+			"This is not hypothetical: it is what happened to this very file between #1541 and "+
+			"2026-09-10. Either set `clean: false` (the Makefile's `proto` target removes "+
+			"server/proto/pb/*.pb.go explicitly, which is the property clean was wanted for), or move "+
+			"the hand-written file(s) out of the generated output directory.",
+			len(atRisk), atRisk)
+	}
+}
+
+// hasGeneratedHeader reports whether b carries a standard Go generated-code
+// header in its first few lines — the same window and prefix
+// TestEveryFileIsGenerated uses, kept in one place so the two checks cannot
+// drift apart and disagree about what "generated" means.
+func hasGeneratedHeader(b []byte) bool {
+	const headerScanLines = 5
+	lines := strings.SplitN(string(b), "\n", headerScanLines+1)
+	if len(lines) > headerScanLines {
+		lines = lines[:headerScanLines]
+	}
+	for _, line := range lines {
+		if strings.HasPrefix(line, generatedCodeHeaderPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// repoRootForBufConfig walks up from the test's working directory until it
+// finds buf.gen.yaml, so this test does not hardcode its own depth below the
+// repository root.
+func repoRootForBufConfig() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "buf.gen.yaml")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no buf.gen.yaml found in any parent of the test working directory")
+		}
+		dir = parent
+	}
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/server/proto/pb/keyorix.pb.go
+++ b/server/proto/pb/keyorix.pb.go
@@ -10714,7 +10714,7 @@ const file_keyorix_proto_rawDesc = "" +
 	"\x05value\x18\x03 \x01(\tR\x05value\x12%\n" +
 	"\x0eversion_number\x18\x04 \x01(\rR\rversionNumber\x12\x1d\n" +
 	"\n" +
-	"read_count\x18\x05 \x01(\rR\treadCount\"\xe5\x03\n" +
+	"read_count\x18\x05 \x01(\rR\treadCount\"\xeb\x03\n" +
 	"\x13CreateSecretRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value\x12\x1d\n" +
@@ -10737,7 +10737,7 @@ const file_keyorix_proto_rawDesc = "" +
 	"_max_readsB\r\n" +
 	"\v_expirationB\f\n" +
 	"\n" +
-	"_parent_id\"G\n" +
+	"_parent_idJ\x04\b\v\x10\x15\"G\n" +
 	"\x10GetSecretRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12#\n" +
 	"\rinclude_value\x18\x02 \x01(\bR\fincludeValue\"\xe6\x02\n" +


### PR DESCRIPTION
Two commits, read in order.

## 1. `make proto` was deleting `generated_code_test.go`

`make proto` had not been run since #1541 landed. Running it today — to close
the descriptor drift described below — produced an unexpected second diff:

```
 server/proto/pb/generated_code_test.go | 106 ------------------------
```

`buf.gen.yaml` set `clean: true`, which deletes the **entire contents** of every
plugin `out:` directory before generating, not just the files the plugins are
about to write. `server/proto/pb` is a plugin output directory that also holds
one hand-written file: #1541's guard asserting every *other* `.go` file in the
package really is generated code.

So from #1541 until today, every `make proto` would have silently removed the
guard that protects this package from hand-written code. The guard's own
deletion was the one failure mode it could not detect.

**Fix:**

1. `clean: false`.
2. The `proto` target removes `server/proto/pb/*.pb.go` explicitly — the
   property `clean` was actually wanted for (no stale generated output when a
   message or RPC is renamed), narrowed to the files the target owns.
3. `TestBufGenerateWillNotDeleteHandWrittenFiles`, because (1) is one line of
   YAML and the obvious instinct for a future reader is to set it back. It
   parses `buf.gen.yaml` and, if `clean` is true, fails naming every
   hand-written `.go` file in a plugin output directory. It also fails if the
   parse yields no plugins, no out dirs, or if `server/proto/pb` stops being an
   output directory — the three ways it could pass while checking nothing.

Validated both directions:

- **green** — both tests pass as committed.
- **red** — `clean: true` restored:
  `1 hand-written file(s) ... would be destroyed by the next make proto: [server/proto/pb/generated_code_test.go]`
- **then** — `make proto` re-run: the guard survives and the generated output
  is byte-identical to the previous run.

## 2. The regeneration itself

`reserved 11 to 20;` was added to `CreateSecretRequest` in ADR-105 phase 0
(reserving `description = 11`, `classification = 12`). Regeneration was
deferred at the time and never picked up.

```
-"read_count\x18\x05 \x01(\rR\treadCount\"\xe5\x03\n"
+"read_count\x18\x05 \x01(\rR\treadCount\"\xeb\x03\n"
-"_parent_id\"G\n"
+"_parent_idJ\x04\b\v\x10\x15\"G\n"
```

`J\x04\b\v\x10\x15` is field 9 (`reserved_range`), 4 bytes, `start=11 end=21` —
exactly the declared reservation and nothing else. No behaviour change: a
reserved range only makes the compiler reject a future reuse of those numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAULgwpMpdNJbHUg8q5RfN
