### PR TITLE
fix(fuzzing): sync every package's crashers, and stop a fetch blip starving the rotation

### DIFF
--- a/.github/workflows/fuzz-rig-scripts.yml
+++ b/.github/workflows/fuzz-rig-scripts.yml
@@ -25,7 +25,10 @@ jobs:
           persist-credentials: false
 
       - name: shellcheck
-        run: shellcheck scripts/fuzzing/runlog.sh scripts/fuzzing/runlog_test.sh scripts/fuzzing/run-rotation.sh scripts/fuzzing/notify-on-crash.sh
+        run: shellcheck scripts/fuzzing/runlog.sh scripts/fuzzing/runlog_test.sh scripts/fuzzing/run-rotation.sh scripts/fuzzing/notify-on-crash.sh scripts/fuzzing/sync-corpus.sh scripts/fuzzing/sync-corpus_test.sh
 
       - name: runlog tests
         run: bash scripts/fuzzing/runlog_test.sh
+
+      - name: sync-corpus tests
+        run: bash scripts/fuzzing/sync-corpus_test.sh

--- a/scripts/fuzzing/run-rotation.sh
+++ b/scripts/fuzzing/run-rotation.sh
@@ -5,25 +5,21 @@
 # runtime that a CI job's budget can't afford.
 #
 # Cycles through every target in targets.conf, each for its configured
-# `go test -fuzz -fuzztime`, forever. Pulls the repo's main branch before EACH
-# target (not just once per full cycle) so fuzzing stays close to the current
-# codebase — this repo merges dozens of commits a day, so a once-per-cycle
-# pull (the original design) could leave a target fuzzing code that was
-# already half a rotation cycle stale by the time it ran. Per-target pulls
-# cost a few seconds of git overhead against hours of fuzzing time, in
-# exchange for freshness bounded by the PRECEDING target's own duration
-# instead of the whole cycle's. After each target run, pushes any new corpus
-# files (crashers or coverage-expanding "interesting" inputs) to the
-# fuzz-corpus branch via sync-corpus.sh, and — on a crash — sends exactly one
-# notification per unique failure via notify-on-crash.sh (a target that keeps
-# re-failing against an already-saved crasher on every subsequent cycle does
-# not re-alert).
+# `go test -fuzz -fuzztime`, forever. Refreshes the repo's main branch before
+# EACH target (not just once per full cycle) so fuzzing stays close to the
+# current codebase. After each target run, pushes any new corpus files
+# (crashers) to the fuzz-corpus branch via sync-corpus.sh, and — on a crash —
+# sends exactly one notification per unique failure via notify-on-crash.sh.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 : "${KEYORIX_REPO:?set KEYORIX_REPO to the path of the main keyorix git clone}"
 : "${NOTIFIED_STATE_DIR:=$SCRIPT_DIR/.state}"
+: "${REMOTE:=origin}"
+# How many times to retry a failed fetch, and the base backoff between tries.
+: "${FETCH_RETRIES:=5}"
+: "${FETCH_BACKOFF:=10}"
 mkdir -p "$NOTIFIED_STATE_DIR"
 
 cd "$KEYORIX_REPO"
@@ -34,41 +30,101 @@ cd "$KEYORIX_REPO"
 # shellcheck source=scripts/fuzzing/runlog.sh
 source "$SCRIPT_DIR/runlog.sh"
 
