### PR TITLE
chore(release): v0.92.1 changelog + fix DAST nuclei install

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -115,10 +115,31 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/bin/nuclei
-          key: nuclei-v3.3.9-${{ runner.os }}
+          key: nuclei-v3.3.9-prebuilt-${{ runner.os }}
 
       - name: Install Nuclei
-        run: '[ -x ~/go/bin/nuclei ] || go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.3.9' # NOSONAR githubactions:S6437 -- pinned to v3.3.9; go.sum not applicable for standalone DAST tool binaries outside the module graph
+        # Use the prebuilt release binary instead of `go install`: nuclei v3.3.9
+        # transitively pins an old github.com/bytedance/sonic that go:linkname's
+        # encoding/json.unquoteBytes -- a symbol removed in Go 1.26+ -- so building
+        # from source fails at link ("invalid reference to encoding/json.unquoteBytes").
+        # The published binary is built by projectdiscovery with a compatible
+        # toolchain. Pinned to v3.3.9 and checksum-verified against the release's
+        # own checksums file.
+        env:
+          NUCLEI_VERSION: 3.3.9
+        run: |
+          if [ ! -x "$HOME/go/bin/nuclei" ]; then
+            mkdir -p "$HOME/go/bin"
+            tmp="$(mktemp -d)"; cd "$tmp"
+            base="https://github.com/projectdiscovery/nuclei/releases/download/v${NUCLEI_VERSION}"
+            curl -fsSL -O "${base}/nuclei_${NUCLEI_VERSION}_linux_amd64.zip"
+            curl -fsSL -O "${base}/nuclei_${NUCLEI_VERSION}_checksums.txt"
+            grep " nuclei_${NUCLEI_VERSION}_linux_amd64.zip$" "nuclei_${NUCLEI_VERSION}_checksums.txt" | sha256sum -c -
+            unzip -o "nuclei_${NUCLEI_VERSION}_linux_amd64.zip" nuclei -d "$HOME/go/bin"
+            chmod +x "$HOME/go/bin/nuclei"
+          fi
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          "$HOME/go/bin/nuclei" -version
 
       - name: Update Nuclei templates
         run: nuclei -update-templates -silent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Keyorix are documented here. This project follows
 
 ## Unreleased
 
+## v0.92.1 — 2026-09-12
+
+### Security
+- **RFC 3161 timestamp tokens are now validated as strict DER before decoding.**
+  A malformed timestamp token (or TSA response) could previously drive the
+  CMS/BER decoding path into excessive memory allocation on the notary verify
+  path (audit-checkpoint anchoring and receipt verification). Keyorix now
+  rejects any token that is not well-formed, definite-length DER — with bounded
+  nesting depth and node count — before it reaches the decoder, closing that
+  denial-of-service vector while still accepting every spec-compliant token
+  (RFC 3161 §2.4.2 requires DER). (#1848)
+
+### Fixed
+- **Keyorix v0.92.0 could not start against an existing PostgreSQL database.**
+  A migrations/audit startup ordering problem prevented boot against a
+  pre-existing Postgres schema; upgrades against an existing database now boot
+  cleanly. (#1850)
+- Dependency updates: Go module patch group (#1855), npm patch group (#1858),
+  and `sigs.k8s.io/controller-runtime` 0.24.1 → 0.25.0 (#1853).
+
 ## v0.92.0 — 2026-09-10
 
 > **Scope note.** `v0.88.0` through `v0.91.0` were tagged without changelog


### PR DESCRIPTION
Release-prep for **v0.92.1**. Two changes:

### CHANGELOG — add the v0.92.1 section
`## Unreleased` on `main` was already empty and `## v0.92.0` already populated, so this only adds the new section for what actually landed since v0.92.0:
- **Security:** strict DER framing validation for RFC 3161 timestamp tokens before decode, closing a memory-exhaustion DoS vector on the notary verify path (#1848).
- **Fixed:** v0.92.0 could not start against an existing PostgreSQL database (#1850).
- Dependency patch bumps (#1855, #1858, #1853).

(The security note is intentionally generic to Keyorix's own hardening — the upstream `digitorus` root cause is under separate coordinated disclosure.)

### DAST — fix the Nuclei install
The `Nuclei DAST` job has been failing on `main` at the *Install Nuclei* step: nuclei v3.3.9 transitively pins an old `github.com/bytedance/sonic` that `go:linkname`s `encoding/json.unquoteBytes`, a symbol removed in Go 1.26+, so building from source fails at link (`invalid reference to encoding/json.unquoteBytes`). Switched to the **prebuilt release binary** (built by projectdiscovery with a compatible toolchain), pinned to v3.3.9 and **checksum-verified** against the release's own checksums file. No product code change.
