### PR TITLE
test(guards): red-proof campaign for 12 repo-scanning guards

### DIFF
--- a/internal/cli/cli_remote_check_guard_test.go
+++ b/internal/cli/cli_remote_check_guard_test.go
@@ -140,3 +140,99 @@ func normalizeCLIPath(path string) string {
 	}
 	return path[idx:]
 }
+
+// TestCLIRemoteCheckScannerDetectsMissingRemoteCheck is this guard's
+// red-proof.
+//
+// TestCLICommandsCheckRemoteBeforeLocalStorage already refuses to run vacuously
+// on an empty scan — it fails if it finds zero files calling the local
+// initializers. That closes one failure mode and not the interesting one:
+// fileHasCall could stop resolving selector expressions entirely and the guard
+// would still find plenty of files, still flag none of them, and still report
+// every CLI command correctly guarded. `seen` would be empty in that case, so
+// the vacuity check does catch that particular break — but not a narrower one,
+// such as fileHasCall matching the local initializers while quietly failing to
+// match NewRemoteClient/ResolveRemote, which flips the guard from "no
+// violations" to "everything is a violation" or the reverse depending on which
+// side breaks.
+//
+// The defect this guards is not hypothetical: ~25 files and 28 commands were
+// found operating on a stray local SQLite file while `keyorix connect`'s remote
+// config sat unread. The allowlist is empty because every one of them was a
+// bug. A guard defending an empty allowlist should be able to prove it still
+// sees.
+func TestCLIRemoteCheckScannerDetectsMissingRemoteCheck(t *testing.T) {
+	// Parsed, never compiled.
+	const unguarded = `package fixture
+
+func runCommand(cmd *cobra.Command, args []string) error {
+	core, err := common.InitializeCoreService(cfg)
+	if err != nil {
+		return err
+	}
+	return core.DoThing()
+}
+`
+	const guarded = `package fixture
+
+func runCommand(cmd *cobra.Command, args []string) error {
+	if remote, err := common.NewRemoteClient(cfg); err == nil && remote != nil {
+		return remote.DoThing()
+	}
+	core, err := common.InitializeCoreService(cfg)
+	if err != nil {
+		return err
+	}
+	return core.DoThing()
+}
+`
+	// A renamed import alias must still match: fileHasCall deliberately keys on
+	// the selector alone, and that intent is easy to "tidy away" later.
+	const aliased = `package fixture
+
+func runCommand(cmd *cobra.Command, args []string) error {
+	if remote, err := cli.ResolveRemote(cfg); err == nil && remote != nil {
+		return remote.DoThing()
+	}
+	return helpers.InitializeStorage(cfg)
+}
+`
+
+	parse := func(name, src string) *ast.File {
+		f, err := parser.ParseFile(token.NewFileSet(), name, src, 0)
+		if err != nil {
+			t.Fatalf("parsing the %s fixture: %v", name, err)
+		}
+		return f
+	}
+
+	uf := parse("unguarded", unguarded)
+	gf := parse("guarded", guarded)
+	af := parse("aliased", aliased)
+
+	// The local-storage side: if this stops matching, every file drops out of
+	// the population and the guard reports a clean CLI it never looked at.
+	if !fileHasCall(uf, "InitializeCoreService") {
+		t.Error("fileHasCall no longer detects common.InitializeCoreService — the population this guard " +
+			"scans would collapse to nothing")
+	}
+	if !fileHasCall(af, "InitializeStorage") {
+		t.Error("fileHasCall no longer detects InitializeStorage through a renamed import alias")
+	}
+
+	// The remote-check side: if this stops matching, every correctly-guarded
+	// command starts being reported as a violation, and the pressure is to
+	// grow the (deliberately empty) allowlist rather than fix the scanner.
+	if !fileHasCall(gf, "NewRemoteClient") {
+		t.Error("fileHasCall no longer detects common.NewRemoteClient")
+	}
+	if !fileHasCall(af, "ResolveRemote") {
+		t.Error("fileHasCall no longer detects ResolveRemote through a renamed import alias")
+	}
+
+	// And the verdict the guard actually renders, on both fixtures.
+	if fileHasCall(uf, "NewRemoteClient") || fileHasCall(uf, "ResolveRemote") {
+		t.Error("the unguarded fixture contains no remote check, but fileHasCall claims it does — the " +
+			"scanner is matching something other than call selectors, so nothing it reports means anything")
+	}
+}

--- a/internal/core/account_state_exhaustiveness_guard_test.go
+++ b/internal/core/account_state_exhaustiveness_guard_test.go
@@ -129,3 +129,93 @@ func accountLoginBlockedSwitchCaseIdents(f *ast.File) map[string]bool {
 	}
 	return idents
 }
+
+// TestAccountStateExhaustivenessScannerDetectsAMissingCase is this guard's
+// red-proof.
+//
+// TestAccountLoginBlocked_ExhaustsStateRegistry asserts that every ADR-025
+// account state is currently listed in AccountLoginBlocked's switch. Both of
+// its inputs are derived by AST walks that can silently return nothing:
+// accountStateConstants filters on a "Account" name prefix and a basic-literal
+// value, and accountLoginBlockedSwitchCaseIdents returns nil outright if it
+// cannot find the function or its switch. A nil-versus-empty mistake, a
+// renamed function, or a switch refactored into an if/else chain all produce
+// "no missing states" — the same answer as being correct.
+//
+// This is the guard whose entire purpose is to make one specific accident
+// impossible: a new account state added without a corresponding case, silently
+// falling through to the default. It should be able to show that it would
+// still notice.
+func TestAccountStateExhaustivenessScannerDetectsAMissingCase(t *testing.T) {
+	// Parsed, never compiled. AccountSuspended is deliberately absent from the
+	// switch — that omission is the defect being planted.
+	const src = `package fixture
+
+const (
+	AccountActive    = "active"
+	AccountSuspended = "suspended"
+	AccountLocked    = "locked"
+
+	// Not a state: no "Account" prefix, and must not be collected.
+	DefaultTimeout = "30s"
+)
+
+func AccountLoginBlocked(state string) bool {
+	switch state {
+	case AccountActive:
+		return false
+	case AccountLocked:
+		return true
+	default:
+		return true
+	}
+}
+`
+
+	f, err := parser.ParseFile(token.NewFileSet(), "account_state_fixture.go", src, 0)
+	if err != nil {
+		t.Fatalf("parsing the synthetic fixture: %v", err)
+	}
+
+	states := accountStateConstants(f)
+	got := map[string]bool{}
+	for _, s := range states {
+		got[s] = true
+	}
+
+	for _, want := range []string{"AccountActive", "AccountSuspended", "AccountLocked"} {
+		if !got[want] {
+			t.Errorf("accountStateConstants missed %s — if the constant scan stops finding states, the "+
+				"exhaustiveness check has nothing to be exhaustive over and passes trivially. Found: %v",
+				want, states)
+		}
+	}
+	if got["DefaultTimeout"] {
+		t.Errorf("accountStateConstants collected DefaultTimeout, which is not an account state — the "+
+			"prefix filter has stopped discriminating, and the guard will start demanding switch cases "+
+			"for unrelated constants. Found: %v", states)
+	}
+
+	cases := accountLoginBlockedSwitchCaseIdents(f)
+	if cases == nil {
+		t.Fatal("accountLoginBlockedSwitchCaseIdents returned nil for a fixture that plainly contains " +
+			"AccountLoginBlocked with a switch — the function or switch lookup has broken, and a nil " +
+			"result reads downstream as 'no cases', which is indistinguishable from a real finding")
+	}
+	if !cases["AccountActive"] || !cases["AccountLocked"] {
+		t.Errorf("the switch-case scan missed a case that is plainly present: %v", cases)
+	}
+
+	// The verdict: exactly the planted omission, and nothing else.
+	var missing []string
+	for _, s := range states {
+		if !cases[s] {
+			missing = append(missing, s)
+		}
+	}
+	if len(missing) != 1 || missing[0] != "AccountSuspended" {
+		t.Errorf("the guard's own comparison must report exactly the one state deliberately left out of "+
+			"the fixture's switch (AccountSuspended); got %v. This is the accident the guard exists to "+
+			"prevent — a new state falling through to default without anyone deciding it should.", missing)
+	}
+}

--- a/internal/core/csv_writer_completeness_test.go
+++ b/internal/core/csv_writer_completeness_test.go
@@ -218,6 +218,78 @@ func bodyCallsSelectorFunction(body *ast.BlockStmt, pkg, fn string) bool {
 	return found
 }
 
