### PR TITLE
build: strip symbols/DWARF (-s -w) from release binaries and images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,14 @@ TRUST_LICENSE_KEYS?=
 # Inject the build identity into both the CLI (internal/cli.version) and the shared
 # internal/version package (read by the server's /health + /system/info). Commit is
 # deterministic per source revision, so release builds stay reproducible (no build date).
-LDFLAGS=-ldflags "-X github.com/keyorixhq/keyorix/internal/cli.version=$(VERSION) -X github.com/keyorixhq/keyorix/internal/version.Version=$(VERSION) -X github.com/keyorixhq/keyorix/internal/version.Commit=$(GIT_COMMIT) -X github.com/keyorixhq/keyorix/internal/trust.updateKeysB64=$(TRUST_UPDATE_KEYS) -X github.com/keyorixhq/keyorix/internal/trust.licenseKeysB64=$(TRUST_LICENSE_KEYS)"
+VERSION_LDFLAGS=-X github.com/keyorixhq/keyorix/internal/cli.version=$(VERSION) -X github.com/keyorixhq/keyorix/internal/version.Version=$(VERSION) -X github.com/keyorixhq/keyorix/internal/version.Commit=$(GIT_COMMIT) -X github.com/keyorixhq/keyorix/internal/trust.updateKeysB64=$(TRUST_UPDATE_KEYS) -X github.com/keyorixhq/keyorix/internal/trust.licenseKeysB64=$(TRUST_LICENSE_KEYS)
+LDFLAGS=-ldflags "$(VERSION_LDFLAGS)"
+# RELEASE_LDFLAGS additionally strips the symbol table + DWARF debug info (-s -w):
+# ~92MB -> ~62MB for keyorix-server. Only the `release` target uses this — build-cli/
+# build-server/build-ui/dev keep full symbols (plain LDFLAGS) for local debugging.
+# Stripping does NOT remove pclntab, so panic stack traces still show function names;
+# only an attached debugger (dlv) loses symbols, an acceptable release-binary tradeoff.
+RELEASE_LDFLAGS=-ldflags "-s -w $(VERSION_LDFLAGS)"
 
 .PHONY: build build-cli build-server build-ui populate-webui-dist install install-cli install-server clean run db-up dev docker-build docker-up docker-down docker-logs proto proto-deps proto-lint release sbom _sbom-generate smoke
 
@@ -118,14 +125,14 @@ dev: install-cli
 release: populate-webui-dist
 	@echo "→ Cross-compiling $(VERSION)"
 	@mkdir -p dist
