### PR TITLE
chore(gitignore): stop four artifacts reappearing in every clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,20 @@ temp/
 # local MCP config (contains credentials)
 .claude/mcp.json
 
+# The whole Claude Code state directory, not just mcp.json. Only the credential
+# file was ignored, so .claude/ itself has been showing up as untracked in
+# `git status` in every clone, in every session, indefinitely -- noise that
+# trains people to skim past a dirty tree instead of reading it. Nothing under
+# here is source.
+.claude/
+
+# Ad-hoc output directories agent sessions write into at the repo root.
+Claude outputs/
+
+# Runtime lock written beside the DEK when a server starts inside a checkout
+# (seen in review clones). An artifact of running the thing, never source.
+dek.lock
+
 data_key
 certs/
 


### PR DESCRIPTION
`.claude/mcp.json` was ignored but `.claude/` was not, so the directory showed as untracked in `git status` in every clone, in every session. Same for `Claude outputs/` and `dek.lock` (a runtime lock written beside the DEK when a server starts inside a checkout).

None of it is source. The cost isn't the files — it's that a permanently dirty `git status` trains you to skim past it, which is how the real thing hides. A repo-wide git-status check flagged the same four across four clones **five times in one day** without once naming anything that mattered.

Separately and not in this commit (it was untracked): removed a directory literally named `-` at the repo root holding `-/out/pb/keyorix{,_grpc}.pb.go` — 584K of protobuf written there on 2026-09-06 by an invocation whose output path got parsed as a flag. Redundant with `server/proto/pb/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAULgwpMpdNJbHUg8q5RfN