### PR TITLE
fix(migrations,audit): v0.92.0 cannot start against an existing PostgreSQL database

### DIFF
--- a/internal/core/audit_chain_migrate_test.go
+++ b/internal/core/audit_chain_migrate_test.go
@@ -7,30 +7,63 @@ import (
 	"testing"
 
 	"github.com/keyorixhq/keyorix/internal/storage/models"
+	"github.com/keyorixhq/keyorix/internal/storage/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
+
+// relegacyChain rewrites EVERY chained event in the database so it carries a
+// GENUINE pre-#1452 hash, in id order, seeded from the first chained row's own
+// stored prev_hash (genesis normally, the anchor value after a retention purge)
+// so the chain linkage stays intact. Whole-database, because that is the real
+// scenario: an install that predates the encoding change has no current-encoded
+// rows at all.
+//
+// The fixture this replaces wrote the literal string "legacy-"+hash[:16] — not
+// a hash under any encoding this code has ever used. Every migration test built
+// on it therefore proved only that MigrateAuditChainEncoding overwrites
+// arbitrary bytes, which is precisely the unconditional-overwrite behaviour
+// that let it re-hash a tampered row as readily as a stale one: the tests
+// asserted the defect as the expectation. With real legacy hashes these tests
+// exercise the upgrade the function exists for, and pass the pre-flight check
+// that now refuses rows matching neither encoding.
+func relegacyChain(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	var events []models.AuditEvent
+	require.NoError(t, db.Order("id ASC").Find(&events).Error)
+
+	var prev string
+	started := false
+	for i := range events {
+		e := events[i]
+		if e.EntryHash == "" {
+			continue // leading unchained (pre-ADR-029) rows, as the real walker skips them
+		}
+		if !started {
+			prev = e.PrevHash // genesis normally; the anchor value after a purge
+			started = true
+		}
+		e.PrevHash = prev
+		entry := store.ComputeAuditEntryHashPre1452(&e, prev)
+		require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e.ID).
+			Updates(map[string]interface{}{"prev_hash": prev, "entry_hash": entry}).Error)
+		prev = entry
+	}
+	require.True(t, started, "fixture must contain at least one chained event to re-encode")
+}
 
 func TestMigrateAuditChainEncoding_Core_AppliesAndVerifiesAfterward(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	c, db, fixed := newReanchorTestCore(t)
 
-	e1 := logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -3))
-	e2 := logChainedEvent(t, c, "secret.updated", fixed.AddDate(0, 0, -2))
-	e3 := logChainedEvent(t, c, "secret.deleted", fixed.AddDate(0, 0, -1))
+	logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -3))
+	logChainedEvent(t, c, "secret.updated", fixed.AddDate(0, 0, -2))
+	logChainedEvent(t, c, "secret.deleted", fixed.AddDate(0, 0, -1))
 
-	// Simulate a legacy-encoded pre-existing chain by rewriting the stored
-	// hashes directly, matching the storage-layer test's approach.
-	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e1.ID).
-		Updates(map[string]interface{}{"entry_hash": "legacy-" + e1.EntryHash[:16]}).Error)
-	var reload2, reload3 models.AuditEvent
-	require.NoError(t, db.First(&reload2, e2.ID).Error)
-	require.NoError(t, db.First(&reload3, e3.ID).Error)
-	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e2.ID).
-		Updates(map[string]interface{}{"prev_hash": "legacy-" + e1.EntryHash[:16], "entry_hash": "legacy-" + e2.EntryHash[:16]}).Error)
-	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e3.ID).
-		Updates(map[string]interface{}{"prev_hash": "legacy-" + e2.EntryHash[:16], "entry_hash": "legacy-" + e3.EntryHash[:16]}).Error)
+	// Genuine pre-#1452 hashes — see relegacyChain.
+	relegacyChain(t, db)
 
 	v, err := c.VerifyAuditChain(ctx)
 	require.NoError(t, err)
@@ -59,8 +92,7 @@ func TestMigrateAuditChainEncoding_Core_DryRunPersistsNothing(t *testing.T) {
 	c, db, fixed := newReanchorTestCore(t)
 
 	e1 := logChainedEvent(t, c, "secret.read", fixed.AddDate(0, 0, -1))
-	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", e1.ID).
-		Updates(map[string]interface{}{"entry_hash": "legacy-" + e1.EntryHash[:16]}).Error)
+	relegacyChain(t, db)
 
 	var before models.AuditEvent
 	require.NoError(t, db.First(&before, e1.ID).Error)
@@ -109,8 +141,7 @@ func TestMigrateAuditChainEncoding_Core_ReSignsAnchorAfterPurge(t *testing.T) {
 	// must stay untouched, since it represents an already-purged predecessor).
 	var earliest models.AuditEvent
 	require.NoError(t, db.Where("event_type != ?", "system.audit_purge").Order("id ASC").First(&earliest).Error)
-	require.NoError(t, db.Model(&models.AuditEvent{}).Where("id = ?", earliest.ID).
-		Updates(map[string]interface{}{"entry_hash": "legacy-" + earliest.EntryHash[:16]}).Error)
+	relegacyChain(t, db)
 
 	v2, err := c.VerifyAuditChain(ctx)
 	require.NoError(t, err)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1644,6 +1644,31 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 				return fmt.Errorf("failed to add groups.deleted_at column: %w", err)
 			}
 		}
+		// groups.name_folded (#1642) has exactly the same existing-DB problem
+		// roles.name_folded had, and was missed because the reasoning stopped at
+		// the wrong question. #1642's own note reads groups.name_folded as safe
+		// because ensureGroupNameIndex is "called from both here AND the fresh-DB
+		// tail" -- true, and irrelevant: ensureGroupNameIndex calls
+		// backfillFoldedColumn, which only backfills and indexes an EXISTING
+		// column and never ALTER TABLE ADD COLUMN it. The call site existed; the
+		// column did not. On any database created before #1642, migrateDatabase
+		// returns early (projectsExists) so AutoMigrate never adds it, and the
+		// backfill's own SELECT is what fails:
+		//
+		//   failed to read groups for name_folded backfill:
+		//   ERROR: column "name_folded" does not exist (SQLSTATE 42703)
+		//
+		// which aborts migrateDatabase and, through CreateStorage ->
+		// server/main.go's log.Fatalf, prevents the server from booting at all.
+		// Found by running v0.92.0 against the DAST rig's real Postgres volume,
+		// 2026-09-11. Literal DDL rather than Migrator.AddColumn because the
+		// model tags this column `not null`, and Postgres rejects ADD COLUMN ...
+		// NOT NULL without a DEFAULT on a table that already has rows.
+		if !columnExists(db, "groups", "name_folded") {
+			if err := exec("ALTER TABLE groups ADD COLUMN name_folded TEXT NOT NULL DEFAULT ''"); err != nil {
+				return err
+			}
+		}
 		if err := ensureGroupNameIndex(db); err != nil {
 			return err
 		}
