### PR TITLE
test(conformance): add class-7 mutation test (LogAuditEvent context lifetime)

### DIFF
--- a/server/http/remote_storage_conformance_mutation_test.go
+++ b/server/http/remote_storage_conformance_mutation_test.go
@@ -6,25 +6,29 @@
 // and mutation-kill testing on its OWN checks, and a historical-positive replay
 // still found it caught 0 of 9 real defects — the checks were validated against
 // mutations of themselves, never against the actual historical bug shapes. This
-// file exists so that mistake is not repeated here: for four of the seven defect
+// file exists so that mistake is not repeated here: for five of the seven defect
 // classes (at least three were required), it faithfully reintroduces the exact
 // historical bug shape and demonstrates the differential harness's assertions --
 // not merely the same Go source, since that source lives in an unexported,
 // different package (internal/storage/store) this test package cannot reach into
 // without either modifying real production files (rejected: risky, and this repo's
 // standing practice is never to leave a workaround in place of a real fix) or
-// literally replaying the pre-fix git tree (rejected for all four: the checks this
+// literally replaying the pre-fix git tree (rejected for all five: the checks this
 // harness's assertions depend on — real router wiring, ADR-085's node-credential
 // role-grant requirement — postdate several of these fixes, so an old tree would
 // need its OWN period-accurate test scaffold, which is a materially different and
 // much larger undertaking than reproducing the wire-level bug itself). Each test
-// below performs the exact HTTP request (or exact cache-sharing call) the pre-fix
-// RemoteStorage method used to perform — using rs's own auth token, against the
-// SAME real server the seed tests use — and shows the outcome differs from the
-// real, fixed proxy method, in the specific way the historical defect did.
+// below performs the exact HTTP request (or exact cache-sharing call, or exact
+// client-side context-handling shape) the pre-fix RemoteStorage method used to
+// perform — using rs's own auth token, against the SAME real server the seed
+// tests use — and shows the outcome differs from the real, fixed proxy method,
+// in the specific way the historical defect did.
 //
 // Every class demonstrated: 1 (Health envelope), 3 (AllowedCIDRs field drop), 4
-// (GetSecretByName wrong route), 6 (LockUserForUpdate cache staleness).
+// (GetSecretByName wrong route), 6 (LockUserForUpdate cache staleness), 7
+// (LogAuditEvent context lifetime — see that test's own doc comment for why
+// this one was added after the other four and why it is the one class where a
+// green check didn't just miss the defect, it certified it as correct).
 package http
 
 import (
@@ -232,4 +236,82 @@ func TestMutation_LockUserForUpdate_CacheStaleness_Class6(t *testing.T) {
 			"assertion (locked.FailedLoginAttempts == the fresh value, not just err == nil) is precisely the "+
 			"shape of check that catches this -- an err == nil check alone would pass on both the fixed and "+
 			"the broken path")
+}
+
+// --- Class 7: LogAuditEvent — context lifetime, not identity ---
+
+// This class is a different SHAPE of reintroduction than 1/3/4/6 above: the
+// historical bug (#1650) is not a wire-payload or route difference an
+// unmodified server can distinguish -- it is a CLIENT-SIDE behavioral defect.
+// The real, fixed RemoteStorage.LogAuditEvent (remote_audit.go) detaches from
+// the caller's own context via auditWriteContext before the outbound POST
+// /api/v1/system/audit/event call; the pre-#1650 code forwarded the caller's
+// context verbatim instead. Faithfully reintroducing that means replaying the
+// exact request the fixed proxy sends (same route, same JSON body, same
+// bearer token) but wiring the caller's own already-cancelled context
+// directly into the outbound *http.Request -- exactly what "forward instead
+// of detach" does at the net/http layer.
+//
+// This is also the specific class remote_proxy_correctness_audit_test.go's
+// check 3 (context-substitution) does not merely miss -- it actively
+// CERTIFIES this shape as correct, because check 3's own definition of
+// "correct" is verbatim ctx forwarding (see that file's class-7 note).
+// TestConformance_LogAuditEvent's cancelled-context subtest (#1650, class 7)
+// demonstrates today's FIXED behavior; until this test existed, nothing had
+// shown that same subtest's assertions would actually have gone red against
+// the real pre-fix shape -- the exact gap this whole file exists to close
+// for the other four classes, left open for class 7 until now.
+func TestMutation_LogAuditEvent_ContextForwardedVerbatim_Class7(t *testing.T) {
+	h := newConformanceHarness(t)
+	ctx := context.Background()
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Sanity: the real (fixed) proxy detaches and persists despite an
+	// already-cancelled caller context -- TestConformance_LogAuditEvent's own
+	// cancelled-context subtest, repeated here so this test carries its own
+	// proof rather than depending on another test having run first.
+	fixedEvent := &models.AuditEvent{
+		EventType: "mutation.logauditevent.class7.fixed", IPAddress: "203.0.113.50",
+		Description: fmt.Sprintf("mutation class7 fixed %d", time.Now().UnixNano()),
+		EventTime:   time.Now().UTC(),
+	}
+	require.NoError(t, h.rs.LogAuditEvent(cancelledCtx, fixedEvent),
+		"sanity: the real (fixed) RemoteStorage.LogAuditEvent must detach from an already-cancelled caller context")
+	require.NotNil(t, findAuditEventByDescription(t, h.ls, ctx, fixedEvent.Description),
+		"sanity: the fixed proxy's write must actually be persisted server-side, not just return a nil error")
+
+	// Faithful reintroduction of the historical class-7 bug: the IDENTICAL
+	// request the fixed rs.LogAuditEvent constructs, except the caller's own
+	// already-cancelled context is wired straight into the *http.Request
+	// instead of a detached one.
+	brokenEvent := &models.AuditEvent{
+		EventType: "mutation.logauditevent.class7.broken", IPAddress: "203.0.113.51",
+		Description: fmt.Sprintf("mutation class7 broken %d", time.Now().UnixNano()),
+		EventTime:   time.Now().UTC(),
+	}
+	body, err := json.Marshal(brokenEvent)
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(cancelledCtx, http.MethodPost, h.server.URL+"/api/v1/system/audit/event", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+h.nodeToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	_, doErr := (&http.Client{Timeout: 5 * time.Second}).Do(req)
+	require.Error(t, doErr,
+		"faithful reintroduction of the historical class-7 bug: an *http.Request built from an already-cancelled "+
+			"context must fail before a single byte reaches the wire -- exactly what RemoteStorage.LogAuditEvent "+
+			"did pre-#1650, when it forwarded the caller's own context instead of detaching it via auditWriteContext")
+	assert.ErrorIs(t, doErr, context.Canceled,
+		"the failure must be attributable to context cancellation specifically, not some unrelated transport error "+
+			"that would make this reintroduction unfaithful to the actual historical bug")
+
+	assert.Nil(t, findAuditEventByDescription(t, h.ls, ctx, brokenEvent.Description),
+		"the broken (pre-#1650-shaped) request must never have reached the server at all, so the event must NOT "+
+			"be persisted -- this is exactly the shape TestConformance_LogAuditEvent's cancelled-context subtest "+
+			"would go red against: its require.NoError(rs.LogAuditEvent(...)) assertion fails (an error IS "+
+			"returned) and its require.NotNil(findAuditEventByDescription(...)) assertion fails (nothing was "+
+			"persisted) -- the exact pair of failures a verbatim-ctx-forwarding LogAuditEvent would have produced, "+
+			"and the reason check 3's 'ctx forwarded verbatim = correct' verdict is actively wrong on this path")
 }


### PR DESCRIPTION
## Summary

The RemoteStorage differential conformance campaign's own doc comment (`internal/storage/store/remote_proxy_correctness_audit_test.go`) lists 7 historical defect classes found by a #1800 historical-positive replay. The mutation-validation file (`server/http/remote_storage_conformance_mutation_test.go`) faithfully reintroduces 4 of them (1, 3, 4, 6) to prove the differential harness's own assertions actually go red against the real historical bug shapes — that's the whole point of the file, per its own doc comment: a check validated only against mutations of itself, never the real bug, is exactly what caused Layer 1's static checks to catch 0 of 9 real defects in the first place.

Class 7 (`LogAuditEvent` forwarding the caller's own cancellable context into the outbound audit write instead of detaching it, `#1650`) had a passing seed test — `TestConformance_LogAuditEvent`'s cancelled-context subtest — but no companion mutation test. So class 7's "the harness would have caught this" claim was asserted, never demonstrated, unlike the other four.

Class 7 is also the most important one to close this gap for: it's the class where the relevant static check (check 3, context-substitution) doesn't just miss the defect, it **actively certifies the buggy shape as correct** — check 3's own definition of "correct" is verbatim ctx forwarding, which on an audit-emitting path is exactly the bug.

## What this adds

`TestMutation_LogAuditEvent_ContextForwardedVerbatim_Class7` — a different *kind* of reintroduction than 1/3/4/6, since the bug is client-side context handling, not a wire-payload or route difference an unmodified server can distinguish. It replays the identical request the fixed `RemoteStorage.LogAuditEvent` sends (same route, same JSON body, same bearer token) but wires the caller's own already-cancelled context directly into the outbound `*http.Request` — exactly what forwarding instead of calling `auditWriteContext` does at the `net/http` layer.

## Test plan

- [x] New test passes as written
- [x] Verified both directions before committing (not just the happy path): temporarily swapped the broken branch's cancelled context for a live one — confirmed the test goes red ("An error is expected but got nil") exactly as it should — then reverted
- [x] All 5 `TestMutation_*` tests pass (4 existing + this one)
- [x] `TestReportConformancePopulation` / `TestConformanceCoverageIsCompleteOrDeclared` unaffected (still 0 uncovered, gate still green)
- [x] `go vet ./server/http/...` clean
- [x] `golangci-lint run ./server/http/...`: 0 issues
- [x] `gosec -severity medium ./server/http/...`: 0 issues
- [x] Full suite: `go test ./...` green — 95/95 packages (`internal/storage/store` needs `-timeout 20m+`, re-run separately at 862.62s, matching the documented baseline)