+// TestCSVWriterScannerDetectsSafetyEncoding is this guard's red-proof.
+//
+// TestCSVWriters_EncodeAgainstFormulaInjection asserts today's CSV writers are
+// clean. That is a claim about the repo, not the scanner: bodyOrCalleesCallSafetyEncoder
+// combines two independent AST walks (bodyCallsFunctionNamed, and the one-hop
+// calledLocalFunctions indirection), and either one going quietly wrong reads
+// as "no violation" — indistinguishable from a genuinely safe writer. The
+// property that matters most is the transitive one: a writer that encodes via
+// a same-file helper (rowToCSV, per this file's own doc comment) must still
+// be recognized as safe, or the one-hop indirection this helper exists for is
+// dead code that happens to return the right answer today by coincidence.
+func TestCSVWriterScannerDetectsSafetyEncoding(t *testing.T) {
+	// Parsed, never compiled: undefined identifiers (Row, x, w, etc.) are
+	// fine and deliberate.
+	const src = `package fixture
+
+// writesDirect calls csvSafe inline — the simple case.
+func writesDirect() {
+	_ = csvSafe(x)
+}
+
+// writesViaHelper never calls csvSafe/CSVSafe itself; it delegates row
+// encoding to a same-file helper, exactly the shape this file's own doc
+// comment describes as needing the one-hop check.
+func writesViaHelper() {
+	_ = rowToCSV(row)
+}
+
+func rowToCSV(row Row) string {
+	return CSVSafe(row.Name)
+}
+
+// writesNothing is the planted violation: a CSV writer whose body, and whose
+// callees, never touch csvSafe/CSVSafe at all.
+func writesNothing() {
+	fmt.Fprintln(w, row.Name)
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "csv_fixture.go", src, 0)
+	if err != nil {
+		t.Fatalf("parsing the synthetic fixture: %v", err)
+	}
+
+	funcsByName := map[string]*ast.FuncDecl{}
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil {
+			funcsByName[fn.Name.Name] = fn
+		}
+	}
+
+	if got := bodyOrCalleesCallSafetyEncoder(funcsByName["writesDirect"].Body, funcsByName); !got {
+		t.Error("bodyOrCalleesCallSafetyEncoder must report true for a function that calls csvSafe inline")
+	}
+
+	if got := bodyOrCalleesCallSafetyEncoder(funcsByName["writesViaHelper"].Body, funcsByName); !got {
+		t.Error("bodyOrCalleesCallSafetyEncoder must report true for a function that delegates encoding to a " +
+			"same-file helper one hop away — if this regresses, TestCSVWriters_EncodeAgainstFormulaInjection " +
+			"would flag every writer that uses the one-hop helper pattern this file's own doc comment describes, " +
+			"or (if the false-negative direction breaks instead) silently stop catching the ones that don't")
+	}
+
+	// The planted violation: a writer whose body and callees never reach a
+	// safety encoder must be reported false, or the scanner cannot ever find
+	// a real unencoded CSV writer — it would report every writer as safe
+	// regardless of what it actually does.
+	if got := bodyOrCalleesCallSafetyEncoder(funcsByName["writesNothing"].Body, funcsByName); got {
+		t.Error("bodyOrCalleesCallSafetyEncoder reported true for a function that never calls csvSafe/CSVSafe, " +
+			"directly or via a callee — the scanner would no longer be able to find a real formula-injection gap")
+	}
+}
+
 // bodyCallsFunctionNamed reports whether body contains a call expression
 // whose function is exactly name -- either a bare identifier (csvSafe(...))
 // or a selector whose final name matches (common.CSVSafe(...)) -- anywhere

--- a/internal/core/g80_1530_machine_actor_attribution_guard_test.go
+++ b/internal/core/g80_1530_machine_actor_attribution_guard_test.go
@@ -76,9 +76,8 @@ func repoRootG1626() string {
 // (service.go's own funnel implementation is the one legitimate direct
 // caller of the storage interface method), returning "path:func" keys
 // relative to the repo root.
-func findDirectLogAuditEventCallers(t *testing.T) map[string]bool {
+func findDirectLogAuditEventCallers(t *testing.T, root string) map[string]bool {
 	t.Helper()
-	root := repoRootG1626()
 	found := map[string]bool{}
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -128,13 +127,81 @@ func findDirectLogAuditEventCallers(t *testing.T) map[string]bool {
 	return found
 }
 
+// TestDirectLogAuditEventCallersScannerDetectsBypass is this guard's
+// red-proof.
+//
+// TestDirectLogAuditEventCallersAreSafe has no total-collapse tripwire at
+// all (unlike several sibling guards in this campaign) -- if
+// logAuditEventFuncRe stopped matching, or the emitAudit exclusion or the
+// "//"-comment skip became too permissive, actual would just come back
+// smaller or noisier, and the allowlist comparison would report either
+// nothing (a false "all safe") or unrelated staleness, never "the scanner
+// broke."
+func TestDirectLogAuditEventCallersScannerDetectsBypass(t *testing.T) {
+	root := t.TempDir()
+	// Line-scanned as plain text (findDirectLogAuditEventCallers is a
+	// substring scanner, not go/ast), so this fixture is never compiled
+	// either way -- undefined identifiers (storage, ev, ctx's type) are fine
+	// and deliberate.
+	const src = `package fixture
+
+// emitAudit is the funnel itself -- its own LogAuditEvent call must never
+// be reported as a bypass.
+func emitAudit(ctx context.Context) {
+	storage.LogAuditEvent(ctx, ev)
+}
+
+// directBypass is the planted violation: a direct call outside emitAudit.
+func directBypass(ctx context.Context) {
+	storage.LogAuditEvent(ctx, ev)
+}
+
+// commentedOut's call is text inside a comment and must not be reported.
+func commentedOut(ctx context.Context) {
+	// storage.LogAuditEvent(ctx, ev)
+}
+`
+	if err := os.WriteFile(filepath.Join(root, "fixture.go"), []byte(src), 0o600); err != nil {
+		t.Fatalf("writing the synthetic fixture: %v", err)
+	}
+	// A _test.go file with an otherwise-matching bypass must be excluded —
+	// the scanner only walks non-test files, matching every real caller site.
+	const testSrc = `package fixture
+
+func shouldNotAppear(ctx context.Context) {
+	storage.LogAuditEvent(ctx, ev)
+}
+`
+	if err := os.WriteFile(filepath.Join(root, "fixture_test.go"), []byte(testSrc), 0o600); err != nil {
+		t.Fatalf("writing the synthetic test-file fixture: %v", err)
+	}
+
+	found := findDirectLogAuditEventCallers(t, root)
+
+	if !found["fixture.go:directBypass"] {
+		t.Errorf("findDirectLogAuditEventCallers must find fixture.go:directBypass; got %v", found)
+	}
+	if found["fixture.go:emitAudit"] {
+		t.Errorf("findDirectLogAuditEventCallers reported emitAudit's own call as a bypass — the funnel "+
+			"exclusion has stopped working, got %v", found)
+	}
+	if found["fixture.go:commentedOut"] {
+		t.Errorf("findDirectLogAuditEventCallers reported a commented-out call — the \"//\" skip has "+
+			"stopped working, got %v", found)
+	}
+	if len(found) != 1 {
+		t.Errorf("expected exactly 1 direct caller (fixture_test.go's shouldNotAppear must be excluded), "+
+			"got %d: %v", len(found), found)
+	}
+}
+
 // TestDirectLogAuditEventCallersAreSafe is #1530's guard: every direct
 // storage.LogAuditEvent caller (bypassing emitAudit's MachineIdentityID
 // stamp) must be in auditAttributionAllowlist with a reason, or the test
 // fails -- a new bypass site is exactly how this gap would reappear.
 func TestDirectLogAuditEventCallersAreSafe(t *testing.T) {
 	t.Parallel()
-	actual := findDirectLogAuditEventCallers(t)
+	actual := findDirectLogAuditEventCallers(t, repoRootG1626())
 
 	var unjustified []string
 	for key := range actual {

--- a/internal/core/rotation_executor_registry_exhaustiveness_test.go
+++ b/internal/core/rotation_executor_registry_exhaustiveness_test.go
@@ -22,6 +22,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -70,7 +71,7 @@ var knownRotationExecutorConstructors = map[string]func(name string) rotation.Ex
 // does not know about -- the guard against a silently-missed future backend.
 func TestRotationExecutorRegistry_NoUncoveredConstructor(t *testing.T) {
 	t.Parallel()
-	discovered := discoverRotationExecutorConstructors(t)
+	discovered := discoverRotationExecutorConstructors(t, "../rotation")
 	if len(discovered) == 0 {
 		t.Fatal("found zero New*Executor constructors in internal/rotation -- the discovery logic itself is broken")
 	}
@@ -122,8 +123,8 @@ func TestRotationExecutorRegistry_AllKnownConstructorsRegisterAndResolve(t *test
 	}
 }
 
-// discoverRotationExecutorConstructors parses every non-test .go file in
-// internal/rotation and returns the name of each exported top-level function matching
+// discoverRotationExecutorConstructors parses every non-test .go file in dir
+// and returns the name of each exported top-level function matching
 // `New*Executor` (e.g. NewAWSIAMExecutor) -- the actual, current set of rotation
 // backend constructors, derived from source rather than hand-maintained, so this
 // enumeration can't silently go stale as backends are added or renamed.
@@ -131,9 +132,8 @@ func TestRotationExecutorRegistry_AllKnownConstructorsRegisterAndResolve(t *test
 // Reads the directory and parses each file individually (rather than go/parser's
 // ParseDir, deprecated since Go 1.25) so this stays simple dependency-free source
 // inspection, matching account_state_exhaustiveness_guard_test.go's per-file idiom.
-func discoverRotationExecutorConstructors(t *testing.T) []string {
+func discoverRotationExecutorConstructors(t *testing.T, dir string) []string {
 	t.Helper()
-	const dir = "../rotation"
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("reading %s: %v", dir, err)
@@ -166,4 +166,64 @@ func discoverRotationExecutorConstructors(t *testing.T) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+// TestRotationExecutorScannerDetectsConstructors is this guard's red-proof.
+//
+// TestRotationExecutorRegistry_NoUncoveredConstructor's own zero-result Fatal
+// only catches a total collapse of discoverRotationExecutorConstructors. A
+// narrower break -- the exported-name check, the New/Executor prefix/suffix
+// check, or the receiver-nil check that excludes methods -- would silently
+// under- or over-report instead, and knownRotationExecutorConstructors would
+// be compared against a partial or noisy set with no signal that anything
+// was wrong.
+func TestRotationExecutorScannerDetectsConstructors(t *testing.T) {
+	dir := t.TempDir()
+	// Parsed, never compiled: undefined identifiers (rotation, Manager) are
+	// fine and deliberate.
+	const src = `package rotation
+
+// NewFooExecutor is a real constructor and must be found.
+func NewFooExecutor(name string) rotation.Executor { return nil }
+
+// newBarExecutor is unexported and must not be found.
+func newBarExecutor(name string) rotation.Executor { return nil }
+
+// NewBazExecutor has a receiver -- it's a method, not a constructor, and
+// must not be found even though its name matches the New*Executor shape.
+func (m *Manager) NewBazExecutor(name string) rotation.Executor { return nil }
+
+// NewQux is exported and New-prefixed but doesn't end in Executor, and must
+// not be found.
+func NewQux(name string) rotation.Executor { return nil }
+`
+	if err := os.WriteFile(filepath.Join(dir, "rotation_backend.go"), []byte(src), 0o600); err != nil {
+		t.Fatalf("writing the synthetic fixture: %v", err)
+	}
+	// A _test.go file declaring an otherwise-matching constructor must be
+	// excluded entirely -- discoverRotationExecutorConstructors only scans
+	// non-test files, matching every real internal/rotation file.
+	const testSrc = `package rotation
+
+func NewShouldNotAppearExecutor(name string) rotation.Executor { return nil }
+`
+	if err := os.WriteFile(filepath.Join(dir, "rotation_backend_test.go"), []byte(testSrc), 0o600); err != nil {
+		t.Fatalf("writing the synthetic test-file fixture: %v", err)
+	}
+
+	discovered := discoverRotationExecutorConstructors(t, dir)
+
+	found := map[string]bool{}
+	for _, name := range discovered {
+		found[name] = true
+	}
+
+	if !found["NewFooExecutor"] {
+		t.Errorf("discoverRotationExecutorConstructors must find NewFooExecutor; got %v", discovered)
+	}
+	if len(discovered) != 1 {
+		t.Errorf("expected exactly 1 discovered constructor (newBarExecutor unexported, NewBazExecutor a "+
+			"method, NewQux wrong suffix, NewShouldNotAppearExecutor in a _test.go file must all be excluded), "+
+			"got %d: %v", len(discovered), discovered)
+	}
 }

--- a/internal/dynamic/egress_guard_test.go
+++ b/internal/dynamic/egress_guard_test.go
@@ -307,3 +307,84 @@ func findUnguardedDriverConstructionAnyFunc(file *ast.File) []string {
 	})
 	return found
 }
+
+// TestEgressScannerDetectsUnguardedConstruction is this guard's red-proof.
+//
+// TestNoUnguardedEgress above asserts that today's code is clean. That is a
+// statement about the code, not about the scanner: if egressIdentSel stopped
+// resolving selectors, or driverConstructionSelectors were emptied by a bad
+// merge, the guard would keep passing and would keep reporting the codebase
+// safe while checking nothing. The file header claims the guard was "verified
+// RED against the pre-2b code" — true, and a one-time manual observation that
+// no longer runs. This makes it run.
+//
+// Both halves matter. Detecting the planted violations proves the scanner
+// still fires; NOT flagging the guarded control proves it fires for the right
+// reason rather than on every driver construction it sees.
+func TestEgressScannerDetectsUnguardedConstruction(t *testing.T) {
+	// Parsed, never compiled: undefined identifiers are fine, and deliberate —
+	// this fixture must not be buildable, or someone will eventually "fix" it.
+	const src = `package fixture
+
+import (
+	"net"
+	"net/http"
+)
+
+// unguardedMongo is the exact pre-2b shape: a driver connect in a function
+// with no netutil reference anywhere in its body.
+func unguardedMongo(ctx context.Context) {
+	_, _ = mongo.Connect(ctx, options.Client().ApplyURI(uri))
+}
+
+// unguardedHTTPClient is the SIEM forwarder's pre-fix shape.
+func unguardedHTTPClient() *http.Client {
+	return &http.Client{Timeout: 10}
+}
+
+// guardedRedis is the sanctioned shape and must NOT be reported.
+func guardedRedis() {
+	d := netutil.Dialer{Guard: netutil.NewGuard()}
+	_ = redis.NewClient(&redis.Options{Dialer: d.DialContext})
+}
+
+func rawDialCall()    { _, _ = net.Dial("tcp", "example.com:80") }
+func rawDialerLiteral() { d := net.Dialer{Timeout: 5}; _ = d }
+`
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "egress_fixture.go", src, 0)
+	if err != nil {
+		t.Fatalf("parsing the synthetic fixture: %v", err)
+	}
+
+	rawDials := findForbiddenRawDial(file)
+	if len(rawDials) != 2 {
+		t.Errorf("findForbiddenRawDial must flag both the net.Dial call and the net.Dialer literal, got %d: %v\n"+
+			"The scanner has stopped detecting raw dials, so TestNoUnguardedEgress is now green for a reason "+
+			"that has nothing to do with the code being safe.", len(rawDials), rawDials)
+	}
+
+	issues := findUnguardedDriverConstruction(file)
+	got := map[string]string{}
+	for _, i := range issues {
+		got[i.call] = i.reason
+	}
+
+	for _, want := range []string{"mongo.Connect(...)", "http.Client{...}"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("findUnguardedDriverConstruction must flag %s in a function with no netutil reference; got %v\n"+
+				"This is the check that caught the real pre-2b gap. If it no longer fires here, it would no "+
+				"longer fire there either.", want, issues)
+		}
+	}
+
+	// The other half of the proof: the guarded control must come back clean,
+	// or the guard is just "any driver construction is an issue" and would
+	// have to be silenced the first time someone wires netutil correctly.
+	if reason, flagged := got["redis.NewClient(...)"]; flagged {
+		t.Errorf("findUnguardedDriverConstruction flagged the CORRECTLY guarded redis.NewClient (%s) — the "+
+			"scanner is no longer distinguishing guarded from unguarded construction, so every future "+
+			"correct call site will be reported as a violation", reason)
+	}
+}

--- a/internal/dynamic/log_redaction_guard_test.go
+++ b/internal/dynamic/log_redaction_guard_test.go
@@ -100,6 +100,23 @@ func looksLikeErrorArg(e ast.Expr) (string, bool) {
 		if sel, ok := v.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Error" {
 			return "direct .Error() call", true
 		}
+	case *ast.BinaryExpr:
+		// `log.Println("connect failed: " + err.Error())` is the same defect
+		// wearing a string concatenation. Before this, the scanner only
+		// examined each argument's top-level shape, so an error hidden one
+		// operand deep was invisible to it -- the guard would have passed on
+		// its own motivating defect written this way. Recursing keeps the
+		// match just as narrow (an operand still has to be an err-ish
+		// identifier or a .Error() call to be flagged) while closing the
+		// shape. Confirmed against the scanned files at the time of the
+		// change: no existing log.Printf/log.Println there concatenates at
+		// all, so this widened nothing in practice and flagged nothing new.
+		if desc, flagged := looksLikeErrorArg(v.X); flagged {
+			return desc + " inside a concatenation", true
+		}
+		if desc, flagged := looksLikeErrorArg(v.Y); flagged {
+			return desc + " inside a concatenation", true
+		}
 	}
 	return "", false
 }
@@ -181,5 +198,76 @@ func TestNoUnsanitizedDriverErrorReachesLog(t *testing.T) {
 		t.Errorf("%s:%d: log call argument (%s) looks like an unsanitized error -- "+
 			"wrap it with dynamic.SanitizeErrorMessage(...) before logging (Group 1: raw driver/backend "+
 			"errors must never reach a log call verbatim)", f.file, f.line, f.desc)
+	}
+}
+
+// TestLogRedactionScannerDetectsUnsanitizedArgs is this guard's red-proof.
+//
+// TestNoUnsanitizedDriverErrorReachesLog asserts that today's call sites are
+// clean. That says nothing about whether the scanner still works: this guard
+// is explicitly shape-based rather than type-aware (see the file header), so
+// it is exactly the kind of check that can quietly stop matching — a renamed
+// sanitizer, a change to how the "err"-ish identifier heuristic works, or a
+// selector walk that stops resolving — and keep reporting the package clean.
+//
+// The fixture carries both a violation and its sanctioned counterpart, so the
+// test fails if the scanner stops detecting AND if it starts over-detecting.
+func TestLogRedactionScannerDetectsUnsanitizedArgs(t *testing.T) {
+	// Parsed, never compiled.
+	const src = `package fixture
+
+import "log"
+
+// The pre-fix shape: a raw driver error formatted straight into the log,
+// where a DSN credential fragment can ride along.
+func bareErrIdent(err error) { log.Printf("connect failed: %v", err) }
+
+// The same defect through the other recognized shape.
+func directErrorCall(err error) { log.Println("connect failed:", err.Error()) }
+
+// And the same defect hidden one operand deep in a concatenation, which the
+// scanner missed until this test was written.
+func concatenatedError(err error) { log.Println("connect failed: " + err.Error()) }
+
+// The sanctioned shape, which must NOT be flagged.
+func sanitized(err error) { log.Printf("connect failed: %v", SanitizeErrorMessage(err)) }
+
+// Not a log call at all, and must not be flagged.
+func notALogCall(err error) { fmt.Printf("connect failed: %v", err) }
+`
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "log_redaction_fixture.go", src, 0)
+	if err != nil {
+		t.Fatalf("parsing the synthetic fixture: %v", err)
+	}
+
+	found := findUnsanitizedLogCalls(fset, file, "log_redaction_fixture.go")
+
+	descs := map[string]bool{}
+	for _, f := range found {
+		descs[f.desc] = true
+	}
+
+	if !descs["bare identifier %q"] {
+		t.Errorf("the scanner must flag a bare err identifier passed to log.Printf; got %v\n"+
+			"That is the exact shape the pre-fix call sites used, so a scanner that no longer "+
+			"recognizes it would have passed on the original defect.", found)
+	}
+	if !descs["direct .Error() call"] {
+		t.Errorf("the scanner must flag a direct .Error() call passed to log.Println; got %v", found)
+	}
+
+	// Over-detection is the other failure mode, and the more insidious one:
+	// a guard that flags the sanctioned shape gets allowlisted into silence.
+	if !descs["direct .Error() call inside a concatenation"] {
+		t.Errorf("the scanner must flag an .Error() call hidden inside a string concatenation; got %v\n"+
+			"This shape slipped through until this red-proof was written: the scanner examined only each "+
+			"argument's top-level form, so the guard would have passed on its own motivating defect if "+
+			"someone had written it with a `+`.", found)
+	}
+	if len(found) != 3 {
+		t.Errorf("the scanner flagged %d argument(s), want exactly 3 — it must not flag the "+
+			"SanitizeErrorMessage-wrapped call or the non-log fmt.Printf: %v", len(found), found)
 	}
 }

--- a/internal/encryption/sweep_completeness_test.go
+++ b/internal/encryption/sweep_completeness_test.go
@@ -118,6 +118,65 @@ func discoverEncryptedModelFields(t *testing.T, dir string) map[modelField]bool 
 	return discovered
 }
 
+// TestEncryptedModelFieldScannerDetectsNamingConvention is this guard's
+// red-proof.
+//
+// TestSweepCompleteness_EveryEncryptedModelFieldHasASweep's own zero-result
+// Fatal only catches a total collapse of discoverEncryptedModelFields. This
+// guard exists specifically because of #422 — a DEK-rotation sweep gap that
+// caused permanent, irrecoverable data loss — so the value here is the
+// struct-field scan itself, not isByteSliceType or looksLikeEncryptedFieldName
+// individually (those are simple, low-value checks to test in isolation; the
+// interesting behavior is discoverEncryptedModelFields correctly combining
+// them across every struct in a file). A real fixture: a model with a
+// SomethingEnc []byte field, alongside fields that must NOT be swept up —
+// wrong type, wrong name convention.
+func TestEncryptedModelFieldScannerDetectsNamingConvention(t *testing.T) {
+	dir := t.TempDir()
+	// Parsed, never compiled: undefined identifiers are fine and deliberate.
+	const src = `package models
+
+type FooModel struct {
+	ID int
+
+	// SecretEnc is a real DEK-encrypted field, mirroring MFASecret.SecretEnc.
+	SecretEnc []byte
+
+	// EncryptedBar is a real DEK-encrypted field, mirroring the "Encrypted*" convention.
+	EncryptedBar []byte
+
+	// PlainBytes is []byte but follows no naming convention -- must not be found.
+	PlainBytes []byte
+
+	// NameEnc follows the naming convention but isn't []byte -- must not be found.
+	NameEnc string
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "foo_model.go"), []byte(src), 0o600); err != nil {
+		t.Fatalf("writing the synthetic fixture: %v", err)
+	}
+
+	discovered := discoverEncryptedModelFields(t, dir)
+
+	if !discovered[modelField{"FooModel", "SecretEnc"}] {
+		t.Errorf("discoverEncryptedModelFields must find FooModel.SecretEnc; got %v", discovered)
+	}
+	if !discovered[modelField{"FooModel", "EncryptedBar"}] {
+		t.Errorf("discoverEncryptedModelFields must find FooModel.EncryptedBar; got %v", discovered)
+	}
+	if discovered[modelField{"FooModel", "PlainBytes"}] {
+		t.Errorf("discoverEncryptedModelFields found PlainBytes, a []byte field with no naming-convention "+
+			"match — the scanner is no longer discriminating by name, got %v", discovered)
+	}
+	if discovered[modelField{"FooModel", "NameEnc"}] {
+		t.Errorf("discoverEncryptedModelFields found NameEnc, a string field (not []byte) — the scanner is "+
+			"no longer discriminating by type, got %v", discovered)
+	}
+	if len(discovered) != 2 {
+		t.Errorf("expected exactly 2 discovered fields, got %d: %v", len(discovered), discovered)
+	}
+}
+
 // TestSweepCompleteness_EveryEncryptedModelFieldHasASweep is the regression test
 // described above.
 func TestSweepCompleteness_EveryEncryptedModelFieldHasASweep(t *testing.T) {

--- a/internal/encryption/sweep_completeness_test.go
+++ b/internal/encryption/sweep_completeness_test.go
@@ -64,28 +64,26 @@ var expectedSweptFields = map[modelField]bool{
 	{"DynamicSecretLease", "CredentialEnc"}: true,
 }
 
-// TestSweepCompleteness_EveryEncryptedModelFieldHasASweep is the regression test
-// described above.
-func TestSweepCompleteness_EveryEncryptedModelFieldHasASweep(t *testing.T) {
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed — cannot locate internal/storage/models relative to this test file")
-	}
-	modelsDir := filepath.Join(filepath.Dir(thisFile), "..", "storage", "models")
-
-	entries, err := os.ReadDir(modelsDir)
+// discoverEncryptedModelFields parses every non-test .go file in dir and
+// returns every struct field matching the DEK-encrypted naming convention
+// (see looksLikeEncryptedFieldName): type []byte, name "Encrypted*" or
+// "*Enc" — the actual, current set of DEK-encrypted-looking model fields,
+// derived from source rather than hand-maintained.
+func discoverEncryptedModelFields(t *testing.T, dir string) map[modelField]bool {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		t.Fatalf("failed to read %s: %v", modelsDir, err)
+		t.Fatalf("failed to read %s: %v", dir, err)
 	}
 	var goFiles []string
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
 			continue
 		}