@@ -1669,6 +1694,25 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	// so a SCIM-deprovisioned username can be re-provisioned. Additive + idempotent; the
 	// full AutoMigrate below covers fresh DBs.
 	if tableExists(db, "users") {
+		// users.username_folded and users.email_folded (#1642) -- the same
+		// missing-column shape as groups.name_folded above and roles.name_folded
+		// below. ensureUserNameIndex/ensureUserEmailIndex each call
+		// backfillFoldedColumn, which reads the folded column before anything has
+		// created it. groups fails first on a pre-#1642 database, so these two
+		// were still queued behind it when the groups failure was found;
+		// confirmed absent on the same real database (information_schema showed
+		// no *_folded column on users at all). Fixing only the column that
+		// happens to error first would have moved the crash one line down.
+		if !columnExists(db, "users", "username_folded") {
+			if err := exec("ALTER TABLE users ADD COLUMN username_folded TEXT NOT NULL DEFAULT ''"); err != nil {
+				return err
+			}
+		}
+		if !columnExists(db, "users", "email_folded") {
+			if err := exec("ALTER TABLE users ADD COLUMN email_folded TEXT NOT NULL DEFAULT ''"); err != nil {
+				return err
+			}
+		}
 		if err := ensureUserNameIndex(db); err != nil {
 			return err
 		}

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1756,9 +1756,25 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 		// On an existing install AutoMigrate never runs, so this ADD COLUMN
 		// step -- mirroring the groups.DeletedAt AddColumn immediately above
 		// this comment block -- is what actually has to add it here.
-		if m := db.Migrator(); !m.HasColumn(&models.Role{}, "NameFolded") {
-			if err := m.AddColumn(&models.Role{}, "NameFolded"); err != nil {
-				return fmt.Errorf("failed to add roles.name_folded column: %w", err)
+		// Literal DDL, not Migrator.AddColumn. models.Role tags NameFolded
+		// "not null", and GORM renders that straight into the ALTER with no
+		// DEFAULT -- which every engine rejects against a table that already
+		// has rows:
+		//
+		//   SQLite:   Cannot add a NOT NULL column with default value NULL
+		//   Postgres: column "name_folded" of relation "roles" contains null values
+		//
+		// so #1642's roles guard only ever worked on an EMPTY roles table. It
+		// went unnoticed because the one real database this was reproduced on
+		// happened to have roles=0; any install with the seeded admin/operator/
+		// viewer roles would have hit it. Caught by
+		// TestMigrateDatabase_PreFoldedColumnsUpgrade, whose fixture inserts a
+		// role -- the synthetic case was stronger than the real one here.
+		// DEFAULT '' also matches what backfillFoldedColumn selects on, so the
+		// backfill immediately below still picks every pre-existing row up.
+		if !columnExists(db, "roles", "name_folded") {
+			if err := exec("ALTER TABLE roles ADD COLUMN name_folded TEXT NOT NULL DEFAULT ''"); err != nil {
+				return err
 			}
 		}
 		if err := ensureRoleNameIndex(db); err != nil {

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1209,6 +1209,7 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	mfaSecretExists := tableExists(db, "mfa_secrets")
 	mfaRecoveryExists := tableExists(db, "mfa_recovery_codes")
 	mfaChallengeExists := tableExists(db, "mfa_challenges")
+	mfaStepUpGrantExists := tableExists(db, "mfa_step_up_grants")
 	dynConfigExists := tableExists(db, "dynamic_secret_configs")
 	dynLeaseExists := tableExists(db, "dynamic_secret_leases")
 	webauthnCredExists := tableExists(db, "web_authn_credentials")
@@ -1261,6 +1262,35 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 	if !mfaChallengeExists {
 		if err := db.AutoMigrate(&models.MFAChallenge{}); err != nil {
 			return fmt.Errorf("failed to migrate mfa_challenges table: %w", err)
+		}
+	}
+	// mfa_step_up_grants. store-mfa-002 found that MFAStepUpGrant "was never
+	// migrated anywhere" and fixed it by adding the model to the bulk
+	// AutoMigrate list -- which sits AFTER `if projectsExists { return nil }`,
+	// so the fix only ever reached fresh installs. The original finding was
+	// that the table did not exist on any database; it still does not exist on
+	// any UPGRADED one. Same shape as #1642's folded columns: a fresh-DB-only
+	// remedy for an every-install problem.
+	//
+	// Consequence on an upgraded install, confirmed against the DAST rig's real
+	// Postgres volume (2026-09-11), where this table is the only one of the
+	// fresh-path models absent:
+	//
+	//   Create/GetActiveMFAStepUpGrant and PruneMFAStepUpGrants all fail with
+	//   "relation \"mfa_step_up_grants\" does not exist", so the
+	//   mfa_stepup_grant_prune scheduler errors every cycle, and -- with
+	//   classification.restricted_requires_mfa_step_up enabled --
+	//   checkRestrictedMFAGate turns that error into
+	//   "secret %q is restricted: could not verify MFA step-up: ...".
+	//
+	// That gate fails CLOSED, so this is not a bypass: restricted secrets
+	// become unreadable rather than readable without a second factor. It is
+	// still a total functional break of the protection tier meant for the most
+	// sensitive secrets, and unrecoverable in place, since minting a grant
+	// needs the same missing table.
+	if !mfaStepUpGrantExists {
+		if err := db.AutoMigrate(&models.MFAStepUpGrant{}); err != nil {
+			return fmt.Errorf("failed to migrate mfa_step_up_grants table: %w", err)
 		}
 	}
 

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -1924,9 +1924,47 @@ func (f *DefaultStorageFactory) migrateDatabase(db *gorm.DB) error { // NOSONAR 
 // NFC+case-fold output, #1642 — so "Admin"/"admin" can't coexist as two
 // indistinguishable roles in an access review. Idempotent; works on both
 // SQLite and Postgres.
+// dropLegacyGormUniqueTagArtifact removes the uniqueness artifact GORM's plain
+// `unique` struct tag left behind, whichever form the dialect gave it.
+//
+// This distinction is the whole reason the function exists. On SQLite -- the
+// dev and test backend, and therefore the only one CI ever migrates -- a
+// `unique` tag produces a plain index, and DROP INDEX removes it. On Postgres
+// it produces a UNIQUE CONSTRAINT that *owns* an index of the same name, and
+// Postgres refuses to drop that index directly:
+//
+//	ERROR: cannot drop index uni_roles_name because constraint uni_roles_name
+//	on table roles requires it (SQLSTATE 2BP01)
+//
+// which aborted migrateDatabase and stopped the server booting. Found on the
+// DAST rig's real Postgres volume, 2026-09-11, immediately behind the missing
+// folded columns -- the second Postgres-only, upgrade-only defect in the same
+// migration, both invisible to a SQLite test suite.
+//
+// Constraint first, then index: DROP CONSTRAINT removes the owned index with
+// it, so the DROP INDEX that follows is a no-op on Postgres and does the real
+// work on SQLite. Both are IF EXISTS, so this is idempotent either way. The
+// table and constraint names are passed as whole literal statements by the
+// callers rather than built here, keeping the no-runtime-built-identifier
+// discipline the surrounding code follows deliberately.
+func dropLegacyUniqueConstraint(db *gorm.DB, alterStmt string) error {
+	if db.Dialector.Name() != "postgres" {
+		return nil
+	}
+	if err := db.Exec(alterStmt).Error; err != nil {
+		return fmt.Errorf("migration failed (%s): %w", alterStmt, err)
+	}
+	return nil
+}
+
 func ensureRoleNameIndex(db *gorm.DB) error {
 	// Drop the unique constraint/index GORM's original `unique` tag on Name
 	// created. GORM names a plain `unique` tag's index uni_<table>_<column>.
+	// On Postgres that name belongs to a CONSTRAINT, which DROP INDEX alone
+	// cannot remove -- see dropLegacyUniqueConstraint above.
+	if err := dropLegacyUniqueConstraint(db, "ALTER TABLE roles DROP CONSTRAINT IF EXISTS uni_roles_name"); err != nil {
+		return err
+	}
 	if err := db.Exec("DROP INDEX IF EXISTS uni_roles_name").Error; err != nil {
 		return fmt.Errorf("failed to drop legacy roles name index: %w", err)
 	}
@@ -2088,6 +2126,9 @@ func ensureGroupNameIndex(db *gorm.DB) error {
 	// into individual literal statements (no runtime-built identifier) rather
 	// than looping over a slice, so this can't even shape-match a
 	// string-formatted-query finding.
+	if err := dropLegacyUniqueConstraint(db, "ALTER TABLE groups DROP CONSTRAINT IF EXISTS uni_groups_name"); err != nil {
+		return err
+	}
 	if err := db.Exec("DROP INDEX IF EXISTS uni_groups_name").Error; err != nil {
 		return fmt.Errorf("failed to drop legacy groups name index %q: %w", "uni_groups_name", err)
 	}
@@ -2189,6 +2230,9 @@ func ensureUserNameIndex(db *gorm.DB) error {
 	// shape-match a string-formatted-query finding.
 	if err := db.Exec("DROP INDEX IF EXISTS idx_users_username").Error; err != nil {
 		return fmt.Errorf("failed to drop legacy users username index %q: %w", "idx_users_username", err)
+	}
+	if err := dropLegacyUniqueConstraint(db, "ALTER TABLE users DROP CONSTRAINT IF EXISTS uni_users_username"); err != nil {
+		return err
 	}
 	if err := db.Exec("DROP INDEX IF EXISTS uni_users_username").Error; err != nil {
 		return fmt.Errorf("failed to drop legacy users username index %q: %w", "uni_users_username", err)

--- a/internal/storage/pre1642_upgrade_path_test.go
+++ b/internal/storage/pre1642_upgrade_path_test.go
@@ -1,0 +1,104 @@
+// pre1642_upgrade_path_test.go — regression test for the upgrade path, which
+// nothing else in this repository exercises.
+//
+// Every other migration test in this package starts from an empty database, so
+// AutoMigrate creates every column from the model structs and the ordering
+// inside migrateDatabase can never matter. The real upgrade -- new code against
+// a database an older version created -- takes a different path entirely:
+// migrateDatabase returns early once `projects` exists, AutoMigrate never runs,
+// and any column added since that database was built has to be added by an
+// explicit ADD COLUMN step on the existing-DB path.
+//
+// Three columns from #1642 did not have one. The result was not a degraded
+// feature, it was a server that could not boot:
+//
+//	failed to migrate database: failed to read groups for name_folded backfill:
+//	ERROR: column "name_folded" does not exist (SQLSTATE 42703)
+//
+// found by running v0.92.0 against a real PostgreSQL volume created around
+// #1297, and reachable by any operator upgrading across that range.
+//
+// KNOWN BOUNDARY, stated rather than implied: this test runs on SQLite, so it
+// covers the missing-column defect (dialect-independent -- the early return
+// happens on both) and does NOT cover the second defect found in the same
+// migration, where GORM's `unique` tag leaves a UNIQUE CONSTRAINT on Postgres
+// but a plain index on SQLite, so DROP INDEX alone cannot remove it. That one
+// is invisible to any SQLite test by construction and needs a Postgres-backed
+// migration test to catch. Do not read a green run here as "the upgrade path
+// is covered" -- read it as "the column half of it is".
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// preFoldedSchema is the shape of a database created before #1642 introduced
+// the folded-name columns: a `projects` table (which is what puts
+// migrateDatabase on the existing-DB path at all), and groups/users carrying
+// their pre-#1642 columns and nothing more. Deliberately hand-written rather
+// than generated from the models, since generating it from today's structs
+// would recreate exactly the columns whose absence is the thing under test.
+var preFoldedSchema = []string{
+	`CREATE TABLE projects (id INTEGER PRIMARY KEY, name TEXT, deleted_at DATETIME)`,
+	`CREATE TABLE groups (id INTEGER PRIMARY KEY, name TEXT, description TEXT,
+		created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+	`CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, email TEXT,
+		external_id TEXT, created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+	`CREATE TABLE roles (id INTEGER PRIMARY KEY, name TEXT, description TEXT,
+		created_at DATETIME, updated_at DATETIME)`,
+}
+
+// TestMigrateDatabase_PreFoldedColumnsUpgrade is the regression: a pre-#1642
+// database must migrate, not abort. Before the fix this failed on the very
+// first folded-column backfill.
+func TestMigrateDatabase_PreFoldedColumnsUpgrade(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "pre1642.db"))
+	require.NoError(t, err)
+
+	for _, stmt := range preFoldedSchema {
+		require.NoError(t, db.Exec(stmt).Error, "building the pre-#1642 fixture schema")
+	}
+	// Rows matter: backfillFoldedColumn returns early on an empty table, so an
+	// empty fixture would pass even with the columns missing -- the read that
+	// fails is the one that finds something to backfill.
+	require.NoError(t, db.Exec(`INSERT INTO groups (id, name) VALUES (1, 'Engineering')`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO users (id, username, email) VALUES (1, 'Ada', 'ada@example.com')`).Error)
+	require.NoError(t, db.Exec(`INSERT INTO roles (id, name) VALUES (1, 'admin')`).Error)
+
+	// Confirm the fixture really is pre-#1642, so a future change to the schema
+	// literals above cannot quietly turn this into a test of nothing.
+	for _, c := range []struct{ table, column string }{
+		{"groups", "name_folded"},
+		{"users", "username_folded"},
+		{"users", "email_folded"},
+		{"roles", "name_folded"},
+	} {
+		require.Falsef(t, columnExists(db, c.table, c.column),
+			"fixture must NOT already have %s.%s — with it present this test exercises the fresh-DB "+
+				"shape and proves nothing about upgrades", c.table, c.column)
+	}
+
+	require.NoError(t, (&DefaultStorageFactory{}).migrateDatabase(db),
+		"a database created before #1642 must migrate cleanly; this is what crash-looped the server")
+
+	// And the columns must actually be there afterwards, not merely not-crashed.
+	for _, c := range []struct{ table, column string }{
+		{"groups", "name_folded"},
+		{"users", "username_folded"},
+		{"users", "email_folded"},
+		{"roles", "name_folded"},
+	} {
+		require.Truef(t, columnExists(db, c.table, c.column),
+			"%s.%s must exist after migrating a pre-#1642 database", c.table, c.column)
+	}
+
+	// The backfill must have run, not just the ADD COLUMN: a column full of
+	// empty strings would satisfy the check above while leaving every lookup
+	// and uniqueness check broken.
+	var folded string
+	require.NoError(t, db.Raw(`SELECT name_folded FROM groups WHERE id = 1`).Scan(&folded).Error)
+	require.NotEmpty(t, folded, "groups.name_folded must be backfilled for pre-existing rows, not left empty")
+}

--- a/internal/storage/pre1642_upgrade_path_test.go
+++ b/internal/storage/pre1642_upgrade_path_test.go
@@ -102,3 +102,50 @@ func TestMigrateDatabase_PreFoldedColumnsUpgrade(t *testing.T) {
 	require.NoError(t, db.Raw(`SELECT name_folded FROM groups WHERE id = 1`).Scan(&folded).Error)
 	require.NotEmpty(t, folded, "groups.name_folded must be backfilled for pre-existing rows, not left empty")
 }
+
+// TestMigrateDatabase_RecreatesMFAStepUpGrantsOnUpgrade covers the other half
+// of the same root cause: not a column added without an existing-DB step, but
+// a whole TABLE.
+//
+// store-mfa-002 found that MFAStepUpGrant "was never migrated anywhere" and
+// fixed it by adding the model to the bulk AutoMigrate list. That list sits
+// after `if projectsExists { return nil }`, so the remedy only ever reached
+// fresh installs -- the original finding was that the table existed on no
+// database, and afterwards it still existed on no UPGRADED one. Exactly the
+// shape of #1642's folded columns.
+//
+// The fixture drops the table from an already-migrated database rather than
+// hand-building an old schema, because that is precisely what an older
+// database IS from this code's point of view: everything else present,
+// this one table absent.
+func TestMigrateDatabase_RecreatesMFAStepUpGrantsOnUpgrade(t *testing.T) {
+	db, err := gormOpenForTest(t, filepath.Join(t.TempDir(), "stepup.db"))
+	require.NoError(t, err)
+	f := &DefaultStorageFactory{}
+
+	require.NoError(t, f.migrateDatabase(db), "initial fresh migration")
+	require.True(t, tableExists(db, "mfa_step_up_grants"),
+		"sanity: a fresh install must have this table, or the rest of this test proves nothing")
+
+	require.NoError(t, db.Exec("DROP TABLE mfa_step_up_grants").Error)
+	require.False(t, tableExists(db, "mfa_step_up_grants"))
+
+	// projects still exists, so this second run takes the existing-DB path --
+	// the one a real upgrade takes.
+	require.True(t, tableExists(db, "projects"),
+		"the fixture must still look like an initialised database, or migrateDatabase takes the fresh path")
+	require.NoError(t, f.migrateDatabase(db), "the upgrade path must run cleanly")
+
+	require.True(t, tableExists(db, "mfa_step_up_grants"),
+		"mfa_step_up_grants must be created on the existing-DB path. Without it, an upgraded install "+
+			"cannot mint or read a step-up grant: the prune scheduler errors every cycle, and with "+
+			"classification.restricted_requires_mfa_step_up enabled, checkRestrictedMFAGate turns the "+
+			"missing-relation error into a permanent read failure on every restricted secret. It fails "+
+			"closed, so this is lost availability rather than a bypass -- but it is a total break of the "+
+			"tier meant for the most sensitive secrets, and unrecoverable in place, since minting a grant "+
+			"needs the same missing table.")
+
+	// Re-running must stay clean: the guard is an existence check, so a third
+	// pass has to be a no-op rather than a duplicate-table error.
+	require.NoError(t, f.migrateDatabase(db), "migrateDatabase must be idempotent across repeated upgrades")
+}

--- a/internal/storage/store/audit_chain_legacy_hash.go
+++ b/internal/storage/store/audit_chain_legacy_hash.go
@@ -1,0 +1,100 @@
+// audit_chain_legacy_hash.go — the frozen pre-#1452 audit entry-hash encoding.
+//
+// #1452 (2026-08-16) replaced the NUL-delimited field encoding with a
+// length-prefixed one, because the old scheme was not injective: a single
+// NUL-separated write means "a\x00" + "bc" and "a" + "\x00bc" produce the
+// identical byte stream and therefore the identical hash, so two different
+// event contents could share an entry_hash. That fix was correct and is not
+// revisited here.
+//
+// What the fix left behind is the need to READ history. Every audit_events row
+// written before it carries a hash under the old encoding, and until #1474's
+// one-time re-encoding runs, those rows are the only record there is. Without
+// this function the current code cannot tell a legitimately old-encoded row
+// from a tampered one -- it only knows the stored hash is not the hash it would
+// compute now -- which is what let MigrateAuditChainEncoding rewrite tampered
+// rows as readily as stale ones, and what made VerifyAuditChain report
+// "event modified" after an ordinary upgrade.
+//
+// THIS FUNCTION MUST NEVER CHANGE. It is not "the hash function, previous
+// version"; it is a description of bytes that already exist on disk in
+// deployments we do not control. Refactoring it to share code with
+// computeAuditEntryHash would mean a future change to the live encoder
+// silently rewrites what history is understood to have said -- the precise
+// failure this file exists to prevent. It is deliberately a verbatim copy,
+// duplication and all.
+package store
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+
+	"github.com/keyorixhq/keyorix/internal/storage/models"
+)
+
+// ComputeAuditEntryHashPre1452 reproduces the entry-hash derivation exactly as
+// it stood immediately before commit 8425f9dc (#1452): each field written
+// followed by a single NUL byte, in the same field order the current encoding
+// still uses. Verbatim, including the closures, so it can be diffed against
+// `git show 8425f9dc^:internal/storage/store/local_audit_chain.go` line for
+// line by anyone checking this claim.
+// Exported solely so tests in other packages (internal/core's migration
+// coverage) can build fixtures carrying GENUINE pre-#1452 hashes. Those tests
+// previously wrote the literal string "legacy-"+hash[:16], which is not a hash
+// under any encoding, so they proved only that the migration overwrites
+// arbitrary bytes. Nothing in production calls this; it reads history, it never
+// writes it.
+func ComputeAuditEntryHashPre1452(e *models.AuditEvent, prevHash string) string {
+	h := sha256.New()
+	write := func(s string) {
+		// codeql[go/weak-sensitive-data-hashing]
+		h.Write([]byte(s))
+		h.Write([]byte{0})
+	}
+	uptr := func(p *uint) string {
+		if p == nil {
+			return ""
+		}
+		return strconv.FormatUint(uint64(*p), 10)
+	}
+	bptr := func(p *bool) string {
+		if p == nil {
+			return ""
+		}
+		return strconv.FormatBool(*p)
+	}
+
+	write(prevHash)
+	write(e.EventType)
+	write(uptr(e.UserID))
+	write(uptr(e.SecretNodeID))
+	write(uptr(e.ProjectID))
+	write(e.IPAddress)
+	write(e.Description)
+	write(bptr(e.Success))
+	write(strconv.FormatInt(e.EventTime.UnixMicro(), 10))
+	write(e.Diff)
+	write(uptr(e.ImpersonatedBy))
+	write(uptr(e.ActingAs))
+	write(strconv.FormatBool(e.Impersonation))
+	write(e.ActorType)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// auditEntryHashMatchesAnyKnownEncoding reports whether e's stored entry_hash
+// is what EITHER the current or the pre-#1452 encoding derives from e's own
+// contents and stored prev_hash.
+//
+// "Either" is deliberate and is not a weakening. A deployment that upgraded and
+// then took live traffic before running the re-encoding has a chain whose older
+// rows are legacy-encoded and whose newer rows are current-encoded; every one of
+// those rows is honest. Requiring a single encoding across the whole chain would
+// refuse that database, and refusing a legitimate migration teaches operators to
+// reach for a force flag. A row that matches NEITHER encoding is the real signal:
+// its stored hash corresponds to no derivation this code has ever produced from
+// those contents.
+func auditEntryHashMatchesAnyKnownEncoding(e *models.AuditEvent) bool {
+	return computeAuditEntryHash(e, e.PrevHash) == e.EntryHash ||
+		ComputeAuditEntryHashPre1452(e, e.PrevHash) == e.EntryHash
+}

--- a/internal/storage/store/local_audit_chain.go
+++ b/internal/storage/store/local_audit_chain.go
@@ -454,7 +454,22 @@ func verifyBatchEvents(batch []*models.AuditEvent, prevHash string, started bool
 			return prevHash, headID, started, true
 		}
 		if computeAuditEntryHash(e, e.PrevHash) != e.EntryHash {
-			brokenChain(result, e.ID, "entry_hash does not match the event contents (event modified)")
+			// Deliberately does NOT assert tampering. This branch fires whenever
+			// the stored hash disagrees with the recomputed one, and there are
+			// two ways to get there: the event really was modified, or the row
+			// was hashed under the pre-2026-08-16 encoding (#1452 replaced the
+			// NUL-delimited derivation with a length-prefixed one) and has not
+			// been through MigrateAuditChainEncoding yet. This code cannot tell
+			// them apart -- no legacy hash function is retained, so there is
+			// nothing to test the row against -- and on an upgraded install the
+			// second cause is the overwhelmingly likely one, reached simply by
+			// deploying. Saying "event modified" there told an operator, and the
+			// Compliance page's "Audit chain verified: No", that someone had
+			// tampered with the audit log. Observed on a real database on
+			// 2026-09-11 whose every event predates the encoding change.
+			brokenChain(result, e.ID, "entry_hash does not match the event contents — the event was modified, "+
+				"or this row's hash predates the 2026-08-16 audit-hash encoding change and the one-time "+
+				"chain re-encoding (POST /api/v1/audit/migrate-chain-encoding) has not been run")
 			return prevHash, headID, started, true
 		}
 		prevHash = e.EntryHash

--- a/internal/storage/store/local_audit_chain.go
+++ b/internal/storage/store/local_audit_chain.go
@@ -16,6 +16,8 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
+
 	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
 	// Used only for retry-backoff jitter (see the #nosec G404 at its call site below), never
 	// for a security-sensitive value such as a token, key, or ID.
@@ -343,6 +345,22 @@ func (ls *LocalStorage) MigrateAuditChainEncoding(ctx context.Context, dryRun bo
 			}
 		}
 
+		// Pre-flight, inside the same transaction and before a single row is
+		// rewritten. Without it this operation recomputed and overwrote every
+		// entry_hash/prev_hash unconditionally, which on a tampered database
+		// re-hashed the tampered row exactly like a stale one and left the chain
+		// verifying afterwards -- an evidence-erasing write on the one dataset
+		// that exists to be evidence. The only trace was the migration event this
+		// function appends, which says a migration ran, not what it covered up.
+		//
+		// Refusing here costs nothing in the legitimate case (the chain is
+		// intact, just old-encoded) and is the difference between "we detected
+		// tampering" and "we destroyed the proof of it" in the case that matters.
+		// The transaction rolls back, so a refusal leaves the database untouched.
+		if err := refuseIfAuditChainBroken(tx, anchor); err != nil {
+			return err
+		}
+
 		prevHash := auditGenesisHash
 		started := false
 		var lastID uint
@@ -429,6 +447,92 @@ func (ls *LocalStorage) MigrateAuditChainEncoding(ctx context.Context, dryRun bo
 	return result, nil
 }
 
+// refuseIfAuditChainBroken walks the stored chain before MigrateAuditChainEncoding
+// rewrites it, and returns an error if any chained row is inconsistent under BOTH
+// the current and the pre-#1452 encodings, or if the chain linkage itself is
+// broken.
+//
+// The two checks catch different things and both matter:
+//
+//   - content: a row whose stored entry_hash matches neither encoding's
+//     derivation from its own fields. Its contents changed after it was written.
+//   - linkage: a row whose prev_hash does not equal the preceding row's stored
+//     entry_hash. A row was inserted, deleted, or reordered -- which re-encoding
+//     would silently repair by rewriting prev_hash down the whole chain.
+//
+// Mixed encodings are explicitly fine (see auditEntryHashMatchesAnyKnownEncoding):
+// a deployment that upgraded and took traffic before migrating has honest rows in
+// both formats, and refusing that would push operators toward a force flag.
+func refuseIfAuditChainBroken(tx *gorm.DB, anchor *storage.AuditChainAnchor) error {
+	prevHash := auditGenesisHash
+	started := false
+	firstBatch := true
+	var lastID uint
+
+	for {
+		var batch []*models.AuditEvent
+		if err := tx.
+			Where("id > ?", lastID).
+			Order("id ASC").
+			Limit(auditChainVerifyBatch).
+			Find(&batch).Error; err != nil {
+			return err
+		}
+		if len(batch) == 0 {
+			return nil
+		}
+		if firstBatch {
+			firstBatch = false
+			// Same applicability rule the rewrite loop below uses: seed from the
+			// retention anchor only when the first chained row carries a
+			// non-genesis prev_hash, i.e. a prior purge really did move the
+			// chain start.
+			for _, e := range batch {
+				if e.EntryHash == "" {
+					continue
+				}
+				if anchor != nil && e.PrevHash != auditGenesisHash {
+					prevHash = anchor.PrevHash
+				}
+				break
+			}
+		}
+
+		for _, e := range batch {
+			if !started {
+				if e.EntryHash == "" {
+					continue // leading unchained (pre-ADR-029) rows
+				}
+				started = true
+			}
+			if e.EntryHash == "" {
+				return fmt.Errorf("refusing to re-encode the audit chain: event %d has no entry_hash, so "+
+					"chain data was removed after it was written. Re-encoding would rewrite the chain around "+
+					"this gap and produce a chain that verifies. Investigate before migrating", e.ID)
+			}
+			if e.PrevHash != prevHash {
+				return fmt.Errorf("refusing to re-encode the audit chain: event %d's prev_hash does not link "+
+					"to the preceding event, so a row was inserted, deleted, or reordered. Re-encoding "+
+					"rewrites prev_hash for every row and would repair this break invisibly. Investigate "+
+					"before migrating", e.ID)
+			}
+			if !auditEntryHashMatchesAnyKnownEncoding(e) {
+				return fmt.Errorf("refusing to re-encode the audit chain: event %d's entry_hash matches "+
+					"neither the current encoding nor the pre-#1452 one, so its contents changed after it "+
+					"was written -- this is not a stale encoding. Re-encoding would re-hash the modified "+
+					"contents and leave the chain verifying, destroying the evidence. Investigate before "+
+					"migrating", e.ID)
+			}
+			prevHash = e.EntryHash
+		}
+
+		lastID = batch[len(batch)-1].ID
+		if len(batch) < auditChainVerifyBatch {
+			return nil
+		}
+	}
+}
+
 // errAuditMigrationDryRun is a sentinel used to force MigrateAuditChainEncoding's
 // transaction to roll back after computing (but never persisting) its result.
 var errAuditMigrationDryRun = errors.New("audit chain migration dry run")
@@ -454,22 +558,31 @@ func verifyBatchEvents(batch []*models.AuditEvent, prevHash string, started bool
 			return prevHash, headID, started, true
 		}
 		if computeAuditEntryHash(e, e.PrevHash) != e.EntryHash {
-			// Deliberately does NOT assert tampering. This branch fires whenever
-			// the stored hash disagrees with the recomputed one, and there are
-			// two ways to get there: the event really was modified, or the row
-			// was hashed under the pre-2026-08-16 encoding (#1452 replaced the
-			// NUL-delimited derivation with a length-prefixed one) and has not
-			// been through MigrateAuditChainEncoding yet. This code cannot tell
-			// them apart -- no legacy hash function is retained, so there is
-			// nothing to test the row against -- and on an upgraded install the
-			// second cause is the overwhelmingly likely one, reached simply by
-			// deploying. Saying "event modified" there told an operator, and the
-			// Compliance page's "Audit chain verified: No", that someone had
-			// tampered with the audit log. Observed on a real database on
-			// 2026-09-11 whose every event predates the encoding change.
-			brokenChain(result, e.ID, "entry_hash does not match the event contents — the event was modified, "+
-				"or this row's hash predates the 2026-08-16 audit-hash encoding change and the one-time "+
-				"chain re-encoding (POST /api/v1/audit/migrate-chain-encoding) has not been run")
+			// Two different findings share this branch, and saying the wrong one
+			// on a compliance screen is not a cosmetic problem. The stored hash
+			// can disagree with the recomputed one because the event really was
+			// modified, or because the row was hashed under the pre-2026-08-16
+			// encoding (#1452 replaced the NUL-delimited derivation with a
+			// length-prefixed one) and has not been through
+			// MigrateAuditChainEncoding yet. On an upgraded install the second
+			// is reached by doing nothing but deploying.
+			//
+			// Until the frozen legacy encoder existed there was no way to tell
+			// them apart, and this said "event modified" for both -- telling an
+			// operator, and the Compliance page's "Audit chain verified" tile,
+			// that someone had tampered with their audit log after an ordinary
+			// upgrade. Now the row is tested against the old encoding and the
+			// two are reported as what they are.
+			if ComputeAuditEntryHashPre1452(e, e.PrevHash) == e.EntryHash {
+				brokenChain(result, e.ID, "this row's entry_hash is valid under the pre-#1452 audit-hash "+
+					"encoding but not the current one — the chain has not been re-encoded since the "+
+					"2026-08-16 format change. This is an un-migrated upgrade, NOT evidence of tampering: "+
+					"run the one-time re-encoding (POST /api/v1/audit/migrate-chain-encoding), which "+
+					"refuses if it finds a row that matches neither encoding")
+				return prevHash, headID, started, true
+			}
+			brokenChain(result, e.ID, "entry_hash matches neither the current encoding nor the pre-#1452 "+
+				"one, so this event's contents changed after it was written (event modified)")
 			return prevHash, headID, started, true
 		}
 		prevHash = e.EntryHash

--- a/internal/storage/store/local_audit_chain_migrate_test.go
+++ b/internal/storage/store/local_audit_chain_migrate_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -18,10 +19,18 @@ import (
 func appendLegacyEncodedEvent(t *testing.T, ls *LocalStorage, desc string, at time.Time, prevHash string) *models.AuditEvent {
 	t.Helper()
 	e := appendEvent(t, ls, "secret.read", desc, at)
-	legacyEntryHash := "legacy-" + e.EntryHash[:16]
+	// A REAL pre-#1452 hash, derived by the frozen legacy encoder, not a
+	// placeholder. This used to be `"legacy-" + e.EntryHash[:16]` -- a literal
+	// string that is not a hash under any encoding this code has ever used. Every
+	// test below therefore proved only that MigrateAuditChainEncoding overwrites
+	// arbitrary bytes, which was precisely the unconditional-overwrite behaviour
+	// that let it re-hash a tampered row as readily as a stale one. The fixture
+	// asserted the defect as the expectation. With a genuine legacy hash the same
+	// tests now exercise the real upgrade these functions exist for.
+	e.PrevHash = prevHash
+	legacyEntryHash := ComputeAuditEntryHashPre1452(e, prevHash)
 	require.NoError(t, ls.db.Model(&models.AuditEvent{}).Where("id = ?", e.ID).
 		Updates(map[string]interface{}{"prev_hash": prevHash, "entry_hash": legacyEntryHash}).Error)
-	e.PrevHash = prevHash
 	e.EntryHash = legacyEntryHash
 	return e
 }
@@ -176,4 +185,81 @@ func TestMigrateAuditChainEncoding_AlreadyCurrentEncodingIsIdempotent(t *testing
 	v, err := ls.VerifyAuditChain(context.Background(), nil)
 	require.NoError(t, err)
 	assert.True(t, v.Valid, "re-migrating already-current rows must not break the chain: %s", v.Reason)
+}
+
+// TestMigrateAuditChainEncoding_RefusesToLaunderATamperedRow is the protection
+// this operation was missing.
+//
+// Before the pre-flight check, MigrateAuditChainEncoding recomputed and
+// overwrote every row's entry_hash/prev_hash unconditionally. Run on a database
+// where someone had edited an audit event, it re-hashed the edited contents
+// like any other row and the chain verified cleanly afterwards. The only
+// residue was the migration event the function appends, which records that a
+// migration happened, not what it erased.
+//
+// That is an evidence-destroying write on the one dataset whose entire purpose
+// is evidence, reachable through a documented maintenance procedure an operator
+// is told to run after upgrading — and the operator would have every reason to
+// believe the resulting green chain meant their audit log was intact.
+func TestMigrateAuditChainEncoding_RefusesToLaunderATamperedRow(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	e1 := appendLegacyEncodedEvent(t, ls, "first", base, auditGenesisHash)
+	e2 := appendLegacyEncodedEvent(t, ls, "second", base.Add(time.Second), e1.EntryHash)
+	_ = appendLegacyEncodedEvent(t, ls, "third", base.Add(2*time.Second), e2.EntryHash)
+
+	// Tamper: change an event's contents and leave its hash alone — exactly what
+	// a direct database edit looks like. The row now matches neither encoding.
+	require.NoError(t, ls.db.Model(&models.AuditEvent{}).Where("id = ?", e2.ID).
+		Update("description", "second (quietly edited)").Error)
+
+	var before []models.AuditEvent
+	require.NoError(t, ls.db.Order("id ASC").Find(&before).Error)
+
+	_, err := ls.MigrateAuditChainEncoding(context.Background(), false, nil)
+	require.Error(t, err, "a tampered row must stop the migration, not be re-hashed into a valid chain")
+	assert.Contains(t, err.Error(), "matches neither the current encoding nor the pre-#1452 one")
+	assert.Contains(t, err.Error(), "destroying the evidence")
+
+	// The refusal must leave the database exactly as it was: the whole point is
+	// that nothing is rewritten, so a forensic copy taken afterwards is still
+	// the original.
+	var after []models.AuditEvent
+	require.NoError(t, ls.db.Order("id ASC").Find(&after).Error)
+	require.Len(t, after, len(before))
+	for i := range before {
+		assert.Equal(t, before[i].EntryHash, after[i].EntryHash,
+			"event %d's entry_hash must be untouched after a refused migration", before[i].ID)
+		assert.Equal(t, before[i].PrevHash, after[i].PrevHash,
+			"event %d's prev_hash must be untouched after a refused migration", before[i].ID)
+	}
+
+	// A dry run must refuse identically. An operator checking "what would this
+	// do?" before committing must be told about the tampering, not handed a
+	// clean preview of the laundering.
+	_, err = ls.MigrateAuditChainEncoding(context.Background(), true, nil)
+	require.Error(t, err, "dry run must surface the same refusal")
+}
+
+// TestMigrateAuditChainEncoding_RefusesABrokenLink covers the other way
+// re-encoding could repair evidence invisibly: the row contents are all
+// self-consistent, but a row was removed, so prev_hash no longer links. Because
+// the migration rewrites prev_hash for every row as it walks, it would have
+// closed that gap and produced a chain that verifies with a row missing.
+func TestMigrateAuditChainEncoding_RefusesABrokenLink(t *testing.T) {
+	ls := newAuditChainTestStore(t)
+	base := time.Now().UTC()
+
+	e1 := appendLegacyEncodedEvent(t, ls, "first", base, auditGenesisHash)
+	e2 := appendLegacyEncodedEvent(t, ls, "second", base.Add(time.Second), e1.EntryHash)
+	e3 := appendLegacyEncodedEvent(t, ls, "third", base.Add(2*time.Second), e2.EntryHash)
+
+	// Delete the middle event. e3 still points at e2's hash, which is now gone.
+	require.NoError(t, ls.db.Where("id = ?", e2.ID).Delete(&models.AuditEvent{}).Error)
+
+	_, err := ls.MigrateAuditChainEncoding(context.Background(), false, nil)
+	require.Error(t, err, "a deleted row must stop the migration")
+	assert.Contains(t, err.Error(), "inserted, deleted, or reordered")
+	assert.Contains(t, err.Error(), fmt.Sprintf("event %d", e3.ID))
 }


### PR DESCRIPTION
**v0.92.0 does not boot against any PostgreSQL database created before #1642.** `migrateDatabase` aborts, `CreateStorage` → `server/main.go`'s `log.Fatalf` turns that into a boot failure, and the server crash-loops every ~32 seconds:

```
failed to initialize core service: failed to initialize storage: failed to migrate database:
failed to read groups for name_folded backfill:
ERROR: column "name_folded" does not exist (SQLSTATE 42703)
```

Found by running the tagged release against the DAST rig's real Postgres volume (created around #1297), not by reasoning about it. Four distinct defects had to be fixed before it booted, then two more surfaced in the audit chain.

## The migration defects

| commit | defect |
|---|---|
| `93865c12` | `groups.name_folded`, `users.username_folded`, `users.email_folded` never added on the existing-DB path |
| `c577e986` | GORM's `unique` tag leaves a **CONSTRAINT** on Postgres and a plain index on SQLite; `DROP INDEX` cannot remove the former |
| `95bbb19c` | #1642's own `roles.name_folded` guard used `Migrator.AddColumn`, which emits `NOT NULL` with no `DEFAULT` — so it only ever worked on an **empty** roles table |
| `cf3a68b3` | `mfa_step_up_grants` is created only on the fresh-DB path, so it exists on no upgraded install |

**One root cause.** `migrateDatabase` returns early once `projects` exists, so `AutoMigrate` never runs and every column or table added since needs its own explicit step on that path. #1642 spotted this for `roles` and reasoned the siblings were covered because they're *called* from both paths — true, and not the question: `backfillFoldedColumn` only backfills an **existing** column, as the comment four lines above the roles fix says in as many words. The call site existed; the column did not.

Derived from `information_schema` on the failing database rather than guessed:

```
groups: created_at deleted_at description id name updated_at   <- no name_folded
users:  no *_folded columns at all
roles:  no name_folded
```

`groups` errors first, which is why `users` stayed hidden behind it.

**`mfa_step_up_grants` is the one with teeth.** With `classification.restricted_requires_mfa_step_up` enabled, `checkRestrictedMFAGate` turns the missing relation into a permanent read failure on every restricted secret, and it can't be recovered in place because minting a grant needs the same table. The gate **fails closed**, so it's lost availability rather than a bypass — but it's a total break of the tier meant for the most sensitive secrets.

## The audit-chain defects

`a421d6ad` — `VerifyAuditChain` reported `entry_hash does not match the event contents (event modified)` for a row whose hash merely predates the 2026-08-16 encoding change (#1452). On the rig, all 114 events fall between 2026-07-28 and 2026-08-08 — entirely before it. So an ordinary upgrade told the operator, and the Compliance page's `Audit chain verified` tile, that **someone had tampered with their audit log**.

`ee5d786e` — worse, and the reason the frozen legacy encoder now exists. `MigrateAuditChainEncoding` recomputed and overwrote every row's hashes **unconditionally**, verifying nothing first. Run on a tampered database, it re-hashed the edited contents like any stale row and the chain verified afterwards — an evidence-destroying write on the one dataset that exists to be evidence, through a documented procedure operators are told to run after upgrading.

It now refuses, inside the same transaction and before any write, on a row matching **neither** encoding (contents changed) or on broken linkage (row inserted, deleted, reordered — which re-encoding would have repaired invisibly). The transaction rolls back, so a refusal leaves the database byte-identical. Dry run refuses identically.

**Every test of that function was built on a fake.** `"legacy-" + e.EntryHash[:16]` is not a hash under any encoding this code has used. All six tests, across both packages, proved only that the migration overwrites arbitrary bytes — which *is* the defect. They now derive genuine pre-#1452 hashes and all six still pass, which is what shows the refusal doesn't block legitimate migrations.

## Why nothing caught any of this

**Nothing anywhere migrates a database it did not create.** Every migration test starts empty, on SQLite. The upgrade path — new code, old database, Postgres — is the one combination never exercised, and the one every customer is in.

`95bbb19c` adds `TestMigrateDatabase_PreFoldedColumnsUpgrade`, which builds a pre-#1642 schema by hand, inserts rows, and migrates. Against unmodified `main` it reproduces the production failure in SQLite form (`no such column: name_folded`). Its boundary is stated in the file rather than implied: it's SQLite, so it does **not** cover the CONSTRAINT-vs-index defect, which no SQLite test can see by construction.

That test found `95bbb19c`'s own defect within seconds of being written — and the synthetic fixture was *stronger than the real database*, because the rig happens to have `roles=0`.

## Verification

- **Real:** the rig's pre-#1642 Postgres volume migrates and the server comes up `healthy`, `health=200`, 0 restarts. `pg_dump` of the pre-migration database preserved at `results/pre-1642-schema-20260911T083819Z.dump`.
- **Tests:** `internal/storage` and `internal/core` green; full `internal/storage/store` green at 865.8s, in line with its ~860s baseline.
- **DAST against the fixed build:** nuclei 3,463 templates × 126 URLs, 1,005,966 requests, **0 findings**; ZAP API scan 1 Low (the documented `ZAP/100001` accepted exception) and 5 Informational, no Medium or above.

One regression caught on the way and recorded rather than buried: an intermediate version of the verify change dropped the `return` after `brokenChain` on the modified-event branch, so a tampered row was flagged and the walk *continued*. `TestVerifyAuditChain_DetectsModification` failed on the next run.

**This wants a v0.92.1.** The tagged release will fail to boot for anyone upgrading an existing PostgreSQL install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAULgwpMpdNJbHUg8q5RfN
