### PR TITLE
fix(dast): exclude the HSTS matcher from the plaintext nuclei scan

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -155,9 +155,24 @@ jobs:
 
       - name: Run Nuclei (unauthenticated surface)
         run: |
+          # -exclude-matchers targets one named matcher inside a template (as
+          # opposed to -exclude-id, which drops the whole template) -- every
+          # other http-missing-security-headers check (CSP, X-Frame-Options,
+          # X-Content-Type-Options, Referrer-Policy, Permissions-Policy,
+          # X-Permitted-Cross-Domain-Policies, the three Cross-Origin-* headers)
+          # stays active. Alert #825: this DAST job runs the server with
+          # tls.enabled=false (an ephemeral plaintext target, see "Write DAST
+          # config" above), so Strict-Transport-Security is correctly never
+          # sent -- RFC 6797 says a browser MUST ignore HSTS received over
+          # plain HTTP, and server/middleware/security_headers.go only sets it
+          # when tlsEnabled, which server/middleware/security_headers_test.go's
+          # TestSecurityHeaders_HSTSOnlyWithTLS already proves both ways. This
+          # scanner has no way to know that; without the exclusion it flags a
+          # permanent false positive that no code change here can fix.
           nuclei -target http://localhost:8080 \
                  -tags "auth,token,jwt,exposure,misconfig" \
                  -exclude-tags "ssh,network" \
+                 -exclude-matchers "http-missing-security-headers:strict-transport-security" \
                  -sarif-export /tmp/nuclei-results.sarif \
                  -silent \
                  -no-color || true


### PR DESCRIPTION
## Summary
- Closes code-scanning alert #825 (`http-missing-security-headers`): nuclei reports Strict-Transport-Security as missing on `localhost:8080`.
- Root cause: the DAST job intentionally runs the server with `tls.enabled=false` (an ephemeral plaintext CI target). `security_headers.go` correctly only sends HSTS when TLS is terminated — per RFC 6797 a browser must ignore HSTS received over plain HTTP anyway. `TestSecurityHeaders_HSTSOnlyWithTLS` already proves this both ways at the unit level. This is a scanner/environment mismatch, not a real missing header.
- `x-permitted-cross-domain-policies`, the other historical sub-finding under this same generic rule id, is already fixed by #1860 (confirmed via GitHub alert history — alert #826).
- Adds `-exclude-matchers "http-missing-security-headers:strict-transport-security"` to the Nuclei invocation. This targets only the one named matcher inside the template (vs `-exclude-id`, which would drop the whole template) — every other header check (CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, X-Permitted-Cross-Domain-Policies, the three Cross-Origin-* headers) stays fully active.

## Verification
- Confirmed via the actual CI job logs that the only remaining sub-finding is `[http-missing-security-headers:strict-transport-security]`.
- Downloaded the real nuclei v3.3.9 release binary locally and reproduced the finding against a locally-built, locally-run copy of the server (same plaintext/no-TLS config as the DAST job).
- Confirmed `-exclude-matchers "http-missing-security-headers:strict-transport-security"` suppresses only that finding.
- Negative control: temporarily disabled `X-Frame-Options` in the header middleware, rebuilt, and confirmed nuclei (with the same exclude-matchers flag) still correctly flags `x-frame-options` as missing — proving the exclusion is precisely scoped, not a blanket suppression of the whole template.
- `actionlint .github/workflows/dast.yml` passes.

## Test plan
- [x] actionlint clean
- [x] Local reproduction + fix verification against real nuclei v3.3.9 binary
- [x] Negative control (X-Frame-Options) confirms other checks still fire
- [ ] CI green on this PR
- [ ] Manual `workflow_dispatch` DAST run post-merge to confirm alert #825 clears