### PR TITLE
fix(security): X-Permitted-Cross-Domain-Policies header + scope DAST to the web app

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -157,6 +157,7 @@ jobs:
         run: |
           nuclei -target http://localhost:8080 \
                  -tags "auth,token,jwt,exposure,misconfig" \
+                 -exclude-tags "ssh,network" \
                  -sarif-export /tmp/nuclei-results.sarif \
                  -silent \
                  -no-color || true

--- a/server/middleware/security_headers.go
+++ b/server/middleware/security_headers.go
@@ -39,6 +39,9 @@ const contentSecurityPolicy = "default-src 'self'; script-src 'self'; style-src 
 //     CORS; together with COOP this enables cross-origin isolation in the browser.
 //   - Cross-Origin-Opener-Policy: same-origin — isolates the browsing context group so
 //     cross-origin documents cannot share the same context (closes window.opener leaks).
+//   - X-Permitted-Cross-Domain-Policies: none — no Adobe cross-domain policy file is
+//     honored (a legacy Flash/PDF data-exfiltration channel); also a header web security
+//     scanners expect to see set.
 //
 // HSTS is sent only when this process terminates TLS (tlsEnabled); deployments that
 // terminate TLS at a proxy add HSTS there, and sending it over plain HTTP is wrong.
@@ -58,6 +61,7 @@ func SecurityHeaders(tlsEnabled bool) func(http.Handler) http.Handler {
 			h.Set("Cross-Origin-Embedder-Policy", "require-corp")
 			h.Set("Cross-Origin-Opener-Policy", "same-origin")
 			h.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()")
+			h.Set("X-Permitted-Cross-Domain-Policies", "none")
 			if tlsEnabled {
 				h.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
 			}

--- a/server/middleware/security_headers_test.go
+++ b/server/middleware/security_headers_test.go
@@ -23,6 +23,7 @@ func TestSecurityHeaders_AlwaysSet(t *testing.T) {
 	assert.Equal(t, "nosniff", hdr.Get("X-Content-Type-Options"))
 	assert.Equal(t, "DENY", hdr.Get("X-Frame-Options"))
 	assert.Equal(t, "no-referrer", hdr.Get("Referrer-Policy"))
+	assert.Equal(t, "none", hdr.Get("X-Permitted-Cross-Domain-Policies"))
 	// HSTS is NOT sent over plain HTTP (TLS terminated elsewhere or not at all).
 	assert.Empty(t, hdr.Get("Strict-Transport-Security"))
 }


### PR DESCRIPTION
Addresses the code-scanning findings from the (now-working) DAST job.

### `X-Permitted-Cross-Domain-Policies: none`
The `SecurityHeaders` middleware (already applied globally in `router.go`, incl. unauthenticated routes) gains one header: `X-Permitted-Cross-Domain-Policies: none`. Denies any Adobe cross-domain policy file — a legacy Flash/PDF data-exfiltration channel — and clears the `http-missing-security-headers` finding (alert #826). Test updated.

The existing middleware already sets CSP, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, Referrer-Policy, COOP/COEP/CORP, Permissions-Policy, and conditional HSTS — so this is the one remaining gap.

### DAST scan scope
`-exclude-tags ssh,network` on the nuclei run so it only probes the HTTP app, not the CI runner host's own SSH/network services. That runner-host SSH probe produced the `ssh-sha1-hmac-algo` (`localhost:22`) false positive (alert #824) — Keyorix has no SSH.

### Not changed (intentional)
- **Missing HSTS** on the DAST server is correct: HSTS is sent only when Keyorix terminates TLS, and the DAST server runs plain HTTP. Sending HSTS over HTTP is wrong, so that finding is dismissed, not "fixed".
- **`/metrics` unauthenticated** (alert #827) is by design — documented in `config.go`; sensitive scheduler metrics are already gated behind `RequirePermission`. Network-layer restriction is the intended control.

`gofmt`, `go build`, `go test ./server/middleware/` all clean.