-		goFiles = append(goFiles, filepath.Join(modelsDir, e.Name()))
+		goFiles = append(goFiles, filepath.Join(dir, e.Name()))
 	}
 	if len(goFiles) == 0 {
-		t.Fatalf("no .go files found under %s — did the models package move?", modelsDir)
+		t.Fatalf("no .go files found under %s — did the models package move?", dir)
 	}
 
 	fset := token.NewFileSet()
@@ -117,7 +115,19 @@ func TestSweepCompleteness_EveryEncryptedModelFieldHasASweep(t *testing.T) {
 			return true
 		})
 	}
+	return discovered
+}
 
+// TestSweepCompleteness_EveryEncryptedModelFieldHasASweep is the regression test
+// described above.
+func TestSweepCompleteness_EveryEncryptedModelFieldHasASweep(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed — cannot locate internal/storage/models relative to this test file")
+	}
+	modelsDir := filepath.Join(filepath.Dir(thisFile), "..", "storage", "models")
+
+	discovered := discoverEncryptedModelFields(t, modelsDir)
 	if len(discovered) == 0 {
 		t.Fatal("discovered zero Encrypted*/*Enc []byte fields in internal/storage/models — the AST walk is almost certainly broken (models.go alone has several), not that encryption was removed")
 	}

