### PR TITLE
fuzz(rig): keep every run's log forever, copy failing runs to a tracking issue

### DIFF
--- a/.github/workflows/fuzz-rig-scripts.yml
+++ b/.github/workflows/fuzz-rig-scripts.yml
@@ -1,0 +1,31 @@
+name: Fuzz rig scripts
+
+# scripts/fuzzing/ only ever runs on the self-hosted fuzz box, so nothing else
+# in CI exercises it — and ci.yml's fuzz-targets job is skipped on exactly the
+# diffs that touch only these scripts (go_unaffected). This runs the run-log
+# library's tests (fake go/gh, no network, a few seconds) whenever they could
+# have changed.
+on:
+  pull_request:
+    paths: ['scripts/fuzzing/**', '.github/workflows/fuzz-rig-scripts.yml']
+  push:
+    branches: [main]
+    paths: ['scripts/fuzzing/**', '.github/workflows/fuzz-rig-scripts.yml']
+
+permissions: {}
+
+jobs:
+  runlog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: shellcheck
+        run: shellcheck scripts/fuzzing/runlog.sh scripts/fuzzing/runlog_test.sh scripts/fuzzing/run-rotation.sh scripts/fuzzing/notify-on-crash.sh
+
+      - name: runlog tests
+        run: bash scripts/fuzzing/runlog_test.sh

--- a/scripts/fuzzing/README.md
+++ b/scripts/fuzzing/README.md
@@ -20,6 +20,9 @@ long-lived infrastructure — a small home-lab VM/LXC is a good fit.
   "interesting" input the fuzzer found) gets committed and pushed to a
   dedicated `fuzz-corpus` branch automatically — review/merge what's
   interesting from there.
+- A log of every run, gzipped and never overwritten or pruned, plus a copy of
+  every *failing* run's log on a GitHub tracking issue — see
+  [Run logs](#run-logs).
 
 ## Resource limits
 
@@ -86,6 +89,9 @@ one at a time, not concurrently).
        access tokens → Fine-grained tokens**, scoped to this repo, with:
        - **Contents: Read** (to check branch state)
        - **Pull requests: Read and write** (to open/comment on crash-report PRs)
+       - **Issues: Read and write** (to post failing-run logs to the tracking
+         issue — see [Run logs](#run-logs); without it they stay queued on
+         the box)
 
        Store it and add it to `config.env` (systemd `EnvironmentFile=` does not
        expand shell syntax, so paste the token value literally):
@@ -101,6 +107,7 @@ one at a time, not concurrently).
      level):** Create one PAT with both scopes and use it for everything:
      - **Contents: Read and write** (for `git push`)
      - **Pull requests: Read and write** (for `gh pr create`/`gh pr list`)
+     - **Issues: Read and write** (for the failing-run log tracking issue)
 
      Store it and wire it up for both `git push` and `gh`:
      ```
@@ -171,7 +178,7 @@ one at a time, not concurrently).
    this container's kernel namespace doesn't support. If you see that, this
    silently breaks BOTH `journalctl` for every service on the box AND swallows
    `keyorix-fuzz.service`'s own progress echoes (though the underlying `go
-   test` output still lands in real log files under `$NOTIFIED_STATE_DIR`, so
+   test` output still lands in real log files under `$NOTIFIED_STATE_DIR/logs`, so
    fuzzing itself isn't affected — only visibility is). Fix with a drop-in
    that clears the directive, then restart both journald and the fuzz service
    so its output gets captured from the start:
@@ -194,11 +201,17 @@ one at a time, not concurrently).
 
 ## Day-to-day
 
-- **Crash notification arrives** → SSH in, `cat
-  /opt/keyorix-fuzz/state/last-<FuzzName>.log` for the full failure, or check
+- **Crash notification arrives** → the failing run's log is already on the
+  `fuzz rig: failing-run logs` issue (or queued to be). For the whole log, SSH
+  in and `zless /opt/keyorix-fuzz/state/logs/<FuzzName>/latest.log.gz`; or check
   the `fuzz-corpus` branch for the exact new failing-input file (it's a small
   Go-syntax file under `testdata/fuzz/<FuzzName>/`). Reproduce locally with
   `go test -run=<FuzzName>/<hash> ./<package>` once you've pulled that branch.
+- **A comment on the tracking issue with no crash PR** → a run exited non-zero
+  and notify-on-crash.sh found no reproducer on `fuzz-corpus`, so it stayed
+  silent. Read the log in the comment: a timeout, an out-of-memory kill, a
+  build failure — or a real crash whose reproducer never made it to
+  `fuzz-corpus`.
 - **No heartbeat today** → the service or the box is down; check
   `systemctl status keyorix-fuzz.service` / whether the LXC itself is up.
 - **`gh` notification failed** → check `journalctl -u keyorix-fuzz.service -n 50`
@@ -215,6 +228,48 @@ one at a time, not concurrently).
 - **Widening coverage** → add a line to `targets.conf`; no script changes
   needed. The service picks it up on its next full rotation cycle restart
   (`systemctl restart keyorix-fuzz.service` to pick it up immediately).
+
+## Run logs
+
+Every run of every target gets its own log file, and none is ever overwritten
+or pruned (`runlog.sh`, sourced by `run-rotation.sh`). Until 2026-09 each run
+went to `$NOTIFIED_STATE_DIR/last-<FuzzName>.log`, which the same target's next
+run replaced: on the VCD rig `FuzzCombineKEK` exited 1 about 15 times in
+September and `FuzzVerifyReceipt` about 20 times in July–August, and none of
+those runs' output survived to be read.
+
+```
+$FUZZ_LOG_DIR/                 default $NOTIFIED_STATE_DIR/logs (already in the unit's ReadWritePaths)
+  <FuzzName>/
+    20260911T101636Z_6c2ac753ab12_4711_exit0.log.gz   start time, commit, pid, exit status
+    20260911T134001Z_6c2ac753ab12_4711_exit1.log.gz
+    latest.log.gz -> newest finished run
+  .pending-post/               failing runs not yet copied to GitHub
+  .tracking-issue              number of the GitHub issue they go to
+```
+
+Each log starts and ends with `# key: value` lines — host, target, package,
+full commit, Go version, fuzztime, start, finish, duration, exit status — so a
+log still makes sense once it's been copied somewhere else. The `fuzz: elapsed`
+progress lines that make up most of a log compress very well; a year of
+continuous fuzzing is on the order of 100 MB.
+
+**The box itself is not "forever"** — the VCD tenant is temporary — so every
+run that exits non-zero is *also* posted as a comment on one tracking issue in
+this repo, titled `fuzz rig: failing-run logs` (created on first use): the
+log's header, the first `FAIL`/`panic:` line with the same hash
+notify-on-crash.sh uses for its `notified-<FuzzName>-<hash>` marker, and the
+log's last 50 KB with the progress lines removed. That includes the runs
+notify-on-crash.sh treats as "infra failure" and stays silent about.
+
+Posting is queued. If GitHub can't be reached, or `GH_TOKEN` lacks the Issues
+permission, the log stays in `.pending-post/` and is retried after each later
+target, up to 5 at a time, and once when the service starts. A queue that isn't
+draining shows in `journalctl -u keyorix-fuzz.service` as
+`runlog: ... still queued`. Set `FUZZ_POST_FAILURES=0` in `config.env` to keep
+logs on the box only. To start a fresh tracking issue, close the old one and
+delete `$FUZZ_LOG_DIR/.tracking-issue`. If you point `FUZZ_LOG_DIR` outside
+`$NOTIFIED_STATE_DIR`, add it to `ReadWritePaths=` in the unit too.
 
 ## Design notes
 

--- a/scripts/fuzzing/config.env.example
+++ b/scripts/fuzzing/config.env.example
@@ -12,17 +12,28 @@ KEYORIX_REPO=/opt/keyorix-fuzz/keyorix
 FUZZ_CORPUS_WORKTREE=/opt/keyorix-fuzz/keyorix-fuzz-corpus
 FUZZ_CORPUS_BRANCH=fuzz-corpus
 
-# Where per-target logs and crash-notification dedup markers are kept.
+# Where crash-notification dedup markers are kept, and — under logs/ — one
+# gzipped log per fuzz run, never overwritten (see README.md "Run logs").
 NOTIFIED_STATE_DIR=/opt/keyorix-fuzz/state
+
+# Optional: keep run logs somewhere other than $NOTIFIED_STATE_DIR/logs. If
+# you do, add that directory to ReadWritePaths= in keyorix-fuzz.service.
+# FUZZ_LOG_DIR=/opt/keyorix-fuzz/state/logs
+
+# Optional: set to 0 to keep failing-run logs on the box only, instead of also
+# posting them to the "fuzz rig: failing-run logs" GitHub issue.
+# FUZZ_POST_FAILURES=1
 
 # Fine-grained PAT for the gh CLI to open/comment on crash-report PRs.
 # This is SEPARATE from the deploy-key or credential-helper token used for
 # git push — git push needs "Contents: Read and write"; gh pr create/list
-# additionally needs "Pull requests: Read and write".
-# You can use a single PAT with both scopes, or two separate tokens.
+# additionally needs "Pull requests: Read and write", and posting failing-run
+# logs to the tracking issue needs "Issues: Read and write".
+# You can use a single PAT with all the scopes, or two separate tokens.
 #
 # Generate at: https://github.com/settings/tokens?type=beta
-# Required permissions: Contents (Read), Pull requests (Read and write).
+# Required permissions: Contents (Read), Pull requests (Read and write),
+# Issues (Read and write).
 # Store the token in a 600-mode file, then paste the value here:
 #   echo "github_pat_..." > /etc/keyorix-fuzz-gh-token
 #   chown fuzzer:fuzzer /etc/keyorix-fuzz-gh-token

--- a/scripts/fuzzing/notify-on-crash.sh
+++ b/scripts/fuzzing/notify-on-crash.sh
@@ -38,7 +38,9 @@ trap cleanup_ntfy_curl_cfg EXIT
 
 cd "$KEYORIX_REPO"
 
-fail_line="$(grep -m1 -E 'FAIL|panic:' "$LOGFILE" || true)"
+# zgrep: run-rotation.sh hands over the run's log already gzipped by runlog.sh
+# (zgrep reads an uncompressed file just as well).
+fail_line="$(zgrep -m1 -E 'FAIL|panic:' "$LOGFILE" || true)"
 fail_hash="$(printf '%s' "${fail_line:-unknown}" | sha256sum | cut -c1-16)"
 marker="$NOTIFIED_STATE_DIR/notified-$FUNC-$fail_hash"
 
@@ -63,7 +65,7 @@ if ! git ls-tree -r --name-only "origin/$FUZZ_CORPUS_BRANCH" 2>/dev/null | grep 
   exit 0
 fi
 
-summary="$(grep -m8 -E 'FAIL|panic:|--- FAIL|Fatalf|\.go:[0-9]+' "$LOGFILE" | head -c 1500 || true)"
+summary="$(zgrep -m8 -E 'FAIL|panic:|--- FAIL|Fatalf|\.go:[0-9]+' "$LOGFILE" | head -c 1500 || true)"
 
 # ntfy.sh push notification (optional — skip if NTFY_TOPIC is unset or empty)
 if [[ -n "${NTFY_TOPIC:-}" ]]; then

--- a/scripts/fuzzing/run-rotation.sh
+++ b/scripts/fuzzing/run-rotation.sh
@@ -28,6 +28,15 @@ mkdir -p "$NOTIFIED_STATE_DIR"
 
 cd "$KEYORIX_REPO"
 
+# Per-run logs under $FUZZ_LOG_DIR (default $NOTIFIED_STATE_DIR/logs), gzipped
+# and never overwritten, and a GitHub tracking-issue copy of every failing
+# run's log — see the header of runlog.sh for why. Sourced once, at startup.
+# shellcheck source=scripts/fuzzing/runlog.sh
+source "$SCRIPT_DIR/runlog.sh"
+
+# Flush failing-run logs a previous process queued but could not post.
+runlog_post_pending
+
 while true; do
   while IFS='|' read -r pkg func duration; do
     [[ -z "$pkg" ]] && continue
@@ -39,20 +48,26 @@ while true; do
     git reset --hard origin/main --quiet
 
     echo "=== $(date -u +%FT%TZ) fuzzing $func in ./$pkg for $duration ==="
-    logfile="$NOTIFIED_STATE_DIR/last-$func.log"
+    runlog_start "$func" "./$pkg" "$duration"
 
     set +e
     go test "./$pkg" -run="^${func}\$" -fuzz="^${func}\$" -fuzztime="$duration" \
-      >"$logfile" 2>&1
+      >>"$RUNLOG" 2>&1
     status=$?
     set -e
+
+    # Seal and queue the log BEFORE sync-corpus.sh and notify-on-crash.sh,
+    # which talk to GitHub under this script's `set -e`: if either of them
+    # takes the loop down, the log must already be safe (and queued).
+    runlog_finish "$status"
 
     "$SCRIPT_DIR/sync-corpus.sh" "$func" "$status"
 
     if [[ "$status" -ne 0 ]]; then
-      echo "=== $(date -u +%FT%TZ) $func FAILED (exit $status) ==="
-      "$SCRIPT_DIR/notify-on-crash.sh" "$func" "$pkg" "$logfile"
+      echo "=== $(date -u +%FT%TZ) $func FAILED (exit $status) — log: $RUNLOG_FINAL ==="
+      "$SCRIPT_DIR/notify-on-crash.sh" "$func" "$pkg" "$RUNLOG_FINAL"
     fi
+    runlog_post_pending
   done <"$SCRIPT_DIR/targets.conf"
 
   echo "=== $(date -u +%FT%TZ) rotation cycle complete, looping ==="

--- a/scripts/fuzzing/runlog.sh
+++ b/scripts/fuzzing/runlog.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Per-run fuzz logs that are never overwritten, plus an off-box copy of every
+# failing run's log on a single GitHub tracking issue. Sourced by
+# scripts/fuzzing/run-rotation.sh — not meant to be executed on its own.
+# (Same design as dashdiag's scripts/fuzz-runlog.sh.)
+#
+# Why this exists: the rig used to write each target's output to
+# $NOTIFIED_STATE_DIR/last-<Target>.log, overwritten by the same target's next
+# run. On the VCD rig FuzzCombineKEK exited 1 about 15 times in 2026-09 and
+# FuzzVerifyReceipt about 20 times in July-August, and not one of those runs'
+# output survived to be read — the next run had already replaced it. A log
+# that is gone is a finding nobody can triage.
+#
+# Layout under $FUZZ_LOG_DIR (default $NOTIFIED_STATE_DIR/logs, which the
+# systemd unit already allows writes to):
+#   <Target>/<UTC start>_<commit>_<pid>.log              while the run is going
+#                                                        (-2, -3... if that name was taken)
+#   <Target>/<UTC start>_<commit>_<pid>_exit<N>.log.gz   once it has finished
+#   <Target>/latest.log.gz -> the newest finished run
+#   .pending-post/<file>.gz__<Target> -> failing runs not yet copied to GitHub
+#                                         (named so the queue sorts oldest first)
+#
+# Nothing here prunes. The `fuzz: elapsed ...` progress lines that make up
+# most of a log compress very well; a year of continuous fuzzing is on the
+# order of 100 MB of gzip.
+#
+# The box is disposable (the VCD tenant is temporary), so "kept forever on the
+# box" is not kept forever. Every failing run is therefore also posted as a
+# comment on one tracking issue in this repo — including runs
+# notify-on-crash.sh classifies as "infra failure, no reproducer" and stays
+# silent about. Posting is queued: if GitHub is unreachable or GH_TOKEN lacks
+# the Issues permission, the entry stays in .pending-post and is retried after
+# every later target, a few at a time.
+#
+# Everything is best-effort. A logging or posting problem must never stop the
+# fuzzing loop, so failures are reported on stderr and swallowed.
+
+FUZZ_LOG_DIR="${FUZZ_LOG_DIR:-${NOTIFIED_STATE_DIR:-$HOME/.keyorix-fuzz}/logs}"
+# Queue entries are symlinks to the logs, so the directory must be absolute.
+case "$FUZZ_LOG_DIR" in /*) ;; *) FUZZ_LOG_DIR="$PWD/$FUZZ_LOG_DIR" ;; esac
+# Set to 0 to keep logs on the box only.
+FUZZ_POST_FAILURES="${FUZZ_POST_FAILURES:-1}"
+FUZZ_ISSUE_TITLE="${FUZZ_ISSUE_TITLE:-fuzz rig: failing-run logs}"
+# GitHub caps a comment body at 65,536 characters; leave room for the header.
+FUZZ_POST_MAX_BYTES="${FUZZ_POST_MAX_BYTES:-50000}"
+# Queue entries posted per call, so a backlog drains over several targets
+# instead of stalling one gap between targets.
+FUZZ_POST_BATCH="${FUZZ_POST_BATCH:-5}"
+
+RUNLOG=""
+RUNLOG_FINAL=""
+RUNLOG_NAME=""
+RUNLOG_START_EPOCH=0
+
+# runlog_start NAME PKG FUZZTIME — opens a fresh log for one run and sets
+# $RUNLOG. Append to it (>>), never truncate it (>): the header is already
+# there.
+runlog_start() {
+  local name="$1" pkg="$2" fuzztime="$3" dir commit stem base n
+  RUNLOG_NAME="$name"
+  RUNLOG_FINAL=""
+  RUNLOG_START_EPOCH="$(date -u +%s)"
+  dir="$FUZZ_LOG_DIR/$name"
+  if ! mkdir -p "$dir"; then
+    # Still give the caller somewhere to write, so the run itself goes ahead.
+    RUNLOG="$(mktemp "${TMPDIR:-/tmp}/fuzz-$name.XXXXXX.log")"
+    echo "runlog: cannot create $dir — this run's log is only at $RUNLOG" >&2
+    return 0
+  fi
+  commit="$(git rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
+  # Timestamp, commit and PID already make this unique for any real run
+  # (targets fuzz for minutes to hours), but a target that dies instantly —
+  # a build failure, say — can come round again within the same second.
+  # Never reuse a stem that any existing log (finished or not) already has.
+  stem="$dir/$(date -u +%Y%m%dT%H%M%SZ)_${commit}_$$"
+  base="$stem"
+  n=1
+  while compgen -G "${base}[._]*" >/dev/null; do
+    n=$((n + 1))
+    base="${stem}-$n"
+  done
+  RUNLOG="$base.log"
+  {
+    echo "# host:     $(hostname)"
+    echo "# target:   $name"
+    echo "# package:  $pkg"
+    echo "# commit:   $(git rev-parse HEAD 2>/dev/null || echo unknown)"
+    echo "# go:       $(go version 2>/dev/null || echo unknown)"
+    echo "# fuzztime: $fuzztime"
+    echo "# started:  $(date -u +%FT%TZ)"
+    echo "#"
+  } >>"$RUNLOG" || echo "runlog: could not write header to $RUNLOG" >&2
+  return 0
+}
+
+# runlog_finish STATUS — stamps the result, renames the log to carry its exit
+# status, gzips it, points latest.log.gz at it, and queues it for GitHub if
+# the run failed. Sets $RUNLOG_FINAL to the path the log now lives at.
+runlog_finish() {
+  local status="$1" final dir
+  RUNLOG_FINAL="$RUNLOG"
+  [[ -n "$RUNLOG" && -f "$RUNLOG" ]] || return 0
+  {
+    echo "#"
+    echo "# finished: $(date -u +%FT%TZ)"
+    echo "# duration: $(($(date -u +%s) - RUNLOG_START_EPOCH))s"
+    echo "# exit:     $status"
+  } >>"$RUNLOG" || echo "runlog: could not write footer to $RUNLOG" >&2
+
+  # Only logs under $FUZZ_LOG_DIR are renamed and kept; the mktemp fallback
+  # from runlog_start is left where it is.
+  case "$RUNLOG" in "$FUZZ_LOG_DIR"/*) ;; *) return 0 ;; esac
+
+  final="${RUNLOG%.log}_exit${status}.log"
+  # -n: never replace an existing file. gzip also refuses to overwrite an
+  # existing .gz without -f, so neither step can destroy an older log.
+  if mv -n "$RUNLOG" "$final" && [[ ! -e "$RUNLOG" ]] && gzip -9n "$final"; then
+    RUNLOG_FINAL="$final.gz"
+  else
+    echo "runlog: could not finalize $RUNLOG — left uncompressed" >&2
+    [[ -f "$final" ]] && RUNLOG_FINAL="$final"
+  fi
+  dir="$(dirname "$RUNLOG_FINAL")"
+  ln -sfn "$(basename "$RUNLOG_FINAL")" "$dir/latest.log.gz" 2>/dev/null || true
+
+  if [[ "$status" -ne 0 && "$FUZZ_POST_FAILURES" == 1 ]]; then
+    if mkdir -p "$FUZZ_LOG_DIR/.pending-post"; then
+      ln -s "$RUNLOG_FINAL" "$FUZZ_LOG_DIR/.pending-post/$(basename "$RUNLOG_FINAL")__${RUNLOG_NAME}" ||
+        echo "runlog: could not queue $RUNLOG_FINAL for GitHub" >&2
+    fi
+  fi
+  return 0
+}
+
+# Prints the tracking issue's number, creating the issue on first use. The
+# number is cached in a file rather than re-found by search each time: GitHub's
+# search index lags new issues by up to a minute, which would open duplicates.
+# To start a new one: close the issue and delete $FUZZ_LOG_DIR/.tracking-issue.
+runlog_tracking_issue() {
+  local cache="$FUZZ_LOG_DIR/.tracking-issue" num
+  if [[ -s "$cache" ]]; then
+    cat "$cache"
+    return 0
+  fi
+  # List endpoint, not search (see above). The title is a fixed string with no
+  # quotes in it, so embedding it in the jq program is safe.
+  num="$(gh issue list --state open --limit 1000 --json number,title \
+    --jq "[.[] | select(.title == \"$FUZZ_ISSUE_TITLE\")] | sort_by(.number) | .[0].number // empty")" || return 1
+  if [[ -z "$num" ]]; then
+    num="$(gh issue create --title "$FUZZ_ISSUE_TITLE" --body "Opened automatically by the continuous-fuzzing rig (scripts/fuzzing/run-rotation.sh).
+
+Every fuzz run that exits non-zero posts its log here as a comment — whether or not it produced a \`testdata/fuzz\` reproducer, and whether or not notify-on-crash.sh opened a \`fuzz(crash)\` PR for it. This issue is the durable record of *every* failure, including the ones that turn out to be harness flakes or infra failures, so none of them has to be triaged from a log that no longer exists.
+
+Full logs stay on the rig under \`\$FUZZ_LOG_DIR/<Target>/\`, gzipped and never overwritten. See scripts/fuzzing/README.md." | grep -oE '[0-9]+$')" || return 1
+  fi
+  [[ -n "$num" ]] || return 1
+  printf '%s\n' "$num" >"$cache"
+  printf '%s\n' "$num"
+}
+
+# runlog_post_one ISSUE QUEUE_ENTRY — posts one queued log. Returns non-zero
+# if it could not, so the caller stops and retries later.
+runlog_post_one() {
+  local issue="$1" entry="$2" gz name header host status sig_line sig_hash body_file excerpt
+  gz="$(readlink "$entry")"
+  if [[ ! -f "$gz" ]]; then
+    echo "runlog: queued log $gz no longer exists — dropping it from the queue" >&2
+    return 0
+  fi
+  # The log's directory is named after its target.
+  name="$(basename "$(dirname "$gz")")"
+  header="$(zcat -f "$gz" | grep -E '^# [a-z]+: ' || true)"
+  host="$(sed -n 's/^# host: *//p' <<<"$header")"
+  status="$(sed -n 's/^# exit: *//p' <<<"$header")"
+  sig_line="$(zcat -f "$gz" | grep -m1 -E 'FAIL|panic:' || true)"
+  # Same hash notify-on-crash.sh uses for its dedup marker
+  # (notified-<Func>-<hash>), so a comment here can be matched to it.
+  sig_hash="$(printf '%s' "${sig_line:-unknown}" | sha256sum | cut -c1-16)"
+  # Drop the progress ticker and our own header lines (not every line starting
+  # with "# ": Go prints build errors as "# <import path>").
+  excerpt="$(zcat -f "$gz" | grep -vE '^(fuzz: elapsed|# [a-z]+: |#$)' | tail -c "$FUZZ_POST_MAX_BYTES" || true)"
+
+  body_file="$(mktemp)"
+  {
+    echo "### \`$name\` exited ${status:-?} on \`${host:-unknown host}\`"
+    echo
+    echo '```'
+    echo "$header"
+    echo '```'
+    echo
+    echo "**Failure signature:** \`${sig_line:-none found}\` (hash \`$sig_hash\`)"
+    echo
+    echo "**Full log on the rig:** \`$gz\`"
+    echo
+    echo "<details><summary>Log excerpt (fuzz progress lines removed; last ${FUZZ_POST_MAX_BYTES} bytes)</summary>"
+    echo
+    echo '~~~~~~~~'
+    echo "$excerpt"
+    echo '~~~~~~~~'
+    echo
+    echo '</details>'
+  } >"$body_file"
+
+  if gh issue comment "$issue" --body-file "$body_file" >/dev/null; then
+    rm -f "$body_file"
+    return 0
+  fi
+  rm -f "$body_file"
+  return 1
+}
+
+# Posts up to $FUZZ_POST_BATCH queued failing-run logs to the tracking issue.
+# Removes each queue entry only once its comment is confirmed posted.
+runlog_post_pending() {
+  [[ "$FUZZ_POST_FAILURES" == 1 ]] || return 0
+  local queue="$FUZZ_LOG_DIR/.pending-post" issue entry posted=0
+  local -a entries=()
+  [[ -d "$queue" ]] || return 0
+  shopt -s nullglob
+  entries=("$queue"/*)
+  shopt -u nullglob
+  [[ "${#entries[@]}" -gt 0 ]] || return 0
+
+  if ! issue="$(runlog_tracking_issue)"; then
+    echo "runlog: GitHub unreachable or issue not writable — ${#entries[@]} failing-run log(s) still queued in $queue" >&2
+    return 0
+  fi
+  for entry in "${entries[@]}"; do
+    [[ "$posted" -lt "$FUZZ_POST_BATCH" ]] || break
+    if runlog_post_one "$issue" "$entry"; then
+      rm -f "$entry"
+      posted=$((posted + 1))
+    else
+      echo "runlog: could not post $(readlink "$entry") to issue #$issue — will retry after the next target" >&2
+      break
+    fi
+  done
+  return 0
+}

--- a/scripts/fuzzing/runlog_test.sh
+++ b/scripts/fuzzing/runlog_test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Tests for scripts/fuzzing/runlog.sh. Runs with fake `go` and `gh` on PATH, so
+# it needs no network, no Go toolchain and no GitHub token:
+#
+#   bash scripts/fuzzing/runlog_test.sh
+#
+# Runs under the same `set -euo pipefail` as run-rotation.sh, because the
+# property that matters most is that nothing in the library can kill the
+# fuzzing loop when GitHub or the disk misbehaves.
+#
+# Each check is a single-quoted expression that check() evals, so its
+# variables expand when the check runs — which SC2016/SC2034 can't see.
+# shellcheck disable=SC2016,SC2034
+set -euo pipefail
+
+LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/runlog.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/bin" "$WORK/repo"
+# gh stand-in. FAKE_GH=fail makes every call fail (GitHub unreachable).
+# `issue comment` saves each body so the test can inspect what was posted.
+cat >"$WORK/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$*" >>"$FAKE_GH_DIR/calls"
+[[ "${FAKE_GH:-ok}" == fail ]] && { echo "gh: could not resolve host" >&2; exit 1; }
+case "$1 $2" in
+  "issue list") echo "${FAKE_GH_EXISTING:-}" ;;
+  "issue create") echo "https://github.com/example/repo/issues/42" ;;
+  "issue comment")
+    while [[ $# -gt 0 ]]; do
+      if [[ "$1" == --body-file ]]; then
+        n=$(ls "$FAKE_GH_DIR" | grep -c '^body' || true)
+        cp "$2" "$FAKE_GH_DIR/body$n"
+      fi
+      shift
+    done ;;
+esac
+EOF
+printf '#!/usr/bin/env bash\necho "go version go1.26.4 linux/amd64"\n' >"$WORK/bin/go"
+chmod +x "$WORK/bin/gh" "$WORK/bin/go"
+export PATH="$WORK/bin:$PATH"
+export FAKE_GH_DIR="$WORK/gh"
+mkdir -p "$FAKE_GH_DIR"
+
+cd "$WORK/repo"
+git init -q
+git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+
+fails=0
+pass() { echo "ok   - $*"; }
+fail() { echo "FAIL - $*"; fails=$((fails + 1)); }
+check() { if eval "$2"; then pass "$1"; else fail "$1"; fi; }
+
+export FUZZ_LOG_DIR="$WORK/logs"
+# shellcheck source=scripts/fuzzing/runlog.sh
+source "$LIB"
+
+# A run that produces the same kind of output a real one does.
+fake_run() { # status
+  echo "fuzz: elapsed: 0s, gathering baseline coverage: 0/12 completed"
+  echo "fuzz: elapsed: 3s, execs: 1000 (333/sec), new interesting: 1 (total: 13)"
+  if [[ "$1" -ne 0 ]]; then
+    echo "# github.com/example/repo/internal/x"
+    echo "--- FAIL: FuzzParseThing (901.14s)"
+    echo "    context deadline exceeded"
+    echo "FAIL"
+  fi
+}
+
+# 1. A passing run is kept, compressed, stamped, and not queued.
+runlog_start FuzzParseThing ./internal/x 15m
+fake_run 0 >>"$RUNLOG"
+runlog_finish 0
+first="$RUNLOG_FINAL"
+check "passing run is gzipped with its exit status in the name" '[[ "$first" == *_exit0.log.gz && -f "$first" ]]'
+check "header records target and commit" 'zcat "$first" | grep -q "^# target:   FuzzParseThing" && zcat "$first" | grep -q "^# commit:   [0-9a-f]\{40\}"'
+check "footer records exit status" 'zcat "$first" | grep -q "^# exit:     0"'
+check "latest.log.gz points at the run" '[[ "$(readlink "$FUZZ_LOG_DIR/FuzzParseThing/latest.log.gz")" == "$(basename "$first")" ]]'
+check "passing run is not queued for GitHub" '[[ ! -d "$FUZZ_LOG_DIR/.pending-post" ]] || [[ -z "$(ls -A "$FUZZ_LOG_DIR/.pending-post")" ]]'
+first_sum="$(sha256sum "$first")"
+
+# 2. The next run of the same target never touches the earlier log.
+sleep 1
+runlog_start FuzzParseThing ./internal/x 15m
+fake_run 1 >>"$RUNLOG"
+runlog_finish 1
+second="$RUNLOG_FINAL"
+check "second run gets its own file" '[[ "$second" != "$first" && -f "$second" && "$second" == *_exit1.log.gz ]]'
+check "first run's log is byte-for-byte unchanged" '[[ "$(sha256sum "$first")" == "$first_sum" ]]'
+check "latest.log.gz moved to the newer run" '[[ "$(readlink "$FUZZ_LOG_DIR/FuzzParseThing/latest.log.gz")" == "$(basename "$second")" ]]'
+check "failing run is queued for GitHub" '[[ "$(ls "$FUZZ_LOG_DIR/.pending-post" | wc -l)" -eq 1 ]]'
+
+# 2b. Same target, same exit status again: still a new file, old one intact.
+# (This is the case the old last-<Target>.log scheme lost.)
+second_sum="$(sha256sum "$second")"
+sleep 1
+runlog_start FuzzParseThing ./internal/x 15m
+fake_run 1 >>"$RUNLOG"
+runlog_finish 1
+third="$RUNLOG_FINAL"
+check "a repeat failure gets its own file" '[[ "$third" != "$second" && -f "$third" ]]'
+check "the earlier failure's log is byte-for-byte unchanged" '[[ "$(sha256sum "$second")" == "$second_sum" ]]'
+check "three runs, three logs" '[[ "$(ls "$FUZZ_LOG_DIR/FuzzParseThing"/*.log.gz | grep -vc latest)" -eq 3 ]]'
+rm -f "$FUZZ_LOG_DIR/.pending-post/$(basename "$third")__FuzzParseThing"
+
+# 3. GitHub unreachable: nothing is lost, nothing dies, the entry stays queued.
+FAKE_GH=fail runlog_post_pending 2>/dev/null
+check "post_pending survives an unreachable GitHub under set -e" 'true'
+check "entry is still queued after a failed post" '[[ "$(ls "$FUZZ_LOG_DIR/.pending-post" | wc -l)" -eq 1 ]]'
+check "no tracking issue cached after a failed post" '[[ ! -e "$FUZZ_LOG_DIR/.tracking-issue" ]]'
+
+# 4. GitHub back: the issue is created once, the log is posted, the queue drains.
+runlog_post_pending
+check "tracking issue created and cached" '[[ "$(cat "$FUZZ_LOG_DIR/.tracking-issue")" == 42 ]]'
+check "queue is empty after a successful post" '[[ -z "$(ls -A "$FUZZ_LOG_DIR/.pending-post")" ]]'
+check "comment names target, exit status and host" 'grep -q "^### \`FuzzParseThing\` exited 1 on \`$(hostname)\`" "$FAKE_GH_DIR/body0"'
+check "comment carries the failure signature" 'grep -q "FAIL: FuzzParseThing (901.14s)" "$FAKE_GH_DIR/body0"'
+check "comment keeps Go build-error lines that start with \"# \"" 'grep -q "^# github.com/example/repo/internal/x" "$FAKE_GH_DIR/body0"'
+check "comment drops the fuzz progress ticker" '! grep -q "^fuzz: elapsed" "$FAKE_GH_DIR/body0"'
+check "posting never deletes the log itself" '[[ -f "$second" ]]'
+
+# 5. The cached issue is reused: no second `issue create`.
+for i in 1 2 3 4 5 6 7; do
+  runlog_start "FuzzOther$i" ./internal/y 15m
+  fake_run 1 >>"$RUNLOG"
+  runlog_finish 1
+done
+runlog_post_pending
+check "cached issue reused, never a second create" '[[ "$(grep -c "^issue create" "$FAKE_GH_DIR/calls")" -eq 1 ]]'
+check "at most FUZZ_POST_BATCH (5) posted per call" '[[ "$(ls "$FUZZ_LOG_DIR/.pending-post" | wc -l)" -eq 2 ]]'
+runlog_post_pending
+check "backlog drains on the next call" '[[ -z "$(ls -A "$FUZZ_LOG_DIR/.pending-post")" ]]'
+
+# 6. An existing open tracking issue is found instead of opening a new one.
+rm -f "$FUZZ_LOG_DIR/.tracking-issue"
+: >"$FAKE_GH_DIR/calls"
+FAKE_GH_EXISTING=7 bash -c 'source "$0"; runlog_tracking_issue' "$LIB" >"$WORK/found"
+check "existing issue found via the list endpoint" '[[ "$(cat "$WORK/found")" == 7 ]] && ! grep -q "^issue create" "$FAKE_GH_DIR/calls"'
+
+# 7. A relative FUZZ_LOG_DIR is made absolute (queue entries are symlinks).
+rel="$(FUZZ_LOG_DIR=rel-logs bash -c 'source "$0"; echo "$FUZZ_LOG_DIR"' "$LIB")"
+check "relative FUZZ_LOG_DIR becomes absolute" '[[ "$rel" == "$PWD/rel-logs" ]]'
+
+# 7b. With FUZZ_LOG_DIR unset, logs go under $NOTIFIED_STATE_DIR/logs — the
+# one directory the systemd unit's ReadWritePaths already covers.
+dflt="$(env -u FUZZ_LOG_DIR NOTIFIED_STATE_DIR=/opt/keyorix-fuzz/state bash -c 'source "$0"; echo "$FUZZ_LOG_DIR"' "$LIB")"
+check "default FUZZ_LOG_DIR is \$NOTIFIED_STATE_DIR/logs" '[[ "$dflt" == /opt/keyorix-fuzz/state/logs ]]'
+
+# 8. FUZZ_POST_FAILURES=0 keeps logs on the box only.
+FUZZ_POST_FAILURES=0
+runlog_start FuzzLocalOnly ./internal/z 15m
+fake_run 1 >>"$RUNLOG"
+runlog_finish 1
+check "FUZZ_POST_FAILURES=0 keeps the log but does not queue it" '[[ -f "$RUNLOG_FINAL" ]] && ! ls "$FUZZ_LOG_DIR/.pending-post" | grep -q FuzzLocalOnly'
+
+echo
+if [[ "$fails" -ne 0 ]]; then
+  echo "$fails check(s) failed"
+  exit 1
+fi
+echo "all checks passed"


### PR DESCRIPTION
## Why

`run-rotation.sh` wrote each run to `$NOTIFIED_STATE_DIR/last-<Func>.log`, and the same target's next run replaced it. On the VCD rig:

- `FuzzCombineKEK` exited 1 about 15 times in September.
- `FuzzVerifyReceipt` exited non-zero about 20 times in July–August.

None of those runs' output survived to be read. `notify-on-crash.sh` classified every one of them as "infra failure, no reproducer on fuzz-corpus" and stayed silent, so the log was the only record, and it was gone within a rotation.

## What

New `scripts/fuzzing/runlog.sh`, sourced by `run-rotation.sh`. It's the same design as dashdiag's keyorixhq/dashdiag#1083.

- **One log per run, kept forever.** Each run writes to `$FUZZ_LOG_DIR/<Func>/<UTC start>_<commit>_<pid>_exit<N>.log.gz`. The default is `$NOTIFIED_STATE_DIR/logs`, which is already in the unit's `ReadWritePaths`, so **no systemd unit change**. The file has a `# key: value` header and footer: host, full commit, Go version, fuzztime, duration and exit status. Nothing overwrites an old log: `mv -n`, `gzip` without `-f`, and names that can't collide. Nothing prunes either; a year is roughly 100 MB. `latest.log.gz` points at the newest run.
- **A copy off the box for every failing run.** The VCD tenant is temporary, so every non-zero run is also posted as a comment on one tracking issue, `fuzz rig: failing-run logs`, created on first use. The comment has the header, the first `FAIL`/`panic:` line, and the last 50 KB of the log with the progress ticker removed. The failure line carries **the same hash `notify-on-crash.sh` uses for its `notified-<Func>-<hash>` marker**, so a comment can be matched to a PR, a marker or a `gh-error-*` file. Runs that notify-on-crash calls infra failures are posted too.
- **Queued.** If GitHub is unreachable, or `GH_TOKEN` lacks the Issues permission, the entry stays in `.pending-post/`. It's retried after every later target (5 at a time) and once at startup. The issue number is cached, so search-index lag can't open a duplicate issue.
- The log is sealed and queued **before** `sync-corpus.sh` and `notify-on-crash.sh` run. Either one can take the loop down under `set -e`, so the log has to be safe by then.
- `notify-on-crash.sh` reads the log with `zgrep`.
- The README (new "Run logs" section, PAT scopes, day-to-day steps) and `config.env.example` are updated.

## Tests

`scripts/fuzzing/runlog_test.sh` has 29 checks and uses fake `go`/`gh`, with no network. It runs in a new small `fuzz-rig-scripts` workflow, triggered on changes under `scripts/fuzzing/`. It's needed because `ci.yml`'s `fuzz-targets` job is skipped on exactly those diffs (`go_unaffected`). The checks match the dashdiag copy, where they're red-proven, plus one for the default log directory.

Also run end-to-end on the real VCD fuzz VM (bash 5, GNU tools): the real `run-rotation.sh`, `sync-corpus.sh` and `notify-on-crash.sh` against a local bare `origin`, with a fake `go` whose three targets pass, fail without a reproducer, and fail with one. Results:

- 43 cycles and 130 logs.
- 0 overwritten, 0 left uncompressed.
- 86 failing runs produced 86 comments, with the queue empty and 1 issue created.
- No `last-*.log` written.
- The comment hashes match notify-on-crash's markers.

`shellcheck` is clean on all four scripts.

## Found while testing, deliberately not fixed here

In that end-to-end run, `FuzzC` wrote a real reproducer to `internal/c/testdata/fuzz/FuzzC/`, and `notify-on-crash.sh` still reported "no reproducer … treating as an infra failure". `sync-corpus.sh` only rsyncs `$KEYORIX_REPO/testdata/fuzz/`, the repo root. Go writes crashers under each package's own `testdata/fuzz/`, and every target lives in `internal/<pkg>/`, so the script is a permanent no-op. That's why `fuzz-corpus` is still one empty commit from 2026-07-28, and why #1243 and #1248 had no reproducer on the branch. Five real `FuzzVerifyReceipt` reproducers are sitting untracked on the VCD box. With this PR, those failures are at least logged and posted. The path fix is a separate PR.

## Deploy note

Add **Issues: Read and write** to the rig's fine-grained PAT, on the box and not through an assistant session. Until then, failing-run logs stay queued and nothing is lost.

The VCD rig pulls `main` before every target, and DNS from that tenant is currently failing. So this reaches the box only once DNS is fixed.