-	GOOS=linux  GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_linux_amd64    .
-	GOOS=linux  GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_linux_arm64    .
-	GOOS=darwin GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_darwin_amd64   .
-	GOOS=darwin GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_darwin_arm64   .
-	GOOS=linux  GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_linux_amd64  ./server
-	GOOS=linux  GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_linux_arm64  ./server
-	GOOS=darwin GOARCH=amd64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_darwin_amd64 ./server
-	GOOS=darwin GOARCH=arm64  CGO_ENABLED=0 go build $(LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_darwin_arm64 ./server
+	GOOS=linux  GOARCH=amd64  CGO_ENABLED=0 go build $(RELEASE_LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_linux_amd64    .
+	GOOS=linux  GOARCH=arm64  CGO_ENABLED=0 go build $(RELEASE_LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_linux_arm64    .
+	GOOS=darwin GOARCH=amd64  CGO_ENABLED=0 go build $(RELEASE_LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_darwin_amd64   .
+	GOOS=darwin GOARCH=arm64  CGO_ENABLED=0 go build $(RELEASE_LDFLAGS) -trimpath -o dist/$(BINARY_CLI)_darwin_arm64   .
+	GOOS=linux  GOARCH=amd64  CGO_ENABLED=0 go build $(RELEASE_LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_linux_amd64  ./server
+	GOOS=linux  GOARCH=arm64  CGO_ENABLED=0 go build $(RELEASE_LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_linux_arm64  ./server
+	GOOS=darwin GOARCH=amd64  CGO_ENABLED=0 go build $(RELEASE_LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_darwin_amd64 ./server
+	GOOS=darwin GOARCH=arm64  CGO_ENABLED=0 go build $(RELEASE_LDFLAGS) -trimpath -o dist/$(BINARY_SERVER)_darwin_arm64 ./server
 	$(MAKE) _sbom-generate
 	@cd dist && (sha256sum * > checksums.txt 2>/dev/null || shasum -a 256 * > checksums.txt)
 	@git checkout -- server/webui/dist/index.html 2>/dev/null || true

--- a/cmd/keyorix-k8s-sync/Dockerfile
+++ b/cmd/keyorix-k8s-sync/Dockerfile
@@ -11,6 +11,7 @@ COPY . .
 ARG VERSION=dev
 ARG GIT_COMMIT=none
 RUN set -- \
+    "-s -w" \
     "-X github.com/keyorixhq/keyorix/internal/cli.version=${VERSION}" \
     "-X github.com/keyorixhq/keyorix/internal/version.Version=${VERSION}" \
     "-X github.com/keyorixhq/keyorix/internal/version.Commit=${GIT_COMMIT}" && \

--- a/cmd/keyorix-mcp/Dockerfile
+++ b/cmd/keyorix-mcp/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY . .
 ARG VERSION=dev
 RUN CGO_ENABLED=0 go build \
-    -ldflags "-X main.version=${VERSION}" \
+    -ldflags "-s -w -X main.version=${VERSION}" \
     -trimpath -o /out/keyorix-mcp ./cmd/keyorix-mcp
 
 # Runtime stage — distroless static, non-root (no shell, no package manager). The MCP

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -o /out/keyorix-operator ./cmd
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/keyorix-operator ./cmd
 
 # Runtime stage — distroless static, non-root. The operator reaches the Keyorix server
 # over HTTPS (ca-certificates baked into the static base) and the Kubernetes API via the

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,6 +11,7 @@ COPY . .
 ARG VERSION=dev
 ARG GIT_COMMIT=none
 RUN set -- \
+    "-s -w" \
     "-X github.com/keyorixhq/keyorix/internal/cli.version=${VERSION}" \
     "-X github.com/keyorixhq/keyorix/internal/version.Version=${VERSION}" \
     "-X github.com/keyorixhq/keyorix/internal/version.Commit=${GIT_COMMIT}" && \


### PR DESCRIPTION
## Summary
- No GoReleaser config exists in this repo (checked for `.goreleaser.yml`/`.yaml` — absent). The actual release paths are the Makefile's `release` target (invoked by `release.yml` on a `vX.Y.Z` tag) and four Dockerfiles built by `docker-publish.yml` on every push to `main` and every tag: `server/Dockerfile`, `cmd/keyorix-k8s-sync/Dockerfile`, `cmd/keyorix-mcp/Dockerfile`, `operator/Dockerfile`. None of them previously passed `-s -w`.
- A plain build produces a ~92MB `keyorix-server` binary; `-s -w` (strip symbol table + DWARF) brings it to ~62MB — confirmed locally, exact numbers below.

## Changes
- **Makefile**: split `LDFLAGS` into a new `RELEASE_LDFLAGS` (`-s -w` plus the existing `-X` version/commit/trust-key injection, factored into a shared `VERSION_LDFLAGS` var so the two lists can't drift apart). Only the `release` target uses `RELEASE_LDFLAGS` — `build-cli`/`build-server`/`build-ui`/`dev` keep plain `LDFLAGS` (full symbols) for local debugging.
- **server/Dockerfile, cmd/keyorix-k8s-sync/Dockerfile**: appended `"-s -w"` to the existing ldflags list; the `-X` version/commit injection is untouched.
- **cmd/keyorix-mcp/Dockerfile**: prepended `-s -w` to its existing `-X` ldflags.
- **operator/Dockerfile**: had no ldflags at all (no version injection either) — added `-ldflags "-s -w"` as a small scope extension beyond "append to existing," since it's the same shipped release path via `docker-publish.yml` and leaving it unstripped while fixing the other three would be an obvious, easily-closed gap in the same change.

## Verification
- Built the server binary both ways with the exact Makefile-equivalent flags (confirmed via `make -n release`): **92.3MB unstripped vs 62.2MB with `-s -w`**.
- Confirmed the `-X`-injected version/commit strings (`v1.2.3`, `abc123`) survive stripping via `strings` on the stripped binary.
- Ran the stripped binary — starts cleanly and serves `/health` correctly.
- Confirmed `make -n build-server` (dev path) still has no `-s -w` — dev builds are unchanged.
- `-s -w` does not remove Go's pclntab, so panic stack traces still show function names; only an attached debugger (dlv) loses symbols, an acceptable release-binary tradeoff.
- `hadolint` on all 4 touched Dockerfiles: only pre-existing `DL3018` (apk version pinning) warnings, confirmed present identically on `origin/main` before this change — nothing new introduced.

## Test plan
- [x] Local build size comparison (92.3MB -> 62.2MB)
- [x] Version/commit injection survives stripping
- [x] Stripped binary runs and serves `/health`
- [x] Dev build path (`build-server`/`build-ui`) confirmed unaffected
- [x] hadolint clean (no new warnings)
- [ ] CI green on this PR