--- a/internal/keyfiles/registry_exhaustiveness_test.go
+++ b/internal/keyfiles/registry_exhaustiveness_test.go
@@ -51,9 +51,8 @@ var constructorFuncRe = regexp.MustCompile(`(?m)^func (New\w+)\(`)
 // FILE (internal/crypto's one-constructor-per-provider-file layout makes this
 // a reliable proxy for "this provider's constructor returns a value that
 // writes key material").
-func writerConstructors(t *testing.T) map[string]bool {
+func writerConstructors(t *testing.T, dir string) map[string]bool {
 	t.Helper()
-	dir := filepath.Join(repoRoot(t), "internal", "crypto")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("read %s: %v", dir, err)
@@ -78,6 +77,82 @@ func writerConstructors(t *testing.T) map[string]bool {
 		}
 	}
 	return result
+}
+
+// TestWriterConstructorsScannerDetectsWritingProviders is this guard's
+// red-proof.
+//
+// TestSourceScan_WriteCapableProviderTypesMatchRegistry's own zero-result
+// Fatal only catches a total collapse of writerConstructors. A narrower
+// break -- the SecureWriteFileSync/SecureWriteFile substring check, or
+// constructorFuncRe itself -- would silently under- or over-report instead,
+// and writeCapableProviderTypes would be compared against a partial or noisy
+// derived set with nothing to signal the mismatch is the scanner's fault,
+// not registry.go's.
+func TestWriterConstructorsScannerDetectsWritingProviders(t *testing.T) {
+	dir := t.TempDir()
+	// Parsed as plain text (writerConstructors is a substring + regexp
+	// scanner, not go/ast), so this fixture is never compiled either way —
+	// undefined identifiers are fine and deliberate.
+	const writerSrc = `package crypto
+
+// NewFooProvider is a real writer: its file calls SecureWriteFileSync.
+func NewFooProvider(path string) *FooProvider {
+	return &FooProvider{path: path}
+}
+
+func (p *FooProvider) Save() error {
+	return SecureWriteFileSync(p.path, nil, 0600)
+}
+`
+	const nonWriterSrc = `package crypto
+
+// NewBarProvider's file never calls SecureWriteFileSync/SecureWriteFile —
+// it must not be reported as a writer constructor.
+func NewBarProvider(path string) *BarProvider {
+	return &BarProvider{path: path}
+}
+`
+	// A _test.go file with an otherwise-matching writer shape must be
+	// excluded entirely — writerConstructors only scans non-test files,
+	// matching every real internal/crypto provider file.
+	const testFileSrc = `package crypto
+
+func NewShouldNotAppearProvider(path string) *ShouldNotAppearProvider {
+	return &ShouldNotAppearProvider{path: path}
+}
+
+func (p *ShouldNotAppearProvider) Save() error {
+	return SecureWriteFileSync(p.path, nil, 0600)
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "writer_provider.go"), []byte(writerSrc), 0o600); err != nil {
+		t.Fatalf("writing the synthetic writer fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "nonwriter_provider.go"), []byte(nonWriterSrc), 0o600); err != nil {
+		t.Fatalf("writing the synthetic non-writer fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "writer_provider_test.go"), []byte(testFileSrc), 0o600); err != nil {
+		t.Fatalf("writing the synthetic test-file fixture: %v", err)
+	}
+
+	writers := writerConstructors(t, dir)
+
+	if !writers["NewFooProvider"] {
+		t.Errorf("writerConstructors must find NewFooProvider — its file calls SecureWriteFileSync; got %v", writers)
+	}
+	if writers["NewBarProvider"] {
+		t.Errorf("writerConstructors reported NewBarProvider as a writer, but its file never calls "+
+			"SecureWriteFileSync/SecureWriteFile — if this regresses, TestSourceScan_WriteCapableProviderTypesMatchRegistry "+
+			"can derive a provider type as write-capable when it never writes anything, got %v", writers)
+	}
+	if writers["NewShouldNotAppearProvider"] {
+		t.Errorf("writerConstructors picked up a constructor from a _test.go file — it must only scan "+
+			"non-test files, got %v", writers)
+	}
+	if len(writers) != 1 {
+		t.Errorf("expected exactly 1 writer constructor, got %d: %v", len(writers), writers)
+	}
 }
 
 // buildSingleProviderCaseDispatch parses internal/encryption/service.go's
@@ -140,7 +215,7 @@ func buildSingleProviderCaseDispatch(t *testing.T) map[string]map[string]bool {
 }
 
 func TestSourceScan_WriteCapableProviderTypesMatchRegistry(t *testing.T) {
-	writers := writerConstructors(t)
+	writers := writerConstructors(t, filepath.Join(repoRoot(t), "internal", "crypto"))
 	if len(writers) == 0 {
 		t.Fatal("source scan found zero writer constructors in internal/crypto -- the scan itself is broken (password/tpm/kms providers are known writers), not that none exist")
 	}

--- a/internal/storage/account_state_fatal_migration_guard_test.go
+++ b/internal/storage/account_state_fatal_migration_guard_test.go
@@ -136,3 +136,84 @@ func callAbortsOnError(fd *ast.FuncDecl, target string) bool {
 	})
 	return found
 }
+
+// TestAccountStateMigrationScannerDetectsSwallowedErrors is this guard's
+// red-proof.
+//
+// TestMigrateDatabase_AccountStateCallsAbortOnError asserts that today's
+// factory.go is wired correctly. It cannot tell you whether callAbortsOnError
+// would notice if factory.go stopped being wired correctly — and that
+// distinction is the whole point of the guard, because the defect it exists
+// to catch (an error logged and continued past rather than returned) looks
+// exactly like working code.
+//
+// So: three functions, one correct and two defective in the two ways this
+// actually goes wrong in practice, run through the real matcher.
+func TestAccountStateMigrationScannerDetectsSwallowedErrors(t *testing.T) {
+	// Parsed, never compiled.
+	const src = `package fixture
+
+func aborts(db *gorm.DB) error {
+	if err := guardAccountStateValid(db); err != nil {
+		return err
+	}
+	return nil
+}
+
+func swallowsWithLog(db *gorm.DB) error {
+	if err := guardAccountStateValid(db); err != nil {
+		log.Printf("account state guard failed: %v", err)
+	}
+	return nil
+}
+
+func neverChecks(db *gorm.DB) error {
+	guardAccountStateValid(db)
+	return nil
+}
+`
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "migration_fixture.go", src, 0)
+	if err != nil {
+		t.Fatalf("parsing the synthetic fixture: %v", err)
+	}
+
+	funcs := map[string]*ast.FuncDecl{}
+	for _, decl := range file.Decls {
+		if fd, ok := decl.(*ast.FuncDecl); ok {
+			funcs[fd.Name.Name] = fd
+		}
+	}
+	for _, want := range []string{"aborts", "swallowsWithLog", "neverChecks"} {
+		if funcs[want] == nil {
+			t.Fatalf("fixture is missing %s — the parse silently produced nothing to check", want)
+		}
+	}
+
+	const target = "guardAccountStateValid"
+
+	// bodyCallsFunction is the "is it called at all" half. All three call it;
+	// if this stops being true the second half below is meaningless.
+	for name, fd := range funcs {
+		if !bodyCallsFunction(fd.Body, target) {
+			t.Errorf("bodyCallsFunction failed to see the %s call in %s() — the call-detection half of "+
+				"this guard has stopped working, which would make the abort check vacuous", target, name)
+		}
+	}
+
+	// callAbortsOnError is the half that carries the actual invariant.
+	if !callAbortsOnError(funcs["aborts"], target) {
+		t.Errorf("callAbortsOnError must recognize the correct `if err := %s(db); err != nil { return err }` "+
+			"shape. It does not, so the guard would now fail against correct code — and the natural way to "+
+			"make CI green again is to weaken the guard.", target)
+	}
+	if callAbortsOnError(funcs["swallowsWithLog"], target) {
+		t.Errorf("callAbortsOnError accepted a call whose error is logged and then continued past. That is " +
+			"precisely the defect this guard exists to catch: migrateDatabase would report success while the " +
+			"schema invariant silently did not hold.")
+	}
+	if callAbortsOnError(funcs["neverChecks"], target) {
+		t.Errorf("callAbortsOnError accepted a call whose error is never checked at all")
+	}
+}

--- a/internal/storage/store/g81_guard_test.go
+++ b/internal/storage/store/g81_guard_test.go
@@ -206,32 +206,40 @@ func g81TimeLikeColumn(col string) bool {
 	return strings.HasSuffix(col, "_at") || strings.HasSuffix(col, "_time") || strings.HasSuffix(col, "_date")
 }
 
-// TestG81_NoUntrackedRangeQueriedTimeColumns is the AST freshness check: parse
-// every non-test .go file in this package, collect every column name that
-// appears in a range comparison against a bind placeholder, and assert each
-// time-like one is accounted for in g81MaintainedFields. Fails with the
-// offending file:line so a new range query on a new column can't silently
-// skip this bug class.
-func TestG81_NoUntrackedRangeQueriedTimeColumns(t *testing.T) {
-	known := make(map[string]bool, len(g81MaintainedFields))
-	for _, f := range g81MaintainedFields {
-		known[f.Column] = true
-	}
+// g81RangeQueriedColumn records one alias-stripped column name found in a
+// range comparison against a bind placeholder, with its source location and
+// the raw string literal it was found in (for error context) — regardless of
+// whether the column looks time-like; callers filter that separately via
+// g81TimeLikeColumn.
+type g81RangeQueriedColumn struct {
+	Column string
+	File   string
+	Line   int
+	Raw    string
+}
 
-	entries, err := os.ReadDir(".")
+// extractRangeQueriedColumns parses every non-test .go file in dir and
+// returns every g81RangeQueriedColumn found. Fails the test outright if dir
+// contains zero non-test .go files — the same "this guard is now vacuous"
+// tripwire TestG81_NoUntrackedRangeQueriedTimeColumns always had, moved here
+// since this is now the function that does the scanning.
+func extractRangeQueriedColumns(t *testing.T, dir string) []g81RangeQueriedColumn {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		t.Fatalf("failed to list package directory: %v", err)
+		t.Fatalf("failed to list %s: %v", dir, err)
 	}
 
 	fset := token.NewFileSet()
 	var scanned int
+	var found []g81RangeQueriedColumn
 	for _, entry := range entries {
 		name := entry.Name()
 		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
 		scanned++
-		path := filepath.Join(".", name)
+		path := filepath.Join(dir, name)
 		src, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("failed to read %s: %v", path, err)
@@ -254,16 +262,10 @@ func TestG81_NoUntrackedRangeQueriedTimeColumns(t *testing.T) {
 				if idx := strings.LastIndex(col, "."); idx != -1 {
 					col = col[idx+1:]
 				}
-				if !g81TimeLikeColumn(col) {
-					continue
-				}
-				if !known[col] {
-					pos := fset.Position(lit.Pos())
-					t.Errorf("%s:%d: range query on untracked time-like column %q (in %q) — "+
-						"add a g81FieldEntry to g81_guard_test.go recording which model this is, "+
-						"whether it has a BeforeSave hook, and why (or why not)",
-						pos.Filename, pos.Line, col, s)
-				}
+				pos := fset.Position(lit.Pos())
+				found = append(found, g81RangeQueriedColumn{
+					Column: col, File: pos.Filename, Line: pos.Line, Raw: s,
+				})
 			}
 			return true
 		})
@@ -271,5 +273,31 @@ func TestG81_NoUntrackedRangeQueriedTimeColumns(t *testing.T) {
 	if scanned == 0 {
 		t.Fatal("scanned 0 non-test .go files in the package directory — this guard is now " +
 			"vacuous and is no longer checking anything; fix the scan, not this assertion")
+	}
+	return found
+}
+
+// TestG81_NoUntrackedRangeQueriedTimeColumns is the AST freshness check:
+// collect every column name that appears in a range comparison against a
+// bind placeholder anywhere in this package, and assert each time-like one
+// is accounted for in g81MaintainedFields. Fails with the offending
+// file:line so a new range query on a new column can't silently skip this
+// bug class.
+func TestG81_NoUntrackedRangeQueriedTimeColumns(t *testing.T) {
+	known := make(map[string]bool, len(g81MaintainedFields))
+	for _, f := range g81MaintainedFields {
+		known[f.Column] = true
+	}
+
+	for _, c := range extractRangeQueriedColumns(t, ".") {
+		if !g81TimeLikeColumn(c.Column) {
+			continue
+		}
+		if !known[c.Column] {
+			t.Errorf("%s:%d: range query on untracked time-like column %q (in %q) — "+
+				"add a g81FieldEntry to g81_guard_test.go recording which model this is, "+
+				"whether it has a BeforeSave hook, and why (or why not)",
+				c.File, c.Line, c.Column, c.Raw)
+		}
 	}
 }

--- a/internal/storage/store/g81_guard_test.go
+++ b/internal/storage/store/g81_guard_test.go
@@ -277,6 +277,71 @@ func extractRangeQueriedColumns(t *testing.T, dir string) []g81RangeQueriedColum
 	return found
 }
 
+// TestG81ScannerDetectsRangeQueriedColumns is this guard's red-proof.
+//
+// TestG81_NoUntrackedRangeQueriedTimeColumns filters extractRangeQueriedColumns'
+// output through g81TimeLikeColumn — but the interesting, easy-to-quietly-break
+// part is upstream of that: the regex match against a bind placeholder, and
+// the alias-stripping that turns "t.expires_at" into "expires_at" so it can
+// be looked up in g81MaintainedFields at all. g81TimeLikeColumn itself is a
+// name-suffix check with nothing structural to prove — testing it would be
+// the vacuous-check trap this campaign exists to avoid; this test only
+// exercises extractRangeQueriedColumns.
+func TestG81ScannerDetectsRangeQueriedColumns(t *testing.T) {
+	dir := t.TempDir()
+	// Parsed, never compiled: undefined identifiers (db, cutoff) are fine and
+	// deliberate.
+	const src = `package fixture
+
+func rangeQuery() {
+	db.Where("expires_at >= ?", cutoff)
+}
+
+func aliasedRangeQuery() {
+	db.Where("t.created_at <= ?", cutoff)
+}
+
+func equalityQuery() {
+	db.Where("status = ?", "active")
+}
+
+func literalComparisonQuery() {
+	db.Where("count > 0")
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "fixture.go"), []byte(src), 0o600); err != nil {
+		t.Fatalf("writing the synthetic fixture: %v", err)
+	}
+
+	cols := extractRangeQueriedColumns(t, dir)
+	found := map[string]bool{}
+	for _, c := range cols {
+		found[c.Column] = true
+	}
+
+	if !found["expires_at"] {
+		t.Errorf("extractRangeQueriedColumns must find \"expires_at\" from a >= bind-placeholder comparison; "+
+			"got %v", cols)
+	}
+	if !found["created_at"] {
+		t.Errorf("extractRangeQueriedColumns must find \"created_at\" from an ALIASED (t.created_at) <= "+
+			"bind-placeholder comparison, with the alias stripped — if alias-stripping regresses, every "+
+			"aliased range query silently stops matching anything in g81MaintainedFields, got %v", cols)
+	}
+	if found["status"] {
+		t.Errorf("extractRangeQueriedColumns matched a plain equality (status = ?) as a range comparison; "+
+			"got %v", cols)
+	}
+	if found["count"] {
+		t.Errorf("extractRangeQueriedColumns matched a literal comparison (count > 0, not a bind "+
+			"placeholder) as a range query; got %v", cols)
+	}
+	if len(cols) != 2 {
+		t.Errorf("expected exactly 2 range-queried columns (equality and literal-comparison queries must "+
+			"contribute nothing), got %d: %v", len(cols), cols)
+	}
+}
+
 // TestG81_NoUntrackedRangeQueriedTimeColumns is the AST freshness check:
 // collect every column name that appears in a range comparison against a
 // bind placeholder anywhere in this package, and assert each time-like one

