### PR TITLE
fix(ci): grant actions:read to SARIF-upload jobs, widen golangci-lint timeout

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -128,6 +128,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -177,6 +178,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -223,6 +225,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     container:
       image: semgrep/semgrep:1.172.0@sha256:65dcd4408adda7c183a6b4550cb1e9b19f7f627a6fbb7e0559bd466bedc44d7b
     steps:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,14 @@
 version: "2"
 
 run:
-  timeout: 5m
+  # Widened from 5m (2026-09): a 17-way simultaneous Go dependency bump
+  # (dependabot's go-patch-minor group) invalidated the lint cache and pushed
+  # a real, zero-issue run to 5m58s -- golangci-lint exits 4 ("Timeout
+  # exceeded") on a slow-but-clean run exactly like a genuinely hung one, so
+  # this was a false-negative CI failure, not a real lint violation. Widened
+  # generously rather than tuned to the observed run, per this repo's own
+  # "timeouts detect hangs, they don't enforce speed" standing practice.
+  timeout: 12m
   tests: true
 
 linters:


### PR DESCRIPTION
## What's broken and why

Every hadolint, semgrep (`scan`), and CodeQL Analyze (`server`/`operator`/`javascript-typescript`) run fails today — confirmed on `main`'s own latest push, not just on open PRs — at its SARIF upload/analysis step:

```
##[error]Resource not accessible by integration - https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run
```

`github/codeql-action`'s upload/analyze steps query workflow-run status as part of normal operation. `contents: read` + `security-events: write` alone doesn't cover that call — `actions: read` does. Added to all five affected jobs (`hadolint.yml`, `semgrep.yml`, `codeql.yml` ×3, and `trivy.yml` proactively, since it has the identical pattern and would hit the same gap).

`osv-scan` fails with a **different** message despite already having `actions: read` in `osv-scanner.yml`:

```
Please verify that the necessary features are enabled: Advanced Security must be enabled for this repository to use code scanning.
```

That's a genuine GitHub Advanced Security licensing/enablement gap at the repo level, not a workflow permissions bug — a repo admin needs to enable GHAS in Settings → Code security and analysis. Not fixed here; can't be fixed from a PR.

## The unrelated timeout fix

`golangci-lint`'s `run.timeout` was `5m`. Under dependabot's 17-way `go-patch-minor` bump (#1855), a real, clean (`0 issues`) run took 5m58s — almost certainly the lint cache getting invalidated by the simultaneous `go.sum` churn. `golangci-lint` exits 4 ("Timeout exceeded") on a slow-but-clean run exactly like a genuinely hung one, so this was a false-negative CI failure, not a real lint violation. Widened to `12m`.

## Verification

- `actionlint` clean on all four edited workflow files.
- This PR's own CI run is the verification that the permissions grant actually closes the gap — once these checks go green here, #1853/#1854/#1855 (blocked by the same shared infra) need `main` merged into their branches to pick this up, since `pull_request`-triggered workflows run off the PR's own head ref, not `main`.