+log() { echo "=== $(date -u +%FT%TZ) $* ==="; }
+
+# sync_main refreshes the fuzzing checkout to the latest origin/main, but a
+# failed fetch must NEVER take the service down. Under the old code a single
+# `git fetch` failure (a DNS blip, a brief network drop — routine on the vCD
+# tenant) exited the script under `set -e`; systemd's Restart=always then
+# restarted it from the TOP of targets.conf. With per-target fetches that meant
+# a flaky network pinned the rig on target #1 forever: confirmed live, only
+# FuzzCombineKEK (the first target) was fuzzed for two weeks while every other
+# target went untouched. So: retry with backoff, and if the fetch still fails,
+# log it and fuzz the checkout we already have (stale main is far better than no
+# fuzzing) rather than exiting.
+sync_main() {
+  local i
+  for ((i = 1; i <= FETCH_RETRIES; i++)); do
+    if git fetch "$REMOTE" main --quiet 2>/dev/null; then
+      git checkout main --quiet 2>/dev/null || true
+      git reset --hard "$REMOTE/main" --quiet
+      return 0
+    fi
+    log "fetch of $REMOTE/main failed (attempt $i/$FETCH_RETRIES) — retrying in $((FETCH_BACKOFF * i))s"
+    sleep "$((FETCH_BACKOFF * i))"
+  done
+  log "fetch still failing after $FETCH_RETRIES attempts — fuzzing the existing checkout ($(git rev-parse --short HEAD 2>/dev/null || echo unknown)) instead of exiting"
+  return 0
+}
+
+# Load the target list once into an array so a restart can resume where it left
+# off. targets.conf lines are pkg|func|duration; blanks and #-comments skipped.
+targets=()
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  case "$line" in \#*) continue ;; esac
+  targets+=("$line")
+done <"$SCRIPT_DIR/targets.conf"
+if [[ ${#targets[@]} -eq 0 ]]; then
+  echo "run-rotation: no targets in $SCRIPT_DIR/targets.conf" >&2
+  exit 1
+fi
+
+# Resume from the next target after the last one we started, so a restart
+# (reboot, OOM, deploy) does not always redo target #1 — the failure mode that,
+# combined with the fetch-fatal bug above, starved every target but the first.
+pos_file="$NOTIFIED_STATE_DIR/rotation-pos"
+start=0
+if [[ -r "$pos_file" ]]; then
+  saved=$(cat "$pos_file" 2>/dev/null || echo 0)
+  [[ "$saved" =~ ^[0-9]+$ ]] && start=$((saved % ${#targets[@]}))
+fi
+
 # Flush failing-run logs a previous process queued but could not post.
 runlog_post_pending
 
+i=$start
 while true; do
-  while IFS='|' read -r pkg func duration; do
-    [[ -z "$pkg" ]] && continue
-    case "$pkg" in \#*) continue ;; *) ;; esac
+  entry="${targets[$i]}"
+  IFS='|' read -r pkg func duration <<<"$entry"
+  # Persist the NEXT index before running, so a mid-run restart resumes on the
+  # following target rather than repeating this one forever if it is the crasher.
+  echo "$(((i + 1) % ${#targets[@]}))" >"$pos_file"
 
-    echo "=== $(date -u +%FT%TZ) pulling latest main ==="
-    git fetch origin main --quiet
-    git checkout main --quiet
-    git reset --hard origin/main --quiet
+  log "refreshing main"
+  sync_main
 
-    echo "=== $(date -u +%FT%TZ) fuzzing $func in ./$pkg for $duration ==="
-    runlog_start "$func" "./$pkg" "$duration"
+  log "fuzzing $func in ./$pkg for $duration"
+  runlog_start "$func" "./$pkg" "$duration"
 
-    set +e
-    go test "./$pkg" -run="^${func}\$" -fuzz="^${func}\$" -fuzztime="$duration" \
-      >>"$RUNLOG" 2>&1
-    status=$?
-    set -e
+  set +e
+  go test "./$pkg" -run="^${func}\$" -fuzz="^${func}\$" -fuzztime="$duration" \
+    >>"$RUNLOG" 2>&1
+  status=$?
+  set -e
 
-    # Seal and queue the log BEFORE sync-corpus.sh and notify-on-crash.sh,
-    # which talk to GitHub under this script's `set -e`: if either of them
-    # takes the loop down, the log must already be safe (and queued).
-    runlog_finish "$status"
+  # Seal and queue the log BEFORE sync-corpus.sh and notify-on-crash.sh, which
+  # talk to GitHub under `set -e`: if either takes the loop down, the log must
+  # already be safe (and queued).
+  runlog_finish "$status"
 
-    "$SCRIPT_DIR/sync-corpus.sh" "$func" "$status"
+  # sync-corpus.sh pushes to GitHub and notify-on-crash.sh calls the gh API;
+  # either can fail transiently (network, auth, a racing push). Never let that
+  # take the rotation down — the whole point of this runner is to keep fuzzing.
+  # Both are also invoked with `|| true`-style guards so a non-zero exit is
+  # logged, not fatal under `set -e`.
+  "$SCRIPT_DIR/sync-corpus.sh" "$func" "$status" || log "sync-corpus failed for $func (non-fatal) — reproducer, if any, stays in the checkout for the next run"
 
-    if [[ "$status" -ne 0 ]]; then
-      echo "=== $(date -u +%FT%TZ) $func FAILED (exit $status) — log: $RUNLOG_FINAL ==="
-      "$SCRIPT_DIR/notify-on-crash.sh" "$func" "$pkg" "$RUNLOG_FINAL"
-    fi
-    runlog_post_pending
-  done <"$SCRIPT_DIR/targets.conf"
+  if [[ "$status" -ne 0 ]]; then
+    log "$func exited $status — log: $RUNLOG_FINAL"
+    # notify-on-crash.sh opens a PR + alerts ONLY when a real reproducer landed
+    # on the fuzz-corpus branch; a setup/build/network failure or an
+    # end-of-fuzztime timeout produces none and is left as a quiet logged entry
+    # on the tracking issue, not a crash alert.
+    "$SCRIPT_DIR/notify-on-crash.sh" "$func" "$pkg" "$RUNLOG_FINAL" || log "notify-on-crash failed for $func (non-fatal)"
+  fi
+  runlog_post_pending
 
-  echo "=== $(date -u +%FT%TZ) rotation cycle complete, looping ==="
+  i=$(((i + 1) % ${#targets[@]}))
+  [[ "$i" -eq 0 ]] && log "rotation cycle complete, looping"
 done

--- a/scripts/fuzzing/sync-corpus.sh
+++ b/scripts/fuzzing/sync-corpus.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# Copies any new/changed files under testdata/fuzz/ from the main fuzzing
-# clone into a SEPARATE git worktree checked out on the fuzz-corpus branch,
-# then commits + pushes from there.
+# Copies any new/changed crash reproducers under **every** testdata/fuzz/ in the
+# main fuzzing clone into a SEPARATE git worktree checked out on the fuzz-corpus
+# branch, then commits + pushes from there.
 #
-# Deliberately does not touch git branches in $KEYORIX_REPO itself — that
-# clone stays on main throughout a run (run-rotation.sh resets it to
-# origin/main once per cycle), so results land on a distinct branch without
-# ever disturbing the checkout the fuzzer is actively running against.
+# Deliberately does not touch git branches in $KEYORIX_REPO itself — that clone
+# stays on main throughout a run (run-rotation.sh resets it to origin/main), so
+# results land on a distinct branch without ever disturbing the checkout the
+# fuzzer is actively running against.
 #
-# Safe to call after every rotation cycle regardless of outcome: it's a no-op
-# when there's nothing new under testdata/fuzz/.
+# Safe to call after every target regardless of outcome: a no-op when there is
+# nothing new under any testdata/fuzz/.
 set -euo pipefail
 
 FUNC="${1:?fuzz func name}"
@@ -19,27 +19,36 @@ STATUS="${2:-0}"
 : "${FUZZ_CORPUS_WORKTREE:?set FUZZ_CORPUS_WORKTREE to a git worktree checked out on the fuzz-corpus branch}"
 : "${FUZZ_CORPUS_BRANCH:=fuzz-corpus}"
 
-mkdir -p "$FUZZ_CORPUS_WORKTREE/testdata/fuzz"
+# Go's fuzz engine writes a crash reproducer into the *package's own*
+# testdata/fuzz/<FuncName>/ — e.g. internal/notary/testdata/fuzz/FuzzVerifyReceipt/
+# — NOT a single repo-root testdata/fuzz/. The previous version of this script
+# rsynced only "$KEYORIX_REPO/testdata/fuzz/" (the repo root), which for this
+# module never exists, so every crash reproducer this rig ever found was
+# silently dropped: the fuzz-corpus branch sat at an empty commit for months and
+# notify-on-crash.sh then classified every real crash as "infra failure, no
+# reproducer on the branch". That is the root cause of keyorixhq/keyorix#1243
+# and #1248 being wrongly closed. Discover the dirs across the whole tree
+# instead (matching CI/discover, and dashdiag's sibling script which already
+# globs '*/testdata/fuzz/*').
+#
+# Non-crashing "new interesting" corpus stays in the local build cache
+# ($GOCACHE/fuzz) and is never written into the tree, so anything found here is
+# by construction a real failing input worth a human's attention.
+cd "$KEYORIX_REPO"
+mapfile -t fuzz_dirs < <(find . -type d -path '*/testdata/fuzz' -not -path './.git/*' -printf '%P\n' | sort)
+if [[ ${#fuzz_dirs[@]} -eq 0 ]]; then
+  exit 0 # no target has produced a reproducer yet — the normal common case
+fi
 
-# Go's fuzz engine only ever creates testdata/fuzz/<FuncName>/ when a target
-# actually CRASHES — never for ordinary coverage-expanding exploration (that
-# non-crashing "new interesting" corpus stays in the local build cache,
-# $GOCACHE/fuzz, and is never written into the source tree). So on any target
-# that hasn't crashed yet, $KEYORIX_REPO/testdata/fuzz doesn't exist at all —
-# this is the normal, expected common case, not an error. Without this guard,
-# rsync's sender failed with "No such file or directory" (exit 23), and
-# because run-rotation.sh calls this script with `set -e` active, that
-# non-zero exit killed the ENTIRE run-rotation.sh process — which systemd's
-# Restart=always then restarted from the top of targets.conf, re-fuzzing the
-# FIRST target instead of advancing to the next one. Confirmed live: the rig
-# had been stuck re-fuzzing target #1 in a 3-hour crash/restart loop since
-# deployment, having never once reached a second target or a corpus commit.
-[[ -d "$KEYORIX_REPO/testdata/fuzz" ]] || exit 0
-
-rsync -a --update "$KEYORIX_REPO/testdata/fuzz/" "$FUZZ_CORPUS_WORKTREE/testdata/fuzz/"
+mkdir -p "$FUZZ_CORPUS_WORKTREE"
+# -R/--relative recreates each source's full relative path under the worktree,
+# so internal/notary/testdata/fuzz/... lands at the same path on the branch and,
+# once merged to main, becomes seed corpus for that package. --update never
+# overwrites a corpus file already on the branch with an older copy.
+rsync -aR --update "${fuzz_dirs[@]}" "$FUZZ_CORPUS_WORKTREE/"
 
 cd "$FUZZ_CORPUS_WORKTREE"
-git add testdata/fuzz/
+git add -- '*/testdata/fuzz/*' 'testdata/fuzz/*' 2>/dev/null || git add -A
 
 if git diff --cached --quiet; then
   exit 0

--- a/scripts/fuzzing/sync-corpus_test.sh
+++ b/scripts/fuzzing/sync-corpus_test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Tests for sync-corpus.sh — specifically that it picks up crash reproducers
+# from a package's own testdata/fuzz/ (internal/<pkg>/testdata/fuzz/...), the
+# path the previous version silently ignored. No network: pushes go to a local
+# bare repo standing in for origin.
+#
+# check() evals a single-quoted expression, so its variables expand at call
+# time — which SC2016/SC2034 cannot see.
+# shellcheck disable=SC2016,SC2034
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fails=0
+check() { if eval "$2"; then echo "ok   - $1"; else echo "FAIL - $1"; fails=$((fails + 1)); fi; }
+
+# A bare "origin" for the fuzz-corpus branch, a fuzzing clone (KEYORIX_REPO),
+# and a worktree checked out on fuzz-corpus.
+git init -q --bare "$WORK/origin.git"
+git init -q -b main "$WORK/repo"
+(
+  cd "$WORK/repo"
+  git config user.email t@t
+  git config user.name t
+  git remote add origin "$WORK/origin.git"
+  git commit -q --allow-empty -m init
+  git branch fuzz-corpus
+  git push -q origin main fuzz-corpus
+  git worktree add -q "$WORK/corpus" fuzz-corpus
+)
+
+export KEYORIX_REPO="$WORK/repo"
+export FUZZ_CORPUS_WORKTREE="$WORK/corpus"
+export FUZZ_CORPUS_BRANCH=fuzz-corpus
+corpus_head() { git -C "$WORK/corpus" rev-parse HEAD; }
+
+# 1. Nothing under any testdata/fuzz/ -> no-op, no new commit.
+before="$(corpus_head)"
+bash "$HERE/sync-corpus.sh" FuzzNothing 0
+check "no reproducer anywhere is a no-op" '[[ "$(corpus_head)" == "$before" ]]'
+
+# 2. A crasher in a PACKAGE's testdata/fuzz/ (the case the old script dropped).
+mkdir -p "$WORK/repo/internal/notary/testdata/fuzz/FuzzVerifyReceipt"
+printf 'go test fuzz v1\n[]byte("boom")\n' \
+  >"$WORK/repo/internal/notary/testdata/fuzz/FuzzVerifyReceipt/deadbeef"
+bash "$HERE/sync-corpus.sh" FuzzVerifyReceipt 1
+check "package-level reproducer is committed" '[[ "$(corpus_head)" != "$before" ]]'
+check "reproducer landed at its package path on the branch" '[[ -f "$WORK/corpus/internal/notary/testdata/fuzz/FuzzVerifyReceipt/deadbeef" ]]'
+check "commit message marks a crash" 'git -C "$WORK/corpus" log -1 --format=%s | grep -q "CRASH found"'
+check "reproducer was pushed to origin" 'git -C "$WORK/origin.git" ls-tree -r --name-only fuzz-corpus | grep -q "internal/notary/testdata/fuzz/FuzzVerifyReceipt/deadbeef"'
+
+# 3. Re-running with no new files is a no-op (idempotent).
+after="$(corpus_head)"
+bash "$HERE/sync-corpus.sh" FuzzVerifyReceipt 1
+check "second run with nothing new is a no-op" '[[ "$(corpus_head)" == "$after" ]]'
+
+# 4. A second package's crasher is also picked up (glob is tree-wide).
+mkdir -p "$WORK/repo/internal/saml/testdata/fuzz/FuzzSAMLMetadata"
+printf 'go test fuzz v1\n[]byte("x")\n' \
+  >"$WORK/repo/internal/saml/testdata/fuzz/FuzzSAMLMetadata/cafe"
+bash "$HERE/sync-corpus.sh" FuzzSAMLMetadata 1
+check "a different package's reproducer is also synced" '[[ -f "$WORK/corpus/internal/saml/testdata/fuzz/FuzzSAMLMetadata/cafe" ]]'
+
+echo
+if [[ "$fails" -ne 0 ]]; then
+  echo "$fails check(s) failed"
+  exit 1
+fi
+echo "all checks passed"


### PR DESCRIPTION
Rig-script fixes surfaced by the vCD fuzz-box analysis. No product code — `scripts/fuzzing/` only.

## 1. `sync-corpus.sh` dropped every crash reproducer

It rsynced only the repo-root `testdata/fuzz/`. Go writes crashers into each **package's** `testdata/fuzz/` (e.g. `internal/notary/testdata/fuzz/FuzzVerifyReceipt/`), so for this module the root path never exists and every reproducer the rig ever found was silently discarded. The `fuzz-corpus` branch has sat at one empty commit since July, and `notify-on-crash.sh` — which gates on "does a reproducer exist on the branch?" — then classified every real crash as an infra failure and stayed silent.

**This is the root cause of #1243 and #1248 being closed as "no reproducer exists":** the reproducers were on the box the whole time (I recovered 5 of them; they're now committed as `FuzzVerifyReceipt` seed corpus in #1848). The script now discovers every `*/testdata/fuzz` in the tree and rsyncs with `-R` so each lands at its package path on the branch — and becomes seed corpus once merged. Same globbing CI discovery and dashdiag's sibling script already use.

## 2. A `git fetch` blip pinned the rig on target #1

`run-rotation.sh` ran `git fetch` under `set -e`, so one failed fetch (a DNS blip — routine on the vCD tenant) exited the script; `Restart=always` then restarted it at the **top** of `targets.conf`. With per-target fetches, a flaky network meant only the first target ever ran — confirmed live: `FuzzCombineKEK` was the only keyorix target fuzzed for two weeks. `sync_main` now retries with backoff and, if the fetch still fails, fuzzes the existing checkout rather than exiting (stale `main` is far better than no fuzzing).

## 3. Rotation position + non-fatal sub-scripts

The next target index is persisted to `$NOTIFIED_STATE_DIR/rotation-pos` and resumed on start, so a genuine restart (reboot/OOM/deploy) doesn't always redo target #1. And `sync-corpus.sh` / `notify-on-crash.sh` are now invoked non-fatally: a transient GitHub push or API error is logged, not fatal under `set -e` (I hit exactly this in testing — a failing `sync-corpus.sh` took the whole loop down).

## Tests

`sync-corpus_test.sh` (new, runs in the `fuzz-rig-scripts` workflow with shellcheck over all the scripts; fake origin, no network):
- a package-level reproducer is committed and pushed **at its package path**;
- picked up tree-wide across multiple packages;
- no-op when nothing new; idempotent on re-run.

`run-rotation.sh` validated end-to-end on an Ubuntu VM (bash 5, GNU tools) with a fake `go` and a `git` whose `fetch` fails:
- retry recovers, all targets rotate (63 cycles each in 25 s, vs. only target #1 before);
- with `fetch` failing permanently, every target still fuzzes on the stale checkout and the loop never exits;
- the position resumes across a restart.

shellcheck clean; `scripts/preflight.sh` clean.

## Deploy note

Once merged, the rigs pick this up on their next `main` refresh. On first run after merge, `sync-corpus.sh` will push the reproducers currently sitting untracked in the keyorix box's checkout up to the `fuzz-corpus` branch — expected, and how the branch finally gets populated.

Refs #1847.