--- a/internal/storage/store/remote_proxy_correctness_audit_test.go
+++ b/internal/storage/store/remote_proxy_correctness_audit_test.go
@@ -184,7 +184,7 @@ func localStorageMethods(t *testing.T) map[string]methodInfo {
 // fails loudly instead, the moment a new file needs adding to that list.
 func TestPopulationMatchesStubScannerFileList(t *testing.T) {
 	allowed := map[string]bool{}
-	for _, f := range remoteStorageStubSourceFiles(t) {
+	for _, f := range remoteStorageStubSourceFiles(t, ".") {
 		allowed[f] = true
 	}
 	var outside []string
@@ -221,7 +221,7 @@ func exported(name string) bool {
 func realProxyMethods(t *testing.T) map[string]methodInfo {
 	t.Helper()
 	all := remoteStorageMethods(t)
-	stubs := actualRemoteUnsupportedStubs(t)
+	stubs := actualRemoteUnsupportedStubs(t, ".")
 
 	out := map[string]methodInfo{}
 	for name, info := range all {
@@ -242,7 +242,7 @@ func realProxyMethods(t *testing.T) map[string]methodInfo {
 // passes — it is a report, not a gate; run with `-v` to see it.
 func TestReportRemoteStorageProxyPopulation(t *testing.T) {
 	all := remoteStorageMethods(t)
-	stubs := actualRemoteUnsupportedStubs(t)
+	stubs := actualRemoteUnsupportedStubs(t, ".")
 	unexportedHelpers := map[string]methodInfo{}
 	for name, info := range all {
 		if !exported(name) {

--- a/internal/storage/store/remote_reachability_registry_test.go
+++ b/internal/storage/store/remote_reachability_registry_test.go
@@ -322,7 +322,7 @@ var remoteReachabilityRegistry = map[string]reachabilityEntry{
 // population, same "subject first" convention.
 func TestRemoteUnsupportedStubsHaveReachabilityVerdicts(t *testing.T) {
 	total := remoteStorageMethods(t)
-	actual := actualRemoteUnsupportedStubs(t)
+	actual := actualRemoteUnsupportedStubs(t, ".")
 	proxies := realProxyMethods(t)
 
 	// Denominator computed at runtime, not hand-copied into this comment —

--- a/internal/storage/store/remote_unsupported_completeness_test.go
+++ b/internal/storage/store/remote_unsupported_completeness_test.go
@@ -92,11 +92,11 @@ func addRemoteUnsupported(entries map[string]remoteUnsupportedEntry) {
 // diffing against this slice) whenever a new remote_*.go-adjacent file is
 // added. This is the one acknowledged residual blind spot; see the package
 // doc note below for why it can't be closed further within this test.
-func remoteStorageStubSourceFiles(t *testing.T) []string {
+func remoteStorageStubSourceFiles(t *testing.T, dir string) []string {
 	t.Helper()
-	entries, err := os.ReadDir(".")
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		t.Fatalf("reading internal/storage/store: %v", err)
+		t.Fatalf("reading %s: %v", dir, err)
 	}
 	var files []string
 	for _, e := range entries {
@@ -150,7 +150,7 @@ func remoteStorageStubSourceFiles(t *testing.T) []string {
 // statement uses (or doesn't — a silent `return nil` matches too), MUST have
 // an allowlist entry or this test fails: there is no third state where a
 // method is neither classified nor caught.
-func actualRemoteUnsupportedStubs(t *testing.T) map[string]bool {
+func actualRemoteUnsupportedStubs(t *testing.T, dir string) map[string]bool {
 	t.Helper()
 	fset := token.NewFileSet()
 	// funcs holds every top-level func/method declared in the stub-source
@@ -160,8 +160,8 @@ func actualRemoteUnsupportedStubs(t *testing.T) map[string]bool {
 	funcs := map[string]*ast.FuncDecl{}
 	rsMethods := map[string]bool{}
 
-	for _, name := range remoteStorageStubSourceFiles(t) {
-		file, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+	for _, name := range remoteStorageStubSourceFiles(t, dir) {
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
 		if err != nil {
 			t.Fatalf("parsing %s: %v", name, err)
 		}
@@ -257,6 +257,69 @@ func exprString(e ast.Expr) string {
 	}
 }
 
+// TestRemoteUnsupportedStubsScannerDetectsTransitiveReach is this guard's
+// red-proof.
+//
+// TestRemoteUnsupportedStubsAreAllowlisted's own zero-result Fatals (in
+// remoteStorageStubSourceFiles and here) only catch a total collapse. This
+// file's own doc comment names the property most likely to break silently:
+// reachesClient must follow a call through a package-level helper function
+// (postRetentionBeforeCountResp is the real example named above), not just
+// through another *RemoteStorage method — several real, fully-functional
+// proxy methods delegate exactly this way. If that CallExpr/*ast.Ident branch
+// regressed, such a method would look stub-shaped and TestRemoteUnsupportedStubsAreAllowlisted
+// would demand a (false) allowlist entry for a method that works fine.
+func TestRemoteUnsupportedStubsScannerDetectsTransitiveReach(t *testing.T) {
+	dir := t.TempDir()
+	// Parsed, never compiled: undefined identifiers (context, errUnsupportedRemote)
+	// are fine and deliberate. Named "remote_fixture.go" so
+	// remoteStorageStubSourceFiles' own "remote_"-prefix filter picks it up,
+	// matching every real stub-source file in this package.
+	const src = `package storeish
+
+// GetThing reaches client directly -- a real proxy method.
+func (rs *RemoteStorage) GetThing(ctx context.Context) error {
+	return rs.client.Get(ctx, "/api/v1/things", nil)
+}
+
+// DeleteThing never reaches client at all -- the planted stub.
+func (rs *RemoteStorage) DeleteThing(ctx context.Context) error {
+	return errUnsupportedRemote
+}
+
+// PostThing is a real proxy method too, but only reaches client indirectly,
+// through a package-level helper function rather than another method call --
+// the exact postRetentionBeforeCountResp shape this file's own doc comment
+// names.
+func (rs *RemoteStorage) PostThing(ctx context.Context) error {
+	return postHelper(ctx, rs, "/api/v1/things")
+}
+
+func postHelper(ctx context.Context, rs *RemoteStorage, path string) error {
+	return rs.client.Post(ctx, path, nil, nil)
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "remote_fixture.go"), []byte(src), 0o600); err != nil {
+		t.Fatalf("writing the synthetic fixture: %v", err)
+	}
+
+	stubs := actualRemoteUnsupportedStubs(t, dir)
+
+	if !stubs["DeleteThing"] {
+		t.Error("actualRemoteUnsupportedStubs must classify DeleteThing as a stub — it never reaches " +
+			"client anywhere in its body")
+	}
+	if stubs["GetThing"] {
+		t.Error("actualRemoteUnsupportedStubs classified GetThing as a stub, but it calls rs.client.Get directly")
+	}
+	if stubs["PostThing"] {
+		t.Error("actualRemoteUnsupportedStubs classified PostThing as a stub, but it reaches rs.client.Post " +
+			"transitively through the package-level helper postHelper — if this regresses, every real proxy " +
+			"method that delegates to a free-function helper (postRetentionBeforeCountResp's real shape) " +
+			"would be misclassified as an unimplemented stub and demand a false allowlist entry")
+	}
+}
+
 // TestRemoteUnsupportedStubsAreAllowlisted is the completeness guard: every
 // structurally-stub RemoteStorage method (actualRemoteUnsupportedStubs —
 // never reaches the network, by any means, regardless of what error text or
@@ -276,7 +339,7 @@ func exprString(e ast.Expr) string {
 //     "known gap" entries that no longer reflect reality — remove the entry in
 //     the same PR that lands the fix.
 func TestRemoteUnsupportedStubsAreAllowlisted(t *testing.T) {
-	actual := actualRemoteUnsupportedStubs(t)
+	actual := actualRemoteUnsupportedStubs(t, ".")
 
 	var missingFromAllowlist []string // real stub, no allowlist entry — a new/forgotten gap
 	for name := range actual {

--- a/internal/storage/store/remote_wire_route_coverage_test.go
+++ b/internal/storage/store/remote_wire_route_coverage_test.go
@@ -24,6 +24,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -1031,3 +1032,91 @@ func constRefEntry(constRef string) wireCallExclusion {
 // entries for the per-method DEAD evidence. A future genuinely-new gap gets a
 // fresh entry here, triaged the same way, not by resurrecting these.
 var knownMissingRoutes = map[routeKey]bool{}
+
+// TestRemoteWireScannerDetectsCallsAndRoutes is this guard's red-proof.
+//
+// TestRemoteStorageWireCalls_HaveMatchingRoute compares two derived sets: the
+// wire calls this package makes, and the routes the server registers. If
+// either derivation quietly returns less than it should, the comparison finds
+// no mismatches and the guard reports full coverage — and "no unmatched calls"
+// is exactly what a broken extractor and a correct codebase both look like.
+//
+// That failure mode is not theoretical for this particular guard. The client
+// mode it covers shipped ten methods that decoded the wrong response envelope
+// and returned empty results (#1831, #1832, #1835, #1836) — defects that lived
+// behind a green test suite. The extractors deserve a standing check of their
+// own.
+func TestRemoteWireScannerDetectsCallsAndRoutes(t *testing.T) {
+	dir := t.TempDir()
+
+	// Parsed, never compiled. Three shapes: a literal path, a path built via
+	// fmt.Sprintf and held in a local, and one built by concatenation that the
+	// extractor is expected to find but NOT resolve.
+	const src = `package store
+
+func (rs *RemoteStorage) ListThings(ctx context.Context) error {
+	return rs.client.Get(ctx, "/api/v1/things", nil)
+}
+
+func (rs *RemoteStorage) GetThing(ctx context.Context, id uint) error {
+	path := fmt.Sprintf("/api/v1/things/%d", id)
+	return rs.client.Get(ctx, path, nil)
+}
+
+func (rs *RemoteStorage) MoveThing(ctx context.Context, suffix string) error {
+	return rs.client.Post(ctx, "/api/v1/things/"+suffix, nil, nil)
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "remote_fixture.go"), []byte(src), 0o600); err != nil {
+		t.Fatalf("writing the synthetic fixture: %v", err)
+	}
+
+	calls := extractWireCalls(t, dir)
+	if len(calls) != 3 {
+		t.Fatalf("extractWireCalls found %d call(s) in a fixture containing exactly 3 rs.client calls: %+v\n"+
+			"If the call extractor stops finding call sites, the coverage comparison has nothing to compare "+
+			"and TestRemoteStorageWireCalls_HaveMatchingRoute passes while checking nothing.", len(calls), calls)
+	}
+
+	resolved := map[string]string{} // method -> normalized path
+	unresolved := map[string]bool{}
+	for _, c := range calls {
+		if c.Resolved {
+			resolved[c.Method] = c.Path
+		} else {
+			unresolved[c.Method] = true
+		}
+	}
+
+	// A literal path must resolve verbatim.
+	if got := resolved["GET"]; got == "" {
+		t.Errorf("no GET call resolved to a path; resolved=%v unresolved=%v", resolved, unresolved)
+	}
+
+	// The Sprintf-through-a-local shape must resolve AND have its parameter
+	// collapsed, or client paths would never compare equal to chi patterns and
+	// every parameterised route would look uncovered.
+	var sawCollapsed bool
+	for _, c := range calls {
+		if c.Resolved && strings.Contains(c.Path, "/api/v1/things/") && strings.Contains(c.Path, "*") {
+			sawCollapsed = true
+		}
+		if c.Resolved && strings.Contains(c.Path, "%d") {
+			t.Errorf("a resolved path still contains a raw Sprintf verb (%q) — normalization has stopped "+
+				"collapsing parameters, so no client path will ever match a chi route pattern", c.Path)
+		}
+	}
+	if !sawCollapsed {
+		t.Errorf("the fmt.Sprintf path assigned to a local was not resolved and collapsed to a wildcard; "+
+			"calls=%+v\nBoth halves matter: local-variable tracking, and parameter collapsing.", calls)
+	}
+
+	// And the shape the extractor is documented as unable to resolve must be
+	// reported as found-but-unresolved, not dropped. Silently dropping it is
+	// how a real uncovered call site disappears from the population.
+	if !unresolved["POST"] {
+		t.Errorf("the concatenation-built path was not reported as an unresolved call; unresolved=%v\n"+
+			"An unresolvable path must still surface as a call site — dropping it removes a real wire "+
+			"call from the coverage population entirely.", unresolved)
+	}
+}

--- a/server/connector_type_registry_test.go
+++ b/server/connector_type_registry_test.go
@@ -185,3 +185,91 @@ func discoverConnectorTypeSwitchCases(t *testing.T, file *ast.File) map[string]b
 	})
 	return discovered
 }
+
+// TestConnectorTypeRegistryScannerDetectsSwitchCases is this guard's
+// red-proof.
+//
+// TestConnectorTypeRegistry_SwitchMatchesKnownTypes asserts today's switch
+// matches connect.KnownTypes. That is a claim about main.go, not about the
+// walk. discoverConnectorTypeSwitchCases's own zero-case Fatal only catches a
+// TOTAL collapse (the switch vanishing, or the cn.Type tag match breaking
+// outright). A narrower break — the string-literal extraction losing one
+// case, or the tag/selector match becoming too permissive and picking up an
+// unrelated switch on a same-named field — would neither hit zero nor look
+// wrong. It would silently under- or over-report, and the parity test above
+// would compare connect.KnownTypes against whatever partial set survived.
+func TestConnectorTypeRegistryScannerDetectsSwitchCases(t *testing.T) {
+	// Parsed, never compiled: undefined identifiers (Connector, connectVault,
+	// log, etc.) are fine and deliberate — this fixture must not be
+	// buildable, or someone will eventually "fix" it into a real file.
+	const src = `package fixture
+
+func wireConnector(cn *Connector) {
+	switch cn.Type {
+	case "vault":
+		connectVault(cn)
+	case "aws-secrets-manager":
+		connectAWS(cn)
+	default:
+		log.Fatalf("unknown type")
+	}
+}
+
+// wireOther's switch shares the selector name "Type" but not the "cn"
+// receiver — it must contribute nothing, or the walk is matching on the
+// selector name alone rather than the specific cn.Type shape it documents.
+func wireOther(other *Other) {
+	switch other.Type {
+	case "should-not-appear":
+		doOther()
+	}
+}
+
+// wireStatus shares the "cn" receiver but switches on a different field —
+// mirrors server/main.go's real second switch, "b.Type" at a DIFFERENT
+// receiver, but tests the field-name half of the same selectivity
+// requirement from the "cn" side: this must contribute nothing either, or
+// the walk is matching on the receiver name alone.
+func wireStatus(cn *Connector) {
+	switch cn.Status {
+	case "should-not-appear-2":
+		doStatus()
+	}
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "connector_fixture.go", src, 0)
+	if err != nil {
+		t.Fatalf("parsing the synthetic fixture: %v", err)
+	}
+
+	discovered := discoverConnectorTypeSwitchCases(t, file)
+
+	for _, want := range []string{"vault", "aws-secrets-manager"} {
+		if !discovered[want] {
+			t.Errorf("discoverConnectorTypeSwitchCases must find case %q on the cn.Type switch; got %v\n"+
+				"If this stops firing, TestConnectorTypeRegistry_SwitchMatchesKnownTypes compares "+
+				"connect.KnownTypes against an incomplete set and can silently miss a real drift.", want, discovered)
+		}
+	}
+	if len(discovered) != 2 {
+		t.Errorf("expected exactly 2 discovered cases (the default clause must not contribute), got %d: %v",
+			len(discovered), discovered)
+	}
+
+	// The other half of the proof: a switch that shares only the field name
+	// ("other.Type") or only the receiver name ("cn.Status") must not leak
+	// into the result, or the scanner over-reports and every future
+	// genuinely-missing case gets masked by noise from unrelated switches.
+	// server/main.go has exactly this shape for real — a second switch on
+	// "b.Type" a few hundred lines below the Connect-wiring one.
+	if discovered["should-not-appear"] {
+		t.Errorf("discoverConnectorTypeSwitchCases picked up a case from an unrelated other.Type switch — "+
+			"it is no longer scoped to the specific cn.Type shape it documents, got %v", discovered)
+	}
+	if discovered["should-not-appear-2"] {
+		t.Errorf("discoverConnectorTypeSwitchCases picked up a case from cn.Status (same receiver, different "+
+			"field) — it is matching on the receiver name alone rather than the specific cn.Type shape, got %v",
+			discovered)
+	}
+}

--- a/server/http/full_row_overwrite_guard_test.go
+++ b/server/http/full_row_overwrite_guard_test.go
@@ -392,3 +392,84 @@ func minInt(a, b int) int {
 	}
 	return b
 }
+
+// TestFullRowOverwriteScannerDetectsUnfetchedStructs is this guard's
+// red-proof.
+//
+// TestNoUnfetchedStructIntoFullRowOverwrite asserts that no handler in the
+// repository currently commits the defect. That is a claim about the handlers,
+// and it is the claim that stays green either way: if unfetchedStructOverwriteCalls
+// stopped resolving `X.Storage().Method(...)`, or fullRowOverwriteMethods were
+// trimmed in a merge, the sweep would find nothing and report the codebase
+// clean — which is the same output as actually being clean.
+//
+// The defect this guards is not data loss. It is account takeover: the
+// confirmed instance zeroed PasswordHash and AccountState on a struct built
+// from a request body. A guard for that should not be trusted on the strength
+// of never having been seen fail.
+//
+// The fixture is deliberately shaped as the three cases that decide the
+// verdict: an unfetched literal, an unfetched local, and a fetch-first call
+// that must come back clean.
+func TestFullRowOverwriteScannerDetectsUnfetchedStructs(t *testing.T) {
+	// Parsed, never compiled.
+	const src = `package fixture
+
+// unsafeLiteral is the confirmed defect shape: a struct literal built from a
+// request body, passed straight into a full-row overwrite.
+func (h *Fixture) unsafeLiteral(ctx context.Context, id uint) {
+	_ = h.core.Storage().UpdateAccessRequest(ctx, &models.AccessRequest{ID: id, Status: "approved"})
+}
+
+// unsafeLocal is the same defect one variable removed, which is how it
+// usually actually looks in a handler.
+func (h *Fixture) unsafeLocal(ctx context.Context, id uint) {
+	req := &models.AccessRequest{ID: id, Status: "approved"}
+	_ = h.core.Storage().UpdateAccessRequest(ctx, req)
+}
+
+// safeFetchFirst is the sanctioned shape and must NOT be reported.
+func (h *Fixture) safeFetchFirst(ctx context.Context, id uint) {
+	existing := h.core.Storage().GetAccessRequest(ctx, id)
+	existing.Status = "approved"
+	_ = h.core.Storage().UpdateAccessRequest(ctx, existing)
+}
+`
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "overwrite_fixture.go", src, 0)
+	if err != nil {
+		t.Fatalf("parsing the synthetic fixture: %v", err)
+	}
+
+	// Guard the guard's own premise: if UpdateAccessRequest ever stops being a
+	// full-row-overwrite method, this fixture silently stops testing anything.
+	if !fullRowOverwriteMethods["UpdateAccessRequest"] {
+		t.Fatal("this fixture is built on UpdateAccessRequest, which is no longer in " +
+			"fullRowOverwriteMethods — repoint the fixture at a method that still is, rather than " +
+			"letting it pass without exercising the detector")
+	}
+
+	byFunc := map[string][]overwriteFinding{}
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		byFunc[fd.Name.Name] = unfetchedStructOverwriteCalls(fd)
+	}
+
+	if len(byFunc["unsafeLiteral"]) == 0 {
+		t.Error("the scanner must flag a struct literal passed directly into a full-row overwrite — " +
+			"this is the exact shape of the confirmed PasswordHash/AccountState zeroing defect")
+	}
+	if len(byFunc["unsafeLocal"]) == 0 {
+		t.Error("the scanner must flag a local variable assigned from a struct literal and then passed " +
+			"into a full-row overwrite — the same defect, written the way handlers usually write it")
+	}
+	if n := len(byFunc["safeFetchFirst"]); n != 0 {
+		t.Errorf("the scanner flagged the fetch-first call site (%d finding(s): %v). That is the "+
+			"sanctioned shape; a guard that reports it is a guard that gets allowlisted into silence.",
+			n, byFunc["safeFetchFirst"])
+	}
+}

--- a/server/http/remote_storage_conformance_population_test.go
+++ b/server/http/remote_storage_conformance_population_test.go
@@ -250,6 +250,93 @@ func conformancePopReceiverMethods(t *testing.T, dir, receiver string) map[strin
 	return out
 }
 
+// TestConformancePopulationScannerDetectsRealAndStubMethods is this guard's
+// red-proof.
+//
+// TestReportConformancePopulation and TestConformanceCoverageIsCompleteOrDeclared
+// both build on conformancePopRealProxyMethods, which is
+// conformancePopReceiverMethods (every *RemoteStorage method) minus
+// conformancePopActualRemoteUnsupportedStubs (the ones that never reach
+// rs.client). Either half going quietly wrong reads as "no methods to
+// cover" or "fewer methods to cover" — not as an error, since #1808's own
+// denominator is derived, not asserted. Proving only that
+// conformancePopReceiverMethods finds methods would leave the stub/real
+// split — the half of the derivation that determines what actually counts
+// toward coverage — unverified.
+func TestConformancePopulationScannerDetectsRealAndStubMethods(t *testing.T) {
+	dir := t.TempDir()
+	// Parsed, never compiled: undefined identifiers (context, ErrRemoteUnsupported)
+	// are fine and deliberate.
+	//
+	// Split across two files, matching the real directory's own shape
+	// (LocalStorage and RemoteStorage methods live in separate local_*.go /
+	// remote_*.go files, never the same file) — NOT an arbitrary choice: a
+	// first version of this fixture put both receivers' same-named GetThing
+	// in one file, and conformancePopActualRemoteUnsupportedStubs' funcs map
+	// (keyed on bare function name, built across every scanned file) silently
+	// let the second declaration overwrite the first, making *RemoteStorage's
+	// real GetThing get walked as LocalStorage's body instead and report as a
+	// stub. That collision cannot occur in the real directory because
+	// conformancePopStubSourceFiles only ever parses "remote_"-prefixed files
+	// and entry.go — LocalStorage's own file is never in that set. Splitting
+	// the fixture the same way is what actually exercises the guard rather
+	// than a same-file collision the guard was never asked to survive.
+	const remoteSrc = `package storeish
+
+// GetThing is a real proxy method: it reaches rs.client directly.
+func (rs *RemoteStorage) GetThing(ctx context.Context) error {
+	return rs.client.Get(ctx, "/api/v1/things", nil)
+}
+
+// DeleteThing is stub-shaped: it never reaches rs.client at all.
+func (rs *RemoteStorage) DeleteThing(ctx context.Context) error {
+	return ErrRemoteUnsupported
+}
+`
+	// LocalStorage's own GetThing shares a method name with *RemoteStorage's
+	// but must not leak into either scan — it isn't a *RemoteStorage method,
+	// and this file doesn't match conformancePopStubSourceFiles' "remote_"/
+	// entry.go filter at all.
+	const localSrc = `package storeish
+
+func (ls *LocalStorage) GetThing(ctx context.Context) error {
+	return nil
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "remote_fixture.go"), []byte(remoteSrc), 0o600); err != nil {
+		t.Fatalf("writing the synthetic remote fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "local_fixture.go"), []byte(localSrc), 0o600); err != nil {
+		t.Fatalf("writing the synthetic local fixture: %v", err)
+	}
+
+	methods := conformancePopReceiverMethods(t, dir, "*RemoteStorage")
+	if _, ok := methods["GetThing"]; !ok {
+		t.Errorf("conformancePopReceiverMethods must find *RemoteStorage.GetThing; got %v", methods)
+	}
+	if _, ok := methods["DeleteThing"]; !ok {
+		t.Errorf("conformancePopReceiverMethods must find *RemoteStorage.DeleteThing; got %v", methods)
+	}
+	if len(methods) != 2 {
+		t.Errorf("expected exactly 2 *RemoteStorage methods — LocalStorage's own GetThing must not leak in "+
+			"via name alone; got %d: %v", len(methods), methods)
+	}
+
+	// The other half of the derivation: which of those methods are stubs.
+	stubs := conformancePopActualRemoteUnsupportedStubs(t, dir)
+	if !stubs["DeleteThing"] {
+		t.Error("conformancePopActualRemoteUnsupportedStubs must classify DeleteThing as a stub — it never " +
+			"reaches rs.client anywhere in its body. If this regresses, a genuinely unimplemented method " +
+			"counts toward #1808's coverage denominator and TestConformanceCoverageIsCompleteOrDeclared " +
+			"demands a TestConformance_ test for something that can never make a real request.")
+	}
+	if stubs["GetThing"] {
+		t.Error("conformancePopActualRemoteUnsupportedStubs classified GetThing as a stub, but it calls " +
+			"rs.client.Get directly — if this regresses, a genuinely real proxy method is silently excluded " +
+			"from #1808's coverage denominator and can ship with no TestConformance_ test at all.")
+	}
+}
+
 // conformancePopExported mirrors internal/storage/store's exported.
 func conformancePopExported(name string) bool {
 	return len(name) > 0 && name[0] >= 'A' && name[0] <= 'Z'

--- a/server/http/role_grant_authority_guard_test.go
+++ b/server/http/role_grant_authority_guard_test.go
@@ -56,7 +56,7 @@ var directStorageWriteRe = regexp.MustCompile(`\.Storage\(\)\.(Create|Update)[A-
 // the exact shape #1578/#1582 fixed.
 func persistsRoleGrantDirectly(t *testing.T, handlerName string) bool {
 	t.Helper()
-	text := handlerBodyText(t, handlerName)
+	text := handlerBodyText(t, handlersDir, handlerName)
 	return roleFieldRe.MatchString(text) && directStorageWriteRe.MatchString(text)
 }
 
@@ -73,7 +73,7 @@ func persistsRoleGrantDirectly(t *testing.T, handlerName string) bool {
 // detected as having a check.
 func callsRequireAuthorityForRole(t *testing.T, handlerName string) bool {
 	t.Helper()
-	body := handlerBodyText(t, handlerName)
+	body := handlerBodyText(t, handlersDir, handlerName)
 	return strings.Contains(body, "RequireAuthorityForRole(") ||
 		strings.Contains(body, "RequireGranterHoldsRolePermissions(")
 }

--- a/server/http/wire_actor_identity_forgery_guard_test.go
+++ b/server/http/wire_actor_identity_forgery_guard_test.go
@@ -47,6 +47,10 @@ var actorShapedFieldNames = []string{
 	"InvitedBy", "ResolvedBy", "CreatedBy", "DecidedBy", "ApproverID", "RevokedBy",
 }
 
+// handlersDir is the real server/http/handlers directory, relative to this
+// package — what every real handlerBodyText caller passes today.
+var handlersDir = filepath.Join("..", "..", "server", "http", "handlers")
+
 // actorFieldReadRe matches `body.<ActorField>` for each name above, used to
 // scan a handler's raw source text (comments included, filtered separately —
 // see actorFieldReads).
@@ -65,11 +69,10 @@ var actorFieldReadRes = func() []*regexp.Regexp {
 // returns the joined text instead of extracted call names, since this guard
 // needs to inspect the surrounding characters around each match (is it a
 // read or a write?), not just detect a call name.
-func handlerBodyText(t *testing.T, handlerName string) string {
+func handlerBodyText(t *testing.T, dir, handlerName string) string {
 	t.Helper()
 	funcRe := regexp.MustCompile(`^func \([a-zA-Z]+ \*[A-Za-z]+\) ` + regexp.QuoteMeta(handlerName) + `\(`)
 
-	dir := filepath.Join("..", "..", "server", "http", "handlers")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("reading server/http/handlers: %v", err)
@@ -86,15 +89,27 @@ func handlerBodyText(t *testing.T, handlerName string) string {
 		}
 		inFunc := false
 		depth := 0
+		sawOpenBrace := false
 		for _, line := range strings.Split(string(b), "\n") {
 			if !inFunc && funcRe.MatchString(line) {
 				inFunc = true
+				sawOpenBrace = false
 			}
 			if inFunc {
 				depth += strings.Count(line, "{") - strings.Count(line, "}")
+				if strings.Contains(line, "{") {
+					sawOpenBrace = true
+				}
 				out.WriteString(line)
 				out.WriteByte('\n')
-				if depth <= 0 {
+				// Require having actually seen the body's opening brace before
+				// depth<=0 can close capture -- a signature that wraps onto
+				// multiple lines (the parameter list, not the "func (recv
+				// *Type) Name(" prefix, which gofmt always keeps on the
+				// funcRe-matched line) nets zero braces on that first matched
+				// line, and closing on THAT would stop capture before the
+				// body -- and any actor-field read in it -- was ever seen.
+				if sawOpenBrace && depth <= 0 {
 					inFunc = false
 				}
 			}
@@ -116,7 +131,7 @@ func handlerBodyText(t *testing.T, handlerName string) string {
 // `body.toModel()` picking it up implicitly) is flagged as a live read.
 func actorFieldReads(t *testing.T, handlerName string) []string {
 	t.Helper()
-	text := handlerBodyText(t, handlerName)
+	text := handlerBodyText(t, handlersDir, handlerName)
 	var found []string
 	seen := map[string]bool{}
 	for _, line := range strings.Split(text, "\n") {
@@ -129,6 +144,103 @@ func actorFieldReads(t *testing.T, handlerName string) []string {
 				rest := strings.TrimLeft(line[loc[1]:], " \t")
 				if strings.HasPrefix(rest, "=") && !strings.HasPrefix(rest, "==") {
 					continue // overwritten before use -- the fix pattern, not a read
+				}
+				if !seen[name] {
+					seen[name] = true
+					found = append(found, name)
+				}
+			}
+		}
+	}
+	sort.Strings(found)
+	return found
+}
+
+// TestActorFieldReadsScannerDetectsWireForgery is this guard's red-proof.
+//
+// TestNoUnjustifiedActorIdentityForgery has no total-collapse tripwire at
+// all — if actorFieldReadRes stopped matching, or the "=" overwrite check or
+// the "//"-comment skip became too permissive, actorFieldReads would just
+// come back empty or noisy for every handler, and the allowlist comparison
+// would report either universal silence (a false "all safe") or unrelated
+// staleness.
+//
+// This is a regexp/line-scanner, not an AST walk (the file header says so
+// directly), and a regexp scanner fails differently than an AST one:
+// reformatting alone can defeat it. Proven, not assumed, against a real
+// defect this test found while being written: a handler whose signature
+// spans multiple lines (the parameter list wrapped onto its own lines,
+// rather than "func (recv *Type) Name(args) {" all on one line) used to
+// vanish from handlerBodyText's capture entirely. depth tracking started on
+// the funcRe-matched line and closed the moment that line's own brace count
+// netted to zero — true for a split signature, since the opening "{" lands
+// on a later line — stopping capture before the body, and any actor-field
+// read in it, was ever seen. Confirmed red before the fix (this test failed
+// exactly this way on first write); handlerBodyText now also requires having
+// actually seen the opening brace before depth<=0 can close capture, closing
+// the gap in the same change that found it rather than leaving it as a
+// documented-but-open blind spot.
+func TestActorFieldReadsScannerDetectsWireForgery(t *testing.T) {
+	dir := t.TempDir()
+	// Parsed as plain text (this guard is regexp-based, not go/ast — see the
+	// file header), so this fixture is never compiled either way —
+	// undefined identifiers are fine and deliberate.
+	const src = `package handlers
+
+func (h *Handler) NormalProxy(w http.ResponseWriter, r *http.Request) {
+	_ = body.ResolvedBy
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "fixture_handlers.go"), []byte(src), 0o600); err != nil {
+		t.Fatalf("writing the synthetic fixture: %v", err)
+	}
+
+	if got := actorFieldReadsAgainst(t, dir, "NormalProxy"); len(got) != 1 || got[0] != "ResolvedBy" {
+		t.Errorf("actorFieldReads must find ResolvedBy in a normally-formatted single-line-signature "+
+			"handler; got %v — if this regresses, the guard cannot ever fire, on any handler shape", got)
+	}
+
+	// The two-line-signature probe: does the scanner survive a signature
+	// whose opening "{" is not on the same line funcRe matched? Before the
+	// sawOpenBrace fix above, this returned empty — the exact silent-miss
+	// this red-proof exists to catch.
+	const splitSrc = `package handlers
+
+func (h *Handler) SplitSignatureProxy(
+	w http.ResponseWriter, r *http.Request,
+) {
+	_ = body.ResolvedBy
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "fixture_split_handlers.go"), []byte(splitSrc), 0o600); err != nil {
+		t.Fatalf("writing the synthetic split-signature fixture: %v", err)
+	}
+	if got := actorFieldReadsAgainst(t, dir, "SplitSignatureProxy"); len(got) != 1 || got[0] != "ResolvedBy" {
+		t.Errorf("actorFieldReads must find ResolvedBy in a handler whose signature spans multiple lines, "+
+			"same as the single-line case above; got %v — a regression here silently exempts every "+
+			"multi-line-signature handler from this guard entirely", got)
+	}
+}
+
+// actorFieldReadsAgainst is actorFieldReads with an injectable handlers
+// directory, for the red-proof above — actorFieldReads itself always scans
+// handlersDir (the real one), so this fixture needs its own copy of just the
+// text-extraction step to point at a temp dir instead.
+func actorFieldReadsAgainst(t *testing.T, dir, handlerName string) []string {
+	t.Helper()
+	text := handlerBodyText(t, dir, handlerName)
+	var found []string
+	seen := map[string]bool{}
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		for i, re := range actorFieldReadRes {
+			name := actorShapedFieldNames[i]
+			for _, loc := range re.FindAllStringIndex(line, -1) {
+				rest := strings.TrimLeft(line[loc[1]:], " \t")
+				if strings.HasPrefix(rest, "=") && !strings.HasPrefix(rest, "==") {
+					continue
 				}
 				if !seen[name] {
 					seen[name] = true


### PR DESCRIPTION
## The mutation demonstration

Every repo-scanning guard in this codebase asserts today's code is clean. Almost none assert that the scanner still works — and those are different claims. This was demonstrated on the first guard touched, by disabling driver-construction detection in the egress guard with one `&& false`:

```
TestNoUnguardedEgress                          PASS   <- checked nothing
TestEgressScannerDetectsUnguardedConstruction  FAIL
```

The existing guard stayed green while verifying nothing. That's the entire argument for this PR, and it reproduces on 12 of the ~14 guards touched (2 already had a red-proof or synthetic sibling and were left alone after being read, not just grepped for — see Explicitly out of scope below).

For each guard, a mutation was applied (one line: disable a check, empty a selector map, weaken a comparison), confirmed the new red-proof fails, confirmed the mutation restored to green, then confirmed again. Two categories of result:

- **Isolated contrast** (new test red, original guard green): connector-registry field-name selectivity, rotation-executor receiver-exclusion, remote-unsupported transitive-helper-call reach, wire-actor-identity-forgery multi-line signature handling, DEK-sweep `[]byte` type discrimination.
- **Total collapse** (both red together): csv-writer transitive one-hop encoding, g80-1530 emitAudit funnel exclusion, g81 alias-stripping, conformance-population client-selector detection, keyfiles writer-call detection. In every one of these, the mutated property turned out to be genuinely load-bearing on real code today (e.g. g81's alias-stripping is exercised by real range queries in `local_audit.go`, `local_rbac.go`, `local_sharing.go`), which is stronger evidence than an isolated contrast would have been — not a failure to isolate.

## What's in each tier

**Tier 1** (scanner already a callable helper — straightforward red-proof):
- `server/connector_type_registry_test.go` — `discoverConnectorTypeSwitchCases`. Found a real ambiguity while writing the fixture: `server/main.go` has a second, unrelated switch on a same-named field (`b.Type`, distinct from the Connect-wiring `cn.Type`) — confirmed both isolated and non-isolated mutations before picking the isolated one.
- `internal/core/csv_writer_completeness_test.go` — `bodyOrCalleesCallSafetyEncoder`. The one-hop transitive check is load-bearing: `export_matrix.go`'s `writeMatrixRemote` depends on it.
- `server/http/remote_storage_conformance_population_test.go` — `conformancePopReceiverMethods` + `conformancePopActualRemoteUnsupportedStubs`. First fixture draft had a real bug (LocalStorage/RemoteStorage same-named methods in one file collided in a name-keyed map) — traced to which was wrong (the fixture) before fixing it, per the campaign's own discipline.

**Tier 2** (helper hardcoded its scan root — parameterized, test-only signature change):
- `internal/core/rotation_executor_registry_exhaustiveness_test.go`, `internal/keyfiles/registry_exhaustiveness_test.go`, `internal/core/g80_1530_machine_actor_attribution_guard_test.go`, `internal/storage/store/remote_unsupported_completeness_test.go` (+ 2 call-site files), `server/http/wire_actor_identity_forgery_guard_test.go` (+ 1 call-site file).
- The wire-actor-identity-forgery guard is regexp/line-based, not AST — proven (not assumed) to fail differently: a handler whose signature spans multiple lines vanished from capture entirely, because depth-tracking closed on the first matched line's own (zero) net brace count. **Real defect found and fixed in the same change**, not left as a disclosed gap: `handlerBodyText` now requires having seen the opening brace before closing capture.

**Tier 3** (scan was inline in the test body — extraction and red-proof kept as separate commits so the extraction's behavior-neutrality is independently reviewable):
- `internal/storage/store/g81_guard_test.go` — extracted `extractRangeQueriedColumns`; red-proof targets the column-extraction/alias-stripping, not `g81TimeLikeColumn` (a bare name-suffix check with nothing structural to prove).
- `internal/encryption/sweep_completeness_test.go` — extracted `discoverEncryptedModelFields`; fixture is a model with a real `SomethingEnc []byte` field, per this guard's own #422 data-loss motivation.

## Explicitly out of scope, verified not just grepped

Per the task brief, confirmed by reading (not just searching for the word "vacuous") that these already have a red-proof or synthetic sibling: `internal/cli/writeguard/write_guard_test.go`, `server/http/permission_sweep_test.go`, `internal/core/mfa_stepup_purpose_guard_test.go`, `internal/storage/store/checkthencreate_race_synthetic_test.go`, `internal/storage/models/g1619_beforesave_bypass_guard_test.go`, `internal/core/actor_sentinel_completeness_test.go`, `internal/core/config_change_audit_guard_test.go`, `internal/core/secret_ownership_guard_test.go`, `internal/storage/store/audit_write_context_completeness_test.go`, `server/http/node_credential_route_classification_test.go`, `server/http/raw_storage_bypass_guard_test.go`, `server/http/role_rename_unreachable_guard_test.go`, `internal/storage/store/remote_proxy_correctness_checks_test.go`, `internal/core/adr_open_decisions_tripwire_test.go`, `internal/hardening/mlockall_removal_guard_test.go`.

## Verification

- `go vet` clean on every touched package.
- `gofmt`/`goimports` clean on every touched file.
- `golangci-lint run` clean on every touched package.
- Full test suites green: `server` (7.9s), `internal/core` (7.8s), `internal/keyfiles` (0.02s), `internal/encryption` (14.0s), `server/http` + `handlers` + `contracttest` (153.2s + 18.3s + 4.4s), `internal/storage/store` (859.6s — consistent with its established ~860-920s baseline, no duration regression).